### PR TITLE
Redo Retry implementation for the client

### DIFF
--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -6,7 +6,6 @@
 
 use std::cell::RefCell;
 use std::cmp::min;
-use std::convert::TryInto;
 use std::rc::Rc;
 
 use neqo_common::{hex, qdebug, qinfo, qtrace};
@@ -158,15 +157,6 @@ impl Crypto {
         self.streams[token.epoch as usize]
             .tx
             .mark_as_lost(token.offset, token.length);
-    }
-
-    pub fn retry(&mut self) {
-        let sent = self.streams[0].tx.highest_sent();
-        self.streams[0].tx.mark_as_lost(0, sent.try_into().unwrap());
-
-        for s in &self.streams[1..] {
-            debug_assert_eq!(s.tx.highest_sent(), 0);
-        }
     }
 
     pub fn get_frame(

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -556,13 +556,6 @@ impl SendStream {
         }
     }
 
-    pub fn retry(&mut self) {
-        if let Some(buf) = self.state.tx_buf_mut() {
-            let sent = buf.highest_sent();
-            self.mark_as_lost(0, sent.try_into().unwrap(), true);
-        }
-    }
-
     pub fn final_size(&self) -> Option<u64> {
         self.state.final_size()
     }
@@ -749,12 +742,6 @@ impl SendStreams {
 
     pub fn clear_terminal(&mut self) {
         self.0.retain(|_, stream| !stream.is_terminal())
-    }
-
-    pub(crate) fn retry(&mut self) {
-        for stream in self.0.values_mut() {
-            stream.retry();
-        }
     }
 
     pub(crate) fn get_frame(

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -26,6 +26,17 @@ pub enum PNSpace {
     ApplicationData = 2,
 }
 
+impl PNSpace {
+    pub fn iter() -> impl Iterator<Item = &'static PNSpace> {
+        const SPACES: &[PNSpace] = &[
+            PNSpace::Initial,
+            PNSpace::Handshake,
+            PNSpace::ApplicationData,
+        ];
+        SPACES.iter()
+    }
+}
+
 impl From<Epoch> for PNSpace {
     fn from(epoch: Epoch) -> Self {
         match epoch {


### PR DESCRIPTION
In our tests with real servers, we identified a problem with our Retry
code.  We were sending two Initial packets with CRYPTO data in it with
a direct marking of that data as lost in between.  However, when the
second packet is acknowledged, the first will be marked as lost and the
loss recovery tokens associated with that packet will be sent twice.
But those should not be.

This change lifts the level at which retry operates.  The packets are
marked as lost and the regular "lost packet" processing invoked.  There
is a TODO there with respect to congestion control; we don't currently
have a congestion controller, but when we do that will need to be
scrubbed when a Retry comes in.