### PR TITLE
Make timers make more sense, and de-traitize recovery tokens

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -9,7 +9,7 @@
 #![allow(dead_code)]
 use std::cell::RefCell;
 use std::cmp::{max, min};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::fmt::{self, Debug};
 use std::mem;
 use std::net::SocketAddr;
@@ -25,17 +25,14 @@ use crate::crypto::{Crypto, CryptoGenerator};
 use crate::dump::*;
 use crate::events::{ConnectionEvent, ConnectionEvents};
 use crate::flow_mgr::{FlowControlGenerator, FlowMgr};
-use crate::frame::{
-    decode_frame, AckRange, Frame, FrameGenerator, FrameGeneratorToken, FrameType, StreamType,
-    TxMode,
-};
+use crate::frame::{decode_frame, AckRange, Frame, FrameGenerator, FrameType, StreamType, TxMode};
 use crate::packet::{
     decode_packet_hdr, decrypt_packet, encode_packet, ConnectionId, PacketDecoder, PacketHdr,
     PacketNumberDecoder, PacketType,
 };
-use crate::recovery::{LossRecovery, LossRecoveryMode};
-use crate::recv_stream::{RecvStream, RX_STREAM_DATA_WINDOW};
-use crate::send_stream::{SendStream, StreamGenerator};
+use crate::recovery::{LossRecovery, LossRecoveryMode, TokenType};
+use crate::recv_stream::{RecvStream, RecvStreams, RX_STREAM_DATA_WINDOW};
+use crate::send_stream::{SendStream, SendStreams, StreamGenerator};
 use crate::stats::Stats;
 use crate::stream_id::{StreamId, StreamIndex, StreamIndexes};
 use crate::tparams::consts as tp_const;
@@ -144,11 +141,12 @@ pub struct Connection {
     idle_timeout: Option<Instant>,
     pub(crate) indexes: StreamIndexes,
     connection_ids: HashMap<u64, (Vec<u8>, [u8; 16])>, // (sequence number, (connection id, reset token))
-    pub(crate) send_streams: BTreeMap<StreamId, SendStream>,
-    pub(crate) recv_streams: BTreeMap<StreamId, RecvStream>,
+    pub(crate) send_streams: SendStreams,
+    pub(crate) recv_streams: RecvStreams,
     pmtu: usize,
     pub(crate) flow_mgr: Rc<RefCell<FlowMgr>>,
     loss_recovery: LossRecovery,
+    loss_recovery_state: (LossRecoveryMode, Option<Instant>),
     events: Rc<RefCell<ConnectionEvents>>,
     token: Option<Vec<u8>>,
     send_vn: Option<(PacketHdr, SocketAddr, SocketAddr)>,
@@ -259,11 +257,12 @@ impl Connection {
             idle_timeout: None,
             indexes: StreamIndexes::new(),
             connection_ids: HashMap::new(),
-            send_streams: BTreeMap::new(),
-            recv_streams: BTreeMap::new(),
+            send_streams: SendStreams::default(),
+            recv_streams: RecvStreams::default(),
             pmtu: 1280,
             flow_mgr: Rc::new(RefCell::new(FlowMgr::default())),
             loss_recovery: LossRecovery::new(),
+            loss_recovery_state: (LossRecoveryMode::None, None),
             events: Rc::new(RefCell::new(ConnectionEvents::default())),
             token: None,
             send_vn: None,
@@ -428,8 +427,10 @@ impl Connection {
     }
 
     /// Get the time that we next need to be called back, relative to `now`.
-    fn next_delay(&self, now: Instant) -> Option<Duration> {
-        let time = match (self.loss_recovery.get_timer(), self.acks.ack_time()) {
+    fn next_delay(&mut self, now: Instant) -> Option<Duration> {
+        self.loss_recovery_state = self.loss_recovery.get_timer();
+
+        let time = match (self.loss_recovery_state.1, self.acks.ack_time()) {
             (Some(t_lr), Some(t_ack)) => Some(min(t_lr, t_ack)),
             (Some(t), _) | (_, Some(t)) => Some(t),
             _ => None,
@@ -1163,18 +1164,39 @@ impl Connection {
 
         let acked_ranges =
             Frame::decode_ack_frame(largest_acknowledged, first_ack_range, ack_ranges)?;
-        let (mut acked_packets, mut lost_packets) = self.loss_recovery.on_ack_received(
+        let (acked_packets, lost_packets) = self.loss_recovery.on_ack_received(
             PNSpace::from(epoch),
             largest_acknowledged,
             acked_ranges,
             Duration::from_millis(ack_delay),
             now,
         );
-        for acked in &mut acked_packets {
-            acked.mark_acked(self);
+        for acked in acked_packets {
+            for token in acked.tokens {
+                match token {
+                    TokenType::Ack(at) => self.acks.acked(at),
+                    TokenType::Stream(st) => self.send_streams.acked(st),
+                    TokenType::Crypto(ct) => self.crypto.acked(ct),
+                    TokenType::Flow(ft) => {
+                        self.flow_mgr.borrow_mut().acked(ft, &mut self.send_streams)
+                    }
+                }
+            }
         }
-        for lost in &mut lost_packets {
-            lost.mark_lost(self);
+        for lost in lost_packets {
+            for token in lost.tokens {
+                match token {
+                    TokenType::Ack(_) => {}
+                    TokenType::Stream(st) => self.send_streams.lost(st),
+                    TokenType::Crypto(ct) => self.crypto.lost(ct),
+                    TokenType::Flow(ft) => self.flow_mgr.borrow_mut().lost(
+                        ft,
+                        &mut self.send_streams,
+                        &mut self.recv_streams,
+                        &mut self.indexes,
+                    ),
+                }
+            }
         }
 
         Ok(())
@@ -1189,8 +1211,20 @@ impl Connection {
         // Tell 0-RTT packets that they were "lost".
         // TODO(mt) remove these from "bytes in flight" when we
         // have a congestion controller.
-        for mut dropped in self.loss_recovery.drop_0rtt() {
-            dropped.mark_lost(self);
+        for dropped in self.loss_recovery.drop_0rtt() {
+            for token in dropped.tokens {
+                match token {
+                    TokenType::Ack(_) => {}
+                    TokenType::Stream(st) => self.send_streams.lost(st),
+                    TokenType::Crypto(ct) => self.crypto.lost(ct),
+                    TokenType::Flow(ft) => self.flow_mgr.borrow_mut().lost(
+                        ft,
+                        &mut self.send_streams,
+                        &mut self.recv_streams,
+                        &mut self.indexes,
+                    ),
+                }
+            }
         }
         self.send_streams.clear();
         self.recv_streams.clear();
@@ -1270,16 +1304,7 @@ impl Connection {
                 .max_streams(self.indexes.local_max_stream_uni, StreamType::UniDi)
         }
 
-        let send_to_remove = self
-            .send_streams
-            .iter()
-            .filter(|(_, stream)| stream.is_terminal())
-            .map(|(id, _)| *id)
-            .collect::<Vec<_>>();
-
-        for id in send_to_remove {
-            self.send_streams.remove(&id);
-        }
+        self.send_streams.clear_terminal();
     }
 
     /// Get or make a stream, and implicitly open additional streams as
@@ -1373,7 +1398,7 @@ impl Connection {
         }
 
         Ok((
-            self.send_streams.get_mut(&stream_id),
+            self.send_streams.get_mut(stream_id).ok(),
             self.recv_streams.get_mut(&stream_id),
         ))
     }
@@ -1486,48 +1511,28 @@ impl Connection {
     /// Returns how many bytes were successfully sent. Could be less
     /// than total, based on receiver credit space available, etc.
     pub fn stream_send(&mut self, stream_id: u64, data: &[u8]) -> Res<usize> {
-        let stream = self
-            .send_streams
-            .get_mut(&stream_id.into())
-            .ok_or_else(|| Error::InvalidStreamId)?;
-
-        stream.send(data)
+        self.send_streams.get_mut(stream_id.into())?.send(data)
     }
 
     /// Bytes that stream_send() is guaranteed to accept for sending.
     /// i.e. that will not be blocked by flow credits or send buffer max
     /// capacity.
     pub fn stream_avail_send_space(&self, stream_id: u64) -> Res<u64> {
-        let stream = self
-            .send_streams
-            .get(&stream_id.into())
-            .ok_or_else(|| Error::InvalidStreamId)?;
-
         Ok(min(
-            stream.avail(),
+            self.send_streams.get(stream_id.into())?.avail(),
             self.flow_mgr.borrow().conn_credit_avail(),
         ))
     }
 
     /// Close the stream. Enqueued data will be sent.
     pub fn stream_close_send(&mut self, stream_id: u64) -> Res<()> {
-        let stream = self
-            .send_streams
-            .get_mut(&stream_id.into())
-            .ok_or_else(|| Error::InvalidStreamId)?;
-
-        stream.close();
+        self.send_streams.get_mut(stream_id.into())?.close();
         Ok(())
     }
 
     /// Abandon transmission of in-flight and future stream data.
     pub fn stream_reset_send(&mut self, stream_id: u64, err: AppError) -> Res<()> {
-        let stream = self
-            .send_streams
-            .get_mut(&stream_id.into())
-            .ok_or_else(|| Error::InvalidStreamId)?;
-
-        stream.reset(err);
+        self.send_streams.get_mut(stream_id.into())?.reset(err);
         Ok(())
     }
 
@@ -1555,20 +1560,49 @@ impl Connection {
     }
 
     /// Get events that indicate state changes on the connection.
-    pub fn events(&mut self) -> Vec<ConnectionEvent> {
-        // Turn it into a vec for simplicity's sake
-        self.events.borrow_mut().events().into_iter().collect()
+    pub fn events(&mut self) -> impl Iterator<Item = ConnectionEvent> {
+        self.events.borrow_mut().events().into_iter()
     }
 
     fn check_loss_detection_timeout(&mut self, now: Instant) {
         qdebug!([self] "check_loss_timeouts");
 
-        match self.loss_recovery.check_loss_timer(now) {
-            LossRecoveryMode::None => {}
-            LossRecoveryMode::LostPackets(mut packets) => {
-                qinfo!([self] "lost packets: {}", packets.len());
-                for lost in packets.iter_mut() {
-                    lost.mark_lost(self);
+        if matches!(self.loss_recovery_state.0, LossRecoveryMode::None) {
+            // LR not the active timer
+            return;
+        }
+
+        if self.loss_recovery_state.1 > Some(now) {
+            // LR timer, but hasn't expired.
+            return;
+        }
+
+        // Timer expired and LR was active timer.
+        match &mut self.loss_recovery_state.0 {
+            LossRecoveryMode::None => unreachable!(),
+            LossRecoveryMode::LostPackets => {
+                // Time threshold loss detection
+                let (pn_space, _) = self
+                    .loss_recovery
+                    .get_earliest_loss_time()
+                    .expect("must be sent packets if in LostPackets mode");
+                let packets = self.loss_recovery.detect_lost_packets(pn_space, now);
+
+                qinfo!("lost packets: {}", packets.len());
+                for lost in packets {
+                    for token in lost.tokens {
+                        match token {
+                            TokenType::Ack(_) => {} // Do nothing
+                            TokenType::Stream(st) => self.send_streams.lost(st),
+                            TokenType::Crypto(ct) => self.crypto.lost(ct),
+                            TokenType::Flow(ft) => self.flow_mgr.borrow_mut().lost(
+                                ft,
+                                &mut self.send_streams,
+                                &mut self.recv_streams,
+                                &mut self.indexes,
+                            ),
+                        }
+                    }
                 }
             }
             LossRecoveryMode::CryptoTimerExpired => {
@@ -1576,6 +1610,7 @@ impl Connection {
                     [self]
                     "check_loss_detection_timeout - retransmit_unacked_crypto"
                 );
+                self.loss_recovery.increment_crypto_count();
                 // TODO
                 // if (has unacknowledged crypto data):
                 //   RetransmitUnackedCryptoData()
@@ -1593,6 +1628,7 @@ impl Connection {
                     [self]
                     "check_loss_detection_timeout -send_one_or_two_packets"
                 );
+                self.loss_recovery.increment_pto_count();
                 // TODO
                 // SendOneOrTwoPackets()
             }
@@ -1622,7 +1658,7 @@ impl FrameGenerator for CloseGenerator {
         epoch: Epoch,
         _mode: TxMode,
         _remaining: usize,
-    ) -> Option<(Frame, Option<Box<FrameGeneratorToken>>)> {
+    ) -> Option<(Frame, Option<TokenType>)> {
         if epoch != 3 {
             return None;
         }

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -134,7 +134,7 @@ impl Crypto {
         Ok(cs.as_mut().unwrap())
     }
 
-    pub(crate) fn acked(&mut self, token: CryptoGeneratorToken) {
+    pub fn acked(&mut self, token: CryptoGeneratorToken) {
         qinfo!(
             "Acked crypto frame epoch={} offset={} length={}",
             token.epoch,
@@ -146,7 +146,7 @@ impl Crypto {
             .mark_as_acked(token.offset, token.length as usize);
     }
 
-    pub(crate) fn lost(&mut self, _token: CryptoGeneratorToken) {
+    pub fn lost(&mut self, _token: CryptoGeneratorToken) {
         // TODO(agrover@mozilla.com): @ekr: resend?
     }
 }
@@ -172,7 +172,7 @@ pub(crate) struct CryptoDxState {
 }
 
 impl CryptoDxState {
-    pub(crate) fn new(
+    pub fn new(
         direction: CryptoDxDirection,
         epoch: Epoch,
         secret: &SymKey,
@@ -192,7 +192,7 @@ impl CryptoDxState {
         }
     }
 
-    pub(crate) fn new_initial<S: Into<String>>(
+    pub fn new_initial<S: Into<String>>(
         direction: CryptoDxDirection,
         label: S,
         dcid: &[u8],

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -17,8 +17,9 @@ use neqo_crypto::{
 };
 
 use crate::connection::Role;
-use crate::frame::{Frame, FrameGenerator, FrameGeneratorToken, TxMode};
+use crate::frame::{Frame, FrameGenerator, TxMode};
 use crate::packet::{CryptoCtx, PacketNumber};
+use crate::recovery::TokenType;
 use crate::recv_stream::RxStreamOrderer;
 use crate::send_stream::TxBuffer;
 use crate::tparams::{TpZeroRttChecker, TransportParametersHandler};
@@ -131,6 +132,22 @@ impl Crypto {
         }
 
         Ok(cs.as_mut().unwrap())
+    }
+
+    pub(crate) fn acked(&mut self, token: CryptoGeneratorToken) {
+        qinfo!(
+            "Acked crypto frame epoch={} offset={} length={}",
+            token.epoch,
+            token.offset,
+            token.length
+        );
+        self.streams[token.epoch as usize]
+            .tx
+            .mark_as_acked(token.offset, token.length as usize);
+    }
+
+    pub(crate) fn lost(&mut self, _token: CryptoGeneratorToken) {
+        // TODO(agrover@mozilla.com): @ekr: resend?
     }
 }
 
@@ -275,7 +292,7 @@ impl FrameGenerator for CryptoGenerator {
         epoch: u16,
         mode: TxMode,
         remaining: usize,
-    ) -> Option<(Frame, Option<Box<FrameGeneratorToken>>)> {
+    ) -> Option<(Frame, Option<TokenType>)> {
         let tx_stream = &mut conn.crypto.streams[epoch as usize].tx;
         if let Some((offset, data)) = tx_stream.next_bytes(mode) {
             let data_len = data.len();
@@ -295,7 +312,7 @@ impl FrameGenerator for CryptoGenerator {
             );
             Some((
                 frame,
-                Some(Box::new(CryptoGeneratorToken {
+                Some(TokenType::Crypto(CryptoGeneratorToken {
                     epoch,
                     offset,
                     length: data_len as u64,
@@ -307,26 +324,9 @@ impl FrameGenerator for CryptoGenerator {
     }
 }
 
-struct CryptoGeneratorToken {
+#[derive(Debug)]
+pub(crate) struct CryptoGeneratorToken {
     epoch: u16,
     offset: u64,
     length: u64,
-}
-
-impl FrameGeneratorToken for CryptoGeneratorToken {
-    fn acked(&mut self, conn: &mut Connection) {
-        qinfo!(
-            [conn]
-            "Acked crypto frame epoch={} offset={} length={}",
-            self.epoch,
-            self.offset,
-            self.length
-        );
-        conn.crypto.streams[self.epoch as usize]
-            .tx
-            .mark_as_acked(self.offset, self.length as usize);
-    }
-    fn lost(&mut self, _conn: &mut Connection) {
-        // TODO(agrover@mozilla.com): @ekr: resend?
-    }
 }

--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -15,9 +15,14 @@ use std::time::Instant;
 use neqo_common::{qinfo, qtrace, qwarn, Encoder};
 use neqo_crypto::Epoch;
 
-use crate::frame::{Frame, FrameGenerator, FrameGeneratorToken, StreamType, TxMode};
-use crate::stream_id::{StreamId, StreamIndex};
+use crate::frame::{Frame, FrameGenerator, StreamType, TxMode};
+use crate::recovery::TokenType;
+use crate::recv_stream::RecvStreams;
+use crate::send_stream::SendStreams;
+use crate::stream_id::{StreamId, StreamIndex, StreamIndexes};
 use crate::{AppError, Connection};
+
+pub type FlowControlGeneratorToken = Frame;
 
 #[derive(Debug, Default)]
 pub struct FlowMgr {
@@ -153,6 +158,102 @@ impl FlowMgr {
     pub(crate) fn set_need_close_frame(&mut self, new: bool) {
         self.need_close_frame = new
     }
+
+    pub(crate) fn acked(
+        &mut self,
+        token: FlowControlGeneratorToken,
+        send_streams: &mut SendStreams,
+    ) {
+        if let Frame::ResetStream {
+            stream_id,
+            application_error_code,
+            final_size,
+        } = token
+        {
+            qinfo!(
+                "Reset received stream={} err={} final_size={}",
+                stream_id,
+                application_error_code,
+                final_size
+            );
+            send_streams.reset_acked(stream_id.into());
+        }
+    }
+
+    pub(crate) fn lost(
+        &mut self,
+        token: FlowControlGeneratorToken,
+        send_streams: &mut SendStreams,
+        recv_streams: &mut RecvStreams,
+        indexes: &mut StreamIndexes,
+    ) {
+        match token {
+            // Always resend ResetStream if lost
+            Frame::ResetStream {
+                stream_id,
+                application_error_code,
+                final_size,
+            } => {
+                qinfo!(
+                    "Reset lost stream={} err={} final_size={}",
+                    stream_id,
+                    application_error_code,
+                    final_size
+                );
+                if send_streams.get(stream_id.into()).is_ok() {
+                    self.stream_reset(stream_id.into(), application_error_code, final_size);
+                }
+            }
+            // Resend MaxStreams if lost (with updated value)
+            Frame::MaxStreams { stream_type, .. } => {
+                let local_max = match stream_type {
+                    StreamType::BiDi => &mut indexes.local_max_stream_bidi,
+                    StreamType::UniDi => &mut indexes.local_max_stream_uni,
+                };
+
+                self.max_streams(*local_max, stream_type)
+            }
+            // Only resend "*Blocked" frames if still blocked
+            Frame::DataBlocked { .. } => {
+                if self.conn_credit_avail() == 0 {
+                    self.data_blocked()
+                }
+            }
+            Frame::StreamDataBlocked { stream_id, .. } => {
+                if let Ok(ss) = send_streams.get(stream_id.into()) {
+                    if ss.credit_avail() == 0 {
+                        self.stream_data_blocked(stream_id.into(), ss.max_stream_data())
+                    }
+                }
+            }
+            Frame::StreamsBlocked { stream_type, .. } => match stream_type {
+                StreamType::UniDi => {
+                    if indexes.peer_next_stream_uni >= indexes.peer_max_stream_uni {
+                        self.streams_blocked(indexes.peer_max_stream_uni, StreamType::UniDi);
+                    }
+                }
+                StreamType::BiDi => {
+                    if indexes.peer_next_stream_bidi >= indexes.peer_max_stream_bidi {
+                        self.streams_blocked(indexes.peer_max_stream_bidi, StreamType::BiDi);
+                    }
+                }
+            },
+            // Resend StopSending
+            Frame::StopSending {
+                stream_id,
+                application_error_code,
+            } => self.stop_sending(stream_id.into(), application_error_code),
+            // Resend MaxStreamData if not SizeKnown
+            // (maybe_send_flowc_update() checks this.)
+            Frame::MaxStreamData { stream_id, .. } => {
+                if let Some(rs) = recv_streams.get_mut(&stream_id.into()) {
+                    rs.maybe_send_flowc_update()
+                }
+            }
+            Frame::PathResponse { .. } => qinfo!("Path Response lost, not re-sent"),
+            _ => qwarn!("Unexpected Flow frame {:?} lost, not re-sent", token),
+        }
+    }
 }
 
 impl Iterator for FlowMgr {
@@ -179,7 +280,7 @@ impl Iterator for FlowMgr {
 }
 
 #[derive(Default)]
-pub struct FlowControlGenerator {}
+pub(crate) struct FlowControlGenerator {}
 
 impl FrameGenerator for FlowControlGenerator {
     fn generate(
@@ -189,7 +290,7 @@ impl FrameGenerator for FlowControlGenerator {
         epoch: Epoch,
         _mode: TxMode,
         remaining: usize,
-    ) -> Option<(Frame, Option<Box<FrameGeneratorToken>>)> {
+    ) -> Option<(Frame, Option<TokenType>)> {
         if epoch != 3 {
             return None;
         }
@@ -208,118 +309,6 @@ impl FrameGenerator for FlowControlGenerator {
         }
         // There is enough space we can add this frame to the packet.
         let frame = conn.flow_mgr.borrow_mut().next().expect("just peeked this");
-        Some((
-            frame.clone(),
-            Some(Box::new(FlowControlGeneratorToken(frame))),
-        ))
-    }
-}
-
-struct FlowControlGeneratorToken(Frame);
-
-impl FrameGeneratorToken for FlowControlGeneratorToken {
-    fn acked(&mut self, conn: &mut Connection) {
-        if let Frame::ResetStream {
-            stream_id,
-            application_error_code,
-            final_size,
-        } = self.0
-        {
-            qinfo!(
-                [conn]
-                "Reset received stream={} err={} final_size={}",
-                stream_id,
-                application_error_code,
-                final_size
-            );
-            if let Some(ss) = conn.send_streams.get_mut(&stream_id.into()) {
-                ss.reset_acked()
-            }
-        }
-    }
-
-    fn lost(&mut self, conn: &mut Connection) {
-        match self.0 {
-            // Always resend ResetStream if lost
-            Frame::ResetStream {
-                stream_id,
-                application_error_code,
-                final_size,
-            } => {
-                qinfo!(
-                    [conn]
-                    "Reset lost stream={} err={} final_size={}",
-                    stream_id,
-                    application_error_code,
-                    final_size
-                );
-                if conn.send_streams.contains_key(&stream_id.into()) {
-                    conn.flow_mgr.borrow_mut().stream_reset(
-                        stream_id.into(),
-                        application_error_code,
-                        final_size,
-                    );
-                }
-            }
-            // Resend MaxStreams if lost (with updated value)
-            Frame::MaxStreams { stream_type, .. } => {
-                let local_max = match stream_type {
-                    StreamType::BiDi => &mut conn.indexes.local_max_stream_bidi,
-                    StreamType::UniDi => &mut conn.indexes.local_max_stream_uni,
-                };
-
-                conn.flow_mgr
-                    .borrow_mut()
-                    .max_streams(*local_max, stream_type)
-            }
-            // Only resend "*Blocked" frames if still blocked
-            Frame::DataBlocked { .. } => {
-                if conn.flow_mgr.borrow().conn_credit_avail() == 0 {
-                    conn.flow_mgr.borrow_mut().data_blocked()
-                }
-            }
-            Frame::StreamDataBlocked { stream_id, .. } => {
-                if let Some(ss) = conn.send_streams.get(&stream_id.into()) {
-                    if ss.credit_avail() == 0 {
-                        conn.flow_mgr
-                            .borrow_mut()
-                            .stream_data_blocked(stream_id.into(), ss.max_stream_data())
-                    }
-                }
-            }
-            Frame::StreamsBlocked { stream_type, .. } => match stream_type {
-                StreamType::UniDi => {
-                    if conn.indexes.peer_next_stream_uni >= conn.indexes.peer_max_stream_uni {
-                        conn.flow_mgr
-                            .borrow_mut()
-                            .streams_blocked(conn.indexes.peer_max_stream_uni, StreamType::UniDi);
-                    }
-                }
-                StreamType::BiDi => {
-                    if conn.indexes.peer_next_stream_bidi >= conn.indexes.peer_max_stream_bidi {
-                        conn.flow_mgr
-                            .borrow_mut()
-                            .streams_blocked(conn.indexes.peer_max_stream_bidi, StreamType::BiDi);
-                    }
-                }
-            },
-            // Resend StopSending
-            Frame::StopSending {
-                stream_id,
-                application_error_code,
-            } => conn
-                .flow_mgr
-                .borrow_mut()
-                .stop_sending(stream_id.into(), application_error_code),
-            // Resend MaxStreamData if not SizeKnown
-            // (maybe_send_flowc_update() checks this.)
-            Frame::MaxStreamData { stream_id, .. } => {
-                if let Some(rs) = conn.recv_streams.get_mut(&stream_id.into()) {
-                    rs.maybe_send_flowc_update()
-                }
-            }
-            Frame::PathResponse { .. } => qinfo!("Path Response lost, not re-sent"),
-            _ => qwarn!("Unexpected Flow frame {:?} lost, not re-sent", self.0),
-        }
+        Some((frame.clone(), Some(TokenType::Flow(frame))))
     }
 }

--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -151,11 +151,11 @@ impl FlowMgr {
         }
     }
 
-    pub(crate) fn need_close_frame(&self) -> bool {
+    pub fn need_close_frame(&self) -> bool {
         self.need_close_frame
     }
 
-    pub(crate) fn set_need_close_frame(&mut self, new: bool) {
+    pub fn set_need_close_frame(&mut self, new: bool) {
         self.need_close_frame = new
     }
 

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -12,6 +12,7 @@ use std::time::Instant;
 use neqo_common::{qdebug, Decoder, Encoder};
 use neqo_crypto::Epoch;
 
+use crate::recovery::TokenType;
 use crate::stream_id::StreamIndex;
 use crate::{Connection, ConnectionError, Error, Res};
 
@@ -581,7 +582,7 @@ pub enum TxMode {
     Pto,
 }
 
-pub trait FrameGenerator {
+pub(crate) trait FrameGenerator {
     fn generate(
         &mut self,
         conn: &mut Connection,
@@ -589,23 +590,12 @@ pub trait FrameGenerator {
         epoch: Epoch,
         tx_mode: TxMode,
         remaining: usize,
-    ) -> Option<(Frame, Option<Box<FrameGeneratorToken>>)>;
+    ) -> Option<(Frame, Option<TokenType>)>;
 }
 
 impl Debug for FrameGenerator {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("<FrameGenerator Function>")
-    }
-}
-
-pub trait FrameGeneratorToken {
-    fn acked(&mut self, conn: &mut Connection);
-    fn lost(&mut self, conn: &mut Connection);
-}
-
-impl Debug for FrameGeneratorToken {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("<FrameGenerator Token>")
     }
 }
 

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -241,11 +241,11 @@ impl LossRecovery {
         val
     }
 
-    pub(crate) fn increment_crypto_count(&mut self) {
+    pub fn increment_crypto_count(&mut self) {
         self.crypto_count += 1;
     }
 
-    pub(crate) fn increment_pto_count(&mut self) {
+    pub fn increment_pto_count(&mut self) {
         self.pto_count += 1;
     }
 
@@ -348,11 +348,7 @@ impl LossRecovery {
         max(rtt * 9 / 8, GRANULARITY)
     }
 
-    pub(crate) fn detect_lost_packets(
-        &mut self,
-        pn_space: PNSpace,
-        now: Instant,
-    ) -> Vec<SentPacket> {
+    pub fn detect_lost_packets(&mut self, pn_space: PNSpace, now: Instant) -> Vec<SentPacket> {
         self.enable_timed_loss_detection = false;
         let loss_delay = self.loss_delay();
 
@@ -411,7 +407,7 @@ impl LossRecovery {
         lost_packets
     }
 
-    pub(crate) fn get_timer(&mut self) -> LossRecoveryState {
+    pub fn get_timer(&mut self) -> LossRecoveryState {
         qdebug!([self] "get_loss_detection_timer.");
 
         let mut has_crypto_out = false;
@@ -484,7 +480,7 @@ impl LossRecovery {
     }
 
     /// Find when the earliest sent packet should be considered lost.
-    pub(crate) fn get_earliest_loss_time(&self) -> Option<(PNSpace, Instant)> {
+    pub fn get_earliest_loss_time(&self) -> Option<(PNSpace, Instant)> {
         if !self.enable_timed_loss_detection {
             return None;
         }

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -24,6 +24,8 @@ use neqo_common::qtrace;
 
 pub const RX_STREAM_DATA_WINDOW: u64 = 0xFFFF; // 64 KiB
 
+pub(crate) type RecvStreams = BTreeMap<StreamId, RecvStream>;
+
 /// Holds data not yet read by application. Orders and dedupes data ranges
 /// from incoming STREAM frames.
 #[derive(Debug, Default, PartialEq)]

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -701,41 +701,41 @@ impl SendStream {
 pub(crate) struct SendStreams(HashMap<StreamId, SendStream>);
 
 impl SendStreams {
-    pub(crate) fn get(&self, id: StreamId) -> Res<&SendStream> {
+    pub fn get(&self, id: StreamId) -> Res<&SendStream> {
         self.0.get(&id).ok_or_else(|| Error::InvalidStreamId)
     }
 
-    pub(crate) fn get_mut(&mut self, id: StreamId) -> Res<&mut SendStream> {
+    pub fn get_mut(&mut self, id: StreamId) -> Res<&mut SendStream> {
         self.0.get_mut(&id).ok_or_else(|| Error::InvalidStreamId)
     }
 
-    pub(crate) fn insert(&mut self, id: StreamId, stream: SendStream) {
+    pub fn insert(&mut self, id: StreamId, stream: SendStream) {
         self.0.insert(id, stream);
     }
 
-    pub(crate) fn acked(&mut self, token: StreamGeneratorToken) {
+    pub fn acked(&mut self, token: StreamGeneratorToken) {
         if let Some(ss) = self.0.get_mut(&token.id) {
             ss.mark_as_acked(token.offset, token.length as usize, token.fin);
         }
     }
 
-    pub(crate) fn reset_acked(&mut self, id: StreamId) {
+    pub fn reset_acked(&mut self, id: StreamId) {
         if let Some(ss) = self.0.get_mut(&id) {
             ss.reset_acked()
         }
     }
 
-    pub(crate) fn lost(&mut self, token: StreamGeneratorToken) {
+    pub fn lost(&mut self, token: StreamGeneratorToken) {
         if let Some(ss) = self.0.get_mut(&token.id) {
             ss.mark_as_lost(token.offset, token.length as usize, token.fin);
         }
     }
 
-    pub(crate) fn clear(&mut self) {
+    pub fn clear(&mut self) {
         self.0.clear()
     }
 
-    pub(crate) fn clear_terminal(&mut self) {
+    pub fn clear_terminal(&mut self) {
         self.0.retain(|_, stream| !stream.is_terminal())
     }
 }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -8,7 +8,7 @@
 
 use std::cell::RefCell;
 use std::cmp::{max, min};
-use std::collections::{btree_map::IterMut, BTreeMap};
+use std::collections::{hash_map::IterMut, BTreeMap, HashMap};
 use std::mem;
 use std::rc::Rc;
 use std::time::Instant;
@@ -698,7 +698,7 @@ impl SendStream {
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct SendStreams(BTreeMap<StreamId, SendStream>);
+pub(crate) struct SendStreams(HashMap<StreamId, SendStream>);
 
 impl SendStreams {
     pub(crate) fn get(&self, id: StreamId) -> Res<&SendStream> {
@@ -736,16 +736,7 @@ impl SendStreams {
     }
 
     pub(crate) fn clear_terminal(&mut self) {
-        let send_to_remove: SmallVec<[_; 8]> = self
-            .0
-            .iter()
-            .filter(|(_, stream)| stream.is_terminal())
-            .map(|(id, _)| *id)
-            .collect();
-
-        for id in send_to_remove {
-            self.0.remove(&id);
-        }
+        self.0.retain(|_, stream| !stream.is_terminal())
     }
 }
 

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -121,7 +121,7 @@ const MAX_ACKS_PER_FRAME: usize = 32;
 
 /// A structure that tracks what was included in an ACK.
 #[derive(Debug)]
-pub(crate) struct AckToken {
+pub struct AckToken {
     space: PNSpace,
     ranges: Vec<PacketRange>,
 }
@@ -336,7 +336,7 @@ impl AckTracker {
         }
     }
 
-    pub(crate) fn acked(&mut self, token: AckToken) {
+    pub fn acked(&mut self, token: AckToken) {
         self.spaces[token.space as usize].acknowledged(&token.ranges);
     }
 }


### PR DESCRIPTION
Redo timers. More clearly separate the two parts of a)
figuring out the duration and mode of the timer to set and
b) handling when a timer expired. There was some common code
that should not have been common, or at least was confusing,
I thought.

The way it works now is that the timer duration and mode is
set in next_delay() called in process_output(). This may
set a timer but also remembers what loss recovery mode is
active (if any) in loss_detection_state.

Then some time later, process_input() will be called, either
because a timer expired or because new packets have arrived.
check_loss_detection_timeout() handles this, and knows that
if a timer was the cause what to do without further steps, by
looking at loss_detection_state. There are still TODOs in
check_loss_detection_timeout for actually altering output but
we're in a good place now to add an "output policy" state
machine to handle behavior across multiple calls to
process_output() once we move to returning a single packet.

The OTHER big thing that was yak-shaved from the first was
to use an enum for tracking SentPacket tokens instead of
a trait object. Basically, calling a method on a subsystem
with the token as a parameter is much better than calling
a method on the token and passing in the entire connection,
from an ownership perspective. Doing so works well with
breaking up the functional parts of connection into
individual structs. Now, instead of Connection being passed
to a method, only the relevant parts need to be passed.
Remembering the type of tokens is necessary for this to work.

Along with this was creating a SendStreams struct. In
addition to making the above easier, it also allowed spots
of repetitive code around streams to be unified.

Also, with new code I've been using pub(crate) instead of
vanilla pub. I think we'll want to eventually do a mass
conversion but this should be a step towards using it more.

Finally, made Connection::events return an iterator instead
of a Vec.