### PR TITLE
Implement Congestion Control, PTO, OoO acks, and limit pkt size to pmtu

### DIFF
--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -30,8 +30,8 @@ const MAX_AUTH_TAG: usize = 32;
 #[derive(Debug)]
 pub struct Crypto {
     pub(crate) tls: Agent,
-    pub(crate) streams: [CryptoStream; 4],
-    pub(crate) states: [Option<CryptoState>; 4],
+    pub(crate) streams: CryptoStreams,
+    pub(crate) states: CryptoStates,
 }
 
 impl Crypto {
@@ -62,7 +62,7 @@ impl Crypto {
     }
 
     // Create the initial crypto state.
-    pub fn create_initial_state(&mut self, role: Role, dcid: &[u8]) -> CryptoState {
+    pub fn create_initial_state(&mut self, role: Role, dcid: &[u8]) -> Res<()> {
         const CLIENT_INITIAL_LABEL: &str = "client in";
         const SERVER_INITIAL_LABEL: &str = "server in";
 
@@ -78,61 +78,12 @@ impl Crypto {
             Role::Server => (SERVER_INITIAL_LABEL, CLIENT_INITIAL_LABEL),
         };
 
-        CryptoState {
-            epoch: 0,
+        self.states.states[0] = Some(CryptoState {
             tx: CryptoDxState::new_initial(CryptoDxDirection::Write, write_label, dcid),
             rx: CryptoDxState::new_initial(CryptoDxDirection::Read, read_label, dcid),
-        }
-    }
+        });
 
-    // Get a crypto state, making it if necessary, otherwise return an error.
-    pub fn obtain_crypto_state(&mut self, role: Role, epoch: Epoch) -> Res<&mut CryptoState> {
-        #[cfg(debug_assertions)]
-        let label = format!("{}", self);
-        #[cfg(not(debug_assertions))]
-        let label = "";
-
-        let cs = &mut self.states[epoch as usize];
-        if cs.is_none() {
-            qtrace!([label] "Build crypto state for epoch {}", epoch);
-            assert!(epoch != 0); // This state is made directly.
-
-            let cipher = match (epoch, self.tls.info()) {
-                (1, _) => self.tls.preinfo()?.early_data_cipher(),
-                (_, None) => self.tls.preinfo()?.cipher_suite(),
-                (_, Some(info)) => Some(info.cipher_suite()),
-            };
-            if cipher.is_none() {
-                qdebug!([label] "cipher info not available yet");
-                return Err(Error::KeysNotFound);
-            }
-            let cipher = cipher.unwrap();
-
-            let rx = self
-                .tls
-                .read_secret(epoch)
-                .map(|rs| CryptoDxState::new(CryptoDxDirection::Read, epoch, rs, cipher));
-            let tx = self
-                .tls
-                .write_secret(epoch)
-                .map(|ws| CryptoDxState::new(CryptoDxDirection::Write, epoch, ws, cipher));
-
-            // Validate the key setup.
-            match (&rx, &tx, role, epoch) {
-                (None, Some(_), Role::Client, 1)
-                | (Some(_), None, Role::Server, 1)
-                | (Some(_), Some(_), _, _) => {}
-                (None, None, _, _) => {
-                    qdebug!([label] "Keying material not available for epoch {}", epoch);
-                    return Err(Error::KeysNotFound);
-                }
-                _ => panic!("bad configuration of keys"),
-            }
-
-            *cs = Some(CryptoState { epoch, rx, tx });
-        }
-
-        Ok(cs.as_mut().unwrap())
+        Ok(())
     }
 
     pub fn acked(&mut self, token: CryptoRecoveryToken) {
@@ -142,56 +93,17 @@ impl Crypto {
             token.offset,
             token.length
         );
-        self.streams[token.epoch as usize]
-            .tx
-            .mark_as_acked(token.offset, token.length);
+        self.streams.acked(token);
     }
 
-    pub fn lost(&mut self, token: CryptoRecoveryToken) {
+    pub fn lost(&mut self, token: &CryptoRecoveryToken) {
         qinfo!(
             "Lost crypto frame epoch={} offset={} length={}",
             token.epoch,
             token.offset,
             token.length
         );
-        self.streams[token.epoch as usize]
-            .tx
-            .mark_as_lost(token.offset, token.length);
-    }
-
-    pub fn get_frame(
-        &mut self,
-        epoch: u16,
-        mode: TxMode,
-        remaining: usize,
-    ) -> Option<(Frame, Option<RecoveryToken>)> {
-        let tx_stream = &mut self.streams[epoch as usize].tx;
-        if let Some((offset, data)) = tx_stream.next_bytes(mode) {
-            let frame_hdr_len = crypto_frame_hdr_len(offset, remaining);
-            let length = min(data.len(), remaining - frame_hdr_len);
-            let frame = Frame::Crypto {
-                offset,
-                data: data[..length].to_vec(),
-            };
-            tx_stream.mark_as_sent(offset, length);
-
-            qdebug!(
-                "Emitting crypto frame epoch={}, offset={}, len={}",
-                epoch,
-                offset,
-                length
-            );
-            Some((
-                frame,
-                Some(RecoveryToken::Crypto(CryptoRecoveryToken {
-                    epoch,
-                    offset,
-                    length,
-                })),
-            ))
-        } else {
-            None
-        }
+        self.streams.lost(token);
     }
 }
 
@@ -312,11 +224,144 @@ impl std::fmt::Display for CryptoDxState {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CryptoState {
-    pub epoch: Epoch,
     pub tx: Option<CryptoDxState>,
     pub rx: Option<CryptoDxState>,
+}
+
+#[derive(Debug, Default)]
+pub struct CryptoStates {
+    pub states: [Option<CryptoState>; 4],
+}
+
+impl std::fmt::Display for CryptoStates {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "CryptoStates")
+    }
+}
+
+impl CryptoStates {
+    // Get a crypto state, making it if necessary, otherwise return an error.
+    pub fn obtain(&mut self, role: Role, epoch: Epoch, tls: &Agent) -> Res<&mut CryptoState> {
+        #[cfg(debug_assertions)]
+        let label = format!("{}", self);
+        #[cfg(not(debug_assertions))]
+        let label = "";
+
+        let cs = &mut self.states[epoch as usize];
+        if cs.is_none() {
+            qtrace!([label] "Build crypto state for epoch {}", epoch);
+            assert!(epoch != 0); // This state is made directly.
+
+            let cipher = match (epoch, tls.info()) {
+                (1, _) => tls.preinfo()?.early_data_cipher(),
+                (_, None) => tls.preinfo()?.cipher_suite(),
+                (_, Some(info)) => Some(info.cipher_suite()),
+            }
+            .ok_or_else(|| {
+                qdebug!([label] "cipher info not available yet");
+                Error::KeysNotFound
+            })?;
+
+            let rx = tls
+                .read_secret(epoch)
+                .map(|rs| CryptoDxState::new(CryptoDxDirection::Read, epoch, rs, cipher));
+            let tx = tls
+                .write_secret(epoch)
+                .map(|ws| CryptoDxState::new(CryptoDxDirection::Write, epoch, ws, cipher));
+
+            // Validate the key setup.
+            match (&rx, &tx, role, epoch) {
+                (None, Some(_), Role::Client, 1)
+                | (Some(_), None, Role::Server, 1)
+                | (Some(_), Some(_), _, _) => {}
+                (None, None, _, _) => {
+                    qdebug!([label] "Keying material not available for epoch {}", epoch);
+                    return Err(Error::KeysNotFound);
+                }
+                _ => panic!("bad configuration of keys"),
+            }
+
+            *cs = Some(CryptoState { rx, tx });
+        }
+
+        Ok(cs.as_mut().unwrap())
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct CryptoStreams {
+    pub txs: [TxBuffer; 4],
+    pub rxs: [RxStreamOrderer; 4],
+}
+
+impl CryptoStreams {
+    pub fn send(&mut self, epoch: u16, data: &[u8]) {
+        self.txs[epoch as usize].send(data);
+    }
+
+    pub fn inbound_frame(&mut self, epoch: u16, offset: u64, data: Vec<u8>) -> Res<()> {
+        self.rxs[epoch as usize].inbound_frame(offset, data)
+    }
+
+    pub fn data_ready(&self, epoch: u16) -> bool {
+        self.rxs[epoch as usize].data_ready()
+    }
+
+    pub fn read_to_end(&mut self, epoch: u16, buf: &mut Vec<u8>) -> Res<u64> {
+        self.rxs[epoch as usize].read_to_end(buf)
+    }
+
+    pub fn acked(&mut self, token: CryptoRecoveryToken) {
+        self.txs[token.epoch as usize].mark_as_acked(token.offset, token.length)
+    }
+
+    pub fn lost(&mut self, token: &CryptoRecoveryToken) {
+        self.txs[token.epoch as usize].mark_as_lost(token.offset, token.length)
+    }
+
+    pub fn sent(&mut self, epoch: u16, offset: u64, length: usize) {
+        self.txs[epoch as usize].mark_as_sent(offset, length)
+    }
+
+    pub fn next_bytes(&self, epoch: u16, mode: TxMode) -> Option<(u64, &[u8])> {
+        self.txs[epoch as usize].next_bytes(mode)
+    }
+
+    pub fn get_frame(
+        &mut self,
+        epoch: u16,
+        mode: TxMode,
+        remaining: usize,
+    ) -> Option<(Frame, Option<RecoveryToken>)> {
+        if let Some((offset, data)) = self.next_bytes(epoch, mode) {
+            let frame_hdr_len = crypto_frame_hdr_len(offset, remaining);
+            let length = min(data.len(), remaining - frame_hdr_len);
+            let frame = Frame::Crypto {
+                offset,
+                data: data[..length].to_vec(),
+            };
+            self.sent(epoch, offset, length);
+
+            qdebug!(
+                "Emitting crypto frame epoch={}, offset={}, len={}",
+                epoch,
+                offset,
+                length
+            );
+            Some((
+                frame,
+                Some(RecoveryToken::Crypto(CryptoRecoveryToken {
+                    epoch,
+                    offset,
+                    length,
+                })),
+            ))
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, Default)]

--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -55,6 +55,11 @@ impl FlowMgr {
     pub fn conn_increase_max_credit(&mut self, new: u64) -> bool {
         if new > self.max_data {
             self.max_data = new;
+
+            // Make a dummy DataBlocked frame so we can remove based on discriminant
+            let frame = Frame::DataBlocked { data_limit: 0 };
+            self.from_conn.remove(&mem::discriminant(&frame));
+
             true
         } else {
             false
@@ -72,6 +77,11 @@ impl FlowMgr {
 
     pub fn path_response(&mut self, data: [u8; 8]) {
         let frame = Frame::PathResponse { data };
+        self.from_conn.insert(mem::discriminant(&frame), frame);
+    }
+
+    pub fn max_data(&mut self, maximum_data: u64) {
+        let frame = Frame::MaxData { maximum_data };
         self.from_conn.insert(mem::discriminant(&frame), frame);
     }
 
@@ -205,12 +215,12 @@ impl FlowMgr {
 
     pub(crate) fn lost(
         &mut self,
-        token: FlowControlRecoveryToken,
+        token: &FlowControlRecoveryToken,
         send_streams: &mut SendStreams,
         recv_streams: &mut RecvStreams,
         indexes: &mut StreamIndexes,
     ) {
-        match token {
+        match *token {
             // Always resend ResetStream if lost
             Frame::ResetStream {
                 stream_id,

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -591,7 +591,6 @@ pub fn decode_frame(dec: &mut Decoder) -> Res<Frame> {
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum TxMode {
     Normal,
-    #[allow(dead_code)]
     Pto,
 }
 

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -8,6 +8,8 @@
 
 use std::cmp::{max, min};
 use std::collections::BTreeMap;
+use std::convert::TryFrom;
+use std::fmt::{self, Display};
 use std::ops::{Index, IndexMut};
 use std::time::{Duration, Instant};
 
@@ -19,7 +21,13 @@ use crate::crypto::CryptoRecoveryToken;
 use crate::flow_mgr::FlowControlRecoveryToken;
 use crate::send_stream::StreamRecoveryToken;
 use crate::tracking::{AckToken, PNSpace};
-use crate::State;
+
+const fn const_max(a: usize, b: usize) -> usize {
+    [a, b][(a < b) as usize]
+}
+const fn const_min(a: usize, b: usize) -> usize {
+    [a, b][(a >= b) as usize]
+}
 
 const GRANULARITY: Duration = Duration::from_millis(20);
 // Defined in -recovery 6.2 as 500ms but using lower value until we have RTT
@@ -27,6 +35,13 @@ const GRANULARITY: Duration = Duration::from_millis(20);
 const INITIAL_RTT: Duration = Duration::from_millis(100);
 
 const PACKET_THRESHOLD: u64 = 3;
+const MAX_DATAGRAM_SIZE: usize = 1200; // per -recovery B.1
+const INITIAL_WINDOW: u64 = const_min(
+    10 * MAX_DATAGRAM_SIZE,
+    const_max(2 * MAX_DATAGRAM_SIZE, 14720),
+) as u64;
+const MIN_CONG_WINDOW: u64 = MAX_DATAGRAM_SIZE as u64 * 2;
+const PERSISTENT_CONG_THRESH: u32 = 3;
 
 #[derive(Debug, Clone)]
 pub enum RecoveryToken {
@@ -39,12 +54,13 @@ pub enum RecoveryToken {
 #[derive(Debug, Clone)]
 pub struct SentPacket {
     ack_eliciting: bool,
-    //in_flight: bool, // TODO needed only for cc
-    //size: u64, // TODO needed only for cc
     time_sent: Instant,
     pub(crate) tokens: Vec<RecoveryToken>,
 
     time_declared_lost: Option<Instant>,
+
+    in_flight: bool,
+    size: usize,
 }
 
 #[derive(Debug, Default)]
@@ -138,6 +154,7 @@ pub(crate) enum LossRecoveryMode {
 pub(crate) struct LossRecoverySpace {
     tx_pn: u64,
     largest_acked: Option<u64>,
+    largest_acked_sent_time: Option<Instant>,
     sent_packets: BTreeMap<u64, SentPacket>,
 }
 
@@ -210,11 +227,151 @@ impl LossRecoverySpaces {
     }
 }
 
+#[derive(Debug)]
+struct CongestionControl {
+    congestion_window: u64, // = kInitialWindow
+    bytes_in_flight: u64,
+    congestion_recovery_start_time: Option<Instant>,
+    ssthresh: u64,
+}
+
+impl Default for CongestionControl {
+    fn default() -> Self {
+        CongestionControl {
+            congestion_window: INITIAL_WINDOW,
+            bytes_in_flight: 0,
+            congestion_recovery_start_time: None,
+            ssthresh: u64::max_value(),
+        }
+    }
+}
+
+impl Display for CongestionControl {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "CongCtrl")
+    }
+}
+
+impl CongestionControl {
+    #[cfg(test)]
+    pub fn cwnd(&self) -> u64 {
+        self.congestion_window
+    }
+
+    fn cwnd_avail(&self) -> u64 {
+        // BIF can be higher than cwnd due to PTO packets, which are sent even
+        // if avail is 0, but still count towards BIF.
+        self.congestion_window.saturating_sub(self.bytes_in_flight)
+    }
+
+    // OnPacketAckedCC
+    fn on_packet_acked(&mut self, pkt: &SentPacket) {
+        assert!(self.bytes_in_flight >= u64::try_from(pkt.size).unwrap());
+        self.bytes_in_flight -= u64::try_from(pkt.size).unwrap();
+
+        if self.in_congestion_recovery(pkt.time_sent) {
+            // Do not increase congestion window in recovery period.
+            return;
+        }
+        if self.app_limited() {
+            // Do not increase congestion_window if application limited.
+            return;
+        }
+
+        if self.congestion_window < self.ssthresh {
+            // Slow start.
+            self.congestion_window += u64::try_from(pkt.size).unwrap();
+            qinfo!([self], "slow start; cwnd {}", self.congestion_window);
+        } else {
+            // Congestion avoidance.
+            qinfo!(
+                [self],
+                "congestion avoidance; cwnd {} ssthresh {}",
+                self.congestion_window,
+                self.ssthresh
+            );
+            self.congestion_window += u64::try_from(MAX_DATAGRAM_SIZE * pkt.size as usize).unwrap()
+                / self.congestion_window
+        }
+    }
+
+    fn on_packets_lost(
+        &mut self,
+        now: Instant,
+        largest_acked_sent: Option<Instant>,
+        pto: Duration,
+        lost_packets: &[SentPacket],
+    ) {
+        for pkt in lost_packets {
+            assert!(self.bytes_in_flight >= u64::try_from(pkt.size).unwrap());
+            self.bytes_in_flight -= u64::try_from(pkt.size).unwrap();
+        }
+
+        qdebug!([self], "Pkts lost {}", lost_packets.len());
+
+        let last_lost_pkt = lost_packets.last().unwrap();
+        self.on_congestion_event(now, last_lost_pkt.time_sent);
+
+        let in_persistent_congestion = {
+            let congestion_period = pto * PERSISTENT_CONG_THRESH;
+            largest_acked_sent < Some(last_lost_pkt.time_sent - congestion_period)
+        };
+        if in_persistent_congestion {
+            qinfo!([self], "persistent congestion");
+            self.congestion_window = MIN_CONG_WINDOW;
+        }
+    }
+
+    fn on_packet_sent(&mut self, size: usize) {
+        self.bytes_in_flight += u64::try_from(size).unwrap();
+        assert!(self.bytes_in_flight <= self.congestion_window);
+        qdebug!(
+            [self],
+            "Pkt Sent len {}, bif {}, cwnd {}",
+            size,
+            self.bytes_in_flight,
+            self.congestion_window
+        );
+    }
+
+    fn in_congestion_recovery(&self, sent_time: Instant) -> bool {
+        self.congestion_recovery_start_time
+            .map(|start| sent_time <= start)
+            .unwrap_or(false)
+    }
+
+    fn on_congestion_event(&mut self, now: Instant, sent_time: Instant) {
+        // Start a new congestion event if packet was sent after the
+        // start of the previous congestion recovery period.
+        if !self.in_congestion_recovery(sent_time) {
+            self.congestion_recovery_start_time = Some(now);
+            self.congestion_window /= 2; // kLossReductionFactor = 0.5
+            self.congestion_window = max(self.congestion_window, MIN_CONG_WINDOW);
+            self.ssthresh = self.congestion_window;
+            qinfo!(
+                [self],
+                "Cong event -> recovery; cwnd {}, ssthresh {}",
+                self.congestion_window,
+                self.ssthresh
+            );
+        } else {
+            qdebug!([self], "Cong event but already in recovery");
+        }
+    }
+
+    fn app_limited(&self) -> bool {
+        //TODO(agrover): how do we get this info??
+        false
+    }
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct LossRecovery {
     pto_count: u32,
     time_of_last_sent_ack_eliciting_packet: Option<Instant>,
     rtt_vals: RttVals,
+
+    cc: CongestionControl,
 
     enable_timed_loss_detection: bool,
     spaces: LossRecoverySpaces,
@@ -234,17 +391,28 @@ impl LossRecovery {
         }
     }
 
+    #[cfg(test)]
+    pub fn cwnd(&self) -> u64 {
+        self.cc.cwnd()
+    }
+
+    pub fn cwnd_avail(&self) -> u64 {
+        self.cc.cwnd_avail()
+    }
+
     pub fn next_pn(&mut self, pn_space: PNSpace) -> u64 {
-        let val = self.spaces[pn_space].tx_pn;
+        self.spaces[pn_space].tx_pn
+    }
+
+    pub fn inc_pn(&mut self, pn_space: PNSpace) {
         self.spaces[pn_space].tx_pn += 1;
-        val
     }
 
     pub fn increment_pto_count(&mut self) {
         self.pto_count += 1;
     }
 
-    pub fn largest_acknowledged(&self, pn_space: PNSpace) -> Option<u64> {
+    pub fn largest_acknowledged_pn(&self, pn_space: PNSpace) -> Option<u64> {
         self.spaces[pn_space].largest_acked
     }
 
@@ -256,12 +424,15 @@ impl LossRecovery {
         self.spaces[PNSpace::ApplicationData].remove_ignored()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn on_packet_sent(
         &mut self,
         pn_space: PNSpace,
         packet_number: u64,
         ack_eliciting: bool,
         tokens: Vec<RecoveryToken>,
+        size: usize,
+        in_flight: bool,
         now: Instant,
     ) {
         qdebug!([self] "packet {:?}-{} sent.", pn_space, packet_number);
@@ -272,12 +443,15 @@ impl LossRecovery {
                 ack_eliciting,
                 tokens,
                 time_declared_lost: None,
+                size,
+                in_flight,
             },
         );
         if ack_eliciting {
             self.time_of_last_sent_ack_eliciting_packet = Some(now);
-            // TODO implement cc
-            //     cc.on_packet_sent(sent_bytes)
+        }
+        if in_flight {
+            self.cc.on_packet_sent(size)
         }
     }
 
@@ -307,11 +481,14 @@ impl LossRecovery {
             // If the largest acknowledged is newly acked and any newly acked
             // packet was ack-eliciting, update the RTT. (-recovery 5.1)
             let largest_acked_pkt = acked_packets.get(&largest_acked).expect("must be there");
+            space.largest_acked_sent_time = Some(largest_acked_pkt.time_sent);
             if any_ack_eliciting {
                 let latest_rtt = now - largest_acked_pkt.time_sent;
                 self.rtt_vals.update_rtt(latest_rtt, ack_delay);
             }
         }
+        // Copy into local so self.spaces no longer borrowed
+        let largest_acked_sent_time = space.largest_acked_sent_time;
 
         // TODO Process ECN information if present.
 
@@ -323,6 +500,20 @@ impl LossRecovery {
             .into_iter()
             .map(|(_k, v)| v)
             .collect::<Vec<_>>();
+
+        // OnPacketAcked
+        for pkt in acked_packets.iter().filter(|pkt| pkt.in_flight) {
+            self.cc.on_packet_acked(pkt)
+        }
+
+        if !lost_packets.is_empty() {
+            self.cc.on_packets_lost(
+                now,
+                largest_acked_sent_time,
+                self.rtt_vals.pto(),
+                &lost_packets,
+            );
+        }
 
         (acked_packets, lost_packets)
     }
@@ -360,6 +551,7 @@ impl LossRecovery {
         );
 
         let packet_space = &mut self.spaces[pn_space];
+        let largest_acked = packet_space.largest_acked;
 
         // Lost for retrans/CC purposes
         let mut lost_pns = SmallVec::<[_; 8]>::new();
@@ -367,7 +559,6 @@ impl LossRecovery {
         // Lost for we-can-actually-forget-about-it purposes
         let mut really_lost_pns = SmallVec::<[_; 8]>::new();
 
-        let largest_acked = packet_space.largest_acked;
         let current_rtt = self.rtt_vals.rtt();
         for (pn, packet) in packet_space
             .sent_packets
@@ -396,9 +587,6 @@ impl LossRecovery {
             };
 
             if lost && packet.time_declared_lost.is_none() {
-                // TODO
-                // Inform the congestion controller of lost packets.
-
                 // Track declared-lost packets for a little while, maybe they
                 // will still show up?
                 packet.time_declared_lost = Some(now);
@@ -436,7 +624,7 @@ impl LossRecovery {
         lost_packets
     }
 
-    pub fn get_timer(&mut self, conn_state: &State) -> LossRecoveryState {
+    pub fn get_timer(&mut self) -> LossRecoveryState {
         qdebug!([self] "get_loss_detection_timer.");
 
         let has_ack_eliciting_out = self
@@ -451,7 +639,7 @@ impl LossRecovery {
             has_ack_eliciting_out,
         );
 
-        if !has_ack_eliciting_out && *conn_state == State::Connected {
+        if !has_ack_eliciting_out {
             return LossRecoveryState::new(LossRecoveryMode::None, None);
         }
 
@@ -514,6 +702,8 @@ mod tests {
     use super::*;
     use std::convert::TryInto;
     use std::time::{Duration, Instant};
+
+    const ON_SENT_SIZE: usize = 100;
 
     fn assert_rtts(
         lr: &LossRecovery,
@@ -587,7 +777,15 @@ mod tests {
 
     fn pace(lr: &mut LossRecovery, count: u64) {
         for pn in 0..count {
-            lr.on_packet_sent(PNSpace::ApplicationData, pn, true, Vec::new(), pn_time(pn));
+            lr.on_packet_sent(
+                PNSpace::ApplicationData,
+                pn,
+                true,
+                Vec::new(),
+                ON_SENT_SIZE,
+                true,
+                pn_time(pn),
+            );
         }
     }
 
@@ -701,12 +899,22 @@ mod tests {
         // So send two packets with 1/4 RTT between them.  Acknowledge pn 1 after 1 RTT.
         // pn 0 should then be marked lost because it is then outstanding for 5RTT/4
         // the loss time for packets is 9RTT/8.
-        lr.on_packet_sent(PNSpace::ApplicationData, 0, true, Vec::new(), pn_time(0));
+        lr.on_packet_sent(
+            PNSpace::ApplicationData,
+            0,
+            true,
+            Vec::new(),
+            ON_SENT_SIZE,
+            true,
+            pn_time(0),
+        );
         lr.on_packet_sent(
             PNSpace::ApplicationData,
             1,
             true,
             Vec::new(),
+            ON_SENT_SIZE,
+            true,
             pn_time(0) + INITIAL_RTT / 4,
         );
         let (_, lost) = lr.on_ack_received(
@@ -743,7 +951,7 @@ mod tests {
         assert_sent_times(&lr, None, None, Some(pn1_sent_time));
 
         // After time elapses, pn 1 is marked lost.
-        let lr_state = lr.get_timer(&State::Connected);
+        let lr_state = lr.get_timer();
         let pn1_lost_time = pn1_sent_time + (INITIAL_RTT * 9 / 8);
         assert_eq!(lr_state.callback_time, Some(pn1_lost_time));
         match lr_state.mode {

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -201,6 +201,8 @@ impl RecvdPackets {
 
     /// Add the packet to the tracked set.
     pub fn set_received(&mut self, now: Instant, pn: u64, ack_eliciting: bool) {
+        let next_in_order_pn = self.ranges.get(0).map(|pr| pr.largest + 1).unwrap_or(0);
+        qdebug!("next in order pn: {}", next_in_order_pn);
         let i = self.add(pn);
 
         // The new addition was the largest, so update the time we use for calculating ACK delay.
@@ -221,9 +223,12 @@ impl RecvdPackets {
         }
 
         if ack_eliciting {
-            // On the first ack-eliciting packet since sending an ACK, set a delay.
-            // On the second, remove that delay.
-            if self.ack_time.is_none() && self.space == PNSpace::ApplicationData {
+            // Send ACK right away if out-of-order
+            // On the first in-order ack-eliciting packet since sending an ACK,
+            // set a delay. On the second, remove that delay.
+            if pn != next_in_order_pn {
+                self.ack_time = Some(now);
+            } else if self.ack_time.is_none() && self.space == PNSpace::ApplicationData {
                 self.ack_time = Some(now + ACK_DELAY);
             } else {
                 self.ack_time = Some(now);


### PR DESCRIPTION
Sorry for the mega-patch, I started on CC and then kept running into things :smiley: 

Probe Timeout:
* SendStream: Add support for TxMode::Pto
* Add OutputMode enum to allow different behavior for packet generation in
  the normal case (CongestionControlled) and in the PTO case
  (ProbeTimeout).

Output:
* Use above PTO changes in packet output.
* Rename Connection::output_path() to output_pkt_for_path() for clarity.
* Do not replace path in Connection::output() with None before calling
  output_pkt_for_path(). We can't do this or Path::pmtu() will be wrong.
  Instead, handle it inside the called function. This will work until we
  support more than one path.
* Move construction of PacketHdr before frame sources are polled. This
  is needed so the frame sources can have accurate bytes-remaining
  values passed to them.
* packet.rs: For ^^, add overhead(), to learn how many bytes the header
  will take when encoded.
* Change LossRecovery::next_pn() to return but not increment PN, since we
  now construct headers that may not be used in a sent packet. Add inc_pn()
  to call once we know a PN will be used.
* Add PTO tests.

Crypto refactorings (needed for output changes):
* Change Crypto::create_initial_state() to set state internally rather than
  returning the state to the caller to set.
* Refactor crypto to enable a stream and a state to be independently
  borrowed.

Congestion Control:
* Implement congestion control, largely based on spec pseudocode.
* Add cfg(test) method Connection::new_client_fixed_len_dcid() that
  always generates an 8 byte dcid, and use this for unit tests. This
  eases CC testing by eliminating variability in byte counts.
* Add tests

Sent packet tracking (tracking.rs):
* Ask for an ack immediately if received packed is out of order.

FlowMgr:
* Remove pending DataBlocked frame if max credit is increased.
* Support max_data frame for testing purposes.

Misc:
* LossRecovery::get_timer() doesn't need to take state as param.
* Rename LossRecovery::largest_acknowledged() to largest_acknowledged_pn()
  for clarity.
* SendStream: Improve testing of overlapping ranges a little.
* Add Path::mtu() and remove Connection::mtu()