### PR TITLE
Fix h3 stream fin

### DIFF
--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1962,4 +1962,115 @@ mod tests {
         assert_eq!(hconn.state(), Http3State::GoingAway);
         hconn.close(now(), 0, String::from(""));
     }
+
+    #[test]
+    fn test_stream_fin_wo_data() {
+        let (mut hconn, mut neqo_trans_conn, _) = connect_and_receive_control_stream(true);
+        let request_stream_id = hconn
+            .fetch(
+                &"GET".to_string(),
+                &"https".to_string(),
+                &"something.com".to_string(),
+                &"/".to_string(),
+                &Vec::<(String, String)>::new(),
+            )
+            .unwrap();
+        assert_eq!(request_stream_id, 0);
+
+        let out = hconn.process(None, now());
+        neqo_trans_conn.process(out.dgram(), now());
+
+        // find the new request/response stream and send frame v on it.
+        let events = neqo_trans_conn.events();
+        for e in events {
+            match e {
+                ConnectionEvent::NewStream {
+                    stream_id,
+                    stream_type,
+                } => {
+                    assert_eq!(stream_id, request_stream_id);
+                    assert_eq!(stream_type, StreamType::BiDi);
+                }
+                ConnectionEvent::RecvStreamReadable { stream_id } => {
+                    assert_eq!(stream_id, request_stream_id);
+                    let mut buf = [0u8; 100];
+                    let (amount, fin) = neqo_trans_conn.stream_recv(stream_id, &mut buf).unwrap();
+                    assert_eq!(fin, true);
+                    assert_eq!(amount, 18);
+                    assert_eq!(
+                        buf[..18],
+                        [
+                            0x01, 0x10, 0x00, 0x00, 0xd1, 0xd7, 0x50, 0x89, 0x41, 0xe9, 0x2a, 0x67,
+                            0x35, 0x53, 0x2e, 0x43, 0xd3, 0xc1
+                        ]
+                    );
+
+                    // Send some good data wo fin
+                    let data = &[
+                        // headers
+                        0x01, 0x06, 0x00, 0x00, 0xd9, 0x54, 0x01, 0x33,
+                        // the data frame is complete.
+                        0x0, 0x3, 0x61, 0x62, 0x63,
+                    ];
+                    let _ = neqo_trans_conn.stream_send(stream_id, data);
+                }
+                _ => {}
+            }
+        }
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
+
+        // Recv some good data wo fin
+        let http_events = hconn.events();
+        for e in http_events {
+            match e {
+                Http3Event::DataReadable { stream_id } => {
+                    assert_eq!(stream_id, request_stream_id);
+                    let mut buf = [0u8; 100];
+                    match hconn.read_data(now(), stream_id, &mut buf) {
+                        Err(_e) => {
+                            assert!(false);
+                        }
+                        Ok((len, fin)) => {
+                            assert_eq!(&buf[..len], &[0x61, 0x62, 0x63]);
+                            assert_eq!(fin, false);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // ok NOW send fin
+        neqo_trans_conn.stream_close_send(0).unwrap();
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
+
+        // fin wo data should generate DataReadable
+        match hconn.events().into_iter().next().unwrap() {
+            Http3Event::DataReadable { stream_id } => {
+                assert_eq!(stream_id, request_stream_id);
+                let mut buf = [0u8; 100];
+                match hconn.read_data(now(), stream_id, &mut buf) {
+                    Err(_e) => {
+                        assert!(false);
+                    }
+                    Ok((len, fin)) => {
+                        assert_eq!(0, len);
+                        assert_eq!(fin, true);
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        // Stream should now be closed and gone
+        let mut buf = [0u8; 100];
+        assert_eq!(
+            hconn.read_data(now(), 0, &mut buf),
+            Err(Error::TransportError(
+                neqo_transport::Error::InvalidStreamId
+            ))
+        );
+    }
 }


### PR DESCRIPTION
Testing against F5 revealed http3 doesn't generate an event if a 0-length stream frame with fin set is received.

Hat tip: Martin Duke