### PR TITLE
Remove usage of slice-deque crate

### DIFF
--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -10,7 +10,6 @@ neqo-crypto = { path = "../neqo-crypto" }
 neqo-common = { path = "../neqo-common" }
 lazy_static = "1.0"
 rand = "0.6"
-slice-deque = "0.3"
 log = "0.4.0"
 smallvec = "1.0.0"
 


### PR DESCRIPTION
It doesn't work on FreeBSD.

The cool feature of SliceDeque was it could represent the collection as a slice, using vmm magic. Not having this capability means that data that wraps across the end of the buffer will need to be presented twice in `next_bytes` (since non-contiguous) rather than as a single range that could be put into a stream frame.

fixes #60