### PR TITLE
Gecko inits log as well, so we cannot hard fail.

### DIFF
--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -29,8 +29,11 @@ pub fn init() {
                 record.args()
             )
         });
-        builder.init();
-        ::log::log!(::log::Level::Info, "Logging initialized");
+        if let Err(e) = builder.try_init() {
+            ::log::log!(::log::Level::Info, "Logging initialization error {:?}", e);
+        } else {
+            ::log::log!(::log::Level::Info, "Logging initialized");
+        }
     });
 }
 


### PR DESCRIPTION
We cannot use builder.init because it will panic when it is used with gecko. Other rust components may already initialized logging.