### PR TITLE
Don't make connections from bad packets

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -833,9 +833,9 @@ impl Connection {
                 if self.process_packet(&hdr, body, now)? {
                     continue;
                 }
+                self.start_handshake(hdr, &d)?;
+                self.process_migrations(&d)?;
             }
-            self.start_handshake(hdr, &d)?;
-            self.process_migrations(&d)?;
         }
         Ok(())
     }


### PR DESCRIPTION
If we get a packet that doesn't encrypt, we will advance the connection
state.  This is bad, because we crash later when we try to access the
idle timeout, which we don't set.