### PR TITLE
The http3 server should be able to cancel a stream as well

### DIFF
--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -91,6 +91,7 @@ fn http_serve(request_headers: &[Header], _error: bool) -> Response {
             (String::from("content-length"), response.len().to_string()),
         ],
         response,
+        None,
     )
 }
 

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -730,8 +730,14 @@ impl Http3Connection {
             }
             if transaction.done_reading_request() {
                 if let Some(ref mut cb) = self.handler {
-                    let (headers, data, close_error) = (cb)(transaction.get_request_headers(), false);
-                    qdebug!("Sending response: {:?} {:?} {:?}", headers, data, close_error);
+                    let (headers, data, close_error) =
+                        (cb)(transaction.get_request_headers(), false);
+                    qdebug!(
+                        "Sending response: {:?} {:?} {:?}",
+                        headers,
+                        data,
+                        close_error
+                    );
                     match close_error {
                         Some(e) => {
                             let _ = self.conn.stream_stop_sending(stream_id, e.code());
@@ -742,7 +748,7 @@ impl Http3Connection {
                                 transaction.set_response(&headers, data, &mut self.qpack_encoder);
                             }
                         }
-                        None => transaction.set_response(&headers, data, &mut self.qpack_encoder)
+                        None => transaction.set_response(&headers, data, &mut self.qpack_encoder),
                     };
                 }
                 if transaction.is_state_sending() {

--- a/neqo-http3/src/transaction_server.rs
+++ b/neqo-http3/src/transaction_server.rs
@@ -13,7 +13,7 @@ use neqo_qpack::encoder::QPackEncoder;
 use neqo_transport::Connection;
 use std::mem;
 
-pub type Response = (Vec<Header>, Vec<u8>);
+pub type Response = (Vec<Header>, Vec<u8>, Option<Error>);
 pub type RequestHandler = Box<dyn FnMut(&[Header], bool) -> Response>;
 
 #[derive(PartialEq, Debug)]

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -31,6 +31,7 @@ fn new_stream_callback(request_headers: &[Header], error: bool) -> Response {
             (String::from("content-length"), String::from("3")),
         ],
         b"123".to_vec(),
+        None,
     )
 }
 


### PR DESCRIPTION
This is just extending server functionality a bit. A proper fix will need http3 refactoring (issue #20). Until that is done this change makes possible at least a bit of automatic testing for mozilla-central.

With this change we can cancel request.