### PR TITLE
Issue #372: Properly set decoder capacity in decoder::test_duplicate

### DIFF
--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -911,7 +911,7 @@ mod tests {
     fn test_duplicate() {
         let (mut decoder, mut conn_c, mut conn_s, recv_stream_id, send_stream_id) = connect();
 
-        assert!(decoder.set_capacity(60).is_ok());
+        assert!(decoder.set_capacity(100).is_ok());
 
         // send an instruction
         let _ = conn_s.stream_send(


### PR DESCRIPTION
The duplicated entry is 50 bytes. This means that the table's capacity
has to be 100 bytes.