### PR TITLE
Add info message if we get a valid retry packet

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -527,6 +527,7 @@ impl Connection {
                             path.remote_cid = hdr.scid.expect("Retry pkt must have SCID");
                         }
                     }
+                    qinfo!("received valid Retry, but we don't do anything with these yet.");
                     self.retry_token = Some(token.clone());
                     return Ok(());
                 }


### PR DESCRIPTION
We don't yet actually retry (#15), but it's good to be
clear why the connection is stuck, so it's not just a
mystery.