### PR TITLE
transport: Remove derive_more dependency.

### DIFF
--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT/Apache-2.0"
 [dependencies]
 neqo-crypto = { path = "../neqo-crypto" }
 neqo-common = { path = "../neqo-common" }
-derive_more = "0.13"
 lazy_static = "1.0"
 rand = "0.6"
 slice-deque = "0.3"

--- a/neqo-transport/src/packet.rs
+++ b/neqo-transport/src/packet.rs
@@ -9,7 +9,6 @@
 // A lot of methods and types contain the word Packet
 #![allow(clippy::module_name_repetitions)]
 
-use derive_more::Deref;
 use rand::Rng;
 
 use neqo_common::{hex, matches, qtrace, Decoder, Encoder};
@@ -63,8 +62,16 @@ impl PacketType {
 pub type Version = u32;
 pub type PacketNumber = u64;
 
-#[derive(Clone, Default, Deref, Eq, Hash, PartialEq)]
+#[derive(Clone, Default, Eq, Hash, PartialEq)]
 pub struct ConnectionId(pub Vec<u8>);
+
+impl std::ops::Deref for ConnectionId {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl ConnectionId {
     pub fn generate(len: usize) -> Self {


### PR DESCRIPTION
I need to update this dependency to get rid of old syn and quote in
mozilla-central.

But it seems like in this case it's easier to get rid of it, it saves like five
lines of code, and brings in a ton of dependencies.

Let me know if you want to keep it and update the dependency instead, but I
think it's not worth it in this case.