### PR TITLE
Basic self encryption

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -173,7 +173,7 @@ impl<'a, 'b> PartialEq<Decoder<'b>> for Decoder<'a> {
 }
 
 /// Encoder is good for building data structures.
-#[derive(Default, PartialEq)]
+#[derive(Clone, Default, PartialEq)]
 pub struct Encoder {
     buf: Vec<u8>,
 }

--- a/neqo-crypto/bindings/bindings.toml
+++ b/neqo-crypto/bindings/bindings.toml
@@ -143,6 +143,7 @@ functions = [
     "PK11_FindKeyByAnyCert",
     "PK11_FreeSlot",
     "PK11_FreeSymKey",
+    "PK11_GenerateRandom",
     "PK11_GetBlockSize",
     "PK11_GetInternalSlot",
     "PK11_GetKeyData",

--- a/neqo-crypto/src/err.rs
+++ b/neqo-crypto/src/err.rs
@@ -45,6 +45,7 @@ pub enum Error {
         desc: String,
     },
     OverrunError,
+    SelfEncryptFailure,
     TimeTravelError,
     UnsupportedCipher,
     UnsupportedVersion,

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -28,6 +28,7 @@ pub mod hp;
 mod prio;
 mod replay;
 mod secrets;
+pub mod selfencrypt;
 mod ssl;
 mod time;
 

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -11,6 +11,7 @@
 
 use crate::err::{secstatus_to_res, Error, Res};
 
+use std::convert::TryInto;
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
@@ -77,5 +78,25 @@ impl SymKey {
 impl std::fmt::Debug for SymKey {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "SymKey")
+    }
+}
+
+/// Generate a randomized buffer.
+pub fn random(size: usize) -> Res<Vec<u8>> {
+    let mut buf = vec![0; size];
+    secstatus_to_res(unsafe { PK11_GenerateRandom(buf.as_mut_ptr(), buf.len().try_into()?) })?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod test {
+    use super::random;
+    use test_fixture::fixture_init;
+
+    #[test]
+    fn randomness() {
+        fixture_init();
+        // If this ever fails, there is either a bug, or it's time to buy a lottery ticket.
+        assert_ne!(random(16), random(16));
     }
 }

--- a/neqo-crypto/src/selfencrypt.rs
+++ b/neqo-crypto/src/selfencrypt.rs
@@ -1,0 +1,144 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::aead::Aead;
+use crate::constants::*;
+use crate::err::{Error, Res};
+use crate::hkdf;
+use crate::p11::{random, SymKey};
+
+use neqo_common::{hex, qinfo, qtrace, Encoder};
+
+use std::mem;
+
+#[derive(Debug)]
+pub struct SelfEncrypt {
+    version: Version,
+    cipher: Cipher,
+    key_id: u8,
+    key: SymKey,
+    old_key: Option<SymKey>,
+}
+
+impl SelfEncrypt {
+    const VERSION: u8 = 1;
+    const SALT_LENGTH: usize = 16;
+
+    pub fn new(version: Version, cipher: Cipher) -> Res<Self> {
+        let sz = hkdf::key_size(version, cipher)?;
+        let key = hkdf::generate_key(version, cipher, sz)?;
+        Ok(SelfEncrypt {
+            version,
+            cipher,
+            key_id: 0,
+            key,
+            old_key: None,
+        })
+    }
+
+    fn make_aead(&self, k: &SymKey, salt: &[u8]) -> Res<Aead> {
+        debug_assert_eq!(salt.len(), SelfEncrypt::SALT_LENGTH);
+        let salt = hkdf::import_key(self.version, self.cipher, salt)?;
+        let secret = hkdf::extract(self.version, self.cipher, Some(&salt), k)?;
+        Aead::new(self.version, self.cipher, &secret, "neqo self")
+    }
+
+    /// Rotate keys.  This causes any previous key that is being held to be replaced by the current key.
+    pub fn rotate(&mut self) -> Res<()> {
+        let sz = hkdf::key_size(self.version, self.cipher)?;
+        let new_key = hkdf::generate_key(self.version, self.cipher, sz)?;
+        self.old_key = Some(mem::replace(&mut self.key, new_key));
+        let (kid, _) = self.key_id.overflowing_add(1);
+        self.key_id = kid;
+        qinfo!(["SelfEncrypt"], "Rotated keys to {}", self.key_id);
+        Ok(())
+    }
+
+    /// Seal an item using the underlying key.  This produces a single buffer that contains
+    /// the encrypted `plaintext`, plus a version number and salt.
+    /// `aad` is only used as input to the AEAD, it is not included in the output; the
+    /// caller is responsible for carrying the AAD as appropriate.
+    pub fn seal(&self, aad: &[u8], plaintext: &[u8]) -> Res<Vec<u8>> {
+        // Format is:
+        // struct {
+        //   uint8 version;
+        //   uint8 key_id;
+        //   uint8 salt[16];
+        //   opaque aead_encrypted(plaintext)[length as expanded];
+        // };
+        // AAD covers the entire header, plus the value of the AAD parameter that is provided.
+        let salt = random(SelfEncrypt::SALT_LENGTH)?;
+        let aead = self.make_aead(&self.key, &salt)?;
+        let encoded_len = 2 + salt.len() + plaintext.len() + aead.expansion();
+
+        let mut enc = Encoder::with_capacity(encoded_len);
+        enc.encode_byte(SelfEncrypt::VERSION);
+        enc.encode_byte(self.key_id);
+        enc.encode(&salt);
+
+        let mut extended_aad = enc.clone();
+        extended_aad.encode(aad);
+
+        let offset = enc.len();
+        let mut output: Vec<u8> = enc.into();
+        output.resize(encoded_len, 0);
+        aead.encrypt(0, &extended_aad, plaintext, &mut output[offset..])?;
+        qtrace!(
+            ["SelfEncrypt"],
+            "seal {} {} -> {}",
+            hex(aad),
+            hex(plaintext),
+            hex(&output)
+        );
+        Ok(output)
+    }
+
+    fn select_key(&self, kid: u8) -> Option<&SymKey> {
+        if kid == self.key_id {
+            Some(&self.key)
+        } else {
+            let (prev_key_id, _) = self.key_id.overflowing_sub(1);
+            if kid == prev_key_id {
+                self.old_key.as_ref()
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Open the protected `ciphertext`.
+    pub fn open(&self, aad: &[u8], ciphertext: &[u8]) -> Res<Vec<u8>> {
+        if ciphertext[0] != SelfEncrypt::VERSION {
+            return Err(Error::SelfEncryptFailure);
+        }
+        let key = if let Some(k) = self.select_key(ciphertext[1]) {
+            k
+        } else {
+            return Err(Error::SelfEncryptFailure);
+        };
+        let offset = 2 + SelfEncrypt::SALT_LENGTH;
+
+        let mut extended_aad = Encoder::with_capacity(offset + aad.len());
+        extended_aad.encode(&ciphertext[0..offset]);
+        extended_aad.encode(aad);
+
+        let aead = self.make_aead(key, &ciphertext[2..offset])?;
+        // NSS insists on having extra space available for decryption.
+        let padded_len = ciphertext.len() - offset;
+        let mut output = vec![0; padded_len];
+        let decrypted = aead.decrypt(0, &extended_aad, &ciphertext[offset..], &mut output)?;
+        let final_len = decrypted.len();
+        output.truncate(final_len);
+        qtrace!(
+            ["SelfEncrypt"],
+            "open {} {} -> {}",
+            hex(aad),
+            hex(ciphertext),
+            hex(&output)
+        );
+        Ok(output)
+    }
+}

--- a/neqo-crypto/tests/selfencrypt.rs
+++ b/neqo-crypto/tests/selfencrypt.rs
@@ -1,0 +1,90 @@
+#![deny(warnings)]
+
+use neqo_crypto::constants::*;
+use neqo_crypto::{init, selfencrypt::SelfEncrypt, Error};
+
+#[test]
+fn se_create() {
+    init();
+    SelfEncrypt::new(TLS_VERSION_1_3, TLS_AES_128_GCM_SHA256).expect("constructor works");
+}
+
+const PLAINTEXT: &[u8] = b"PLAINTEXT";
+const AAD: &[u8] = b"AAD";
+
+fn sealed() -> (SelfEncrypt, Vec<u8>) {
+    init();
+    let se = SelfEncrypt::new(TLS_VERSION_1_3, TLS_AES_128_GCM_SHA256).unwrap();
+    let sealed = se.seal(AAD, PLAINTEXT).expect("sealing works");
+    (se, sealed)
+}
+
+#[test]
+fn seal_open() {
+    let (se, sealed) = sealed();
+    let opened = se.open(AAD, &sealed).expect("opening works");
+    assert_eq!(&opened[..], PLAINTEXT);
+}
+
+#[test]
+fn seal_rotate_open() {
+    let (mut se, sealed) = sealed();
+    se.rotate().expect("rotate should be infallible");
+    let opened = se.open(AAD, &sealed).expect("opening works");
+    assert_eq!(&opened[..], PLAINTEXT);
+}
+
+#[test]
+fn seal_rotate_twice_open() {
+    let (mut se, sealed) = sealed();
+    se.rotate().expect("rotate should be infallible");
+    se.rotate().expect("rotate should be infallible");
+    let res = se.open(AAD, &sealed);
+    assert_eq!(res.unwrap_err(), Error::SelfEncryptFailure);
+}
+
+#[test]
+fn damage_version() {
+    let (se, mut sealed) = sealed();
+    sealed[0] ^= 0x80;
+    let res = se.open(AAD, &sealed);
+    assert_eq!(res.unwrap_err(), Error::SelfEncryptFailure);
+}
+
+fn assert_bad_data<T>(res: Result<T, Error>) {
+    if let Err(Error::NssError { name, .. }) = res {
+        assert_eq!(name, "SEC_ERROR_BAD_DATA");
+    }
+}
+
+#[test]
+fn damage_salt() {
+    let (se, mut sealed) = sealed();
+    sealed[4] ^= 0x10;
+    let res = se.open(AAD, &sealed);
+    assert_bad_data(res);
+}
+
+#[test]
+fn damage_ciphertext() {
+    let (se, mut sealed) = sealed();
+    sealed[20] ^= 0x2f;
+    let res = se.open(AAD, &sealed);
+    assert_bad_data(res);
+}
+
+#[test]
+fn damage_auth_tag() {
+    let (se, mut sealed) = sealed();
+    let idx = sealed.len() - 1;
+    sealed[idx] ^= 0x3;
+    let res = se.open(AAD, &sealed);
+    assert_bad_data(res);
+}
+
+#[test]
+fn truncate() {
+    let (se, sealed) = sealed();
+    let res = se.open(AAD, &sealed[0..(sealed.len() - 1)]);
+    assert_bad_data(res);
+}

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -246,9 +246,9 @@ impl CryptoDxState {
         }
     }
 
-    pub fn new_initial<S: Into<String>>(
+    pub fn new_initial(
         direction: CryptoDxDirection,
-        label: S,
+        label: &str,
         dcid: &[u8],
     ) -> Option<CryptoDxState> {
         const INITIAL_SALT: &[u8] = &[


### PR DESCRIPTION
This self-encryption capability enables the generation of tokens that can only be processed by the same instance of the class.  It has basic key rotation capabilities built in so that keys can be swapped out over time.

There isn't any provision for synchronizing these between instances (which is what you would need for a real server), but this is probably enough for our immediate purposes.

This builds on #220, #219, and #215, so you might want to look at those first.