### PR TITLE
Close connection if idle timeout expires

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -7,7 +7,7 @@
 #![deny(warnings)]
 use neqo_common::Datagram;
 use neqo_crypto::init_db;
-use neqo_http3::{Http3Connection, Http3Event, Http3State};
+use neqo_http3::{Http3Connection, Http3Event, Http3State, Output};
 use neqo_transport::Connection;
 use std::collections::HashSet;
 use std::io::{self, ErrorKind};
@@ -150,30 +150,50 @@ fn process_loop(
             return client.state();
         }
 
-        let exiting = !handler.handle(args, client);
+        let mut exiting = !handler.handle(args, client);
 
-        let out_dgram = client.process_output(Instant::now());
-        emit_datagram(&socket, out_dgram.dgram());
+        loop {
+            let output = client.process_output(Instant::now());
+            match output {
+                Output::Datagram(dgram) => emit_datagram(&socket, Some(dgram)),
+                Output::Callback(duration) => {
+                    eprintln!("Timeout for {:?}", duration);
+                    socket.set_read_timeout(Some(duration)).unwrap();
+                    break;
+                }
+                Output::None => {
+                    eprintln!("Output::None");
+                    socket.set_read_timeout(None).unwrap();
+                    exiting = true;
+                    break;
+                }
+            }
+        }
 
         if exiting {
             return client.state();
         }
 
-        let sz = match socket.recv(&mut buf[..]) {
+        match socket.recv(&mut buf[..]) {
+            Err(ref err) if err.kind() == ErrorKind::WouldBlock => {
+                // timer expired
+                client.process_timer(Instant::now());
+            }
             Err(err) => {
                 eprintln!("UDP error: {}", err);
                 exit(1)
             }
-            Ok(sz) => sz,
+            Ok(sz) => {
+                if sz == buf.len() {
+                    eprintln!("Received more than {} bytes", buf.len());
+                    continue;
+                }
+                if sz > 0 {
+                    let d = Datagram::new(*remote_addr, *local_addr, &buf[..sz]);
+                    client.process_input(d, Instant::now());
+                }
+            }
         };
-        if sz == buf.len() {
-            eprintln!("Received more than {} bytes", buf.len());
-            continue;
-        }
-        if sz > 0 {
-            let d = Datagram::new(*remote_addr, *local_addr, &buf[..sz]);
-            client.process_input(d, Instant::now());
-        }
     }
 }
 
@@ -261,18 +281,21 @@ fn client(args: Args, socket: UdpSocket, local_addr: SocketAddr, remote_addr: So
         &args,
     );
 
-    let client_stream_id = client
-        .fetch(
-            &args.method,
-            &args.url.scheme(),
-            &args.url.host_str().unwrap(),
-            &args.url.path(),
-            &args.headers.h,
-        )
-        .unwrap();
+    let client_stream_id = client.fetch(
+        &args.method,
+        &args.url.scheme(),
+        &args.url.host_str().unwrap(),
+        &args.url.path(),
+        &args.headers.h,
+    );
+
+    if let Err(err) = client_stream_id {
+        eprintln!("Could not connect: {:?}", err);
+        return;
+    }
 
     let mut h2 = PostConnectHandler::default();
-    h2.streams.insert(client_stream_id);
+    h2.streams.insert(client_stream_id.unwrap());
     process_loop(
         &local_addr,
         &remote_addr,

--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -231,8 +231,13 @@ fn main() -> Result<(), io::Error> {
                 )
             });
 
-            for dgram in dgrams {
-                server.process_input(dgram, Instant::now());
+            if dgrams.is_empty() {
+                // timer expired
+                server.process_timer(Instant::now())
+            } else {
+                for dgram in dgrams {
+                    server.process_input(dgram, Instant::now());
+                }
             }
             if let Http3State::Closed(e) = server.state() {
                 println!("Closed connection from {:?}: {:?}", remote_addr, e);

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -320,6 +320,12 @@ impl Http3Connection {
         self.check_state_change(now);
     }
 
+    pub fn process_timer(&mut self, now: Instant) {
+        qdebug!([self] "Process timer.");
+        self.conn.process_timer(now);
+        self.check_state_change(now);
+    }
+
     pub fn conn(&mut self) -> &mut Connection {
         &mut self.conn
     }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -13,6 +13,7 @@ pub mod request_stream_server;
 
 use neqo_qpack;
 use neqo_transport;
+pub use neqo_transport::Output;
 
 use self::hframe::HFrameType;
 

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -66,6 +66,7 @@ pub enum Error {
     InvalidResumptionToken,
     WrongRole,
     InvalidInput,
+    IdleTimeout,
     PeerError(TransportError),
 }
 
@@ -102,7 +103,8 @@ impl Error {
             | Error::VersionNegotiation
             | Error::WrongRole
             | Error::InvalidResumptionToken
-            | Error::InvalidInput => 1,
+            | Error::InvalidInput
+            | Error::IdleTimeout => 1,
         }
     }
 }


### PR DESCRIPTION
If no other things are happening, set a 1 minute idle
timeout, at which point connection moves to Closing state.
Since next_delay() will now always return something, it
no longer needs to be an Option.

Add error value as needed.

Remove Connection::process() in favor of using same-named
helper code in tests. Unfortunately this requires changes
to all call sites.

fixes #38