### PR TITLE
Updated the run test http 3 programs example to match the new args.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ To run test http 0.9 programs (neqo-client and neqo-server):
 To run test http 3 programs (neqo-client and neqo-http3-server):
 
 * `cargo build`
-* `./target/debug/neqo-http3-server -p 12345 --db ./test-fixture/db`
+* `./target/debug/neqo-http3-server [::]:12345 --db ./test-fixture/db`
 * `./target/debug/neqo-client http://127.0.0.1:12345/ --db ./test-fixture/db`
 


### PR DESCRIPTION
As seen [here](https://github.com/mozilla/neqo/blob/master/neqo-http3-server/src/main.rs#L32) the host:ports to listen to have changed lately.

The readme was unfortunately not up to date anymore.