### PR TITLE
Pull out unrelated things from #280

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -6,13 +6,11 @@
 
 // The class implementing a QUIC connection.
 
-#![allow(dead_code)]
 use std::cell::RefCell;
 use std::cmp::{max, Ordering};
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::{self, Debug};
-use std::mem;
 use std::net::SocketAddr;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
@@ -26,7 +24,7 @@ use neqo_crypto::{
     SecretAgentInfo, Server,
 };
 
-use crate::crypto::Crypto;
+use crate::crypto::{Crypto, CryptoState};
 use crate::dump::*;
 use crate::events::{ConnectionEvent, ConnectionEvents};
 use crate::flow_mgr::FlowMgr;
@@ -154,6 +152,14 @@ impl Path {
 
     pub fn received_on(&self, d: &Datagram) -> bool {
         self.local == d.destination() && self.remote == d.source()
+    }
+
+    fn mtu(&self) -> usize {
+        if self.local.is_ipv4() {
+            1252
+        } else {
+            1232 // IPv6
+        }
     }
 }
 
@@ -349,7 +355,7 @@ impl Connection {
                 remote_cid: dcid.clone(),
             }),
         );
-        c.crypto.states[0] = Some(c.crypto.create_initial_state(Role::Client, &dcid));
+        c.crypto.create_initial_state(Role::Client, &dcid)?;
         Ok(c)
     }
 
@@ -435,14 +441,6 @@ impl Connection {
     /// Set a local transport parameter, possibly overriding a default value.
     pub fn set_local_tparam(&self, key: u16, value: TransportParameter) {
         self.tps.borrow_mut().local.set(key, value)
-    }
-
-    fn pmtu(&self) -> usize {
-        match &self.path {
-            Some(path) if path.local.is_ipv4() => 1252,
-            Some(_) => 1232, // IPv6
-            None => 1280,
-        }
     }
 
     /// Set the connection ID that was originally chosen by the client.
@@ -626,7 +624,7 @@ impl Connection {
 
     /// Get the time that we next need to be called back, relative to `now`.
     fn next_delay(&mut self, now: Instant) -> Duration {
-        self.loss_recovery_state = self.loss_recovery.get_timer(&self.state);
+        self.loss_recovery_state = self.loss_recovery.get_timer();
 
         let mut delays = SmallVec::<[_; 4]>::new();
 
@@ -753,7 +751,7 @@ impl Connection {
 
         // Switching crypto state here might not happen eventually.
         // https://github.com/quicwg/base-drafts/issues/2823
-        self.crypto.states[0] = Some(self.crypto.create_initial_state(self.role, scid));
+        self.crypto.create_initial_state(self.role, scid)?;
         Ok(())
     }
 
@@ -817,8 +815,7 @@ impl Connection {
                         if !self.is_valid_initial(&hdr) {
                             return Ok(());
                         }
-                        self.crypto.states[0] =
-                            Some(self.crypto.create_initial_state(self.role, &hdr.dcid));
+                        self.crypto.create_initial_state(self.role, &hdr.dcid)?;
                     }
                 }
                 State::Handshaking | State::Connected => {
@@ -849,7 +846,7 @@ impl Connection {
                 // on the assert for doesn't exist.
                 // OK, we have a valid packet.
                 self.idle_timeout.on_packet_received(now);
-                dump_packet(self, "<- RX", &hdr, &body);
+                dump_packet(self, "-> RX", &hdr, &body);
                 if self.process_packet(&hdr, body, now)? {
                     continue;
                 }
@@ -866,15 +863,12 @@ impl Connection {
         // the rest of the datagram on the floor, but don't generate an error.
         let largest_acknowledged = self
             .loss_recovery
-            .largest_acknowledged(PNSpace::from(hdr.epoch));
+            .largest_acknowledged_pn(PNSpace::from(hdr.epoch));
         match self.crypto.obtain_crypto_state(self.role, hdr.epoch) {
-            Ok(cs) => match cs.rx.as_ref() {
-                Some(rx) => {
-                    let pn_decoder = PacketNumberDecoder::new(largest_acknowledged);
-                    decrypt_packet(rx, pn_decoder, &mut hdr, slc).ok()
-                }
-                _ => None,
-            },
+            Ok(CryptoState { rx: Some(rx), .. }) => {
+                let pn_decoder = PacketNumberDecoder::new(largest_acknowledged);
+                decrypt_packet(rx, pn_decoder, &mut hdr, slc).ok()
+            }
             _ => None,
         }
     }
@@ -973,41 +967,40 @@ impl Connection {
 
     fn output(&mut self, now: Instant) -> Option<Datagram> {
         let mut out = None;
-        // Can't call a method on self while iterating over self.paths
-        let paths = mem::replace(&mut self.path, Default::default());
-        for p in &paths {
-            match self.output_path(&p, now) {
-                Ok(Some(dgram)) => {
-                    out = Some(dgram);
-                    break;
+        if self.path.is_some() {
+            match self.output_pkt_for_path(now) {
+                Ok(res) => {
+                    out = res;
                 }
                 Err(e) => {
                     if !matches!(self.state, State::Closing{..}) {
                         // An error here causes us to transition to closing.
                         self.absorb_error(now, Err(e));
                         // Rerun to give a chance to send a CONNECTION_CLOSE.
-                        out = match self.output_path(&p, now) {
+                        out = match self.output_pkt_for_path(now) {
                             Ok(x) => x,
                             Err(e) => {
                                 qwarn!([self], "two output_path errors in a row: {:?}", e);
                                 None
                             }
                         };
-                        break;
                     }
                 }
-                _ => (),
             };
         }
-        self.path = paths;
         out
     }
 
+    #[allow(clippy::cognitive_complexity)]
     /// Build a datagram, possibly from multiple packets (for different PN
     /// spaces) and each containing 1+ frames.
-    fn output_path(&mut self, path: &Path, now: Instant) -> Res<Option<Datagram>> {
+    fn output_pkt_for_path(&mut self, now: Instant) -> Res<Option<Datagram>> {
         let mut out_bytes = Vec::new();
         let mut needs_padding = false;
+        let path = self
+            .path
+            .take()
+            .expect("we know we have a path because calling fn checked");
 
         // Frames for different epochs must go in different packets, but then these
         // packets can go in a single datagram
@@ -1016,13 +1009,9 @@ impl Connection {
             let mut encoder = Encoder::default();
             let mut tokens = Vec::new();
 
-            // Try to make our own crypo state and if we can't, skip this epoch.
+            // Ensure we have tx crypto state for this epoch, or skip it.
             match self.crypto.obtain_crypto_state(self.role, epoch) {
-                Ok(cs) => {
-                    if cs.tx.is_none() {
-                        continue;
-                    }
-                }
+                Ok(CryptoState { tx: Some(_), .. }) => {}
                 _ => continue,
             }
 
@@ -1030,7 +1019,7 @@ impl Connection {
             match &self.state {
                 State::Init | State::WaitInitial | State::Handshaking | State::Connected => {
                     loop {
-                        let remaining = self.pmtu() - out_bytes.len() - encoder.len();
+                        let remaining = path.mtu() - out_bytes.len() - encoder.len();
 
                         // Check sources in turn for available frames
                         if let Some((frame, token)) = self
@@ -1048,7 +1037,7 @@ impl Connection {
                             if let Some(t) = token {
                                 tokens.push(t);
                             }
-                            if out_bytes.len() + encoder.len() == self.pmtu() {
+                            if out_bytes.len() + encoder.len() == path.mtu() {
                                 // No more space for frames.
                                 break;
                             }
@@ -1134,12 +1123,13 @@ impl Connection {
             let mut packet = encode_packet(tx, &hdr, &encoder);
             dump_packet(self, "TX ->", &hdr, &encoder);
             out_bytes.append(&mut packet);
-            if out_bytes.len() >= self.pmtu() {
+            if out_bytes.len() >= path.mtu() {
                 break;
             }
         }
 
         if out_bytes.is_empty() {
+            self.path = Some(path);
             return Ok(None);
         }
 
@@ -1148,7 +1138,9 @@ impl Connection {
             qdebug!([self], "pad Initial to 1200");
             out_bytes.resize(1200, 0);
         }
-        Ok(Some(Datagram::new(path.local, path.remote, out_bytes)))
+        let dgram = Some(Datagram::new(path.local, path.remote, out_bytes));
+        self.path = Some(path);
+        Ok(dgram)
     }
 
     fn client_start(&mut self, now: Instant) -> Res<()> {
@@ -1456,7 +1448,7 @@ impl Connection {
                     RecoveryToken::Stream(st) => self.send_streams.lost(&st),
                     RecoveryToken::Crypto(ct) => self.crypto.lost(ct),
                     RecoveryToken::Flow(ft) => self.flow_mgr.borrow_mut().lost(
-                        ft,
+                        &ft,
                         &mut self.send_streams,
                         &mut self.recv_streams,
                         &mut self.indexes,
@@ -1525,7 +1517,7 @@ impl Connection {
                     RecoveryToken::Stream(st) => self.send_streams.lost(&st),
                     RecoveryToken::Crypto(ct) => self.crypto.lost(ct),
                     RecoveryToken::Flow(ft) => self.flow_mgr.borrow_mut().lost(
-                        ft,
+                        &ft,
                         &mut self.send_streams,
                         &mut self.recv_streams,
                         &mut self.indexes,
@@ -1921,7 +1913,7 @@ impl Connection {
                             RecoveryToken::Stream(st) => self.send_streams.lost(&st),
                             RecoveryToken::Crypto(ct) => self.crypto.lost(ct),
                             RecoveryToken::Flow(ft) => self.flow_mgr.borrow_mut().lost(
-                                ft,
+                                &ft,
                                 &mut self.send_streams,
                                 &mut self.recv_streams,
                                 &mut self.indexes,
@@ -1964,6 +1956,7 @@ impl ::std::fmt::Display for Connection {
 mod tests {
     use super::*;
     use crate::frame::StreamType;
+    use std::mem;
     use test_fixture::{self, assertions, fixture_init, loopback, now};
 
     // This is fabulous: because test_fixture uses the public API for Connection,

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -355,7 +355,7 @@ impl Connection {
                 remote_cid: dcid.clone(),
             }),
         );
-        c.crypto.create_initial_state(Role::Client, &dcid)?;
+        c.crypto.create_initial_state(Role::Client, &dcid);
         Ok(c)
     }
 
@@ -751,7 +751,7 @@ impl Connection {
 
         // Switching crypto state here might not happen eventually.
         // https://github.com/quicwg/base-drafts/issues/2823
-        self.crypto.create_initial_state(self.role, scid)?;
+        self.crypto.create_initial_state(self.role, scid);
         Ok(())
     }
 
@@ -815,7 +815,7 @@ impl Connection {
                         if !self.is_valid_initial(&hdr) {
                             return Ok(());
                         }
-                        self.crypto.create_initial_state(self.role, &hdr.dcid)?;
+                        self.crypto.create_initial_state(self.role, &hdr.dcid);
                     }
                 }
                 State::Handshaking | State::Connected => {
@@ -1010,9 +1010,11 @@ impl Connection {
             let mut tokens = Vec::new();
 
             // Ensure we have tx crypto state for this epoch, or skip it.
-            match self.crypto.obtain_crypto_state(self.role, epoch) {
-                Ok(CryptoState { tx: Some(_), .. }) => {}
-                _ => continue,
+            if !matches!(
+                self.crypto.obtain_crypto_state(self.role, epoch),
+                Ok(CryptoState { tx: Some(_), .. })
+            ) {
+                continue;
             }
 
             let mut ack_eliciting = false;

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -62,7 +62,7 @@ impl Crypto {
     }
 
     // Create the initial crypto state.
-    pub fn create_initial_state(&mut self, role: Role, dcid: &[u8]) -> CryptoState {
+    pub fn create_initial_state(&mut self, role: Role, dcid: &[u8]) -> Res<()> {
         const CLIENT_INITIAL_LABEL: &str = "client in";
         const SERVER_INITIAL_LABEL: &str = "server in";
 
@@ -78,11 +78,12 @@ impl Crypto {
             Role::Server => (SERVER_INITIAL_LABEL, CLIENT_INITIAL_LABEL),
         };
 
-        CryptoState {
+        self.states[0] = Some(CryptoState {
             epoch: 0,
             tx: CryptoDxState::new_initial(CryptoDxDirection::Write, write_label, dcid),
             rx: CryptoDxState::new_initial(CryptoDxDirection::Read, read_label, dcid),
-        }
+        });
+        Ok(())
     }
 
     // Get a crypto state, making it if necessary, otherwise return an error.

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -62,7 +62,7 @@ impl Crypto {
     }
 
     // Create the initial crypto state.
-    pub fn create_initial_state(&mut self, role: Role, dcid: &[u8]) -> Res<()> {
+    pub fn create_initial_state(&mut self, role: Role, dcid: &[u8]) {
         const CLIENT_INITIAL_LABEL: &str = "client in";
         const SERVER_INITIAL_LABEL: &str = "server in";
 
@@ -83,7 +83,6 @@ impl Crypto {
             tx: CryptoDxState::new_initial(CryptoDxDirection::Write, write_label, dcid),
             rx: CryptoDxState::new_initial(CryptoDxDirection::Read, read_label, dcid),
         });
-        Ok(())
     }
 
     // Get a crypto state, making it if necessary, otherwise return an error.

--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -51,10 +51,16 @@ impl FlowMgr {
         assert!(self.used_data <= self.max_data)
     }
 
+    // Dummy DataBlocked frame for discriminant use below
+    const DB_FRAME: Frame = Frame::DataBlocked { data_limit: 0 };
+
     /// Returns whether max credit was actually increased.
     pub fn conn_increase_max_credit(&mut self, new: u64) -> bool {
         if new > self.max_data {
             self.max_data = new;
+
+            self.from_conn.remove(&mem::discriminant(&Self::DB_FRAME));
+
             true
         } else {
             false
@@ -72,6 +78,11 @@ impl FlowMgr {
 
     pub fn path_response(&mut self, data: [u8; 8]) {
         let frame = Frame::PathResponse { data };
+        self.from_conn.insert(mem::discriminant(&frame), frame);
+    }
+
+    pub fn max_data(&mut self, maximum_data: u64) {
+        let frame = Frame::MaxData { maximum_data };
         self.from_conn.insert(mem::discriminant(&frame), frame);
     }
 
@@ -205,12 +216,12 @@ impl FlowMgr {
 
     pub(crate) fn lost(
         &mut self,
-        token: FlowControlRecoveryToken,
+        token: &FlowControlRecoveryToken,
         send_streams: &mut SendStreams,
         recv_streams: &mut RecvStreams,
         indexes: &mut StreamIndexes,
     ) {
-        match token {
+        match *token {
             // Always resend ResetStream if lost
             Frame::ResetStream {
                 stream_id,

--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -52,14 +52,14 @@ impl FlowMgr {
     }
 
     // Dummy DataBlocked frame for discriminant use below
-    const DB_FRAME: Frame = Frame::DataBlocked { data_limit: 0 };
 
     /// Returns whether max credit was actually increased.
     pub fn conn_increase_max_credit(&mut self, new: u64) -> bool {
         if new > self.max_data {
             self.max_data = new;
 
-            self.from_conn.remove(&mem::discriminant(&Self::DB_FRAME));
+            const DB_FRAME: Frame = Frame::DataBlocked { data_limit: 0 };
+            self.from_conn.remove(&mem::discriminant(&DB_FRAME));
 
             true
         } else {

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -588,7 +588,6 @@ pub fn decode_frame(dec: &mut Decoder) -> Res<Frame> {
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum TxMode {
     Normal,
-    #[allow(dead_code)]
     Pto,
 }
 

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -16,7 +16,7 @@ use std::rc::Rc;
 use slice_deque::SliceDeque;
 use smallvec::SmallVec;
 
-use neqo_common::{matches, qerror, qinfo, qtrace, qwarn, Encoder};
+use neqo_common::{matches, qdebug, qerror, qinfo, qtrace, qwarn, Encoder};
 
 use crate::events::ConnectionEvents;
 use crate::flow_mgr::FlowMgr;
@@ -299,20 +299,31 @@ impl TxBuffer {
         can_buffer
     }
 
-    pub fn next_bytes(&self, _mode: TxMode) -> Option<(u64, &[u8])> {
-        let (start, maybe_len) = self.ranges.first_unmarked_range();
+    pub fn next_bytes(&self, mode: TxMode) -> Option<(u64, &[u8])> {
+        match mode {
+            TxMode::Normal => {
+                let (start, maybe_len) = self.ranges.first_unmarked_range();
 
-        if start == self.retired + u64::try_from(self.buffered()).unwrap() {
-            return None;
-        }
+                if start == self.retired + u64::try_from(self.buffered()).unwrap() {
+                    return None;
+                }
 
-        let buff_off = usize::try_from(start - self.retired).unwrap();
-        match maybe_len {
-            Some(len) => Some((
-                start,
-                &self.send_buf[buff_off..buff_off + usize::try_from(len).unwrap()],
-            )),
-            None => Some((start, &self.send_buf[buff_off..])),
+                let buff_off = usize::try_from(start - self.retired).unwrap();
+                match maybe_len {
+                    Some(len) => Some((
+                        start,
+                        &self.send_buf[buff_off..buff_off + usize::try_from(len).unwrap()],
+                    )),
+                    None => Some((start, &self.send_buf[buff_off..])),
+                }
+            }
+            TxMode::Pto => {
+                if self.buffered() == 0 {
+                    None
+                } else {
+                    Some((self.retired, &self.send_buf))
+                }
+            }
         }
     }
 
@@ -758,7 +769,7 @@ impl SendStreams {
         for (stream_id, stream) in self {
             let fin = stream.final_size();
             if let Some((offset, data)) = stream.next_bytes(mode) {
-                qtrace!(
+                qdebug!(
                     "Stream {} sending bytes {}-{}, epoch {}, mode {:?}, remaining {}",
                     stream_id.as_u64(),
                     offset,
@@ -879,6 +890,15 @@ mod tests {
 
         let res = rt.first_unmarked_range();
         assert_eq!(res, (0, Some(5)));
+        assert_eq!(
+            rt.used.iter().nth(0).unwrap(),
+            (&5, &(5, RangeState::Acked))
+        );
+        assert_eq!(
+            rt.used.iter().nth(1).unwrap(),
+            (&13, &(2, RangeState::Sent))
+        );
+        assert!(rt.used.iter().nth(2).is_none());
         rt.mark_range(0, 5, RangeState::Sent);
 
         let res = rt.first_unmarked_range();


### PR DESCRIPTION
### A new PR with the mostly-ok stuff from 280

*Should cut down #280's size as it's worked-on and clear out the "easy" stuff first.*

Probe Timeout:
* SendStream: Add support for TxMode::Pto

Output:
* Rename Connection::output_path() to output_pkt_for_path() for clarity.
* Do not replace path in Connection::output() with None before calling
  output_pkt_for_path(). We can't do this or Path::pmtu() will be wrong.
  Instead, handle it inside the called function. This will work until we
  support more than one path.

Crypto:
* Change Crypto::create_initial_state() to set state internally rather than
  returning the state to the caller to set.

Sent packet tracking (tracking.rs):
* Ask for an ack immediately if received packed is out of order.
* Add test

FlowMgr:
* Remove pending DataBlocked frame if max credit is increased.
* Support max_data frame for testing purposes.

Misc:
* LossRecovery::get_timer() doesn't need to take state as param.
* Rename LossRecovery::largest_acknowledged() to largest_acknowledged_pn()
  for clarity.
* SendStream: Improve testing of overlapping ranges a little.
* Add Path::mtu() and remove Connection::pmtu()