### PR TITLE
No Issue: Pad datagrams with Initial packets only if necessary

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1279,8 +1279,8 @@ impl Connection {
             self.path = Some(path);
             Ok(None)
         } else {
-            // Pad Initial packets sent by the client to mtu bytes.
-            if self.role == Role::Client && needs_padding {
+            // Pad Initial packets sent by the client to mtu bytes, if necessary.
+            if self.role == Role::Client && needs_padding && out_bytes.len() < path.mtu() {
                 qdebug!([self], "pad Initial to max_datagram_size");
                 out_bytes.resize(path.mtu(), 0);
             }


### PR DESCRIPTION
Although the packet-coalescing loop attempts to keep datagrams
under _path mtu_ bytes, it is possible that datagrams end up
slightly longer. When a client connection is sending a datagram in
that case and that datagram contains an `Initial` packet,
`resize()`ing the packet would actually truncate meaningful
content.