### PR TITLE
Remove bad assert in TxBuffer::mark_as_acked()

### DIFF
--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -335,8 +335,6 @@ impl TxBuffer {
     }
 
     pub fn mark_as_acked(&mut self, offset: u64, len: usize) {
-        assert!(self.ranges.highest_offset() >= offset + len as u64);
-
         self.ranges.mark_range(offset, len, RangeState::Acked);
 
         // We can drop contig acked range from the buffer


### PR DESCRIPTION
It is not true that highest_offset >= offset+len, because we unmark ranges
that were sent but need to be retransmitted (b/c lost.) If this happens and
then an ack comes in for the range, that is ok.

fixes #352