### PR TITLE
Retry with self-encrypt

### DIFF
--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -6,15 +6,24 @@
 
 #![deny(warnings)]
 
-use neqo_common::{qtrace, Datagram, Decoder};
-use neqo_crypto::AuthenticationStatus;
+use neqo_common::{hex, qdebug, qtrace, Datagram, Decoder, Encoder};
+use neqo_crypto::{
+    aead::Aead,
+    constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
+    hkdf,
+    hp::HpKey,
+    AuthenticationStatus,
+};
 use neqo_transport::{
-    server::ActiveConnectionRef, server::Server, Connection, ConnectionError, Error,
-    FixedConnectionIdManager, Output, State, StreamType, QUIC_VERSION,
+    server::{ActiveConnectionRef, Server},
+    Connection, ConnectionError, Error, FixedConnectionIdManager, Output, State, StreamType,
+    QUIC_VERSION,
 };
 use test_fixture::{self, assertions, default_client, now};
 
 use std::cell::RefCell;
+use std::convert::TryFrom;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -25,8 +34,9 @@ fn default_server() -> Server {
         test_fixture::DEFAULT_KEYS,
         test_fixture::DEFAULT_ALPN,
         test_fixture::anti_replay(),
-        Rc::new(RefCell::new(FixedConnectionIdManager::new(7))),
+        Rc::new(RefCell::new(FixedConnectionIdManager::new(9))),
     )
+    .expect("should create a server")
 }
 
 fn connected_server(server: &mut Server) -> ActiveConnectionRef {
@@ -148,13 +158,247 @@ fn retry_0rtt() {
 }
 
 #[test]
-fn retry_bad_token() {
-    // TODO(mt) - attempt a retry but get a bad token
+fn retry_different_ip() {
+    let mut server = default_server();
+    server.set_retry_required(true);
+    let mut client = default_client();
+
+    let dgram = client.process(None, now()).dgram(); // Initial
+    assert!(dgram.is_some());
+    let dgram = server.process(dgram, now()).dgram(); // Retry
+    assert!(dgram.is_some());
+
+    assertions::assert_retry(&dgram.as_ref().unwrap());
+
+    let dgram = client.process(dgram, now()).dgram(); // Initial w/token
+    assert!(dgram.is_some());
+
+    // Change the source IP on the address from the client.
+    let dgram = dgram.unwrap();
+    let other_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
+    let other_addr = SocketAddr::new(other_v4, 443);
+    let from_other = Datagram::new(other_addr, dgram.destination(), &dgram[..]);
+    let dgram = server.process(Some(from_other), now()).dgram();
+    assert!(dgram.is_none());
 }
 
 #[test]
 fn retry_bad_odcid() {
-    // TODO(mt) - retry works, but the ODCID transport parameter is wrong
+    let mut server = default_server();
+    server.set_retry_required(true);
+    let mut client = default_client();
+
+    let dgram = client.process(None, now()).dgram(); // Initial
+    assert!(dgram.is_some());
+    let dgram = server.process(dgram, now()).dgram(); // Retry
+    assert!(dgram.is_some());
+
+    let retry = &dgram.as_ref().unwrap();
+    assertions::assert_retry(retry);
+
+    let mut dec = Decoder::new(retry); // Start after version.
+    dec.skip(5);
+    dec.skip_vec(1); // DCID
+    dec.skip_vec(1); // SCID
+    let odcid_len = dec.decode_byte().unwrap();
+    assert_ne!(odcid_len, 0);
+    let odcid_offset = retry.len() - dec.remaining();
+    assert!(odcid_offset < retry.len());
+    let mut tweaked_retry = retry[..].to_vec();
+    tweaked_retry[odcid_offset] ^= 0x45; // damage the ODCID
+    let tweaked_packet = Datagram::new(retry.source(), retry.destination(), tweaked_retry);
+
+    // The client should ignore this packet.
+    let dgram = client.process(Some(tweaked_packet), now()).dgram();
+    assert!(dgram.is_none());
+}
+
+#[test]
+fn retry_bad_token() {
+    let mut client = default_client();
+    let mut retry_server = default_server();
+    retry_server.set_retry_required(true);
+    let mut server = default_server();
+
+    // Send a retry to one server, then replay it to the other.
+    let client_initial1 = client.process(None, now()).dgram();
+    assert!(client_initial1.is_some());
+    let retry = retry_server.process(client_initial1, now()).dgram();
+    assert!(retry.is_some());
+    let client_initial2 = client.process(retry.clone(), now()).dgram();
+    assert!(client_initial2.is_some());
+
+    let dgram = server.process(client_initial2, now()).dgram();
+    assert!(dgram.is_none());
+}
+
+// Generate an AEAD and header protection object for a client Initial.
+fn client_initial_aead_and_hp(dcid: &[u8]) -> (Aead, HpKey) {
+    const INITIAL_SALT: &[u8] = &[
+        0x7f, 0xbc, 0xdb, 0x0e, 0x7c, 0x66, 0xbb, 0xe9, 0x19, 0x3a, 0x96, 0xcd, 0x21, 0x51, 0x9e,
+        0xbd, 0x7a, 0x02, 0x64, 0x4a,
+    ];
+    let initial_secret = hkdf::extract(
+        TLS_VERSION_1_3,
+        TLS_AES_128_GCM_SHA256,
+        Some(
+            hkdf::import_key(TLS_VERSION_1_3, TLS_AES_128_GCM_SHA256, INITIAL_SALT)
+                .as_ref()
+                .unwrap(),
+        ),
+        hkdf::import_key(TLS_VERSION_1_3, TLS_AES_128_GCM_SHA256, dcid)
+            .as_ref()
+            .unwrap(),
+    )
+    .unwrap();
+
+    let secret = hkdf::expand_label(
+        TLS_VERSION_1_3,
+        TLS_AES_128_GCM_SHA256,
+        &initial_secret,
+        &[],
+        "client in",
+    )
+    .unwrap();
+    (
+        Aead::new(TLS_VERSION_1_3, TLS_AES_128_GCM_SHA256, &secret, "quic ").unwrap(),
+        HpKey::extract(TLS_VERSION_1_3, TLS_AES_128_GCM_SHA256, &secret, "quic hp").unwrap(),
+    )
+}
+
+// This tests a simulated on-path attacker that intercepts the first
+// client Initial packet and spoofs a retry.
+// The tricky part is in rewriting the second client Initial so that
+// the server doesn't reject the Initial for having a bad token.
+// The client is the only one that can detect this, and that is because
+// the original connection ID is not in transport parameters.
+//
+// Note that this depends on having the server produce a CID that is
+// at least 8 bytes long.  Otherwise, the second Initial won't have a
+// long enough connection ID.
+#[test]
+fn mitm_retry() {
+    let mut client = default_client();
+    let mut retry_server = default_server();
+    retry_server.set_retry_required(true);
+    let mut server = default_server();
+
+    // Trigger initial and a second client Initial.
+    let client_initial1 = client.process(None, now()).dgram();
+    assert!(client_initial1.is_some());
+    let retry = retry_server.process(client_initial1, now()).dgram();
+    assert!(retry.is_some());
+    let client_initial2 = client.process(retry.clone(), now()).dgram();
+    assert!(client_initial2.is_some());
+
+    // Now to start the epic process of decrypting the packet,
+    // rewriting the header to remove the token, and then re-encrypting.
+    let client_initial2 = client_initial2.unwrap();
+    // First, decode the initial up to the packet number.
+    let ci = &client_initial2[..];
+    let mut dec = Decoder::new(&ci);
+    let type_and_ver = dec.decode(5).unwrap().to_vec();
+    assert_eq!(type_and_ver[0] & 0xf0, 0xc0);
+    let dcid = dec.decode_vec(1).unwrap().to_vec();
+    let scid = dec.decode_vec(1).unwrap().to_vec();
+    dec.skip_vvec(); // Token.
+    let mut payload_len = usize::try_from(dec.decode_varint().unwrap()).unwrap();
+    let pn_offset = ci.len() - dec.remaining();
+
+    // Now we have enough information to make keys.
+    let (aead, hp) = client_initial_aead_and_hp(&dcid);
+    // Make a copy of the header that can be modified.
+    // Save 4 extra in case the packet number is that long.
+    let mut header = ci[0..pn_offset + 4].to_vec();
+
+    // Sample for masking and apply the mask.
+    let sample_start = pn_offset + 4;
+    let sample_end = sample_start + 16;
+    let mask = hp.mask(&ci[sample_start..sample_end]).unwrap();
+    header[0] ^= mask[0] & 0xf;
+    let pn_len = 1 + usize::from(header[0] & 0x3);
+    for i in 0..pn_len {
+        header[pn_offset + i] ^= mask[1 + i];
+    }
+    // Trim down to size.
+    header.truncate(pn_offset + pn_len);
+    dec.skip(pn_len);
+    payload_len -= pn_len;
+
+    // Decrypt.
+    // The packet number should be 1.
+    let pn = Decoder::new(&header[pn_offset..])
+        .decode_uint(pn_len)
+        .unwrap();
+    assert_eq!(pn, 1);
+    let mut plaintext_buf = Vec::with_capacity(ci.len());
+    plaintext_buf.resize_with(ci.len(), u8::default);
+    let input = dec.decode(payload_len).unwrap();
+    let plaintext = aead
+        .decrypt(pn, &header, input, &mut plaintext_buf)
+        .unwrap();
+
+    // Now re-encode without the token.
+    let mut enc = Encoder::with_capacity(header.len());
+    enc.encode(&header[..5])
+        .encode_vec(1, &dcid)
+        .encode_vec(1, &scid)
+        .encode_vvec(&[])
+        .encode_varint(u64::try_from(payload_len + pn_len).unwrap());
+    let pn_offset = enc.len();
+    let notoken_header = enc.encode_uint(pn_len, pn).to_vec();
+    qtrace!("notoken_header={}", hex(&notoken_header));
+
+    // Encrypt.
+    let mut notoken_packet = Encoder::with_capacity(1200)
+        .encode(&notoken_header)
+        .to_vec();
+    notoken_packet.resize_with(1200, u8::default);
+    aead.encrypt(
+        pn,
+        &notoken_header,
+        plaintext,
+        &mut notoken_packet[notoken_header.len()..],
+    )
+    .unwrap();
+    // Unlike with decryption, don't truncate.
+    // All 1200 bytes are needed to reach the minimum datagram size.
+
+    // Mask header[0] and packet number.
+    let sample_start = pn_offset + 4;
+    let sample_end = sample_start + 16;
+    let mask = hp.mask(&notoken_packet[sample_start..sample_end]).unwrap();
+    qtrace!(
+        "sample={} mask={}",
+        hex(&notoken_packet[sample_start..sample_end]),
+        hex(&mask)
+    );
+    notoken_packet[0] ^= mask[0] & 0xf;
+    for i in 0..pn_len {
+        notoken_packet[pn_offset + i] ^= mask[1 + i];
+    }
+    qtrace!("packet={}", hex(&notoken_packet));
+
+    let new_datagram = Datagram::new(
+        client_initial2.source(),
+        client_initial2.destination(),
+        notoken_packet,
+    );
+    qdebug!("passing modified Initial to the main server");
+    let dgram = server.process(Some(new_datagram), now()).dgram();
+    assert!(dgram.is_some());
+
+    let dgram = client.process(dgram, now()).dgram(); // Generate an ACK.
+    assert!(dgram.is_some());
+    let dgram = server.process(dgram, now()).dgram();
+    assert!(dgram.is_none());
+    assert!(test_fixture::maybe_authenticate(&mut client));
+    let dgram = client.process(dgram, now()).dgram();
+    assert!(dgram.is_none());
+    assert_eq!(
+        *client.state(),
+        State::Closed(ConnectionError::Transport(Error::InvalidRetry))
+    );
 }
 
 #[test]


### PR DESCRIPTION
This looks like a lot of code, but it's the last commit as a delta to #226.  This adds proper retry tokens to the server code and some new tests for those.

There's a really big test that simulates an attacker spoofing a retry, so that we can test that the client checks for the original connection ID transport parameter.  That was hard to write, so I'll bet that it's hard to read.  I stared at it for a bit trying to work out how to factor it down, but it's all interlinked in awkward ways.  I do want to factor out the ability to decrypt and re-encrypt initial packets, but would prefer not to build all the supporting machinery for that capability today.  I'd prefer to open an issue to track that, so that we can dedicate the right amount of time to the task.