### PR TITLE
Splitted the request handler function into a RequestHandler type.

### DIFF
--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -8,6 +8,7 @@
 
 use neqo_common::{qdebug, qinfo, Datagram};
 use neqo_crypto::{init_db, AntiReplay};
+use neqo_http3::request_stream_server::{Header, Response};
 use neqo_http3::{Http3Connection, Http3State};
 use neqo_transport::{Connection, Output};
 use std::collections::HashMap;
@@ -63,10 +64,7 @@ impl Args {
     }
 }
 
-fn http_serve(
-    request_headers: &[(String, String)],
-    _error: bool,
-) -> (Vec<(String, String)>, Vec<u8>) {
+fn http_serve(request_headers: &[Header], _error: bool) -> Response {
     println!("Serve a request");
 
     println!("Headers: {:?}", request_headers);

--- a/neqo-http3/src/request_stream_client.rs
+++ b/neqo-http3/src/request_stream_client.rs
@@ -7,6 +7,7 @@
 use crate::hframe::{HFrame, HFrameReader, H3_FRAME_TYPE_DATA, H3_FRAME_TYPE_HEADERS};
 
 use crate::connection::Http3Events;
+use crate::request_stream_server::Header;
 
 use neqo_common::{qdebug, qinfo, Encoder};
 use neqo_qpack::decoder::QPackDecoder;
@@ -27,13 +28,7 @@ struct Request {
 }
 
 impl Request {
-    pub fn new(
-        method: &str,
-        scheme: &str,
-        host: &str,
-        path: &str,
-        headers: &[(String, String)],
-    ) -> Request {
+    pub fn new(method: &str, scheme: &str, host: &str, path: &str, headers: &[Header]) -> Request {
         let mut r = Request {
             method: method.to_owned(),
             scheme: scheme.to_owned(),
@@ -136,7 +131,7 @@ impl RequestStreamClient {
         scheme: &str,
         host: &str,
         path: &str,
-        headers: &[(String, String)],
+        headers: &[Header],
         conn_events: Http3Events,
     ) -> RequestStreamClient {
         qinfo!("Create a request stream_id={}", stream_id);

--- a/neqo-http3/src/request_stream_server.rs
+++ b/neqo-http3/src/request_stream_server.rs
@@ -12,6 +12,10 @@ use neqo_qpack::encoder::QPackEncoder;
 use neqo_transport::Connection;
 use std::mem;
 
+pub type Header = (String, String);
+pub type Response = (Vec<Header>, Vec<u8>);
+pub type RequestHandler = Box<FnMut(&[Header], bool) -> Response>;
+
 #[derive(PartialEq, Debug)]
 enum RequestStreamServerState {
     WaitingForRequestHeaders,
@@ -27,7 +31,7 @@ pub struct RequestStreamServer {
     state: RequestStreamServerState,
     stream_id: u64,
     frame_reader: HFrameReader,
-    request_headers: Option<Vec<(String, String)>>,
+    request_headers: Option<Vec<Header>>,
     response_buf: Option<Vec<u8>>,
     fin: bool,
 }
@@ -44,7 +48,7 @@ impl RequestStreamServer {
         }
     }
 
-    pub fn get_request_headers(&self) -> &[(String, String)] {
+    pub fn get_request_headers(&self) -> &[Header] {
         if let Some(h) = &self.request_headers {
             h
         } else {
@@ -52,12 +56,7 @@ impl RequestStreamServer {
         }
     }
 
-    pub fn set_response(
-        &mut self,
-        headers: &[(String, String)],
-        data: Vec<u8>,
-        encoder: &mut QPackEncoder,
-    ) {
+    pub fn set_response(&mut self, headers: &[Header], data: Vec<u8>, encoder: &mut QPackEncoder) {
         qdebug!([self] "Encoding headers");
         let encoded_headers = encoder.encode_header_block(&headers, self.stream_id);
         let hframe = HFrame::Headers {

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -7,13 +7,11 @@
 #![allow(unused_assignments)]
 
 use neqo_common::Datagram;
+use neqo_http3::request_stream_server::{Header, Response};
 use neqo_http3::{Http3Connection, Http3State};
 use test_fixture::*;
 
-fn new_stream_callback(
-    request_headers: &[(String, String)],
-    error: bool,
-) -> (Vec<(String, String)>, Vec<u8>) {
+fn new_stream_callback(request_headers: &[Header], error: bool) -> Response {
     println!("Error: {}", error);
 
     assert_eq!(


### PR DESCRIPTION
WIP to fix #41 .
There's a couple of uses of &[Header] and Vec<Header>.

@martinthomson would it be worth considering switching every use to a Vec and having a Headers type? 

I'm not really sure of the performance implications, but it might make the code easier to read ?

