### PR TITLE
Change transport event interface and implementation

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -357,7 +357,7 @@ mod old {
     impl HandlerOld for PostConnectHandlerOld {
         fn handle(&mut self, args: &Args, client: &mut Connection) -> bool {
             let mut data = vec![0; 4000];
-            for event in client.events() {
+            while let Some(event) = client.next_event() {
                 match event {
                     ConnectionEvent::RecvStreamReadable { stream_id } => {
                         if !self.streams.contains(&stream_id) {

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -154,7 +154,7 @@ struct H9Handler {
 impl Handler for H9Handler {
     fn handle(&mut self, client: &mut Connection) -> bool {
         let mut data = vec![0; 4000];
-        for event in client.events() {
+        while let Some(event) = client.next_event() {
             eprintln!("Event: {:?}", event);
             match event {
                 ConnectionEvent::RecvStreamReadable { stream_id } => {

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -836,8 +836,7 @@ mod tests {
         let out = conn_c.process(None, now());
         conn_s.process(out.dgram(), now());
         let mut found_instruction = false;
-        let events = conn_s.events();
-        for e in events {
+        while let Some(e) = conn_s.next_event() {
             if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
                 let mut buf = [0u8; 100];
                 let (amount, fin) = conn_s.stream_recv(stream_id, &mut buf).unwrap();
@@ -944,8 +943,7 @@ mod tests {
         let out = conn_c.process(None, now());
         conn_s.process(out.dgram(), now());
         let mut found_instruction = false;
-        let events = conn_s.events();
-        for e in events {
+        while let Some(e) = conn_s.next_event() {
             if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
                 let mut buf = [0u8; 100];
                 let (amount, fin) = conn_s.stream_recv(stream_id, &mut buf).unwrap();
@@ -1047,8 +1045,7 @@ mod tests {
         let out = conn_c.process(None, now());
         conn_s.process(out.dgram(), now());
         let mut found_instruction = false;
-        let events = conn_s.events();
-        for e in events {
+        while let Some(e) = conn_s.next_event() {
             if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
                 let mut buf = [0u8; 100];
                 let (amount, fin) = conn_s.stream_recv(stream_id, &mut buf).unwrap();
@@ -1143,8 +1140,7 @@ mod tests {
         let out = conn_c.process(None, now());
         conn_s.process(out.dgram(), now());
         let mut found_instruction = false;
-        let events = conn_s.events();
-        for e in events {
+        while let Some(e) = conn_s.next_event() {
             if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
                 let mut buf = [0u8; 100];
                 let (amount, fin) = conn_s.stream_recv(stream_id, &mut buf).unwrap();

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -561,8 +561,7 @@ mod tests {
         let out = conn_c.process(None, now());
         conn_s.process(out.dgram(), now());
         let mut found_instruction = false;
-        let events = conn_s.events();
-        for e in events {
+        while let Some(e) = conn_s.next_event() {
             if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
                 let mut buf = [0u8; 100];
                 let (amount, fin) = conn_s.stream_recv(stream_id, &mut buf).unwrap();

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -175,7 +175,7 @@ fn main() {
             continue;
         }
         let mut streams = Vec::new();
-        for event in server.events() {
+        while let Some(event) = server.next_event() {
             if let ConnectionEvent::RecvStreamReadable { stream_id } = event {
                 streams.push(stream_id)
             }

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1636,7 +1636,7 @@ impl Connection {
                     );
 
                     if next_stream_id.is_uni() {
-                        self.events.new_stream(next_stream_id, StreamType::UniDi);
+                        self.events.new_stream(next_stream_id);
                     } else {
                         let send_initial_max_stream_data = self
                             .tps
@@ -1652,7 +1652,7 @@ impl Connection {
                                 self.events.clone(),
                             ),
                         );
-                        self.events.new_stream(next_stream_id, StreamType::BiDi);
+                        self.events.new_stream(next_stream_id);
                     }
 
                     *next_stream_idx += 1;

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1822,7 +1822,8 @@ impl Connection {
         Ok(())
     }
 
-    /// Get events that indicate state changes on the connection.
+    /// Get all current events. Best used just in debug/testing code, use
+    /// next_event() instead.
     pub fn events(&mut self) -> impl Iterator<Item = ConnectionEvent> {
         self.events.events()
     }
@@ -1830,6 +1831,13 @@ impl Connection {
     /// Return true if there are outstanding events.
     pub fn has_events(&self) -> bool {
         self.events.has_events()
+    }
+
+    /// Get events that indicate state changes on the connection. This method
+    /// correctly handles cases where handling one event can obsolete
+    /// previously-queued events, or cause new events to be generated.
+    pub fn next_event(&mut self) -> Option<ConnectionEvent> {
+        self.events.next_event()
     }
 
     fn check_loss_detection_timeout(&mut self, now: Instant) {

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -138,6 +138,7 @@ impl ConnectionEvents {
         self.events.borrow_mut().pop_front()
     }
 
+    #[allow(clippy::block_in_if_condition_stmt)]
     fn insert(&self, event: ConnectionEvent) {
         let mut q = self.events.borrow_mut();
 

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -55,10 +55,10 @@ impl ConnectionEvents {
         self.insert(ConnectionEvent::AuthenticationNeeded);
     }
 
-    pub fn new_stream(&self, stream_id: StreamId, stream_type: StreamType) {
+    pub fn new_stream(&self, stream_id: StreamId) {
         self.insert(ConnectionEvent::NewStream {
             stream_id: stream_id.as_u64(),
-            stream_type,
+            stream_type: stream_id.stream_type(),
         });
     }
 

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -7,8 +7,10 @@
 // Collecting a list of events relevant to whoever is using the Connection.
 
 use std::cell::RefCell;
-use std::collections::BTreeSet;
+use std::collections::VecDeque;
 use std::rc::Rc;
+
+use neqo_common::matches;
 
 use crate::connection::State;
 use crate::frame::StreamType;
@@ -47,7 +49,7 @@ pub enum ConnectionEvent {
 #[derive(Debug, Default, Clone)]
 #[allow(clippy::module_name_repetitions)]
 pub struct ConnectionEvents {
-    events: Rc<RefCell<BTreeSet<ConnectionEvent>>>,
+    events: Rc<RefCell<VecDeque<ConnectionEvent>>>,
 }
 
 impl ConnectionEvents {
@@ -62,12 +64,6 @@ impl ConnectionEvents {
         });
     }
 
-    pub fn send_stream_writable(&self, stream_id: StreamId) {
-        self.insert(ConnectionEvent::SendStreamWritable {
-            stream_id: stream_id.as_u64(),
-        });
-    }
-
     pub fn recv_stream_readable(&self, stream_id: StreamId) {
         self.insert(ConnectionEvent::RecvStreamReadable {
             stream_id: stream_id.as_u64(),
@@ -75,13 +71,28 @@ impl ConnectionEvents {
     }
 
     pub fn recv_stream_reset(&self, stream_id: StreamId, app_error: AppError) {
+        // If reset, no longer readable.
+        self.remove(|evt| matches!(evt, ConnectionEvent::RecvStreamReadable { stream_id: x } if *x == stream_id.as_u64()));
+        // If reset multiple times, just return the last event.
+        self.remove(|evt| matches!(evt, ConnectionEvent::RecvStreamReset { stream_id: x, .. } if *x == stream_id.as_u64()));
+
         self.insert(ConnectionEvent::RecvStreamReset {
             stream_id: stream_id.as_u64(),
             app_error,
         });
     }
 
+    pub fn send_stream_writable(&self, stream_id: StreamId) {
+        self.insert(ConnectionEvent::SendStreamWritable {
+            stream_id: stream_id.as_u64(),
+        });
+    }
+
     pub fn send_stream_stop_sending(&self, stream_id: StreamId, app_error: AppError) {
+        // If stopped, no longer writable.
+        self.remove(|evt| matches!(evt, ConnectionEvent::SendStreamWritable { stream_id: x } if *x == stream_id.as_u64()));
+        // If stopped multiple times, just return the last event.
+        self.remove(|evt| matches!(evt, ConnectionEvent::SendStreamStopSending { stream_id: x, .. } if *x == stream_id.as_u64()));
         self.insert(ConnectionEvent::SendStreamStopSending {
             stream_id: stream_id.as_u64(),
             app_error,
@@ -89,6 +100,10 @@ impl ConnectionEvents {
     }
 
     pub fn send_stream_complete(&self, stream_id: StreamId) {
+        self.remove(|evt| matches!(evt, ConnectionEvent::SendStreamWritable { stream_id: x } if *x == stream_id.as_u64()));
+
+        self.remove(|evt| matches!(evt, ConnectionEvent::SendStreamStopSending { stream_id: x, .. } if *x == stream_id.as_u64()));
+
         self.insert(ConnectionEvent::SendStreamComplete {
             stream_id: stream_id.as_u64(),
         });
@@ -99,23 +114,104 @@ impl ConnectionEvents {
     }
 
     pub fn connection_state_change(&self, state: State) {
+        // If closing, existing events no longer relevant.
+        match state {
+            State::Closing { .. } | State::Closed(_) => self.events.borrow_mut().clear(),
+            _ => (),
+        }
         self.insert(ConnectionEvent::StateChange(state));
     }
 
     pub fn client_0rtt_rejected(&self) {
+        // If 0rtt rejected, must start over and existing events are no longer
+        // relevant.
         self.events.borrow_mut().clear();
         self.insert(ConnectionEvent::ZeroRttRejected);
     }
 
     pub fn events(&self) -> impl Iterator<Item = ConnectionEvent> {
-        self.events.replace(BTreeSet::new()).into_iter()
-    }
-
-    fn insert(&self, event: ConnectionEvent) {
-        self.events.borrow_mut().insert(event);
+        self.events.replace(VecDeque::new()).into_iter()
     }
 
     pub fn has_events(&self) -> bool {
         !self.events.borrow().is_empty()
+    }
+
+    pub fn next_event(&self) -> Option<ConnectionEvent> {
+        self.events.borrow_mut().pop_front()
+    }
+
+    fn insert(&self, event: ConnectionEvent) {
+        let mut q = self.events.borrow_mut();
+        if !q.contains(&event) {
+            q.push_back(event);
+        }
+    }
+
+    fn remove<F>(&self, f: F)
+    where
+        F: Fn(&ConnectionEvent) -> bool,
+    {
+        self.events.borrow_mut().retain(|evt| !f(evt))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ConnectionError, Error};
+
+    #[test]
+    fn event_culling() {
+        let evts = ConnectionEvents::default();
+
+        evts.client_0rtt_rejected();
+        evts.client_0rtt_rejected();
+        assert_eq!(evts.events().count(), 1);
+        assert_eq!(evts.events().count(), 0);
+
+        evts.new_stream(4.into());
+        evts.new_stream(4.into());
+        assert_eq!(evts.events().count(), 1);
+
+        evts.recv_stream_readable(6.into());
+        evts.recv_stream_reset(6.into(), 66);
+        evts.recv_stream_reset(6.into(), 65);
+        assert_eq!(evts.events().count(), 1);
+
+        evts.send_stream_writable(8.into());
+        evts.send_stream_writable(8.into());
+        evts.send_stream_stop_sending(8.into(), 55);
+        evts.send_stream_stop_sending(8.into(), 56);
+        assert_eq!(evts.events().count(), 1);
+
+        evts.send_stream_writable(8.into());
+        evts.send_stream_writable(8.into());
+        evts.send_stream_stop_sending(8.into(), 55);
+        evts.send_stream_stop_sending(8.into(), 56);
+        evts.send_stream_complete(8.into());
+        assert_eq!(evts.events().count(), 1);
+
+        evts.send_stream_writable(8.into());
+        evts.send_stream_writable(9.into());
+        evts.send_stream_stop_sending(10.into(), 55);
+        evts.send_stream_stop_sending(11.into(), 56);
+        evts.send_stream_complete(12.into());
+        assert_eq!(evts.events().count(), 5);
+
+        evts.send_stream_writable(8.into());
+        evts.send_stream_writable(9.into());
+        evts.send_stream_stop_sending(10.into(), 55);
+        evts.send_stream_stop_sending(11.into(), 56);
+        evts.send_stream_complete(12.into());
+        evts.client_0rtt_rejected();
+        assert_eq!(evts.events().count(), 1);
+
+        evts.send_stream_writable(9.into());
+        evts.send_stream_stop_sending(10.into(), 55);
+        evts.connection_state_change(State::Closed(ConnectionError::Transport(
+            Error::StreamStateError,
+        )));
+        assert_eq!(evts.events().count(), 1);
     }
 }


### PR DESCRIPTION
A small refactoring commit, and then:

Change transport event interface and implementation
    
Add a next_event() method and prefer it over events(). Using it allows event loops to receive additional events added as previous events are processed, as well as not receiving events that have been obsoleted.
    
Use VecDeque to chronologically order events. Change some events to removeother events that are no longer relevant or correct.
    
Add Connection::has_events() for use by Server::process_connection().
    
fixes #200
