### PR TITLE
Put comma after use of [self] in log messages

### DIFF
--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -47,30 +47,25 @@ macro_rules! qlog {
 #[macro_export]
 macro_rules! qerror {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Error, $ctx, $($arg)*););
-    ([$ctx:expr] $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Error, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Error, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qwarn {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Warn, $ctx, $($arg)*););
-    ([$ctx:expr] $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Warn, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Warn, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qinfo {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Info, $ctx, $($arg)*););
-    ([$ctx:expr] $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Info, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Info, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qdebug {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Debug, $ctx, $($arg)*););
-    ([$ctx:expr] $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Debug, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Debug, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qtrace {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Trace, $ctx, $($arg)*););
-    ([$ctx:expr] $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Trace, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Trace, $($arg)*); } );
 }

--- a/neqo-common/tests/log.rs
+++ b/neqo-common/tests/log.rs
@@ -31,11 +31,11 @@ fn args() {
 #[test]
 fn context() {
     let context = "context";
-    qerror!([context] "error");
-    qwarn!([context] "warn");
-    qinfo!([context] "info");
-    qdebug!([context] "debug");
-    qtrace!([context] "trace");
+    qerror!([context], "error");
+    qwarn!([context], "warn");
+    qinfo!([context], "info");
+    qdebug!([context], "debug");
+    qtrace!([context], "trace");
 }
 
 #[test]

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -75,7 +75,7 @@ fn get_alpn(fd: *mut ssl::PRFileDesc, pre: bool) -> Res<Option<String>> {
         }
         _ => None,
     };
-    qinfo!([format!("{:p}", fd)] "got ALPN {:?}", alpn);
+    qinfo!([format!("{:p}", fd)], "got ALPN {:?}", alpn);
     Ok(alpn)
 }
 
@@ -290,7 +290,11 @@ impl SecretAgent {
             if st.is_none() {
                 *st = Some(alert.description);
             } else {
-                qwarn!([format!("{:p}", fd)] "duplicate alert {}", alert.description);
+                qwarn!(
+                    [format!("{:p}", fd)],
+                    "duplicate alert {}",
+                    alert.description
+                );
             }
         }
     }
@@ -510,7 +514,7 @@ impl SecretAgent {
 
     fn capture_error<T>(&mut self, res: Res<T>) -> Res<T> {
         if let Err(e) = &res {
-            qwarn!([self] "error: {:?}", e);
+            qwarn!([self], "error: {:?}", e);
             self.state = HandshakeState::Failed(e.clone());
         }
         res
@@ -528,7 +532,7 @@ impl SecretAgent {
             let info = self.capture_error(SecretAgentInfo::new(self.fd))?;
             HandshakeState::Complete(info)
         };
-        qinfo!([self] "state -> {:?}", self.state);
+        qinfo!([self], "state -> {:?}", self.state);
         Ok(())
     }
 
@@ -602,7 +606,7 @@ impl SecretAgent {
         if let HandshakeState::Authenticated(ref err) = self.state {
             let result =
                 secstatus_to_res(unsafe { ssl::SSL_AuthCertificateComplete(self.fd, *err) });
-            qdebug!([self] "SSL_AuthCertificateComplete: {:?}", result);
+            qdebug!([self], "SSL_AuthCertificateComplete: {:?}", result);
             // This should return SECSuccess, so don't use update_state().
             self.capture_error(result)?;
         }
@@ -679,7 +683,7 @@ impl Client {
         let resumption = resumption_ptr.as_mut().unwrap();
         let mut v = Vec::with_capacity(len as usize);
         v.extend_from_slice(std::slice::from_raw_parts(token, len as usize));
-        qdebug!([format!("{:p}", fd)] "Got resumption token");
+        qdebug!([format!("{:p}", fd)], "Got resumption token");
         *resumption = Some(v);
         ssl::SECSuccess
     }

--- a/neqo-crypto/src/agentio.rs
+++ b/neqo-crypto/src/agentio.rs
@@ -177,7 +177,7 @@ impl AgentIoInput {
         }
 
         let src = unsafe { std::slice::from_raw_parts(self.input, amount) };
-        qtrace!([self] "read {}", hex(src));
+        qtrace!([self], "read {}", hex(src));
         let dst = unsafe { std::slice::from_raw_parts_mut(buf, amount) };
         dst.copy_from_slice(&src);
         self.input = self.input.wrapping_add(amount);
@@ -186,7 +186,7 @@ impl AgentIoInput {
     }
 
     fn reset(&mut self) {
-        qtrace!([self] "reset");
+        qtrace!([self], "reset");
         self.input = null();
         self.available = 0;
     }
@@ -232,12 +232,12 @@ impl AgentIo {
     // Stage output from TLS into the output buffer.
     fn save_output(&mut self, buf: *const u8, count: usize) {
         let slice = unsafe { std::slice::from_raw_parts(buf, count) };
-        qtrace!([self] "save output {}", hex(slice));
+        qtrace!([self], "save output {}", hex(slice));
         self.output.extend_from_slice(slice);
     }
 
     pub fn take_output(&mut self) -> Vec<u8> {
-        qtrace!([self] "take output");
+        qtrace!([self], "take output");
         mem::replace(&mut self.output, Vec::new())
     }
 }

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -193,7 +193,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     fn initialize_http3_connection(&mut self) -> Res<()> {
-        qinfo!([self] "Initialize the http3 connection.");
+        qinfo!([self], "Initialize the http3 connection.");
         self.control_stream_local.create(&mut self.conn)?;
         self.send_settings();
         self.create_qpack_streams()?;
@@ -201,7 +201,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     fn send_settings(&mut self) {
-        qdebug!([self] "Send settings.");
+        qdebug!([self], "Send settings.");
         self.control_stream_local.queue_frame(HFrame::Settings {
             settings: vec![
                 (
@@ -217,7 +217,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     fn create_qpack_streams(&mut self) -> Res<()> {
-        qdebug!([self] "create_qpack_streams.");
+        qdebug!([self], "create_qpack_streams.");
         self.qpack_encoder
             .add_send_stream(self.conn.stream_create(StreamType::UniDi)?);
         self.qpack_decoder
@@ -230,7 +230,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     fn check_result<ERR>(&mut self, now: Instant, res: Res<ERR>) -> bool {
         match &res {
             Err(e) => {
-                qinfo!([self] "Connection error: {}.", e);
+                qinfo!([self], "Connection error: {}.", e);
                 self.close(now, e.code(), &format!("{}", e));
                 true
             }
@@ -243,7 +243,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
-        qtrace!([self] "Process.");
+        qtrace!([self], "Process.");
         if let Some(d) = dgram {
             self.process_input(d, now);
         }
@@ -252,12 +252,12 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     pub fn process_input(&mut self, dgram: Datagram, now: Instant) {
-        qtrace!([self] "Process input.");
+        qtrace!([self], "Process input.");
         self.conn.process_input(dgram, now);
     }
 
     pub fn process_timer(&mut self, now: Instant) {
-        qtrace!([self] "Process timer.");
+        qtrace!([self], "Process timer.");
         self.conn.process_timer(now);
     }
 
@@ -266,7 +266,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     pub fn process_http3(&mut self, now: Instant) {
-        qtrace!([self] "Process http3 internal.");
+        qtrace!([self], "Process http3 internal.");
         match self.state {
             Http3State::Connected | Http3State::GoingAway => {
                 let res = self.check_connection_events();
@@ -285,7 +285,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     pub fn process_output(&mut self, now: Instant) -> Output {
-        qtrace!([self] "Process output.");
+        qtrace!([self], "Process output.");
         self.conn.process_output(now)
     }
 
@@ -318,9 +318,9 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
 
     // If this return an error the connection must be closed.
     fn check_connection_events(&mut self) -> Res<()> {
-        qtrace!([self] "Check connection events.");
+        qtrace!([self], "Check connection events.");
         while let Some(e) = self.conn.next_event() {
-            qdebug!([self] "check_connection_events - event {:?}.", e);
+            qdebug!([self], "check_connection_events - event {:?}.", e);
             match e {
                 ConnectionEvent::NewStream {
                     stream_id,
@@ -381,7 +381,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     fn handle_new_stream(&mut self, stream_id: u64, stream_type: StreamType) -> Res<()> {
-        qinfo!([self] "A new stream: {:?} {}.", stream_type, stream_id);
+        qinfo!([self], "A new stream: {:?} {}.", stream_type, stream_id);
         assert!(self.state_active());
         match stream_type {
             StreamType::BiDi => self.handler.handle_new_bidi_stream(
@@ -416,7 +416,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     fn handle_stream_readable(&mut self, stream_id: u64) -> Res<()> {
-        qtrace!([self] "Readable stream {}.", stream_id);
+        qtrace!([self], "Readable stream {}.", stream_id);
 
         assert!(self.state_active());
 
@@ -428,13 +428,13 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
         let mut unblocked_streams: Vec<u64> = Vec::new();
 
         if self.handle_read_stream(stream_id)? {
-            qdebug!([label] "Request/response stream {} read.", stream_id);
+            qdebug!([label], "Request/response stream {} read.", stream_id);
         } else if self
             .control_stream_remote
             .receive_if_this_stream(&mut self.conn, stream_id)?
         {
             qdebug!(
-                [self]
+                [self],
                 "The remote control stream ({}) is readable.",
                 stream_id
             );
@@ -450,13 +450,13 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
             .recv_if_encoder_stream(&mut self.conn, stream_id)?
         {
             qdebug!(
-                [self]
+                [self],
                 "The qpack encoder stream ({}) is readable.",
                 stream_id
             );
         } else if self.qpack_decoder.is_recv_stream(stream_id) {
             qdebug!(
-                [self]
+                [self],
                 "The qpack decoder stream ({}) is readable.",
                 stream_id
             );
@@ -482,14 +482,19 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
         }
 
         for stream_id in unblocked_streams {
-            qinfo!([self] "Stream {} is unblocked", stream_id);
+            qinfo!([self], "Stream {} is unblocked", stream_id);
             self.handle_read_stream(stream_id)?;
         }
         Ok(())
     }
 
     fn handle_stream_reset(&mut self, stream_id: u64, app_err: AppError) -> Res<()> {
-        qinfo!([self] "Handle a stream reset stream_id={} app_err={}", stream_id, app_err);
+        qinfo!(
+            [self],
+            "Handle a stream reset stream_id={} app_err={}",
+            stream_id,
+            app_err
+        );
 
         assert!(self.state_active());
 
@@ -544,10 +549,14 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
         assert!(self.state_active());
 
         if let Some(transaction) = &mut self.transactions.get_mut(&stream_id) {
-            qinfo!([label] "Request/response stream {} is readable.", stream_id);
+            qinfo!(
+                [label],
+                "Request/response stream {} is readable.",
+                stream_id
+            );
             match transaction.receive(&mut self.conn, &mut self.qpack_decoder) {
                 Err(e) => {
-                    qerror!([label] "Error {} ocurred", e);
+                    qerror!([label], "Error {} ocurred", e);
                     return Err(e);
                 }
                 Ok(()) => {
@@ -570,17 +579,17 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
             }
 
             HTTP3_UNI_STREAM_TYPE_PUSH => {
-                qinfo!([self] "A new push stream {}.", stream_id);
+                qinfo!([self], "A new push stream {}.", stream_id);
                 self.handler.handle_new_push_stream()
             }
             QPACK_UNI_STREAM_TYPE_ENCODER => {
-                qinfo!([self] "A new remote qpack encoder stream {}", stream_id);
+                qinfo!([self], "A new remote qpack encoder stream {}", stream_id);
                 self.qpack_decoder
                     .add_recv_stream(stream_id)
                     .map_err(|_| Error::HttpStreamCreationError)
             }
             QPACK_UNI_STREAM_TYPE_DECODER => {
-                qinfo!([self] "A new remote qpack decoder stream {}", stream_id);
+                qinfo!([self], "A new remote qpack decoder stream {}", stream_id);
                 self.qpack_encoder
                     .add_recv_stream(stream_id)
                     .map_err(|_| Error::HttpStreamCreationError)
@@ -595,7 +604,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     pub fn close(&mut self, now: Instant, error: AppError, msg: &str) {
-        qinfo!([self] "Close connection error {:?} msg={}.", error, msg);
+        qinfo!([self], "Close connection error {:?} msg={}.", error, msg);
         assert!(self.state_active());
         self.state = Http3State::Closing(CloseError::Application(error));
         if !self.transactions.is_empty() && (error == 0) {
@@ -606,7 +615,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     pub fn stream_reset(&mut self, stream_id: u64, error: AppError) -> Res<()> {
-        qinfo!([self] "Reset stream {} error={}.", stream_id, error);
+        qinfo!([self], "Reset stream {} error={}.", stream_id, error);
         assert!(self.state_active());
         let mut transaction = self
             .transactions
@@ -623,7 +632,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     pub fn stream_close_send(&mut self, stream_id: u64) -> Res<()> {
-        qinfo!([self] "Close sending side for stream {}.", stream_id);
+        qinfo!([self], "Close sending side for stream {}.", stream_id);
         assert!(self.state_active());
         let transaction = self
             .transactions
@@ -642,15 +651,15 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
         }
         if self.control_stream_remote.frame_reader_done() {
             let f = self.control_stream_remote.get_frame()?;
-            qinfo!([self] "Handle a control frame {:?}", f);
+            qinfo!([self], "Handle a control frame {:?}", f);
             if let HFrame::Settings { .. } = f {
                 if self.settings_received {
-                    qerror!([self] "SETTINGS frame already received");
+                    qerror!([self], "SETTINGS frame already received");
                     return Err(Error::HttpFrameUnexpected);
                 }
                 self.settings_received = true;
             } else if !self.settings_received {
-                qerror!([self] "SETTINGS frame not received");
+                qerror!([self], "SETTINGS frame not received");
                 return Err(Error::HttpMissingSettings);
             }
             return match f {
@@ -673,9 +682,9 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
     }
 
     fn handle_settings(&mut self, s: &[(HSettingType, u64)]) -> Res<()> {
-        qinfo!([self] "Handle SETTINGS frame.");
+        qinfo!([self], "Handle SETTINGS frame.");
         for (t, v) in s {
-            qinfo!([self] " {:?} = {:?}", t, v);
+            qinfo!([self], " {:?} = {:?}", t, v);
             match t {
                 HSettingType::MaxHeaderListSize => {
                     self.max_header_list_size = *v;
@@ -728,7 +737,7 @@ impl Http3Handler<Http3ClientEvents, TransactionClient> for Http3ClientHandler {
 
     fn handle_new_push_stream(&mut self) -> Res<()> {
         // TODO implement PUSH
-        qerror!([self] "PUSH is not implemented!");
+        qerror!([self], "PUSH is not implemented!");
         Err(Error::HttpIdError)
     }
 
@@ -748,7 +757,7 @@ impl Http3Handler<Http3ClientEvents, TransactionClient> for Http3ClientHandler {
         events: &mut Http3ClientEvents,
         stream_id: u64,
     ) -> Res<()> {
-        qtrace!([self] "Writable stream {}.", stream_id);
+        qtrace!([self], "Writable stream {}.", stream_id);
 
         if let Some(t) = transactions.get_mut(&stream_id) {
             if t.is_state_sending_data() {
@@ -766,7 +775,12 @@ impl Http3Handler<Http3ClientEvents, TransactionClient> for Http3ClientHandler {
         stop_stream_id: u64,
         app_err: AppError,
     ) -> Res<()> {
-        qinfo!([self] "Handle stream_stop_sending stream_id={} app_err={}", stop_stream_id, app_err);
+        qinfo!(
+            [self],
+            "Handle stream_stop_sending stream_id={} app_err={}",
+            stop_stream_id,
+            app_err
+        );
 
         if let Some(t) = transactions.get_mut(&stop_stream_id) {
             // close sending side.
@@ -799,7 +813,7 @@ impl Http3Handler<Http3ClientEvents, TransactionClient> for Http3ClientHandler {
         state: &mut Http3State,
         goaway_stream_id: u64,
     ) -> Res<()> {
-        qinfo!([self] "handle_goaway");
+        qinfo!([self], "handle_goaway");
         // Issue reset events for streams >= goaway stream id
         for id in transactions
             .iter()
@@ -820,7 +834,7 @@ impl Http3Handler<Http3ClientEvents, TransactionClient> for Http3ClientHandler {
     }
 
     fn handle_max_push_id(&mut self, stream_id: u64) -> Res<()> {
-        qerror!([self] "handle_max_push_id={}.", stream_id);
+        qerror!([self], "handle_max_push_id={}.", stream_id);
         Err(Error::HttpFrameUnexpected)
     }
 
@@ -853,7 +867,7 @@ impl Http3Handler<Http3ServerEvents, TransactionServer> for Http3ServerHandler {
     }
 
     fn handle_new_push_stream(&mut self) -> Res<()> {
-        qerror!([self] "Error: server receives a push stream!");
+        qerror!([self], "Error: server receives a push stream!");
         Err(Error::HttpStreamCreationError)
     }
 
@@ -883,7 +897,7 @@ impl Http3Handler<Http3ServerEvents, TransactionServer> for Http3ServerHandler {
         _state: &mut Http3State,
         _goaway_stream_id: u64,
     ) -> Res<()> {
-        qerror!([self] "handle_goaway");
+        qerror!([self], "handle_goaway");
         Err(Error::HttpFrameUnexpected)
     }
 
@@ -899,7 +913,7 @@ impl Http3Handler<Http3ServerEvents, TransactionServer> for Http3ServerHandler {
     }
 
     fn handle_max_push_id(&mut self, stream_id: u64) -> Res<()> {
-        qinfo!([self] "handle_max_push_id={}.", stream_id);
+        qinfo!([self], "handle_max_push_id={}.", stream_id);
         // TODO
         Ok(())
     }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -88,7 +88,7 @@ impl Http3Client {
     }
 
     pub fn close(&mut self, now: Instant, error: AppError, msg: &str) {
-        qinfo!([self] "Close the connection error={} msg={}.", error, msg);
+        qinfo!([self], "Close the connection error={} msg={}.", error, msg);
         self.base_handler.close(now, error, msg);
     }
 
@@ -101,7 +101,7 @@ impl Http3Client {
         headers: &[Header],
     ) -> Res<u64> {
         qinfo!(
-            [self]
+            [self],
             "Fetch method={}, scheme={}, host={}, path={}",
             method,
             scheme,
@@ -125,17 +125,22 @@ impl Http3Client {
     }
 
     pub fn stream_reset(&mut self, stream_id: u64, error: AppError) -> Res<()> {
-        qinfo!([self] "reset_stream {} error={}.", stream_id, error);
+        qinfo!([self], "reset_stream {} error={}.", stream_id, error);
         self.base_handler.stream_reset(stream_id, error)
     }
 
     pub fn stream_close_send(&mut self, stream_id: u64) -> Res<()> {
-        qinfo!([self] "Close senidng side stream={}.", stream_id);
+        qinfo!([self], "Close senidng side stream={}.", stream_id);
         self.base_handler.stream_close_send(stream_id)
     }
 
     pub fn send_request_body(&mut self, stream_id: u64, buf: &[u8]) -> Res<usize> {
-        qinfo!([self] "send_request_body from stream {} sending {} bytes.", stream_id, buf.len());
+        qinfo!(
+            [self],
+            "send_request_body from stream {} sending {} bytes.",
+            stream_id,
+            buf.len()
+        );
         self.base_handler
             .transactions
             .get_mut(&stream_id)
@@ -144,7 +149,7 @@ impl Http3Client {
     }
 
     pub fn read_response_headers(&mut self, stream_id: u64) -> Res<(Vec<Header>, bool)> {
-        qinfo!([self] "read_response_headers from stream {}.", stream_id);
+        qinfo!([self], "read_response_headers from stream {}.", stream_id);
         let transaction = self
             .base_handler
             .transactions
@@ -167,7 +172,7 @@ impl Http3Client {
         stream_id: u64,
         buf: &mut [u8],
     ) -> Res<(usize, bool)> {
-        qinfo!([self] "read_data from stream {}.", stream_id);
+        qinfo!([self], "read_data from stream {}.", stream_id);
         let transaction = self
             .base_handler
             .transactions
@@ -219,17 +224,17 @@ impl Http3Client {
     }
 
     pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
-        qtrace!([self] "Process.");
+        qtrace!([self], "Process.");
         self.base_handler.process(dgram, now)
     }
 
     pub fn process_input(&mut self, dgram: Datagram, now: Instant) {
-        qtrace!([self] "Process input.");
+        qtrace!([self], "Process input.");
         self.base_handler.process_input(dgram, now);
     }
 
     pub fn process_timer(&mut self, now: Instant) {
-        qtrace!([self] "Process timer.");
+        qtrace!([self], "Process timer.");
         self.base_handler.process_timer(now);
     }
 
@@ -238,13 +243,13 @@ impl Http3Client {
     }
 
     pub fn process_http3(&mut self, now: Instant) {
-        qtrace!([self] "Process http3 internal.");
+        qtrace!([self], "Process http3 internal.");
 
         self.base_handler.process_http3(now);
     }
 
     pub fn process_output(&mut self, now: Instant) -> Output {
-        qtrace!([self] "Process output.");
+        qtrace!([self], "Process output.");
         self.base_handler.process_output(now)
     }
 }

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -51,17 +51,17 @@ impl Http3Server {
     }
 
     pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
-        qtrace!([self] "Process.");
+        qtrace!([self], "Process.");
         self.base_handler.process(dgram, now)
     }
 
     pub fn process_input(&mut self, dgram: Datagram, now: Instant) {
-        qtrace!([self] "Process input.");
+        qtrace!([self], "Process input.");
         self.base_handler.process_input(dgram, now);
     }
 
     pub fn process_timer(&mut self, now: Instant) {
-        qtrace!([self] "Process timer.");
+        qtrace!([self], "Process timer.");
         self.base_handler.process_timer(now);
     }
 
@@ -70,17 +70,17 @@ impl Http3Server {
     }
 
     pub fn process_http3(&mut self, now: Instant) {
-        qtrace!([self] "Process http3 internal.");
+        qtrace!([self], "Process http3 internal.");
         self.base_handler.process_http3(now);
     }
 
     pub fn process_output(&mut self, now: Instant) -> Output {
-        qtrace!([self] "Process output.");
+        qtrace!([self], "Process output.");
         self.base_handler.process_output(now)
     }
 
     pub fn close(&mut self, now: Instant, error: AppError, msg: &str) {
-        qinfo!([self] "Close connection.");
+        qinfo!([self], "Close connection.");
         self.base_handler.close(now, error, msg);
     }
 
@@ -107,7 +107,7 @@ impl Http3Server {
     }
 
     pub fn set_response(&mut self, stream_id: u64, headers: &[Header], data: Vec<u8>) -> Res<()> {
-        qinfo!([self] "Set new respons for stream {}.", stream_id);
+        qinfo!([self], "Set new respons for stream {}.", stream_id);
         self.base_handler
             .transactions
             .get_mut(&stream_id)
@@ -119,12 +119,17 @@ impl Http3Server {
     }
 
     pub fn stream_stop_sending(&mut self, stream_id: u64, app_error: AppError) -> Res<()> {
-        qdebug!([self] "stop sending stream_id:{} error:{}.", stream_id, app_error);
+        qdebug!(
+            [self],
+            "stop sending stream_id:{} error:{}.",
+            stream_id,
+            app_error
+        );
         self.base_handler.stream_stop_sending(stream_id, app_error)
     }
 
     pub fn stream_reset(&mut self, stream_id: u64, app_error: AppError) -> Res<()> {
-        qdebug!([self] "reset stream_id:{} error:{}.", stream_id, app_error);
+        qdebug!([self], "reset stream_id:{} error:{}.", stream_id, app_error);
         self.base_handler.stream_reset(stream_id, app_error)
     }
 }

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -34,7 +34,7 @@ impl ControlStreamLocal {
     pub fn send(&mut self, conn: &mut Connection) -> Res<()> {
         if let Some(stream_id) = self.stream_id {
             if !self.buf.is_empty() {
-                qtrace!([self] "sending data.");
+                qtrace!([self], "sending data.");
                 let sent = conn.stream_send(stream_id, &self.buf[..])?;
                 if sent == self.buf.len() {
                     self.buf.clear();
@@ -48,7 +48,7 @@ impl ControlStreamLocal {
     }
 
     pub fn create(&mut self, conn: &mut Connection) -> Res<()> {
-        qtrace!([self] "Create a control stream.");
+        qtrace!([self], "Create a control stream.");
         self.stream_id = Some(conn.stream_create(StreamType::UniDi)?);
         let mut enc = Encoder::default();
         enc.encode_varint(HTTP3_UNI_STREAM_TYPE_CONTROL as u64);

--- a/neqo-http3/src/control_stream_remote.rs
+++ b/neqo-http3/src/control_stream_remote.rs
@@ -33,9 +33,9 @@ impl ControlStreamRemote {
     }
 
     pub fn add_remote_stream(&mut self, stream_id: u64) -> Res<()> {
-        qinfo!([self] "A new control stream {}.", stream_id);
+        qinfo!([self], "A new control stream {}.", stream_id);
         if self.stream_id.is_some() {
-            qdebug!([self] "A control stream already exists");
+            qdebug!([self], "A control stream already exists");
             return Err(Error::HttpStreamCreationError);
         }
         self.stream_id = Some(stream_id);
@@ -45,7 +45,7 @@ impl ControlStreamRemote {
     pub fn receive_if_this_stream(&mut self, conn: &mut Connection, stream_id: u64) -> Res<bool> {
         if let Some(id) = self.stream_id {
             if id == stream_id {
-                qdebug!([self] "Receiving data.");
+                qdebug!([self], "Receiving data.");
                 self.fin = self.frame_reader.receive(conn, stream_id)?;
                 return Ok(true);
             }

--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -213,7 +213,7 @@ impl HFrameReader {
             let fin;
             let mut input = match conn.stream_recv(stream_id, &mut buf[..]) {
                 Ok((0, true)) => {
-                    qtrace!([conn] "HFrameReader::receive: stream has been closed");
+                    qtrace!([conn], "HFrameReader::receive: stream has been closed");
                     break match self.state {
                         HFrameReaderState::BeforeFrame => Ok(true),
                         _ => Err(Error::HttpFrameError),
@@ -221,12 +221,22 @@ impl HFrameReader {
                 }
                 Ok((0, false)) => break Ok(false),
                 Ok((amount, f)) => {
-                    qtrace!([conn] "HFrameReader::receive: reading {} byte, fin={}", amount, f);
+                    qtrace!(
+                        [conn],
+                        "HFrameReader::receive: reading {} byte, fin={}",
+                        amount,
+                        f
+                    );
                     fin = f;
                     Decoder::from(&buf[..amount])
                 }
                 Err(e) => {
-                    qdebug!([conn] "HFrameReader::receive: error reading data from stream {}: {:?}", stream_id, e);
+                    qdebug!(
+                        [conn],
+                        "HFrameReader::receive: error reading data from stream {}: {:?}",
+                        stream_id,
+                        e
+                    );
                     break Err(e.into());
                 }
             };
@@ -238,7 +248,7 @@ impl HFrameReader {
             match self.state {
                 HFrameReaderState::BeforeFrame | HFrameReaderState::GetType => match progress {
                     IncrementalDecoderResult::Uint(v) => {
-                        qtrace!([conn] "HFrameReader::receive: read frame type {}", v);
+                        qtrace!([conn], "HFrameReader::receive: read frame type {}", v);
                         self.hframe_type = v;
                         self.decoder = IncrementalDecoder::decode_varint();
                         self.state = HFrameReaderState::GetLength;
@@ -252,7 +262,12 @@ impl HFrameReader {
                 HFrameReaderState::GetLength => {
                     match progress {
                         IncrementalDecoderResult::Uint(len) => {
-                            qtrace!([conn] "HFrameReader::receive: frame type {} length {}", self.hframe_type, len);
+                            qtrace!(
+                                [conn],
+                                "HFrameReader::receive: frame type {} length {}",
+                                self.hframe_type,
+                                len
+                            );
                             self.hframe_len = len;
                             self.state = match self.hframe_type {
                                 // DATA and HEADERS payload are left on the quic stream and picked up separately
@@ -310,7 +325,12 @@ impl HFrameReader {
                 HFrameReaderState::GetData => {
                     match progress {
                         IncrementalDecoderResult::Buffer(data) => {
-                            qtrace!([conn] "received frame {}: {}", self.hframe_type, hex(&data[..]));
+                            qtrace!(
+                                [conn],
+                                "received frame {}: {}",
+                                self.hframe_type,
+                                hex(&data[..])
+                            );
                             self.payload = data;
                             self.state = HFrameReaderState::Done;
                         }

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -46,7 +46,12 @@ impl NewStreamTypeReader {
                     }
                 }
                 Err(e) => {
-                    qdebug!([conn] "Error reading stream type for stream {}: {:?}", stream_id, e);
+                    qdebug!(
+                        [conn],
+                        "Error reading stream type for stream {}: {:?}",
+                        stream_id,
+                        e
+                    );
                     self.fin = true;
                     return None;
                 }

--- a/neqo-http3/src/transaction_server.rs
+++ b/neqo-http3/src/transaction_server.rs
@@ -54,7 +54,7 @@ impl TransactionServer {
     }
 
     pub fn set_response(&mut self, headers: &[Header], data: Vec<u8>, encoder: &mut QPackEncoder) {
-        qdebug!([self] "Encoding headers");
+        qdebug!([self], "Encoding headers");
         let encoded_headers = encoder.encode_header_block(&headers, self.stream_id);
         let hframe = HFrame::Headers {
             len: encoded_headers.len() as u64,
@@ -63,7 +63,7 @@ impl TransactionServer {
         hframe.encode(&mut d);
         d.encode(&encoded_headers);
         if !data.is_empty() {
-            qdebug!([self] "Encoding data");
+            qdebug!([self], "Encoding data");
             let d_frame = HFrame::Data {
                 len: data.len() as u64,
             };
@@ -75,12 +75,12 @@ impl TransactionServer {
     }
 
     fn recv_frame_header(&mut self, conn: &mut Connection) -> Res<(Option<HFrame>, bool)> {
-        qtrace!([self] "receiving frame header");
+        qtrace!([self], "receiving frame header");
         let fin = self.frame_reader.receive(conn, self.stream_id)?;
         if !self.frame_reader.done() {
             Ok((None, fin))
         } else {
-            qinfo!([self] "A new frame has been received.");
+            qinfo!([self], "A new frame has been received.");
             Ok((Some(self.frame_reader.get_frame()?), fin))
         }
     }
@@ -101,7 +101,7 @@ impl TransactionServer {
         } = self.recv_state
         {
             let (amount, fin) = conn.stream_recv(self.stream_id, &mut buf[*offset..])?;
-            qdebug!([label] "read_headers: read {} bytes fin={}.", amount, fin);
+            qdebug!([label], "read_headers: read {} bytes fin={}.", amount, fin);
             *offset += amount as usize;
             if *offset < buf.len() {
                 if fin {
@@ -112,7 +112,10 @@ impl TransactionServer {
             }
 
             // we have read the headers, try decoding them.
-            qinfo!([label] "read_headers: read all headers, try decoding them.");
+            qinfo!(
+                [label],
+                "read_headers: read all headers, try decoding them."
+            );
             match decoder.decode_header_block(buf, self.stream_id)? {
                 Some(headers) => {
                     self.conn_events.headers(self.stream_id, headers, fin);
@@ -137,7 +140,7 @@ impl TransactionServer {
     }
 
     fn handle_frame_in_state_waiting_for_headers(&mut self, frame: HFrame, fin: bool) -> Res<()> {
-        qdebug!([self] "A new frame has been received: {:?}", frame);
+        qdebug!([self], "A new frame has been received: {:?}", frame);
         match frame {
             HFrame::Headers { len } => self.handle_headers_frame(len, fin),
             _ => Err(Error::HttpFrameUnexpected),
@@ -145,7 +148,7 @@ impl TransactionServer {
     }
 
     fn handle_frame_in_state_waiting_for_data(&mut self, frame: HFrame, fin: bool) -> Res<()> {
-        qdebug!([self] "A new frame has been received: {:?}", frame);
+        qdebug!([self], "A new frame has been received: {:?}", frame);
         match frame {
             HFrame::Data { len } => self.handle_data_frame(len, fin),
             _ => Err(Error::HttpFrameUnexpected),
@@ -153,7 +156,7 @@ impl TransactionServer {
     }
 
     fn handle_headers_frame(&mut self, len: u64, fin: bool) -> Res<()> {
-        qinfo!([self] "A new header frame len={} fin={}", len, fin);
+        qinfo!([self], "A new header frame len={} fin={}", len, fin);
         if len == 0 {
             self.conn_events.headers(self.stream_id, Vec::new(), fin);
         } else {
@@ -169,7 +172,7 @@ impl TransactionServer {
     }
 
     fn handle_data_frame(&mut self, len: u64, fin: bool) -> Res<()> {
-        qinfo!([self] "A new data frame len={} fin={}", len, fin);
+        qinfo!([self], "A new data frame len={} fin={}", len, fin);
         if len > 0 {
             if fin {
                 return Err(Error::HttpFrameError);
@@ -193,7 +196,7 @@ impl ::std::fmt::Display for TransactionServer {
 
 impl Http3Transaction for TransactionServer {
     fn send(&mut self, conn: &mut Connection, _encoder: &mut QPackEncoder) -> Res<()> {
-        qtrace!([self] "Sending response.");
+        qtrace!([self], "Sending response.");
         let label = if ::log::log_enabled!(::log::Level::Debug) {
             format!("{}", self)
         } else {
@@ -201,11 +204,11 @@ impl Http3Transaction for TransactionServer {
         };
         if let TransactionSendState::SendingResponse { ref mut buf } = self.send_state {
             let sent = conn.stream_send(self.stream_id, &buf[..])?;
-            qinfo!([label] "{} bytes sent", sent);
+            qinfo!([label], "{} bytes sent", sent);
             if sent == buf.len() {
                 conn.stream_close_send(self.stream_id)?;
                 self.send_state = TransactionSendState::Closed;
-                qinfo!([label] "done sending request");
+                qinfo!([label], "done sending request");
             } else {
                 let mut b = buf.split_off(sent);
                 mem::swap(buf, &mut b);
@@ -223,7 +226,11 @@ impl Http3Transaction for TransactionServer {
         };
 
         loop {
-            qtrace!([label] "[recv_state={:?}] receiving data.", self.recv_state);
+            qtrace!(
+                [label],
+                "[recv_state={:?}] receiving data.",
+                self.recv_state
+            );
             match self.recv_state {
                 TransactionRecvState::WaitingForHeaders => {
                     let (f, fin) = self.recv_frame_header(conn)?;
@@ -258,7 +265,7 @@ impl Http3Transaction for TransactionServer {
                             }
                         }
                         None => {
-                            qinfo!([self] "decoding header is blocked.");
+                            qinfo!([self], "decoding header is blocked.");
                             return Ok(());
                         }
                     }

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -495,21 +495,21 @@ impl Connection {
     /// if the token supports that.
     pub fn set_resumption_token(&mut self, now: Instant, token: &[u8]) -> Res<()> {
         if self.state != State::Init {
-            qerror!([self] "set token in state {:?}", self.state);
+            qerror!([self], "set token in state {:?}", self.state);
             return Err(Error::ConnectionState);
         }
-        qinfo!([self] "resumption token {}", hex(token));
+        qinfo!([self], "resumption token {}", hex(token));
         let mut dec = Decoder::from(token);
         let tp_slice = match dec.decode_vvec() {
             Some(v) => v,
             _ => return Err(Error::InvalidResumptionToken),
         };
-        qtrace!([self] "  transport parameters {}", hex(&tp_slice));
+        qtrace!([self], "  transport parameters {}", hex(&tp_slice));
         let mut dec_tp = Decoder::from(tp_slice);
         let tp = TransportParameters::decode(&mut dec_tp)?;
 
         let tok = dec.decode_remainder();
-        qtrace!([self] "  TLS token {}", hex(&tok));
+        qtrace!([self], "  TLS token {}", hex(&tok));
         match self.crypto.tls {
             Agent::Client(ref mut c) => c.set_resumption_token(&tok)?,
             Agent::Server(_) => return Err(Error::WrongRole),
@@ -533,7 +533,7 @@ impl Connection {
                 });
                 enc.encode(extra);
                 let records = s.send_ticket(now, &enc)?;
-                qinfo!([self] "send session ticket {}", hex(&enc));
+                qinfo!([self], "send session ticket {}", hex(&enc));
                 self.buffer_crypto_records(records);
                 Ok(())
             }
@@ -581,7 +581,7 @@ impl Connection {
             #[cfg(not(debug_assertions))]
             let msg = String::from("");
             if let State::Closed(err) | State::Closing { error: err, .. } = &self.state {
-                qwarn!([self] "Closing again after error {:?}", err);
+                qwarn!([self], "Closing again after error {:?}", err);
             } else {
                 self.set_state(State::Closing {
                     error: ConnectionError::Transport(v.clone()),
@@ -705,10 +705,10 @@ impl Connection {
             // assume that the DCID is OK.
             if hdr.dcid.len() < 8 {
                 if token.is_empty() {
-                    qinfo!([self] "Drop Initial with short DCID");
+                    qinfo!([self], "Drop Initial with short DCID");
                     false
                 } else {
-                    qinfo!([self] "Initial received with token, assuming OK");
+                    qinfo!([self], "Initial received with token, assuming OK");
                     true
                 }
             } else {
@@ -716,31 +716,34 @@ impl Connection {
                 true
             }
         } else {
-            qdebug!([self] "Dropping non-Initial packet");
+            qdebug!([self], "Dropping non-Initial packet");
             false
         }
     }
 
     fn handle_retry(&mut self, scid: &ConnectionId, odcid: &ConnectionId, token: &[u8]) -> Res<()> {
-        qdebug!([self] "received Retry");
+        qdebug!([self], "received Retry");
         if self.retry_info.is_some() {
-            qinfo!([self] "Dropping extra Retry");
+            qinfo!([self], "Dropping extra Retry");
             return Ok(());
         }
         if token.is_empty() {
-            qinfo!([self] "Dropping Retry without a token");
+            qinfo!([self], "Dropping Retry without a token");
             return Ok(());
         }
         match self.path.iter_mut().find(|p| p.remote_cid == *odcid) {
             None => {
-                qinfo!([self] "Ignoring Retry with mismatched ODCID");
+                qinfo!([self], "Ignoring Retry with mismatched ODCID");
                 return Ok(());
             }
             Some(path) => {
                 path.remote_cid = scid.clone();
             }
         }
-        qinfo!([self] "Valid Retry received, restarting with provided token");
+        qinfo!(
+            [self],
+            "Valid Retry received, restarting with provided token"
+        );
         self.retry_info = Some(RetryInfo {
             token: token.to_vec(),
             odcid: odcid.clone(),
@@ -757,7 +760,7 @@ impl Connection {
     fn input(&mut self, d: Datagram, now: Instant) -> Res<()> {
         let mut slc = &d[..];
 
-        qinfo!([self] "input {}", hex( &**d));
+        qinfo!([self], "input {}", hex(&**d));
 
         // Handle each packet in the datagram
         while !slc.is_empty() {
@@ -765,7 +768,12 @@ impl Connection {
             let mut hdr = match res {
                 Ok(h) => h,
                 Err(e) => {
-                    qinfo!([self] "Received indecipherable packet header {} {}", hex(slc), e);
+                    qinfo!(
+                        [self],
+                        "Received indecipherable packet header {} {}",
+                        hex(slc),
+                        e
+                    );
                     return Ok(()); // Drop the remainder of the datagram.
                 }
             };
@@ -800,11 +808,11 @@ impl Connection {
 
             match self.state {
                 State::Init => {
-                    qinfo!([self] "Received message while in Init state");
+                    qinfo!([self], "Received message while in Init state");
                     return Ok(());
                 }
                 State::WaitInitial => {
-                    qinfo!([self] "Received packet in WaitInitial");
+                    qinfo!([self], "Received packet in WaitInitial");
                     if self.role == Role::Server {
                         if !self.is_valid_initial(&hdr) {
                             return Ok(());
@@ -815,7 +823,7 @@ impl Connection {
                 }
                 State::Handshaking | State::Connected => {
                     if !self.is_valid_cid(&hdr.dcid) {
-                        qinfo!([self] "Ignoring packet with CID {:?}", hdr.dcid);
+                        qinfo!([self], "Ignoring packet with CID {:?}", hdr.dcid);
                         return Ok(());
                     }
                 }
@@ -831,7 +839,7 @@ impl Connection {
                 }
             }
 
-            qdebug!([self] "Received unverified packet {:?}", hdr);
+            qdebug!([self], "Received unverified packet {:?}", hdr);
 
             let body = self.decrypt_body(&mut hdr, slc);
             slc = &slc[hdr.hdr_len + hdr.body_len()..];
@@ -883,7 +891,12 @@ impl Connection {
         let ack_eliciting = self.input_packet(hdr.epoch, Decoder::from(&body[..]), now)?;
         let space = PNSpace::from(hdr.epoch);
         if self.acks[space].is_duplicate(hdr.pn) {
-            qdebug!([self] "Received duplicate packet epoch={} pn={}", hdr.epoch, hdr.pn);
+            qdebug!(
+                [self],
+                "Received duplicate packet epoch={} pn={}",
+                hdr.epoch,
+                hdr.pn
+            );
             self.stats.dups_rx += 1;
             Ok(true)
         } else {
@@ -916,7 +929,11 @@ impl Connection {
                 ZeroRttState::Rejected
             };
         } else {
-            qdebug!([self] "Changing to use Server CID={}", hdr.scid.as_ref().unwrap());
+            qdebug!(
+                [self],
+                "Changing to use Server CID={}",
+                hdr.scid.as_ref().unwrap()
+            );
             let p = self
                 .path
                 .iter_mut()
@@ -972,7 +989,7 @@ impl Connection {
                         out = match self.output_path(&p, now) {
                             Ok(x) => x,
                             Err(e) => {
-                                qwarn!([self] "two output_path errors in a row: {:?}", e);
+                                qwarn!([self], "two output_path errors in a row: {:?}", e);
                                 None
                             }
                         };
@@ -1068,7 +1085,7 @@ impl Connection {
                 continue;
             }
 
-            qdebug!([self] "Need to send a packet");
+            qdebug!([self], "Need to send a packet");
             match epoch {
                 // Packets containing Initial packets need padding.
                 0 => needs_padding = true,
@@ -1128,18 +1145,18 @@ impl Connection {
 
         // Pad Initial packets sent by the client to 1200 bytes.
         if self.role == Role::Client && needs_padding {
-            qdebug!([self] "pad Initial to 1200");
+            qdebug!([self], "pad Initial to 1200");
             out_bytes.resize(1200, 0);
         }
         Ok(Some(Datagram::new(path.local, path.remote, out_bytes)))
     }
 
     fn client_start(&mut self, now: Instant) -> Res<()> {
-        qinfo!([self] "client_start");
+        qinfo!([self], "client_start");
         self.handshake(now, 0, None)?;
         self.set_state(State::WaitInitial);
         if self.crypto.tls.preinfo()?.early_data() {
-            qdebug!([self] "Enabling 0-RTT");
+            qdebug!([self], "Enabling 0-RTT");
             self.zero_rtt_state = ZeroRttState::Enabled;
         }
         Ok(())
@@ -1164,7 +1181,7 @@ impl Connection {
     fn buffer_crypto_records(&mut self, records: RecordList) {
         for r in records {
             assert_eq!(r.ct, 22);
-            qdebug!([self] "Adding CRYPTO data {:?}", r);
+            qdebug!([self], "Adding CRYPTO data {:?}", r);
             self.crypto.streams[r.epoch as usize].tx.send(&r.data);
         }
     }
@@ -1204,7 +1221,7 @@ impl Connection {
         let mut rec: Option<Record> = None;
 
         if let Some(d) = data {
-            qdebug!([self] "Handshake received {:0x?} ", d);
+            qdebug!([self], "Handshake received {:0x?} ", d);
             rec = Some(Record {
                 ct: 22, // TODO(ekr@rtfm.com): Symbolic constants for CT. This is handshake.
                 epoch,
@@ -1219,7 +1236,7 @@ impl Connection {
 
         match m {
             Err(e) => {
-                qwarn!([self] "Handshake failed");
+                qwarn!([self], "Handshake failed");
                 return Err(match self.crypto.tls.alert() {
                     Some(a) => Error::CryptoAlert(*a),
                     _ => Error::CryptoError(e),
@@ -1228,10 +1245,10 @@ impl Connection {
             Ok(msgs) => self.buffer_crypto_records(msgs),
         }
         if self.crypto.tls.state().connected() {
-            qinfo!([self] "TLS handshake completed");
+            qinfo!([self], "TLS handshake completed");
 
             if self.crypto.tls.info().map(SecretAgentInfo::alpn).is_none() {
-                qwarn!([self] "No ALPN. Closing connection.");
+                qwarn!([self], "No ALPN. Closing connection.");
                 // 120 = no_application_protocol
                 return Err(Error::CryptoAlert(120));
             }
@@ -1306,7 +1323,7 @@ impl Connection {
             }
             Frame::Crypto { offset, data } => {
                 qdebug!(
-                    [self]
+                    [self],
                     "Crypto frame on epoch={} offset={}, data={:0x?}",
                     epoch,
                     offset,
@@ -1357,7 +1374,11 @@ impl Connection {
             }
             Frame::DataBlocked { data_limit } => {
                 // Should never happen since we set data limit to 2^62-1
-                qwarn!([self] "Received DataBlocked with data limit {}", data_limit);
+                qwarn!(
+                    [self],
+                    "Received DataBlocked with data limit {}",
+                    data_limit
+                );
             }
             Frame::StreamDataBlocked { stream_id, .. } => {
                 // TODO(agrover@mozilla.com): how should we be using
@@ -1401,7 +1422,7 @@ impl Connection {
             Frame::PathResponse { .. } => {
                 // Should never see this, we don't support migration atm and
                 // do not send path challenges
-                qwarn!([self] "Received Path Response");
+                qwarn!([self], "Received Path Response");
             }
             Frame::ConnectionClose {
                 error_code,
@@ -1409,11 +1430,13 @@ impl Connection {
                 reason_phrase,
             } => {
                 let reason_phrase = String::from_utf8_lossy(&reason_phrase);
-                qinfo!([self]
-                       "ConnectionClose received. Error code: {:?} frame type {:x} reason {}",
-                       error_code,
-                       frame_type,
-                       reason_phrase);
+                qinfo!(
+                    [self],
+                    "ConnectionClose received. Error code: {:?} frame type {:x} reason {}",
+                    error_code,
+                    frame_type,
+                    reason_phrase
+                );
                 self.set_state(State::Closed(error_code.into()));
             }
         };
@@ -1453,7 +1476,7 @@ impl Connection {
         now: Instant,
     ) -> Res<()> {
         qinfo!(
-            [self]
+            [self],
             "Rx ACK epoch={}, largest_acked={}, first_ack_range={}, ranges={:?}",
             epoch,
             largest_acknowledged,
@@ -1517,7 +1540,7 @@ impl Connection {
 
     fn set_state(&mut self, state: State) {
         if state > self.state {
-            qinfo!([self] "State change from {:?} -> {:?}", self.state, state);
+            qinfo!([self], "State change from {:?} -> {:?}", self.state, state);
             self.state = state.clone();
             match &self.state {
                 State::Connected => {
@@ -1614,9 +1637,12 @@ impl Connection {
             if stream_idx >= *next_stream_idx {
                 let recv_initial_max_stream_data = if stream_id.is_bidi() {
                     if stream_idx > self.indexes.local_max_stream_bidi {
-                        qwarn!([self] "remote bidi stream create blocked, next={:?} max={:?}",
-                               stream_idx,
-                               self.indexes.local_max_stream_bidi);
+                        qwarn!(
+                            [self],
+                            "remote bidi stream create blocked, next={:?} max={:?}",
+                            stream_idx,
+                            self.indexes.local_max_stream_bidi
+                        );
                         return Err(Error::StreamLimitError);
                     }
                     self.tps
@@ -1625,9 +1651,12 @@ impl Connection {
                         .get_integer(tp_const::INITIAL_MAX_STREAM_DATA_BIDI_REMOTE)
                 } else {
                     if stream_idx > self.indexes.local_max_stream_uni {
-                        qwarn!([self] "remote uni stream create blocked, next={:?} max={:?}",
-                               stream_idx,
-                               self.indexes.local_max_stream_uni);
+                        qwarn!(
+                            [self],
+                            "remote uni stream create blocked, next={:?} max={:?}",
+                            stream_idx,
+                            self.indexes.local_max_stream_uni
+                        );
                         return Err(Error::StreamLimitError);
                     }
                     self.tps
@@ -1709,9 +1738,12 @@ impl Connection {
                     self.flow_mgr
                         .borrow_mut()
                         .streams_blocked(self.indexes.remote_max_stream_uni, StreamType::UniDi);
-                    qwarn!([self] "local uni stream create blocked, next={:?} max={:?}",
-                           self.indexes.remote_next_stream_uni,
-                           self.indexes.remote_max_stream_uni);
+                    qwarn!(
+                        [self],
+                        "local uni stream create blocked, next={:?} max={:?}",
+                        self.indexes.remote_next_stream_uni,
+                        self.indexes.remote_max_stream_uni
+                    );
                     return Err(Error::StreamLimitError);
                 }
                 let new_id = self
@@ -1741,9 +1773,12 @@ impl Connection {
                     self.flow_mgr
                         .borrow_mut()
                         .streams_blocked(self.indexes.remote_max_stream_bidi, StreamType::BiDi);
-                    qwarn!([self] "local bidi stream create blocked, next={:?} max={:?}",
-                           self.indexes.remote_next_stream_bidi,
-                           self.indexes.remote_max_stream_bidi);
+                    qwarn!(
+                        [self],
+                        "local bidi stream create blocked, next={:?} max={:?}",
+                        self.indexes.remote_next_stream_bidi,
+                        self.indexes.remote_max_stream_bidi
+                    );
                     return Err(Error::StreamLimitError);
                 }
                 let new_id = self
@@ -1855,7 +1890,7 @@ impl Connection {
     }
 
     fn check_loss_detection_timeout(&mut self, now: Instant) {
-        qdebug!([self] "check_loss_timeouts");
+        qdebug!([self], "check_loss_timeouts");
 
         if matches!(self.loss_recovery_state.mode(), LossRecoveryMode::None) {
             // LR not the active timer
@@ -1897,7 +1932,7 @@ impl Connection {
             }
             LossRecoveryMode::PTO => {
                 qinfo!(
-                    [self]
+                    [self],
                     "check_loss_detection_timeout -send_one_or_two_packets"
                 );
                 self.loss_recovery.increment_pto_count();

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -67,7 +67,7 @@ impl Crypto {
         const SERVER_INITIAL_LABEL: &str = "server in";
 
         qinfo!(
-            [self]
+            [self],
             "Creating initial cipher state role={:?} dcid={}",
             role,
             hex(dcid)
@@ -94,7 +94,7 @@ impl Crypto {
 
         let cs = &mut self.states[epoch as usize];
         if cs.is_none() {
-            qtrace!([label] "Build crypto state for epoch {}", epoch);
+            qtrace!([label], "Build crypto state for epoch {}", epoch);
             assert!(epoch != 0); // This state is made directly.
 
             let cipher = match (epoch, self.tls.info()) {
@@ -103,7 +103,7 @@ impl Crypto {
                 (_, Some(info)) => Some(info.cipher_suite()),
             };
             if cipher.is_none() {
-                qdebug!([label] "cipher info not available yet");
+                qdebug!([label], "cipher info not available yet");
                 return Err(Error::KeysNotFound);
             }
             let cipher = cipher.unwrap();
@@ -123,7 +123,7 @@ impl Crypto {
                 | (Some(_), None, Role::Server, 1)
                 | (Some(_), Some(_), _, _) => {}
                 (None, None, _, _) => {
-                    qdebug!([label] "Keying material not available for epoch {}", epoch);
+                    qdebug!([label], "Keying material not available for epoch {}", epoch);
                     return Err(Error::KeysNotFound);
                 }
                 _ => panic!("bad configuration of keys"),
@@ -276,7 +276,7 @@ impl CryptoCtx for CryptoDxState {
 
     fn aead_decrypt(&self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>> {
         qinfo!(
-            [self]
+            [self],
             "aead_decrypt pn={} hdr={} body={}",
             pn,
             hex(hdr),
@@ -289,7 +289,7 @@ impl CryptoCtx for CryptoDxState {
 
     fn aead_encrypt(&self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>> {
         qdebug!(
-            [self]
+            [self],
             "aead_encrypt pn={} hdr={} body={}",
             pn,
             hex(hdr),
@@ -300,7 +300,7 @@ impl CryptoCtx for CryptoDxState {
         let mut out = vec![0; size];
         let res = self.aead.encrypt(pn, hdr, body, &mut out)?;
 
-        qdebug!([self] "aead_encrypt ct={}", hex(res),);
+        qdebug!([self], "aead_encrypt ct={}", hex(res),);
 
         Ok(res.to_vec())
     }

--- a/neqo-transport/src/dump.rs
+++ b/neqo-transport/src/dump.rs
@@ -28,5 +28,5 @@ pub fn dump_packet(conn: &Connection, dir: &str, hdr: &PacketHdr, payload: &[u8]
             s.push_str(&format!("\n  {} {}", dir, &x));
         }
     }
-    qdebug!([conn] "pn={} type={:?}{}", hdr.pn, hdr.tipe, s);
+    qdebug!([conn], "pn={} type={:?}{}", hdr.pn, hdr.tipe, s);
 }

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -264,7 +264,7 @@ impl LossRecovery {
         tokens: Vec<RecoveryToken>,
         now: Instant,
     ) {
-        qdebug!([self] "packet {:?}-{} sent.", pn_space, packet_number);
+        qdebug!([self], "packet {:?}-{} sent.", pn_space, packet_number);
         self.spaces[pn_space].sent_packets.insert(
             packet_number,
             SentPacket {
@@ -290,8 +290,12 @@ impl LossRecovery {
         ack_delay: Duration,
         now: Instant,
     ) -> (Vec<SentPacket>, Vec<SentPacket>) {
-        qdebug!([self] "ack received for {:?} - largest_acked={}.",
-                pn_space, largest_acked);
+        qdebug!(
+            [self],
+            "ack received for {:?} - largest_acked={}.",
+            pn_space,
+            largest_acked
+        );
 
         let (acked_packets, any_ack_eliciting) = self.spaces[pn_space].remove_acked(acked_ranges);
         if acked_packets.is_empty() {
@@ -354,9 +358,12 @@ impl LossRecovery {
 
         // Packets sent before this time are deemed lost.
         let lost_deadline = now - loss_delay;
-        qdebug!([self]
+        qdebug!(
+            [self],
             "detect lost packets = now {:?} loss delay {:?} lost_deadline {:?}",
-            now, loss_delay, lost_deadline
+            now,
+            loss_delay,
+            lost_deadline
         );
 
         let packet_space = &mut self.spaces[pn_space];
@@ -437,7 +444,7 @@ impl LossRecovery {
     }
 
     pub fn get_timer(&mut self, conn_state: &State) -> LossRecoveryState {
-        qdebug!([self] "get_loss_detection_timer.");
+        qdebug!([self], "get_loss_detection_timer.");
 
         let has_ack_eliciting_out = self
             .spaces
@@ -445,17 +452,14 @@ impl LossRecovery {
             .flat_map(|spc| spc.sent_packets.values())
             .any(|sp| sp.ack_eliciting);
 
-        qdebug!(
-            [self]
-            "has_ack_eliciting_out={}",
-            has_ack_eliciting_out,
-        );
+        qdebug!([self], "has_ack_eliciting_out={}", has_ack_eliciting_out,);
 
         if !has_ack_eliciting_out && *conn_state == State::Connected {
             return LossRecoveryState::new(LossRecoveryMode::None, None);
         }
 
-        qinfo!([self]
+        qinfo!(
+            [self],
             "sent packets {} {} {}",
             self.spaces[PNSpace::Initial].sent_packets.len(),
             self.spaces[PNSpace::Handshake].sent_packets.len(),
@@ -478,7 +482,12 @@ impl LossRecovery {
             )
         };
 
-        qdebug!([self] "loss_detection_timer mode={:?} timer={:?}", mode, maybe_timer);
+        qdebug!(
+            [self],
+            "loss_detection_timer mode={:?} timer={:?}",
+            mode,
+            maybe_timer
+        );
         LossRecoveryState::new(mode, maybe_timer)
     }
 

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -84,12 +84,12 @@ impl PacketRange {
         assert!(!self.contains(pn));
         // Only insert if this is adjacent the current range.
         if (self.largest + 1) == pn {
-            qtrace!([self] "Adding largest {}", pn);
+            qtrace!([self], "Adding largest {}", pn);
             self.largest += 1;
             self.ack_needed = true;
             true
         } else if self.smallest == (pn + 1) {
-            qtrace!([self] "Adding smallest {}", pn);
+            qtrace!([self], "Adding smallest {}", pn);
             self.smallest -= 1;
             self.ack_needed = true;
             true
@@ -100,7 +100,7 @@ impl PacketRange {
 
     /// Maybe merge a lower-numbered range into this.
     pub fn merge_smaller(&mut self, other: &Self) {
-        qinfo!([self] "Merging {}", other);
+        qinfo!([self], "Merging {}", other);
         // This only works if they are immediately adjacent.
         assert_eq!(self.smallest - 1, other.largest);
 
@@ -113,7 +113,7 @@ impl PacketRange {
     /// Requires that other is equal to this, or a larger range.
     pub fn acknowledged(&mut self, other: &Self) {
         if (other.smallest <= self.smallest) && (other.largest >= self.largest) {
-            qinfo!([self] "Acknowledged");
+            qinfo!([self], "Acknowledged");
             self.ack_needed = false;
         }
     }
@@ -212,10 +212,10 @@ impl RecvdPackets {
         if self.ranges.len() > MAX_TRACKED_RANGES {
             let oldest = self.ranges.pop_back().unwrap();
             if oldest.ack_needed {
-                qwarn!([self] "Dropping unacknowledged ACK range: {}", oldest);
+                qwarn!([self], "Dropping unacknowledged ACK range: {}", oldest);
             // TODO(mt) Record some statistics about this so we can tune MAX_TRACKED_RANGES.
             } else {
-                qdebug!([self] "Drop ACK range: {}", oldest);
+                qdebug!([self], "Drop ACK range: {}", oldest);
             }
             self.min_tracked = oldest.largest + 1;
         }


### PR DESCRIPTION
rustfmt likes this better.

Remove non-comma layout option from log macros.