### PR TITLE
Add test_process_input() that returns frames processed

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -636,7 +636,7 @@ impl Connection {
     #[cfg(test)]
     pub fn test_process_input(&mut self, dgram: Datagram, now: Instant) -> Vec<(Frame, Epoch)> {
         let res = self.input(dgram, now);
-        let frames = self.absorb_error(now, res).unwrap_or(Vec::new());
+        let frames = self.absorb_error(now, res).unwrap_or_default();
         self.cleanup_streams();
         frames
     }

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -602,10 +602,10 @@ impl Connection {
         res
     }
 
-    /// For use with process().  Errors there can be ignored, but this needs to
-    /// ensure that the state is updated.
-    fn absorb_error<T>(&mut self, now: Instant, res: Res<T>) {
-        let _ = self.capture_error(now, 0, res);
+    /// For use with process_input(). Errors there can be ignored, but this
+    /// needs to ensure that the state is updated.
+    fn absorb_error<T>(&mut self, now: Instant, res: Res<T>) -> Option<T> {
+        self.capture_error(now, 0, res).ok()
     }
 
     pub fn process_timer(&mut self, now: Instant) {
@@ -635,7 +635,8 @@ impl Connection {
     /// Just like above but returns frames parsed from the datagram
     #[cfg(test)]
     pub fn test_process_input(&mut self, dgram: Datagram, now: Instant) -> Vec<(Frame, Epoch)> {
-        let frames = self.input(dgram, now).unwrap();
+        let res = self.input(dgram, now);
+        let frames = self.absorb_error(now, res).unwrap_or(Vec::new());
         self.cleanup_streams();
         frames
     }


### PR DESCRIPTION
One issue I've seen with tests is verifying certain things are in a packet
when we can't actually see what was IN the packet. test_process_input()
is the same as process_input() but returns a Vec of the frames just
processed, so unit tests can assert they are as expected. This could be
used by #323 as well as #311 and maybe also #303, and more in the future.

Details:

Change return values of internal functions input() and process_packet()
to return the vec. input_packet() is refactored into process_packet().

If cfg(test), we clone decoded frames and return them, as well as
passing them into input_frame(). In the non-test case, we do not
clone frames and push to the vec, so the vec remains empty, so not much
added overhead in the non-test case.

This also moves duplicate packet check above packet processing.

fixes #322

Move start_handshake check for correct state out from with in it and into
input().