### PR TITLE
Refactor receiving part of the transaction_client:

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -186,7 +186,7 @@ impl Handler for PostConnectHandler {
                         return false;
                     }
 
-                    let headers = client.get_headers(stream_id);
+                    let headers = client.read_response_headers(stream_id);
                     println!("READ HEADERS[{}]: {:?}", stream_id, headers);
                 }
                 Http3Event::DataReadable { stream_id } => {
@@ -196,7 +196,7 @@ impl Handler for PostConnectHandler {
                     }
 
                     let (sz, fin) = client
-                        .read_data(Instant::now(), stream_id, &mut data)
+                        .read_response_data(Instant::now(), stream_id, &mut data)
                         .expect("Read should succeed");
                     if args.omit_read_data {
                         println!("READ[{}]: {} bytes", stream_id, sz);

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -788,9 +788,7 @@ impl Http3Connection {
                     Ok(())
                 }
             }
-            None => Err(Error::TransportError(
-                neqo_transport::Error::InvalidStreamId,
-            )),
+            None => Err(Error::InvalidStreamId),
         }
     }
 
@@ -805,9 +803,7 @@ impl Http3Connection {
                 }
             }
         } else {
-            Err(Error::TransportError(
-                neqo_transport::Error::InvalidStreamId,
-            ))
+            Err(Error::InvalidStreamId)
         }
     }
 
@@ -923,60 +919,55 @@ impl Http3Connection {
     }
 
     // API
-    pub fn get_headers(&mut self, stream_id: u64) -> Res<Option<Vec<Header>>> {
-        let label = if ::log::log_enabled!(::log::Level::Debug) {
-            format!("{}", self)
-        } else {
-            String::new()
-        };
-        if let Some(cs) = &mut self.transactions_client.get_mut(&stream_id) {
-            qdebug!([label] "get_header from stream {}.", stream_id);
-            Ok(cs.get_header())
-        } else {
-            Err(Error::TransportError(
-                neqo_transport::Error::InvalidStreamId,
-            ))
+    pub fn read_response_headers(&mut self, stream_id: u64) -> Res<(Vec<Header>, bool)> {
+        qdebug!([self] "read_response_headers from stream {}.", stream_id);
+        let cs = self
+            .transactions_client
+            .get_mut(&stream_id)
+            .ok_or(Error::InvalidStreamId)?;
+        match cs.read_response_headers() {
+            Ok((headers, fin)) => {
+                if fin {
+                    self.transactions_client.remove(&stream_id);
+                }
+                Ok((headers, fin))
+            }
+            Err(e) => Err(e),
         }
     }
 
-    pub fn read_data(
+    pub fn read_response_data(
         &mut self,
         now: Instant,
         stream_id: u64,
         buf: &mut [u8],
     ) -> Res<(usize, bool)> {
-        let label = if ::log::log_enabled!(::log::Level::Debug) {
-            format!("{}", self)
-        } else {
-            String::new()
-        };
-        if let Some(cs) = &mut self.transactions_client.get_mut(&stream_id) {
-            qdebug!([label] "read_data from stream {}.", stream_id);
-            match cs.read_data(&mut self.conn, buf) {
-                Ok((amount, fin)) => {
-                    if fin {
-                        self.transactions_client.remove(&stream_id);
-                    } else if amount > 0 {
-                        // Directly call receive instead of adding to
-                        // streams_are_readable here. This allows the app to
-                        // pick up subsequent already-received data frames in
-                        // the stream even if no new packets arrive to cause
-                        // process_http3() to run.
-                        cs.receive(&mut self.conn, &mut self.qpack_decoder)?;
-                    }
-                    Ok((amount, fin))
+        qdebug!([self] "read_data from stream {}.", stream_id);
+        let cs = self
+            .transactions_client
+            .get_mut(&stream_id)
+            .ok_or(Error::InvalidStreamId)?;
+
+        match cs.read_response_data(&mut self.conn, buf) {
+            Ok((amount, fin)) => {
+                if fin {
+                    self.transactions_client.remove(&stream_id);
+                } else if amount > 0 {
+                    // Directly call receive instead of adding to
+                    // streams_are_readable here. This allows the app to
+                    // pick up subsequent already-received data frames in
+                    // the stream even if no new packets arrive to cause
+                    // process_http3() to run.
+                    cs.receive(&mut self.conn, &mut self.qpack_decoder)?;
                 }
-                Err(e) => {
-                    if e == Error::MalformedFrame(H3_FRAME_TYPE_DATA) {
-                        self.close(now, e.code(), "");
-                    }
-                    Err(e)
-                }
+                Ok((amount, fin))
             }
-        } else {
-            Err(Error::TransportError(
-                neqo_transport::Error::InvalidStreamId,
-            ))
+            Err(e) => {
+                if e == Error::MalformedFrame(H3_FRAME_TYPE_DATA) {
+                    self.close(now, e.code(), "");
+                }
+                Err(e)
+            }
         }
     }
 
@@ -1696,19 +1687,24 @@ mod tests {
             match e {
                 Http3Event::HeaderReady { stream_id } => {
                     assert_eq!(stream_id, request_stream_id);
-                    let h = hconn.get_headers(stream_id);
+                    let h = hconn.read_response_headers(stream_id);
                     assert_eq!(
                         h,
-                        Ok(Some(vec![
-                            (String::from(":status"), String::from("200")),
-                            (String::from("content-length"), String::from("3"))
-                        ]))
+                        Ok((
+                            vec![
+                                (String::from(":status"), String::from("200")),
+                                (String::from("content-length"), String::from("3"))
+                            ],
+                            false
+                        ))
                     );
                 }
                 Http3Event::DataReadable { stream_id } => {
                     assert_eq!(stream_id, request_stream_id);
                     let mut buf = [0u8; 100];
-                    let (amount, fin) = hconn.read_data(now(), stream_id, &mut buf).unwrap();
+                    let (amount, fin) = hconn
+                        .read_response_data(now(), stream_id, &mut buf)
+                        .unwrap();
                     assert_eq!(fin, false);
                     assert_eq!(amount, 3);
                     assert_eq!(buf[..3], [0x61, 0x62, 0x63]);
@@ -1724,7 +1720,9 @@ mod tests {
                 Http3Event::DataReadable { stream_id } => {
                     assert_eq!(stream_id, request_stream_id);
                     let mut buf = [0u8; 100];
-                    let (amount, fin) = hconn.read_data(now(), stream_id, &mut buf).unwrap();
+                    let (amount, fin) = hconn
+                        .read_response_data(now(), stream_id, &mut buf)
+                        .unwrap();
                     assert_eq!(fin, true);
                     assert_eq!(amount, 3);
                     assert_eq!(buf[..3], [0x64, 0x65, 0x66]);
@@ -1736,12 +1734,9 @@ mod tests {
         // after this stream will be removed from hcoon. We will check this by trying to read
         // from the stream and that should fail.
         let mut buf = [0u8; 100];
-        let res = hconn.read_data(now(), request_stream_id, &mut buf);
+        let res = hconn.read_response_data(now(), request_stream_id, &mut buf);
         assert!(res.is_err());
-        assert_eq!(
-            res.unwrap_err(),
-            Error::TransportError(neqo_transport::Error::InvalidStreamId)
-        );
+        assert_eq!(res.unwrap_err(), Error::InvalidStreamId);
 
         hconn.close(now(), 0, "");
     }
@@ -1796,7 +1791,7 @@ mod tests {
             if let Http3Event::DataReadable { stream_id } = e {
                 assert_eq!(stream_id, request_stream_id);
                 let mut buf = [0u8; 100];
-                let res = hconn.read_data(now(), stream_id, &mut buf);
+                let res = hconn.read_response_data(now(), stream_id, &mut buf);
                 assert!(res.is_err());
                 assert_eq!(res.unwrap_err(), Error::MalformedFrame(H3_FRAME_TYPE_DATA));
             }
@@ -1904,13 +1899,16 @@ mod tests {
             for e in http_events {
                 match e {
                     Http3Event::HeaderReady { stream_id } => {
-                        let h = hconn.get_headers(stream_id);
+                        let h = hconn.read_response_headers(stream_id);
                         assert_eq!(
                             h,
-                            Ok(Some(vec![
-                                (String::from(":status"), String::from("200")),
-                                (String::from("content-length"), String::from("3"))
-                            ]))
+                            Ok((
+                                vec![
+                                    (String::from(":status"), String::from("200")),
+                                    (String::from("content-length"), String::from("3"))
+                                ],
+                                false
+                            ))
                         );
                     }
                     Http3Event::DataReadable { stream_id } => {
@@ -1918,7 +1916,9 @@ mod tests {
                             stream_id == request_stream_id_1 || stream_id == request_stream_id_2
                         );
                         let mut buf = [0u8; 100];
-                        let (amount, _) = hconn.read_data(now(), stream_id, &mut buf).unwrap();
+                        let (amount, _) = hconn
+                            .read_response_data(now(), stream_id, &mut buf)
+                            .unwrap();
                         assert_eq!(amount, 3);
                     }
                     Http3Event::Reset { stream_id, error } => {
@@ -1938,8 +1938,7 @@ mod tests {
         hconn.close(now(), 0, "");
     }
 
-    #[test]
-    fn test_stream_fin_wo_data() {
+    fn connect_and_send_request() -> (Http3Connection, Connection, u64) {
         let (mut hconn, mut neqo_trans_conn, _) = connect_and_receive_control_stream(true);
         let request_stream_id = hconn
             .fetch("GET", "https", "something.com", "/", &[])
@@ -1973,15 +1972,6 @@ mod tests {
                             0x35, 0x53, 0x2e, 0x43, 0xd3, 0xc1
                         ]
                     );
-
-                    // Send some good data wo fin
-                    let data = &[
-                        // headers
-                        0x01, 0x06, 0x00, 0x00, 0xd9, 0x54, 0x01, 0x33,
-                        // the data frame is complete.
-                        0x0, 0x3, 0x61, 0x62, 0x63,
-                    ];
-                    let _ = neqo_trans_conn.stream_send(stream_id, data);
                 }
                 _ => {}
             }
@@ -1989,17 +1979,319 @@ mod tests {
         let out = neqo_trans_conn.process(None, now());
         hconn.process(out.dgram(), now());
 
+        (hconn, neqo_trans_conn, request_stream_id)
+    }
+
+    // Close stream before headers.
+    #[test]
+    fn test_stream_fin_wo_headers() {
+        let (mut hconn, mut neqo_trans_conn, request_stream_id) = connect_and_send_request();
+        // send fin before sending any data.
+        neqo_trans_conn.stream_close_send(0).unwrap();
+
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
+
+        // Recv HeaderReady wo headers with fin.
+        let e = hconn.events().into_iter().next().unwrap();
+        if let Http3Event::HeaderReady { stream_id } = e {
+            assert_eq!(stream_id, request_stream_id);
+            let h = hconn.read_response_headers(stream_id);
+            assert_eq!(h, Ok((vec![], true)));
+        } else {
+            panic!("wrong event type");
+        }
+
+        // Stream should now be closed and gone
+        let mut buf = [0u8; 100];
+        assert_eq!(
+            hconn.read_response_data(now(), 0, &mut buf),
+            Err(Error::InvalidStreamId)
+        );
+    }
+
+    // Close stream imemediately after headers.
+    #[test]
+    fn test_stream_fin_after_headers() {
+        let (mut hconn, mut neqo_trans_conn, request_stream_id) = connect_and_send_request();
+        let data = &[
+            // headers
+            0x01, 0x06, 0x00, 0x00, 0xd9, 0x54, 0x01, 0x33,
+        ];
+        let _ = neqo_trans_conn.stream_send(request_stream_id, data);
+        // ok NOW send fin
+        neqo_trans_conn.stream_close_send(0).unwrap();
+
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
+
+        // Recv HeaderReady with headers and fin.
+        let e = hconn.events().into_iter().next().unwrap();
+        if let Http3Event::HeaderReady { stream_id } = e {
+            assert_eq!(stream_id, request_stream_id);
+            let h = hconn.read_response_headers(stream_id);
+            assert_eq!(
+                h,
+                Ok((
+                    vec![
+                        (String::from(":status"), String::from("200")),
+                        (String::from("content-length"), String::from("3"))
+                    ],
+                    true
+                ))
+            );
+        } else {
+            panic!("wrong event type");
+        }
+
+        // Stream should now be closed and gone
+        let mut buf = [0u8; 100];
+        assert_eq!(
+            hconn.read_response_data(now(), 0, &mut buf),
+            Err(Error::InvalidStreamId)
+        );
+    }
+
+    // Send headers, read headers and than close stream.
+    // We should get HeaderReady and a DataReadable
+    #[test]
+    fn test_stream_fin_after_headers_are_read_wo_data_frame() {
+        let (mut hconn, mut neqo_trans_conn, request_stream_id) = connect_and_send_request();
+        // Send some good data wo fin
+        let data = &[
+            // headers
+            0x01, 0x06, 0x00, 0x00, 0xd9, 0x54, 0x01, 0x33,
+        ];
+        let _ = neqo_trans_conn.stream_send(request_stream_id, data);
+
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
+
+        // Recv headers wo fin
+        let http_events = hconn.events();
+        for e in http_events {
+            match e {
+                Http3Event::HeaderReady { stream_id } => {
+                    assert_eq!(stream_id, request_stream_id);
+                    let h = hconn.read_response_headers(stream_id);
+                    assert_eq!(
+                        h,
+                        Ok((
+                            vec![
+                                (String::from(":status"), String::from("200")),
+                                (String::from("content-length"), String::from("3"))
+                            ],
+                            false
+                        ))
+                    );
+                }
+                Http3Event::DataReadable { .. } => {
+                    panic!("We should not receive a DataGeadable event!");
+                }
+                _ => {}
+            };
+        }
+
+        // ok NOW send fin
+        neqo_trans_conn.stream_close_send(0).unwrap();
+
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
+
+        // Recv DataReadable wo data with fin
+        let http_events = hconn.events();
+        for e in http_events {
+            match e {
+                Http3Event::HeaderReady { .. } => {
+                    panic!("We should not get another HeaderReady!");
+                }
+                Http3Event::DataReadable { stream_id } => {
+                    assert_eq!(stream_id, request_stream_id);
+                    let mut buf = [0u8; 100];
+                    let res = hconn.read_response_data(now(), stream_id, &mut buf);
+                    let (len, fin) = res.expect("should read");
+                    assert_eq!(0, len);
+                    assert_eq!(fin, true);
+                }
+                _ => {}
+            };
+        }
+
+        // Stream should now be closed and gone
+        let mut buf = [0u8; 100];
+        assert_eq!(
+            hconn.read_response_data(now(), 0, &mut buf),
+            Err(Error::InvalidStreamId)
+        );
+    }
+
+    // Send headers anf an empy data frame and a close stream.
+    // We should only recv HeadersReady event
+    #[test]
+    fn test_stream_fin_after_headers_and_a_empty_data_frame() {
+        let (mut hconn, mut neqo_trans_conn, request_stream_id) = connect_and_send_request();
+        // Send some good data wo fin
+        let data = &[
+            // headers
+            0x01, 0x06, 0x00, 0x00, 0xd9, 0x54, 0x01, 0x33, // data
+            0x00, 0x00,
+        ];
+        let _ = neqo_trans_conn.stream_send(request_stream_id, data);
+        // ok NOW send fin
+        neqo_trans_conn.stream_close_send(0).unwrap();
+
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
+
+        // Recv HeaderReady with fin.
+        let http_events = hconn.events();
+        for e in http_events {
+            match e {
+                Http3Event::HeaderReady { stream_id } => {
+                    assert_eq!(stream_id, request_stream_id);
+                    let h = hconn.read_response_headers(stream_id);
+                    assert_eq!(
+                        h,
+                        Ok((
+                            vec![
+                                (String::from(":status"), String::from("200")),
+                                (String::from("content-length"), String::from("3"))
+                            ],
+                            true
+                        ))
+                    );
+                }
+                Http3Event::DataReadable { .. } => {
+                    panic!("We should not receive a DataGeadable event!");
+                }
+                _ => {}
+            };
+        }
+
+        // Stream should now be closed and gone
+        let mut buf = [0u8; 100];
+        assert_eq!(
+            hconn.read_response_data(now(), 0, &mut buf),
+            Err(Error::InvalidStreamId)
+        );
+    }
+
+    // Send headers and an empty data frame. Read headers and then close the stream.
+    // We should get a HeaderReady without fin and a DataReadable wo data and with fin.
+    #[test]
+    fn test_stream_fin_after_headers_an_empty_data_frame_are_read() {
+        let (mut hconn, mut neqo_trans_conn, request_stream_id) = connect_and_send_request();
+        // Send some good data wo fin
+        let data = &[
+            // headers
+            0x01, 0x06, 0x00, 0x00, 0xd9, 0x54, 0x01, 0x33, // the data frame
+            0x0, 0x0,
+        ];
+        let _ = neqo_trans_conn.stream_send(request_stream_id, data);
+
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
+
+        // Recv headers wo fin
+        let http_events = hconn.events();
+        for e in http_events {
+            match e {
+                Http3Event::HeaderReady { stream_id } => {
+                    assert_eq!(stream_id, request_stream_id);
+                    let h = hconn.read_response_headers(stream_id);
+                    assert_eq!(
+                        h,
+                        Ok((
+                            vec![
+                                (String::from(":status"), String::from("200")),
+                                (String::from("content-length"), String::from("3"))
+                            ],
+                            false
+                        ))
+                    );
+                }
+                Http3Event::DataReadable { .. } => {
+                    panic!("We should not receive a DataGeadable event!");
+                }
+                _ => {}
+            };
+        }
+
+        // ok NOW send fin
+        neqo_trans_conn.stream_close_send(0).unwrap();
+
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
+
+        // Recv no data, but do get fin
+        let http_events = hconn.events();
+        for e in http_events {
+            match e {
+                Http3Event::HeaderReady { .. } => {
+                    panic!("We should not get another HeaderReady!");
+                }
+                Http3Event::DataReadable { stream_id } => {
+                    assert_eq!(stream_id, request_stream_id);
+                    let mut buf = [0u8; 100];
+                    let res = hconn.read_response_data(now(), stream_id, &mut buf);
+                    let (len, fin) = res.expect("should read");
+                    assert_eq!(0, len);
+                    assert_eq!(fin, true);
+                }
+                _ => {}
+            };
+        }
+
+        // Stream should now be closed and gone
+        let mut buf = [0u8; 100];
+        assert_eq!(
+            hconn.read_response_data(now(), 0, &mut buf),
+            Err(Error::InvalidStreamId)
+        );
+    }
+
+    #[test]
+    fn test_stream_fin_after_a_data_frame() {
+        let (mut hconn, mut neqo_trans_conn, request_stream_id) = connect_and_send_request();
+        // Send some good data wo fin
+        let data = &[
+            // headers
+            0x01, 0x06, 0x00, 0x00, 0xd9, 0x54, 0x01, 0x33, // the data frame is complete
+            0x0, 0x3, 0x61, 0x62, 0x63,
+        ];
+        let _ = neqo_trans_conn.stream_send(request_stream_id, data);
+
+        let out = neqo_trans_conn.process(None, now());
+        hconn.process(out.dgram(), now());
+
         // Recv some good data wo fin
         let http_events = hconn.events();
         for e in http_events {
-            if let Http3Event::DataReadable { stream_id } = e {
-                assert_eq!(stream_id, request_stream_id);
-                let mut buf = [0u8; 100];
-                let res = hconn.read_data(now(), stream_id, &mut buf);
-                let (len, fin) = res.expect("should have data");
-                assert_eq!(&buf[..len], &[0x61, 0x62, 0x63]);
-                assert_eq!(fin, false);
-            }
+            match e {
+                Http3Event::HeaderReady { stream_id } => {
+                    assert_eq!(stream_id, request_stream_id);
+                    let h = hconn.read_response_headers(stream_id);
+                    assert_eq!(
+                        h,
+                        Ok((
+                            vec![
+                                (String::from(":status"), String::from("200")),
+                                (String::from("content-length"), String::from("3"))
+                            ],
+                            false
+                        ))
+                    );
+                }
+                Http3Event::DataReadable { stream_id } => {
+                    assert_eq!(stream_id, request_stream_id);
+                    let mut buf = [0u8; 100];
+                    let res = hconn.read_response_data(now(), stream_id, &mut buf);
+                    let (len, fin) = res.expect("should have data");
+                    assert_eq!(&buf[..len], &[0x61, 0x62, 0x63]);
+                    assert_eq!(fin, false);
+                }
+                _ => {}
+            };
         }
 
         // ok NOW send fin
@@ -2012,7 +2304,7 @@ mod tests {
         if let Http3Event::DataReadable { stream_id } = e {
             assert_eq!(stream_id, request_stream_id);
             let mut buf = [0u8; 100];
-            let res = hconn.read_data(now(), stream_id, &mut buf);
+            let res = hconn.read_response_data(now(), stream_id, &mut buf);
             let (len, fin) = res.expect("should read");
             assert_eq!(0, len);
             assert_eq!(fin, true);
@@ -2023,10 +2315,8 @@ mod tests {
         // Stream should now be closed and gone
         let mut buf = [0u8; 100];
         assert_eq!(
-            hconn.read_data(now(), 0, &mut buf),
-            Err(Error::TransportError(
-                neqo_transport::Error::InvalidStreamId
-            ))
+            hconn.read_response_data(now(), 0, &mut buf),
+            Err(Error::InvalidStreamId)
         );
     }
 
@@ -2034,13 +2324,7 @@ mod tests {
     fn test_multiple_data_frames() {
         let (mut hconn, mut neqo_trans_conn, _) = connect_and_receive_control_stream(true);
         let request_stream_id = hconn
-            .fetch(
-                &"GET".to_string(),
-                &"https".to_string(),
-                &"something.com".to_string(),
-                &"/".to_string(),
-                &Vec::<Header>::new(),
-            )
+            .fetch("GET", "https", "something.com", "/", &Vec::<Header>::new())
             .unwrap();
         assert_eq!(request_stream_id, 0);
 
@@ -2093,7 +2377,9 @@ mod tests {
             Http3Event::DataReadable { stream_id } => {
                 assert_eq!(stream_id, request_stream_id);
                 let mut buf = [0u8; 100];
-                let (len, fin) = hconn.read_data(now(), stream_id, &mut buf).unwrap();
+                let (len, fin) = hconn
+                    .read_response_data(now(), stream_id, &mut buf)
+                    .unwrap();
                 assert_eq!(&buf[..len], &[0x61, 0x62, 0x63]);
                 assert_eq!(fin, false);
             }
@@ -2103,14 +2389,16 @@ mod tests {
             }
         }
 
-        // Second frame isn't read in first read_data(), but it generates
-        // another DataReadable event so that another read_data() will happen to
+        // Second frame isn't read in first read_response_data(), but it generates
+        // another DataReadable event so that another read_response_data() will happen to
         // pick it up.
         match hconn.events().into_iter().next().unwrap() {
             Http3Event::DataReadable { stream_id } => {
                 assert_eq!(stream_id, request_stream_id);
                 let mut buf = [0u8; 100];
-                let (len, fin) = hconn.read_data(now(), stream_id, &mut buf).unwrap();
+                let (len, fin) = hconn
+                    .read_response_data(now(), stream_id, &mut buf)
+                    .unwrap();
                 assert_eq!(&buf[..len], &[0x64, 0x65, 0x66]);
                 assert_eq!(fin, true);
             }
@@ -2123,10 +2411,8 @@ mod tests {
         // Stream should now be closed and gone
         let mut buf = [0u8; 100];
         assert_eq!(
-            hconn.read_data(now(), 0, &mut buf),
-            Err(Error::TransportError(
-                neqo_transport::Error::InvalidStreamId
-            ))
+            hconn.read_response_data(now(), 0, &mut buf),
+            Err(Error::InvalidStreamId)
         );
     }
 
@@ -2135,10 +2421,10 @@ mod tests {
         let (mut hconn, mut neqo_trans_conn, _) = connect_and_receive_control_stream(true);
         let request_stream_id = hconn
             .fetch(
-                &"GET".to_string(),
-                &"https".to_string(),
-                &"something.com".to_string(),
-                &"/".to_string(),
+                "GET",
+                "https",
+                "something.com",
+                "/",
                 &Vec::<(String, String)>::new(),
             )
             .unwrap();
@@ -2203,7 +2489,9 @@ mod tests {
             Http3Event::DataReadable { stream_id } => {
                 assert_eq!(stream_id, request_stream_id);
                 let mut buf = [0u8; 100];
-                let (len, fin) = hconn.read_data(now(), stream_id, &mut buf).unwrap();
+                let (len, fin) = hconn
+                    .read_response_data(now(), stream_id, &mut buf)
+                    .unwrap();
                 assert_eq!(&buf[..len], &[0x61, 0x62, 0x63]);
                 assert_eq!(fin, true);
             }
@@ -2215,10 +2503,8 @@ mod tests {
         // Stream should now be closed and gone
         let mut buf = [0u8; 100];
         assert_eq!(
-            hconn.read_data(now(), 0, &mut buf),
-            Err(Error::TransportError(
-                neqo_transport::Error::InvalidStreamId
-            ))
+            hconn.read_response_data(now(), 0, &mut buf),
+            Err(Error::InvalidStreamId)
         );
     }
 }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -52,6 +52,8 @@ pub enum Error {
     DecodingFrame,
     NotEnoughData,
     Unexpected,
+    InvalidStreamId,
+    Unavailable,
     // So we can wrap and report these errors.
     TransportError(neqo_transport::Error),
     QpackError(neqo_qpack::Error),
@@ -91,6 +93,8 @@ impl Error {
             | Error::DecodingFrame
             | Error::NotEnoughData
             | Error::Unexpected
+            | Error::InvalidStreamId
+            | Error::Unavailable
             | Error::TransportError(..) => 3,
             Error::QpackError(e) => e.code(),
         }

--- a/neqo-http3/src/transaction_client.rs
+++ b/neqo-http3/src/transaction_client.rs
@@ -8,7 +8,7 @@ use crate::hframe::{HFrame, HFrameReader, H3_FRAME_TYPE_DATA, H3_FRAME_TYPE_HEAD
 
 use crate::connection::Http3Events;
 use crate::Header;
-use neqo_common::{qdebug, qinfo, Encoder};
+use neqo_common::{qdebug, qinfo, qtrace, Encoder};
 use neqo_qpack::decoder::QPackDecoder;
 use neqo_qpack::encoder::QPackEncoder;
 use neqo_transport::Connection;
@@ -63,29 +63,6 @@ impl ::std::fmt::Display for Request {
     }
 }
 
-#[derive(Debug)]
-pub struct Response {
-    status: u32,
-    status_line: Vec<u8>,
-    pub headers: Option<Vec<Header>>,
-    pub data_len: u64,
-    pub trailers: Option<Vec<Header>>,
-    fin: bool,
-}
-
-impl Response {
-    pub fn new() -> Response {
-        Response {
-            status: 0,
-            status_line: Vec::new(),
-            headers: None,
-            data_len: 0,
-            trailers: None,
-            fin: false,
-        }
-    }
-}
-
 /*
  *  Transaction send states:
  *    SendingHeaders : sending headers. From here we may switch to SendingData
@@ -109,6 +86,8 @@ enum TransactionSendState {
  *    ReadingHeaders : we have HEADERS frame and now we are reading header
  *                     block. This may block on encoder instructions. In this
  *                     state we do no read from the stream.
+ *    BlockedDecodingHeaders : Decoding headers is blocked on encoder
+ *                             instructions.
  *    WaitingForData : we got HEADERS, we are waiting for one or more data
  *                     frames. In this state we can receive one or more
  *                     PUSH_PROMIS frames or a HEADERS frame carrying trailers.
@@ -124,12 +103,19 @@ enum TransactionSendState {
 enum TransactionRecvState {
     WaitingForResponseHeaders,
     ReadingHeaders { buf: Vec<u8>, offset: usize },
-    BlockedDecodingHeaders { buf: Vec<u8> },
+    BlockedDecodingHeaders { buf: Vec<u8>, fin: bool },
     WaitingForData,
     ReadingData { remaining_data_len: usize },
     //    ReadingTrailers,
     ClosePending, // Close must first be read by application
     Closed,
+}
+
+#[derive(Debug, PartialEq)]
+enum ResponseHeadersState {
+    NoHeaders,
+    Ready(Option<Vec<Header>>),
+    Read,
 }
 
 //  This is used for normal request/responses.
@@ -138,8 +124,8 @@ pub struct TransactionClient {
     recv_state: TransactionRecvState,
     stream_id: u64,
     request: Request,
-    response: Response,
     frame_reader: HFrameReader,
+    response_headers_state: ResponseHeadersState,
     conn_events: Http3Events,
 }
 
@@ -159,7 +145,7 @@ impl TransactionClient {
             recv_state: TransactionRecvState::WaitingForResponseHeaders,
             stream_id,
             request: Request::new(method, scheme, host, path, headers),
-            response: Response::new(),
+            response_headers_state: ResponseHeadersState::NoHeaders,
             frame_reader: HFrameReader::new(),
             conn_events,
         }
@@ -193,13 +179,6 @@ impl TransactionClient {
         Ok(())
     }
 
-    fn recv_frame(&mut self, conn: &mut Connection) -> Res<()> {
-        if self.frame_reader.receive(conn, self.stream_id)? {
-            self.recv_state = TransactionRecvState::ClosePending;
-        }
-        Ok(())
-    }
-
     pub fn receive(&mut self, conn: &mut Connection, decoder: &mut QPackDecoder) -> Res<()> {
         let label = if ::log::log_enabled!(::log::Level::Debug) {
             format!("{}", self)
@@ -210,82 +189,40 @@ impl TransactionClient {
             qdebug!([label] "send_state={:?} recv_state={:?}.", self.send_state, self.recv_state);
             match self.recv_state {
                 TransactionRecvState::WaitingForResponseHeaders => {
-                    self.recv_frame(conn)?;
-                    if !self.frame_reader.done() {
-                        break Ok(());
-                    }
-                    let f = self.frame_reader.get_frame()?;
-                    qdebug!([label] "A new frame has been received: {:?}", f);
-                    match f {
-                        HFrame::Priority { .. } => break Err(Error::UnexpectedFrame),
-                        HFrame::Headers { len } => self.handle_headers_frame(len)?,
-                        HFrame::PushPromise { .. } => break Err(Error::UnexpectedFrame),
-                        _ => {
-                            break { Err(Error::WrongStream) };
+                    match self.recv_frame_header(conn)? {
+                        None => break Ok(()),
+                        Some((f, fin)) => {
+                            self.handle_frame_in_state_waiting_for_headers(f, fin)?;
+                            if fin {
+                                self.set_state_to_close_pending();
+                                break Ok(());
+                            }
                         }
                     };
                 }
-                TransactionRecvState::ReadingHeaders {
-                    ref mut buf,
-                    ref mut offset,
-                } => {
-                    let (amount, fin) = conn.stream_recv(self.stream_id, &mut buf[*offset..])?;
-                    qdebug!(
-                        [label]
-                        "recv_state=ReadingHeaders: read {} bytes fin={}.",
-                        amount,
-                        fin
-                    );
-                    *offset += amount as usize;
-                    if fin {
-                        if *offset < buf.len() {
-                            // Malformated frame
-                            break Err(Error::MalformedFrame(H3_FRAME_TYPE_HEADERS));
-                        }
-                        self.recv_state = TransactionRecvState::Closed;
+                TransactionRecvState::ReadingHeaders { .. } => {
+                    if self.read_headers_frame_body(conn, decoder)? {
                         break Ok(());
-                    }
-                    if *offset < buf.len() {
-                        break Ok(());
-                    }
-                    // we have read the headers.
-                    self.response.headers = decoder.decode_header_block(buf, self.stream_id)?;
-                    if self.response.headers.is_none() {
-                        qdebug!([label] "decoding header is blocked.");
-                        let mut tmp: Vec<u8> = Vec::new();
-                        mem::swap(&mut tmp, buf);
-                        self.recv_state = TransactionRecvState::BlockedDecodingHeaders { buf: tmp };
-                    } else {
-                        self.conn_events.header_ready(self.stream_id);
-                        self.recv_state = TransactionRecvState::WaitingForData;
                     }
                 }
                 TransactionRecvState::BlockedDecodingHeaders { .. } => break Ok(()),
                 TransactionRecvState::WaitingForData => {
-                    self.recv_frame(conn)?;
-                    if self.recv_state == TransactionRecvState::ClosePending {
-                        // Received 0 byte fin? Client must see this.
-                        self.conn_events.data_readable(self.stream_id);
-                    }
-                    if !self.frame_reader.done() {
-                        break Ok(());
-                    }
-                    qdebug!([label] "A new frame has been received.");
-                    match self.frame_reader.get_frame()? {
-                        HFrame::Data { len } => self.handle_data_frame(len)?,
-                        HFrame::PushPromise { .. } => break Err(Error::UnexpectedFrame),
-                        HFrame::Headers { .. } => {
-                            // TODO implement trailers!
-                            break Err(Error::UnexpectedFrame);
+                    match self.recv_frame_header(conn)? {
+                        None => break Ok(()),
+                        Some((f, fin)) => {
+                            self.handle_frame_in_state_waiting_for_data(f, fin)?;
+                            if fin {
+                                self.set_state_to_close_pending();
+                                break Ok(());
+                            }
                         }
-                        _ => break Err(Error::WrongStream),
                     };
                 }
                 TransactionRecvState::ReadingData { .. } => {
                     self.conn_events.data_readable(self.stream_id);
                     break Ok(());
                 }
-                //                TransactionRecvState::ReadingTrailers => break Ok(()),
+                // TransactionRecvState::ReadingTrailers => break Ok(()),
                 TransactionRecvState::ClosePending => {
                     panic!("Stream readable after being closed!");
                 }
@@ -296,43 +233,162 @@ impl TransactionClient {
         }
     }
 
-    fn handle_headers_frame(&mut self, len: u64) -> Res<()> {
-        if self.recv_state == TransactionRecvState::Closed {
-            return Ok(());
+    fn handle_frame_in_state_waiting_for_headers(&mut self, frame: HFrame, fin: bool) -> Res<()> {
+        qdebug!([self] "A new frame has been received: {:?}", frame);
+        match frame {
+            HFrame::Priority { .. } => Err(Error::UnexpectedFrame),
+            HFrame::Headers { len } => self.handle_headers_frame(len, fin),
+            HFrame::PushPromise { .. } => Err(Error::UnexpectedFrame),
+            _ => Err(Error::WrongStream),
         }
+    }
+
+    fn handle_headers_frame(&mut self, len: u64, fin: bool) -> Res<()> {
         if len == 0 {
-            self.recv_state = TransactionRecvState::WaitingForData;
+            self.add_headers(None)
         } else {
+            if fin {
+                return Err(Error::MalformedFrame(H3_FRAME_TYPE_HEADERS));
+            }
             self.recv_state = TransactionRecvState::ReadingHeaders {
                 buf: vec![0; len as usize],
                 offset: 0,
+            };
+            Ok(())
+        }
+    }
+
+    fn handle_frame_in_state_waiting_for_data(&mut self, frame: HFrame, fin: bool) -> Res<()> {
+        match frame {
+            HFrame::Data { len } => self.handle_data_frame(len, fin),
+            HFrame::PushPromise { .. } => Err(Error::UnexpectedFrame),
+            HFrame::Headers { .. } => {
+                // TODO implement trailers!
+                Err(Error::UnexpectedFrame)
+            }
+            _ => Err(Error::WrongStream),
+        }
+    }
+
+    fn handle_data_frame(&mut self, len: u64, fin: bool) -> Res<()> {
+        if len > 0 {
+            if fin {
+                return Err(Error::MalformedFrame(H3_FRAME_TYPE_HEADERS));
+            }
+            self.recv_state = TransactionRecvState::ReadingData {
+                remaining_data_len: len as usize,
             };
         }
         Ok(())
     }
 
-    fn handle_data_frame(&mut self, len: u64) -> Res<()> {
-        self.response.data_len = len;
-        if self.recv_state != TransactionRecvState::Closed {
-            if self.response.data_len > 0 {
-                self.recv_state = TransactionRecvState::ReadingData {
-                    remaining_data_len: len as usize,
-                };
-            } else {
-                self.recv_state = TransactionRecvState::WaitingForData;
-            }
+    fn add_headers(&mut self, headers: Option<Vec<Header>>) -> Res<()> {
+        if self.response_headers_state != ResponseHeadersState::NoHeaders {
+            return Err(Error::InternalError);
         }
+        self.response_headers_state = ResponseHeadersState::Ready(headers);
+        self.conn_events.header_ready(self.stream_id);
+        self.recv_state = TransactionRecvState::WaitingForData;
         Ok(())
     }
 
-    pub fn unblock(&mut self, decoder: &mut QPackDecoder) -> Res<()> {
-        if let TransactionRecvState::BlockedDecodingHeaders { ref mut buf } = self.recv_state {
-            self.response.headers = decoder.decode_header_block(buf, self.stream_id)?;
-            self.conn_events.header_ready(self.stream_id);
-            self.recv_state = TransactionRecvState::WaitingForData;
-            if self.response.headers.is_none() {
-                panic!("We must not be blocked again!");
+    fn set_state_to_close_pending(&mut self) {
+        // Stream has received fin. Depending on headers state set header_ready
+        // or data_readable event so that app can pick up the fin.
+        qdebug!([self] "set_state_to_close_pending:  response_headers_state={:?}", self.response_headers_state);
+        match self.response_headers_state {
+            ResponseHeadersState::NoHeaders => {
+                self.conn_events.header_ready(self.stream_id);
+                self.response_headers_state = ResponseHeadersState::Ready(None);
             }
+            // In Ready state we are already waiting for app to pick up headers
+            // it can also pick up fin, so we do not need a new event.
+            ResponseHeadersState::Ready(..) => {}
+            ResponseHeadersState::Read => self.conn_events.data_readable(self.stream_id),
+        }
+        self.recv_state = TransactionRecvState::ClosePending;
+    }
+
+    fn recv_frame_header(&mut self, conn: &mut Connection) -> Res<Option<(HFrame, bool)>> {
+        qtrace!([self] "receiving frame header");
+        let fin = self.frame_reader.receive(conn, self.stream_id)?;
+        if !self.frame_reader.done() {
+            if fin {
+                //we have received stream fin while waiting for a frame.
+                // !self.frame_reader.done() means that we do not have a new
+                // frame at all. Set state to ClosePending and waith for app
+                // to pick up fin.
+                self.set_state_to_close_pending();
+            }
+            Ok(None)
+        } else {
+            qdebug!([self] "A new frame has been received.");
+            Ok(Some((self.frame_reader.get_frame()?, fin)))
+        }
+    }
+
+    fn read_headers_frame_body(
+        &mut self,
+        conn: &mut Connection,
+        decoder: &mut QPackDecoder,
+    ) -> Res<bool> {
+        let label = if ::log::log_enabled!(::log::Level::Debug) {
+            format!("{}", self)
+        } else {
+            String::new()
+        };
+        if let TransactionRecvState::ReadingHeaders {
+            ref mut buf,
+            ref mut offset,
+        } = self.recv_state
+        {
+            let (amount, fin) = conn.stream_recv(self.stream_id, &mut buf[*offset..])?;
+            qdebug!([label] "read_headers: read {} bytes fin={}.", amount, fin);
+            *offset += amount as usize;
+            if *offset < buf.len() {
+                if fin {
+                    // Malformated frame
+                    return Err(Error::MalformedFrame(H3_FRAME_TYPE_HEADERS));
+                }
+                return Ok(true);
+            }
+
+            // we have read the headers, try decoding them.
+            qdebug!([label] "read_headers: read all headers, try decoding them.");
+            match decoder.decode_header_block(buf, self.stream_id)? {
+                Some(headers) => {
+                    self.add_headers(Some(headers))?;
+                    if fin {
+                        self.set_state_to_close_pending();
+                        return Ok(true);
+                    }
+                }
+                None => {
+                    qdebug!([label] "decoding header is blocked.");
+                    let mut tmp: Vec<u8> = Vec::new();
+                    mem::swap(&mut tmp, buf);
+                    self.recv_state =
+                        TransactionRecvState::BlockedDecodingHeaders { buf: tmp, fin };
+                    return Ok(true);
+                }
+            };
+            Ok(false)
+        } else {
+            panic!("This is only called when recv_state is ReadingHeaders.");
+        }
+    }
+
+    pub fn unblock(&mut self, decoder: &mut QPackDecoder) -> Res<()> {
+        if let TransactionRecvState::BlockedDecodingHeaders { ref mut buf, fin } = self.recv_state {
+            match decoder.decode_header_block(buf, self.stream_id)? {
+                Some(headers) => {
+                    self.add_headers(Some(headers))?;
+                    if fin {
+                        self.set_state_to_close_pending();
+                    }
+                }
+                None => panic!("We must not be blocked again!"),
+            };
         } else {
             panic!("Stream must be in the block state!");
         }
@@ -355,11 +411,29 @@ impl TransactionClient {
             || self.send_state == TransactionSendState::SendingData
     }
 
-    pub fn get_header(&mut self) -> Option<Vec<Header>> {
-        self.response.headers.clone()
+    pub fn read_response_headers(&mut self) -> Res<(Vec<Header>, bool)> {
+        if let ResponseHeadersState::Ready(ref mut headers) = self.response_headers_state {
+            let mut tmp = Vec::new();
+            if let Some(ref mut hdrs) = headers {
+                mem::swap(&mut tmp, hdrs);
+            }
+            self.response_headers_state = ResponseHeadersState::Read;
+            let mut fin = false;
+            if self.recv_state == TransactionRecvState::ClosePending {
+                fin = true;
+                self.recv_state = TransactionRecvState::Closed;
+            }
+            Ok((tmp, fin))
+        } else {
+            Err(Error::Unavailable)
+        }
     }
 
-    pub fn read_data(&mut self, conn: &mut Connection, buf: &mut [u8]) -> Res<(usize, bool)> {
+    pub fn read_response_data(
+        &mut self,
+        conn: &mut Connection,
+        buf: &mut [u8],
+    ) -> Res<(usize, bool)> {
         match self.recv_state {
             TransactionRecvState::ReadingData {
                 ref mut remaining_data_len,

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -288,7 +288,7 @@ impl H3Handler {
                         return false;
                     }
 
-                    let headers = self.h3.get_headers(stream_id);
+                    let headers = self.h3.read_response_headers(stream_id);
                     eprintln!("READ HEADERS[{}]: {:?}", stream_id, headers);
                 }
                 Http3Event::DataReadable { stream_id } => {
@@ -299,7 +299,7 @@ impl H3Handler {
 
                     let (_sz, fin) = self
                         .h3
-                        .read_data(Instant::now(), stream_id, &mut data)
+                        .read_response_data(Instant::now(), stream_id, &mut data)
                         .expect("Read should succeed");
                     eprintln!(
                         "READ[{}]: {}",


### PR DESCRIPTION
- change get_headers/read_data names into something more descriptive,
- make read_response_headers return fin flag as well,
- make read_response_headers and read_response_data a bit nicer,
- add new error InvalidStreamId so that we do not use a transport error,
- add ResponseHeadersState to be easier to decide if we need to add HeadersREady or Data Ready event, also we do not need struct Response,
- the TransactionClient::receive code was not handling fin bit correctly in all cases, I moved setting state to TransactionRecvState::ClosePending in functions actually handling new data and new frames
- make separate functions for some parts of TransactionClient::receive,
- add test for cases wher fin was handled wrong.