### PR TITLE
Http3conn rework

### DIFF
--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::connection::{Http3Events, Http3State};
+use crate::connection::Http3State;
 use neqo_common::matches;
 use neqo_transport::{AppError, StreamType};
 
@@ -105,19 +105,17 @@ impl Http3ClientEvents {
     {
         self.events.borrow_mut().retain(|evt| !f(evt))
     }
-}
 
-impl Http3Events for Http3ClientEvents {
-    fn reset(&self, stream_id: u64, error: AppError) {
+    pub fn reset(&self, stream_id: u64, error: AppError) {
         self.remove_events_for_stream_id(stream_id);
         self.insert(Http3ClientEvent::Reset { stream_id, error });
     }
 
-    fn connection_state_change(&self, state: Http3State) {
+    pub fn connection_state_change(&self, state: Http3State) {
         self.insert(Http3ClientEvent::StateChange(state));
     }
 
-    fn remove_events_for_stream_id(&self, stream_id: u64) {
+    pub fn remove_events_for_stream_id(&self, stream_id: u64) {
         self.remove(|evt| {
             matches!(evt,
                 Http3ClientEvent::HeaderReady { stream_id: x }

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -4,22 +4,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::client_events::Http3ClientEvents;
 use crate::control_stream_local::{ControlStreamLocal, HTTP3_UNI_STREAM_TYPE_CONTROL};
 use crate::control_stream_remote::ControlStreamRemote;
 use crate::hframe::{HFrame, HSettingType};
-use crate::server_connection_events::Http3ServerConnEvents;
 use crate::stream_type_reader::NewStreamTypeReader;
-use crate::transaction_client::TransactionClient;
-use crate::transaction_server::TransactionServer;
 use neqo_common::{matches, qdebug, qerror, qinfo, qtrace, qwarn};
 use neqo_qpack::decoder::{QPackDecoder, QPACK_UNI_STREAM_TYPE_DECODER};
 use neqo_qpack::encoder::{QPackEncoder, QPACK_UNI_STREAM_TYPE_ENCODER};
-use neqo_transport::{AppError, CloseError, Connection, ConnectionEvent, State, StreamType};
+use neqo_transport::{AppError, CloseError, Connection, State, StreamType};
 use std::collections::{BTreeSet, HashMap};
 use std::fmt::Debug;
 use std::mem;
-use std::time::Instant;
 
 use crate::{Error, Res};
 
@@ -27,56 +22,14 @@ const HTTP3_UNI_STREAM_TYPE_PUSH: u64 = 0x1;
 
 const MAX_HEADER_LIST_SIZE_DEFAULT: u64 = u64::max_value();
 
-pub trait Http3Events: Default + Debug {
-    fn reset(&self, stream_id: u64, error: AppError);
-    fn connection_state_change(&self, state: Http3State);
-    fn remove_events_for_stream_id(&self, remove_stream_id: u64);
-}
-
 pub trait Http3Transaction: Debug {
     fn send(&mut self, conn: &mut Connection, encoder: &mut QPackEncoder) -> Res<()>;
     fn receive(&mut self, conn: &mut Connection, decoder: &mut QPackDecoder) -> Res<()>;
     fn has_data_to_send(&self) -> bool;
-    fn is_state_sending_data(&self) -> bool;
     fn reset_receiving_side(&mut self);
     fn stop_sending(&mut self);
     fn done(&self) -> bool;
     fn close_send(&mut self, conn: &mut Connection) -> Res<()>;
-}
-
-pub trait Http3Handler<E: Http3Events, T: Http3Transaction> {
-    fn new() -> Self;
-    fn handle_stream_creatable(&mut self, events: &mut E, stream_type: StreamType) -> Res<()>;
-    fn handle_new_push_stream(&mut self) -> Res<()>;
-    fn handle_new_bidi_stream(
-        &mut self,
-        transactions: &mut HashMap<u64, T>,
-        events: &mut E,
-        stream_id: u64,
-    ) -> Res<()>;
-    fn handle_send_stream_writable(
-        &mut self,
-        transactions: &mut HashMap<u64, T>,
-        events: &mut E,
-        stream_id: u64,
-    ) -> Res<()>;
-    fn handle_stream_stop_sending(
-        &mut self,
-        transactions: &mut HashMap<u64, T>,
-        events: &mut E,
-        conn: &mut Connection,
-        stop_stream_id: u64,
-        app_err: AppError,
-    ) -> Res<()>;
-    fn handle_goaway(
-        &mut self,
-        transactions: &mut HashMap<u64, T>,
-        events: &mut E,
-        state: &mut Http3State,
-        goaway_stream_id: u64,
-    ) -> Res<()>;
-    fn handle_max_push_id(&mut self, stream_id: u64) -> Res<()>;
-    fn handle_authentication_needed(&self, events: &mut E) -> Res<()>;
 }
 
 #[derive(Debug, PartialEq, PartialOrd, Ord, Eq, Clone)]
@@ -89,7 +42,7 @@ pub enum Http3State {
 }
 
 #[derive(Debug)]
-pub struct Http3Connection<E: Http3Events, T: Http3Transaction, H: Http3Handler<E, T>> {
+pub struct Http3Connection<T: Http3Transaction> {
     pub state: Http3State,
     max_header_list_size: u64,
     control_stream_local: ControlStreamLocal,
@@ -99,22 +52,16 @@ pub struct Http3Connection<E: Http3Events, T: Http3Transaction, H: Http3Handler<
     pub qpack_decoder: QPackDecoder,
     settings_received: bool,
     streams_have_data_to_send: BTreeSet<u64>,
-    pub events: E,
     pub transactions: HashMap<u64, T>,
-    handler: H,
 }
 
-impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>> ::std::fmt::Display
-    for Http3Connection<E, T, H>
-{
+impl<T: Http3Transaction> ::std::fmt::Display for Http3Connection<T> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "Http3 connection")
     }
 }
 
-impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
-    Http3Connection<E, T, H>
-{
+impl<T: Http3Transaction> Http3Connection<T> {
     pub fn new(max_table_size: u32, max_blocked_streams: u16) -> Self {
         if max_table_size > (1 << 30) - 1 {
             panic!("Wrong max_table_size");
@@ -129,9 +76,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
             qpack_decoder: QPackDecoder::new(max_table_size, max_blocked_streams),
             settings_received: false,
             streams_have_data_to_send: BTreeSet::new(),
-            events: E::default(),
             transactions: HashMap::new(),
-            handler: H::new(),
         }
     }
 
@@ -169,42 +114,6 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
         Ok(())
     }
 
-    // This function takes the provided result and check for an error.
-    // An error results in closing the connection.
-    fn check_result<ERR>(&mut self, conn: &mut Connection, now: Instant, res: Res<ERR>) -> bool {
-        match &res {
-            Err(e) => {
-                qinfo!([self], "Connection error: {}.", e);
-                self.close(conn, now, e.code(), &format!("{}", e));
-                self.events
-                    .connection_state_change(Http3State::Closing(CloseError::Application(
-                        e.code(),
-                    )));
-                true
-            }
-            _ => false,
-        }
-    }
-
-    pub fn process_http3(&mut self, conn: &mut Connection, now: Instant) {
-        qtrace!([self], "Process http3 internal.");
-        match self.state {
-            Http3State::Connected | Http3State::GoingAway => {
-                let res = self.check_connection_events(conn);
-                if self.check_result(conn, now, res) {
-                    return;
-                }
-                let res = self.process_sending(conn);
-                self.check_result(conn, now, res);
-            }
-            Http3State::Closed { .. } => {}
-            _ => {
-                let res = self.check_connection_events(conn);
-                let _ = self.check_result(conn, now, res);
-            }
-        }
-    }
-
     pub fn insert_streams_have_data_to_send(&mut self, stream_id: u64) {
         self.streams_have_data_to_send.insert(stream_id);
     }
@@ -213,7 +122,7 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
         !self.streams_have_data_to_send.is_empty()
     }
 
-    fn process_sending(&mut self, conn: &mut Connection) -> Res<()> {
+    pub fn process_sending(&mut self, conn: &mut Connection) -> Res<()> {
         // check if control stream has data to send.
         self.control_stream_local.send(conn)?;
 
@@ -231,111 +140,40 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
         Ok(())
     }
 
-    // If this return an error the connection must be closed.
-    fn check_connection_events(&mut self, conn: &mut Connection) -> Res<()> {
-        qtrace!([self], "Check connection events.");
-        while let Some(e) = conn.next_event() {
-            qdebug!([self], "check_connection_events - event {:?}.", e);
-            match e {
-                ConnectionEvent::NewStream {
-                    stream_id,
-                    stream_type,
-                } => self.handle_new_stream(conn, stream_id, stream_type)?,
-                ConnectionEvent::SendStreamWritable { stream_id } => {
-                    self.handler.handle_send_stream_writable(
-                        &mut self.transactions,
-                        &mut self.events,
-                        stream_id,
-                    )?
-                }
-                ConnectionEvent::RecvStreamReadable { stream_id } => {
-                    self.handle_stream_readable(conn, stream_id)?
-                }
-                ConnectionEvent::RecvStreamReset {
-                    stream_id,
-                    app_error,
-                } => self.handle_stream_reset(conn, stream_id, app_error)?,
-                ConnectionEvent::SendStreamStopSending {
-                    stream_id,
-                    app_error,
-                } => self.handler.handle_stream_stop_sending(
-                    &mut self.transactions,
-                    &mut self.events,
-                    conn,
-                    stream_id,
-                    app_error,
-                )?,
-                ConnectionEvent::SendStreamComplete { stream_id } => {
-                    self.handle_stream_complete(stream_id)?
-                }
-                ConnectionEvent::SendStreamCreatable { stream_type } => self
-                    .handler
-                    .handle_stream_creatable(&mut self.events, stream_type)?,
-                ConnectionEvent::AuthenticationNeeded => self
-                    .handler
-                    .handle_authentication_needed(&mut self.events)?,
-                ConnectionEvent::StateChange(state) => {
-                    match state {
-                        State::Connected => self.handle_connection_connected(conn)?,
-                        State::Closing { error, .. } => {
-                            self.handle_connection_closing(error.clone().into())?
-                        }
-                        State::Closed(error) => {
-                            self.handle_connection_closed(error.clone().into())?
-                        }
-                        _ => {}
-                    };
-                }
-                ConnectionEvent::ZeroRttRejected => {
-                    // TODO(mt) work out what to do here.
-                    // Everything will have to be redone: SETTINGS, qpack streams, and requests.
-                }
-            }
+    pub fn handle_new_unidi_stream(&mut self, conn: &mut Connection, stream_id: u64) -> Res<bool> {
+        qtrace!([self], "A new stream: {}.", stream_id);
+        assert!(self.state_active());
+        let stream_type;
+        let fin;
+        {
+            let ns = &mut self
+                .new_streams
+                .entry(stream_id)
+                .or_insert_with(NewStreamTypeReader::new);
+            stream_type = ns.get_type(conn, stream_id);
+            fin = ns.fin();
         }
-        Ok(())
+
+        if fin {
+            self.new_streams.remove(&stream_id);
+            Ok(false)
+        } else if let Some(t) = stream_type {
+            self.new_streams.remove(&stream_id);
+            self.decode_new_stream(conn, t, stream_id)
+        } else {
+            Ok(false)
+        }
     }
 
-    fn handle_new_stream(
+    // There are 2 events that must be return to a client/server handler to properly consumes them:
+    //   1) reading a new stream founds that is a push stream
+    //   2) a control stream has received frames MaxPushId or Goaway which handling is specific to
+    //      the client and server.
+    pub fn handle_stream_readable(
         &mut self,
         conn: &mut Connection,
         stream_id: u64,
-        stream_type: StreamType,
-    ) -> Res<()> {
-        qinfo!([self], "A new stream: {:?} {}.", stream_type, stream_id);
-        assert!(self.state_active());
-        match stream_type {
-            StreamType::BiDi => self.handler.handle_new_bidi_stream(
-                &mut self.transactions,
-                &mut self.events,
-                stream_id,
-            ),
-            StreamType::UniDi => {
-                let stream_type;
-                let fin;
-                {
-                    let ns = &mut self
-                        .new_streams
-                        .entry(stream_id)
-                        .or_insert_with(NewStreamTypeReader::new);
-                    stream_type = ns.get_type(conn, stream_id);
-                    fin = ns.fin();
-                }
-
-                if fin {
-                    self.new_streams.remove(&stream_id);
-                    Ok(())
-                } else if let Some(t) = stream_type {
-                    self.decode_new_stream(conn, t, stream_id)?;
-                    self.new_streams.remove(&stream_id);
-                    Ok(())
-                } else {
-                    Ok(())
-                }
-            }
-        }
-    }
-
-    fn handle_stream_readable(&mut self, conn: &mut Connection, stream_id: u64) -> Res<()> {
+    ) -> Res<(bool, Vec<HFrame>)> {
         qtrace!([self], "Readable stream {}.", stream_id);
 
         assert!(self.state_active());
@@ -345,8 +183,10 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
         } else {
             String::new()
         };
-        let mut unblocked_streams: Vec<u64> = Vec::new();
 
+        let mut push = false;
+        let mut unblocked_streams = Vec::new();
+        let mut control_frames = Vec::new();
         if self.handle_read_stream(conn, stream_id)? {
             qdebug!([label], "Request/response stream {} read.", stream_id);
         } else if self
@@ -361,7 +201,9 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
             while self.control_stream_remote.frame_reader_done()
                 || self.control_stream_remote.recvd_fin()
             {
-                self.handle_control_frame()?;
+                if let Some(f) = self.handle_control_frame()? {
+                    control_frames.push(f);
+                }
                 self.control_stream_remote
                     .receive_if_this_stream(conn, stream_id)?;
             }
@@ -385,8 +227,8 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
                 self.new_streams.remove(&stream_id);
             }
             if let Some(t) = stream_type {
-                self.decode_new_stream(conn, t, stream_id)?;
                 self.new_streams.remove(&stream_id);
+                push = self.decode_new_stream(conn, t, stream_id)?;
             }
         } else {
             // For a new stream we receive NewStream event and a
@@ -397,20 +239,19 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
             // entry for the stream in self.new_streams.
             qdebug!("Unknown stream.");
         }
-
         for stream_id in unblocked_streams {
             qinfo!([self], "Stream {} is unblocked", stream_id);
             self.handle_read_stream(conn, stream_id)?;
         }
-        Ok(())
+        Ok((push, control_frames))
     }
 
-    fn handle_stream_reset(
+    pub fn handle_stream_reset(
         &mut self,
         conn: &mut Connection,
         stream_id: u64,
         app_err: AppError,
-    ) -> Res<()> {
+    ) -> Res<bool> {
         qinfo!(
             [self],
             "Handle a stream reset stream_id={} app_err={}",
@@ -421,8 +262,6 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
         assert!(self.state_active());
 
         if let Some(t) = self.transactions.get_mut(&stream_id) {
-            // Post the reset event.
-            self.events.reset(stream_id, app_err);
             // Close both sides of the transaction_client.
             t.reset_receiving_side();
             t.stop_sending();
@@ -431,34 +270,38 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
             let _ = conn.stream_reset_send(stream_id, app_err);
             // remove the stream
             self.transactions.remove(&stream_id);
+            Ok(true)
+        } else {
+            Ok(false)
         }
-        Ok(())
     }
 
-    fn handle_stream_complete(&mut self, _stream_id: u64) -> Res<()> {
-        Ok(())
-    }
-
-    fn handle_connection_connected(&mut self, conn: &mut Connection) -> Res<()> {
-        assert_eq!(self.state, Http3State::Initializing);
-        self.events.connection_state_change(Http3State::Connected);
-        self.state = Http3State::Connected;
-        self.initialize_http3_connection(conn)
-    }
-
-    fn handle_connection_closing(&mut self, error_code: CloseError) -> Res<()> {
-        assert!(self.state_active() || self.state_closing());
-        self.events
-            .connection_state_change(Http3State::Closing(error_code));
-        self.state = Http3State::Closing(error_code);
-        Ok(())
-    }
-
-    fn handle_connection_closed(&mut self, error_code: CloseError) -> Res<()> {
-        self.events
-            .connection_state_change(Http3State::Closed(error_code));
-        self.state = Http3State::Closed(error_code);
-        Ok(())
+    pub fn handle_state_change(&mut self, conn: &mut Connection, state: &State) -> Res<bool> {
+        match state {
+            State::Connected => {
+                assert_eq!(self.state, Http3State::Initializing);
+                self.state = Http3State::Connected;
+                self.initialize_http3_connection(conn)?;
+                Ok(true)
+            }
+            State::Closing { error, .. } => {
+                if !matches!(self.state, Http3State::Closing(_)| Http3State::Closed(_)) {
+                    self.state = Http3State::Closing(error.clone().into());
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            State::Closed(error) => {
+                if !matches!(self.state, Http3State::Closed(_)) {
+                    self.state = Http3State::Closing(error.clone().into());
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            _ => Ok(false),
+        }
     }
 
     fn handle_read_stream(&mut self, conn: &mut Connection, stream_id: u64) -> Res<bool> {
@@ -493,52 +336,53 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
         }
     }
 
+    // Returns true if it is a push stream.
     fn decode_new_stream(
         &mut self,
         conn: &mut Connection,
         stream_type: u64,
         stream_id: u64,
-    ) -> Res<()> {
+    ) -> Res<bool> {
         match stream_type {
             HTTP3_UNI_STREAM_TYPE_CONTROL => {
                 self.control_stream_remote.add_remote_stream(stream_id)?;
-                Ok(())
+                Ok(false)
             }
 
             HTTP3_UNI_STREAM_TYPE_PUSH => {
                 qinfo!([self], "A new push stream {}.", stream_id);
-                self.handler.handle_new_push_stream()
+                Ok(true)
             }
             QPACK_UNI_STREAM_TYPE_ENCODER => {
                 qinfo!([self], "A new remote qpack encoder stream {}", stream_id);
                 self.qpack_decoder
                     .add_recv_stream(stream_id)
-                    .map_err(|_| Error::HttpStreamCreationError)
+                    .map_err(|_| Error::HttpStreamCreationError)?;
+                Ok(false)
             }
             QPACK_UNI_STREAM_TYPE_DECODER => {
                 qinfo!([self], "A new remote qpack decoder stream {}", stream_id);
                 self.qpack_encoder
                     .add_recv_stream(stream_id)
-                    .map_err(|_| Error::HttpStreamCreationError)
+                    .map_err(|_| Error::HttpStreamCreationError)?;
+                Ok(false)
             }
             // TODO reserved stream types
             _ => {
                 conn.stream_stop_sending(stream_id, Error::HttpStreamCreationError.code())?;
-                Ok(())
+                Ok(false)
             }
         }
     }
 
-    pub fn close(&mut self, conn: &mut Connection, now: Instant, error: AppError, msg: &str) {
-        qinfo!([self], "Close connection error {:?} msg={}.", error, msg);
-        if !matches!(self.state, Http3State::Closing(_) | Http3State::Closed(_)) {
-            self.state = Http3State::Closing(CloseError::Application(error));
-            if !self.transactions.is_empty() && (error == 0) {
-                qwarn!("close() called when streams still active");
-            }
-            self.transactions.clear();
-            conn.close(now, error, msg);
+    pub fn close(&mut self, error: AppError) {
+        qinfo!([self], "Close connection error {:?}.", error);
+        assert!(self.state_active());
+        self.state = Http3State::Closing(CloseError::Application(error));
+        if !self.transactions.is_empty() && (error == 0) {
+            qwarn!("close() called when streams still active");
         }
+        self.transactions.clear();
     }
 
     pub fn stream_reset(
@@ -559,7 +403,6 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
         transaction.reset_receiving_side();
         // Stream maybe already be closed and we may get an error here, but we do not care.
         conn.stream_stop_sending(stream_id, error)?;
-        self.events.remove_events_for_stream_id(stream_id);
         Ok(())
     }
 
@@ -577,7 +420,9 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
         Ok(())
     }
 
-    fn handle_control_frame(&mut self) -> Res<()> {
+    // If the control stream has received frames MaxPushId or Goaway which handling is specific to
+    // the client and server, we must give them to the specific client/server handler..
+    fn handle_control_frame(&mut self) -> Res<Option<HFrame>> {
         if self.control_stream_remote.recvd_fin() {
             return Err(Error::HttpClosedCriticalStream);
         }
@@ -597,20 +442,14 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
             return match f {
                 HFrame::Settings { settings } => {
                     self.handle_settings(&settings)?;
-                    Ok(())
+                    Ok(None)
                 }
                 HFrame::CancelPush { .. } => Err(Error::HttpFrameUnexpected),
-                HFrame::Goaway { stream_id } => self.handler.handle_goaway(
-                    &mut self.transactions,
-                    &mut self.events,
-                    &mut self.state,
-                    stream_id,
-                ),
-                HFrame::MaxPushId { push_id } => self.handler.handle_max_push_id(push_id),
+                HFrame::Goaway { .. } | HFrame::MaxPushId { .. } => Ok(Some(f)),
                 _ => Err(Error::HttpFrameUnexpected),
             };
         }
-        Ok(())
+        Ok(None)
     }
 
     fn handle_settings(&mut self, s: &[(HSettingType, u64)]) -> Res<()> {
@@ -634,10 +473,6 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
         matches!(self.state, Http3State::Connected | Http3State::GoingAway)
     }
 
-    fn state_closing(&self) -> bool {
-        matches!(self.state, Http3State::Closing(_))
-    }
-
     pub fn state(&self) -> Http3State {
         self.state.clone()
     }
@@ -647,216 +482,5 @@ impl<E: Http3Events + Default, T: Http3Transaction, H: Http3Handler<E, T>>
             self.streams_have_data_to_send.insert(stream_id);
         }
         self.transactions.insert(stream_id, transaction);
-    }
-}
-
-#[derive(Default)]
-pub struct Http3ClientHandler {}
-
-impl Http3Handler<Http3ClientEvents, TransactionClient> for Http3ClientHandler {
-    fn new() -> Self {
-        Http3ClientHandler::default()
-    }
-
-    fn handle_stream_creatable(
-        &mut self,
-        events: &mut Http3ClientEvents,
-        stream_type: StreamType,
-    ) -> Res<()> {
-        events.new_requests_creatable(stream_type);
-        Ok(())
-    }
-
-    fn handle_new_push_stream(&mut self) -> Res<()> {
-        // TODO implement PUSH
-        qerror!([self], "PUSH is not implemented!");
-        Err(Error::HttpIdError)
-    }
-
-    fn handle_new_bidi_stream(
-        &mut self,
-        _transactions: &mut HashMap<u64, TransactionClient>,
-        _events: &mut Http3ClientEvents,
-        _stream_id: u64,
-    ) -> Res<()> {
-        qerror!("Client received a new bidirectional stream!");
-        Err(Error::HttpStreamCreationError)
-    }
-
-    fn handle_send_stream_writable(
-        &mut self,
-        transactions: &mut HashMap<u64, TransactionClient>,
-        events: &mut Http3ClientEvents,
-        stream_id: u64,
-    ) -> Res<()> {
-        qtrace!([self], "Writable stream {}.", stream_id);
-
-        if let Some(t) = transactions.get_mut(&stream_id) {
-            if t.is_state_sending_data() {
-                events.data_writable(stream_id);
-            }
-        }
-        Ok(())
-    }
-
-    fn handle_stream_stop_sending(
-        &mut self,
-        transactions: &mut HashMap<u64, TransactionClient>,
-        events: &mut Http3ClientEvents,
-        conn: &mut Connection,
-        stop_stream_id: u64,
-        app_err: AppError,
-    ) -> Res<()> {
-        qinfo!(
-            [self],
-            "Handle stream_stop_sending stream_id={} app_err={}",
-            stop_stream_id,
-            app_err
-        );
-
-        if let Some(t) = transactions.get_mut(&stop_stream_id) {
-            // close sending side.
-            t.stop_sending();
-
-            // If error is Error::EarlyResponse we will post StopSending event,
-            // otherwise post reset.
-            if app_err == Error::HttpEarlyResponse.code() && !t.is_sending_closed() {
-                events.stop_sending(stop_stream_id, app_err);
-            }
-            // if error is not Error::EarlyResponse we will close receiving part as well.
-            if app_err != Error::HttpEarlyResponse.code() {
-                events.reset(stop_stream_id, app_err);
-                // The server may close its sending side as well, but just to be sure
-                // we will do it ourselves.
-                let _ = conn.stream_stop_sending(stop_stream_id, app_err);
-                t.reset_receiving_side();
-            }
-            if t.done() {
-                transactions.remove(&stop_stream_id);
-            }
-        }
-        Ok(())
-    }
-
-    fn handle_goaway(
-        &mut self,
-        transactions: &mut HashMap<u64, TransactionClient>,
-        events: &mut Http3ClientEvents,
-        state: &mut Http3State,
-        goaway_stream_id: u64,
-    ) -> Res<()> {
-        qinfo!([self], "handle_goaway");
-        // Issue reset events for streams >= goaway stream id
-        for id in transactions
-            .iter()
-            .filter(|(id, _)| **id >= goaway_stream_id)
-            .map(|(id, _)| *id)
-        {
-            events.reset(id, Error::HttpRequestRejected.code())
-        }
-        events.goaway_received();
-
-        // Actually remove (i.e. don't retain) these streams
-        transactions.retain(|id, _| *id < goaway_stream_id);
-
-        if *state == Http3State::Connected {
-            *state = Http3State::GoingAway;
-        }
-        Ok(())
-    }
-
-    fn handle_max_push_id(&mut self, stream_id: u64) -> Res<()> {
-        qerror!([self], "handle_max_push_id={}.", stream_id);
-        Err(Error::HttpFrameUnexpected)
-    }
-
-    fn handle_authentication_needed(&self, events: &mut Http3ClientEvents) -> Res<()> {
-        events.authentication_needed();
-        Ok(())
-    }
-}
-
-impl ::std::fmt::Display for Http3ClientHandler {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Http3 connection client")
-    }
-}
-
-#[derive(Default, Debug)]
-pub struct Http3ServerHandler {}
-
-impl Http3Handler<Http3ServerConnEvents, TransactionServer> for Http3ServerHandler {
-    fn new() -> Self {
-        Http3ServerHandler::default()
-    }
-
-    fn handle_stream_creatable(
-        &mut self,
-        _events: &mut Http3ServerConnEvents,
-        _stream_type: StreamType,
-    ) -> Res<()> {
-        Ok(())
-    }
-
-    fn handle_new_push_stream(&mut self) -> Res<()> {
-        qerror!([self], "Error: server receives a push stream!");
-        Err(Error::HttpStreamCreationError)
-    }
-
-    fn handle_new_bidi_stream(
-        &mut self,
-        transactions: &mut HashMap<u64, TransactionServer>,
-        events: &mut Http3ServerConnEvents,
-        stream_id: u64,
-    ) -> Res<()> {
-        transactions.insert(stream_id, TransactionServer::new(stream_id, events.clone()));
-        Ok(())
-    }
-
-    fn handle_send_stream_writable(
-        &mut self,
-        _transactions: &mut HashMap<u64, TransactionServer>,
-        _events: &mut Http3ServerConnEvents,
-        _stream_id: u64,
-    ) -> Res<()> {
-        Ok(())
-    }
-
-    fn handle_goaway(
-        &mut self,
-        _transactions: &mut HashMap<u64, TransactionServer>,
-        _events: &mut Http3ServerConnEvents,
-        _state: &mut Http3State,
-        _goaway_stream_id: u64,
-    ) -> Res<()> {
-        qerror!([self], "handle_goaway");
-        Err(Error::HttpFrameUnexpected)
-    }
-
-    fn handle_stream_stop_sending(
-        &mut self,
-        _transactions: &mut HashMap<u64, TransactionServer>,
-        _events: &mut Http3ServerConnEvents,
-        _conn: &mut Connection,
-        _stop_stream_id: u64,
-        _app_err: AppError,
-    ) -> Res<()> {
-        Ok(())
-    }
-
-    fn handle_max_push_id(&mut self, stream_id: u64) -> Res<()> {
-        qinfo!([self], "handle_max_push_id={}.", stream_id);
-        // TODO
-        Ok(())
-    }
-
-    fn handle_authentication_needed(&self, _events: &mut Http3ServerConnEvents) -> Res<()> {
-        Err(Error::HttpInternalError)
-    }
-}
-
-impl ::std::fmt::Display for Http3ServerHandler {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Http3 connection server")
     }
 }

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -8,8 +8,8 @@ use crate::connection::{Http3Connection, Http3State, Http3Transaction};
 use crate::hframe::HFrame;
 use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents};
 use crate::transaction_server::TransactionServer;
-use neqo_common::{qdebug, qinfo, qtrace};
 use crate::{Error, Header, Res};
+use neqo_common::{qdebug, qinfo, qtrace};
 use neqo_transport::{AppError, Connection, ConnectionEvent, StreamType};
 use std::time::Instant;
 

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -1,0 +1,187 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::connection::{Http3Connection, Http3State, Http3Transaction};
+use crate::hframe::HFrame;
+use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents};
+use crate::transaction_server::TransactionServer;
+use neqo_common::{qdebug, qinfo, qtrace};
+use crate::{Error, Header, Res};
+use neqo_transport::{AppError, Connection, ConnectionEvent, StreamType};
+use std::time::Instant;
+
+#[derive(Debug)]
+pub struct Http3ServerHandler {
+    base_handler: Http3Connection<TransactionServer>,
+    events: Http3ServerConnEvents,
+}
+
+impl ::std::fmt::Display for Http3ServerHandler {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "Http3 server connection")
+    }
+}
+
+impl Http3ServerHandler {
+    pub fn new(max_table_size: u32, max_blocked_streams: u16) -> Self {
+        Http3ServerHandler {
+            base_handler: Http3Connection::new(max_table_size, max_blocked_streams),
+            events: Http3ServerConnEvents::default(),
+        }
+    }
+    pub fn set_response(&mut self, stream_id: u64, headers: &[Header], data: Vec<u8>) -> Res<()> {
+        self.base_handler
+            .transactions
+            .get_mut(&stream_id)
+            .ok_or(Error::InvalidStreamId)?
+            .set_response(headers, data, &mut self.base_handler.qpack_encoder);
+        self.base_handler
+            .insert_streams_have_data_to_send(stream_id);
+        Ok(())
+    }
+
+    pub fn stream_reset(
+        &mut self,
+        conn: &mut Connection,
+        stream_id: u64,
+        app_error: AppError,
+    ) -> Res<()> {
+        self.base_handler.stream_reset(conn, stream_id, app_error)?;
+        self.events.remove_events_for_stream_id(stream_id);
+        Ok(())
+    }
+
+    pub fn process_http3(&mut self, conn: &mut Connection, now: Instant) {
+        qtrace!([self], "Process http3 internal.");
+        match self.base_handler.state() {
+            Http3State::Connected | Http3State::GoingAway => {
+                let res = self.check_connection_events(conn);
+                if self.check_result(conn, now, res) {
+                    return;
+                }
+                let res = self.base_handler.process_sending(conn);
+                self.check_result(conn, now, res);
+            }
+            Http3State::Closed { .. } => {}
+            _ => {
+                let res = self.check_connection_events(conn);
+                let _ = self.check_result(conn, now, res);
+            }
+        }
+    }
+
+    pub fn next_event(&mut self) -> Option<Http3ServerConnEvent> {
+        self.events.next_event()
+    }
+
+    pub fn should_be_processed(&self) -> bool {
+        self.base_handler.has_data_to_send() | self.events.has_events()
+    }
+
+    // This function takes the provided result and check for an error.
+    // An error results in closing the connection.
+    fn check_result<ERR>(&mut self, conn: &mut Connection, now: Instant, res: Res<ERR>) -> bool {
+        match &res {
+            Err(e) => {
+                qinfo!([self], "Connection error: {}.", e);
+                conn.close(now, e.code(), &format!("{}", e));
+                self.base_handler.close(e.code());
+                self.events
+                    .connection_state_change(self.base_handler.state());
+                true
+            }
+            _ => false,
+        }
+    }
+
+    // If this return an error the connection must be closed.
+    fn check_connection_events(&mut self, conn: &mut Connection) -> Res<()> {
+        qtrace!([self], "Check connection events.");
+        while let Some(e) = conn.next_event() {
+            qdebug!([self], "check_connection_events - event {:?}.", e);
+            match e {
+                ConnectionEvent::NewStream {
+                    stream_id,
+                    stream_type,
+                } => match stream_type {
+                    StreamType::BiDi => self.base_handler.add_transaction(
+                        stream_id,
+                        TransactionServer::new(stream_id, self.events.clone()),
+                    ),
+                    StreamType::UniDi => {
+                        if self.base_handler.handle_new_unidi_stream(conn, stream_id)? {
+                            return Err(Error::HttpStreamCreationError);
+                        }
+                    }
+                },
+                ConnectionEvent::SendStreamWritable { .. } => {}
+                ConnectionEvent::RecvStreamReadable { stream_id } => {
+                    self.handle_stream_readable(conn, stream_id)?
+                }
+                ConnectionEvent::RecvStreamReset {
+                    stream_id,
+                    app_error,
+                } => {
+                    let _ = self
+                        .base_handler
+                        .handle_stream_reset(conn, stream_id, app_error)?;
+                }
+                ConnectionEvent::SendStreamStopSending {
+                    stream_id,
+                    app_error,
+                } => self.handle_stream_stop_sending(conn, stream_id, app_error),
+                ConnectionEvent::SendStreamComplete { .. } => {}
+                ConnectionEvent::SendStreamCreatable { .. } => {}
+                ConnectionEvent::AuthenticationNeeded => return Err(Error::HttpInternalError),
+                ConnectionEvent::StateChange(state) => {
+                    if self.base_handler.handle_state_change(conn, &state)? {
+                        self.events
+                            .connection_state_change(self.base_handler.state());
+                    }
+                }
+                ConnectionEvent::ZeroRttRejected => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_stream_readable(&mut self, conn: &mut Connection, stream_id: u64) -> Res<()> {
+        let (push, control_frames) = self.base_handler.handle_stream_readable(conn, stream_id)?;
+        if push {
+            return Err(Error::HttpStreamCreationError);
+        } else {
+            for f in control_frames.into_iter() {
+                match f {
+                    HFrame::MaxPushId { .. } => {
+                        // TODO implement push
+                        Ok(())
+                    }
+                    HFrame::Goaway { .. } => Err(Error::HttpFrameUnexpected),
+                    _ => {
+                        unreachable!("we should only put MaxPushId and Goaway into control_frames.")
+                    }
+                }?;
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_stream_stop_sending(
+        &mut self,
+        conn: &mut Connection,
+        stop_stream_id: u64,
+        app_err: AppError,
+    ) {
+        if let Some(t) = self.base_handler.transactions.get_mut(&stop_stream_id) {
+            // close sending side.
+            t.stop_sending();
+            // receiving side may be closed already, just ignore an error in the following line.
+            let _ = conn.stream_stop_sending(stop_stream_id, app_err);
+            t.reset_receiving_side();
+            self.base_handler.transactions.remove(&stop_stream_id);
+        }
+    }
+}

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -9,6 +9,7 @@
 mod client_events;
 mod connection;
 pub mod connection_client;
+mod connection_server;
 mod control_stream_local;
 mod control_stream_remote;
 pub mod hframe;

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -5,9 +5,10 @@
 // except according to those terms.
 
 use crate::connection::Http3State;
+use crate::connection_server::Http3ServerHandler;
 use crate::server_connection_events::Http3ServerConnEvent;
 use crate::server_events::{
-    ClientRequestStream, Http3Handler, Http3ServerEvent, Http3ServerEvents,
+    ClientRequestStream, Http3ServerEvent, Http3ServerEvents,
 };
 use crate::Res;
 use neqo_common::{qtrace, Datagram};
@@ -19,7 +20,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::time::Instant;
 
-type HandlerRef = Rc<RefCell<Http3Handler>>;
+type HandlerRef = Rc<RefCell<Http3ServerHandler>>;
 
 pub struct Http3Server {
     server: Server,
@@ -93,7 +94,7 @@ impl Http3Server {
         let max_blocked_streams = self.max_blocked_streams;
         for mut conn in active_conns {
             let handler = self.http3_handlers.entry(conn.clone()).or_insert_with(|| {
-                Rc::new(RefCell::new(Http3Handler::new(
+                Rc::new(RefCell::new(Http3ServerHandler::new(
                     max_table_size,
                     max_blocked_streams,
                 )))

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -7,9 +7,7 @@
 use crate::connection::Http3State;
 use crate::connection_server::Http3ServerHandler;
 use crate::server_connection_events::Http3ServerConnEvent;
-use crate::server_events::{
-    ClientRequestStream, Http3ServerEvent, Http3ServerEvents,
-};
+use crate::server_events::{ClientRequestStream, Http3ServerEvent, Http3ServerEvents};
 use crate::Res;
 use neqo_common::{qtrace, Datagram};
 use neqo_crypto::AntiReplay;

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::connection::{Http3Events, Http3State};
+use crate::connection::Http3State;
 use crate::Header;
 use neqo_common::matches;
 use neqo_transport::AppError;
@@ -77,18 +77,16 @@ impl Http3ServerConnEvents {
             fin,
         });
     }
-}
 
-impl Http3Events for Http3ServerConnEvents {
-    fn reset(&self, stream_id: u64, error: AppError) {
+    pub fn reset(&self, stream_id: u64, error: AppError) {
         self.insert(Http3ServerConnEvent::Reset { stream_id, error });
     }
 
-    fn connection_state_change(&self, state: Http3State) {
+    pub fn connection_state_change(&self, state: Http3State) {
         self.insert(Http3ServerConnEvent::StateChange(state));
     }
 
-    fn remove_events_for_stream_id(&self, stream_id: u64) {
+    pub fn remove_events_for_stream_id(&self, stream_id: u64) {
         self.remove(|evt| {
             matches!(evt,
                 Http3ServerConnEvent::Reset { stream_id: x, .. } if *x == stream_id)

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -4,199 +4,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::connection::{Http3Connection, Http3State, Http3Transaction};
-use crate::hframe::HFrame;
-use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents};
-use crate::transaction_server::TransactionServer;
-use crate::{Error, Header, Res};
-use neqo_common::{qdebug, qinfo, qtrace};
+use crate::connection::Http3State;
+use crate::connection_server::Http3ServerHandler;
+use crate::{Header, Res};
+use neqo_common::{qdebug, qinfo};
 use neqo_transport::server::ActiveConnectionRef;
-use neqo_transport::{AppError, Connection, ConnectionEvent, StreamType};
+use neqo_transport::{AppError, Connection};
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
-use std::time::Instant;
-
-pub type Http3ServerConnection = Http3Connection<TransactionServer>;
-
-#[derive(Debug)]
-pub struct Http3Handler {
-    base_handler: Http3ServerConnection,
-    events: Http3ServerConnEvents,
-}
-
-impl ::std::fmt::Display for Http3Handler {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Http3 server connection")
-    }
-}
-
-impl Http3Handler {
-    pub fn new(max_table_size: u32, max_blocked_streams: u16) -> Self {
-        Http3Handler {
-            base_handler: Http3Connection::new(max_table_size, max_blocked_streams),
-            events: Http3ServerConnEvents::default(),
-        }
-    }
-    pub fn set_response(&mut self, stream_id: u64, headers: &[Header], data: Vec<u8>) -> Res<()> {
-        self.base_handler
-            .transactions
-            .get_mut(&stream_id)
-            .ok_or(Error::InvalidStreamId)?
-            .set_response(headers, data, &mut self.base_handler.qpack_encoder);
-        self.base_handler
-            .insert_streams_have_data_to_send(stream_id);
-        Ok(())
-    }
-
-    pub fn stream_reset(
-        &mut self,
-        conn: &mut Connection,
-        stream_id: u64,
-        app_error: AppError,
-    ) -> Res<()> {
-        self.base_handler.stream_reset(conn, stream_id, app_error)?;
-        self.events.remove_events_for_stream_id(stream_id);
-        Ok(())
-    }
-
-    pub fn process_http3(&mut self, conn: &mut Connection, now: Instant) {
-        qtrace!([self], "Process http3 internal.");
-        match self.base_handler.state() {
-            Http3State::Connected | Http3State::GoingAway => {
-                let res = self.check_connection_events(conn);
-                if self.check_result(conn, now, res) {
-                    return;
-                }
-                let res = self.base_handler.process_sending(conn);
-                self.check_result(conn, now, res);
-            }
-            Http3State::Closed { .. } => {}
-            _ => {
-                let res = self.check_connection_events(conn);
-                let _ = self.check_result(conn, now, res);
-            }
-        }
-    }
-
-    pub fn next_event(&mut self) -> Option<Http3ServerConnEvent> {
-        self.events.next_event()
-    }
-
-    pub fn should_be_processed(&self) -> bool {
-        self.base_handler.has_data_to_send() | self.events.has_events()
-    }
-
-    // This function takes the provided result and check for an error.
-    // An error results in closing the connection.
-    fn check_result<ERR>(&mut self, conn: &mut Connection, now: Instant, res: Res<ERR>) -> bool {
-        match &res {
-            Err(e) => {
-                qinfo!([self], "Connection error: {}.", e);
-                conn.close(now, e.code(), &format!("{}", e));
-                self.base_handler.close(e.code());
-                self.events
-                    .connection_state_change(self.base_handler.state());
-                true
-            }
-            _ => false,
-        }
-    }
-
-    // If this return an error the connection must be closed.
-    fn check_connection_events(&mut self, conn: &mut Connection) -> Res<()> {
-        qtrace!([self], "Check connection events.");
-        while let Some(e) = conn.next_event() {
-            qdebug!([self], "check_connection_events - event {:?}.", e);
-            match e {
-                ConnectionEvent::NewStream {
-                    stream_id,
-                    stream_type,
-                } => match stream_type {
-                    StreamType::BiDi => self.base_handler.add_transaction(
-                        stream_id,
-                        TransactionServer::new(stream_id, self.events.clone()),
-                    ),
-                    StreamType::UniDi => {
-                        if self.base_handler.handle_new_unidi_stream(conn, stream_id)? {
-                            return Err(Error::HttpStreamCreationError);
-                        }
-                    }
-                },
-                ConnectionEvent::SendStreamWritable { .. } => {}
-                ConnectionEvent::RecvStreamReadable { stream_id } => {
-                    self.handle_stream_readable(conn, stream_id)?
-                }
-                ConnectionEvent::RecvStreamReset {
-                    stream_id,
-                    app_error,
-                } => {
-                    let _ = self
-                        .base_handler
-                        .handle_stream_reset(conn, stream_id, app_error)?;
-                }
-                ConnectionEvent::SendStreamStopSending {
-                    stream_id,
-                    app_error,
-                } => self.handle_stream_stop_sending(conn, stream_id, app_error),
-                ConnectionEvent::SendStreamComplete { .. } => {}
-                ConnectionEvent::SendStreamCreatable { .. } => {}
-                ConnectionEvent::AuthenticationNeeded => return Err(Error::HttpInternalError),
-                ConnectionEvent::StateChange(state) => {
-                    if self.base_handler.handle_state_change(conn, &state)? {
-                        self.events
-                            .connection_state_change(self.base_handler.state());
-                    }
-                }
-                ConnectionEvent::ZeroRttRejected => {}
-            }
-        }
-        Ok(())
-    }
-
-    fn handle_stream_readable(&mut self, conn: &mut Connection, stream_id: u64) -> Res<()> {
-        let (push, control_frames) = self.base_handler.handle_stream_readable(conn, stream_id)?;
-        if push {
-            return Err(Error::HttpStreamCreationError);
-        } else {
-            for f in control_frames.into_iter() {
-                match f {
-                    HFrame::MaxPushId { .. } => {
-                        // TODO implement push
-                        Ok(())
-                    }
-                    HFrame::Goaway { .. } => Err(Error::HttpFrameUnexpected),
-                    _ => {
-                        unreachable!("we should only put MaxPushId and Goaway into control_frames.")
-                    }
-                }?;
-            }
-        }
-        Ok(())
-    }
-
-    fn handle_stream_stop_sending(
-        &mut self,
-        conn: &mut Connection,
-        stop_stream_id: u64,
-        app_err: AppError,
-    ) {
-        if let Some(t) = self.base_handler.transactions.get_mut(&stop_stream_id) {
-            // close sending side.
-            t.stop_sending();
-            // receiving side may be closed already, just ignore an error in the following line.
-            let _ = conn.stream_stop_sending(stop_stream_id, app_err);
-            t.reset_receiving_side();
-            self.base_handler.transactions.remove(&stop_stream_id);
-        }
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct ClientRequestStream {
     conn: ActiveConnectionRef,
-    handler: Rc<RefCell<Http3Handler>>,
+    handler: Rc<RefCell<Http3ServerHandler>>,
     stream_id: u64,
 }
 
@@ -214,7 +36,7 @@ impl ::std::fmt::Display for ClientRequestStream {
 impl ClientRequestStream {
     pub fn new(
         conn: ActiveConnectionRef,
-        handler: Rc<RefCell<Http3Handler>>,
+        handler: Rc<RefCell<Http3ServerHandler>>,
         stream_id: u64,
     ) -> Self {
         ClientRequestStream {

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -4,40 +4,49 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::connection::{Http3Connection, Http3ServerHandler, Http3State};
+use crate::connection::{Http3Connection, Http3State, Http3Transaction};
+use crate::hframe::HFrame;
 use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents};
 use crate::transaction_server::TransactionServer;
 use crate::{Error, Header, Res};
-use neqo_common::{qdebug, qinfo};
+use neqo_common::{qdebug, qinfo, qtrace};
 use neqo_transport::server::ActiveConnectionRef;
-use neqo_transport::{AppError, Connection};
+use neqo_transport::{AppError, Connection, ConnectionEvent, StreamType};
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
 use std::time::Instant;
 
-pub type Http3ServerConnection =
-    Http3Connection<Http3ServerConnEvents, TransactionServer, Http3ServerHandler>;
+pub type Http3ServerConnection = Http3Connection<TransactionServer>;
 
 #[derive(Debug)]
 pub struct Http3Handler {
-    handler: Http3ServerConnection,
+    base_handler: Http3ServerConnection,
+    events: Http3ServerConnEvents,
+}
+
+impl ::std::fmt::Display for Http3Handler {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "Http3 server connection")
+    }
 }
 
 impl Http3Handler {
     pub fn new(max_table_size: u32, max_blocked_streams: u16) -> Self {
         Http3Handler {
-            handler: Http3Connection::new(max_table_size, max_blocked_streams),
+            base_handler: Http3Connection::new(max_table_size, max_blocked_streams),
+            events: Http3ServerConnEvents::default(),
         }
     }
     pub fn set_response(&mut self, stream_id: u64, headers: &[Header], data: Vec<u8>) -> Res<()> {
-        self.handler
+        self.base_handler
             .transactions
             .get_mut(&stream_id)
             .ok_or(Error::InvalidStreamId)?
-            .set_response(headers, data, &mut self.handler.qpack_encoder);
-        self.handler.insert_streams_have_data_to_send(stream_id);
+            .set_response(headers, data, &mut self.base_handler.qpack_encoder);
+        self.base_handler
+            .insert_streams_have_data_to_send(stream_id);
         Ok(())
     }
 
@@ -47,19 +56,140 @@ impl Http3Handler {
         stream_id: u64,
         app_error: AppError,
     ) -> Res<()> {
-        self.handler.stream_reset(conn, stream_id, app_error)
+        self.base_handler.stream_reset(conn, stream_id, app_error)?;
+        self.events.remove_events_for_stream_id(stream_id);
+        Ok(())
     }
 
     pub fn process_http3(&mut self, conn: &mut Connection, now: Instant) {
-        self.handler.process_http3(conn, now);
+        qtrace!([self], "Process http3 internal.");
+        match self.base_handler.state() {
+            Http3State::Connected | Http3State::GoingAway => {
+                let res = self.check_connection_events(conn);
+                if self.check_result(conn, now, res) {
+                    return;
+                }
+                let res = self.base_handler.process_sending(conn);
+                self.check_result(conn, now, res);
+            }
+            Http3State::Closed { .. } => {}
+            _ => {
+                let res = self.check_connection_events(conn);
+                let _ = self.check_result(conn, now, res);
+            }
+        }
     }
 
     pub fn next_event(&mut self) -> Option<Http3ServerConnEvent> {
-        self.handler.events.next_event()
+        self.events.next_event()
     }
 
     pub fn should_be_processed(&self) -> bool {
-        self.handler.has_data_to_send() | self.handler.events.has_events()
+        self.base_handler.has_data_to_send() | self.events.has_events()
+    }
+
+    // This function takes the provided result and check for an error.
+    // An error results in closing the connection.
+    fn check_result<ERR>(&mut self, conn: &mut Connection, now: Instant, res: Res<ERR>) -> bool {
+        match &res {
+            Err(e) => {
+                qinfo!([self], "Connection error: {}.", e);
+                conn.close(now, e.code(), &format!("{}", e));
+                self.base_handler.close(e.code());
+                self.events
+                    .connection_state_change(self.base_handler.state());
+                true
+            }
+            _ => false,
+        }
+    }
+
+    // If this return an error the connection must be closed.
+    fn check_connection_events(&mut self, conn: &mut Connection) -> Res<()> {
+        qtrace!([self], "Check connection events.");
+        while let Some(e) = conn.next_event() {
+            qdebug!([self], "check_connection_events - event {:?}.", e);
+            match e {
+                ConnectionEvent::NewStream {
+                    stream_id,
+                    stream_type,
+                } => match stream_type {
+                    StreamType::BiDi => self.base_handler.add_transaction(
+                        stream_id,
+                        TransactionServer::new(stream_id, self.events.clone()),
+                    ),
+                    StreamType::UniDi => {
+                        if self.base_handler.handle_new_unidi_stream(conn, stream_id)? {
+                            return Err(Error::HttpStreamCreationError);
+                        }
+                    }
+                },
+                ConnectionEvent::SendStreamWritable { .. } => {}
+                ConnectionEvent::RecvStreamReadable { stream_id } => {
+                    self.handle_stream_readable(conn, stream_id)?
+                }
+                ConnectionEvent::RecvStreamReset {
+                    stream_id,
+                    app_error,
+                } => {
+                    let _ = self
+                        .base_handler
+                        .handle_stream_reset(conn, stream_id, app_error)?;
+                }
+                ConnectionEvent::SendStreamStopSending {
+                    stream_id,
+                    app_error,
+                } => self.handle_stream_stop_sending(conn, stream_id, app_error),
+                ConnectionEvent::SendStreamComplete { .. } => {}
+                ConnectionEvent::SendStreamCreatable { .. } => {}
+                ConnectionEvent::AuthenticationNeeded => return Err(Error::HttpInternalError),
+                ConnectionEvent::StateChange(state) => {
+                    if self.base_handler.handle_state_change(conn, &state)? {
+                        self.events
+                            .connection_state_change(self.base_handler.state());
+                    }
+                }
+                ConnectionEvent::ZeroRttRejected => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_stream_readable(&mut self, conn: &mut Connection, stream_id: u64) -> Res<()> {
+        let (push, control_frames) = self.base_handler.handle_stream_readable(conn, stream_id)?;
+        if push {
+            return Err(Error::HttpStreamCreationError);
+        } else {
+            for f in control_frames.into_iter() {
+                match f {
+                    HFrame::MaxPushId { .. } => {
+                        // TODO implement push
+                        Ok(())
+                    }
+                    HFrame::Goaway { .. } => Err(Error::HttpFrameUnexpected),
+                    _ => {
+                        unreachable!("we should only put MaxPushId and Goaway into control_frames.")
+                    }
+                }?;
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_stream_stop_sending(
+        &mut self,
+        conn: &mut Connection,
+        stop_stream_id: u64,
+        app_err: AppError,
+    ) {
+        if let Some(t) = self.base_handler.transactions.get_mut(&stop_stream_id) {
+            // close sending side.
+            t.stop_sending();
+            // receiving side may be closed already, just ignore an error in the following line.
+            let _ = conn.stream_stop_sending(stop_stream_id, app_err);
+            t.reset_receiving_side();
+            self.base_handler.transactions.remove(&stop_stream_id);
+        }
     }
 }
 

--- a/neqo-http3/src/transaction_client.rs
+++ b/neqo-http3/src/transaction_client.rs
@@ -472,6 +472,10 @@ impl TransactionClient {
             _ => Ok((0, false)),
         }
     }
+
+    pub fn is_state_sending_data(&self) -> bool {
+        self.send_state == TransactionSendState::SendingData
+    }
 }
 
 impl ::std::fmt::Display for TransactionClient {
@@ -586,10 +590,6 @@ impl Http3Transaction for TransactionClient {
         } else {
             false
         }
-    }
-
-    fn is_state_sending_data(&self) -> bool {
-        self.send_state == TransactionSendState::SendingData
     }
 
     fn reset_receiving_side(&mut self) {

--- a/neqo-http3/src/transaction_server.rs
+++ b/neqo-http3/src/transaction_server.rs
@@ -333,11 +333,9 @@ impl Http3Transaction for TransactionServer {
         matches!(self.send_state, TransactionSendState::SendingResponse { .. })
     }
 
-    fn is_state_sending_data(&self) -> bool {
-        self.has_data_to_send()
+    fn reset_receiving_side(&mut self) {
+        self.recv_state = TransactionRecvState::Closed;
     }
-
-    fn reset_receiving_side(&mut self) {}
 
     fn stop_sending(&mut self) {}
 

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -453,7 +453,7 @@ fn test_h9(nctx: &NetworkCtx, client: &mut Connection) -> Result<(), String> {
 fn test_h3(nctx: &NetworkCtx, peer: &Peer, client: Connection) -> Result<(), String> {
     let mut hc = H3Handler {
         streams: HashSet::new(),
-        h3: Http3Client::new_with_conn(client, 128, 128).expect("must succeed"),
+        h3: Http3Client::new_with_conn(client, 128, 128),
         host: String::from(peer.host),
         path: String::from("/"),
     };


### PR DESCRIPTION
Http3Connection only handles common elements:
- holds control and qpack streams,
- holds a HashMap of active transactions,
- holds the Http3State of a http3 connection,
- performs sending data for control, qpack and transaction streams,
- handles decoding of new unidi streams(the client/server handlers differ in how they handle a  Push streams, therefore handle_new_unidi_stream returns if a stream was a push stream and the client/server handler consume them appropriately),
- handles streams reading (this function may return that a stream is a push stream or a list of control frames to be handle by the client/server handler)

The client/server handlers:
- holds a base_handler(Http3Connection)
- http3 events
- neqo_transport::Connection (this is only for the client)
- process_htttp3 has been moved from Http3Connection to the client/server handlers,
- also check_connection_events which iterates through ConnectionEvents and calls handlers for the events (handlers are implemented in Http3Connection or in the client/server handlers)

Move server_events::Http3Handler into a separate file.