### PR TITLE
Qlog

### DIFF
--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -12,7 +12,7 @@ neqo-crypto = { version = "0.1", path = "./../neqo-crypto" }
 neqo-transport = { version = "0.1", path = "./../neqo-transport" }
 neqo-common = { version="0.1", path="./../neqo-common" }
 neqo-http3 = { version = "0.1", path = "./../neqo-http3" }
-structopt = "0.2.15"
+structopt = "0.3.7"
 url = "1.7.2"
 
 [features]

--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -14,6 +14,10 @@ neqo-common = { version="0.1", path="./../neqo-common" }
 neqo-http3 = { version = "0.1", path = "./../neqo-http3" }
 structopt = "0.3.7"
 url = "1.7.2"
+qlog = "0.1.0"
+serde = "1"
+serde_json = "1"
+chrono = "0.4.10"
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -17,7 +17,6 @@ url = "1.7.2"
 qlog = "0.1.0"
 serde = "1"
 serde_json = "1"
-chrono = "0.4.10"
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -8,17 +8,13 @@
 #![allow(clippy::option_option)]
 #![warn(clippy::use_self)]
 
-use qlog::{CommonFields, Configuration, Qlog, TimeUnits, Trace, VantagePoint, VantagePointType};
+use qlog::Qlog;
 use serde_json;
 
-use chrono::offset::Utc;
-use chrono::DateTime;
-use std::time::SystemTime;
-
 use neqo_common::{
-    hex,
+    self as common, hex,
     log::{NeqoQlog, NeqoQlogRef},
-    matches, Datagram,
+    matches, Datagram, Role,
 };
 use neqo_crypto::{init, AuthenticationStatus};
 use neqo_http3::{Header, Http3Client, Http3ClientEvent, Http3State, Output};
@@ -315,45 +311,12 @@ fn client(
     );
 }
 
-fn init_qlog_trace() -> qlog::Trace {
-    Trace {
-        vantage_point: VantagePoint {
-            name: Some("neqo-client".into()),
-            ty: VantagePointType::Client,
-            flow: None,
-        },
-        title: Some("neqo-client trace".to_string()),
-        description: Some("Example qlog trace description".to_string()),
-        configuration: Some(Configuration {
-            time_offset: Some("0".into()),
-            time_units: Some(TimeUnits::Us),
-            original_uris: None,
-        }),
-        common_fields: Some(CommonFields {
-            group_id: None,
-            protocol_type: None,
-            reference_time: Some({
-                let system_time = SystemTime::now();
-                let datetime: DateTime<Utc> = system_time.into();
-                datetime.to_rfc3339()
-            }),
-        }),
-        event_fields: vec![
-            "relative_time".to_string(),
-            "category".to_string(),
-            "event".to_string(),
-            "data".to_string(),
-        ],
-        events: Vec::new(),
-    }
-}
-
 fn main() -> Result<(), std::io::Error> {
     init();
 
     let qtrace: NeqoQlogRef = Rc::new(RefCell::new(NeqoQlog::new(
         Instant::now(),
-        init_qlog_trace(),
+        common::qlog::new_trace(Role::Client),
     )));
 
     let args = Args::from_args();

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -395,7 +395,7 @@ fn main() -> Result<(), std::io::Error> {
 
         qlog.traces.push(owned_trace);
 
-        let qlogpath = output_qlog.unwrap_or_else(|| "output.qlg".into());
+        let qlogpath = output_qlog.unwrap();
 
         match OpenOptions::new()
             .write(true)

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -36,6 +36,8 @@ use std::time::Instant;
 use structopt::StructOpt;
 use url::Url;
 
+const DEFAULT_QLOG_OUTPUT: &str = "output.qlog";
+
 #[derive(Debug, StructOpt)]
 #[structopt(
     name = "neqo-client",
@@ -70,7 +72,7 @@ pub struct Args {
     /// Do not print received data
     omit_read_data: bool,
 
-    #[structopt(long, default_value = "output.qlog")]
+    #[structopt(long)]
     /// Output QLOG trace to a file.
     qlog: Option<Option<PathBuf>>,
 }
@@ -395,7 +397,7 @@ fn main() -> Result<(), std::io::Error> {
 
         qlog.traces.push(owned_trace);
 
-        let qlogpath = output_qlog.unwrap();
+        let qlogpath = output_qlog.unwrap_or_else(|| DEFAULT_QLOG_OUTPUT.into());
 
         match OpenOptions::new()
             .write(true)

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -70,7 +70,7 @@ pub struct Args {
     /// Do not print received data
     omit_read_data: bool,
 
-    #[structopt(long, default_value = "output.qlg")]
+    #[structopt(long, default_value = "output.qlog")]
     /// Output QLOG trace to a file.
     qlog: Option<Option<PathBuf>>,
 }

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -397,7 +397,12 @@ fn main() -> Result<(), std::io::Error> {
 
         let qlogpath = output_qlog.unwrap_or_else(|| "output.qlg".into());
 
-        match OpenOptions::new().write(true).create(true).open(&qlogpath) {
+        match OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&qlogpath)
+        {
             Ok(mut f) => {
                 eprintln!("Writing QLOG to {}", qlogpath.display());
                 let data = serde_json::to_string_pretty(&qlog)?;

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -384,7 +384,7 @@ fn main() -> Result<(), std::io::Error> {
 
     if let Some(output_qlog) = args.qlog {
         let mut qlog = Qlog {
-            qlog_version: "draft-00".into(),
+            qlog_version: qlog::QLOG_VERSION.into(),
             title: None,
             description: None,
             summary: None,

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -11,6 +11,7 @@ log = "0.4.0"
 env_logger = "0.6.1"
 lazy_static = "1.3.0"
 qlog = "0.1.0"
+chrono = "0.4.10"
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -10,6 +10,7 @@ num-traits = "0.2"
 log = "0.4.0"
 env_logger = "0.6.1"
 lazy_static = "1.3.0"
+qlog = "0.1.0"
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -12,6 +12,7 @@ mod datagram;
 mod incrdecoder;
 pub mod log;
 pub mod once;
+pub mod qlog;
 pub mod timer;
 
 pub use self::codec::{Decoder, Encoder};
@@ -50,4 +51,27 @@ pub const fn const_max(a: usize, b: usize) -> usize {
 #[must_use]
 pub const fn const_min(a: usize, b: usize) -> usize {
     [a, b][(a >= b) as usize]
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+/// Client or Server.
+pub enum Role {
+    Client,
+    Server,
+}
+
+impl Role {
+    #[must_use]
+    pub fn remote(self) -> Self {
+        match self {
+            Self::Client => Self::Server,
+            Self::Server => Self::Client,
+        }
+    }
+}
+
+impl ::std::fmt::Display for Role {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -17,6 +17,7 @@ pub mod timer;
 pub use self::codec::{Decoder, Encoder};
 pub use self::datagram::Datagram;
 pub use self::incrdecoder::{IncrementalDecoder, IncrementalDecoderResult};
+pub use self::log::NeqoQlogRef;
 
 #[macro_use]
 extern crate lazy_static;

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -4,10 +4,31 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use env_logger::Builder;
+use std::cell::RefCell;
 use std::io::Write;
+use std::rc::Rc;
 use std::sync::Once;
 use std::time::Instant;
+
+use env_logger::Builder;
+use qlog::Trace;
+
+pub struct NeqoQlog {
+    pub trace: Trace,
+    pub zero_time: Instant,
+}
+
+impl NeqoQlog {
+    #[must_use]
+    pub fn new(now: Instant, trace: Trace) -> Self {
+        Self {
+            trace,
+            zero_time: now,
+        }
+    }
+}
+
+pub type NeqoQlogRef = Rc<RefCell<NeqoQlog>>;
 
 static INIT_ONCE: Once = Once::new();
 
@@ -38,7 +59,7 @@ pub fn init() {
 }
 
 #[macro_export]
-macro_rules! qlog {
+macro_rules! log_invoke {
     ($lvl:expr, $ctx:expr, $($arg:tt)*) => ( {
         ::neqo_common::log::init();
         ::log::log!($lvl, "[{}] {}", $ctx, format!($($arg)*));
@@ -46,26 +67,26 @@ macro_rules! qlog {
 }
 #[macro_export]
 macro_rules! qerror {
-    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Error, $ctx, $($arg)*););
+    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Error, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Error, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qwarn {
-    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Warn, $ctx, $($arg)*););
+    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Warn, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Warn, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qinfo {
-    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Info, $ctx, $($arg)*););
+    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Info, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Info, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qdebug {
-    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Debug, $ctx, $($arg)*););
+    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Debug, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Debug, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qtrace {
-    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Trace, $ctx, $($arg)*););
+    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Trace, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Trace, $($arg)*); } );
 }

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -5,6 +5,7 @@
 // except according to those terms.
 
 use std::cell::RefCell;
+use std::fmt;
 use std::io::Write;
 use std::rc::Rc;
 use std::sync::Once;
@@ -25,6 +26,12 @@ impl NeqoQlog {
             trace,
             zero_time: now,
         }
+    }
+}
+
+impl fmt::Debug for NeqoQlog {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "NeqoQlog with zero time of {:?}", self.zero_time)
     }
 }
 

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -1,0 +1,52 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use chrono::{DateTime, Utc};
+
+use std::time::SystemTime;
+
+use qlog::{CommonFields, Configuration, TimeUnits, Trace, VantagePoint, VantagePointType};
+
+use crate::Role;
+
+#[must_use]
+pub fn new_trace(role: Role) -> qlog::Trace {
+    let role_str = match role {
+        Role::Client => "client",
+        Role::Server => "server",
+    };
+
+    Trace {
+        vantage_point: VantagePoint {
+            name: Some(format!("neqo-{}", role_str)),
+            ty: VantagePointType::Server,
+            flow: None,
+        },
+        title: Some(format!("neqo-{} trace", role_str)),
+        description: Some("Example qlog trace description".to_string()),
+        configuration: Some(Configuration {
+            time_offset: Some("0".into()),
+            time_units: Some(TimeUnits::Us),
+            original_uris: None,
+        }),
+        common_fields: Some(CommonFields {
+            group_id: None,
+            protocol_type: None,
+            reference_time: Some({
+                let system_time = SystemTime::now();
+                let datetime: DateTime<Utc> = system_time.into();
+                datetime.to_rfc3339()
+            }),
+        }),
+        event_fields: vec![
+            "relative_time".to_string(),
+            "category".to_string(),
+            "event".to_string(),
+            "data".to_string(),
+        ],
+        events: Vec::new(),
+    }
+}

--- a/neqo-http3-server/Cargo.toml
+++ b/neqo-http3-server/Cargo.toml
@@ -17,7 +17,6 @@ log = "0.4.0"
 qlog = "0.1.0"
 serde = "1"
 serde_json = "1"
-chrono = "0.4.10"
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-http3-server/Cargo.toml
+++ b/neqo-http3-server/Cargo.toml
@@ -10,7 +10,7 @@ neqo-crypto = { version = "0.1", path = "./../neqo-crypto" }
 neqo-transport = { version = "0.1", path = "./../neqo-transport" }
 neqo-common = { version="0.1", path="./../neqo-common" }
 neqo-http3 = { version = "0.1", path = "./../neqo-http3" }
-structopt = "0.2.15"
+structopt = "0.3.7"
 mio = "0.6.17"
 mio-extras = "2.0.5"
 log = "0.4.0"

--- a/neqo-http3-server/Cargo.toml
+++ b/neqo-http3-server/Cargo.toml
@@ -14,6 +14,10 @@ structopt = "0.3.7"
 mio = "0.6.17"
 mio-extras = "2.0.5"
 log = "0.4.0"
+qlog = "0.1.0"
+serde = "1"
+serde_json = "1"
+chrono = "0.4.10"
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -5,39 +5,37 @@
 // except according to those terms.
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
-#![allow(clippy::option_option)]
 #![warn(clippy::use_self)]
-
-use chrono::offset::Utc;
-use chrono::DateTime;
-use qlog::{CommonFields, Configuration, Qlog, TimeUnits, Trace, VantagePoint, VantagePointType};
-use std::time::SystemTime;
-
-use neqo_common::{
-    log::{NeqoQlog, NeqoQlogRef},
-    qdebug, qinfo, Datagram,
-};
-use neqo_crypto::{init_db, AntiReplay};
-use neqo_http3::{Http3Server, Http3ServerEvent};
-use neqo_transport::{FixedConnectionIdManager, Output};
 
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::{self, Write};
+use std::mem;
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use structopt::StructOpt;
-
 use mio::net::UdpSocket;
 use mio::{Events, Poll, PollOpt, Ready, Token};
 use mio_extras::timer::{Builder, Timeout, Timer};
+use qlog::Qlog;
+use structopt::StructOpt;
+
+use neqo_common::{
+    self as common,
+    log::{NeqoQlog, NeqoQlogRef},
+    qdebug, qinfo, Datagram, Role,
+};
+use neqo_crypto::{init_db, AntiReplay};
+use neqo_http3::{Http3Server, Http3ServerEvent, Http3State};
+use neqo_transport::{ConnectionId, FixedConnectionIdManager, Output};
 
 const TIMER_TOKEN: Token = Token(0xffff_ffff);
+
+type Res<T> = Result<T, io::Error>;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "neqo-http3-server", about = "A basic HTTP3 server.")]
@@ -66,9 +64,9 @@ struct Args {
     /// This server still only does HTTP3 no matter what the ALPN says.
     alpn: String,
 
-    #[structopt(long, default_value = "output.qlog")]
-    /// Output QLOG trace to a file.
-    qlog: Option<Option<PathBuf>>,
+    #[structopt(name = "qlog-dir", long)]
+    /// Enable QLOG logging and QLOG traces to this directory
+    qlog_dir: Option<PathBuf>,
 }
 
 impl Args {
@@ -81,7 +79,15 @@ impl Args {
     }
 }
 
-fn process_events(server: &mut Http3Server) {
+pub fn cid_to_string(cid: &ConnectionId) -> String {
+    let mut ret = String::with_capacity(cid.len() * 2);
+    for b in cid.iter() {
+        ret.push_str(&format!("{:02x}", b));
+    }
+    ret
+}
+
+fn process_events(server: &mut Http3Server, qlog_output_path: &Option<&Path>) -> Res<()> {
     while let Some(event) = server.next_event() {
         eprintln!("Event: {:?}", event);
         match event {
@@ -117,9 +123,57 @@ fn process_events(server: &mut Http3Server) {
             Http3ServerEvent::Data { request, data, fin } => {
                 println!("Data (request={} fin={}): {:?}", request, fin, data);
             }
+            Http3ServerEvent::StateChange {
+                mut conn,
+                state: Http3State::Closed(_),
+            } => {
+                if let Some(qlog_output_path) = qlog_output_path {
+                    // Construct path "<out_dir>/<cid>.qlog"
+                    let mut full_path = qlog_output_path.to_path_buf();
+                    let filename: PathBuf =
+                        cid_to_string(&conn.borrow().path().unwrap().local_cid()).into();
+                    full_path.push(filename);
+                    full_path.set_extension("qlog");
+
+                    if let Some(n_qlog) = conn.borrow_mut().qlog() {
+                        // Make qlog structs. Swap out events from conn, to
+                        // avoid maybe a costly clone().
+                        let mut qlog = Qlog {
+                            qlog_version: qlog::QLOG_VERSION.into(),
+                            title: None,
+                            description: None,
+                            summary: None,
+                            traces: Vec::new(),
+                        };
+
+                        let mut trace = common::qlog::new_trace(Role::Server);
+
+                        mem::swap(&mut trace.events, &mut n_qlog.borrow_mut().trace.events);
+                        qlog.traces.push(trace);
+                        let data = serde_json::to_string_pretty(&qlog)?;
+
+                        eprintln!("Writing QLOG to {}", full_path.display());
+                        match OpenOptions::new()
+                            .write(true)
+                            .create(true)
+                            .truncate(true)
+                            .open(&full_path)
+                        {
+                            Ok(mut f) => {
+                                f.write_all(data.as_bytes()).unwrap();
+                            }
+
+                            Err(e) => {
+                                eprintln!("Could not open qlog: {}", e);
+                            }
+                        }
+                    }
+                }
+            }
             _ => {}
         }
     }
+    Ok(())
 }
 
 fn emit_packets(sockets: &mut Vec<UdpSocket>, out_dgrams: &HashMap<SocketAddr, Vec<Datagram>>) {
@@ -166,41 +220,8 @@ fn process(
     }
 }
 
-fn init_qlog_trace() -> qlog::Trace {
-    Trace {
-        vantage_point: VantagePoint {
-            name: Some("neqo-server".into()),
-            ty: VantagePointType::Server,
-            flow: None,
-        },
-        title: Some("neqo-http3-server trace".to_string()),
-        description: Some("Example qlog trace description".to_string()),
-        configuration: Some(Configuration {
-            time_offset: Some("0".into()),
-            time_units: Some(TimeUnits::Us),
-            original_uris: None,
-        }),
-        common_fields: Some(CommonFields {
-            group_id: None,
-            protocol_type: None,
-            reference_time: Some({
-                let system_time = SystemTime::now();
-                let datetime: DateTime<Utc> = system_time.into();
-                datetime.to_rfc3339()
-            }),
-        }),
-        event_fields: vec![
-            "relative_time".to_string(),
-            "category".to_string(),
-            "event".to_string(),
-            "data".to_string(),
-        ],
-        events: Vec::new(),
-    }
-}
-
 fn main() -> Result<(), io::Error> {
-    let args = Args::from_args();
+    let mut args = Args::from_args();
     assert!(!args.key.is_empty(), "Need at least one key");
 
     init_db(args.db.clone());
@@ -215,9 +236,8 @@ fn main() -> Result<(), io::Error> {
 
     let qtrace: NeqoQlogRef = Rc::new(RefCell::new(NeqoQlog::new(
         Instant::now(),
-        init_qlog_trace(),
+        common::qlog::new_trace(Role::Server),
     )));
-    let mut qtrace_last_flush_time = Instant::now();
 
     let mut sockets = Vec::new();
     let mut servers = HashMap::new();
@@ -283,20 +303,7 @@ fn main() -> Result<(), io::Error> {
 
     let mut events = Events::with_capacity(1024);
 
-    let (mut qlog, qlog_output_path) = if let Some(output_path) = &args.qlog {
-        (
-            Some(Qlog {
-                qlog_version: qlog::QLOG_VERSION.into(),
-                title: None,
-                description: None,
-                summary: None,
-                traces: Vec::new(),
-            }),
-            Some(output_path.clone().unwrap()),
-        )
-    } else {
-        (None, None)
-    };
+    let qlog_output_path = args.qlog_dir.take();
 
     loop {
         poll.poll(&mut events, None)?;
@@ -359,7 +366,7 @@ fn main() -> Result<(), io::Error> {
                             out,
                             &mut timer,
                         );
-                        process_events(server);
+                        process_events(server, &qlog_output_path.as_ref().map(|x| &**x))?;
                         process(server, svr_timeout, event.token().0, None, out, &mut timer);
                     }
                 }
@@ -367,31 +374,5 @@ fn main() -> Result<(), io::Error> {
         }
 
         emit_packets(&mut sockets, &out_dgrams);
-
-        // Consider the time since we last wrote the trace to disk. If it has been more than 5 seconds,
-        // flush it. NB: This is a demonstration implementation. The performance overhead for logging
-        // traces in this manner is not suitable for production.
-        if Instant::now() - qtrace_last_flush_time > Duration::from_secs(5) {
-            if let (Some(qlog), Some(qlog_output_path)) = (&mut qlog, &qlog_output_path) {
-                match OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .truncate(true)
-                    .open(&qlog_output_path)
-                {
-                    Ok(mut f) => {
-                        eprintln!("Writing QLOG to {}", qlog_output_path.display());
-                        qlog.traces.push(qtrace.borrow().trace.clone());
-                        let data = serde_json::to_string_pretty(&qlog)?;
-                        f.write_all(data.as_bytes())?;
-                        qlog.traces.pop();
-                    }
-                    Err(e) => {
-                        eprintln!("Could not open qlog: {}", e);
-                    }
-                }
-            }
-            qtrace_last_flush_time = Instant::now();
-        }
     }
 }

--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -291,7 +291,7 @@ fn main() -> Result<(), io::Error> {
                 summary: None,
                 traces: Vec::new(),
             }),
-            Some(output_path.clone().unwrap_or_else(|| "output.qlog".into())),
+            Some(output_path.clone().unwrap()),
         )
     } else {
         (None, None)

--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -7,14 +7,23 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::use_self)]
 
-use neqo_common::{qdebug, qinfo, Datagram};
+use chrono::offset::Utc;
+use chrono::DateTime;
+use qlog::{CommonFields, Configuration, Qlog, TimeUnits, Trace, VantagePoint, VantagePointType};
+use std::time::SystemTime;
+
+use neqo_common::{
+    log::{NeqoQlog, NeqoQlogRef},
+    qdebug, qinfo, Datagram,
+};
 use neqo_crypto::{init_db, AntiReplay};
 use neqo_http3::{Http3Server, Http3ServerEvent};
 use neqo_transport::{FixedConnectionIdManager, Output};
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::io;
+use std::fs::OpenOptions;
+use std::io::{self, Write};
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::PathBuf;
 use std::process::exit;
@@ -55,6 +64,10 @@ struct Args {
     ///
     /// This server still only does HTTP3 no matter what the ALPN says.
     alpn: String,
+
+    #[structopt(long, default_value = "output.qlog")]
+    /// Output QLOG trace to a file.
+    qlog: Option<Option<PathBuf>>,
 }
 
 impl Args {
@@ -152,6 +165,39 @@ fn process(
     }
 }
 
+fn init_qlog_trace() -> qlog::Trace {
+    Trace {
+        vantage_point: VantagePoint {
+            name: Some("neqo-server".into()),
+            ty: VantagePointType::Server,
+            flow: None,
+        },
+        title: Some("neqo-http3-server trace".to_string()),
+        description: Some("Example qlog trace description".to_string()),
+        configuration: Some(Configuration {
+            time_offset: Some("0".into()),
+            time_units: Some(TimeUnits::Us),
+            original_uris: None,
+        }),
+        common_fields: Some(CommonFields {
+            group_id: None,
+            protocol_type: None,
+            reference_time: Some({
+                let system_time = SystemTime::now();
+                let datetime: DateTime<Utc> = system_time.into();
+                datetime.to_rfc3339()
+            }),
+        }),
+        event_fields: vec![
+            "relative_time".to_string(),
+            "category".to_string(),
+            "event".to_string(),
+            "data".to_string(),
+        ],
+        events: Vec::new(),
+    }
+}
+
 fn main() -> Result<(), io::Error> {
     let args = Args::from_args();
     assert!(!args.key.is_empty(), "Need at least one key");
@@ -165,6 +211,12 @@ fn main() -> Result<(), io::Error> {
         eprintln!("No valid hosts defined");
         exit(1);
     }
+
+    let qtrace: NeqoQlogRef = Rc::new(RefCell::new(NeqoQlog::new(
+        Instant::now(),
+        init_qlog_trace(),
+    )));
+    let mut qtrace_last_flush_time = Instant::now();
 
     let mut sockets = Vec::new();
     let mut servers = HashMap::new();
@@ -218,6 +270,7 @@ fn main() -> Result<(), io::Error> {
                     Rc::new(RefCell::new(FixedConnectionIdManager::new(10))),
                     args.max_table_size,
                     args.max_blocked_streams,
+                    Some(Rc::clone(&qtrace)),
                 )
                 .expect("We cannot make a server!"),
                 None,
@@ -228,6 +281,21 @@ fn main() -> Result<(), io::Error> {
     let buf = &mut [0u8; 2048];
 
     let mut events = Events::with_capacity(1024);
+
+    let (mut qlog, qlog_output_path) = if let Some(output_path) = &args.qlog {
+        (
+            Some(Qlog {
+                qlog_version: qlog::QLOG_VERSION.into(),
+                title: None,
+                description: None,
+                summary: None,
+                traces: Vec::new(),
+            }),
+            Some(output_path.clone().unwrap_or_else(|| "output.qlog".into())),
+        )
+    } else {
+        (None, None)
+    };
 
     loop {
         poll.poll(&mut events, None)?;
@@ -298,5 +366,31 @@ fn main() -> Result<(), io::Error> {
         }
 
         emit_packets(&mut sockets, &out_dgrams);
+
+        // Consider the time since we last wrote the trace to disk. If it has been more than 5 seconds,
+        // flush it. NB: This is a demonstration implementation. The performance overhead for logging
+        // traces in this manner is not suitable for production.
+        if Instant::now() - qtrace_last_flush_time > Duration::from_secs(5) {
+            if let (Some(qlog), Some(qlog_output_path)) = (&mut qlog, &qlog_output_path) {
+                match OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(&qlog_output_path)
+                {
+                    Ok(mut f) => {
+                        eprintln!("Writing QLOG to {}", qlog_output_path.display());
+                        qlog.traces.push(qtrace.borrow().trace.clone());
+                        let data = serde_json::to_string_pretty(&qlog)?;
+                        f.write_all(data.as_bytes())?;
+                        qlog.traces.pop();
+                    }
+                    Err(e) => {
+                        eprintln!("Could not open qlog: {}", e);
+                    }
+                }
+            }
+            qtrace_last_flush_time = Instant::now();
+        }
     }
 }

--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -5,6 +5,7 @@
 // except according to those terms.
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
+#![allow(clippy::option_option)]
 #![warn(clippy::use_self)]
 
 use chrono::offset::Utc;

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -95,8 +95,8 @@ impl<T: Http3Transaction> Http3Connection<T> {
             control_stream_local: ControlStreamLocal::default(),
             control_stream_remote: ControlStreamRemote::new(),
             new_streams: HashMap::new(),
-            qpack_encoder: QPackEncoder::new(true),
-            qpack_decoder: QPackDecoder::new(max_table_size, max_blocked_streams),
+            qpack_encoder: QPackEncoder::new(true, log.clone()),
+            qpack_decoder: QPackDecoder::new(max_table_size, max_blocked_streams, log.clone()),
             settings_state: Http3RemoteSettingsState::NotReceived,
             streams_have_data_to_send: BTreeSet::new(),
             transactions: HashMap::new(),
@@ -382,10 +382,11 @@ impl<T: Http3Transaction> Http3Connection<T> {
             self.control_stream_local = ControlStreamLocal::default();
             self.control_stream_remote = ControlStreamRemote::new();
             self.new_streams.clear();
-            self.qpack_encoder = QPackEncoder::new(true);
+            self.qpack_encoder = QPackEncoder::new(true, self.log.clone());
             self.qpack_decoder = QPackDecoder::new(
                 self.local_settings.max_table_size,
                 self.local_settings.max_blocked_streams,
+                self.log.clone(),
             );
             self.settings_state = Http3RemoteSettingsState::NotReceived;
             self.streams_have_data_to_send.clear();

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -9,7 +9,7 @@ use crate::control_stream_remote::ControlStreamRemote;
 use crate::hframe::HFrame;
 use crate::hsettings_frame::{HSetting, HSettingType, HSettings};
 use crate::stream_type_reader::NewStreamTypeReader;
-use neqo_common::{matches, qdebug, qerror, qinfo, qtrace, qwarn};
+use neqo_common::{log::NeqoQlogRef, matches, qdebug, qerror, qinfo, qtrace, qwarn};
 use neqo_qpack::decoder::{QPackDecoder, QPACK_UNI_STREAM_TYPE_DECODER};
 use neqo_qpack::encoder::{QPackEncoder, QPACK_UNI_STREAM_TYPE_ENCODER};
 use neqo_transport::{AppError, CloseError, Connection, State, StreamType};
@@ -72,6 +72,7 @@ pub struct Http3Connection<T: Http3Transaction> {
     settings_state: Http3RemoteSettingsState,
     streams_have_data_to_send: BTreeSet<u64>,
     pub transactions: HashMap<u64, T>,
+    log: Option<NeqoQlogRef>,
 }
 
 impl<T: Http3Transaction> ::std::fmt::Display for Http3Connection<T> {
@@ -81,7 +82,7 @@ impl<T: Http3Transaction> ::std::fmt::Display for Http3Connection<T> {
 }
 
 impl<T: Http3Transaction> Http3Connection<T> {
-    pub fn new(max_table_size: u32, max_blocked_streams: u16) -> Self {
+    pub fn new(max_table_size: u32, max_blocked_streams: u16, log: Option<NeqoQlogRef>) -> Self {
         if max_table_size > (1 << 30) - 1 {
             panic!("Wrong max_table_size");
         }
@@ -99,6 +100,7 @@ impl<T: Http3Transaction> Http3Connection<T> {
             settings_state: Http3RemoteSettingsState::NotReceived,
             streams_have_data_to_send: BTreeSet::new(),
             transactions: HashMap::new(),
+            log,
         }
     }
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -548,7 +548,7 @@ mod tests {
             },
             conn: default_server(),
             control_stream_id: None,
-            encoder: QPackEncoder::new(true),
+            encoder: QPackEncoder::new(true, None),
         }
     }
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -53,17 +53,23 @@ impl Http3Client {
                 cid_manager,
                 local_addr,
                 remote_addr,
-                log,
+                log.clone(),
             )?,
             max_table_size,
             max_blocked_streams,
+            log,
         ))
     }
 
-    pub fn new_with_conn(c: Connection, max_table_size: u32, max_blocked_streams: u16) -> Self {
+    pub fn new_with_conn(
+        c: Connection,
+        max_table_size: u32,
+        max_blocked_streams: u16,
+        log: Option<NeqoQlogRef>,
+    ) -> Self {
         Self {
             conn: c,
-            base_handler: Http3Connection::new(max_table_size, max_blocked_streams),
+            base_handler: Http3Connection::new(max_table_size, max_blocked_streams, log),
             events: Http3ClientEvents::default(),
         }
     }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -10,7 +10,7 @@ use crate::hframe::HFrame;
 use crate::hsettings_frame::HSettings;
 use crate::transaction_client::TransactionClient;
 use crate::Header;
-use neqo_common::{hex, matches, qdebug, qinfo, qtrace, Datagram, Decoder, Encoder};
+use neqo_common::{hex, matches, qdebug, qinfo, qtrace, Datagram, Decoder, Encoder, NeqoQlogRef};
 use neqo_crypto::{agent::CertificateInfo, AuthenticationStatus, SecretAgentInfo};
 use neqo_transport::{
     AppError, Connection, ConnectionEvent, ConnectionIdManager, Output, Role, StreamType,
@@ -35,6 +35,7 @@ impl ::std::fmt::Display for Http3Client {
 }
 
 impl Http3Client {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         server_name: &str,
         protocols: &[impl AsRef<str>],
@@ -43,9 +44,17 @@ impl Http3Client {
         remote_addr: SocketAddr,
         max_table_size: u32,
         max_blocked_streams: u16,
+        log: Option<NeqoQlogRef>,
     ) -> Res<Self> {
         Ok(Self::new_with_conn(
-            Connection::new_client(server_name, protocols, cid_manager, local_addr, remote_addr)?,
+            Connection::new_client(
+                server_name,
+                protocols,
+                cid_manager,
+                local_addr,
+                remote_addr,
+                log,
+            )?,
             max_table_size,
             max_blocked_streams,
         ))
@@ -489,6 +498,7 @@ mod tests {
             loopback(),
             100,
             100,
+            None,
         )
         .expect("create a default client")
     }
@@ -2620,6 +2630,7 @@ mod tests {
             test_fixture::DEFAULT_ALPN,
             &ar,
             Rc::new(RefCell::new(FixedConnectionIdManager::new(10))),
+            None,
         )
         .unwrap();
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -10,10 +10,12 @@ use crate::hframe::HFrame;
 use crate::hsettings_frame::HSettings;
 use crate::transaction_client::TransactionClient;
 use crate::Header;
-use neqo_common::{hex, matches, qdebug, qinfo, qtrace, Datagram, Decoder, Encoder, NeqoQlogRef};
+use neqo_common::{
+    hex, matches, qdebug, qinfo, qtrace, Datagram, Decoder, Encoder, NeqoQlogRef, Role,
+};
 use neqo_crypto::{agent::CertificateInfo, AuthenticationStatus, SecretAgentInfo};
 use neqo_transport::{
-    AppError, Connection, ConnectionEvent, ConnectionIdManager, Output, Role, StreamType,
+    AppError, Connection, ConnectionEvent, ConnectionIdManager, Output, StreamType,
 };
 use std::cell::RefCell;
 use std::net::SocketAddr;

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -9,7 +9,7 @@ use crate::hframe::HFrame;
 use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents};
 use crate::transaction_server::TransactionServer;
 use crate::{Error, Header, Res};
-use neqo_common::{qdebug, qinfo, qtrace};
+use neqo_common::{log::NeqoQlogRef, qdebug, qinfo, qtrace};
 use neqo_transport::{AppError, Connection, ConnectionEvent, StreamType};
 use std::time::Instant;
 
@@ -26,9 +26,9 @@ impl ::std::fmt::Display for Http3ServerHandler {
 }
 
 impl Http3ServerHandler {
-    pub fn new(max_table_size: u32, max_blocked_streams: u16) -> Self {
+    pub fn new(max_table_size: u32, max_blocked_streams: u16, log: Option<NeqoQlogRef>) -> Self {
         Self {
-            base_handler: Http3Connection::new(max_table_size, max_blocked_streams),
+            base_handler: Http3Connection::new(max_table_size, max_blocked_streams, log),
             events: Http3ServerConnEvents::default(),
         }
     }

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -36,6 +36,7 @@ impl ::std::fmt::Display for Http3Server {
 }
 
 impl Http3Server {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         now: Instant,
         certs: &[impl AsRef<str>],

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -314,7 +314,7 @@ mod tests {
             &[0x0, 0x4, 0x6, 0x1, 0x40, 0x64, 0x7, 0x40, 0x64],
         );
         assert_eq!(sent, Ok(9));
-        let mut encoder = QPackEncoder::new(true);
+        let mut encoder = QPackEncoder::new(true, None);
         encoder.add_send_stream(neqo_trans_conn.stream_create(StreamType::UniDi).unwrap());
         encoder.send(&mut neqo_trans_conn).unwrap();
         let decoder_stream = neqo_trans_conn.stream_create(StreamType::UniDi).unwrap();

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -9,6 +9,7 @@ use crate::connection_server::Http3ServerHandler;
 use crate::server_connection_events::Http3ServerConnEvent;
 use crate::server_events::{ClientRequestStream, Http3ServerEvent, Http3ServerEvents};
 use crate::Res;
+use neqo_common::log::NeqoQlogRef;
 use neqo_common::{qtrace, Datagram};
 use neqo_crypto::AntiReplay;
 use neqo_transport::server::{ActiveConnectionRef, Server};
@@ -43,9 +44,10 @@ impl Http3Server {
         cid_manager: Rc<RefCell<dyn ConnectionIdManager>>,
         max_table_size: u32,
         max_blocked_streams: u16,
+        qlog: Option<NeqoQlogRef>,
     ) -> Res<Self> {
         Ok(Self {
-            server: Server::new(now, certs, protocols, anti_replay, cid_manager)?,
+            server: Server::new(now, certs, protocols, anti_replay, cid_manager, qlog)?,
             max_table_size,
             max_blocked_streams,
             http3_handlers: HashMap::new(),
@@ -180,6 +182,7 @@ mod tests {
             Rc::new(RefCell::new(FixedConnectionIdManager::new(5))),
             100,
             100,
+            None,
         )
         .expect("create a default server")
     }

--- a/neqo-interop/Cargo.toml
+++ b/neqo-interop/Cargo.toml
@@ -11,8 +11,8 @@ neqo-transport = { version = "0.1", path = "./../neqo-transport" }
 neqo-common = { version="0.1", path="./../neqo-common" }
 neqo-http3 = { version = "0.1", path = "./../neqo-http3" }
 
-structopt = "0.2.15"
-lazy_static = "1.3.0"
+structopt = "0.3.7"
+lazy_static = "1.4.0"
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -435,6 +435,7 @@ fn test_connect(nctx: &NetworkCtx, test: &Test, peer: &Peer) -> Result<Connectio
         Rc::new(RefCell::new(FixedConnectionIdManager::new(0))),
         nctx.local_addr,
         nctx.remote_addr,
+        None,
     )
     .expect("must succeed");
     // Temporary here to help out the type inference engine
@@ -524,6 +525,7 @@ fn test_vn(nctx: &NetworkCtx, peer: &Peer) -> Result<Connection, String> {
         Rc::new(RefCell::new(FixedConnectionIdManager::new(0))),
         nctx.local_addr,
         nctx.remote_addr,
+        None,
     )
     .expect("must succeed");
     // Temporary here to help out the type inference engine

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -481,7 +481,7 @@ fn test_h9(nctx: &NetworkCtx, client: &mut Connection) -> Result<(), String> {
 fn test_h3(nctx: &NetworkCtx, peer: &Peer, client: Connection) -> Result<(), String> {
     let mut hc = H3Handler {
         streams: HashSet::new(),
-        h3: Http3Client::new_with_conn(client, 128, 128),
+        h3: Http3Client::new_with_conn(client, 128, 128, None),
         host: String::from(peer.host),
         path: String::from("/"),
     };

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -10,6 +10,7 @@ neqo-common = { path = "./../neqo-common" }
 neqo-transport = { path = "./../neqo-transport" }
 neqo-crypto = { path = "./../neqo-crypto" }
 log = "0.4.0"
+qlog = "0.1.0"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -12,7 +12,7 @@ use crate::qpack_send_buf::QPData;
 use crate::table::HeaderTable;
 use crate::Header;
 use crate::{Error, Res};
-use neqo_common::qdebug;
+use neqo_common::{log::NeqoQlogRef, qdebug};
 use neqo_transport::Connection;
 use std::{mem, str};
 
@@ -81,10 +81,11 @@ pub struct QPackDecoder {
     max_table_size: u32,
     max_blocked_streams: u16,
     blocked_streams: Vec<(u64, u64)>, //stream_id and requested inserts count.
+    log: Option<NeqoQlogRef>,
 }
 
 impl QPackDecoder {
-    pub fn new(max_table_size: u32, max_blocked_streams: u16) -> Self {
+    pub fn new(max_table_size: u32, max_blocked_streams: u16, log: Option<NeqoQlogRef>) -> Self {
         qdebug!("Decoder: creating a new qpack decoder.");
         Self {
             state: QPackDecoderState::ReadInstruction,
@@ -97,6 +98,7 @@ impl QPackDecoder {
             max_table_size,
             max_blocked_streams,
             blocked_streams: Vec::new(),
+            log,
         }
     }
 
@@ -810,7 +812,7 @@ mod tests {
         let send_stream_id = conn.stream_create(StreamType::UniDi).unwrap();
 
         // create a decoder
-        let mut decoder = QPackDecoder::new(300, 100);
+        let mut decoder = QPackDecoder::new(300, 100, None);
         decoder.add_send_stream(send_stream_id);
 
         TestDecoder {

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -5,6 +5,7 @@
 // except according to those terms.
 
 use crate::huffman::encode_huffman;
+use crate::qlog;
 use crate::qpack_helper::read_prefixed_encoded_int_with_connection;
 use crate::qpack_send_buf::QPData;
 use crate::table::{HeaderTable, LookupResult};
@@ -14,6 +15,7 @@ use neqo_common::{log::NeqoQlogRef, qdebug, qtrace};
 use neqo_transport::Connection;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryInto;
+use std::time::Instant;
 
 pub const QPACK_UNI_STREAM_TYPE_ENCODER: u64 = 0x2;
 
@@ -244,6 +246,12 @@ impl QPackEncoder {
             qdebug!([self], "call intruction {:?}", inst);
             match inst {
                 DecoderInstructions::InsertCountIncrement => {
+                    qlog::qpack_read_insert_count_increment_instruction(
+                        &self.log,
+                        Instant::now(),
+                        self.instruction_reader_value,
+                        &self.instruction_reader_value.to_be_bytes(),
+                    );
                     self.insert_count_instruction(self.instruction_reader_value)?
                 }
                 DecoderInstructions::HeaderAck => self.header_ack(self.instruction_reader_value)?,

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -12,6 +12,7 @@ pub mod encoder;
 pub mod huffman;
 mod huffman_decode_helper;
 pub mod huffman_table;
+mod qlog;
 pub mod qpack_helper;
 mod qpack_send_buf;
 mod static_table;

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -14,6 +14,8 @@ use qlog::{
 use std::fmt::LowerHex;
 use std::time::Instant;
 
+// TODO(hawkinsw@obs.cr): There is a copy of this in neqo-transports/src/qlog.rs.
+// Refactor both uses into something in neqo-common.
 fn slice_to_hex_string<T: LowerHex>(slice: &[T]) -> String {
     if slice.is_empty() {
         "0x0".to_string()

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -56,11 +56,11 @@ mod tests {
     use super::*;
     #[test]
     fn test_slice_to_hex_string() {
-        let s = slice_to_hex_string(&vec![10, 9, 8]);
+        let s = slice_to_hex_string(&[10, 9, 8]);
         assert_eq!(r#"0xa98"#, s);
         let s = slice_to_hex_string(&Vec::<u8>::new());
         assert_eq!(r#"0x0"#, s);
-        let s = slice_to_hex_string(&vec![128]);
+        let s = slice_to_hex_string(&[128]);
         assert_eq!(r#"0x80"#, s);
     }
 }

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Functions that handle capturing QLOG traces.
+
+use std::time::Instant;
+
+use neqo_common::NeqoQlogRef;
+use qlog::{
+    EventCategory, EventData::QpackInstructionReceived, EventField,
+    QPackInstruction::InsertCountIncrementInstruction, QpackInstructionTypeName,
+};
+
+fn slice_to_string<T: ToString>(slice: &[T]) -> String {
+    slice
+        .iter()
+        .fold("".to_string(), |acc, x| acc + &x.to_string())
+}
+
+pub fn qpack_read_insert_count_increment_instruction(
+    qlog: &Option<NeqoQlogRef>,
+    now: Instant,
+    increment: u64,
+    data: &[u8],
+) {
+    if let Some(qlog) = qlog {
+        let mut qlog = qlog.borrow_mut();
+        let elapsed = now.duration_since(qlog.zero_time);
+        let instruction_received_data = QpackInstructionReceived {
+            instruction: InsertCountIncrementInstruction {
+                instruction_type: QpackInstructionTypeName::InsertCountIncrementInstruction,
+                increment,
+            },
+            byte_length: Some(8.to_string()),
+            raw: Some(slice_to_string(data)),
+        };
+        qlog.trace.events.push(vec![
+            EventField::Category(EventCategory::Qpack),
+            EventField::RelativeTime(format!("{}", elapsed.as_micros())),
+            EventField::Data(instruction_received_data),
+        ]);
+    }
+}

--- a/neqo-server/Cargo.toml
+++ b/neqo-server/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 neqo-crypto = { path = "./../neqo-crypto" }
 neqo-transport = { path = "./../neqo-transport" }
 neqo-common = { path="./../neqo-common" }
-structopt = "0.2.15"
+structopt = "0.3.7"
 regex = "1"
 
 [features]

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -157,6 +157,7 @@ fn main() {
                 &args.alpn,
                 &anti_replay,
                 Rc::new(RefCell::new(FixedConnectionIdManager::new(10))),
+                None,
             )
             .expect("can't create connection")
         });

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -11,6 +11,7 @@ neqo-common = { path = "../neqo-common" }
 lazy_static = "1.3.0"
 log = "0.4.0"
 smallvec = "1.0.0"
+qlog = "0.1.0"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1456,10 +1456,6 @@ impl Connection {
             self.crypto.install_keys(self.role);
         }
 
-        if let Role::Server = self.role() {
-            qlog::server_connection_started(&self.qlog, now, self.path.as_ref().unwrap());
-        }
-
         Ok(())
     }
 
@@ -1752,6 +1748,8 @@ impl Connection {
             // Remove the randomized client CID from the list of acceptable CIDs.
             assert_eq!(1, self.valid_cids.len());
             self.valid_cids.clear();
+            // Generate a qlog event that the server connection started.
+            qlog::server_connection_started(&self.qlog, now, self.path.as_ref().unwrap());
         } else {
             self.zero_rtt_state = if self.crypto.tls.info().unwrap().early_data_accepted() {
                 ZeroRttState::AcceptedClient

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -19,6 +19,7 @@ use smallvec::SmallVec;
 
 use neqo_common::{
     hex, matches, qdebug, qerror, qinfo, qtrace, qwarn, Datagram, Decoder, Encoder, NeqoQlogRef,
+    Role,
 };
 use neqo_crypto::agent::CertificateInfo;
 use neqo_crypto::{
@@ -53,28 +54,6 @@ pub const LOCAL_STREAM_LIMIT_BIDI: u64 = 16;
 pub const LOCAL_STREAM_LIMIT_UNI: u64 = 16;
 
 const LOCAL_MAX_DATA: u64 = 0x3FFF_FFFF_FFFF_FFFF; // 2^62-1
-
-#[derive(Debug, PartialEq, Copy, Clone)]
-/// Client or Server.
-pub enum Role {
-    Client,
-    Server,
-}
-
-impl Role {
-    pub fn remote(self) -> Self {
-        match self {
-            Self::Client => Self::Server,
-            Self::Server => Self::Client,
-        }
-    }
-}
-
-impl ::std::fmt::Display for Role {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
 
 #[derive(Clone, Debug, PartialEq, Ord, Eq)]
 /// The state of the Connection.
@@ -480,6 +459,16 @@ impl Connection {
             stats: Stats::default(),
             qlog,
         }
+    }
+
+    /// Get the local connection id.
+    pub fn path(&self) -> Option<&Path> {
+        self.path.as_ref()
+    }
+
+    /// Get the qlog (if any) for this connection.
+    pub fn qlog(&self) -> Option<&NeqoQlogRef> {
+        self.qlog.as_ref()
     }
 
     /// Set a local transport parameter, possibly overriding a default value.

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1770,6 +1770,7 @@ impl Connection {
             self.set_state(State::Confirmed);
         }
         qinfo!([self], "Connection established");
+        qlog::connection_tparams_set(&self.qlog, now, &*self.tps.borrow());
         Ok(())
     }
 

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1449,11 +1449,17 @@ impl Connection {
                 unreachable!("Crypto state should not be new or failed after successful handshake")
             }
         }
+
         // There is a chance that this could be called less often, but getting the
         // conditions right is a little tricky, so call it on every  CRYPTO frame.
         if try_update {
             self.crypto.install_keys(self.role);
         }
+
+        if let Role::Server = self.role() {
+            qlog::server_connection_started(&self.qlog, now, self.path.as_ref().unwrap());
+        }
+
         Ok(())
     }
 

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1262,6 +1262,7 @@ impl Connection {
             }
 
             dump_packet(self, "TX ->", pt, pn, &builder[payload_start..]);
+            qlog::packet_sent(&self.qlog, now, pt, pn, &builder[payload_start..]);
 
             qdebug!("Need to send a packet: {:?}", pt);
 

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -11,7 +11,7 @@ use std::ops::{Index, IndexMut, Range};
 use std::rc::Rc;
 use std::time::Instant;
 
-use neqo_common::{hex, matches, qdebug, qerror, qinfo, qtrace};
+use neqo_common::{hex, matches, qdebug, qerror, qinfo, qtrace, Role};
 use neqo_crypto::aead::Aead;
 use neqo_crypto::hp::HpKey;
 use neqo_crypto::{
@@ -20,7 +20,6 @@ use neqo_crypto::{
     TLS_EPOCH_ZERO_RTT, TLS_VERSION_1_3,
 };
 
-use crate::connection::Role;
 use crate::frame::{Frame, TxMode};
 use crate::packet::PacketNumber;
 use crate::recovery::RecoveryToken;

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -94,7 +94,7 @@ impl CloseError {
         }
     }
 
-    fn code(&self) -> u64 {
+    pub fn code(&self) -> u64 {
         match self {
             Self::Transport(c) | Self::Application(c) => *c,
         }

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -30,8 +30,8 @@ mod stream_id;
 mod tparams;
 mod tracking;
 
-pub use self::cid::ConnectionIdManager;
-pub use self::connection::{Connection, FixedConnectionIdManager, Output, Role, State};
+pub use self::cid::{ConnectionId, ConnectionIdManager};
+pub use self::connection::{Connection, FixedConnectionIdManager, Output, State};
 pub use self::events::{ConnectionEvent, ConnectionEvents};
 pub use self::frame::CloseError;
 pub use self::frame::StreamType;

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -20,6 +20,7 @@ mod flow_mgr;
 mod frame;
 mod packet;
 mod path;
+mod qlog;
 mod recovery;
 mod recv_stream;
 mod send_stream;

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -94,4 +94,14 @@ impl Path {
     pub fn datagram<V: Into<Vec<u8>>>(&self, payload: V) -> Datagram {
         Datagram::new(self.local, self.remote, payload)
     }
+
+    /// Get local socketaddr
+    pub fn local_sock(&self) -> &SocketAddr {
+        &self.local
+    }
+
+    /// Get remote socketaddr
+    pub fn remote_sock(&self) -> &SocketAddr {
+        &self.remote
+    }
 }

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -146,7 +146,7 @@ pub fn packet_sent(
             }
         }
 
-        let packet_type = pkt_type_to_qlog_pkt_type(&pt);
+        let packet_type = pkt_type_to_qlog_pkt_type(pt);
 
         qlog.trace.push_transport_event(
             format!("{}", elapsed.as_micros()),
@@ -190,7 +190,7 @@ pub fn packet_received(qlog: &Option<NeqoQlogRef>, now: Instant, payload: &Decry
             }
         }
 
-        let packet_type = pkt_type_to_qlog_pkt_type(&payload.packet_type());
+        let packet_type = pkt_type_to_qlog_pkt_type(payload.packet_type());
 
         qlog.trace.push_transport_event(
             format!("{}", elapsed.as_micros()),
@@ -369,7 +369,7 @@ fn frame_to_qlogframe(frame: &Frame) -> QuicFrame {
     }
 }
 
-fn pkt_type_to_qlog_pkt_type(ptype: &PacketType) -> qlog::PacketType {
+fn pkt_type_to_qlog_pkt_type(ptype: PacketType) -> qlog::PacketType {
     match ptype {
         PacketType::Initial => qlog::PacketType::Initial,
         PacketType::Handshake => qlog::PacketType::Handshake,

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -17,7 +17,7 @@ use qlog::{
 use neqo_common::{hex, qinfo, Decoder, NeqoQlogRef};
 
 use crate::frame::{self, Frame};
-use crate::packet::{DecryptedPacket, PacketType};
+use crate::packet::{DecryptedPacket, PacketNumber, PacketType};
 use crate::path::Path;
 use crate::QUIC_VERSION;
 
@@ -48,6 +48,56 @@ pub fn client_connection_started(qlog: &Option<NeqoQlogRef>, now: Instant, path:
     }
 }
 
+pub fn packet_sent(
+    qlog: &Option<NeqoQlogRef>,
+    now: Instant,
+    pt: PacketType,
+    pn: PacketNumber,
+    body: &[u8],
+) {
+    if let Some(qlog) = qlog {
+        let mut qlog = qlog.borrow_mut();
+        let elapsed = now.duration_since(qlog.zero_time);
+
+        let mut frames = Vec::new();
+        let mut d = Decoder::from(body);
+
+        while d.remaining() > 0 {
+            match Frame::decode(&mut d) {
+                Ok(f) => frames.push(frame_to_qlogframe(&f)),
+                Err(_) => {
+                    qinfo!("qlog: invalid frame");
+                    break;
+                }
+            }
+        }
+
+        let packet_type = pkt_type_to_qlog_pkt_type(&pt);
+
+        qlog.trace.push_transport_event(
+            format!("{}", elapsed.as_micros()),
+            TransportEventType::PacketSent,
+            EventData::PacketSent {
+                packet_type,
+                header: PacketHeader {
+                    packet_number: pn.to_string(),
+                    packet_size: None,
+                    payload_length: None,
+                    version: None,
+                    scil: None,
+                    dcil: None,
+                    scid: None,
+                    dcid: None,
+                },
+                frames: Some(frames),
+                is_coalesced: None,
+                raw_encrypted: None,
+                raw_decrypted: None,
+            },
+        )
+    }
+}
+
 pub fn packet_received(qlog: &Option<NeqoQlogRef>, now: Instant, payload: &DecryptedPacket) {
     if let Some(qlog) = qlog {
         let mut qlog = qlog.borrow_mut();
@@ -58,162 +108,7 @@ pub fn packet_received(qlog: &Option<NeqoQlogRef>, now: Instant, payload: &Decry
 
         while d.remaining() > 0 {
             match Frame::decode(&mut d) {
-                Ok(f) => {
-                    let qlogframe = match f {
-                        Frame::Padding => QuicFrame::Padding {
-                            frame_type: QuicFrameTypeName::Padding,
-                        },
-                        Frame::Ping => QuicFrame::Ping {
-                            frame_type: QuicFrameTypeName::Ping,
-                        },
-                        Frame::Ack { ack_delay, .. } => QuicFrame::Ack {
-                            frame_type: QuicFrameTypeName::Ack,
-                            ack_delay: Some(ack_delay.to_string()),
-                            acked_ranges: None,
-                            ect1: None,
-                            ect0: None,
-                            ce: None,
-                        },
-                        Frame::ResetStream {
-                            stream_id,
-                            application_error_code,
-                            final_size,
-                        } => QuicFrame::ResetStream {
-                            frame_type: QuicFrameTypeName::ResetStream,
-                            stream_id: stream_id.as_u64().to_string(),
-                            error_code: application_error_code,
-                            final_size: final_size.to_string(),
-                        },
-                        Frame::StopSending {
-                            stream_id,
-                            application_error_code,
-                        } => QuicFrame::StopSending {
-                            frame_type: QuicFrameTypeName::StopSending,
-                            stream_id: stream_id.as_u64().to_string(),
-                            error_code: application_error_code,
-                        },
-                        Frame::Crypto { offset, data } => QuicFrame::Crypto {
-                            frame_type: QuicFrameTypeName::Crypto,
-                            offset: offset.to_string(),
-                            length: data.len().to_string(),
-                        },
-                        Frame::NewToken { token } => QuicFrame::NewToken {
-                            frame_type: QuicFrameTypeName::NewToken,
-                            length: token.len().to_string(),
-                            token: hex(&token),
-                        },
-                        Frame::Stream {
-                            fin,
-                            stream_id,
-                            offset,
-                            data,
-                            ..
-                        } => QuicFrame::Stream {
-                            frame_type: QuicFrameTypeName::Stream,
-                            stream_id: stream_id.as_u64().to_string(),
-                            offset: offset.to_string(),
-                            length: data.len().to_string(),
-                            fin,
-                            raw: None,
-                        },
-                        Frame::MaxData { maximum_data } => QuicFrame::MaxData {
-                            frame_type: QuicFrameTypeName::MaxData,
-                            maximum: maximum_data.to_string(),
-                        },
-                        Frame::MaxStreamData {
-                            stream_id,
-                            maximum_stream_data,
-                        } => QuicFrame::MaxStreamData {
-                            frame_type: QuicFrameTypeName::MaxStreamData,
-                            stream_id: stream_id.as_u64().to_string(),
-                            maximum: maximum_stream_data.to_string(),
-                        },
-                        Frame::MaxStreams {
-                            stream_type,
-                            maximum_streams,
-                        } => QuicFrame::MaxStreams {
-                            frame_type: QuicFrameTypeName::MaxData,
-                            stream_type: match stream_type {
-                                frame::StreamType::BiDi => qlog::StreamType::Bidirectional,
-                                frame::StreamType::UniDi => qlog::StreamType::Unidirectional,
-                            },
-                            maximum: maximum_streams.as_u64().to_string(),
-                        },
-                        Frame::DataBlocked { data_limit } => QuicFrame::DataBlocked {
-                            frame_type: QuicFrameTypeName::DataBlocked,
-                            limit: data_limit.to_string(),
-                        },
-                        Frame::StreamDataBlocked {
-                            stream_id,
-                            stream_data_limit,
-                        } => QuicFrame::StreamDataBlocked {
-                            frame_type: QuicFrameTypeName::StreamDataBlocked,
-                            stream_id: stream_id.as_u64().to_string(),
-                            limit: stream_data_limit.to_string(),
-                        },
-                        Frame::StreamsBlocked {
-                            stream_type,
-                            stream_limit,
-                        } => QuicFrame::StreamsBlocked {
-                            frame_type: QuicFrameTypeName::StreamsBlocked,
-                            stream_type: match stream_type {
-                                frame::StreamType::BiDi => qlog::StreamType::Bidirectional,
-                                frame::StreamType::UniDi => qlog::StreamType::Unidirectional,
-                            },
-                            limit: stream_limit.as_u64().to_string(),
-                        },
-                        Frame::NewConnectionId {
-                            sequence_number,
-                            retire_prior,
-                            connection_id,
-                            stateless_reset_token,
-                        } => QuicFrame::NewConnectionId {
-                            frame_type: QuicFrameTypeName::NewConnectionId,
-                            sequence_number: sequence_number.to_string(),
-                            retire_prior_to: retire_prior.to_string(),
-                            length: connection_id.len() as u64,
-                            connection_id: hex(&connection_id),
-                            reset_token: hex(&stateless_reset_token),
-                        },
-                        Frame::RetireConnectionId { sequence_number } => {
-                            QuicFrame::RetireConnectionId {
-                                frame_type: QuicFrameTypeName::RetireConnectionId,
-                                sequence_number: sequence_number.to_string(),
-                            }
-                        }
-                        Frame::PathChallenge { data } => QuicFrame::PathChallenge {
-                            frame_type: QuicFrameTypeName::PathChallenge,
-                            data: Some(hex(&data)),
-                        },
-                        Frame::PathResponse { data } => QuicFrame::PathResponse {
-                            frame_type: QuicFrameTypeName::PathResponse,
-                            data: Some(hex(&data)),
-                        },
-                        Frame::ConnectionClose {
-                            error_code,
-                            frame_type,
-                            reason_phrase,
-                        } => QuicFrame::ConnectionClose {
-                            frame_type: QuicFrameTypeName::ConnectionClose,
-                            error_space: match error_code {
-                                frame::CloseError::Transport(_) => qlog::ErrorSpace::TransportError,
-                                frame::CloseError::Application(_) => {
-                                    qlog::ErrorSpace::ApplicationError
-                                }
-                            },
-                            error_code: error_code.code(),
-                            raw_error_code: 0,
-                            reason: String::from_utf8_lossy(&reason_phrase).to_string(),
-                            trigger_frame_type: Some(frame_type.to_string()),
-                        },
-                        Frame::HandshakeDone => QuicFrame::Unknown {
-                            frame_type: QuicFrameTypeName::Unknown,
-                            raw_frame_type: 0x1e,
-                        },
-                    };
-
-                    frames.push(qlogframe);
-                }
+                Ok(f) => frames.push(frame_to_qlogframe(&f)),
                 Err(_) => {
                     qinfo!("qlog: invalid frame");
                     break;
@@ -221,15 +116,7 @@ pub fn packet_received(qlog: &Option<NeqoQlogRef>, now: Instant, payload: &Decry
             }
         }
 
-        let packet_type = match payload.packet_type() {
-            PacketType::Initial => qlog::PacketType::Initial,
-            PacketType::Handshake => qlog::PacketType::Handshake,
-            PacketType::ZeroRtt => qlog::PacketType::ZeroRtt,
-            PacketType::Short => qlog::PacketType::OneRtt,
-            PacketType::Retry => qlog::PacketType::Retry,
-            PacketType::VersionNegotiation => qlog::PacketType::VersionNegotiation,
-            PacketType::OtherVersion => qlog::PacketType::Unknown,
-        };
+        let packet_type = pkt_type_to_qlog_pkt_type(&payload.packet_type());
 
         qlog.trace.push_transport_event(
             format!("{}", elapsed.as_micros()),
@@ -252,5 +139,170 @@ pub fn packet_received(qlog: &Option<NeqoQlogRef>, now: Instant, payload: &Decry
                 raw_decrypted: None,
             },
         )
+    }
+}
+
+// Helper functions
+
+fn frame_to_qlogframe(frame: &Frame) -> QuicFrame {
+    match frame {
+        Frame::Padding => QuicFrame::Padding {
+            frame_type: QuicFrameTypeName::Padding,
+        },
+        Frame::Ping => QuicFrame::Ping {
+            frame_type: QuicFrameTypeName::Ping,
+        },
+        Frame::Ack { ack_delay, .. } => QuicFrame::Ack {
+            frame_type: QuicFrameTypeName::Ack,
+            ack_delay: Some(ack_delay.to_string()),
+            acked_ranges: None,
+            ect1: None,
+            ect0: None,
+            ce: None,
+        },
+        Frame::ResetStream {
+            stream_id,
+            application_error_code,
+            final_size,
+        } => QuicFrame::ResetStream {
+            frame_type: QuicFrameTypeName::ResetStream,
+            stream_id: stream_id.as_u64().to_string(),
+            error_code: *application_error_code,
+            final_size: final_size.to_string(),
+        },
+        Frame::StopSending {
+            stream_id,
+            application_error_code,
+        } => QuicFrame::StopSending {
+            frame_type: QuicFrameTypeName::StopSending,
+            stream_id: stream_id.as_u64().to_string(),
+            error_code: *application_error_code,
+        },
+        Frame::Crypto { offset, data } => QuicFrame::Crypto {
+            frame_type: QuicFrameTypeName::Crypto,
+            offset: offset.to_string(),
+            length: data.len().to_string(),
+        },
+        Frame::NewToken { token } => QuicFrame::NewToken {
+            frame_type: QuicFrameTypeName::NewToken,
+            length: token.len().to_string(),
+            token: hex(&token),
+        },
+        Frame::Stream {
+            fin,
+            stream_id,
+            offset,
+            data,
+            ..
+        } => QuicFrame::Stream {
+            frame_type: QuicFrameTypeName::Stream,
+            stream_id: stream_id.as_u64().to_string(),
+            offset: offset.to_string(),
+            length: data.len().to_string(),
+            fin: *fin,
+            raw: None,
+        },
+        Frame::MaxData { maximum_data } => QuicFrame::MaxData {
+            frame_type: QuicFrameTypeName::MaxData,
+            maximum: maximum_data.to_string(),
+        },
+        Frame::MaxStreamData {
+            stream_id,
+            maximum_stream_data,
+        } => QuicFrame::MaxStreamData {
+            frame_type: QuicFrameTypeName::MaxStreamData,
+            stream_id: stream_id.as_u64().to_string(),
+            maximum: maximum_stream_data.to_string(),
+        },
+        Frame::MaxStreams {
+            stream_type,
+            maximum_streams,
+        } => QuicFrame::MaxStreams {
+            frame_type: QuicFrameTypeName::MaxData,
+            stream_type: match stream_type {
+                frame::StreamType::BiDi => qlog::StreamType::Bidirectional,
+                frame::StreamType::UniDi => qlog::StreamType::Unidirectional,
+            },
+            maximum: maximum_streams.as_u64().to_string(),
+        },
+        Frame::DataBlocked { data_limit } => QuicFrame::DataBlocked {
+            frame_type: QuicFrameTypeName::DataBlocked,
+            limit: data_limit.to_string(),
+        },
+        Frame::StreamDataBlocked {
+            stream_id,
+            stream_data_limit,
+        } => QuicFrame::StreamDataBlocked {
+            frame_type: QuicFrameTypeName::StreamDataBlocked,
+            stream_id: stream_id.as_u64().to_string(),
+            limit: stream_data_limit.to_string(),
+        },
+        Frame::StreamsBlocked {
+            stream_type,
+            stream_limit,
+        } => QuicFrame::StreamsBlocked {
+            frame_type: QuicFrameTypeName::StreamsBlocked,
+            stream_type: match stream_type {
+                frame::StreamType::BiDi => qlog::StreamType::Bidirectional,
+                frame::StreamType::UniDi => qlog::StreamType::Unidirectional,
+            },
+            limit: stream_limit.as_u64().to_string(),
+        },
+        Frame::NewConnectionId {
+            sequence_number,
+            retire_prior,
+            connection_id,
+            stateless_reset_token,
+        } => QuicFrame::NewConnectionId {
+            frame_type: QuicFrameTypeName::NewConnectionId,
+            sequence_number: sequence_number.to_string(),
+            retire_prior_to: retire_prior.to_string(),
+            length: connection_id.len() as u64,
+            connection_id: hex(&connection_id),
+            reset_token: hex(stateless_reset_token),
+        },
+        Frame::RetireConnectionId { sequence_number } => QuicFrame::RetireConnectionId {
+            frame_type: QuicFrameTypeName::RetireConnectionId,
+            sequence_number: sequence_number.to_string(),
+        },
+        Frame::PathChallenge { data } => QuicFrame::PathChallenge {
+            frame_type: QuicFrameTypeName::PathChallenge,
+            data: Some(hex(data)),
+        },
+        Frame::PathResponse { data } => QuicFrame::PathResponse {
+            frame_type: QuicFrameTypeName::PathResponse,
+            data: Some(hex(data)),
+        },
+        Frame::ConnectionClose {
+            error_code,
+            frame_type,
+            reason_phrase,
+        } => QuicFrame::ConnectionClose {
+            frame_type: QuicFrameTypeName::ConnectionClose,
+            error_space: match error_code {
+                frame::CloseError::Transport(_) => qlog::ErrorSpace::TransportError,
+                frame::CloseError::Application(_) => qlog::ErrorSpace::ApplicationError,
+            },
+            error_code: error_code.code(),
+            raw_error_code: 0,
+            reason: String::from_utf8_lossy(&reason_phrase).to_string(),
+            trigger_frame_type: Some(frame_type.to_string()),
+        },
+        Frame::HandshakeDone => QuicFrame::Unknown {
+            frame_type: QuicFrameTypeName::Unknown,
+            raw_frame_type: 0x1e,
+        },
+    }
+}
+
+fn pkt_type_to_qlog_pkt_type(ptype: &PacketType) -> qlog::PacketType {
+    match ptype {
+        PacketType::Initial => qlog::PacketType::Initial,
+        PacketType::Handshake => qlog::PacketType::Handshake,
+        PacketType::ZeroRtt => qlog::PacketType::ZeroRtt,
+        PacketType::Short => qlog::PacketType::OneRtt,
+        PacketType::Retry => qlog::PacketType::Retry,
+        PacketType::VersionNegotiation => qlog::PacketType::VersionNegotiation,
+        PacketType::OtherVersion => qlog::PacketType::Unknown,
     }
 }

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -1,0 +1,256 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Functions that handle capturing QLOG traces.
+
+use std::string::String;
+use std::time::Instant;
+
+use qlog::{
+    self, ConnectivityEventType, EventData, PacketHeader, QuicFrame, QuicFrameTypeName,
+    TransportEventType,
+};
+
+use neqo_common::{hex, qinfo, Decoder, NeqoQlogRef};
+
+use crate::frame::{self, Frame};
+use crate::packet::{DecryptedPacket, PacketType};
+use crate::path::Path;
+use crate::QUIC_VERSION;
+
+pub fn client_connection_started(qlog: &Option<NeqoQlogRef>, now: Instant, path: &Path) {
+    if let Some(qlog) = qlog {
+        let mut qlog = qlog.borrow_mut();
+        let elapsed = now.duration_since(qlog.zero_time);
+
+        qlog.trace.push_connectivity_event(
+            format!("{}", elapsed.as_micros()),
+            ConnectivityEventType::ConnectionStarted,
+            EventData::ConnectionStarted {
+                ip_version: if path.local_sock().ip().is_ipv4() {
+                    "ipv4".into()
+                } else {
+                    "ipv6".into()
+                },
+                src_ip: format!("{}", path.local_sock().ip()),
+                dst_ip: format!("{}", path.remote_sock().ip()),
+                protocol: Some("QUIC".into()),
+                src_port: path.local_sock().port().into(),
+                dst_port: path.remote_sock().port().into(),
+                quic_version: Some(format!("{:x}", QUIC_VERSION)),
+                src_cid: Some(format!("{}", path.local_cid())),
+                dst_cid: Some(format!("{}", path.remote_cid())),
+            },
+        )
+    }
+}
+
+pub fn packet_received(qlog: &Option<NeqoQlogRef>, now: Instant, payload: &DecryptedPacket) {
+    if let Some(qlog) = qlog {
+        let mut qlog = qlog.borrow_mut();
+        let elapsed = now.duration_since(qlog.zero_time);
+
+        let mut frames = Vec::new();
+        let mut d = Decoder::from(&payload[..]);
+
+        while d.remaining() > 0 {
+            match Frame::decode(&mut d) {
+                Ok(f) => {
+                    let qlogframe = match f {
+                        Frame::Padding => QuicFrame::Padding {
+                            frame_type: QuicFrameTypeName::Padding,
+                        },
+                        Frame::Ping => QuicFrame::Ping {
+                            frame_type: QuicFrameTypeName::Ping,
+                        },
+                        Frame::Ack { ack_delay, .. } => QuicFrame::Ack {
+                            frame_type: QuicFrameTypeName::Ack,
+                            ack_delay: Some(ack_delay.to_string()),
+                            acked_ranges: None,
+                            ect1: None,
+                            ect0: None,
+                            ce: None,
+                        },
+                        Frame::ResetStream {
+                            stream_id,
+                            application_error_code,
+                            final_size,
+                        } => QuicFrame::ResetStream {
+                            frame_type: QuicFrameTypeName::ResetStream,
+                            stream_id: stream_id.as_u64().to_string(),
+                            error_code: application_error_code,
+                            final_size: final_size.to_string(),
+                        },
+                        Frame::StopSending {
+                            stream_id,
+                            application_error_code,
+                        } => QuicFrame::StopSending {
+                            frame_type: QuicFrameTypeName::StopSending,
+                            stream_id: stream_id.as_u64().to_string(),
+                            error_code: application_error_code,
+                        },
+                        Frame::Crypto { offset, data } => QuicFrame::Crypto {
+                            frame_type: QuicFrameTypeName::Crypto,
+                            offset: offset.to_string(),
+                            length: data.len().to_string(),
+                        },
+                        Frame::NewToken { token } => QuicFrame::NewToken {
+                            frame_type: QuicFrameTypeName::NewToken,
+                            length: token.len().to_string(),
+                            token: hex(&token),
+                        },
+                        Frame::Stream {
+                            fin,
+                            stream_id,
+                            offset,
+                            data,
+                            ..
+                        } => QuicFrame::Stream {
+                            frame_type: QuicFrameTypeName::Stream,
+                            stream_id: stream_id.as_u64().to_string(),
+                            offset: offset.to_string(),
+                            length: data.len().to_string(),
+                            fin,
+                            raw: None,
+                        },
+                        Frame::MaxData { maximum_data } => QuicFrame::MaxData {
+                            frame_type: QuicFrameTypeName::MaxData,
+                            maximum: maximum_data.to_string(),
+                        },
+                        Frame::MaxStreamData {
+                            stream_id,
+                            maximum_stream_data,
+                        } => QuicFrame::MaxStreamData {
+                            frame_type: QuicFrameTypeName::MaxStreamData,
+                            stream_id: stream_id.as_u64().to_string(),
+                            maximum: maximum_stream_data.to_string(),
+                        },
+                        Frame::MaxStreams {
+                            stream_type,
+                            maximum_streams,
+                        } => QuicFrame::MaxStreams {
+                            frame_type: QuicFrameTypeName::MaxData,
+                            stream_type: match stream_type {
+                                frame::StreamType::BiDi => qlog::StreamType::Bidirectional,
+                                frame::StreamType::UniDi => qlog::StreamType::Unidirectional,
+                            },
+                            maximum: maximum_streams.as_u64().to_string(),
+                        },
+                        Frame::DataBlocked { data_limit } => QuicFrame::DataBlocked {
+                            frame_type: QuicFrameTypeName::DataBlocked,
+                            limit: data_limit.to_string(),
+                        },
+                        Frame::StreamDataBlocked {
+                            stream_id,
+                            stream_data_limit,
+                        } => QuicFrame::StreamDataBlocked {
+                            frame_type: QuicFrameTypeName::StreamDataBlocked,
+                            stream_id: stream_id.as_u64().to_string(),
+                            limit: stream_data_limit.to_string(),
+                        },
+                        Frame::StreamsBlocked {
+                            stream_type,
+                            stream_limit,
+                        } => QuicFrame::StreamsBlocked {
+                            frame_type: QuicFrameTypeName::StreamsBlocked,
+                            stream_type: match stream_type {
+                                frame::StreamType::BiDi => qlog::StreamType::Bidirectional,
+                                frame::StreamType::UniDi => qlog::StreamType::Unidirectional,
+                            },
+                            limit: stream_limit.as_u64().to_string(),
+                        },
+                        Frame::NewConnectionId {
+                            sequence_number,
+                            retire_prior,
+                            connection_id,
+                            stateless_reset_token,
+                        } => QuicFrame::NewConnectionId {
+                            frame_type: QuicFrameTypeName::NewConnectionId,
+                            sequence_number: sequence_number.to_string(),
+                            retire_prior_to: retire_prior.to_string(),
+                            length: connection_id.len() as u64,
+                            connection_id: hex(&connection_id),
+                            reset_token: hex(&stateless_reset_token),
+                        },
+                        Frame::RetireConnectionId { sequence_number } => {
+                            QuicFrame::RetireConnectionId {
+                                frame_type: QuicFrameTypeName::RetireConnectionId,
+                                sequence_number: sequence_number.to_string(),
+                            }
+                        }
+                        Frame::PathChallenge { data } => QuicFrame::PathChallenge {
+                            frame_type: QuicFrameTypeName::PathChallenge,
+                            data: Some(hex(&data)),
+                        },
+                        Frame::PathResponse { data } => QuicFrame::PathResponse {
+                            frame_type: QuicFrameTypeName::PathResponse,
+                            data: Some(hex(&data)),
+                        },
+                        Frame::ConnectionClose {
+                            error_code,
+                            frame_type,
+                            reason_phrase,
+                        } => QuicFrame::ConnectionClose {
+                            frame_type: QuicFrameTypeName::ConnectionClose,
+                            error_space: match error_code {
+                                frame::CloseError::Transport(_) => qlog::ErrorSpace::TransportError,
+                                frame::CloseError::Application(_) => {
+                                    qlog::ErrorSpace::ApplicationError
+                                }
+                            },
+                            error_code: error_code.code(),
+                            raw_error_code: 0,
+                            reason: String::from_utf8_lossy(&reason_phrase).to_string(),
+                            trigger_frame_type: Some(frame_type.to_string()),
+                        },
+                        Frame::HandshakeDone => QuicFrame::Unknown {
+                            frame_type: QuicFrameTypeName::Unknown,
+                            raw_frame_type: 0x1e,
+                        },
+                    };
+
+                    frames.push(qlogframe);
+                }
+                Err(_) => {
+                    qinfo!("qlog: invalid frame");
+                    break;
+                }
+            }
+        }
+
+        let packet_type = match payload.packet_type() {
+            PacketType::Initial => qlog::PacketType::Initial,
+            PacketType::Handshake => qlog::PacketType::Handshake,
+            PacketType::ZeroRtt => qlog::PacketType::ZeroRtt,
+            PacketType::Short => qlog::PacketType::OneRtt,
+            PacketType::Retry => qlog::PacketType::Retry,
+            PacketType::VersionNegotiation => qlog::PacketType::VersionNegotiation,
+            PacketType::OtherVersion => qlog::PacketType::Unknown,
+        };
+
+        qlog.trace.push_transport_event(
+            format!("{}", elapsed.as_micros()),
+            TransportEventType::PacketReceived,
+            EventData::PacketReceived {
+                packet_type,
+                header: PacketHeader {
+                    packet_number: payload.pn().to_string(),
+                    packet_size: None,
+                    payload_length: None,
+                    version: None,
+                    scil: None,
+                    dcil: None,
+                    scid: None,
+                    dcid: None,
+                },
+                frames: Some(frames),
+                is_coalesced: None,
+                raw_encrypted: None,
+                raw_decrypted: None,
+            },
+        )
+    }
+}

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -335,6 +335,7 @@ impl Server {
             &self.protocols,
             &self.anti_replay,
             cid_mgr.clone(),
+            None,
         );
         if let Ok(mut c) = sconn {
             if let Some(odcid) = odcid {

--- a/neqo-transport/src/stream_id.rs
+++ b/neqo-transport/src/stream_id.rs
@@ -8,7 +8,9 @@
 
 use std::ops::AddAssign;
 
-use crate::connection::{Role, LOCAL_STREAM_LIMIT_BIDI, LOCAL_STREAM_LIMIT_UNI};
+use neqo_common::Role;
+
+use crate::connection::{LOCAL_STREAM_LIMIT_BIDI, LOCAL_STREAM_LIMIT_UNI};
 use crate::frame::StreamType;
 
 pub struct StreamIndexes {

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -245,6 +245,18 @@ impl TransportParameters {
         }
     }
 
+    pub fn get_empty(&self, tipe: u16) -> Option<TransportParameter> {
+        let default = match tipe {
+            DISABLE_MIGRATION => None,
+            _ => panic!("Transport parameter not known or not an Empty"),
+        };
+        match self.params.get(&tipe) {
+            None => default,
+            Some(TransportParameter::Empty) => Some(TransportParameter::Empty),
+            _ => panic!("Internal error"),
+        }
+    }
+
     /// Return true if the remembered transport parameters are OK for 0-RTT.
     /// Generally this means that any value that is currently in effect is greater than
     /// or equal to the promised value.

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -36,6 +36,7 @@ fn default_server() -> Server {
         test_fixture::DEFAULT_ALPN,
         test_fixture::anti_replay(),
         Rc::new(RefCell::new(FixedConnectionIdManager::new(9))),
+        None,
     )
     .expect("should create a server")
 }

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -77,6 +77,7 @@ pub fn default_client() -> Connection {
         Rc::new(RefCell::new(FixedConnectionIdManager::new(3))),
         loopback(),
         loopback(),
+        None,
     )
     .expect("create a default client")
 }
@@ -90,6 +91,7 @@ pub fn default_server() -> Connection {
         DEFAULT_ALPN,
         &anti_replay(),
         Rc::new(RefCell::new(FixedConnectionIdManager::new(5))),
+        None,
     )
     .expect("create a default server")
 }
@@ -141,6 +143,7 @@ pub fn default_http3_client() -> Http3Client {
         loopback(),
         100,
         100,
+        None,
     )
     .expect("create a default client")
 }

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -160,6 +160,7 @@ pub fn default_http3_server() -> Http3Server {
         Rc::new(RefCell::new(FixedConnectionIdManager::new(5))),
         100,
         100,
+        None,
     )
     .expect("create a default server")
 }


### PR DESCRIPTION
Add optional qlog context when creating a Connection.

Pass qlog context into Connection from neqo-client. Add cmdline option
to save qlog to a file.

Implement initial trace hooks for client connected start and packet
received. Still a lot more to do.