### PR TITLE
transport: use smallvec

### DIFF
--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -12,6 +12,7 @@ lazy_static = "1.0"
 rand = "0.6"
 slice-deque = "0.1.16"
 log = "0.4.0"
+smallvec = "0.6.6"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -14,6 +14,8 @@ use std::mem;
 use std::ops::Bound::{Included, Unbounded};
 use std::rc::Rc;
 
+use smallvec::SmallVec;
+
 use crate::flow_mgr::FlowMgr;
 use crate::stream_id::StreamId;
 use crate::ConnectionEvents;
@@ -129,7 +131,7 @@ impl RxStreamOrderer {
 
         if insert_new {
             // Now handle possible overlap with next entries
-            let mut to_remove = Vec::new(); // TODO(agrover@mozilla.com): use smallvec?
+            let mut to_remove = SmallVec::<[_; 8]>::new();
 
             for (&next_start, next_data) in self.data_ranges.range_mut(new_start..) {
                 let next_end = next_start + next_data.len() as u64;

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -13,8 +13,10 @@ use std::mem;
 use std::rc::Rc;
 use std::time::Instant;
 
-use neqo_common::{qerror, qinfo, qtrace, qwarn, Encoder};
 use slice_deque::SliceDeque;
+use smallvec::SmallVec;
+
+use neqo_common::{qerror, qinfo, qtrace, qwarn, Encoder};
 
 use crate::flow_mgr::FlowMgr;
 use crate::frame::TxMode;
@@ -167,7 +169,7 @@ impl RangeTracker {
             .map(|(len, _)| *len);
 
         if let Some(len_from_zero) = acked_range_from_zero {
-            let mut to_remove = Vec::new();
+            let mut to_remove = SmallVec::<[_; 8]>::new();
 
             let mut new_len_from_zero = len_from_zero;
 
@@ -215,7 +217,7 @@ impl RangeTracker {
         let len = len as u64;
         let end_off = off + len;
 
-        let mut to_remove = Vec::new();
+        let mut to_remove = SmallVec::<[_; 8]>::new();
         let mut to_add = None;
 
         // Walk backwards through possibly affected existing ranges


### PR DESCRIPTION
Smallvec allocates space for some number of entries on the stack
and then can alloc from the heap if more space is needed. This
prevents a heap allocation for small temporary vecs.

Because of the borrow-checker, we use vecs in a number of places
to gather results and then act upon them in a later step. Using
smallvec can keep these from allocating most of the time.

Note: Smallvec is already used extensively in Gecko so it will not
increase the number of dependent crates we'll need to review.