### PR TITLE
transport/lossdetection: Refactor

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -34,7 +34,7 @@ use crate::packet::{
     decode_packet_hdr, decrypt_packet, encode_packet, ConnectionId, PacketDecoder, PacketHdr,
     PacketNumberDecoder, PacketType,
 };
-use crate::recovery::LossRecovery;
+use crate::recovery::{LossRecovery, LossRecoveryMode};
 use crate::recv_stream::{RecvStream, RX_STREAM_DATA_WINDOW};
 use crate::send_stream::{SendStream, StreamGenerator};
 use crate::stats::Stats;
@@ -437,6 +437,8 @@ impl Connection {
 
         self.cleanup_streams();
 
+        self.check_loss_detection_timeout(now);
+
         if let Some(idle_timeout) = self.idle_timeout {
             if now >= idle_timeout {
                 // Timer expired. Reconnect?
@@ -459,12 +461,10 @@ impl Connection {
             (Some(t), _) | (_, Some(t)) => Some(t),
             _ => None,
         };
-        match time {
-            // TODO(agrover,mt) - need to analyze and fix #47
-            // rather than just clamping to zero here.
-            Some(t) => Some(max(now, t).duration_since(now)),
-            _ => None,
-        }
+
+        // TODO(agrover, mt) - need to analyze and fix #47
+        // rather than just clamping to zero here.
+        time.map(|t| max(now, t).duration_since(now))
     }
 
     /// Get output packets, as a result of receiving packets, or actions taken
@@ -484,10 +484,7 @@ impl Connection {
                 }
             }
             State::Closed(..) => (Vec::new(), None),
-            _ => {
-                self.check_loss_detection_timeout(now);
-                (self.output(now), self.next_delay(now))
-            }
+            _ => (self.output(now), self.next_delay(now)),
         }
     }
 
@@ -1653,26 +1650,41 @@ impl Connection {
     }
 
     fn check_loss_detection_timeout(&mut self, now: Instant) {
-        qdebug!([self] "check_loss_detection_timeout");
-        let (mut lost_packets, retransmit_unacked_crypto, send_one_or_two_packets) =
-            self.loss_recovery.on_loss_detection_timeout(now);
-        if !lost_packets.is_empty() {
-            qdebug!([self] "check_loss_detection_timeout loss detected.");
-            for lost in lost_packets.iter_mut() {
-                lost.mark_lost(self);
+        qdebug!([self] "check_loss_timeouts");
+
+        match self.loss_recovery.check_loss_timer(now) {
+            LossRecoveryMode::None => {}
+            LossRecoveryMode::LostPackets(mut packets) => {
+                qinfo!([self] "LD: loss_detection: lost packets: {}", packets.len());
+                for lost in packets.iter_mut() {
+                    lost.mark_lost(self);
+                }
             }
-        } else if retransmit_unacked_crypto {
-            qdebug!(
-                [self]
-                "check_loss_detection_timeout - retransmit_unacked_crypto"
-            );
-        // TODO
-        } else if send_one_or_two_packets {
-            qdebug!(
-                [self]
-                "check_loss_detection_timeout -send_one_or_two_packets"
-            );
-            // TODO
+            LossRecoveryMode::CryptoTimerExpired => {
+                qinfo!(
+                    [self]
+                    "LD: check_loss_detection_timeout - retransmit_unacked_crypto"
+                );
+                // TODO
+                // if (has unacknowledged crypto data):
+                //   RetransmitUnackedCryptoData()
+                // else if (endpoint is client without 1-RTT keys):
+                //   // Client sends an anti-deadlock packet: Initial is padded
+                //   // to earn more anti-amplification credit,
+                //   // a Handshake packet proves address ownership.
+                //   if (has Handshake keys):
+                //      SendOneHandshakePacket()
+                //    else:
+                //      SendOnePaddedInitialPacket()
+            }
+            LossRecoveryMode::PTO => {
+                qinfo!(
+                    [self]
+                    "LD: check_loss_detection_timeout -send_one_or_two_packets"
+                );
+                // TODO
+                // SendOneOrTwoPackets()
+            }
         }
     }
 }

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1655,7 +1655,7 @@ impl Connection {
         match self.loss_recovery.check_loss_timer(now) {
             LossRecoveryMode::None => {}
             LossRecoveryMode::LostPackets(mut packets) => {
-                qinfo!([self] "LD: loss_detection: lost packets: {}", packets.len());
+                qinfo!([self] "lost packets: {}", packets.len());
                 for lost in packets.iter_mut() {
                     lost.mark_lost(self);
                 }
@@ -1663,7 +1663,7 @@ impl Connection {
             LossRecoveryMode::CryptoTimerExpired => {
                 qinfo!(
                     [self]
-                    "LD: check_loss_detection_timeout - retransmit_unacked_crypto"
+                    "check_loss_detection_timeout - retransmit_unacked_crypto"
                 );
                 // TODO
                 // if (has unacknowledged crypto data):
@@ -1680,7 +1680,7 @@ impl Connection {
             LossRecoveryMode::PTO => {
                 qinfo!(
                     [self]
-                    "LD: check_loss_detection_timeout -send_one_or_two_packets"
+                    "check_loss_detection_timeout -send_one_or_two_packets"
                 );
                 // TODO
                 // SendOneOrTwoPackets()


### PR DESCRIPTION
The goal is to keep less state, or at least make it more explicit, to make
it easier to diagnose timer-related bugs.

connection.rs:

Move check_loss_detection_timeout to process_input(), I think this lines
up better with idle timeout check that is there.

Match on LossRecoveryMode in check_loss_detection_timeout().

Use map() to avoid match in next_delay()

recovery.rs:

Document why INITIAL_RTT is not what spec says.

Add LossRecoveryMode enum to better describe exclusive nature of the loss
recovery timer.

Remove loss_time from LossRecoverySpace. Instead of using its values to
mean whether the time-based loss detection timer should be active, use
an explicit boolean enable_timed_loss_detection.

Remove LossRecovery::loss_detection_timer. Instead, calculate it when
get_loss_detection_timer() is called. This should make it easier to debug
if the timer is set incorrectly. get_loss_detection_timer() also returns
the mode it's in, in case the caller cares.

Use a BTreeMap instead of HashMap for sent_packets. This makes finding
earliest sent time faster.

Put the array of LossRecoverySpace into a new struct LossRecoverySpaces
for borrow-checking reasons.

Inline update_largest_acked() into on_ack_received(). Make remove_acked()
return if any were ack-eliciting, so we can be correct and update RTT if
largest_acked has changed and if ANY acked packets (not just largest)
were ack-eliciting.

Put loss_delay calc in its own method.

Only iterate over sent packets once instead of twice in
get_loss_detection_timer().

Change retval of get_earliest_loss_time() from (Option<Instant>, PNSpace)
to Option<(PNSpace, Instant)> since doubtful if PNSpace is useful if no
earliest loss time was found.

Change tests as needed for the fact that we no longer track loss time for
each space, only earliest sent time.

Use SmallVec in detect_lost_packets().