### PR TITLE
Change Frame::new_stream to possibly fail

### DIFF
--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -262,12 +262,16 @@ impl Frame {
         data: &[u8],
         fin: bool,
         space: usize,
-    ) -> (Frame, usize) {
-        let mut remaining = space - 1 - Encoder::varint_len(stream_id);
+    ) -> Option<(Frame, usize)> {
+        let mut remaining = space.saturating_sub(1 + Encoder::varint_len(stream_id));
         if offset > 0 {
-            remaining -= Encoder::varint_len(offset);
+            remaining = remaining.saturating_sub(Encoder::varint_len(offset));
         }
         let (fin, fill) = if data.len() > remaining {
+            if remaining == 0 {
+                return None;
+            }
+
             // More data than fits, fill the packet and negate |fin|.
             (false, true)
         } else if data.len() == remaining {
@@ -287,7 +291,7 @@ impl Frame {
             fin,
             remaining
         );
-        (
+        Some((
             Frame::Stream {
                 stream_id: stream_id.into(),
                 offset,
@@ -296,7 +300,7 @@ impl Frame {
                 fill,
             },
             remaining,
-        )
+        ))
     }
 
     pub fn marshal(&self, enc: &mut Encoder) {

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -774,29 +774,31 @@ impl SendStreams {
         for (stream_id, stream) in self {
             let complete = stream.final_size().is_some();
             if let Some((offset, data)) = stream.next_bytes(mode) {
-                let (frame, length) =
-                    Frame::new_stream(stream_id.as_u64(), offset, data, complete, remaining);
-                qdebug!(
-                    "Stream {} sending bytes {}-{}, epoch {}, mode {:?}",
-                    stream_id.as_u64(),
-                    offset,
-                    offset + length as u64,
-                    epoch,
-                    mode,
-                );
-                let fin = complete && length == data.len();
-                debug_assert!(!fin || matches!(frame, Frame::Stream{fin: true, .. }));
-                stream.mark_as_sent(offset, length, fin);
-
-                return Some((
-                    frame,
-                    Some(RecoveryToken::Stream(StreamRecoveryToken {
-                        id: *stream_id,
+                if let Some((frame, length)) =
+                    Frame::new_stream(stream_id.as_u64(), offset, data, complete, remaining)
+                {
+                    qdebug!(
+                        "Stream {} sending bytes {}-{}, epoch {}, mode {:?}",
+                        stream_id.as_u64(),
                         offset,
-                        length,
-                        fin,
-                    })),
-                ));
+                        offset + length as u64,
+                        epoch,
+                        mode,
+                    );
+                    let fin = complete && length == data.len();
+                    debug_assert!(!fin || matches!(frame, Frame::Stream{fin: true, .. }));
+                    stream.mark_as_sent(offset, length, fin);
+
+                    return Some((
+                        frame,
+                        Some(RecoveryToken::Stream(StreamRecoveryToken {
+                            id: *stream_id,
+                            offset,
+                            length,
+                            fin,
+                        })),
+                    ));
+                }
             }
         }
         None


### PR DESCRIPTION
If space doesn't allow room for the Stream frame header as well as at least
one byte of data (if not fin-only), then return None.

Co-authored-by: Martin Thomson <mt@lowentropy.net>