### PR TITLE
Define an enum for authentication status

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -6,7 +6,7 @@
 
 #![deny(warnings)]
 use neqo_common::{matches, Datagram};
-use neqo_crypto::init;
+use neqo_crypto::{init, AuthenticationStatus};
 use neqo_http3::{Header, Http3Connection, Http3Event, Http3State, Output};
 use neqo_transport::Connection;
 use std::collections::HashSet;
@@ -162,7 +162,7 @@ impl Handler for PreConnectHandler {
     fn handle(&mut self, _args: &Args, client: &mut Http3Connection) -> bool {
         let authentication_needed = |e| matches!(e, Http3Event::AuthenticationNeeded);
         if client.events().into_iter().any(authentication_needed) {
-            client.authenticated(0, Instant::now());
+            client.authenticated(AuthenticationStatus::Ok, Instant::now());
         }
         Http3State::Connected != client.state()
     }

--- a/neqo-crypto/Cargo.toml
+++ b/neqo-crypto/Cargo.toml
@@ -10,7 +10,7 @@ neqo-common = { path = "../neqo-common" }
 log = "0.4.0"
 
 [build-dependencies]
-bindgen = "0.49"
+bindgen = "0.51"
 serde = "1.0"
 serde_derive = "1.0"
 toml = "0.4"

--- a/neqo-crypto/bindings/bindings.toml
+++ b/neqo-crypto/bindings/bindings.toml
@@ -222,3 +222,8 @@ enums = [
 [nspr_time]
 types = ["PRTime"]
 functions = ["PR_Now"]
+
+[mozpkix]
+cplusplus = true
+types = ["mozilla::pkix::ErrorCode"]
+enums = ["mozilla::pkix::ErrorCode"]

--- a/neqo-crypto/bindings/mozpkix.hpp
+++ b/neqo-crypto/bindings/mozpkix.hpp
@@ -1,0 +1,1 @@
+#include "mozpkix/pkixnss.h"

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -218,15 +218,12 @@ fn build_bindings(base: &str, bindings: &Bindings, includes: &[PathBuf]) {
 
     let mut builder = Builder::default().header(header).generate_comments(false);
 
-    builder = builder.clang_arg(String::from("-v"));
+    builder = builder.clang_arg("-v");
     for i in includes {
         builder = builder.clang_arg(String::from("-I") + i.to_str().unwrap());
     }
     if bindings.cplusplus {
-        builder = builder
-            .clang_arg(String::from("-x"))
-            .clang_arg(String::from("c++"));
-        builder = builder.clang_arg(String::from("-std=c++11"));
+        builder = builder.clang_args(&["-x", "c++", "-std=c++11"]);
     }
 
     // Apply the configuration.

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -7,6 +7,7 @@
 use crate::agentio::{emit_record, ingest_record, AgentIo, METHODS};
 pub use crate::agentio::{Record, RecordList};
 use crate::assert_initialized;
+use crate::auth::AuthenticationStatus;
 pub use crate::cert::CertificateInfo;
 use crate::constants::*;
 use crate::convert::to_c_uint;
@@ -17,8 +18,7 @@ use crate::prio;
 use crate::replay::AntiReplay;
 use crate::result;
 use crate::secrets::SecretHolder;
-use crate::ssl;
-use crate::ssl::PRBool;
+use crate::ssl::{self, PRBool};
 use crate::time::{PRTime, Time};
 
 use neqo_common::{qdebug, qinfo, qwarn};
@@ -506,10 +506,10 @@ impl SecretAgent {
     /// Call this function to mark the peer as authenticated.
     /// Only call this function if handshake/handshake_raw returns
     /// HandshakeState::AuthenticationPending, or it will panic.
-    pub fn authenticated(&mut self, error: PRErrorCode) {
+    pub fn authenticated(&mut self, status: AuthenticationStatus) {
         assert_eq!(self.state, HandshakeState::AuthenticationPending);
         *self.auth_required = false;
-        self.state = HandshakeState::Authenticated(error);
+        self.state = HandshakeState::Authenticated(status.into());
     }
 
     fn capture_error<T>(&mut self, res: Res<T>) -> Res<T> {

--- a/neqo-crypto/src/agentio.rs
+++ b/neqo-crypto/src/agentio.rs
@@ -6,7 +6,7 @@
 
 use crate::constants::*;
 use crate::convert::to_c_uint;
-use crate::err::{Error, NSPRErrorCodes, PR_SetError, Res};
+use crate::err::{nspr, Error, PR_SetError, Res};
 use crate::prio;
 use crate::result;
 use crate::ssl;
@@ -171,7 +171,7 @@ impl AgentIoInput {
     fn read_input(&mut self, buf: *mut u8, count: usize) -> Res<usize> {
         let amount = min(self.available, count);
         if amount == 0 {
-            unsafe { PR_SetError(NSPRErrorCodes::PR_WOULD_BLOCK_ERROR, 0) };
+            unsafe { PR_SetError(nspr::PR_WOULD_BLOCK_ERROR, 0) };
             return Err(Error::NoDataAvailable);
         }
 

--- a/neqo-crypto/src/auth.rs
+++ b/neqo-crypto/src/auth.rs
@@ -1,0 +1,99 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::err::{mozpkix, sec, ssl, PRErrorCode};
+
+/// The outcome of authentication.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AuthenticationStatus {
+    Ok,
+    CaInvalid,
+    CaNotV3,
+    CertAlgorithmDisabled,
+    CertExpired,
+    CertInvalidTime,
+    CertIsCa,
+    CertKeyUsage,
+    CertMitm,
+    CertNotYetValid,
+    CertRevoked,
+    CertSelfSigned,
+    CertSubjectInvalid,
+    CertUntrusted,
+    CertWeakKey,
+    IssuerEmptyName,
+    IssuerExpired,
+    IssuerNotYetValid,
+    IssuerUnknown,
+    IssuerUntrusted,
+    PolicyRejection,
+    Unknown,
+}
+
+impl Into<PRErrorCode> for AuthenticationStatus {
+    fn into(self) -> PRErrorCode {
+        match self {
+            Self::Ok => 0,
+            Self::CaInvalid => sec::SEC_ERROR_CA_CERT_INVALID,
+            Self::CaNotV3 => mozpkix::MOZILLA_PKIX_ERROR_V1_CERT_USED_AS_CA,
+            Self::CertAlgorithmDisabled => sec::SEC_ERROR_CERT_SIGNATURE_ALGORITHM_DISABLED,
+            Self::CertExpired => sec::SEC_ERROR_EXPIRED_CERTIFICATE,
+            Self::CertInvalidTime => sec::SEC_ERROR_INVALID_TIME,
+            Self::CertIsCa => mozpkix::MOZILLA_PKIX_ERROR_CA_CERT_USED_AS_END_ENTITY,
+            Self::CertKeyUsage => sec::SEC_ERROR_INADEQUATE_KEY_USAGE,
+            Self::CertMitm => mozpkix::MOZILLA_PKIX_ERROR_MITM_DETECTED,
+            Self::CertNotYetValid => mozpkix::MOZILLA_PKIX_ERROR_NOT_YET_VALID_CERTIFICATE,
+            Self::CertRevoked => sec::SEC_ERROR_REVOKED_CERTIFICATE,
+            Self::CertSelfSigned => mozpkix::MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT,
+            Self::CertSubjectInvalid => ssl::SSL_ERROR_BAD_CERT_DOMAIN,
+            Self::CertUntrusted => sec::SEC_ERROR_UNTRUSTED_CERT,
+            Self::CertWeakKey => mozpkix::MOZILLA_PKIX_ERROR_INADEQUATE_KEY_SIZE,
+            Self::IssuerEmptyName => mozpkix::MOZILLA_PKIX_ERROR_EMPTY_ISSUER_NAME,
+            Self::IssuerExpired => sec::SEC_ERROR_EXPIRED_ISSUER_CERTIFICATE,
+            Self::IssuerNotYetValid => mozpkix::MOZILLA_PKIX_ERROR_NOT_YET_VALID_ISSUER_CERTIFICATE,
+            Self::IssuerUnknown => sec::SEC_ERROR_UNKNOWN_ISSUER,
+            Self::IssuerUntrusted => sec::SEC_ERROR_UNTRUSTED_ISSUER,
+            Self::PolicyRejection => {
+                mozpkix::MOZILLA_PKIX_ERROR_ADDITIONAL_POLICY_CONSTRAINT_FAILED
+            }
+            Self::Unknown => sec::SEC_ERROR_LIBRARY_FAILURE,
+        }
+    }
+}
+
+// Note that this mapping should be removed after gecko eventually learns how to
+// map into the enumerated type.
+impl From<PRErrorCode> for AuthenticationStatus {
+    fn from(v: PRErrorCode) -> Self {
+        match v {
+            0 => Self::Ok,
+            sec::SEC_ERROR_CA_CERT_INVALID => Self::CaInvalid,
+            mozpkix::MOZILLA_PKIX_ERROR_V1_CERT_USED_AS_CA => Self::CaNotV3,
+            sec::SEC_ERROR_CERT_SIGNATURE_ALGORITHM_DISABLED => Self::CertAlgorithmDisabled,
+            sec::SEC_ERROR_EXPIRED_CERTIFICATE => Self::CertExpired,
+            sec::SEC_ERROR_INVALID_TIME => Self::CertInvalidTime,
+            mozpkix::MOZILLA_PKIX_ERROR_CA_CERT_USED_AS_END_ENTITY => Self::CertIsCa,
+            sec::SEC_ERROR_INADEQUATE_KEY_USAGE => Self::CertKeyUsage,
+            mozpkix::MOZILLA_PKIX_ERROR_MITM_DETECTED => Self::CertMitm,
+            mozpkix::MOZILLA_PKIX_ERROR_NOT_YET_VALID_CERTIFICATE => Self::CertNotYetValid,
+            sec::SEC_ERROR_REVOKED_CERTIFICATE => Self::CertRevoked,
+            mozpkix::MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT => Self::CertSelfSigned,
+            ssl::SSL_ERROR_BAD_CERT_DOMAIN => Self::CertSubjectInvalid,
+            sec::SEC_ERROR_UNTRUSTED_CERT => Self::CertUntrusted,
+            mozpkix::MOZILLA_PKIX_ERROR_INADEQUATE_KEY_SIZE => Self::CertWeakKey,
+            mozpkix::MOZILLA_PKIX_ERROR_EMPTY_ISSUER_NAME => Self::IssuerEmptyName,
+            sec::SEC_ERROR_EXPIRED_ISSUER_CERTIFICATE => Self::IssuerExpired,
+            mozpkix::MOZILLA_PKIX_ERROR_NOT_YET_VALID_ISSUER_CERTIFICATE => Self::IssuerNotYetValid,
+            sec::SEC_ERROR_UNKNOWN_ISSUER => Self::IssuerUnknown,
+            sec::SEC_ERROR_UNTRUSTED_ISSUER => Self::IssuerUntrusted,
+            mozpkix::MOZILLA_PKIX_ERROR_ADDITIONAL_POLICY_CONSTRAINT_FAILED => {
+                Self::PolicyRejection
+            }
+            sec::SEC_ERROR_LIBRARY_FAILURE => Self::Unknown,
+            _ => Self::Unknown,
+        }
+    }
+}

--- a/neqo-crypto/src/err.rs
+++ b/neqo-crypto/src/err.rs
@@ -5,12 +5,18 @@
 // except according to those terms.
 
 #![allow(dead_code)]
-#![allow(non_snake_case)]
 
 include!(concat!(env!("OUT_DIR"), "/nspr_error.rs"));
-include!(concat!(env!("OUT_DIR"), "/nss_secerr.rs"));
-include!(concat!(env!("OUT_DIR"), "/nss_sslerr.rs"));
-pub mod NSPRErrorCodes {
+mod codes {
+    #![allow(non_snake_case)]
+    include!(concat!(env!("OUT_DIR"), "/nss_secerr.rs"));
+    include!(concat!(env!("OUT_DIR"), "/nss_sslerr.rs"));
+    include!(concat!(env!("OUT_DIR"), "/mozpkix.rs"));
+}
+pub use codes::mozilla_pkix_ErrorCode as mozpkix;
+pub use codes::SECErrorCodes as sec;
+pub use codes::SSLErrorCodes as ssl;
+pub mod nspr {
     include!(concat!(env!("OUT_DIR"), "/nspr_err.rs"));
 }
 
@@ -65,14 +71,14 @@ impl From<std::num::TryFromIntError> for Error {
 
 #[cfg(test)]
 mod tests {
-    use crate::err::{NSPRErrorCodes, SECErrorCodes, SSLErrorCodes};
+    use crate::err::{nspr, sec, ssl};
     use test_fixture::fixture_init;
 
     #[test]
     fn error_code() {
         fixture_init();
-        assert_eq!(15 - 0x3000, SSLErrorCodes::SSL_ERROR_BAD_MAC_READ);
-        assert_eq!(166 - 0x2000, SECErrorCodes::SEC_ERROR_LIBPKIX_INTERNAL);
-        assert_eq!(-5998, NSPRErrorCodes::PR_WOULD_BLOCK_ERROR);
+        assert_eq!(15 - 0x3000, ssl::SSL_ERROR_BAD_MAC_READ);
+        assert_eq!(166 - 0x2000, sec::SEC_ERROR_LIBPKIX_INTERNAL);
+        assert_eq!(-5998, nspr::PR_WOULD_BLOCK_ERROR);
     }
 }

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -18,6 +18,7 @@ mod p11;
 pub mod aead;
 pub mod agent;
 mod agentio;
+mod auth;
 mod cert;
 pub mod constants;
 mod convert;
@@ -37,11 +38,12 @@ pub use self::agent::{
     SecretAgentPreInfo, Server, ZeroRttCheckResult, ZeroRttChecker,
 };
 pub use self::constants::*;
-pub use self::err::{Error, PRErrorCode, Res, SSLErrorCodes};
+pub use self::err::{Error, PRErrorCode, Res};
 pub use self::ext::{ExtensionHandler, ExtensionHandlerResult, ExtensionWriterResult};
 pub use self::p11::SymKey;
 pub use self::replay::AntiReplay;
 pub use self::secrets::SecretDirection;
+pub use auth::AuthenticationStatus;
 
 use neqo_common::once::OnceResult;
 

--- a/neqo-crypto/tests/agent.rs
+++ b/neqo-crypto/tests/agent.rs
@@ -40,7 +40,7 @@ fn basic() {
     assert!(bytes.is_empty());
     assert_eq!(*client.state(), HandshakeState::AuthenticationPending);
 
-    client.authenticated(0);
+    client.authenticated(AuthenticationStatus::Ok);
     assert_eq!(*client.state(), HandshakeState::Authenticated(0));
 
     // Calling handshake() again indicates that we're happy with the cert.
@@ -104,7 +104,7 @@ fn raw() {
     assert!(client_records.is_empty());
     assert_eq!(*client.state(), HandshakeState::AuthenticationPending);
 
-    client.authenticated(0);
+    client.authenticated(AuthenticationStatus::Ok);
     assert_eq!(*client.state(), HandshakeState::Authenticated(0));
 
     // Calling handshake() again indicates that we're happy with the cert.

--- a/neqo-crypto/tests/handshake.rs
+++ b/neqo-crypto/tests/handshake.rs
@@ -45,7 +45,7 @@ fn handshake(now: Instant, client: &mut SecretAgent, server: &mut SecretAgent) {
         };
 
         if *b.state() == HandshakeState::AuthenticationPending {
-            b.authenticated(0);
+            b.authenticated(AuthenticationStatus::Ok);
             records = b.handshake_raw(now, None).unwrap();
         }
         mem::swap(&mut a, &mut b);

--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -429,6 +429,7 @@ impl HFrameReader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use neqo_crypto::AuthenticationStatus;
     use neqo_transport::StreamType;
     use num_traits::Num;
     use test_fixture::*;
@@ -449,7 +450,7 @@ mod tests {
         let out = conn_s.process(out.dgram(), now());
         let out = conn_c.process(out.dgram(), now());
         conn_s.process(out.dgram(), now());
-        conn_c.authenticated(0, now());
+        conn_c.authenticated(AuthenticationStatus::Ok, now());
         let out = conn_c.process(None, now());
         conn_s.process(out.dgram(), now());
 

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -7,6 +7,7 @@
 #![allow(unused_assignments)]
 
 use neqo_common::{matches, Datagram};
+use neqo_crypto::AuthenticationStatus;
 use neqo_http3::transaction_server::Response;
 use neqo_http3::{Header, Http3Connection, Http3Event, Http3State};
 use test_fixture::*;
@@ -50,7 +51,7 @@ fn connect() -> (Http3Connection, Http3Connection, Option<Datagram>) {
     let _ = hconn_s.process(out.dgram(), now()); //consume ACK
     let authentication_needed = |e| matches!(e, Http3Event::AuthenticationNeeded);
     assert!(hconn_c.events().into_iter().any(authentication_needed));
-    hconn_c.authenticated(0, now());
+    hconn_c.authenticated(AuthenticationStatus::Ok, now());
     let out = hconn_c.process(None, now()); // Handshake
     assert_eq!(hconn_c.state(), Http3State::Connected);
     let out = hconn_s.process(out.dgram(), now()); // Handshake

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -7,7 +7,7 @@
 #![deny(warnings)]
 
 use neqo_common::{matches, Datagram};
-use neqo_crypto::init;
+use neqo_crypto::{init, AuthenticationStatus};
 use neqo_http3::{Header, Http3Connection, Http3Event};
 use neqo_transport::{Connection, ConnectionError, ConnectionEvent, Error, State, StreamType};
 use std::collections::HashSet;
@@ -126,7 +126,7 @@ impl Handler for PreConnectHandler {
     fn handle(&mut self, client: &mut Connection) -> bool {
         let authentication_needed = |e| matches!(e, ConnectionEvent::AuthenticationNeeded);
         if client.events().any(authentication_needed) {
-            client.authenticated(0, Instant::now());
+            client.authenticated(AuthenticationStatus::Ok, Instant::now());
         }
         match client.state() {
             State::Connected => false,

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -8,7 +8,7 @@
 
 use neqo_common::matches;
 use neqo_common::once::OnceResult;
-use neqo_crypto::{init_db, AntiReplay};
+use neqo_crypto::{init_db, AntiReplay, AuthenticationStatus};
 use neqo_transport::{Connection, ConnectionEvent, State};
 use std::mem;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
@@ -75,7 +75,7 @@ pub fn default_server() -> Connection {
 pub fn maybe_autenticate(conn: &mut Connection) -> bool {
     let authentication_needed = |e| matches!(e, ConnectionEvent::AuthenticationNeeded);
     if conn.events().any(authentication_needed) {
-        conn.authenticated(0, now());
+        conn.authenticated(AuthenticationStatus::Ok, now());
         return true;
     }
     false


### PR DESCRIPTION
Note that the From<PRErrorCode> here is for convenience.  Ideally, that
doesn't exist in this code, because users of the API won't have a
PRErrorCode to pass in.  But I suspect that gecko will, and mapping into
the enum is busy-work that you might not want to do right away.

Closes #142.