### PR TITLE
Implement PTO probe and also honor PMTU

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1027,6 +1027,7 @@ impl Connection {
     }
 
     #[allow(clippy::cognitive_complexity)]
+    #[allow(clippy::useless_let_if_seq)]
     /// Build a datagram, possibly from multiple packets (for different PN
     /// spaces) and each containing 1+ frames.
     fn output_pkt_for_path(&mut self, now: Instant) -> Res<Option<Datagram>> {
@@ -1361,7 +1362,7 @@ impl Connection {
                 ..
             } => {
                 // TODO(agrover@mozilla.com): use final_size for connection MaxData calc
-                if let (_, Some(rs)) = self.obtain_stream(stream_id.into())? {
+                if let (_, Some(rs)) = self.obtain_stream(stream_id)? {
                     rs.reset(application_error_code);
                 }
             }
@@ -1370,8 +1371,8 @@ impl Connection {
                 application_error_code,
             } => {
                 self.events
-                    .send_stream_stop_sending(stream_id.into(), application_error_code);
-                if let (Some(ss), _) = self.obtain_stream(stream_id.into())? {
+                    .send_stream_stop_sending(stream_id, application_error_code);
+                if let (Some(ss), _) = self.obtain_stream(stream_id)? {
                     ss.reset(application_error_code);
                 }
             }
@@ -1399,7 +1400,7 @@ impl Connection {
                 data,
                 ..
             } => {
-                if let (_, Some(rs)) = self.obtain_stream(stream_id.into())? {
+                if let (_, Some(rs)) = self.obtain_stream(stream_id)? {
                     rs.inbound_stream_frame(fin, offset, data)?;
                 }
             }
@@ -1408,7 +1409,7 @@ impl Connection {
                 stream_id,
                 maximum_stream_data,
             } => {
-                if let (Some(ss), _) = self.obtain_stream(stream_id.into())? {
+                if let (Some(ss), _) = self.obtain_stream(stream_id)? {
                     ss.set_max_stream_data(maximum_stream_data);
                 }
             }

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1092,7 +1092,8 @@ impl Connection {
                         let used =
                             out_bytes.len() + encoder.len() + hdr.overhead(&tx.aead, path.mtu());
                         let remaining = path.mtu() - used;
-                        if remaining == 0 {
+                        if remaining < 2 {
+                            // All useful frames are at least 2 bytes.
                             break;
                         }
 

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1401,8 +1401,6 @@ impl Connection {
                 // TODO(agrover@mozilla.com): how should we be using
                 // currently-unused stream_data_limit?
 
-                let stream_id: StreamId = stream_id.into();
-
                 // Terminate connection with STREAM_STATE_ERROR if send-only
                 // stream (-transport 19.13)
                 if stream_id.is_send_only(self.role()) {

--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -96,7 +96,7 @@ impl FlowMgr {
         final_size: u64,
     ) {
         let frame = Frame::ResetStream {
-            stream_id: stream_id.as_u64(),
+            stream_id,
             application_error_code,
             final_size,
         };
@@ -107,7 +107,7 @@ impl FlowMgr {
     /// Indicate to sending remote we are no longer interested in the stream
     pub fn stop_sending(&mut self, stream_id: StreamId, application_error_code: AppError) {
         let frame = Frame::StopSending {
-            stream_id: stream_id.as_u64(),
+            stream_id,
             application_error_code,
         };
         self.from_streams
@@ -117,7 +117,7 @@ impl FlowMgr {
     /// Update sending remote with more credits
     pub fn max_stream_data(&mut self, stream_id: StreamId, maximum_stream_data: u64) {
         let frame = Frame::MaxStreamData {
-            stream_id: stream_id.as_u64(),
+            stream_id,
             maximum_stream_data,
         };
         self.from_streams
@@ -127,7 +127,7 @@ impl FlowMgr {
     /// Indicate to receiving remote we need more credits
     pub fn stream_data_blocked(&mut self, stream_id: StreamId, stream_data_limit: u64) {
         let frame = Frame::StreamDataBlocked {
-            stream_id: stream_id.as_u64(),
+            stream_id,
             stream_data_limit,
         };
         self.from_streams
@@ -187,7 +187,7 @@ impl FlowMgr {
         {
             qinfo!(
                 "Reset received stream={} err={} final_size={}",
-                stream_id,
+                stream_id.as_u64(),
                 application_error_code,
                 final_size
             );
@@ -206,7 +206,7 @@ impl FlowMgr {
             {
                 qinfo!(
                     "Queued ResetStream for {} removed because previous ResetStream was acked",
-                    stream_id
+                    stream_id.as_u64()
                 );
             }
 
@@ -230,7 +230,7 @@ impl FlowMgr {
             } => {
                 qinfo!(
                     "Reset lost stream={} err={} final_size={}",
-                    stream_id,
+                    stream_id.as_u64(),
                     application_error_code,
                     final_size
                 );

--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -195,7 +195,7 @@ impl FlowMgr {
             if self
                 .from_streams
                 .remove(&(
-                    stream_id.into(),
+                    stream_id,
                     mem::discriminant(&Frame::ResetStream {
                         stream_id,
                         application_error_code,
@@ -210,7 +210,7 @@ impl FlowMgr {
                 );
             }
 
-            send_streams.reset_acked(stream_id.into());
+            send_streams.reset_acked(stream_id);
         }
     }
 
@@ -234,8 +234,8 @@ impl FlowMgr {
                     application_error_code,
                     final_size
                 );
-                if send_streams.get(stream_id.into()).is_ok() {
-                    self.stream_reset(stream_id.into(), application_error_code, final_size);
+                if send_streams.get(stream_id).is_ok() {
+                    self.stream_reset(stream_id, application_error_code, final_size);
                 }
             }
             // Resend MaxStreams if lost (with updated value)
@@ -254,9 +254,9 @@ impl FlowMgr {
                 }
             }
             Frame::StreamDataBlocked { stream_id, .. } => {
-                if let Ok(ss) = send_streams.get(stream_id.into()) {
+                if let Ok(ss) = send_streams.get(stream_id) {
                     if ss.credit_avail() == 0 {
-                        self.stream_data_blocked(stream_id.into(), ss.max_stream_data())
+                        self.stream_data_blocked(stream_id, ss.max_stream_data())
                     }
                 }
             }
@@ -276,11 +276,11 @@ impl FlowMgr {
             Frame::StopSending {
                 stream_id,
                 application_error_code,
-            } => self.stop_sending(stream_id.into(), application_error_code),
+            } => self.stop_sending(stream_id, application_error_code),
             // Resend MaxStreamData if not SizeKnown
             // (maybe_send_flowc_update() checks this.)
             Frame::MaxStreamData { stream_id, .. } => {
-                if let Some(rs) = recv_streams.get_mut(&stream_id.into()) {
+                if let Some(rs) = recv_streams.get_mut(&stream_id) {
                     rs.maybe_send_flowc_update()
                 }
             }

--- a/neqo-transport/src/packet.rs
+++ b/neqo-transport/src/packet.rs
@@ -12,6 +12,7 @@
 use rand::Rng;
 
 use neqo_common::{hex, matches, qtrace, Decoder, Encoder};
+use neqo_crypto::aead::Aead;
 use neqo_crypto::Epoch;
 
 use std::convert::TryFrom;
@@ -155,6 +156,44 @@ impl PacketHdr {
 
     pub fn body_len(&self) -> usize {
         self.body_len
+    }
+
+    // header length plus auth tag
+    pub fn overhead(&self, aead: &Aead, pmtu: usize) -> usize {
+        match &self.tipe {
+            PacketType::Short => {
+                let mut enc = Encoder::default();
+                // Leading byte.
+                let pnl = pn_length(self.pn);
+                enc.encode_byte(PACKET_BIT_SHORT | PACKET_BIT_FIXED_QUIC | encode_pnl(pnl));
+                enc.encode(&self.dcid.0);
+                enc.encode_uint(pnl, self.pn);
+                enc.len() + aead.expansion()
+            }
+            PacketType::VN(_) => encode_packet_vn(&self).len(),
+            PacketType::Retry { .. } => encode_retry(&self).len(),
+            PacketType::Initial(..) | PacketType::ZeroRTT | PacketType::Handshake => {
+                let mut enc = Encoder::default();
+
+                let pnl = pn_length(self.pn);
+                enc.encode_byte(
+                    PACKET_BIT_LONG
+                        | PACKET_BIT_FIXED_QUIC
+                        | self.tipe.code() << 4
+                        | encode_pnl(pnl),
+                );
+                enc.encode_uint(4, self.version.unwrap());
+                enc.encode_vec(1, &*self.dcid);
+                enc.encode_vec(1, &*self.scid.as_ref().unwrap());
+
+                if let PacketType::Initial(token) = &self.tipe {
+                    enc.encode_vvec(&token);
+                }
+                enc.encode_varint((pnl + pmtu + aead.expansion()) as u64);
+                enc.encode_uint(pnl, self.pn);
+                enc.len() + aead.expansion()
+            }
+        }
     }
 }
 

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -234,9 +234,11 @@ impl LossRecovery {
     }
 
     pub fn next_pn(&mut self, pn_space: PNSpace) -> u64 {
-        let val = self.spaces[pn_space].tx_pn;
+        self.spaces[pn_space].tx_pn
+    }
+
+    pub fn inc_pn(&mut self, pn_space: PNSpace) {
         self.spaces[pn_space].tx_pn += 1;
-        val
     }
 
     pub fn increment_pto_count(&mut self) {

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -201,7 +201,7 @@ impl RecvdPackets {
 
     /// Add the packet to the tracked set.
     pub fn set_received(&mut self, now: Instant, pn: u64, ack_eliciting: bool) {
-        let next_in_order_pn = self.ranges.get(0).map(|pr| pr.largest + 1).unwrap_or(0);
+        let next_in_order_pn = self.ranges.front().map_or(0, |pr| pr.largest + 1);
         qdebug!("next in order pn: {}", next_in_order_pn);
         let i = self.add(pn);
 


### PR DESCRIPTION
First two commits are trivial.

Last commit is broken out from #280 (pretty much everything but congestion control):

Output:
* Handle TxMode::Normal and also TxMode::Pto in packet output.
* Move construction of PacketHdr before frame sources are polled. This
  is needed so the frame sources can have accurate bytes-remaining
  values passed to them.
* packet.rs: For ^^, add overhead(), to learn how many bytes the header
  will take when encoded.
* Change LossRecovery::next_pn() to return but not increment PN, since we
  now construct headers that may not be used in a sent packet. Add inc_pn()
  to call once we know a PN will be used.
* Add PTO tests.

Crypto refactorings (needed for output changes):
* Refactor crypto to enable a stream and a state to be independently
  borrowed.

fixes #289