### PR TITLE
Use matches! where possible

### DIFF
--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -690,10 +690,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     fn state_active(&self) -> bool {
-        match self.state {
-            Http3State::Connected | Http3State::GoingAway => true,
-            _ => false,
-        }
+        matches!(self.state, Http3State::Connected | Http3State::GoingAway)
     }
 
     fn state_closing(&self) -> bool {

--- a/neqo-http3/src/transaction_server.rs
+++ b/neqo-http3/src/transaction_server.rs
@@ -9,7 +9,7 @@ use crate::hframe::{HFrame, HFrameReader};
 use crate::server_events::Http3ServerEvents;
 use crate::Header;
 use crate::{Error, Res};
-use neqo_common::{qdebug, qinfo, qtrace, Encoder};
+use neqo_common::{matches, qdebug, qinfo, qtrace, Encoder};
 use neqo_qpack::decoder::QPackDecoder;
 use neqo_qpack::encoder::QPackEncoder;
 use neqo_transport::Connection;
@@ -323,11 +323,7 @@ impl Http3Transaction for TransactionServer {
     }
 
     fn has_data_to_send(&self) -> bool {
-        if let TransactionSendState::SendingResponse { .. } = self.send_state {
-            true
-        } else {
-            false
-        }
+        matches!(self.send_state, TransactionSendState::SendingResponse { .. })
     }
 
     fn is_state_sending_data(&self) -> bool {

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -6,7 +6,7 @@
 
 // Directly relating to QUIC frames.
 
-use neqo_common::{qdebug, Decoder, Encoder};
+use neqo_common::{matches, qdebug, Decoder, Encoder};
 
 use crate::stream_id::StreamIndex;
 use crate::{AppError, TransportError};
@@ -345,10 +345,7 @@ impl Frame {
     }
 
     pub fn ack_eliciting(&self) -> bool {
-        match self {
-            Frame::Ack { .. } | Frame::Padding => false,
-            _ => true,
-        }
+        !matches!(self, Frame::Ack { .. } | Frame::Padding)
     }
 
     /// Converts AckRanges as encoded in a ACK frame (see -transport

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -21,7 +21,7 @@ use crate::events::ConnectionEvents;
 use crate::flow_mgr::FlowMgr;
 use crate::stream_id::StreamId;
 use crate::{AppError, Error, Res};
-use neqo_common::qtrace;
+use neqo_common::{matches, qtrace};
 
 pub const RX_STREAM_DATA_WINDOW: u64 = 0xFFFF; // 64 KiB
 
@@ -464,18 +464,15 @@ impl RecvStream {
     }
 
     pub fn is_terminal(&self) -> bool {
-        match self.state {
-            RecvStreamState::ResetRecvd | RecvStreamState::DataRead => true,
-            _ => false,
-        }
+        matches!(
+            self.state,
+            RecvStreamState::ResetRecvd | RecvStreamState::DataRead
+        )
     }
 
     // App got all data but did not get the fin signal.
     fn needs_to_inform_app_about_fin(&self) -> bool {
-        match self.state {
-            RecvStreamState::DataRecvd { .. } => true,
-            _ => false,
-        }
+        matches!(self.state, RecvStreamState::DataRecvd { .. })
     }
 
     fn data_ready(&self) -> bool {
@@ -751,5 +748,4 @@ mod tests {
         assert_eq!(rx_ord.buffered(), 15);
         assert_eq!(rx_ord.retired(), 2);
     }
-
 }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -606,10 +606,7 @@ impl SendStream {
     }
 
     pub fn is_terminal(&self) -> bool {
-        match self.state {
-            SendStreamState::DataRecvd { .. } | SendStreamState::ResetRecvd => true,
-            _ => false,
-        }
+        matches!(self.state, SendStreamState::DataRecvd { .. } | SendStreamState::ResetRecvd)
     }
 
     pub fn send(&mut self, buf: &[u8]) -> Res<usize> {


### PR DESCRIPTION
For boolean functions implemented with a match, use
the matches! macro for implementation, where possible.