### PR TITLE
Calling stream_stop_sending should do something

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -2767,7 +2767,10 @@ mod tests {
         assert!(!server.events().any(stream_readable));
 
         client.process(out.dgram(), now());
-        assert_eq!(Err(Error::FinalSizeError), client.stream_send(stream_id, &[0x00]));
+        assert_eq!(
+            Err(Error::FinalSizeError),
+            client.stream_send(stream_id, &[0x00])
+        );
     }
 
     #[test]
@@ -2790,7 +2793,9 @@ mod tests {
 
         // The client resets the stream. The packet with reset should arrive after the server
         // has already requested stop_sending.
-        client.stream_reset_send(stream_id, Error::NoError.code()).unwrap();
+        client
+            .stream_reset_send(stream_id, Error::NoError.code())
+            .unwrap();
         let out_reset_frame = client.process(None, now());
         // Call stop sending.
         assert_eq!(
@@ -2805,6 +2810,9 @@ mod tests {
 
         // The client gets the STOP_SENDING frame.
         client.process(out.dgram(), now());
-        assert_eq!(Err(Error::InvalidStreamId), client.stream_send(stream_id, &[0x00]));
+        assert_eq!(
+            Err(Error::InvalidStreamId),
+            client.stream_send(stream_id, &[0x00])
+        );
     }
 }

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -506,6 +506,7 @@ impl RecvStream {
         qtrace!("stop_sending called when in state {}", self.state.name());
         match &self.state {
             RecvStreamState::Recv { .. } | RecvStreamState::SizeKnown { .. } => {
+                self.state.transition(RecvStreamState::ResetRecvd);
                 self.flow_mgr.borrow_mut().stop_sending(self.stream_id, err)
             }
             RecvStreamState::DataRecvd { .. } => self.state.transition(RecvStreamState::DataRead),

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -625,7 +625,7 @@ impl SendStream {
         }
 
         if !matches!(self.state, SendStreamState::Send{..}) {
-            return Err(Error::FinalSizeError)
+            return Err(Error::FinalSizeError);
         }
 
         let can_send_bytes = min(self.avail(), buf.len() as u64);

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -624,6 +624,11 @@ impl SendStream {
             });
         }
 
+        match self.state {
+            SendStreamState::Send {..} => {}
+            _ => { return Err(Error::FinalSizeError) }
+        }
+
         let can_send_bytes = min(self.avail(), buf.len() as u64);
 
         if can_send_bytes == 0 {

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -16,7 +16,7 @@ use std::rc::Rc;
 use slice_deque::SliceDeque;
 use smallvec::SmallVec;
 
-use neqo_common::{qerror, qinfo, qtrace, qwarn, Encoder};
+use neqo_common::{matches, qerror, qinfo, qtrace, qwarn, Encoder};
 
 use crate::events::ConnectionEvents;
 use crate::flow_mgr::FlowMgr;
@@ -624,9 +624,8 @@ impl SendStream {
             });
         }
 
-        match self.state {
-            SendStreamState::Send { .. } => {}
-            _ => return Err(Error::FinalSizeError),
+        if !matches!(self.state, SendStreamState::Send{..}) {
+            return Err(Error::FinalSizeError)
         }
 
         let can_send_bytes = min(self.avail(), buf.len() as u64);

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -625,8 +625,8 @@ impl SendStream {
         }
 
         match self.state {
-            SendStreamState::Send {..} => {}
-            _ => { return Err(Error::FinalSizeError) }
+            SendStreamState::Send { .. } => {}
+            _ => return Err(Error::FinalSizeError),
         }
 
         let can_send_bytes = min(self.avail(), buf.len() as u64);


### PR DESCRIPTION
After calling stream_stop_sending on a stream, we should not accept anymore data from the peer on that stream.