### PR TITLE
Track lost packets for a while after they are declared lost

### DIFF
--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -325,7 +325,7 @@ pub struct CryptoStream {
     pub rx: RxStreamOrderer,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CryptoRecoveryToken {
     epoch: u16,
     offset: u64,

--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -180,6 +180,25 @@ impl FlowMgr {
                 application_error_code,
                 final_size
             );
+
+            if self
+                .from_streams
+                .remove(&(
+                    stream_id.into(),
+                    mem::discriminant(&Frame::ResetStream {
+                        stream_id,
+                        application_error_code,
+                        final_size,
+                    }),
+                ))
+                .is_some()
+            {
+                qinfo!(
+                    "Queued ResetStream for {} removed because previous ResetStream was acked",
+                    stream_id
+                );
+            }
+
             send_streams.reset_acked(stream_id.into());
         }
     }

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -28,7 +28,7 @@ const INITIAL_RTT: Duration = Duration::from_millis(100);
 
 const PACKET_THRESHOLD: u64 = 3;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum RecoveryToken {
     Ack(AckToken),
     Stream(StreamRecoveryToken),
@@ -36,13 +36,15 @@ pub enum RecoveryToken {
     Flow(FlowControlRecoveryToken),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SentPacket {
     ack_eliciting: bool,
     //in_flight: bool, // TODO needed only for cc
     //size: u64, // TODO needed only for cc
     time_sent: Instant,
     pub(crate) tokens: Vec<RecoveryToken>,
+
+    time_declared_lost: Option<Instant>,
 }
 
 #[derive(Debug, Default)]
@@ -269,6 +271,7 @@ impl LossRecovery {
                 time_sent: now,
                 ack_eliciting,
                 tokens,
+                time_declared_lost: None,
             },
         );
         if ack_eliciting {
@@ -344,6 +347,7 @@ impl LossRecovery {
             .collect()
     }
 
+    /// Detect packets whose contents may need to be retransmitted.
     pub fn detect_lost_packets(&mut self, pn_space: PNSpace, now: Instant) -> Vec<SentPacket> {
         self.enable_timed_loss_detection = false;
         let loss_delay = self.loss_delay();
@@ -357,48 +361,77 @@ impl LossRecovery {
 
         let packet_space = &mut self.spaces[pn_space];
 
+        // Lost for retrans/CC purposes
         let mut lost_pns = SmallVec::<[_; 8]>::new();
+
+        // Lost for we-can-actually-forget-about-it purposes
+        let mut really_lost_pns = SmallVec::<[_; 8]>::new();
+
+        let largest_acked = packet_space.largest_acked;
+        let current_rtt = self.rtt_vals.rtt();
         for (pn, packet) in packet_space
             .sent_packets
-            .iter()
+            .iter_mut()
             // BTreeMap iterates in order of ascending PN
-            .take_while(|(&k, _)| Some(k) < packet_space.largest_acked)
+            .take_while(|(&k, _)| Some(k) < largest_acked)
         {
-            if packet.time_sent <= lost_deadline {
+            let lost = if packet.time_sent <= lost_deadline {
                 qdebug!(
                     "lost={}, time sent {:?} is before lost_deadline {:?}",
                     pn,
                     packet.time_sent,
                     lost_deadline
                 );
-                lost_pns.push(*pn);
-            } else if packet_space.largest_acked >= Some(*pn + PACKET_THRESHOLD) {
-                // Packets with packet numbers more than PACKET_THRESHOLD
-                // before largest acked are deemed lost.
+                true
+            } else if largest_acked >= Some(*pn + PACKET_THRESHOLD) {
                 qdebug!(
                     "lost={}, is >= {} from largest acked {:?}",
                     pn,
                     PACKET_THRESHOLD,
-                    packet_space.largest_acked
+                    largest_acked
                 );
+                true
+            } else {
+                false
+            };
+
+            if lost && packet.time_declared_lost.is_none() {
+                // TODO
+                // Inform the congestion controller of lost packets.
+
+                // Track declared-lost packets for a little while, maybe they
+                // will still show up?
+                packet.time_declared_lost = Some(now);
+
                 lost_pns.push(*pn);
+            } else if packet
+                .time_declared_lost
+                .map(|tdl| tdl + (current_rtt * 2) < now)
+                .unwrap_or(false)
+            {
+                really_lost_pns.push(*pn);
             } else {
                 // OOO but not quite lost yet. Set the timed loss detect timer
                 self.enable_timed_loss_detection = true;
             }
         }
 
+        for pn in really_lost_pns {
+            packet_space
+                .sent_packets
+                .remove(&pn)
+                .expect("PN must be in sent_packets");
+        }
+
         let mut lost_packets = Vec::with_capacity(lost_pns.len());
         for pn in lost_pns {
             let lost_packet = packet_space
                 .sent_packets
-                .remove(&pn)
-                .expect("PN must be in sent_packets");
+                .get(&pn)
+                .expect("PN must be in sent_packets")
+                .clone();
             lost_packets.push(lost_packet);
         }
-
-        // TODO
-        // Inform the congestion controller of lost packets.
 
         lost_packets
     }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -819,7 +819,7 @@ fn stream_frame_hdr_len(stream_id: StreamId, offset: u64, remaining: usize) -> u
     hdr_len + Encoder::varint_len(remaining as u64)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StreamRecoveryToken {
     pub(crate) id: StreamId,
     offset: u64,

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -131,7 +131,7 @@ const MAX_TRACKED_RANGES: usize = 100;
 const MAX_ACKS_PER_FRAME: usize = 32;
 
 /// A structure that tracks what was included in an ACK.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AckToken {
     space: PNSpace,
     ranges: Vec<PacketRange>,


### PR DESCRIPTION
Separate the idea of when a packet should be declared lost (and thus
retransmitted) from when we should actually forget about what the packet
contained. Hold on to SentPackets for at least 2*RTT beyond when they are
declared lost.

This will make it possible for things to go directly from "lost" to "acked"
state. Crypto and Stream tokens should already handle this because they're
based on TxBuffer, which already handles ranges going from unmarked (as
would be the case if lost) directly to acked, and has tests to check this.
Ack tokens do nothing when lost, so no issue. Flow tokens don't care about
being acked except for ResetStream: remove requeued ResetStream if present.

Requires SentPacket and members be clone()able, since detect_lost_packets()
must return a Vec of these, and also now hold on to them. I held off on
refcounting them for the moment. Maybe some refactoring in the future can
make this unnecessary.

fixes #266