### PR TITLE
Remove "delete head" rule for mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,7 +15,3 @@ pull_request_rules:
     actions:
       dismiss_reviews:
         approved: true
-  - name: delete head branch after merge
-    conditions: []
-    actions:
-      delete_head_branch: {}


### PR DESCRIPTION
GitHub provides this capability now.  And the rule was causing all of our PRs to report an orange dot (in progress) rather than a tick (CI passed), which was annoying.