### PR TITLE
Create events for when send streams become blocked

### DIFF
--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -18,6 +18,8 @@ pub enum Http3ClientEvent {
     HeaderReady { stream_id: u64 },
     /// A stream can accept new data.
     DataWritable { stream_id: u64 },
+    /// A stream has no more send credits available.
+    DataBlocked { stream_id: u64 },
     /// New bytes available for reading.
     DataReadable { stream_id: u64 },
     /// Peer reset the stream.
@@ -48,6 +50,10 @@ impl Http3ClientEvents {
 
     pub fn data_writable(&self, stream_id: u64) {
         self.insert(Http3ClientEvent::DataWritable { stream_id });
+    }
+
+    pub fn data_blocked(&self, stream_id: u64) {
+        self.insert(Http3ClientEvent::DataBlocked { stream_id });
     }
 
     pub fn data_readable(&self, stream_id: u64) {

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -320,6 +320,9 @@ impl Http3Client {
                     stream_id,
                     app_error,
                 } => self.handle_stream_stop_sending(stream_id, app_error)?,
+                ConnectionEvent::SendStreamBlocked { stream_id } => {
+                    self.events.data_blocked(stream_id)
+                }
                 ConnectionEvent::SendStreamComplete { .. } => {}
                 ConnectionEvent::SendStreamCreatable { stream_type } => {
                     self.events.new_requests_creatable(stream_type)

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -117,7 +117,9 @@ impl Http3ServerHandler {
                         }
                     }
                 },
-                ConnectionEvent::SendStreamWritable { .. } => {}
+                ConnectionEvent::SendStreamWritable { stream_id } => {
+                    self.events.data_writable(stream_id)
+                }
                 ConnectionEvent::RecvStreamReadable { stream_id } => {
                     self.handle_stream_readable(conn, stream_id)?
                 }
@@ -133,6 +135,9 @@ impl Http3ServerHandler {
                     stream_id,
                     app_error,
                 } => self.handle_stream_stop_sending(conn, stream_id, app_error),
+                ConnectionEvent::SendStreamBlocked { stream_id } => {
+                    self.events.data_blocked(stream_id)
+                }
                 ConnectionEvent::SendStreamComplete { .. } => {}
                 ConnectionEvent::SendStreamCreatable { .. } => {}
                 ConnectionEvent::AuthenticationNeeded => return Err(Error::HttpInternalError),

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -27,6 +27,10 @@ pub enum Http3ServerConnEvent {
         data: Vec<u8>,
         fin: bool,
     },
+    /// A stream can accept new data.
+    DataWritable { stream_id: u64 },
+    /// A stream has no more send credits available.
+    DataBlocked { stream_id: u64 },
     /// Peer reset the stream.
     Reset { stream_id: u64, error: AppError },
     /// Connection state change.
@@ -68,6 +72,14 @@ impl Http3ServerConnEvents {
             headers,
             fin,
         });
+    }
+
+    pub fn data_writable(&self, stream_id: u64) {
+        self.insert(Http3ServerConnEvent::DataWritable { stream_id });
+    }
+
+    pub fn data_blocked(&self, stream_id: u64) {
+        self.insert(Http3ServerConnEvent::DataBlocked { stream_id });
     }
 
     pub fn data(&self, stream_id: u64, data: Vec<u8>, fin: bool) {

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -34,6 +34,8 @@ pub enum ConnectionEvent {
     RecvStreamReset { stream_id: u64, app_error: AppError },
     /// Peer has sent STOP_SENDING
     SendStreamStopSending { stream_id: u64, app_error: AppError },
+    /// There is no more credit to send on this stream.
+    SendStreamBlocked { stream_id: u64 },
     /// Peer has acked everything sent on the stream.
     SendStreamComplete { stream_id: u64 },
     /// Peer increased MAX_STREAMS
@@ -82,6 +84,12 @@ impl ConnectionEvents {
 
     pub fn send_stream_writable(&self, stream_id: StreamId) {
         self.insert(ConnectionEvent::SendStreamWritable {
+            stream_id: stream_id.as_u64(),
+        });
+    }
+
+    pub fn send_stream_blocked(&self, stream_id: StreamId) {
+        self.insert(ConnectionEvent::SendStreamBlocked {
             stream_id: stream_id.as_u64(),
         });
     }


### PR DESCRIPTION
In light of use cases like #261, it seems like a good idea
to create/expose a DataBlocked event (a parallel of a DataWritable
event) when a send stream becomes blocked because of a lack
of credits.