### PR TITLE
Use Instant and Duration instead of u64(nanos) for time calcs

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -189,7 +189,7 @@ struct PostConnectHandler {
 impl Handler for PostConnectHandler {
     fn handle(&mut self, client: &mut Http3Connection) -> bool {
         let mut data = vec![0; 4000];
-        client.process_http3();
+        client.process_http3(now());
         for event in client.events() {
             match event {
                 Http3Event::HeaderReady { stream_id } => {
@@ -208,7 +208,7 @@ impl Handler for PostConnectHandler {
                     }
 
                     let (_sz, fin) = client
-                        .read_data(stream_id, &mut data)
+                        .read_data(now(), stream_id, &mut data)
                         .expect("Read should succeed");
                     println!(
                         "READ[{}]: {}",
@@ -217,7 +217,7 @@ impl Handler for PostConnectHandler {
                     );
                     if fin {
                         println!("<FIN[{}]>", stream_id);
-                        client.close(0, "kthxbye!");
+                        client.close(now(), 0, "kthxbye!");
                         return false;
                     }
                 }

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -341,7 +341,7 @@ mod old {
                         );
                         if fin {
                             println!("<FIN[{}]>", stream_id);
-                            client.close(0, 0, "kthxbye!");
+                            client.close(now(), 0, "kthxbye!");
                             return false;
                         }
                     }

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -13,7 +13,7 @@ pub mod log;
 pub use self::codec::{Decoder, Encoder};
 pub use self::incrdecoder::{IncrementalDecoder, IncrementalDecoderResult};
 
-use std::time::SystemTime;
+use std::time::Instant;
 
 // Cribbed from the |matches| crate, for simplicity.
 #[macro_export]
@@ -26,11 +26,8 @@ macro_rules! matches {
     }
 }
 
-pub fn now() -> u64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64
+pub fn now() -> Instant {
+    Instant::now()
 }
 
 pub fn hex(buf: &[u8]) -> String {

--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -217,7 +217,7 @@ fn main() -> Result<(), io::Error> {
                 continue;
             }
 
-            server.process_http3();
+            server.process_http3(now());
             let (conn_out_dgrams, _timer) = server.process_output(now());
             // TODO: each connection might want a different timer, how's that
             // gonna work?

--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -501,6 +501,7 @@ impl HFrameReader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use neqo_common::now;
     use neqo_crypto::init_db;
     use neqo_transport::frame::StreamType;
     use num_traits::Num;
@@ -508,10 +509,6 @@ mod tests {
 
     fn loopback() -> SocketAddr {
         "127.0.0.1:443".parse().unwrap()
-    }
-
-    fn now() -> u64 {
-        0
     }
 
     #[allow(clippy::many_single_char_names)]

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -6,10 +6,12 @@
 
 #![allow(unused_assignments)]
 
+use neqo_common::now;
 use neqo_http3::{Http3Connection, Http3State};
 use neqo_transport::{Connection, Datagram};
 
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use neqo_crypto::init_db;
 
@@ -42,7 +44,11 @@ fn new_stream_callback(
     )
 }
 
-fn connect() -> (Http3Connection, Http3Connection, (Vec<Datagram>, u64)) {
+fn connect() -> (
+    Http3Connection,
+    Http3Connection,
+    (Vec<Datagram>, Option<Duration>),
+) {
     init_db("../neqo-transport/db");
 
     let mut hconn_c = Http3Connection::new(
@@ -60,16 +66,16 @@ fn connect() -> (Http3Connection, Http3Connection, (Vec<Datagram>, u64)) {
 
     assert_eq!(hconn_c.state(), Http3State::Initializing);
     assert_eq!(hconn_s.state(), Http3State::Initializing);
-    let mut r = hconn_c.process(Vec::new(), 0);
-    r = hconn_s.process(r.0, 0);
-    r = hconn_c.process(r.0, 0);
-    r = hconn_s.process(r.0, 0);
+    let mut r = hconn_c.process(Vec::new(), now());
+    r = hconn_s.process(r.0, now());
+    r = hconn_c.process(r.0, now());
+    r = hconn_s.process(r.0, now());
     assert_eq!(hconn_c.state(), Http3State::Connected);
     assert_eq!(hconn_s.state(), Http3State::Connected);
-    r = hconn_c.process(r.0, 0);
-    r = hconn_s.process(r.0, 0);
+    r = hconn_c.process(r.0, now());
+    r = hconn_s.process(r.0, now());
     // assert_eq!(hconn_s.settings_received, true);
-    r = hconn_c.process(r.0, 0);
+    r = hconn_c.process(r.0, now());
     // assert_eq!(hconn_c.settings_received, true);
 
     (hconn_c, hconn_s, r)
@@ -89,12 +95,12 @@ fn test_fetch() {
         .fetch("GET", "https", "something.com", "/", &[])
         .unwrap();
     assert_eq!(req, 0);
-    r = hconn_c.process(r.0, 0);
+    r = hconn_c.process(r.0, now());
     eprintln!("-----server");
-    r = hconn_s.process(r.0, 0);
+    r = hconn_s.process(r.0, now());
 
     eprintln!("-----client");
-    r = hconn_c.process(r.0, 0);
+    r = hconn_c.process(r.0, now());
     // TODO: some kind of client API needed to read result of fetch
     // TODO: assert result is as expected e.g. (200 "abc")
     // assert!(false);

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -145,7 +145,7 @@ impl Handler for H9Handler {
                     self.rbytes += sz;
                     if fin {
                         eprintln!("<FIN[{}]>", stream_id);
-                        client.close(0, 0, "kthxbye!");
+                        client.close(now(), 0, "kthxbye!");
                         self.rsfin = true;
                         return false;
                     }
@@ -426,7 +426,7 @@ fn test_h3(nctx: &NetworkCtx, peer: &Peer, client: Connection) -> Result<(), Str
     let mut hc = H3Handler {
         streams: HashSet::new(),
         h3: Http3Connection::new(client, 128, 128, None),
-        host: String::from(peer.host.clone()),
+        host: String::from(peer.host),
         path: String::from("/"),
     };
 

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -262,7 +262,7 @@ fn process_loop_h3(
 impl H3Handler {
     fn handle(&mut self) -> bool {
         let mut data = vec![0; 4000];
-        self.h3.process_http3();
+        self.h3.process_http3(now());
         for event in self.h3.events() {
             match event {
                 Http3Event::HeaderReady { stream_id } => {
@@ -282,7 +282,7 @@ impl H3Handler {
 
                     let (_sz, fin) = self
                         .h3
-                        .read_data(stream_id, &mut data)
+                        .read_data(now(), stream_id, &mut data)
                         .expect("Read should succeed");
                     println!(
                         "READ[{}]: {}",
@@ -291,7 +291,7 @@ impl H3Handler {
                     );
                     if fin {
                         println!("<FIN[{}]>", stream_id);
-                        self.h3.close(0, "kthxbye!");
+                        self.h3.close(now(), 0, "kthxbye!");
                         return false;
                     }
                 }

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -797,6 +797,7 @@ fn read_prefixed_encoded_int_with_connection_wrap(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use neqo_common::now;
     use neqo_crypto::init_db;
     use neqo_transport::frame::StreamType;
     use neqo_transport::ConnectionEvent;
@@ -804,10 +805,6 @@ mod tests {
 
     fn loopback() -> SocketAddr {
         "127.0.0.1:443".parse().unwrap()
-    }
-
-    fn now() -> u64 {
-        0
     }
 
     fn connect() -> (QPackDecoder, Connection, Connection, u64, u64) {

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -530,6 +530,7 @@ impl ::std::fmt::Display for QPackEncoder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use neqo_common::now;
     use neqo_crypto::init_db;
     use neqo_transport::frame::StreamType;
     use neqo_transport::ConnectionEvent;
@@ -537,10 +538,6 @@ mod tests {
 
     fn loopback() -> SocketAddr {
         "127.0.0.1:443".parse().unwrap()
-    }
-
-    fn now() -> u64 {
-        0
     }
 
     fn connect(huffman: bool) -> (QPackEncoder, Connection, Connection, u64, u64) {

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -49,8 +49,8 @@ const CID_LENGTH: usize = 8;
 
 const TIME_THRESHOLD: f64 = 9.0 / 8.0;
 const PACKET_THRESHOLD: u64 = 3;
-// TODO granularity
-const GRANULARITY: Duration = Duration::from_millis(1);
+
+const GRANULARITY: Duration = Duration::from_millis(20);
 const INITIAL_RTT: Duration = Duration::from_millis(100);
 
 const LOCAL_STREAM_LIMIT_BIDI: u64 = 16;
@@ -2555,7 +2555,7 @@ impl RttVals {
     }
 
     fn pto(&self) -> Duration {
-        self.smoothed_rtt.unwrap_or_else(|| self.latest_rtt)
+        self.smoothed_rtt.unwrap_or(self.latest_rtt)
             + max(4 * self.rttvar, GRANULARITY)
             + self.max_ack_delay
     }
@@ -2840,7 +2840,7 @@ impl LossRecovery {
             let packet_space = self.space(*space);
 
             if let Some(new_loss_time) = packet_space.loss_time {
-                if loss_time.is_none() || Some(new_loss_time) < loss_time {
+                if loss_time.map(|i| new_loss_time < i).unwrap_or(true) {
                     loss_time = Some(new_loss_time);
                     pn_space = *space;
                 }

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -13,6 +13,7 @@ use std::mem;
 use std::net::SocketAddr;
 use std::ops::{AddAssign, Deref, DerefMut};
 use std::rc::Rc;
+use std::time::{Duration, Instant};
 
 use neqo_common::{hex, matches, qdebug, qerror, qinfo, qtrace, qwarn, Decoder, Encoder};
 use neqo_crypto::aead::Aead;
@@ -49,8 +50,8 @@ const CID_LENGTH: usize = 8;
 const TIME_THRESHOLD: f64 = 9.0 / 8.0;
 const PACKET_THRESHOLD: u64 = 3;
 // TODO granularity
-const GRANULARITY: u64 = 1000; // 1ms in microseconds
-const INITIAL_RTT: u64 = 100_000; // 100ms in microseconds
+const GRANULARITY: Duration = Duration::from_millis(1);
+const INITIAL_RTT: Duration = Duration::from_millis(100);
 
 const LOCAL_STREAM_LIMIT_BIDI: u64 = 16;
 const LOCAL_STREAM_LIMIT_UNI: u64 = 16;
@@ -78,7 +79,7 @@ pub enum State {
         error: ConnectionError,
         frame_type: FrameType,
         msg: String,
-        timeout: u64,
+        timeout: Instant,
     },
     Closed(ConnectionError),
 }
@@ -188,7 +189,7 @@ impl AddAssign<u64> for StreamIndex {
     }
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PNSpace {
     Initial,
     Handshake,
@@ -647,7 +648,7 @@ pub struct Connection {
     tx_pns: [u64; 3],
     // TODO(ekr@rtfm.com): Prioritized generators, rather than a vec
     generators: Vec<Box<FrameGenerator>>,
-    deadline: u64,
+    idle_timeout: Option<Instant>,
     local_max_stream_idx_uni: StreamIndex,
     local_max_stream_idx_bidi: StreamIndex,
     local_next_stream_idx_uni: StreamIndex,
@@ -797,7 +798,7 @@ impl Connection {
             ],
             crypto_states: [None, None, None, None],
             tx_pns: [0; 3],
-            deadline: 0,
+            idle_timeout: None,
             local_max_stream_idx_bidi: StreamIndex::new(LOCAL_STREAM_LIMIT_BIDI),
             local_max_stream_idx_uni: StreamIndex::new(LOCAL_STREAM_LIMIT_UNI),
             local_next_stream_idx_uni: StreamIndex::new(0),
@@ -870,7 +871,12 @@ impl Connection {
 
     // This function wraps a call to another function and sets the connection state
     // properly if that call fails.
-    fn capture_error<T>(&mut self, cur_time: u64, frame_type: FrameType, res: Res<T>) -> Res<T> {
+    fn capture_error<T>(
+        &mut self,
+        cur_time: Instant,
+        frame_type: FrameType,
+        res: Res<T>,
+    ) -> Res<T> {
         if let Err(v) = &res {
             #[cfg(debug_assertions)]
             let msg = format!("{:?}", v);
@@ -888,13 +894,13 @@ impl Connection {
 
     /// For use with process().  Errors there can be ignored, but this needs to
     /// ensure that the state is updated.
-    fn absorb_error(&mut self, cur_time: u64, res: Res<()>) {
+    fn absorb_error(&mut self, cur_time: Instant, res: Res<()>) {
         let _ = self.capture_error(cur_time, 0, res);
     }
 
     /// Call in to process activity on the connection. Either new packets have
     /// arrived or a timeout has expired (or both).
-    pub fn process_input<I>(&mut self, in_dgrams: I, cur_time: u64)
+    pub fn process_input<I>(&mut self, in_dgrams: I, cur_time: Instant)
     where
         I: IntoIterator<Item = Datagram>,
     {
@@ -905,39 +911,54 @@ impl Connection {
 
         self.cleanup_streams();
 
-        if cur_time >= self.deadline {
-            // Timer expired.
-            if let State::Init = self.state {
-                let res = self.client_start();
-                self.absorb_error(cur_time, res);
+        if let Some(idle_timeout) = self.idle_timeout {
+            if cur_time >= idle_timeout {
+                // Timer expired. Reconnect?
+                // TODO(agrover@mozilla.com) reinitialize many members of
+                // struct Connection
+                self.state = State::Init;
             }
+        }
+
+        if self.state == State::Init {
+            let res = self.client_start();
+            self.absorb_error(cur_time, res);
         }
     }
 
     /// Get output packets, as a result of receiving packets, or actions taken
     /// by the application.
-    pub fn process_output(&mut self, cur_time: u64) -> (Vec<Datagram>, u64) {
+    /// Returns datagrams to send, and how long to wait before calling again
+    /// even if no incoming packets.
+    pub fn process_output(&mut self, cur_time: Instant) -> (Vec<Datagram>, Option<Duration>) {
         match &self.state {
             State::Closing { error, timeout, .. } => {
                 if *timeout < cur_time {
-                    (self.output(cur_time), 0)
+                    (self.output(cur_time), None)
                 } else {
                     // Close timeout expired, move to Closed
                     let st = State::Closed(error.clone());
                     self.set_state(st);
-                    (Vec::new(), 0)
+                    (Vec::new(), None)
                 }
             }
-            State::Closed(..) => (Vec::new(), 0),
+            State::Closed(..) => (Vec::new(), None),
             _ => {
                 self.check_loss_detection_timeout(cur_time);
-                (self.output(cur_time), self.loss_recovery.get_timer())
+                (
+                    self.output(cur_time),
+                    self.loss_recovery.get_timer(cur_time),
+                )
             }
         }
     }
 
     /// Process input and generate output.
-    pub fn process<I>(&mut self, in_dgrams: I, cur_time: u64) -> (Vec<Datagram>, u64)
+    pub fn process<I>(
+        &mut self,
+        in_dgrams: I,
+        cur_time: Instant,
+    ) -> (Vec<Datagram>, Option<Duration>)
     where
         I: IntoIterator<Item = Datagram>,
     {
@@ -949,7 +970,7 @@ impl Connection {
         &self.scid[..] == cid
     }
 
-    fn input(&mut self, d: Datagram, cur_time: u64) -> Res<()> {
+    fn input(&mut self, d: Datagram, cur_time: Instant) -> Res<()> {
         let mut slc = &d[..];
 
         qinfo!([self] "input {}", hex( &**d));
@@ -1110,7 +1131,7 @@ impl Connection {
     }
 
     // Return whether the packet had ack-eliciting frames.
-    fn input_packet(&mut self, epoch: Epoch, mut d: Decoder, cur_time: u64) -> Res<(bool)> {
+    fn input_packet(&mut self, epoch: Epoch, mut d: Decoder, cur_time: Instant) -> Res<(bool)> {
         let mut ack_eliciting = false;
 
         // Handle each frame in the packet
@@ -1147,7 +1168,7 @@ impl Connection {
         }
     }
 
-    fn output(&mut self, cur_time: u64) -> Vec<Datagram> {
+    fn output(&mut self, cur_time: Instant) -> Vec<Datagram> {
         if let Some(scid) = self.send_vn.take() {
             return vec![self.output_vn(scid)];
         }
@@ -1179,7 +1200,7 @@ impl Connection {
 
     // Iterate through all the generators, inserting as many frames as will
     // fit.
-    fn output_path(&mut self, path: &Path, cur_time: u64) -> Res<Vec<Datagram>> {
+    fn output_path(&mut self, path: &Path, cur_time: Instant) -> Res<Vec<Datagram>> {
         let mut out_packets = Vec::new();
 
         let mut initial_only = false;
@@ -1327,13 +1348,13 @@ impl Connection {
         Ok(())
     }
 
-    fn get_closing_period_time(&self, cur_time: u64) -> u64 {
+    fn get_closing_period_time(&self, cur_time: Instant) -> Instant {
         // Spec says close time should be at least PTO times 3.
         cur_time + (self.loss_recovery.rtt_vals.pto() * 3)
     }
 
     /// Close the connection.
-    pub fn close<S: Into<String>>(&mut self, cur_time: u64, error: AppError, msg: S) {
+    pub fn close<S: Into<String>>(&mut self, cur_time: Instant, error: AppError, msg: S) {
         self.set_state(State::Closing {
             error: ConnectionError::Application(error),
             frame_type: 0,
@@ -1421,7 +1442,7 @@ impl Connection {
         Ok(())
     }
 
-    fn input_frame(&mut self, epoch: Epoch, frame: Frame, cur_time: u64) -> Res<()> {
+    fn input_frame(&mut self, epoch: Epoch, frame: Frame, cur_time: Instant) -> Res<()> {
         match frame {
             Frame::Padding => {
                 // Ignore
@@ -1599,7 +1620,7 @@ impl Connection {
         ack_delay: u64,
         first_ack_range: u64,
         ack_ranges: Vec<AckRange>,
-        cur_time: u64,
+        cur_time: Instant,
     ) -> Res<()> {
         qinfo!(
             [self]
@@ -1616,7 +1637,7 @@ impl Connection {
             PNSpace::from(epoch),
             largest_acknowledged,
             acked_ranges,
-            ack_delay,
+            Duration::from_millis(ack_delay),
             cur_time,
         );
         for acked in &mut acked_packets {
@@ -1687,7 +1708,7 @@ impl Connection {
         let cs = &mut self.crypto_states[epoch as usize];
 
         match cs {
-            Some(ref mut cs) => Ok(cs),
+            Some(cs) => Ok(cs),
             None => {
                 qtrace!("No crypto state for epoch {}", epoch);
                 assert!(epoch != 0); // This state is made directly.
@@ -2035,7 +2056,7 @@ impl Connection {
         self.events.borrow_mut().events().into_iter().collect()
     }
 
-    fn check_loss_detection_timeout(&mut self, cur_time: u64) {
+    fn check_loss_detection_timeout(&mut self, cur_time: Instant) {
         qdebug!([self] "check_loss_detection_timeout");
         let (mut lost_packets, retransmit_unacked_crypto, send_one_or_two_packets) =
             self.loss_recovery.on_loss_detection_timeout(cur_time);
@@ -2468,7 +2489,7 @@ pub struct SentPacket {
     //in_flight: bool, // TODO needed only for cc
     is_crypto_packet: bool,
     //size: u64, // TODO needed only for cc
-    time_sent: u64,
+    time_sent: Instant,
     tokens: Vec<Box<FrameGeneratorToken>>, // a list of tokens.
 }
 
@@ -2488,74 +2509,91 @@ impl SentPacket {
 
 #[derive(Debug, Default)]
 struct RttVals {
-    latest_rtt: u64,
-    smoothed_rtt: u64,
-    rttvar: u64,
-    min_rtt: u64,
-    max_ack_delay: u64,
+    latest_rtt: Duration,
+    smoothed_rtt: Option<Duration>,
+    rttvar: Duration,
+    min_rtt: Duration,
+    max_ack_delay: Duration,
 }
 
 impl RttVals {
-    fn update_rtt(&mut self, latest_rtt: u64, mut ack_delay: u64) {
+    fn update_rtt(&mut self, latest_rtt: Duration, ack_delay: Duration) {
         self.latest_rtt = latest_rtt;
         // min_rtt ignores ack delay.
         self.min_rtt = min(self.min_rtt, self.latest_rtt);
         // Limit ack_delay by max_ack_delay
-        ack_delay = min(ack_delay, self.max_ack_delay);
+        let ack_delay = min(ack_delay, self.max_ack_delay);
         // Adjust for ack delay if it's plausible.
         if self.latest_rtt - self.min_rtt > ack_delay {
             self.latest_rtt -= ack_delay;
         }
         // Based on {{?RFC6298}}.
-        if self.smoothed_rtt == 0 {
-            self.smoothed_rtt = self.latest_rtt;
-            self.rttvar = self.latest_rtt / 2;
-        } else {
-            let rttvar_sample = if self.smoothed_rtt > self.latest_rtt {
-                self.smoothed_rtt - self.latest_rtt
-            } else {
-                self.latest_rtt - self.smoothed_rtt
-            };
-            self.rttvar =
-                (3.0 / 4.0 * (self.rttvar as f64) + 1.0 / 4.0 * (rttvar_sample as f64)) as u64;
-            self.smoothed_rtt = (7.0 / 8.0 * (self.smoothed_rtt as f64)
-                + 1.0 / 8.0 * (self.latest_rtt as f64)) as u64;
+        match self.smoothed_rtt {
+            None => {
+                self.smoothed_rtt = Some(self.latest_rtt);
+                self.rttvar = self.latest_rtt / 2;
+            }
+            Some(smoothed_rtt) => {
+                let rttvar_sample = if smoothed_rtt > self.latest_rtt {
+                    smoothed_rtt - self.latest_rtt
+                } else {
+                    self.latest_rtt - smoothed_rtt
+                };
+
+                self.rttvar = Duration::from_micros(
+                    (3.0 / 4.0 * (self.rttvar.as_micros() as f64)
+                        + 1.0 / 4.0 * (rttvar_sample.as_micros() as f64))
+                        as u64,
+                );
+                self.smoothed_rtt = Some(Duration::from_micros(
+                    (7.0 / 8.0 * (smoothed_rtt.as_micros() as f64)
+                        + 1.0 / 8.0 * (self.latest_rtt.as_micros() as f64))
+                        as u64,
+                ));
+            }
         }
     }
 
-    fn pto(&self) -> u64 {
-        self.smoothed_rtt + max(4 * self.rttvar, GRANULARITY) + self.max_ack_delay
+    fn pto(&self) -> Duration {
+        self.smoothed_rtt.unwrap_or_else(|| self.latest_rtt)
+            + max(4 * self.rttvar, GRANULARITY)
+            + self.max_ack_delay
     }
 
-    fn timer_for_crypto_retransmission(&mut self, crypto_count: u32) -> u64 {
-        let mut timeout = if self.smoothed_rtt == 0 {
-            2 * INITIAL_RTT
-        } else {
-            2 * self.smoothed_rtt
+    fn timer_for_crypto_retransmission(&mut self, crypto_count: u32) -> Duration {
+        let timeout = match self.smoothed_rtt {
+            Some(smoothed_rtt) => 2 * smoothed_rtt,
+            None => 2 * INITIAL_RTT,
         };
 
-        timeout = max(timeout, GRANULARITY);
-        timeout * 2u64.pow(crypto_count)
+        let timeout = max(timeout, GRANULARITY);
+        timeout * 2u32.pow(crypto_count)
     }
 }
 
 #[derive(Debug, Default)]
 struct LossRecoverySpace {
-    largest_acked: u64,
-    loss_time: u64,
+    largest_acked: Option<u64>,
+    loss_time: Option<Instant>,
     sent_packets: HashMap<u64, SentPacket>,
 }
 
 impl LossRecoverySpace {
-    pub fn largest_acknowledged(&self) -> u64 {
+    pub fn largest_acknowledged(&self) -> Option<u64> {
         self.largest_acked
     }
 
     // Update the largest acknowledged and return the packet that this corresponds to.
-    fn update_largest_acked(&mut self, largest_acked: u64) -> Option<&SentPacket> {
-        if largest_acked > self.largest_acked {
-            self.largest_acked = largest_acked;
-        }
+    fn update_largest_acked(&mut self, new_largest_acked: u64) -> Option<&SentPacket> {
+        let largest_acked = if let Some(curr_largest_acked) = self.largest_acked {
+            max(curr_largest_acked, new_largest_acked)
+        } else {
+            new_largest_acked
+        };
+        self.largest_acked = Some(largest_acked);
+
+        // TODO(agrover@mozilla.com): Should this really return Some even if
+        // largest_acked hasn't been updated?
         self.sent_packets.get(&largest_acked)
     }
 
@@ -2577,11 +2615,11 @@ impl LossRecoverySpace {
 
 #[derive(Debug, Default)]
 struct LossRecovery {
-    loss_detection_timer: u64,
+    loss_detection_timer: Option<Instant>,
     crypto_count: u32,
     pto_count: u32,
-    time_of_last_sent_ack_eliciting_packet: u64,
-    time_of_last_sent_crypto_packet: u64,
+    time_of_last_sent_ack_eliciting_packet: Option<Instant>,
+    time_of_last_sent_crypto_packet: Option<Instant>,
     rtt_vals: RttVals,
     packet_spaces: [LossRecoverySpace; 3],
 }
@@ -2590,8 +2628,8 @@ impl LossRecovery {
     fn new() -> LossRecovery {
         LossRecovery {
             rtt_vals: RttVals {
-                min_rtt: u64::max_value(),
-                max_ack_delay: 25_000, // 25ms in microseconds
+                min_rtt: Duration::from_secs(u64::max_value()),
+                max_ack_delay: Duration::from_millis(25),
                 ..RttVals::default()
             },
 
@@ -2613,9 +2651,8 @@ impl LossRecovery {
         ack_eliciting: bool,
         is_crypto_packet: bool,
         tokens: Vec<Box<FrameGeneratorToken>>,
-        cur_time_nanos: u64,
+        cur_time: Instant,
     ) {
-        let cur_time = cur_time_nanos / 1000; //TODO currently LossRecovery does everything in microseconds.
         qdebug!([self] "packet {} sent.", packet_number);
         self.space_mut(pn_space).sent_packets.insert(
             packet_number,
@@ -2627,10 +2664,10 @@ impl LossRecovery {
             },
         );
         if is_crypto_packet {
-            self.time_of_last_sent_crypto_packet = cur_time;
+            self.time_of_last_sent_crypto_packet = Some(cur_time);
         }
         if ack_eliciting {
-            self.time_of_last_sent_ack_eliciting_packet = cur_time;
+            self.time_of_last_sent_ack_eliciting_packet = Some(cur_time);
             // TODO implement cc
             //     cc.on_packet_sent(sent_bytes)
         }
@@ -2644,18 +2681,17 @@ impl LossRecovery {
         pn_space: PNSpace,
         largest_acked: u64,
         acked_ranges: Vec<(u64, u64)>,
-        ack_delay: u64,
-        cur_time_nanos: u64,
+        ack_delay: Duration,
+        cur_time: Instant,
     ) -> (Vec<SentPacket>, Vec<SentPacket>) {
-        let cur_time = cur_time_nanos / 1000; //TODO currently LossRecovery does everything in microseconds.
         qdebug!([self] "ack received - largest_acked={}.", largest_acked);
 
-        let last_sent = self.space_mut(pn_space).update_largest_acked(largest_acked);
+        let new_largest = self.space_mut(pn_space).update_largest_acked(largest_acked);
         // If the largest acknowledged is newly acked and
         // ack-eliciting, update the RTT.
-        if let Some(sent) = last_sent {
-            if sent.ack_eliciting {
-                let latest_rtt = cur_time - sent.time_sent;
+        if let Some(new_largest) = new_largest {
+            if new_largest.ack_eliciting {
+                let latest_rtt = cur_time - new_largest.time_sent;
                 self.rtt_vals.update_rtt(latest_rtt, ack_delay);
             }
         }
@@ -2677,48 +2713,48 @@ impl LossRecovery {
         (acked_packets, lost_packets)
     }
 
-    fn detect_lost_packets(&mut self, pn_space: PNSpace, cur_time: u64) -> Vec<SentPacket> {
-        self.space_mut(pn_space).loss_time = 0;
+    fn detect_lost_packets(&mut self, pn_space: PNSpace, cur_time: Instant) -> Vec<SentPacket> {
+        self.space_mut(pn_space).loss_time = None;
 
-        let loss_delay = (TIME_THRESHOLD
-            * (max(self.rtt_vals.latest_rtt, self.rtt_vals.smoothed_rtt) as f64))
-            as u64;
-
-        // Packets sent before this time are deemed lost.
-        // (cur_time < loss_delay, can happen in test)
-        let lost_send_time = if cur_time < loss_delay {
-            0
-        } else {
-            cur_time - loss_delay
-        };
-
-        // Packets with packet numbers before this are deemed lost.
-        let lost_pn = self
-            .space_mut(pn_space)
-            .largest_acked
-            .saturating_sub(PACKET_THRESHOLD);
-
-        qdebug!(
-            [self]
-            "detect lost packets - time={}, pn={}",
-            lost_send_time,
-            lost_pn
+        let loss_delay = Duration::from_micros(
+            (TIME_THRESHOLD
+                * (max(
+                    match self.rtt_vals.smoothed_rtt {
+                        None => self.rtt_vals.latest_rtt,
+                        Some(smoothed_rtt) => max(self.rtt_vals.latest_rtt, smoothed_rtt),
+                    },
+                    GRANULARITY,
+                ))
+                .as_micros() as f64) as u64,
         );
 
+        let loss_deadline = cur_time - loss_delay;
+        qdebug!([self]
+            "detect lost packets = cur_time {:?} loss delay {:?} loss_deadline {:?}",
+            cur_time, loss_delay, loss_deadline
+        );
+
+        // Packets with packet numbers before this are deemed lost.
         let packet_space = self.space_mut(pn_space);
 
         let mut lost = Vec::new();
         for (pn, packet) in &packet_space.sent_packets {
-            // Mark packet as lost, or set time when it should be marked.
-            if *pn <= packet_space.largest_acked {
-                if packet.time_sent <= lost_send_time || *pn <= lost_pn {
+            if Some(*pn) <= packet_space.largest_acked {
+                // Packets with packet numbers more than PACKET_THRESHOLD
+                // before largest acked are deemed lost.
+                if packet.time_sent <= loss_deadline
+                    || Some(*pn + PACKET_THRESHOLD) <= packet_space.largest_acked
+                {
                     qdebug!("lost={}", pn);
                     lost.push(*pn);
-                } else if packet_space.loss_time == 0 {
-                    packet_space.loss_time = packet.time_sent + loss_delay;
+                } else if packet_space.loss_time.is_none() {
+                    // Update loss_time when previously there was none
+                    packet_space.loss_time = Some(packet.time_sent + loss_delay);
                 } else {
+                    // Update loss_time when there was an existing value. Take
+                    // the lower.
                     packet_space.loss_time =
-                        min(packet_space.loss_time, packet.time_sent + loss_delay);
+                        min(packet_space.loss_time, Some(packet.time_sent + loss_delay));
                 }
             }
         }
@@ -2773,47 +2809,65 @@ impl LossRecovery {
         );
 
         if !has_ack_eliciting_out && !has_crypto_out {
-            self.loss_detection_timer = 0;
+            self.loss_detection_timer = None;
             return;
         }
 
         let (loss_time, _) = self.get_earliest_loss_time();
 
-        if loss_time != 0 {
+        if loss_time.is_some() {
             self.loss_detection_timer = loss_time;
         } else if has_crypto_out {
-            self.loss_detection_timer = self.time_of_last_sent_crypto_packet
-                + self
+            self.loss_detection_timer = self.time_of_last_sent_crypto_packet.map(|i| {
+                i + self
                     .rtt_vals
-                    .timer_for_crypto_retransmission(self.crypto_count);
+                    .timer_for_crypto_retransmission(self.crypto_count)
+            });
         } else {
             // Calculate PTO duration
-            let timeout = self.rtt_vals.pto() * 2u64.pow(self.pto_count);
-            self.loss_detection_timer = self.time_of_last_sent_ack_eliciting_packet + timeout;
+            let timeout = self.rtt_vals.pto() * 2u32.pow(self.pto_count);
+            self.loss_detection_timer = self
+                .time_of_last_sent_ack_eliciting_packet
+                .map(|i| i + timeout);
         }
-        qdebug!([self] "loss_detection_timer={}", self.loss_detection_timer);
+        qdebug!([self] "loss_detection_timer={:?}", self.loss_detection_timer);
     }
 
-    #[allow(clippy::if_same_then_else)]
-    fn get_earliest_loss_time(&self) -> (u64, PNSpace) {
+    fn get_earliest_loss_time(&self) -> (Option<Instant>, PNSpace) {
         let mut loss_time = self.packet_spaces[PNSpace::Initial as usize].loss_time;
         let mut pn_space = PNSpace::Initial;
         for space in &[PNSpace::Handshake, PNSpace::ApplicationData] {
-            let packet_space = &self.packet_spaces[*space as usize];
+            let packet_space = self.space(*space);
 
-            if loss_time == 0 {
-                loss_time = packet_space.loss_time;
-                pn_space = *space;
-            } else if packet_space.loss_time != 0 && packet_space.loss_time < loss_time {
-                loss_time = packet_space.loss_time;
-                pn_space = *space;
+            if let Some(new_loss_time) = packet_space.loss_time {
+                if loss_time.is_none() || Some(new_loss_time) < loss_time {
+                    loss_time = Some(new_loss_time);
+                    pn_space = *space;
+                }
             }
         }
+
         (loss_time, pn_space)
     }
 
-    pub fn get_timer(&self) -> u64 {
-        self.loss_detection_timer * 1000
+    /// This is when we'd like to be called back, so we can see if losses have
+    /// occurred.
+    pub fn get_timer(&self, cur_time: Instant) -> Option<Duration> {
+        match self.loss_detection_timer {
+            None => None,
+            Some(time) => {
+                // if cur_time is greater than timer, then we want to be called back
+                // immediately?
+                if cur_time >= time {
+                    // TODO(agrover@mozilla.com): Look into this more
+                    // Specify smallest unit of time
+                    Some(Duration::from_nanos(0))
+                } else {
+                    // Some time in the future
+                    Some(time - cur_time)
+                }
+            }
+        }
     }
 
     //  The 3 return values for this function: (Vec<SentPacket>, bool, bool).
@@ -2822,14 +2876,17 @@ impl LossRecovery {
     //  3) PTO, one or two packets should be transmitted.
     pub fn on_loss_detection_timeout(
         &mut self,
-        cur_time_nanos: u64,
+        cur_time: Instant,
     ) -> (Vec<SentPacket>, bool, bool) {
-        let cur_time = cur_time_nanos / 1000; //TODO(dragana) currently LossRecovery does everything in microseconds.
         let mut lost_packets = Vec::new();
         //TODO(dragana) enable retransmit_unacked_crypto and send_one_or_two_packets when functionanlity to send not-lost packet is there.
         //let mut retransmit_unacked_crypto = false;
         //let mut send_one_or_two_packets = false;
-        if cur_time < self.loss_detection_timer {
+        if self
+            .loss_detection_timer
+            .map(|timer| cur_time < timer)
+            .unwrap_or(false)
+        {
             return (
                 lost_packets, false, false
                 //retransmit_unacked_crypto,
@@ -2838,7 +2895,7 @@ impl LossRecovery {
         }
 
         let (loss_time, pn_space) = self.get_earliest_loss_time();
-        if loss_time != 0 {
+        if loss_time.is_some() {
             // Time threshold loss Detection
             lost_packets = self.detect_lost_packets(pn_space, cur_time);
         } else {
@@ -2893,8 +2950,8 @@ mod tests {
         "127.0.0.1:443".parse().unwrap()
     }
 
-    fn now() -> u64 {
-        0
+    fn now() -> Instant {
+        Instant::now()
     }
 
     #[test]
@@ -3132,14 +3189,14 @@ mod tests {
 
     fn assert_values(
         lr: &LossRecovery,
-        latest_rtt: u64,
-        smoothed_rtt: u64,
-        rttvar: u64,
-        min_rtt: u64,
-        loss_time: [u64; 3],
+        latest_rtt: Duration,
+        smoothed_rtt: Duration,
+        rttvar: Duration,
+        min_rtt: Duration,
+        loss_time: [Option<Instant>; 3],
     ) {
         println!(
-            "{} {} {} {} {} {} {}",
+            "{:?} {:?} {:?} {:?} {:?} {:?} {:?}",
             lr.rtt_vals.latest_rtt,
             lr.rtt_vals.smoothed_rtt,
             lr.rtt_vals.rttvar,
@@ -3149,7 +3206,7 @@ mod tests {
             lr.space(PNSpace::ApplicationData).loss_time,
         );
         assert_eq!(lr.rtt_vals.latest_rtt, latest_rtt);
-        assert_eq!(lr.rtt_vals.smoothed_rtt, smoothed_rtt);
+        assert_eq!(lr.rtt_vals.smoothed_rtt, Some(smoothed_rtt));
         assert_eq!(lr.rtt_vals.rttvar, rttvar);
         assert_eq!(lr.rtt_vals.min_rtt, min_rtt);
         assert_eq!(lr.space(PNSpace::Initial).loss_time, loss_time[0]);
@@ -3161,14 +3218,16 @@ mod tests {
     fn test_loss_recovery1() {
         let mut lr_module = LossRecovery::new();
 
-        lr_module.on_packet_sent(PNSpace::ApplicationData, 0, true, false, Vec::new(), 0);
+        let start = now();
+
+        lr_module.on_packet_sent(PNSpace::ApplicationData, 0, true, false, Vec::new(), start);
         lr_module.on_packet_sent(
             PNSpace::ApplicationData,
             1,
             true,
             false,
             Vec::new(),
-            10_000_000,
+            start + Duration::from_millis(10),
         );
 
         lr_module.on_packet_sent(
@@ -3177,7 +3236,7 @@ mod tests {
             true,
             false,
             Vec::new(),
-            20_000_000,
+            start + Duration::from_millis(20),
         );
 
         lr_module.on_packet_sent(
@@ -3186,7 +3245,7 @@ mod tests {
             true,
             false,
             Vec::new(),
-            30_000_000,
+            start + Duration::from_millis(30),
         );
         lr_module.on_packet_sent(
             PNSpace::ApplicationData,
@@ -3194,7 +3253,7 @@ mod tests {
             true,
             false,
             Vec::new(),
-            40_000_000,
+            start + Duration::from_millis(40),
         );
         lr_module.on_packet_sent(
             PNSpace::ApplicationData,
@@ -3202,81 +3261,171 @@ mod tests {
             true,
             false,
             Vec::new(),
-            50_000_000,
+            start + Duration::from_millis(50),
         );
 
         // Calculating rtt for the first ack
-        lr_module.on_ack_received(PNSpace::ApplicationData, 0, Vec::new(), 2000, 50_000_000);
-        assert_values(&lr_module, 50_000, 50_000, 25_000, 50_000, [0, 0, 0]);
+        lr_module.on_ack_received(
+            PNSpace::ApplicationData,
+            0,
+            Vec::new(),
+            Duration::from_micros(2000),
+            start + Duration::from_millis(50),
+        );
+        assert_values(
+            &lr_module,
+            Duration::from_millis(50),
+            Duration::from_millis(50),
+            Duration::from_millis(25),
+            Duration::from_millis(50),
+            [None, None, None],
+        );
 
         // Calculating rtt for further acks
-        lr_module.on_ack_received(PNSpace::ApplicationData, 1, vec![(1, 0)], 2000, 60_000_000);
-        assert_values(&lr_module, 50_000, 50_000, 18_750, 50_000, [0, 0, 0]);
+        lr_module.on_ack_received(
+            PNSpace::ApplicationData,
+            1,
+            vec![(1, 0)],
+            Duration::from_micros(2000),
+            start + Duration::from_millis(60),
+        );
+        assert_values(
+            &lr_module,
+            Duration::from_millis(50),
+            Duration::from_millis(50),
+            Duration::from_micros(18_750),
+            Duration::from_millis(50),
+            [None, None, None],
+        );
 
         // Calculating rtt for further acks
-        lr_module.on_ack_received(PNSpace::ApplicationData, 2, vec![(2, 0)], 2000, 70_000_000);
-        assert_values(&lr_module, 50_000, 50_000, 14_062, 50_000, [0, 0, 0]);
+        lr_module.on_ack_received(
+            PNSpace::ApplicationData,
+            2,
+            vec![(2, 0)],
+            Duration::from_micros(2000),
+            start + Duration::from_millis(70),
+        );
+        assert_values(
+            &lr_module,
+            Duration::from_millis(50),
+            Duration::from_millis(50),
+            Duration::from_micros(14_062),
+            Duration::from_millis(50),
+            [None, None, None],
+        );
 
         // Calculating rtt for further acks; test min_rtt
-        lr_module.on_ack_received(PNSpace::ApplicationData, 3, vec![(3, 0)], 2000, 75_000_000);
-        assert_values(&lr_module, 45_000, 49_375, 11_796, 45_000, [0, 0, 0]);
+        lr_module.on_ack_received(
+            PNSpace::ApplicationData,
+            3,
+            vec![(3, 0)],
+            Duration::from_micros(2000),
+            start + Duration::from_millis(75),
+        );
+        assert_values(
+            &lr_module,
+            Duration::from_micros(45_000),
+            Duration::from_micros(49_375),
+            Duration::from_micros(11_796),
+            Duration::from_micros(45_000),
+            [None, None, None],
+        );
 
         // Calculating rtt for further acks; test ack_delay
-        lr_module.on_ack_received(PNSpace::ApplicationData, 4, vec![(4, 0)], 2000, 95_000_000);
-        assert_values(&lr_module, 53_000, 49828, 9_753, 45_000, [0, 0, 0]);
+        lr_module.on_ack_received(
+            PNSpace::ApplicationData,
+            4,
+            vec![(4, 0)],
+            Duration::from_micros(2000),
+            start + Duration::from_millis(95),
+        );
+        assert_values(
+            &lr_module,
+            Duration::from_micros(53_000),
+            Duration::from_micros(49828),
+            Duration::from_micros(9_753),
+            Duration::from_micros(45_000),
+            [None, None, None],
+        );
 
         // Calculating rtt for further acks; test max_ack_delay
         lr_module.on_ack_received(
             PNSpace::ApplicationData,
             5,
             vec![(5, 0)],
-            28000,
-            150_000_000,
+            Duration::from_millis(28000),
+            start + Duration::from_millis(150),
         );
-        assert_values(&lr_module, 75000, 52974, 13607, 45000, [0, 0, 0]);
+        assert_values(
+            &lr_module,
+            Duration::from_micros(75000),
+            Duration::from_micros(52974),
+            Duration::from_micros(13607),
+            Duration::from_micros(45000),
+            [None, None, None],
+        );
 
         // Calculating rtt for further acks; test acking already acked packet
         lr_module.on_ack_received(
             PNSpace::ApplicationData,
             5,
             vec![(5, 0)],
-            28000,
-            160_000_000,
+            Duration::from_millis(28000),
+            start + Duration::from_millis(160),
         );
-        assert_values(&lr_module, 75000, 52974, 13607, 45000, [0, 0, 0]);
+        assert_values(
+            &lr_module,
+            Duration::from_micros(75000),
+            Duration::from_micros(52974),
+            Duration::from_micros(13607),
+            Duration::from_micros(45000),
+            [None, None, None],
+        );
     }
 
     // Test crypto timeout.
     #[test]
     fn test_loss_recovery2() {
         let mut lr_module = LossRecovery::new();
-        lr_module.on_packet_sent(PNSpace::ApplicationData, 0, true, true, Vec::new(), 0);
-        assert_eq!(lr_module.get_timer(), 200_000_000);
+
+        let start = now();
+
+        lr_module.on_packet_sent(PNSpace::ApplicationData, 0, true, true, Vec::new(), start);
+        assert_eq!(lr_module.get_timer(start), Some(Duration::from_millis(200)));
         lr_module.on_packet_sent(
             PNSpace::ApplicationData,
             1,
             true,
             false,
             Vec::new(),
-            10_000_000,
+            start + Duration::from_millis(10),
         );
-        assert_eq!(lr_module.get_timer(), 200_000_000);
+        // Last crypto packet sent at time "start", so timeout at
+        // start+10millis should be 190.
+        assert_eq!(
+            lr_module.get_timer(start + Duration::from_millis(10)),
+            Some(Duration::from_millis(190))
+        );
         lr_module.on_packet_sent(
             PNSpace::ApplicationData,
             2,
             true,
             false,
             Vec::new(),
-            20_000_000,
+            start + Duration::from_millis(20),
         );
-        assert_eq!(lr_module.get_timer(), 200_000_000);
+        assert_eq!(
+            lr_module.get_timer(start + Duration::from_millis(20)),
+            Some(Duration::from_millis(180))
+        );
         lr_module.on_packet_sent(
             PNSpace::ApplicationData,
             3,
             true,
             false,
             Vec::new(),
-            30_000_000,
+            start + Duration::from_millis(30),
         );
         lr_module.on_packet_sent(
             PNSpace::ApplicationData,
@@ -3284,7 +3433,7 @@ mod tests {
             true,
             false,
             Vec::new(),
-            40_000_000,
+            start + Duration::from_millis(40),
         );
         lr_module.on_packet_sent(
             PNSpace::ApplicationData,
@@ -3292,7 +3441,7 @@ mod tests {
             true,
             false,
             Vec::new(),
-            50_000_000,
+            start + Duration::from_millis(50),
         );
 
         lr_module.on_packet_sent(
@@ -3301,58 +3450,126 @@ mod tests {
             true,
             false,
             Vec::new(),
-            60_000_000,
+            start + Duration::from_millis(60),
         );
 
         // This is a PTO for crypto packet.
-        assert_eq!(lr_module.get_timer(), 200_000_000);
+        assert_eq!(
+            lr_module.get_timer(start + Duration::from_millis(60)),
+            Some(Duration::from_millis(140))
+        );
 
         // Receive an ack for packet 0.
-        lr_module.on_ack_received(PNSpace::ApplicationData, 0, vec![(0, 0)], 2000, 100_000_000);
-        assert_values(&lr_module, 100_000, 100_000, 50_000, 100_000, [0, 0, 0]);
-        assert_eq!(lr_module.get_timer(), 385_000_000);
+        lr_module.on_ack_received(
+            PNSpace::ApplicationData,
+            0,
+            vec![(0, 0)],
+            Duration::from_micros(2000),
+            start + Duration::from_millis(100),
+        );
+        assert_values(
+            &lr_module,
+            Duration::from_micros(100_000),
+            Duration::from_micros(100_000),
+            Duration::from_micros(50_000),
+            Duration::from_micros(100_000),
+            [None, None, None],
+        );
+        assert_eq!(
+            lr_module.get_timer(start + Duration::from_millis(100)),
+            Some(Duration::from_millis(285))
+        );
 
         // Receive an ack with a gap. acks 0 and 2.
         lr_module.on_ack_received(
             PNSpace::ApplicationData,
             2,
             vec![(0, 0), (2, 2)],
-            2000,
-            105_000_000,
+            Duration::from_micros(2000),
+            start + Duration::from_millis(105),
         );
-        assert_values(&lr_module, 85_000, 98_125, 41_250, 85_000, [0, 0, 120_390]);
-        assert_eq!(lr_module.get_timer(), 120_390_000);
+        assert_values(
+            &lr_module,
+            Duration::from_micros(85_000),
+            Duration::from_micros(98_125),
+            Duration::from_micros(41_250),
+            Duration::from_micros(85_000),
+            [None, None, Some(start + Duration::from_micros(120_390))],
+        );
+        assert_eq!(
+            lr_module.get_timer(start + Duration::from_millis(105)),
+            Some(Duration::from_micros(120_390) - Duration::from_millis(105))
+        );
 
-        // Timer expires, packet 1 is lost. packet 1 is lost
-        lr_module.on_loss_detection_timeout(120_390_000);
-        assert_values(&lr_module, 85_000, 98_125, 41_250, 85_000, [0, 0, 0]);
-        assert_eq!(lr_module.get_timer(), 348_125_000);
+        // Timer expires, packet 1 is lost.
+        lr_module.on_loss_detection_timeout(start + Duration::from_micros(120_390));
+        assert_values(
+            &lr_module,
+            Duration::from_micros(85_000),
+            Duration::from_micros(98_125),
+            Duration::from_micros(41_250),
+            Duration::from_micros(85_000),
+            [None, None, None],
+        );
+        assert_eq!(
+            lr_module.get_timer(start + Duration::from_nanos(120_390_000)),
+            Some(Duration::from_nanos(348_125_000) - Duration::from_nanos(120_390_000))
+        );
 
         // dupacks loss detection. ackes 0, 2 and 6, markes packet 3 as lost.
         lr_module.on_ack_received(
             PNSpace::ApplicationData,
             6,
             vec![(0, 0), (2, 2), (6, 6)],
-            2000,
-            130_000_000,
+            Duration::from_micros(2000),
+            start + Duration::from_nanos(130_000_000),
         );
-        assert_values(&lr_module, 70_000, 94_609, 37_968, 70_000, [0, 0, 146_435]);
-        assert_eq!(lr_module.get_timer(), 146_435_000);
+        assert_values(
+            &lr_module,
+            Duration::from_micros(70_000),
+            Duration::from_micros(94_609),
+            Duration::from_micros(37_968),
+            Duration::from_micros(70_000),
+            [None, None, Some(start + Duration::from_micros(146_435))],
+        );
+        assert_eq!(
+            lr_module.get_timer(start + Duration::from_nanos(130_000_000)),
+            Some(Duration::from_nanos(146_435_000) - Duration::from_nanos(130_000_000))
+        );
 
         // Timer expires, packet 4 is lost.
-        lr_module.on_loss_detection_timeout(146_500_000);
-        assert_values(&lr_module, 70_000, 94_609, 37_968, 70_000, [0, 0, 156_435]);
-        assert_eq!(lr_module.get_timer(), 156_435_000);
+        lr_module.on_loss_detection_timeout(start + Duration::from_nanos(146_500_000));
+        assert_values(
+            &lr_module,
+            Duration::from_micros(70_000),
+            Duration::from_micros(94_609),
+            Duration::from_micros(37_968),
+            Duration::from_micros(70_000),
+            [None, None, Some(start + Duration::from_micros(156_435))],
+        );
+        assert_eq!(
+            lr_module.get_timer(start + Duration::from_nanos(146_500_000)),
+            Some(Duration::from_nanos(156_435_000) - Duration::from_nanos(146_500_000))
+        );
 
         // Timer expires, packet 5 is lost.
-        lr_module.on_loss_detection_timeout(156_500_000);
-        assert_values(&lr_module, 70_000, 94_609, 37_968, 70_000, [0, 0, 0]);
+        lr_module.on_loss_detection_timeout(start + Duration::from_nanos(156_500_000));
+        assert_values(
+            &lr_module,
+            Duration::from_micros(70_000),
+            Duration::from_micros(94_609),
+            Duration::from_micros(37_968),
+            Duration::from_micros(70_000),
+            [None, None, None],
+        );
 
         // there is no more outstanding data - timer is set to 0.
-        assert_eq!(lr_module.get_timer(), 0);
+        assert_eq!(
+            lr_module.get_timer(start + Duration::from_nanos(156_500_000)),
+            None
+        );
     }
 
-    #[test]
     #[test]
     fn test_dup_server_flight1() {
         init_db("./db");

--- a/neqo-transport/src/packet.rs
+++ b/neqo-transport/src/packet.rs
@@ -123,9 +123,9 @@ pub struct PacketNumberDecoder {
     expected: u64,
 }
 impl PacketNumberDecoder {
-    pub fn new(largest_acknowledged: u64) -> PacketNumberDecoder {
+    pub fn new(largest_acknowledged: Option<u64>) -> PacketNumberDecoder {
         PacketNumberDecoder {
-            expected: largest_acknowledged + 1,
+            expected: largest_acknowledged.map(|x| x + 1).unwrap_or(0),
         }
     }
 
@@ -573,7 +573,7 @@ mod tests {
 
     fn test_decrypt_packet(f: &TestFixture, packet: Vec<u8>) -> Res<(PacketHdr, Vec<u8>)> {
         let mut phdr = decode_packet_hdr(f, &packet)?;
-        let body = decrypt_packet(f, PacketNumberDecoder::new(0), &mut phdr, &packet)?;
+        let body = decrypt_packet(f, PacketNumberDecoder::new(Some(0)), &mut phdr, &packet)?;
         Ok((phdr, body))
     }
 

--- a/neqo-transport/tests/conn_vectors.rs
+++ b/neqo-transport/tests/conn_vectors.rs
@@ -1,6 +1,6 @@
 // Tests with the test vectors from the spec.
 #![deny(warnings)]
-use neqo_common::Encoder;
+use neqo_common::{now, Encoder};
 use neqo_crypto::init_db;
 use neqo_transport::connection::State;
 use neqo_transport::{Connection, Datagram};
@@ -20,7 +20,7 @@ fn process_client_initial() {
     let pkt: Vec<u8> = Encoder::from_hex(INITIAL_PACKET).into();
     let dgram = Datagram::new(loopback(), loopback(), pkt);
     assert_eq!(*server.state(), State::WaitInitial);
-    let (out, _) = server.process(vec![dgram], 0);
+    let (out, _) = server.process(vec![dgram], now());
     assert_eq!(*server.state(), State::Handshaking);
     assert_eq!(out.len(), 1);
 }


### PR DESCRIPTION
Replace use of u64 as nanoseconds with instances of Instant and
Duration, sometimes wrapped by Option as needed. This eliminates any
confusion about time units for calculations, and also between values
that are absolute time (Instant) or some delta, possibly in the future
(Duration). Resolves at least 2 bugs.

Modify tests as needed. Some values in test_loss_recovery2() needed
to be modified in order to account for the new notion that things are
calculated based on the current "time" as represented by start + some
Duration for how much time has passed.

Make largest_acked and loss_time in LossRecoverySpace options, since
they may not exist (and 0 is a valid value for largest_acked). This
also affects LossRecoverySpace::largest_acknowledged() and
PacketNumberDecoder::new().

Rename deadline to idle_timeout, that seems to be the gist of what
it's trying to be someday.

Replace now() test functions with the one defined in neqo-common.

Clippy fixes.

fixes #28
fixes #24