### PR TITLE
Sort internal errors

### DIFF
--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -48,16 +48,17 @@ pub enum Error {
     RequestRejected,
     GeneralProtocolError,
     MalformedFrame(HFrameType),
-    NoMoreData,
-    DecodingFrame,
-    NotEnoughData,
-    Unexpected,
-    InvalidStreamId,
-    Unavailable,
-    AlreadyClosed,
-    // So we can wrap and report these errors.
-    TransportError(neqo_transport::Error),
     QpackError(neqo_qpack::Error),
+
+    // Internal errors from here.
+    AlreadyClosed,
+    DecodingFrame,
+    InvalidStreamId,
+    NoMoreData,
+    NotEnoughData,
+    TransportError(neqo_transport::Error),
+    Unavailable,
+    Unexpected,
 }
 
 impl Error {
@@ -89,16 +90,9 @@ impl Error {
                 0..=0xfe => (*t as neqo_transport::AppError) + 0x100,
                 _ => 0x1ff,
             },
-            // These are all internal errors.
-            Error::NoMoreData
-            | Error::DecodingFrame
-            | Error::NotEnoughData
-            | Error::Unexpected
-            | Error::InvalidStreamId
-            | Error::Unavailable
-            | Error::AlreadyClosed
-            | Error::TransportError(..) => 3,
             Error::QpackError(e) => e.code(),
+            // These are all internal errors.
+            _ => 3,
         }
     }
 

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -53,26 +53,28 @@ pub enum Error {
     InvalidMigration,
     CryptoError(neqo_crypto::Error),
     CryptoAlert(u8),
-    TypeError,
-    NoMoreData,
-    TooMuchData,
-    UnknownFrameType,
-    InvalidPacket,
-    DecryptError,
-    InvalidStreamId,
-    DecodingFrame,
-    UnexpectedMessage,
-    HandshakeFailed,
-    KeysNotFound,
-    ConnectionState,
+
+    // All internal errors from here.
     AckedUnsentPacket,
-    VersionNegotiation,
-    InvalidResumptionToken,
-    WrongRole,
-    InvalidInput,
+    ConnectionState,
+    DecodingFrame,
+    DecryptError,
+    HandshakeFailed,
     IdleTimeout,
-    PeerError(TransportError),
+    InvalidInput,
+    InvalidPacket,
+    InvalidResumptionToken,
     InvalidRetry,
+    InvalidStreamId,
+    KeysNotFound,
+    NoMoreData,
+    PeerError(TransportError),
+    TooMuchData,
+    TypeError,
+    UnexpectedMessage,
+    UnknownFrameType,
+    VersionNegotiation,
+    WrongRole,
 }
 
 impl Error {
@@ -90,28 +92,8 @@ impl Error {
             Error::InvalidMigration => 12,
             Error::CryptoAlert(a) => 0x100 + u64::from(*a),
             Error::PeerError(a) => *a,
-            // TODO(ekr@rtfm.com): Map these errors.
-            Error::CryptoError(_)
-            | Error::TypeError
-            | Error::NoMoreData
-            | Error::TooMuchData
-            | Error::UnknownFrameType
-            | Error::InvalidPacket
-            | Error::DecryptError
-            | Error::InvalidStreamId
-            | Error::DecodingFrame
-            | Error::UnexpectedMessage
-            | Error::HandshakeFailed
-            | Error::KeysNotFound
-            | Error::ConnectionState
-            | Error::AckedUnsentPacket
-            | Error::VersionNegotiation
-            | Error::WrongRole
-            | Error::InvalidResumptionToken
-            | Error::InvalidInput
-            | Error::InvalidRetry
-            | Error::IdleTimeout
-            | Error::InternalError => 1,
+            // All the rest are internal errors.
+            _ => 1,
         }
     }
 }


### PR DESCRIPTION
Our error codes are a little unwieldy, but keeping the non-numbered ones
in some order might help with finding them.