### PR TITLE
Operate on one datagram at a time

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -123,8 +123,8 @@ trait Handler {
     fn handle(&mut self, client: &mut Http3Connection) -> bool;
 }
 
-fn emit_packets(socket: &UdpSocket, out_dgrams: &[Datagram]) {
-    for d in out_dgrams {
+fn emit_datagram(socket: &UdpSocket, d: Option<Datagram>) {
+    if let Some(d) = d {
         let sent = socket.send(&d[..]).expect("Error sending datagram");
         if sent != d.len() {
             eprintln!("Unable to send all {} bytes of datagram", d.len());
@@ -140,18 +140,15 @@ fn process_loop(
     handler: &mut Handler,
 ) -> neqo_http3::connection::Http3State {
     let buf = &mut [0u8; 2048];
-    let mut in_dgrams = Vec::new();
     loop {
-        client.process_input(in_dgrams.drain(..), Instant::now());
-
         if let Http3State::Closed(..) = client.state() {
             return client.state();
         }
 
         let exiting = !handler.handle(client);
 
-        let (out_dgrams, _timer) = client.process_output(Instant::now());
-        emit_packets(&socket, &out_dgrams);
+        let (out_dgram, _timer) = client.process_output(Instant::now());
+        emit_datagram(&socket, out_dgram);
 
         if exiting {
             return client.state();
@@ -169,7 +166,8 @@ fn process_loop(
             continue;
         }
         if sz > 0 {
-            in_dgrams.push(Datagram::new(*remote_addr, *local_addr, &buf[..sz]));
+            let d = Datagram::new(*remote_addr, *local_addr, &buf[..sz]);
+            client.process_input(d, Instant::now());
         }
     }
 }
@@ -302,7 +300,7 @@ mod old {
     use neqo_common::Datagram;
     use neqo_transport::{Connection, ConnectionEvent, State, StreamType};
 
-    use super::{emit_packets, Args};
+    use super::{emit_datagram, Args};
 
     trait HandlerOld {
         fn handle(&mut self, client: &mut Connection) -> bool;
@@ -367,18 +365,15 @@ mod old {
         handler: &mut HandlerOld,
     ) -> State {
         let buf = &mut [0u8; 2048];
-        let mut in_dgrams = Vec::new();
         loop {
-            client.process_input(in_dgrams.drain(..), Instant::now());
-
             if let State::Closed(..) = client.state() {
                 return client.state().clone();
             }
 
             let exiting = !handler.handle(client);
 
-            let (out_dgrams, _timer) = client.process_output(Instant::now());
-            emit_packets(&socket, &out_dgrams);
+            let (out_dgram, _timer) = client.process_output(Instant::now());
+            emit_datagram(&socket, out_dgram);
 
             if exiting {
                 return client.state().clone();
@@ -396,7 +391,8 @@ mod old {
                 continue;
             }
             if sz > 0 {
-                in_dgrams.push(Datagram::new(*remote_addr, *local_addr, &buf[..sz]));
+                let d = Datagram::new(*remote_addr, *local_addr, &buf[..sz]);
+                client.process_input(d, Instant::now());
             }
         }
     }

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -147,8 +147,8 @@ fn process_loop(
 
         let exiting = !handler.handle(client);
 
-        let (out_dgram, _timer) = client.process_output(Instant::now());
-        emit_datagram(&socket, out_dgram);
+        let out_dgram = client.process_output(Instant::now());
+        emit_datagram(&socket, out_dgram.dgram());
 
         if exiting {
             return client.state();
@@ -372,8 +372,8 @@ mod old {
 
             let exiting = !handler.handle(client);
 
-            let (out_dgram, _timer) = client.process_output(Instant::now());
-            emit_datagram(&socket, out_dgram);
+            let out_dgram = client.process_output(Instant::now());
+            emit_datagram(&socket, out_dgram.dgram());
 
             if exiting {
                 return client.state().clone();

--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -214,7 +214,7 @@ fn main() -> Result<(), io::Error> {
         }
 
         // Process each connections' packets
-        for (remote_addr, mut dgrams) in in_dgrams {
+        for (remote_addr, dgrams) in in_dgrams {
             let (server, svr_timeout) = connections.entry(remote_addr).or_insert_with(|| {
                 println!("New connection from {:?}", remote_addr);
                 (
@@ -233,7 +233,9 @@ fn main() -> Result<(), io::Error> {
                 )
             });
 
-            server.process_input(dgrams.drain(..), Instant::now());
+            for dgram in dgrams {
+                server.process_input(dgram, Instant::now());
+            }
             if let Http3State::Closed(e) = server.state() {
                 println!("Closed connection from {:?}: {:?}", remote_addr, e);
                 if let Some(svr_timeout) = svr_timeout {

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -304,22 +304,22 @@ impl Http3Connection {
         }
     }
 
-    pub fn process<I>(&mut self, in_dgrams: I, now: Instant) -> (Vec<Datagram>, Option<Duration>)
-    where
-        I: IntoIterator<Item = Datagram>,
-    {
+    pub fn process(
+        &mut self,
+        dgram: Option<Datagram>,
+        now: Instant,
+    ) -> (Option<Datagram>, Option<Duration>) {
         qdebug!([self] "Process.");
-        self.process_input(in_dgrams, now);
+        if let Some(d) = dgram {
+            self.process_input(d, now);
+        }
         self.process_http3(now);
         self.process_output(now)
     }
 
-    pub fn process_input<I>(&mut self, in_dgrams: I, now: Instant)
-    where
-        I: IntoIterator<Item = Datagram>,
-    {
+    pub fn process_input(&mut self, dgram: Datagram, now: Instant) {
         qdebug!([self] "Process input.");
-        self.conn.process_input(in_dgrams, now);
+        self.conn.process_input(dgram, now);
         self.check_state_change(now);
     }
 
@@ -346,7 +346,7 @@ impl Http3Connection {
         }
     }
 
-    pub fn process_output(&mut self, now: Instant) -> (Vec<Datagram>, Option<Duration>) {
+    pub fn process_output(&mut self, now: Instant) -> (Option<Datagram>, Option<Duration>) {
         qdebug!([self] "Process output.");
         self.conn.process_output(now)
     }
@@ -1068,13 +1068,13 @@ mod tests {
         }
         if client {
             assert_eq!(hconn.state(), Http3State::Initializing);
-            let mut r = hconn.process(vec![], now());
+            let (d, _) = hconn.process(None, now());
             assert_eq!(hconn.state(), Http3State::Initializing);
             assert_eq!(*neqo_trans_conn.state(), State::WaitInitial);
-            r = neqo_trans_conn.process(r.0, now());
+            let (d, _) = neqo_trans_conn.process(d, now());
             assert_eq!(*neqo_trans_conn.state(), State::Handshaking);
             assert_eq!(hconn.state(), Http3State::Initializing);
-            r = hconn.process(r.0, now());
+            let (d, _) = hconn.process(d, now());
             let http_events = hconn.events();
             for e in http_events {
                 match e {
@@ -1083,15 +1083,15 @@ mod tests {
                 }
             }
             assert_eq!(hconn.state(), Http3State::Connected);
-            neqo_trans_conn.process(r.0, now());
+            neqo_trans_conn.process(d, now());
         } else {
             assert_eq!(hconn.state(), Http3State::Initializing);
-            let mut r = neqo_trans_conn.process(vec![], now());
-            r = hconn.process(r.0, now());
-            r = neqo_trans_conn.process(r.0, now());
-            r = hconn.process(r.0, now());
+            let (d, _) = neqo_trans_conn.process(None, now());
+            let (d, _) = hconn.process(d, now());
+            let (d, _) = neqo_trans_conn.process(d, now());
+            let (d, _) = hconn.process(d, now());
             assert_eq!(hconn.state(), Http3State::Connected);
-            neqo_trans_conn.process(r.0, now());
+            neqo_trans_conn.process(d, now());
         }
 
         let events = neqo_trans_conn.events();
@@ -1171,8 +1171,8 @@ mod tests {
         let decoder_stream = neqo_trans_conn.stream_create(StreamType::UniDi).unwrap();
         sent = neqo_trans_conn.stream_send(decoder_stream, &[0x3]);
         assert_eq!(sent, Ok(1));
-        let r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         // assert no error occured.
         assert_eq!(hconn.state(), Http3State::Connected);
@@ -1197,8 +1197,8 @@ mod tests {
     fn test_client_close_control_stream() {
         let (mut hconn, mut neqo_trans_conn, _) = connect_and_receive_control_stream(true);
         neqo_trans_conn.stream_close_send(3).unwrap();
-        let r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
         assert_closed(&hconn, Error::ClosedCriticalStream);
     }
 
@@ -1208,8 +1208,8 @@ mod tests {
     fn test_server_close_control_stream() {
         let (mut hconn, mut neqo_trans_conn, _) = connect_and_receive_control_stream(false);
         neqo_trans_conn.stream_close_send(2).unwrap();
-        let r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
         assert_closed(&hconn, Error::ClosedCriticalStream);
     }
 
@@ -1224,8 +1224,8 @@ mod tests {
         let sent =
             neqo_trans_conn.stream_send(control_stream, &[0x0, 0x2, 0x4, 0x0, 0x2, 0x1, 0x3]);
         assert_eq!(sent, Ok(7));
-        let r = neqo_trans_conn.process(Vec::new(), now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
         assert_closed(&hconn, Error::MissingSettings);
     }
 
@@ -1240,8 +1240,8 @@ mod tests {
         let sent =
             neqo_trans_conn.stream_send(control_stream, &[0x0, 0x2, 0x4, 0x0, 0x2, 0x1, 0x3]);
         assert_eq!(sent, Ok(7));
-        let r = neqo_trans_conn.process(Vec::new(), now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
         assert_closed(&hconn, Error::MissingSettings);
     }
 
@@ -1253,8 +1253,8 @@ mod tests {
         // send the second SETTINGS frame.
         let sent = neqo_trans_conn.stream_send(3, &[0x4, 0x6, 0x1, 0x40, 0x64, 0x7, 0x40, 0x64]);
         assert_eq!(sent, Ok(8));
-        let r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
         assert_closed(&hconn, Error::UnexpectedFrame);
     }
 
@@ -1266,8 +1266,8 @@ mod tests {
         // send the second SETTINGS frame.
         let sent = neqo_trans_conn.stream_send(2, &[0x4, 0x6, 0x1, 0x40, 0x64, 0x7, 0x40, 0x64]);
         assert_eq!(sent, Ok(8));
-        let r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
         assert_closed(&hconn, Error::UnexpectedFrame);
     }
 
@@ -1281,8 +1281,8 @@ mod tests {
             let _ = neqo_trans_conn.stream_send(2, v);
         }
 
-        let r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         assert_closed(&hconn, Error::WrongStream);
     }
@@ -1327,9 +1327,9 @@ mod tests {
             new_stream_id,
             &vec![0x41, 0x19, 0x4, 0x4, 0x6, 0x0, 0x8, 0x0],
         );
-        let mut r = neqo_trans_conn.process(vec![], now());
-        r = hconn.process(r.0, now());
-        neqo_trans_conn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        let (d, _) = hconn.process(d, now());
+        neqo_trans_conn.process(d, now());
 
         // check for stop-sending with Error::UnknownStreamType.
         let events = neqo_trans_conn.events();
@@ -1363,9 +1363,9 @@ mod tests {
             new_stream_id,
             &vec![0x41, 0x19, 0x4, 0x4, 0x6, 0x0, 0x8, 0x0],
         );
-        let mut r = neqo_trans_conn.process(vec![], now());
-        r = hconn.process(r.0, now());
-        neqo_trans_conn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        let (d, _) = hconn.process(d, now());
+        neqo_trans_conn.process(d, now());
 
         // check for stop-sending with Error::UnknownStreamType.
         let events = neqo_trans_conn.events();
@@ -1395,9 +1395,9 @@ mod tests {
         // create a push stream.
         let push_stream_id = neqo_trans_conn.stream_create(StreamType::UniDi).unwrap();
         let _ = neqo_trans_conn.stream_send(push_stream_id, &vec![0x1]);
-        let mut r = neqo_trans_conn.process(vec![], now());
-        r = hconn.process(r.0, now());
-        neqo_trans_conn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        let (d, _) = hconn.process(d, now());
+        neqo_trans_conn.process(d, now());
 
         // check for stop-sending with Error::Error::PushRefused.
         let events = neqo_trans_conn.events();
@@ -1427,9 +1427,9 @@ mod tests {
         // create a push stream.
         let push_stream_id = neqo_trans_conn.stream_create(StreamType::UniDi).unwrap();
         let _ = neqo_trans_conn.stream_send(push_stream_id, &vec![0x1]);
-        let mut r = neqo_trans_conn.process(vec![], now());
-        r = hconn.process(r.0, now());
-        neqo_trans_conn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        let (d, _) = hconn.process(d, now());
+        neqo_trans_conn.process(d, now());
 
         // check for stop-sending with Error::WrongStreamDirection.
         let events = neqo_trans_conn.events();
@@ -1466,8 +1466,8 @@ mod tests {
             Ok(0)
         );
 
-        let mut r = hconn.process(vec![], now());
-        neqo_trans_conn.process(r.0, now());
+        let (d, _) = hconn.process(None, now());
+        neqo_trans_conn.process(d, now());
 
         // find the new request/response stream and send frame v on it.
         let events = neqo_trans_conn.events();
@@ -1484,11 +1484,11 @@ mod tests {
             }
         }
         // Generate packet with the above bad h3 input
-        r = neqo_trans_conn.process(vec![], now());
+        let (d, _) = neqo_trans_conn.process(None, now());
         // Process bad input and generate stop sending frame
-        r = hconn.process(r.0, now());
+        let (d, _) = hconn.process(d, now());
         // Process stop sending frame and generate an event and a reset frame
-        r = neqo_trans_conn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(d, now());
 
         let mut stop_sending_event_found = false;
         for e in neqo_trans_conn.events() {
@@ -1508,7 +1508,7 @@ mod tests {
         assert_eq!(hconn.state(), Http3State::Connected);
 
         // Process reset frame
-        hconn.conn.process(r.0, now());
+        hconn.conn.process(d, now());
         let mut reset_event_found = false;
         for e in hconn.conn.events() {
             match e {
@@ -1565,57 +1565,57 @@ mod tests {
         // send the stream type
         let mut sent = neqo_trans_conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
-        let mut r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         // start sending SETTINGS frame
         sent = neqo_trans_conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
-        r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
-        r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x6]);
         assert_eq!(sent, Ok(1));
-        r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
-        r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x8]);
         assert_eq!(sent, Ok(1));
-        r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
-        r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         assert_eq!(hconn.state(), Http3State::Connected);
 
         // Now test PushPromise
         sent = neqo_trans_conn.stream_send(control_stream, &[0x5]);
         assert_eq!(sent, Ok(1));
-        r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x5]);
         assert_eq!(sent, Ok(1));
-        r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
-        r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         // PUSH_PROMISE on a control stream will cause an error
         assert_closed(&hconn, Error::WrongStream);
@@ -1635,8 +1635,8 @@ mod tests {
             .unwrap();
         assert_eq!(request_stream_id, 0);
 
-        let mut r = hconn.process(vec![], now());
-        neqo_trans_conn.process(r.0, now());
+        let (d, _) = hconn.process(None, now());
+        neqo_trans_conn.process(d, now());
 
         // find the new request/response stream and send frame v on it.
         let events = neqo_trans_conn.events();
@@ -1682,8 +1682,8 @@ mod tests {
                 _ => {}
             }
         }
-        r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         let http_events = hconn.events();
         for e in http_events {
@@ -1757,8 +1757,8 @@ mod tests {
             .unwrap();
         assert_eq!(request_stream_id, 0);
 
-        let mut r = hconn.process(vec![], now());
-        neqo_trans_conn.process(r.0, now());
+        let (d, _) = hconn.process(None, now());
+        neqo_trans_conn.process(d, now());
 
         // find the new request/response stream and send frame v on it.
         let events = neqo_trans_conn.events();
@@ -1792,8 +1792,8 @@ mod tests {
                 _ => {}
             }
         }
-        r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         let http_events = hconn.events();
         for e in http_events {
@@ -1884,8 +1884,8 @@ mod tests {
             .unwrap();
         assert_eq!(request_stream_id_3, 8);
 
-        let mut r = hconn.process(vec![], now());
-        neqo_trans_conn.process(r.0, now());
+        let (d, _) = hconn.process(None, now());
+        neqo_trans_conn.process(d, now());
 
         let _ = neqo_trans_conn.stream_send(
             3, //control_stream,
@@ -1923,8 +1923,8 @@ mod tests {
                 _ => {}
             }
         }
-        r = neqo_trans_conn.process(vec![], now());
-        hconn.process(r.0, now());
+        let (d, _) = neqo_trans_conn.process(None, now());
+        hconn.process(d, now());
 
         let mut stream_reset = false;
         let mut http_events = hconn.events();

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -13,14 +13,15 @@ use neqo_common::{
 };
 use neqo_qpack::decoder::{QPackDecoder, QPACK_UNI_STREAM_TYPE_DECODER};
 use neqo_qpack::encoder::{QPackEncoder, QPACK_UNI_STREAM_TYPE_ENCODER};
-use neqo_transport::Role;
+use neqo_transport::{
+    AppError, CloseError, Connection, ConnectionEvent, Output, Role, State, StreamType,
+};
 
-use neqo_transport::{AppError, CloseError, Connection, ConnectionEvent, State, StreamType};
 use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap};
 use std::mem;
 use std::rc::Rc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use crate::{Error, Res};
 
@@ -304,11 +305,7 @@ impl Http3Connection {
         }
     }
 
-    pub fn process(
-        &mut self,
-        dgram: Option<Datagram>,
-        now: Instant,
-    ) -> (Option<Datagram>, Option<Duration>) {
+    pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
         qdebug!([self] "Process.");
         if let Some(d) = dgram {
             self.process_input(d, now);
@@ -346,7 +343,7 @@ impl Http3Connection {
         }
     }
 
-    pub fn process_output(&mut self, now: Instant) -> (Option<Datagram>, Option<Duration>) {
+    pub fn process_output(&mut self, now: Instant) -> Output {
         qdebug!([self] "Process output.");
         self.conn.process_output(now)
     }
@@ -1068,13 +1065,13 @@ mod tests {
         }
         if client {
             assert_eq!(hconn.state(), Http3State::Initializing);
-            let (d, _) = hconn.process(None, now());
+            let out = hconn.process(None, now());
             assert_eq!(hconn.state(), Http3State::Initializing);
             assert_eq!(*neqo_trans_conn.state(), State::WaitInitial);
-            let (d, _) = neqo_trans_conn.process(d, now());
+            let out = neqo_trans_conn.process(out.dgram(), now());
             assert_eq!(*neqo_trans_conn.state(), State::Handshaking);
             assert_eq!(hconn.state(), Http3State::Initializing);
-            let (d, _) = hconn.process(d, now());
+            let out = hconn.process(out.dgram(), now());
             let http_events = hconn.events();
             for e in http_events {
                 match e {
@@ -1083,15 +1080,15 @@ mod tests {
                 }
             }
             assert_eq!(hconn.state(), Http3State::Connected);
-            neqo_trans_conn.process(d, now());
+            neqo_trans_conn.process(out.dgram(), now());
         } else {
             assert_eq!(hconn.state(), Http3State::Initializing);
-            let (d, _) = neqo_trans_conn.process(None, now());
-            let (d, _) = hconn.process(d, now());
-            let (d, _) = neqo_trans_conn.process(d, now());
-            let (d, _) = hconn.process(d, now());
+            let out = neqo_trans_conn.process(None, now());
+            let out = hconn.process(out.dgram(), now());
+            let out = neqo_trans_conn.process(out.dgram(), now());
+            let out = hconn.process(out.dgram(), now());
             assert_eq!(hconn.state(), Http3State::Connected);
-            neqo_trans_conn.process(d, now());
+            neqo_trans_conn.process(out.dgram(), now());
         }
 
         let events = neqo_trans_conn.events();
@@ -1171,8 +1168,8 @@ mod tests {
         let decoder_stream = neqo_trans_conn.stream_create(StreamType::UniDi).unwrap();
         sent = neqo_trans_conn.stream_send(decoder_stream, &[0x3]);
         assert_eq!(sent, Ok(1));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         // assert no error occured.
         assert_eq!(hconn.state(), Http3State::Connected);
@@ -1197,8 +1194,8 @@ mod tests {
     fn test_client_close_control_stream() {
         let (mut hconn, mut neqo_trans_conn, _) = connect_and_receive_control_stream(true);
         neqo_trans_conn.stream_close_send(3).unwrap();
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, Error::ClosedCriticalStream);
     }
 
@@ -1208,8 +1205,8 @@ mod tests {
     fn test_server_close_control_stream() {
         let (mut hconn, mut neqo_trans_conn, _) = connect_and_receive_control_stream(false);
         neqo_trans_conn.stream_close_send(2).unwrap();
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, Error::ClosedCriticalStream);
     }
 
@@ -1224,8 +1221,8 @@ mod tests {
         let sent =
             neqo_trans_conn.stream_send(control_stream, &[0x0, 0x2, 0x4, 0x0, 0x2, 0x1, 0x3]);
         assert_eq!(sent, Ok(7));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, Error::MissingSettings);
     }
 
@@ -1240,8 +1237,8 @@ mod tests {
         let sent =
             neqo_trans_conn.stream_send(control_stream, &[0x0, 0x2, 0x4, 0x0, 0x2, 0x1, 0x3]);
         assert_eq!(sent, Ok(7));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, Error::MissingSettings);
     }
 
@@ -1253,8 +1250,8 @@ mod tests {
         // send the second SETTINGS frame.
         let sent = neqo_trans_conn.stream_send(3, &[0x4, 0x6, 0x1, 0x40, 0x64, 0x7, 0x40, 0x64]);
         assert_eq!(sent, Ok(8));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, Error::UnexpectedFrame);
     }
 
@@ -1266,8 +1263,8 @@ mod tests {
         // send the second SETTINGS frame.
         let sent = neqo_trans_conn.stream_send(2, &[0x4, 0x6, 0x1, 0x40, 0x64, 0x7, 0x40, 0x64]);
         assert_eq!(sent, Ok(8));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, Error::UnexpectedFrame);
     }
 
@@ -1281,8 +1278,8 @@ mod tests {
             let _ = neqo_trans_conn.stream_send(2, v);
         }
 
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         assert_closed(&hconn, Error::WrongStream);
     }
@@ -1327,9 +1324,9 @@ mod tests {
             new_stream_id,
             &vec![0x41, 0x19, 0x4, 0x4, 0x6, 0x0, 0x8, 0x0],
         );
-        let (d, _) = neqo_trans_conn.process(None, now());
-        let (d, _) = hconn.process(d, now());
-        neqo_trans_conn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        let out = hconn.process(out.dgram(), now());
+        neqo_trans_conn.process(out.dgram(), now());
 
         // check for stop-sending with Error::UnknownStreamType.
         let events = neqo_trans_conn.events();
@@ -1363,9 +1360,9 @@ mod tests {
             new_stream_id,
             &vec![0x41, 0x19, 0x4, 0x4, 0x6, 0x0, 0x8, 0x0],
         );
-        let (d, _) = neqo_trans_conn.process(None, now());
-        let (d, _) = hconn.process(d, now());
-        neqo_trans_conn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        let out = hconn.process(out.dgram(), now());
+        neqo_trans_conn.process(out.dgram(), now());
 
         // check for stop-sending with Error::UnknownStreamType.
         let events = neqo_trans_conn.events();
@@ -1395,9 +1392,9 @@ mod tests {
         // create a push stream.
         let push_stream_id = neqo_trans_conn.stream_create(StreamType::UniDi).unwrap();
         let _ = neqo_trans_conn.stream_send(push_stream_id, &vec![0x1]);
-        let (d, _) = neqo_trans_conn.process(None, now());
-        let (d, _) = hconn.process(d, now());
-        neqo_trans_conn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        let out = hconn.process(out.dgram(), now());
+        neqo_trans_conn.process(out.dgram(), now());
 
         // check for stop-sending with Error::Error::PushRefused.
         let events = neqo_trans_conn.events();
@@ -1427,9 +1424,9 @@ mod tests {
         // create a push stream.
         let push_stream_id = neqo_trans_conn.stream_create(StreamType::UniDi).unwrap();
         let _ = neqo_trans_conn.stream_send(push_stream_id, &vec![0x1]);
-        let (d, _) = neqo_trans_conn.process(None, now());
-        let (d, _) = hconn.process(d, now());
-        neqo_trans_conn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        let out = hconn.process(out.dgram(), now());
+        neqo_trans_conn.process(out.dgram(), now());
 
         // check for stop-sending with Error::WrongStreamDirection.
         let events = neqo_trans_conn.events();
@@ -1466,8 +1463,8 @@ mod tests {
             Ok(0)
         );
 
-        let (d, _) = hconn.process(None, now());
-        neqo_trans_conn.process(d, now());
+        let out = hconn.process(None, now());
+        neqo_trans_conn.process(out.dgram(), now());
 
         // find the new request/response stream and send frame v on it.
         let events = neqo_trans_conn.events();
@@ -1484,11 +1481,11 @@ mod tests {
             }
         }
         // Generate packet with the above bad h3 input
-        let (d, _) = neqo_trans_conn.process(None, now());
+        let out = neqo_trans_conn.process(None, now());
         // Process bad input and generate stop sending frame
-        let (d, _) = hconn.process(d, now());
+        let out = hconn.process(out.dgram(), now());
         // Process stop sending frame and generate an event and a reset frame
-        let (d, _) = neqo_trans_conn.process(d, now());
+        let out = neqo_trans_conn.process(out.dgram(), now());
 
         let mut stop_sending_event_found = false;
         for e in neqo_trans_conn.events() {
@@ -1508,7 +1505,7 @@ mod tests {
         assert_eq!(hconn.state(), Http3State::Connected);
 
         // Process reset frame
-        hconn.conn.process(d, now());
+        hconn.conn.process(out.dgram(), now());
         let mut reset_event_found = false;
         for e in hconn.conn.events() {
             match e {
@@ -1565,57 +1562,57 @@ mod tests {
         // send the stream type
         let mut sent = neqo_trans_conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         // start sending SETTINGS frame
         sent = neqo_trans_conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x6]);
         assert_eq!(sent, Ok(1));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x8]);
         assert_eq!(sent, Ok(1));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         assert_eq!(hconn.state(), Http3State::Connected);
 
         // Now test PushPromise
         sent = neqo_trans_conn.stream_send(control_stream, &[0x5]);
         assert_eq!(sent, Ok(1));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x5]);
         assert_eq!(sent, Ok(1));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         sent = neqo_trans_conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         // PUSH_PROMISE on a control stream will cause an error
         assert_closed(&hconn, Error::WrongStream);
@@ -1635,8 +1632,8 @@ mod tests {
             .unwrap();
         assert_eq!(request_stream_id, 0);
 
-        let (d, _) = hconn.process(None, now());
-        neqo_trans_conn.process(d, now());
+        let out = hconn.process(None, now());
+        neqo_trans_conn.process(out.dgram(), now());
 
         // find the new request/response stream and send frame v on it.
         let events = neqo_trans_conn.events();
@@ -1682,8 +1679,8 @@ mod tests {
                 _ => {}
             }
         }
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         let http_events = hconn.events();
         for e in http_events {
@@ -1757,8 +1754,8 @@ mod tests {
             .unwrap();
         assert_eq!(request_stream_id, 0);
 
-        let (d, _) = hconn.process(None, now());
-        neqo_trans_conn.process(d, now());
+        let out = hconn.process(None, now());
+        neqo_trans_conn.process(out.dgram(), now());
 
         // find the new request/response stream and send frame v on it.
         let events = neqo_trans_conn.events();
@@ -1792,8 +1789,8 @@ mod tests {
                 _ => {}
             }
         }
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         let http_events = hconn.events();
         for e in http_events {
@@ -1884,8 +1881,8 @@ mod tests {
             .unwrap();
         assert_eq!(request_stream_id_3, 8);
 
-        let (d, _) = hconn.process(None, now());
-        neqo_trans_conn.process(d, now());
+        let out = hconn.process(None, now());
+        neqo_trans_conn.process(out.dgram(), now());
 
         let _ = neqo_trans_conn.stream_send(
             3, //control_stream,
@@ -1923,8 +1920,8 @@ mod tests {
                 _ => {}
             }
         }
-        let (d, _) = neqo_trans_conn.process(None, now());
-        hconn.process(d, now());
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
 
         let mut stream_reset = false;
         let mut http_events = hconn.events();

--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -517,10 +517,10 @@ mod tests {
 
         let mut conn_c = default_client();
         let mut conn_s = default_server();
-        let (d, _) = conn_c.process(None, now());
-        let (d, _) = conn_s.process(d, now());
-        let (d, _) = conn_c.process(d, now());
-        conn_s.process(d, now());
+        let out = conn_c.process(None, now());
+        let out = conn_s.process(out.dgram(), now());
+        let out = conn_c.process(out.dgram(), now());
+        conn_s.process(out.dgram(), now());
 
         // create a stream
         let stream_id = conn_s.stream_create(StreamType::BiDi).unwrap();
@@ -538,8 +538,8 @@ mod tests {
             buf.push(v);
         }
         conn_s.stream_send(stream_id, &buf).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
 
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
@@ -676,33 +676,33 @@ mod tests {
 
         // Send and read settings frame 040406040804
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x6]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x8]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         if !fr.done() {
@@ -735,48 +735,48 @@ mod tests {
 
         // Read settings frame 400406064004084100
         conn_s.stream_send(stream_id, &[0x40]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x6]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x6]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x40]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x8]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x41]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x0]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         if !fr.done() {
@@ -808,25 +808,25 @@ mod tests {
 
         // Read pushpromise frame 05054101010203
         conn_s.stream_send(stream_id, &[0x5]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x5]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x41]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s
             .stream_send(stream_id, &[0x1, 0x1, 0x2, 0x3])
             .unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         // headers are still on the stream.
@@ -865,8 +865,8 @@ mod tests {
         conn_s
             .stream_send(stream_id, &[0x0, 0x3, 0x1, 0x2, 0x3])
             .unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         // payloead is still on the stream.
@@ -908,14 +908,14 @@ mod tests {
         let mut buf: Vec<_> = enc.into();
         buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
         conn_s.stream_send(stream_id, &buf).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         // now receive a CANCEL_PUSH fram to see that frame reader is ok.
         conn_s.stream_send(stream_id, &[0x03, 0x01, 0x05]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         assert!(fr.done());

--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -517,10 +517,10 @@ mod tests {
 
         let mut conn_c = default_client();
         let mut conn_s = default_server();
-        let mut r = conn_c.process(vec![], now());
-        r = conn_s.process(r.0, now());
-        r = conn_c.process(r.0, now());
-        conn_s.process(r.0, now());
+        let (d, _) = conn_c.process(None, now());
+        let (d, _) = conn_s.process(d, now());
+        let (d, _) = conn_c.process(d, now());
+        conn_s.process(d, now());
 
         // create a stream
         let stream_id = conn_s.stream_create(StreamType::BiDi).unwrap();
@@ -538,8 +538,8 @@ mod tests {
             buf.push(v);
         }
         conn_s.stream_send(stream_id, &buf).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
 
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
@@ -661,18 +661,13 @@ mod tests {
 
     // We have 3 code paths in frame_reader:
     // 1) All frames except DATA, HEADERES and PUSH_PROMISE (here we test SETTING and SETTINGS with larger varints)
-    // 2) PUSH_PUROMISE and
+    // 2) PUSH_PROMISE and
     // 1) DATA and HEADERS frame (for this we will test DATA)
 
     // Test SETTINGS
     #[test]
     fn test_frame_reading_with_stream_settings1() {
-        let mut conn_c = default_client();
-        let mut conn_s = default_server();
-        let mut r = conn_c.process(vec![], now());
-        r = conn_s.process(r.0, now());
-        r = conn_c.process(r.0, now());
-        conn_s.process(r.0, now());
+        let (mut conn_c, mut conn_s) = connect();
 
         // create a stream
         let stream_id = conn_s.stream_create(StreamType::BiDi).unwrap();
@@ -681,33 +676,33 @@ mod tests {
 
         // Send and read settings frame 040406040804
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x6]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x8]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         if !fr.done() {
@@ -731,12 +726,7 @@ mod tests {
     // Test SETTINGS with larger varints
     #[test]
     fn test_frame_reading_with_stream_settings2() {
-        let mut conn_c = default_client();
-        let mut conn_s = default_server();
-        let mut r = conn_c.process(vec![], now());
-        r = conn_s.process(r.0, now());
-        r = conn_c.process(r.0, now());
-        conn_s.process(r.0, now());
+        let (mut conn_c, mut conn_s) = connect();
 
         // create a stream
         let stream_id = conn_s.stream_create(StreamType::BiDi).unwrap();
@@ -745,48 +735,48 @@ mod tests {
 
         // Read settings frame 400406064004084100
         conn_s.stream_send(stream_id, &[0x40]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x6]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x6]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x40]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x8]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x41]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x0]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         if !fr.done() {
@@ -809,12 +799,7 @@ mod tests {
     // Test PUSH_PROMISE
     #[test]
     fn test_frame_reading_with_stream_push_promise() {
-        let mut conn_c = default_client();
-        let mut conn_s = default_server();
-        let mut r = conn_c.process(vec![], now());
-        r = conn_s.process(r.0, now());
-        r = conn_c.process(r.0, now());
-        conn_s.process(r.0, now());
+        let (mut conn_c, mut conn_s) = connect();
 
         // create a stream
         let stream_id = conn_s.stream_create(StreamType::BiDi).unwrap();
@@ -823,25 +808,25 @@ mod tests {
 
         // Read pushpromise frame 05054101010203
         conn_s.stream_send(stream_id, &[0x5]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x5]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x41]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s
             .stream_send(stream_id, &[0x1, 0x1, 0x2, 0x3])
             .unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         // headers are still on the stream.
@@ -869,12 +854,7 @@ mod tests {
     // Test DATA
     #[test]
     fn test_frame_reading_with_stream_data() {
-        let mut conn_c = default_client();
-        let mut conn_s = default_server();
-        let mut r = conn_c.process(vec![], now());
-        r = conn_s.process(r.0, now());
-        r = conn_c.process(r.0, now());
-        conn_s.process(r.0, now());
+        let (mut conn_c, mut conn_s) = connect();
 
         // create a stream
         let stream_id = conn_s.stream_create(StreamType::BiDi).unwrap();
@@ -885,8 +865,8 @@ mod tests {
         conn_s
             .stream_send(stream_id, &[0x0, 0x3, 0x1, 0x2, 0x3])
             .unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         // payloead is still on the stream.
@@ -910,43 +890,35 @@ mod tests {
         }
     }
 
-    // Test an unknow frame
+    // Test an unknown frame
     #[test]
     fn test_unknown_frame() {
-        let mut conn_c = default_client();
-        let mut conn_s = default_server();
-        let mut r = conn_c.process(vec![], now());
-        r = conn_s.process(r.0, now());
-        r = conn_c.process(r.0, now());
-        conn_s.process(r.0, now());
+        let (mut conn_c, mut conn_s) = connect();
 
         // create a stream
         let stream_id = conn_s.stream_create(StreamType::BiDi).unwrap();
 
         let mut fr: HFrameReader = HFrameReader::new();
 
-        // Read an unknown frame
-        let mut buf: [u8; 1500] = [0; 1500];
-        // random type 1028
-        buf[0] = 0x44;
-        buf[1] = 0x04;
-        // length 1496
-        buf[2] = 0x45;
-        buf[3] = 0xd8;
+        // Construct an unknown frame.
+        const UNKNOWN_FRAME_LEN: usize = 832;
+        let mut enc = Encoder::with_capacity(UNKNOWN_FRAME_LEN + 4);
+        enc.encode_varint(1028u64); // Arbitrary type.
+        enc.encode_varint(UNKNOWN_FRAME_LEN as u64);
+        let mut buf: Vec<_> = enc.into();
+        buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
         conn_s.stream_send(stream_id, &buf).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         // now receive a CANCEL_PUSH fram to see that frame reader is ok.
         conn_s.stream_send(stream_id, &[0x03, 0x01, 0x05]).unwrap();
-        r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
-        if !fr.done() {
-            assert!(false);
-        }
+        assert!(fr.done());
         let f1 = fr.get_frame();
         if let Ok(f) = f1 {
             if let HFrame::CancelPush { push_id } = f {

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -8,7 +8,6 @@
 
 use neqo_common::Datagram;
 use neqo_http3::{Http3Connection, Http3State};
-use std::time::Duration;
 use test_fixture::*;
 
 fn new_stream_callback(
@@ -36,11 +35,7 @@ fn new_stream_callback(
     )
 }
 
-fn connect() -> (
-    Http3Connection,
-    Http3Connection,
-    (Vec<Datagram>, Option<Duration>),
-) {
+fn connect() -> (Http3Connection, Http3Connection, Option<Datagram>) {
     let mut hconn_c = Http3Connection::new(default_client(), 100, 100, None);
     let mut hconn_s = Http3Connection::new(
         default_server(),
@@ -51,41 +46,41 @@ fn connect() -> (
 
     assert_eq!(hconn_c.state(), Http3State::Initializing);
     assert_eq!(hconn_s.state(), Http3State::Initializing);
-    let mut r = hconn_c.process(Vec::new(), now());
-    r = hconn_s.process(r.0, now());
-    r = hconn_c.process(r.0, now());
-    r = hconn_s.process(r.0, now());
+    let (d, _) = hconn_c.process(None, now()); // Initial
+    let (d, _) = hconn_s.process(d, now()); // Initial + Handshake
+    let (d, _) = hconn_c.process(d, now()); // Handshake
     assert_eq!(hconn_c.state(), Http3State::Connected);
+    let (d, _) = hconn_s.process(d, now()); // Handshake
     assert_eq!(hconn_s.state(), Http3State::Connected);
-    r = hconn_c.process(r.0, now());
-    r = hconn_s.process(r.0, now());
+    let (d, _) = hconn_c.process(d, now());
+    let (d, _) = hconn_s.process(d, now());
     // assert_eq!(hconn_s.settings_received, true);
-    r = hconn_c.process(r.0, now());
+    let (d, _) = hconn_c.process(d, now());
     // assert_eq!(hconn_c.settings_received, true);
 
-    (hconn_c, hconn_s, r)
+    (hconn_c, hconn_s, d)
 }
 
 #[test]
 fn test_connect() {
-    let (_hconn_c, _hconn_s, _r) = connect();
+    let (_hconn_c, _hconn_s, _d) = connect();
 }
 
 #[test]
 fn test_fetch() {
-    let (mut hconn_c, mut hconn_s, mut r) = connect();
+    let (mut hconn_c, mut hconn_s, d) = connect();
 
     eprintln!("-----client");
     let req = hconn_c
         .fetch("GET", "https", "something.com", "/", &[])
         .unwrap();
     assert_eq!(req, 0);
-    r = hconn_c.process(r.0, now());
+    let (d, _) = hconn_c.process(d, now());
     eprintln!("-----server");
-    r = hconn_s.process(r.0, now());
+    let (d, _) = hconn_s.process(d, now());
 
     eprintln!("-----client");
-    r = hconn_c.process(r.0, now());
+    let _ = hconn_c.process(d, now());
     // TODO: some kind of client API needed to read result of fetch
     // TODO: assert result is as expected e.g. (200 "abc")
     // assert!(false);

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -470,11 +470,7 @@ impl Handler for VnHandler {
     fn rewrite_out(&mut self, d: &Datagram) -> Option<Datagram> {
         let mut payload = d[..].to_vec();
         payload[1] = 0x1a;
-        Some(Datagram::new(
-            d.source().clone(),
-            d.destination().clone(),
-            payload,
-        ))
+        Some(Datagram::new(*d.source(), *d.destination(), payload))
     }
 }
 fn test_vn(nctx: &NetworkCtx, peer: &Peer) -> Result<(Connection), String> {

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -38,15 +38,15 @@ struct Args {
 
 trait Handler {
     fn handle(&mut self, client: &mut Connection) -> bool;
-    fn rewrite_out(&mut self, _dgrams: &mut Vec<Datagram>) {}
+    fn rewrite_out(&mut self, _dgram: &Datagram) -> Option<Datagram> {
+        None
+    }
 }
 
-fn emit_packets(socket: &UdpSocket, out_dgrams: &[Datagram]) {
-    for d in out_dgrams {
-        let sent = socket.send(&d[..]).expect("Error sending datagram");
-        if sent != d.len() {
-            eprintln!("Unable to send all {} bytes of datagram", d.len());
-        }
+fn emit_datagram(socket: &UdpSocket, d: Datagram) {
+    let sent = socket.send(&d[..]).expect("Error sending datagram");
+    if sent != d.len() {
+        eprintln!("Unable to send all {} bytes of datagram", d.len());
     }
 }
 
@@ -77,20 +77,19 @@ fn process_loop(
     timeout: Duration,
 ) -> Result<State, String> {
     let buf = &mut [0u8; 2048];
-    let mut in_dgrams = Vec::new();
     let timer = Timer::new(timeout);
 
     loop {
-        client.process_input(in_dgrams.drain(..), Instant::now());
-
         if let State::Closed(..) = client.state() {
             return Ok(client.state().clone());
         }
 
         let exiting = !handler.handle(client);
-        let (mut out_dgrams, _timer) = client.process_output(Instant::now());
-        handler.rewrite_out(&mut out_dgrams);
-        emit_packets(&nctx.socket, &out_dgrams);
+        let (out_dgram, _timer) = client.process_output(Instant::now());
+        if let Some(dgram) = out_dgram {
+            let dgram = handler.rewrite_out(&dgram).unwrap_or(dgram);
+            emit_datagram(&nctx.socket, dgram);
+        }
 
         if exiting {
             return Ok(client.state().clone());
@@ -116,7 +115,8 @@ fn process_loop(
             continue;
         }
         if sz > 0 {
-            in_dgrams.push(Datagram::new(nctx.remote_addr, nctx.local_addr, &buf[..sz]));
+            let received = Datagram::new(nctx.remote_addr, nctx.local_addr, &buf[..sz]);
+            client.process_input(received, Instant::now());
         }
     }
 }
@@ -229,21 +229,18 @@ fn process_loop_h3(
     timeout: Duration,
 ) -> Result<State, String> {
     let buf = &mut [0u8; 2048];
-    let mut in_dgrams = Vec::new();
     let timer = Timer::new(timeout);
 
     loop {
-        handler
-            .h3
-            .process_input(in_dgrams.drain(..), Instant::now());
-
         if let State::Closed(..) = handler.h3.conn().state() {
             return Ok(handler.h3.conn().state().clone());
         }
 
         let exiting = !handler.handle();
-        let (out_dgrams, _timer) = handler.h3.conn().process_output(Instant::now());
-        emit_packets(&nctx.socket, &out_dgrams);
+        let (out_dgram, _timer) = handler.h3.conn().process_output(Instant::now());
+        if let Some(dgram) = out_dgram {
+            emit_datagram(&nctx.socket, dgram);
+        }
 
         if exiting {
             return Ok(handler.h3.conn().state().clone());
@@ -268,7 +265,8 @@ fn process_loop_h3(
             continue;
         }
         if sz > 0 {
-            in_dgrams.push(Datagram::new(nctx.remote_addr, nctx.local_addr, &buf[..sz]));
+            let received = Datagram::new(nctx.remote_addr, nctx.local_addr, &buf[..sz]);
+            handler.h3.process_input(received, Instant::now());
         }
     }
 }
@@ -469,12 +467,14 @@ impl Handler for VnHandler {
         }
     }
 
-    fn rewrite_out(&mut self, dgrams: &mut Vec<Datagram>) {
-        if dgrams.is_empty() {
-            return;
-        }
-        assert!(dgrams.len() == 1);
-        dgrams[0].d[1] = 0x1a;
+    fn rewrite_out(&mut self, d: &Datagram) -> Option<Datagram> {
+        let mut payload = d[..].to_vec();
+        payload[1] = 0x1a;
+        Some(Datagram::new(
+            d.source().clone(),
+            d.destination().clone(),
+            payload,
+        ))
     }
 }
 fn test_vn(nctx: &NetworkCtx, peer: &Peer) -> Result<(Connection), String> {

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -85,8 +85,8 @@ fn process_loop(
         }
 
         let exiting = !handler.handle(client);
-        let (out_dgram, _timer) = client.process_output(Instant::now());
-        if let Some(dgram) = out_dgram {
+        let out_dgram = client.process_output(Instant::now());
+        if let Some(dgram) = out_dgram.dgram() {
             let dgram = handler.rewrite_out(&dgram).unwrap_or(dgram);
             emit_datagram(&nctx.socket, dgram);
         }
@@ -237,8 +237,8 @@ fn process_loop_h3(
         }
 
         let exiting = !handler.handle();
-        let (out_dgram, _timer) = handler.h3.conn().process_output(Instant::now());
-        if let Some(dgram) = out_dgram {
+        let out_dgram = handler.h3.conn().process_output(Instant::now());
+        if let Some(dgram) = out_dgram.dgram() {
             emit_datagram(&nctx.socket, dgram);
         }
 

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -831,8 +831,8 @@ mod tests {
         }
         // send an instruction
         let _ = conn_s.stream_send(recv_stream_id, instruction);
-        let (packet, _) = conn_s.process(None, now());
-        conn_c.process(packet, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         if let Err(e) = decoder.read_instructions(&mut conn_c, recv_stream_id) {
             match err {
                 Some(expected_err) => {
@@ -850,8 +850,8 @@ mod tests {
         }
 
         decoder.send(&mut conn_c).unwrap();
-        let (d, _) = conn_c.process(None, now());
-        conn_s.process(d, now());
+        let out = conn_c.process(None, now());
+        conn_s.process(out.dgram(), now());
         let mut found_instruction = false;
         let events = conn_s.events();
         for e in events {
@@ -945,23 +945,23 @@ mod tests {
                 0x68, 0x04, 0x31, 0x32, 0x33, 0x34,
             ],
         );
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         if let Err(_) = decoder.read_instructions(&mut conn_c, recv_stream_id) {
             assert!(false)
         }
 
         // send the second instruction, a duplicate instruction.
         let _ = conn_s.stream_send(recv_stream_id, &[0x00]);
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         if let Err(_) = decoder.read_instructions(&mut conn_c, recv_stream_id) {
             assert!(false)
         }
 
         decoder.send(&mut conn_c).unwrap();
-        let (d, _) = conn_c.process(None, now());
-        conn_s.process(d, now());
+        let out = conn_c.process(None, now());
+        conn_s.process(out.dgram(), now());
         let mut found_instruction = false;
         let events = conn_s.events();
         for e in events {
@@ -1054,8 +1054,8 @@ mod tests {
             // send an instruction
             if t.encoder_inst.len() > 0 {
                 let _ = conn_s.stream_send(recv_stream_id, t.encoder_inst);
-                let (d, _) = conn_s.process(None, now());
-                conn_c.process(d, now());
+                let out = conn_s.process(None, now());
+                conn_c.process(out.dgram(), now());
                 if let Err(_) = decoder.read_instructions(&mut conn_c, recv_stream_id) {
                     assert!(false);
                 }
@@ -1075,8 +1075,8 @@ mod tests {
 
         // test header acks and the insert count increment command
         decoder.send(&mut conn_c).unwrap();
-        let (d, _) = conn_c.process(None, now());
-        conn_s.process(d, now());
+        let out = conn_c.process(None, now());
+        conn_s.process(out.dgram(), now());
         let mut found_instruction = false;
         let events = conn_s.events();
         for e in events {
@@ -1161,8 +1161,8 @@ mod tests {
             // send an instruction.
             if t.encoder_inst.len() > 0 {
                 let _ = conn_s.stream_send(recv_stream_id, t.encoder_inst);
-                let (d, _) = conn_s.process(None, now());
-                conn_c.process(d, now());
+                let out = conn_s.process(None, now());
+                conn_c.process(out.dgram(), now());
                 // read the instruction.
                 if let Err(_) = decoder.read_instructions(&mut conn_c, recv_stream_id) {
                     assert!(false);
@@ -1183,8 +1183,8 @@ mod tests {
 
         // test header acks and the insert count increment command
         decoder.send(&mut conn_c).unwrap();
-        let (d, _) = conn_c.process(None, now());
-        conn_s.process(d, now());
+        let out = conn_c.process(None, now());
+        conn_s.process(out.dgram(), now());
         let mut found_instruction = false;
         let events = conn_s.events();
         for e in events {

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -802,12 +802,7 @@ mod tests {
     use test_fixture::*;
 
     fn connect() -> (QPackDecoder, Connection, Connection, u64, u64) {
-        let mut conn_c = default_client();
-        let mut conn_s = default_server();
-        let (d, _) = conn_c.process(None, now());
-        let (d, _) = conn_s.process(d, now());
-        let (d, _) = conn_c.process(d, now());
-        conn_s.process(d, now());
+        let (mut conn_c, mut conn_s) = test_fixture::connect();
 
         // create a stream
         let recv_stream_id = conn_s.stream_create(StreamType::UniDi).unwrap();

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -804,10 +804,10 @@ mod tests {
     fn connect() -> (QPackDecoder, Connection, Connection, u64, u64) {
         let mut conn_c = default_client();
         let mut conn_s = default_server();
-        let mut r = conn_c.process(vec![], now());
-        r = conn_s.process(r.0, now());
-        r = conn_c.process(r.0, now());
-        conn_s.process(r.0, now());
+        let (d, _) = conn_c.process(None, now());
+        let (d, _) = conn_s.process(d, now());
+        let (d, _) = conn_c.process(d, now());
+        conn_s.process(d, now());
 
         // create a stream
         let recv_stream_id = conn_s.stream_create(StreamType::UniDi).unwrap();
@@ -836,8 +836,8 @@ mod tests {
         }
         // send an instruction
         let _ = conn_s.stream_send(recv_stream_id, instruction);
-        let mut r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (packet, _) = conn_s.process(None, now());
+        conn_c.process(packet, now());
         if let Err(e) = decoder.read_instructions(&mut conn_c, recv_stream_id) {
             match err {
                 Some(expected_err) => {
@@ -855,8 +855,8 @@ mod tests {
         }
 
         decoder.send(&mut conn_c).unwrap();
-        r = conn_c.process(vec![], now());
-        conn_s.process(r.0, now());
+        let (d, _) = conn_c.process(None, now());
+        conn_s.process(d, now());
         let mut found_instruction = false;
         let events = conn_s.events();
         for e in events {
@@ -950,23 +950,23 @@ mod tests {
                 0x68, 0x04, 0x31, 0x32, 0x33, 0x34,
             ],
         );
-        let r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         if let Err(_) = decoder.read_instructions(&mut conn_c, recv_stream_id) {
             assert!(false)
         }
 
         // send the second instruction, a duplicate instruction.
         let _ = conn_s.stream_send(recv_stream_id, &[0x00]);
-        let mut r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         if let Err(_) = decoder.read_instructions(&mut conn_c, recv_stream_id) {
             assert!(false)
         }
 
         decoder.send(&mut conn_c).unwrap();
-        r = conn_c.process(vec![], now());
-        conn_s.process(r.0, now());
+        let (d, _) = conn_c.process(None, now());
+        conn_s.process(d, now());
         let mut found_instruction = false;
         let events = conn_s.events();
         for e in events {
@@ -1059,8 +1059,8 @@ mod tests {
             // send an instruction
             if t.encoder_inst.len() > 0 {
                 let _ = conn_s.stream_send(recv_stream_id, t.encoder_inst);
-                let r = conn_s.process(vec![], now());
-                conn_c.process(r.0, now());
+                let (d, _) = conn_s.process(None, now());
+                conn_c.process(d, now());
                 if let Err(_) = decoder.read_instructions(&mut conn_c, recv_stream_id) {
                     assert!(false);
                 }
@@ -1080,8 +1080,8 @@ mod tests {
 
         // test header acks and the insert count increment command
         decoder.send(&mut conn_c).unwrap();
-        let r = conn_c.process(vec![], now());
-        conn_s.process(r.0, now());
+        let (d, _) = conn_c.process(None, now());
+        conn_s.process(d, now());
         let mut found_instruction = false;
         let events = conn_s.events();
         for e in events {
@@ -1166,8 +1166,8 @@ mod tests {
             // send an instruction.
             if t.encoder_inst.len() > 0 {
                 let _ = conn_s.stream_send(recv_stream_id, t.encoder_inst);
-                let r = conn_s.process(vec![], now());
-                conn_c.process(r.0, now());
+                let (d, _) = conn_s.process(None, now());
+                conn_c.process(d, now());
                 // read the instruction.
                 if let Err(_) = decoder.read_instructions(&mut conn_c, recv_stream_id) {
                     assert!(false);
@@ -1188,8 +1188,8 @@ mod tests {
 
         // test header acks and the insert count increment command
         decoder.send(&mut conn_c).unwrap();
-        let r = conn_c.process(vec![], now());
-        conn_s.process(r.0, now());
+        let (d, _) = conn_c.process(None, now());
+        conn_s.process(d, now());
         let mut found_instruction = false;
         let events = conn_s.events();
         for e in events {

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -557,8 +557,8 @@ mod tests {
         encoder_instruction: &[u8],
     ) {
         encoder.send(&mut conn_c).unwrap();
-        let (d, _) = conn_c.process(None, now());
-        conn_s.process(d, now());
+        let out = conn_c.process(None, now());
+        conn_s.process(out.dgram(), now());
         let mut found_instruction = false;
         let events = conn_s.events();
         for e in events {
@@ -774,7 +774,7 @@ mod tests {
     }
 
     #[test]
-    fn test_header_block_encoder() {
+    fn test_header_block_encoder_non() {
         let test_cases: [TestElement; 6] = [
             // test a header with ref to static - encode_indexed
             TestElement {
@@ -1007,8 +1007,8 @@ mod tests {
 
         // receive an insert count increment.
         conn_s.stream_send(recv_stream_id, &[0x01]).unwrap();
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         if let Err(_) = encoder.read_instructions(&mut conn_c, recv_stream_id) {
             assert!(false);
         } else {
@@ -1084,8 +1084,8 @@ mod tests {
 
         // receive an insert count increment.
         let _ = conn_s.stream_send(recv_stream_id, &[0x01]);
-        let (d, _) = conn_s.process(None, now());
-        conn_c.process(d, now());
+        let out = conn_s.process(None, now());
+        conn_c.process(out.dgram(), now());
         if let Err(_) = encoder.read_instructions(&mut conn_c, recv_stream_id) {
             assert!(false);
         } else {
@@ -1130,13 +1130,13 @@ mod tests {
         if wait == 0 {
             // receive a header_ack.
             let _ = conn_s.stream_send(recv_stream_id, &[0x81]);
-            let (d, _) = conn_s.process(None, now());
-            conn_c.process(d, now());
+            let out = conn_s.process(None, now());
+            conn_c.process(out.dgram(), now());
         } else {
             // reveice a stream canceled
             let _ = conn_s.stream_send(recv_stream_id, &[0x41]);
-            let (d, _) = conn_s.process(None, now());
-            conn_c.process(d, now());
+            let out = conn_s.process(None, now());
+            conn_c.process(out.dgram(), now());
         }
         if let Err(_) = encoder.read_instructions(&mut conn_c, recv_stream_id) {
             assert!(false);

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -535,12 +535,7 @@ mod tests {
     use test_fixture::*;
 
     fn connect(huffman: bool) -> (QPackEncoder, Connection, Connection, u64, u64) {
-        let mut conn_c = default_client();
-        let mut conn_s = default_server();
-        let (d, _) = conn_c.process(None, now());
-        let (d, _) = conn_s.process(d, now());
-        let (d, _) = conn_c.process(d, now());
-        conn_s.process(d, now());
+        let (mut conn_c, mut conn_s) = test_fixture::connect();
 
         // create a stream
         let recv_stream_id = conn_s.stream_create(StreamType::UniDi).unwrap();

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -537,10 +537,10 @@ mod tests {
     fn connect(huffman: bool) -> (QPackEncoder, Connection, Connection, u64, u64) {
         let mut conn_c = default_client();
         let mut conn_s = default_server();
-        let mut r = conn_c.process(vec![], now());
-        r = conn_s.process(r.0, now());
-        r = conn_c.process(r.0, now());
-        conn_s.process(r.0, now());
+        let (d, _) = conn_c.process(None, now());
+        let (d, _) = conn_s.process(d, now());
+        let (d, _) = conn_c.process(d, now());
+        conn_s.process(d, now());
 
         // create a stream
         let recv_stream_id = conn_s.stream_create(StreamType::UniDi).unwrap();
@@ -562,8 +562,8 @@ mod tests {
         encoder_instruction: &[u8],
     ) {
         encoder.send(&mut conn_c).unwrap();
-        let r = conn_c.process(vec![], now());
-        conn_s.process(r.0, now());
+        let (d, _) = conn_c.process(None, now());
+        conn_s.process(d, now());
         let mut found_instruction = false;
         let events = conn_s.events();
         for e in events {
@@ -1012,8 +1012,8 @@ mod tests {
 
         // receive an insert count increment.
         conn_s.stream_send(recv_stream_id, &[0x01]).unwrap();
-        let r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         if let Err(_) = encoder.read_instructions(&mut conn_c, recv_stream_id) {
             assert!(false);
         } else {
@@ -1089,8 +1089,8 @@ mod tests {
 
         // receive an insert count increment.
         let _ = conn_s.stream_send(recv_stream_id, &[0x01]);
-        let r = conn_s.process(vec![], now());
-        conn_c.process(r.0, now());
+        let (d, _) = conn_s.process(None, now());
+        conn_c.process(d, now());
         if let Err(_) = encoder.read_instructions(&mut conn_c, recv_stream_id) {
             assert!(false);
         } else {
@@ -1135,13 +1135,13 @@ mod tests {
         if wait == 0 {
             // receive a header_ack.
             let _ = conn_s.stream_send(recv_stream_id, &[0x81]);
-            let r = conn_s.process(vec![], now());
-            conn_c.process(r.0, now());
+            let (d, _) = conn_s.process(None, now());
+            conn_c.process(d, now());
         } else {
             // reveice a stream canceled
             let _ = conn_s.stream_send(recv_stream_id, &[0x41]);
-            let r = conn_s.process(vec![], now());
-            conn_c.process(r.0, now());
+            let (d, _) = conn_s.process(None, now());
+            conn_c.process(d, now());
         }
         if let Err(_) = encoder.read_instructions(&mut conn_c, recv_stream_id) {
             assert!(false);

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -177,8 +177,8 @@ fn main() {
             http_serve(&mut server, stream_id);
         }
 
-        let (out, _timer) = server.process_output(Instant::now());
-        if let Some(dgram) = out {
+        let out = server.process_output(Instant::now());
+        if let Some(dgram) = out.dgram() {
             emit_datagram(&socket, dgram);
         }
     }

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -112,14 +112,12 @@ fn http_serve(server: &mut Connection, stream: u64) {
     server.stream_close_send(stream).expect("Stream closed");
 }
 
-fn emit_packets(socket: &UdpSocket, out_dgrams: &[Datagram]) {
-    for d in out_dgrams {
-        let sent = socket
-            .send_to(&d[..], d.destination())
-            .expect("Error sending datagram");
-        if sent != d.len() {
-            eprintln!("Unable to send all {} bytes of datagram", d.len());
-        }
+fn emit_datagram(socket: &UdpSocket, d: Datagram) {
+    let sent = socket
+        .send_to(&d[..], d.destination())
+        .expect("Error sending datagram");
+    if sent != d.len() {
+        eprintln!("Unable to send all {} bytes of datagram", d.len());
     }
 }
 
@@ -139,16 +137,13 @@ fn main() {
     println!("Server waiting for connection on: {:?}", local_addr);
 
     let buf = &mut [0u8; 2048];
-    let mut in_dgrams = Vec::new();
     let mut connections: HashMap<SocketAddr, Connection> = HashMap::new();
     loop {
+        // TODO use timer to set socket.set_read_timeout.
         let (sz, remote_addr) = socket.recv_from(&mut buf[..]).expect("UDP error");
         if sz == buf.len() {
-            eprintln!("Might have received more than {} bytes", buf.len());
+            eprintln!("Discarding packet that might be truncated");
             continue;
-        }
-        if sz > 0 {
-            in_dgrams.push(Datagram::new(remote_addr, local_addr, &buf[..sz]));
         }
 
         let mut server = connections.entry(remote_addr).or_insert_with(|| {
@@ -157,8 +152,10 @@ fn main() {
                 .expect("can't create connection")
         });
 
-        // TODO use timer to set socket.set_read_timeout.
-        server.process_input(in_dgrams.drain(..), Instant::now());
+        if sz > 0 {
+            let dgram = Datagram::new(remote_addr, local_addr, &buf[..sz]);
+            server.process_input(dgram, Instant::now());
+        }
         if let State::Closed(e) = server.state() {
             eprintln!("Closed connection from {:?}: {:?}", remote_addr, e);
             connections.remove(&remote_addr);
@@ -180,7 +177,9 @@ fn main() {
             http_serve(&mut server, stream_id);
         }
 
-        let (out_dgrams, _timer) = server.process_output(Instant::now());
-        emit_packets(&socket, &out_dgrams);
+        let (out, _timer) = server.process_output(Instant::now());
+        if let Some(dgram) = out {
+            emit_datagram(&socket, dgram);
+        }
     }
 }

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -496,6 +496,7 @@ impl Connection {
         self.valid_cids.contains(cid) || self.paths.iter().any(|p| p.local_cids.contains(cid))
     }
 
+    #[allow(clippy::cognitive_complexity)]
     fn input(&mut self, d: Datagram, now: Instant) -> Res<()> {
         let mut slc = &d[..];
 

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -739,7 +739,7 @@ impl Connection {
             // Try to make our own crypo state and if we can't, skip this epoch.
             match self.crypto.obtain_crypto_state(self.role, epoch) {
                 Ok(cs) => {
-                    if !cs.tx.is_some() {
+                    if cs.tx.is_none() {
                         continue;
                     }
                 }
@@ -822,7 +822,7 @@ impl Connection {
             out_bytes.append(&mut packet);
         }
 
-        if out_bytes.len() == 0 {
+        if out_bytes.is_empty() {
             return Ok(None);
         }
 

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -25,7 +25,7 @@ mod stream_id;
 mod tparams;
 mod tracking;
 
-pub use self::connection::{Connection, Role, State};
+pub use self::connection::{Connection, Output, Role, State};
 pub use self::events::{ConnectionEvent, ConnectionEvents};
 pub use self::frame::CloseError;
 pub use self::frame::StreamType;

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -71,6 +71,16 @@ impl Server {
         let dgram = Datagram::new(*received.destination(), *received.source(), retry);
         Ok(RetryResult::SendRetry(dgram))
     }
+
+    // pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> (Option<Datagram>, Option<Duration>) {
+    //     let hdr = match decode_packet_hdr(self, &received[..]) {
+    //         Ok(h) => h,
+    //         Err(e) => {
+    //             qtrace!([self] "Discarding {:?}", received);
+    //             return (None, self.next_timer())
+    //         }
+    //     };
+    // }
 }
 
 impl PacketDecoder for Server {

--- a/neqo-transport/tests/conn_vectors.rs
+++ b/neqo-transport/tests/conn_vectors.rs
@@ -72,7 +72,7 @@ fn process_client_initial() {
     let pkt: Vec<u8> = Encoder::from_hex(INITIAL_PACKET).into();
     let dgram = Datagram::new(loopback(), loopback(), pkt);
     assert_eq!(*server.state(), State::WaitInitial);
-    let (out, _) = server.process(vec![dgram], now());
+    let (out, _) = server.process(Some(dgram), now());
     assert_eq!(*server.state(), State::Handshaking);
-    assert_eq!(out.len(), 1);
+    assert!(out.is_some());
 }

--- a/neqo-transport/tests/conn_vectors.rs
+++ b/neqo-transport/tests/conn_vectors.rs
@@ -72,7 +72,7 @@ fn process_client_initial() {
     let pkt: Vec<u8> = Encoder::from_hex(INITIAL_PACKET).into();
     let dgram = Datagram::new(loopback(), loopback(), pkt);
     assert_eq!(*server.state(), State::WaitInitial);
-    let (out, _) = server.process(Some(dgram), now());
+    let out = server.process(Some(dgram), now());
     assert_eq!(*server.state(), State::Handshaking);
-    assert!(out.is_some());
+    assert!(out.dgram().is_some());
 }

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -76,8 +76,8 @@ pub fn handshake(client: &mut Connection, server: &mut Connection) {
     let mut datagram = None;
     let is_done = |c: &Connection| matches!(c.state(), State::Connected | State::Closing { .. } | State::Closed(..));
     while !is_done(a) {
-        let (d, _) = a.process(datagram, now());
-        datagram = d;
+        let d = a.process(datagram, now());
+        datagram = d.dgram();
         mem::swap(&mut a, &mut b);
     }
 }


### PR DESCRIPTION
When trying to add Retry for a server, I found that the API that handles
multiple packets was inconvenient.  There is no real need to have the
loop inside Connection anyway, so I externalized it.  This simplifies
the API and implementation a decent amount and should help avoid
problems.

This isn't complete at the moment because we don't set any timeout when
there is more data to send.  As a result, if we have more to say than
fits in a single packet, we won't say it until given the opportunity.
For the moment, that means either hitting the loss recovery timer or
getting a new packet inbound.  The way that the generators are
structured makes it very difficult to do that right now because we have
a single generator squatting on the queue always.

As part of fixing process_input and process_output, I removed the idle
timeout code that was there.  It wasn't in any way right, so I am not
concerned about its loss; I just moved the TODO.