### PR TITLE
Http3 nits

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -202,7 +202,7 @@ impl Handler for PostConnectHandler {
                         return false;
                     }
 
-                    let headers = client.get_headers(stream_id);
+                    let headers = client.get_response_headers(stream_id);
                     println!("READ HEADERS[{}]: {:?}", stream_id, headers);
                 }
                 Http3Event::DataReadable { stream_id } => {
@@ -212,7 +212,7 @@ impl Handler for PostConnectHandler {
                     }
 
                     let (sz, fin) = client
-                        .read_data(Instant::now(), stream_id, &mut data)
+                        .read_response_data(Instant::now(), stream_id, &mut data)
                         .expect("Read should succeed");
                     if args.omit_read_data {
                         println!("READ[{}]: {} bytes", stream_id, sz);

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -284,7 +284,7 @@ impl H3Handler {
                         return false;
                     }
 
-                    let headers = self.h3.get_headers(stream_id);
+                    let headers = self.h3.get_response_headers(stream_id);
                     eprintln!("READ HEADERS[{}]: {:?}", stream_id, headers);
                 }
                 Http3Event::DataReadable { stream_id } => {
@@ -295,7 +295,7 @@ impl H3Handler {
 
                     let (_sz, fin) = self
                         .h3
-                        .read_data(Instant::now(), stream_id, &mut data)
+                        .read_response_data(Instant::now(), stream_id, &mut data)
                         .expect("Read should succeed");
                     eprintln!(
                         "READ[{}]: {}",


### PR DESCRIPTION
Http3 nits:
- move API functions to single place,
- make some functions easier to read,
- rename read_data and get_headers into read_response_data, get_reasponse_headers (the names are more descriptive)
