### PR TITLE
Rework Http3Events a little

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -161,7 +161,7 @@ struct PreConnectHandler {}
 impl Handler for PreConnectHandler {
     fn handle(&mut self, _args: &Args, client: &mut Http3Connection) -> bool {
         let authentication_needed = |e| matches!(e, Http3Event::AuthenticationNeeded);
-        if client.events().into_iter().any(authentication_needed) {
+        if client.events().any(authentication_needed) {
             client.authenticated(AuthenticationStatus::Ok, Instant::now());
         }
         Http3State::Connected != client.state()

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -11,6 +11,7 @@ neqo-transport = { path = "./../neqo-transport" }
 neqo-qpack = { path = "./../neqo-qpack" }
 num-traits = "0.2"
 log = "0.4.0"
+smallvec = "0.6.6"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1114,10 +1114,7 @@ impl Http3Events {
                 | Http3Event::NewPushStream { stream_id }
                 | Http3Event::Reset { stream_id, .. }
                 | Http3Event::StopSending { stream_id, .. } => *stream_id == remove_stream_id,
-                Http3Event::AuthenticationNeeded
-                | Http3Event::GoawayReceived
-                | Http3Event::StateChange { .. }
-                | Http3Event::RequestsCreatable => false,
+                _ => false,
             })
             .cloned()
             .collect::<SmallVec<[_; 8]>>();

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1176,12 +1176,12 @@ mod tests {
             assert!(out.as_dgram_ref().is_none());
 
             let authentication_needed = |e| matches!(e, Http3Event::AuthenticationNeeded);
-            assert!(hconn.events().into_iter().any(authentication_needed));
+            assert!(hconn.events().any(authentication_needed));
             hconn.authenticated(AuthenticationStatus::Ok, now());
 
             let out = hconn.process(out.dgram(), now());
             let connected = |e| matches!(e, Http3Event::StateChange(Http3State::Connected));
-            assert!(hconn.events().into_iter().any(connected));
+            assert!(hconn.events().any(connected));
 
             assert_eq!(hconn.state(), Http3State::Connected);
             neqo_trans_conn.process(out.dgram(), now());
@@ -1876,7 +1876,7 @@ mod tests {
 
         // Get DataWritable for the request stream so that we can write the request body.
         let data_writable = |e| matches!(e, Http3Event::DataWritable { .. });
-        assert!(hconn.events().into_iter().any(data_writable));
+        assert!(hconn.events().any(data_writable));
         let sent = hconn.send_request_body(request_stream_id, &[0x64, 0x65, 0x66]);
         assert_eq!(sent, Ok(3));
         let _ = hconn.stream_close_send(request_stream_id);
@@ -1940,7 +1940,7 @@ mod tests {
 
         // Get DataWritable for the request stream so that we can write the request body.
         let data_writable = |e| matches!(e, Http3Event::DataWritable { .. });
-        assert!(hconn.events().into_iter().any(data_writable));
+        assert!(hconn.events().any(data_writable));
         let sent = hconn.send_request_body(request_stream_id, request_body);
         assert_eq!(sent, Ok(request_body.len()));
 
@@ -2052,7 +2052,7 @@ mod tests {
 
         // Get DataWritable for the request stream so that we can write the request body.
         let data_writable = |e| matches!(e, Http3Event::DataWritable { .. });
-        assert!(hconn.events().into_iter().any(data_writable));
+        assert!(hconn.events().any(data_writable));
 
         // Send the first frame.
         let sent = hconn.send_request_body(request_stream_id, first_frame);
@@ -2268,7 +2268,7 @@ mod tests {
 
         // Get DataWritable for the request stream so that we can write the request body.
         let data_writable = |e| matches!(e, Http3Event::DataWritable { .. });
-        assert!(hconn.events().into_iter().any(data_writable));
+        assert!(hconn.events().any(data_writable));
         let sent = hconn.send_request_body(request_stream_id, &[0u8; 10000]);
         assert_eq!(sent, Ok(10000));
 
@@ -2370,7 +2370,7 @@ mod tests {
 
         // Get DataWritable for the request stream so that we can write the request body.
         let data_writable = |e| matches!(e, Http3Event::DataWritable { .. });
-        assert!(hconn.events().into_iter().any(data_writable));
+        assert!(hconn.events().any(data_writable));
         let sent = hconn.send_request_body(request_stream_id, &[0u8; 10000]);
         assert_eq!(sent, Ok(10000));
 
@@ -2435,7 +2435,7 @@ mod tests {
 
         // Get DataWritable for the request stream so that we can write the request body.
         let data_writable = |e| matches!(e, Http3Event::DataWritable { .. });
-        assert!(hconn.events().into_iter().any(data_writable));
+        assert!(hconn.events().any(data_writable));
         let sent = hconn.send_request_body(request_stream_id, &[0u8; 10000]);
         assert_eq!(sent, Ok(10000));
 
@@ -2495,7 +2495,7 @@ mod tests {
 
         // Get DataWritable for the request stream so that we can write the request body.
         let data_writable = |e| matches!(e, Http3Event::DataWritable { .. });
-        assert!(hconn.events().into_iter().any(data_writable));
+        assert!(hconn.events().any(data_writable));
         let sent = hconn.send_request_body(request_stream_id, &[0u8; 10000]);
         assert_eq!(sent, Ok(10000));
 
@@ -2575,7 +2575,7 @@ mod tests {
 
         // Get DataWritable for the request stream so that we can write the request body.
         let data_writable = |e| matches!(e, Http3Event::DataWritable { .. });
-        assert!(hconn.events().into_iter().any(data_writable));
+        assert!(hconn.events().any(data_writable));
         let sent = hconn.send_request_body(request_stream_id, &[0u8; 10000]);
         assert_eq!(sent, Ok(10000));
 
@@ -2649,7 +2649,7 @@ mod tests {
 
         // Get DataWritable for the request stream so that we can write the request body.
         let data_writable = |e| matches!(e, Http3Event::DataWritable { .. });
-        assert!(hconn.events().into_iter().any(data_writable));
+        assert!(hconn.events().any(data_writable));
         let sent = hconn.send_request_body(request_stream_id, &[0u8; 10000]);
         assert_eq!(sent, Ok(10000));
 
@@ -2948,7 +2948,7 @@ mod tests {
         hconn.process(out.dgram(), now());
 
         // Recv HeaderReady wo headers with fin.
-        let e = hconn.events().into_iter().next().unwrap();
+        let e = hconn.events().next().unwrap();
         if let Http3Event::HeaderReady { stream_id } = e {
             assert_eq!(stream_id, request_stream_id);
             let h = hconn.read_response_headers(stream_id);
@@ -2981,7 +2981,7 @@ mod tests {
         hconn.process(out.dgram(), now());
 
         // Recv HeaderReady with headers and fin.
-        let e = hconn.events().into_iter().next().unwrap();
+        let e = hconn.events().next().unwrap();
         if let Http3Event::HeaderReady { stream_id } = e {
             assert_eq!(stream_id, request_stream_id);
             let h = hconn.read_response_headers(stream_id);
@@ -3255,7 +3255,7 @@ mod tests {
         hconn.process(out.dgram(), now());
 
         // fin wo data should generate DataReadable
-        let e = hconn.events().into_iter().next().unwrap();
+        let e = hconn.events().next().unwrap();
         if let Http3Event::DataReadable { stream_id } = e {
             assert_eq!(stream_id, request_stream_id);
             let mut buf = [0u8; 100];
@@ -3329,7 +3329,7 @@ mod tests {
         hconn.process(out.dgram(), now());
 
         // Read first frame
-        match hconn.events().into_iter().nth(1).unwrap() {
+        match hconn.events().nth(1).unwrap() {
             Http3Event::DataReadable { stream_id } => {
                 assert_eq!(stream_id, request_stream_id);
                 let mut buf = [0u8; 100];
@@ -3348,7 +3348,7 @@ mod tests {
         // Second frame isn't read in first read_response_data(), but it generates
         // another DataReadable event so that another read_response_data() will happen to
         // pick it up.
-        match hconn.events().into_iter().next().unwrap() {
+        match hconn.events().next().unwrap() {
             Http3Event::DataReadable { stream_id } => {
                 assert_eq!(stream_id, request_stream_id);
                 let mut buf = [0u8; 100];
@@ -3442,7 +3442,7 @@ mod tests {
         hconn.process(None, now());
 
         // Read first frame
-        match hconn.events().into_iter().nth(1).unwrap() {
+        match hconn.events().nth(1).unwrap() {
             Http3Event::DataReadable { stream_id } => {
                 assert_eq!(stream_id, request_stream_id);
                 let mut buf = [0u8; 100];

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -50,7 +50,7 @@ fn connect() -> (Http3Connection, Http3Connection, Option<Datagram>) {
     let out = hconn_c.process(out.dgram(), now()); // ACK
     let _ = hconn_s.process(out.dgram(), now()); //consume ACK
     let authentication_needed = |e| matches!(e, Http3Event::AuthenticationNeeded);
-    assert!(hconn_c.events().into_iter().any(authentication_needed));
+    assert!(hconn_c.events().any(authentication_needed));
     hconn_c.authenticated(AuthenticationStatus::Ok, now());
     let out = hconn_c.process(None, now()); // Handshake
     assert_eq!(hconn_c.state(), Http3State::Connected);


### PR DESCRIPTION
Instead of "create a new http3events with undesired events
filtered out" strategy, remove events more directly.

Change authentication_needed() to take &self for consistency.
We're using runtime checks instead of compile-time ownership
checks.

Have events() return Iterator instead of collections, as
previously done for transport layer.

Rename test called fetch() to fetch_basic(), to make it
easier to run by itself (its entire name is not the prefix
for other tests).

Further test changes to handle events() returning Iterator.

fixes #195