### PR TITLE
Http3 nits

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -202,7 +202,7 @@ impl Handler for PostConnectHandler {
                         return false;
                     }
 
-                    let headers = client.get_headers(stream_id);
+                    let headers = client.get_response_headers(stream_id);
                     println!("READ HEADERS[{}]: {:?}", stream_id, headers);
                 }
                 Http3Event::DataReadable { stream_id } => {
@@ -212,7 +212,7 @@ impl Handler for PostConnectHandler {
                     }
 
                     let (sz, fin) = client
-                        .read_data(Instant::now(), stream_id, &mut data)
+                        .read_response_data(Instant::now(), stream_id, &mut data)
                         .expect("Read should succeed");
                     if args.omit_read_data {
                         println!("READ[{}]: {} bytes", stream_id, sz);

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -13,9 +13,7 @@ use neqo_common::{
 };
 use neqo_qpack::decoder::{QPackDecoder, QPACK_UNI_STREAM_TYPE_DECODER};
 use neqo_qpack::encoder::{QPackEncoder, QPACK_UNI_STREAM_TYPE_ENCODER};
-use neqo_transport::{
-    AppError, CloseError, Connection, ConnectionEvent, Output, Role, State, StreamType,
-};
+use neqo_transport::{AppError, CloseError, Connection, ConnectionEvent, Output, Role, StreamType};
 
 use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap};
@@ -285,26 +283,6 @@ impl Http3Connection {
         self.conn.role()
     }
 
-    pub fn check_state_change(&mut self, now: Instant) {
-        match self.state {
-            Http3State::Initializing => {
-                if self.conn.state().clone() == State::Connected {
-                    self.state = Http3State::Connected;
-                    self.events.connected();
-                    let res = self.initialize_http3_connection();
-                    self.check_result(now, res);
-                }
-            }
-            Http3State::Connected => {
-                if let State::Closing { error, .. } = self.conn.state().clone() {
-                    self.events.connection_closing();
-                    self.state = Http3State::Closing(error.into());
-                }
-            }
-            _ => {}
-        }
-    }
-
     pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
         qdebug!([self] "Process.");
         if let Some(d) = dgram {
@@ -317,7 +295,6 @@ impl Http3Connection {
     pub fn process_input(&mut self, dgram: Datagram, now: Instant) {
         qdebug!([self] "Process input.");
         self.conn.process_input(dgram, now);
-        self.check_state_change(now);
     }
 
     pub fn conn(&mut self) -> &mut Connection {
@@ -339,7 +316,11 @@ impl Http3Connection {
                 let res = self.process_sending();
                 self.check_result(now, res);
             }
-            _ => {}
+            Http3State::Closed { .. } => {}
+            _ => {
+                let res = self.check_connection_events();
+                let _ = self.check_result(now, res);
+            }
         }
     }
 
@@ -392,6 +373,12 @@ impl Http3Connection {
         Ok(())
     }
 
+    // Active state means that we still can recv new streams, recv data and send data.
+    // This is Connected state and GoingAway (in this state some streams are still active).
+    fn state_active(&self) -> bool {
+        (self.state == Http3State::Connected) || (self.state == Http3State::GoingAway)
+    }
+
     // If this return an error the connection must be closed.
     fn check_connection_events(&mut self) -> Res<()> {
         qdebug!([self] "check_connection_events");
@@ -403,8 +390,11 @@ impl Http3Connection {
                     stream_id,
                     stream_type,
                 } => self.handle_new_stream(stream_id, stream_type)?,
-                ConnectionEvent::SendStreamWritable { .. } => {}
+                ConnectionEvent::SendStreamWritable { .. } => {
+                    assert!(self.state_active());
+                }
                 ConnectionEvent::RecvStreamReadable { stream_id } => {
+                    assert!(self.state_active());
                     self.streams_are_readable.insert(stream_id);
                 }
                 ConnectionEvent::RecvStreamReset {
@@ -421,6 +411,10 @@ impl Http3Connection {
                 ConnectionEvent::SendStreamCreatable { stream_type } => {
                     self.handle_stream_creatable(stream_type)?
                 }
+                ConnectionEvent::ConnectionConnected => self.handle_connection_connected()?,
+                ConnectionEvent::ConnectionClosing { error_code, .. } => {
+                    self.handle_connection_closing(error_code)?
+                }
                 ConnectionEvent::ConnectionClosed { error_code, .. } => {
                     self.handle_connection_closed(error_code)?
                 }
@@ -435,6 +429,7 @@ impl Http3Connection {
 
     fn handle_new_stream(&mut self, stream_id: u64, stream_type: StreamType) -> Res<()> {
         qdebug!([self] "A new stream: {:?} {}.", stream_type, stream_id);
+        assert!(self.state_active());
         match stream_type {
             StreamType::BiDi => match self.role() {
                 Role::Server => self.handle_new_client_request(stream_id),
@@ -469,6 +464,7 @@ impl Http3Connection {
 
     fn handle_stream_readable(&mut self, stream_id: u64) -> Res<()> {
         qdebug!([self] "Readable stream {}.", stream_id);
+        assert!(self.state_active());
         let label = if ::log::log_enabled!(::log::Level::Debug) {
             format!("{}", self)
         } else {
@@ -541,22 +537,39 @@ impl Http3Connection {
     }
 
     fn handle_stream_reset(&mut self, stream_id: u64, app_err: AppError) -> Res<()> {
+        assert!(self.state_active());
         self.events.reset(stream_id, app_err);
         Ok(())
     }
 
     fn handle_stream_stop_sending(&mut self, _stream_id: u64, _app_err: AppError) -> Res<()> {
+        assert!(self.state_active());
         Ok(())
     }
 
     fn handle_stream_complete(&mut self, _stream_id: u64) -> Res<()> {
+        assert!(self.state_active());
         Ok(())
     }
 
     fn handle_stream_creatable(&mut self, stream_type: StreamType) -> Res<()> {
+        assert!(self.state_active());
         if stream_type == StreamType::BiDi {
             self.events.new_requests_creatable();
         }
+        Ok(())
+    }
+
+    fn handle_connection_connected(&mut self) -> Res<()> {
+        assert_eq!(self.state, Http3State::Initializing);
+        self.events.connection_connected();
+        self.state = Http3State::Connected;
+        self.initialize_http3_connection()
+    }
+
+    fn handle_connection_closing(&mut self, error_code: CloseError) -> Res<()> {
+        self.events.connection_closing(error_code);
+        self.state = Http3State::Closing(error_code);
         Ok(())
     }
 
@@ -849,7 +862,7 @@ impl Http3Connection {
                     Http3Event::Reset { .. }
                     | Http3Event::ConnectionConnected
                     | Http3Event::GoawayReceived
-                    | Http3Event::ConnectionClosing
+                    | Http3Event::ConnectionClosing { .. }
                     | Http3Event::ConnectionClosed { .. } => true,
                     Http3Event::RequestsCreatable => false,
                 })
@@ -952,34 +965,23 @@ impl Http3Connection {
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone)]
 pub enum Http3Event {
     /// Space available in the buffer for an application write to succeed.
-    HeaderReady {
-        stream_id: u64,
-    },
+    HeaderReady { stream_id: u64 },
     /// New bytes available for reading.
-    DataReadable {
-        stream_id: u64,
-    },
+    DataReadable { stream_id: u64 },
     /// Peer reset the stream.
-    Reset {
-        stream_id: u64,
-        error: AppError,
-    },
+    Reset { stream_id: u64, error: AppError },
     /// A new push stream
-    NewPushStream {
-        stream_id: u64,
-    },
+    NewPushStream { stream_id: u64 },
     /// New stream can be created
     RequestsCreatable,
-    // Connection change state to Connected.
+    /// Connection change state to Connected.
     ConnectionConnected,
-    // Client has received a GOAWAY frame
+    /// Client has received a GOAWAY frame
     GoawayReceived,
-    // Connection change state to Closing.
-    ConnectionClosing,
-    // Connection change state to Closed.
-    ConnectionClosed {
-        error_code: CloseError,
-    },
+    /// Connection change state to Closing.
+    ConnectionClosing { error_code: CloseError },
+    /// Connection change state to Closed.
+    ConnectionClosed { error_code: CloseError },
 }
 
 #[derive(Debug, Default, Clone)]
@@ -1008,7 +1010,7 @@ impl Http3Events {
         self.insert(Http3Event::RequestsCreatable);
     }
 
-    pub fn connected(&self) {
+    pub fn connection_connected(&self) {
         self.insert(Http3Event::ConnectionConnected);
     }
 
@@ -1016,8 +1018,8 @@ impl Http3Events {
         self.insert(Http3Event::GoawayReceived);
     }
 
-    pub fn connection_closing(&self) {
-        self.insert(Http3Event::ConnectionClosing);
+    pub fn connection_closing(&self, error_code: CloseError) {
+        self.insert(Http3Event::ConnectionClosing { error_code });
     }
 
     pub fn connection_closed(&self, error_code: CloseError) {
@@ -1041,6 +1043,7 @@ impl Http3Events {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use neqo_transport::State;
     use test_fixture::*;
 
     fn assert_closed(hconn: &Http3Connection, expected: Error) {
@@ -1143,6 +1146,7 @@ mod tests {
                 ConnectionEvent::SendStreamWritable { stream_id } => {
                     assert!((stream_id == 2) || (stream_id == 6) || (stream_id == 10));
                 }
+                ConnectionEvent::ConnectionConnected => {}
                 _ => panic!("unexpected event"),
             }
         }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -8,8 +8,8 @@
 
 pub mod connection;
 pub mod hframe;
-mod request_stream_client;
-pub mod request_stream_server;
+mod transaction_client;
+pub mod transaction_server;
 
 use neqo_qpack;
 use neqo_transport;
@@ -17,7 +17,7 @@ use neqo_transport;
 use self::hframe::HFrameType;
 
 pub use connection::{Http3Connection, Http3Event, Http3State};
-pub use request_stream_server::RequestStreamServer;
+pub use transaction_server::TransactionServer;
 
 type Res<T> = Result<T, Error>;
 

--- a/neqo-http3/src/transaction_client.rs
+++ b/neqo-http3/src/transaction_client.rs
@@ -93,22 +93,40 @@ impl Response {
 }
 
 /*
- *  States:
- *    SendingRequest,
- *    WaitingForResponseHeaders : we wait for headers. in this state we can also get PRIORITY frame
- *                                or a PUSH_PROMISE.
- *    ReadingHeaders : we got HEADERS frame headerand now we are reading header block.
- *    WaitingForData : we got HEADERS, we are waiting for one or more data frames. In this state we
- *                    can receive one or more PUSH_PROMIS frames or a HEADERS frame carrying trailers.
- *    ReadingData : we got a DATA frame, now we leting app read payload. From here we will go back to
- *                 WaitingForData state to wait for more data frames or to CLosed state
- *    ReadingTrailers : reading trailers.
- *    Closed : waiting for app to pick up data, after that we can delete the RequestStreamClient.
+ *  Transaction send states:
+ *    SendingHeaders : sending headers. From here we may switch to SendingData  *                     or Closed (if the app does not want to send data and
+ *                     has alreadyclosed the send stream).
+ *    SendingData : We are sending request data until the app closes stream.
+ *    Closed
  */
 
 #[derive(PartialEq, Debug)]
-enum RequestStreamClientState {
-    SendingRequest,
+enum TransactionSendState {
+    SendingHeaders,
+    SendingData,
+    Closed,
+}
+
+/*
+ * Transaction receive state:
+ *    WaitingForResponseHeaders : we wait for headers. in this state we can
+ *                                also get PRIORITY frame or a PUSH_PROMISE.
+ *    ReadingHeaders : we have HEADERS frame and now we are reading header
+ *                     block. This may block on encoder instructions. In this
+ *                     state we do no read from the stream.
+ *    WaitingForData : we got HEADERS, we are waiting for one or more data
+ *                     frames. In this state we can receive one or more
+ *                     PUSH_PROMIS frames or a HEADERS frame carrying trailers.
+ *    ReadingData : we got a DATA frame, now we letting the app read payload.
+ *                  From here we will go back to WaitingForData state to wait
+ *                  for more data frames or to CLosed state
+ *    ReadingTrailers : reading trailers.
+ *    ClosePending : waiting for app to pick up data, after that we can delete
+ * the TransactionClient.
+ *    Closed
+ */
+#[derive(PartialEq, Debug)]
+enum TransactionRecvState {
     WaitingForResponseHeaders,
     ReadingHeaders { buf: Vec<u8>, offset: usize },
     BlockedDecodingHeaders { buf: Vec<u8> },
@@ -120,8 +138,9 @@ enum RequestStreamClientState {
 }
 
 //  This is used for normal request/responses.
-pub struct RequestStreamClient {
-    state: RequestStreamClientState,
+pub struct TransactionClient {
+    send_state: TransactionSendState,
+    recv_state: TransactionRecvState,
     stream_id: u64,
     request: Request,
     response: Response,
@@ -129,7 +148,7 @@ pub struct RequestStreamClient {
     conn_events: Http3Events,
 }
 
-impl RequestStreamClient {
+impl TransactionClient {
     pub fn new(
         stream_id: u64,
         method: &str,
@@ -138,10 +157,11 @@ impl RequestStreamClient {
         path: &str,
         headers: &[(String, String)],
         conn_events: Http3Events,
-    ) -> RequestStreamClient {
+    ) -> TransactionClient {
         qinfo!("Create a request stream_id={}", stream_id);
-        RequestStreamClient {
-            state: RequestStreamClientState::SendingRequest,
+        TransactionClient {
+            send_state: TransactionSendState::SendingHeaders,
+            recv_state: TransactionRecvState::WaitingForResponseHeaders,
             stream_id,
             request: Request::new(method, scheme, host, path, headers),
             response: Response::new(),
@@ -157,7 +177,7 @@ impl RequestStreamClient {
         } else {
             String::new()
         };
-        if self.state == RequestStreamClientState::SendingRequest {
+        if self.send_state == TransactionSendState::SendingHeaders {
             if self.request.buf.is_none() {
                 self.request.encode_request(encoder, self.stream_id);
             }
@@ -167,7 +187,7 @@ impl RequestStreamClient {
                 if sent == d.len() {
                     self.request.buf = None;
                     conn.stream_close_send(self.stream_id)?;
-                    self.state = RequestStreamClientState::WaitingForResponseHeaders;
+                    self.send_state = TransactionSendState::Closed;
                     qdebug!([label] "done sending request");
                 } else {
                     let b = d.split_off(sent);
@@ -180,7 +200,7 @@ impl RequestStreamClient {
 
     fn recv_frame(&mut self, conn: &mut Connection) -> Res<()> {
         if self.frame_reader.receive(conn, self.stream_id)? {
-            self.state = RequestStreamClientState::ClosePending;
+            self.recv_state = TransactionRecvState::ClosePending;
         }
         Ok(())
     }
@@ -192,14 +212,9 @@ impl RequestStreamClient {
             String::new()
         };
         loop {
-            qdebug!([label] "state={:?}.", self.state);
-            match self.state {
-                RequestStreamClientState::SendingRequest => {
-                    /*TODO(dd.mozilla@gmail.com) if we get response while streaming data. We may also get a stop_sending...*/
-                    // this currently cannot happen
-                    break Ok(());
-                }
-                RequestStreamClientState::WaitingForResponseHeaders => {
+            qdebug!([label] "send_state={:?} recv_state={:?}.", self.send_state, self.recv_state);
+            match self.recv_state {
+                TransactionRecvState::WaitingForResponseHeaders => {
                     self.recv_frame(conn)?;
                     if !self.frame_reader.done() {
                         break Ok(());
@@ -207,7 +222,6 @@ impl RequestStreamClient {
                     let f = self.frame_reader.get_frame()?;
                     qdebug!([label] "A new frame has been received: {:?}", f);
                     match f {
-                        //self.frame_reader.get_frame()? {
                         HFrame::Priority { .. } => break Err(Error::UnexpectedFrame),
                         HFrame::Headers { len } => self.handle_headers_frame(len)?,
                         HFrame::PushPromise { .. } => break Err(Error::UnexpectedFrame),
@@ -216,14 +230,14 @@ impl RequestStreamClient {
                         }
                     };
                 }
-                RequestStreamClientState::ReadingHeaders {
+                TransactionRecvState::ReadingHeaders {
                     ref mut buf,
                     ref mut offset,
                 } => {
                     let (amount, fin) = conn.stream_recv(self.stream_id, &mut buf[*offset..])?;
                     qdebug!(
                         [label]
-                        "state=ReadingHeaders: read {} bytes fin={}.",
+                        "recv_state=ReadingHeaders: read {} bytes fin={}.",
                         amount,
                         fin
                     );
@@ -233,7 +247,7 @@ impl RequestStreamClient {
                             // Malformated frame
                             break Err(Error::MalformedFrame(H3_FRAME_TYPE_HEADERS));
                         }
-                        self.state = RequestStreamClientState::Closed;
+                        self.recv_state = TransactionRecvState::Closed;
                         break Ok(());
                     }
                     if *offset < buf.len() {
@@ -245,16 +259,16 @@ impl RequestStreamClient {
                         qdebug!([label] "decoding header is blocked.");
                         let mut tmp: Vec<u8> = Vec::new();
                         mem::swap(&mut tmp, buf);
-                        self.state = RequestStreamClientState::BlockedDecodingHeaders { buf: tmp };
+                        self.recv_state = TransactionRecvState::BlockedDecodingHeaders { buf: tmp };
                     } else {
                         self.conn_events.header_ready(self.stream_id);
-                        self.state = RequestStreamClientState::WaitingForData;
+                        self.recv_state = TransactionRecvState::WaitingForData;
                     }
                 }
-                RequestStreamClientState::BlockedDecodingHeaders { .. } => break Ok(()),
-                RequestStreamClientState::WaitingForData => {
+                TransactionRecvState::BlockedDecodingHeaders { .. } => break Ok(()),
+                TransactionRecvState::WaitingForData => {
                     self.recv_frame(conn)?;
-                    if self.state == RequestStreamClientState::ClosePending {
+                    if self.recv_state == TransactionRecvState::ClosePending {
                         // Received 0 byte fin? Client must see this.
                         self.conn_events.data_readable(self.stream_id);
                     }
@@ -272,15 +286,15 @@ impl RequestStreamClient {
                         _ => break Err(Error::WrongStream),
                     };
                 }
-                RequestStreamClientState::ReadingData { .. } => {
+                TransactionRecvState::ReadingData { .. } => {
                     self.conn_events.data_readable(self.stream_id);
                     break Ok(());
                 }
-                //                RequestStreamClientState::ReadingTrailers => break Ok(()),
-                RequestStreamClientState::ClosePending => {
+                //                TransactionRecvState::ReadingTrailers => break Ok(()),
+                TransactionRecvState::ClosePending => {
                     panic!("Stream readable after being closed!");
                 }
-                RequestStreamClientState::Closed => {
+                TransactionRecvState::Closed => {
                     panic!("Stream readable after being closed!");
                 }
             };
@@ -288,13 +302,13 @@ impl RequestStreamClient {
     }
 
     fn handle_headers_frame(&mut self, len: u64) -> Res<()> {
-        if self.state == RequestStreamClientState::Closed {
+        if self.recv_state == TransactionRecvState::Closed {
             return Ok(());
         }
         if len == 0 {
-            self.state = RequestStreamClientState::WaitingForData;
+            self.recv_state = TransactionRecvState::WaitingForData;
         } else {
-            self.state = RequestStreamClientState::ReadingHeaders {
+            self.recv_state = TransactionRecvState::ReadingHeaders {
                 buf: vec![0; len as usize],
                 offset: 0,
             };
@@ -304,23 +318,23 @@ impl RequestStreamClient {
 
     fn handle_data_frame(&mut self, len: u64) -> Res<()> {
         self.response.data_len = len;
-        if self.state != RequestStreamClientState::Closed {
+        if self.recv_state != TransactionRecvState::Closed {
             if self.response.data_len > 0 {
-                self.state = RequestStreamClientState::ReadingData {
+                self.recv_state = TransactionRecvState::ReadingData {
                     remaining_data_len: len as usize,
                 };
             } else {
-                self.state = RequestStreamClientState::WaitingForData;
+                self.recv_state = TransactionRecvState::WaitingForData;
             }
         }
         Ok(())
     }
 
     pub fn unblock(&mut self, decoder: &mut QPackDecoder) -> Res<()> {
-        if let RequestStreamClientState::BlockedDecodingHeaders { ref mut buf } = self.state {
+        if let TransactionRecvState::BlockedDecodingHeaders { ref mut buf } = self.recv_state {
             self.response.headers = decoder.decode_header_block(buf, self.stream_id)?;
             self.conn_events.header_ready(self.stream_id);
-            self.state = RequestStreamClientState::WaitingForData;
+            self.recv_state = TransactionRecvState::WaitingForData;
             if self.response.headers.is_none() {
                 panic!("We must not be blocked again!");
             }
@@ -331,17 +345,19 @@ impl RequestStreamClient {
     }
 
     pub fn close_send(&mut self, conn: &mut Connection) -> Res<()> {
-        self.state = RequestStreamClientState::WaitingForResponseHeaders;
+        self.send_state = TransactionSendState::Closed;
         conn.stream_close_send(self.stream_id)?;
         Ok(())
     }
 
     pub fn done(&self) -> bool {
-        self.state == RequestStreamClientState::Closed
+        self.send_state == TransactionSendState::Closed
+            && self.recv_state == TransactionRecvState::Closed
     }
 
     pub fn has_data_to_send(&self) -> bool {
-        self.state == RequestStreamClientState::SendingRequest
+        self.send_state == TransactionSendState::SendingHeaders
+            || self.send_state == TransactionSendState::SendingData
     }
 
     pub fn get_header(&mut self) -> Option<Vec<(String, String)>> {
@@ -349,8 +365,8 @@ impl RequestStreamClient {
     }
 
     pub fn read_data(&mut self, conn: &mut Connection, buf: &mut [u8]) -> Res<(usize, bool)> {
-        match self.state {
-            RequestStreamClientState::ReadingData {
+        match self.recv_state {
+            TransactionRecvState::ReadingData {
                 ref mut remaining_data_len,
             } => {
                 let to_read = if *remaining_data_len > buf.len() {
@@ -366,15 +382,15 @@ impl RequestStreamClient {
                     if *remaining_data_len > 0 {
                         return Err(Error::MalformedFrame(H3_FRAME_TYPE_DATA));
                     }
-                    self.state = RequestStreamClientState::Closed;
+                    self.recv_state = TransactionRecvState::Closed;
                 } else if *remaining_data_len == 0 {
-                    self.state = RequestStreamClientState::WaitingForData;
+                    self.recv_state = TransactionRecvState::WaitingForData;
                 }
 
                 Ok((amount, fin))
             }
-            RequestStreamClientState::ClosePending => {
-                self.state = RequestStreamClientState::Closed;
+            TransactionRecvState::ClosePending => {
+                self.recv_state = TransactionRecvState::Closed;
                 Ok((0, true))
             }
             _ => Ok((0, false)),
@@ -382,8 +398,8 @@ impl RequestStreamClient {
     }
 }
 
-impl ::std::fmt::Display for RequestStreamClient {
+impl ::std::fmt::Display for TransactionClient {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "RequestStreamClient {}", self.stream_id)
+        write!(f, "TransactionClient {}", self.stream_id)
     }
 }

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -284,7 +284,7 @@ impl H3Handler {
                         return false;
                     }
 
-                    let headers = self.h3.get_headers(stream_id);
+                    let headers = self.h3.get_response_headers(stream_id);
                     eprintln!("READ HEADERS[{}]: {:?}", stream_id, headers);
                 }
                 Http3Event::DataReadable { stream_id } => {
@@ -295,7 +295,7 @@ impl H3Handler {
 
                     let (_sz, fin) = self
                         .h3
-                        .read_data(Instant::now(), stream_id, &mut data)
+                        .read_response_data(Instant::now(), stream_id, &mut data)
                         .expect("Read should succeed");
                     eprintln!(
                         "READ[{}]: {}",

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1310,16 +1310,19 @@ impl Connection {
                                 ZeroRttState::Rejected
                             }
                     }
+                    self.events.connection_connected();
                 }
-                State::Closing { .. } => {
+                State::Closing { error, .. } => {
                     self.send_streams.clear();
                     self.recv_streams.clear();
                     self.flow_mgr.borrow_mut().set_need_close_frame(true);
+                    self.events.connection_closing(error.clone().into());
                 }
-                State::Closed(..) => {
+                State::Closed(error) => {
                     // Equivalent to spec's "draining" state -- never send anything.
                     self.send_streams.clear();
                     self.recv_streams.clear();
+                    self.events.connection_closed(error.clone().into(), 0, "");
                 }
                 _ => {}
             }

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -33,6 +33,10 @@ pub enum ConnectionEvent {
     SendStreamComplete { stream_id: u64 },
     /// Peer increased MAX_STREAMS
     SendStreamCreatable { stream_type: StreamType },
+    /// Connection connected
+    ConnectionConnected,
+    /// Connection closing
+    ConnectionClosing { error_code: CloseError },
     /// Connection closed
     ConnectionClosed {
         error_code: CloseError,
@@ -92,6 +96,14 @@ impl ConnectionEvents {
 
     pub fn send_stream_creatable(&self, stream_type: StreamType) {
         self.insert(ConnectionEvent::SendStreamCreatable { stream_type });
+    }
+
+    pub fn connection_connected(&self) {
+        self.insert(ConnectionEvent::ConnectionConnected);
+    }
+
+    pub fn connection_closing(&self, error_code: CloseError) {
+        self.insert(ConnectionEvent::ConnectionClosing { error_code });
     }
 
     pub fn connection_closed(&self, error_code: CloseError, frame_type: u64, reason_phrase: &str) {


### PR DESCRIPTION
Http3 nits:

- move API functions to single place,

- make some functions easier to read,

-  rename read_data and get_headers into read_response_data, get_reasponse_headers (the names are more descriptive)