### PR TITLE
Key updates

### DIFF
--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -655,18 +655,20 @@ impl SecretAgent {
         self.fd = null_mut();
     }
 
-    // State returns the status of the handshake.
+    /// State returns the status of the handshake.
     #[must_use]
     pub fn state(&self) -> &HandshakeState {
         &self.state
     }
+    /// Take a read secret.  This will only return a non-`None` value once.
     #[must_use]
-    pub fn read_secret(&self, epoch: Epoch) -> Option<&p11::SymKey> {
-        self.secrets.read().get(epoch)
+    pub fn read_secret(&mut self, epoch: Epoch) -> Option<p11::SymKey> {
+        self.secrets.take_read(epoch)
     }
+    /// Take a write secret.
     #[must_use]
-    pub fn write_secret(&self, epoch: Epoch) -> Option<&p11::SymKey> {
-        self.secrets.write().get(epoch)
+    pub fn write_secret(&mut self, epoch: Epoch) -> Option<p11::SymKey> {
+        self.secrets.take_write(epoch)
     }
 }
 

--- a/neqo-crypto/src/secrets.rs
+++ b/neqo-crypto/src/secrets.rs
@@ -4,14 +4,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::agentio::as_c_void;
 use crate::constants::*;
 use crate::err::Res;
 use crate::p11::{PK11SymKey, PK11_ReferenceSymKey, SymKey};
 use crate::ssl::{PRFileDesc, SSLSecretCallback, SSLSecretDirection};
 
 use neqo_common::qdebug;
-use std::ops::Deref;
 use std::os::raw::c_void;
+use std::pin::Pin;
 use std::ptr::NonNull;
 
 experimental_api!(SSL_SecretCallback(
@@ -45,7 +46,7 @@ pub struct DirectionalSecrets {
 }
 
 impl DirectionalSecrets {
-    pub fn put(&mut self, epoch: Epoch, key: SymKey) {
+    fn put(&mut self, epoch: Epoch, key: SymKey) {
         assert!(epoch > 0);
         let i = (epoch - 1) as usize;
         assert!(i < self.secrets.len());
@@ -53,11 +54,11 @@ impl DirectionalSecrets {
         self.secrets[i] = Some(key);
     }
 
-    pub fn get(&self, epoch: Epoch) -> Option<&SymKey> {
+    pub fn take(&mut self, epoch: Epoch) -> Option<SymKey> {
         assert!(epoch > 0);
         let i = (epoch - 1) as usize;
         assert!(i < self.secrets.len());
-        self.secrets[i].as_ref()
+        self.secrets[i].take()
     }
 }
 
@@ -86,10 +87,10 @@ impl Secrets {
             None => panic!("NSS shouldn't be passing out NULL secrets"),
             Some(p) => SymKey::new(p),
         };
-        self.put(dir.into(), epoch, key);
+        self.put(SecretDirection::from(dir), epoch, key);
     }
 
-    pub fn put(&mut self, dir: SecretDirection, epoch: Epoch, key: SymKey) {
+    fn put(&mut self, dir: SecretDirection, epoch: Epoch, key: SymKey) {
         qdebug!("{:?} secret available for {:?}", dir, epoch);
         let keys = match dir {
             SecretDirection::Read => &mut self.r,
@@ -97,33 +98,34 @@ impl Secrets {
         };
         keys.put(epoch, key);
     }
-
-    pub fn read(&self) -> &DirectionalSecrets {
-        &self.r
-    }
-
-    pub fn write(&self) -> &DirectionalSecrets {
-        &self.w
-    }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SecretHolder {
-    secrets: Box<Secrets>,
+    secrets: Pin<Box<Secrets>>,
 }
 
 impl SecretHolder {
     /// This registers with NSS.  The lifetime of this object needs to match the lifetime
     /// of the connection, or bad things might happen.
     pub fn register(&mut self, fd: *mut PRFileDesc) -> Res<()> {
-        let p = &*self.secrets as *const Secrets as *const c_void;
-        unsafe { SSL_SecretCallback(fd, Some(Secrets::secret_available), p as *mut c_void) }
+        let p = as_c_void(&mut self.secrets);
+        unsafe { SSL_SecretCallback(fd, Some(Secrets::secret_available), p) }
+    }
+
+    pub fn take_read(&mut self, epoch: Epoch) -> Option<SymKey> {
+        self.secrets.r.take(epoch)
+    }
+
+    pub fn take_write(&mut self, epoch: Epoch) -> Option<SymKey> {
+        self.secrets.w.take(epoch)
     }
 }
 
-impl Deref for SecretHolder {
-    type Target = Secrets;
-    fn deref(&self) -> &Self::Target {
-        self.secrets.as_ref()
+impl Default for SecretHolder {
+    fn default() -> Self {
+        Self {
+            secrets: Box::pin(Secrets::default()),
+        }
     }
 }

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -568,7 +568,7 @@ impl Connection {
     /// Call by application when the peer cert has been verified
     pub fn authenticated(&mut self, status: AuthenticationStatus, now: Instant) {
         self.crypto.tls.authenticated(status);
-        let res = self.handshake(now, PNSpace::Initial, None);
+        let res = self.handshake(now, PNSpace::Handshake, None);
         self.absorb_error(now, res);
     }
 

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1333,16 +1333,14 @@ impl Connection {
     fn handshake(&mut self, now: Instant, space: PNSpace, data: Option<&[u8]>) -> Res<()> {
         qdebug!("Handshake space={} data={:0x?}", space, data);
 
-        let rec = if let Some(d) = data {
+        let rec = data.map(|d| {
             qdebug!([self], "Handshake received {:0x?} ", d);
-            Some(Record {
+            Record {
                 ct: 22, // TODO(ekr@rtfm.com): Symbolic constants for CT. This is handshake.
                 epoch: space.into(),
                 data: d.to_vec(),
-            })
-        } else {
-            None
-        };
+            }
+        });
         let try_update = rec.is_some();
 
         match self.crypto.tls.handshake_raw(now, rec) {

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1664,7 +1664,7 @@ impl Connection {
 
         // Setting application keys has to occur after 0-RTT rejection.
         let pto = self.loss_recovery.pto();
-        self.crypto.set_application_keys(now + pto)?;
+        self.crypto.install_application_keys(now + pto)?;
         self.validate_odcid()?;
         self.set_initial_limits();
         self.set_state(State::Connected);

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -5,19 +5,24 @@
 // except according to those terms.
 
 use std::cell::RefCell;
+use std::cmp::max;
+use std::mem;
+use std::ops::{Index, IndexMut, Range};
 use std::rc::Rc;
+use std::time::Instant;
 
 use neqo_common::{hex, matches, qdebug, qinfo, qtrace};
 use neqo_crypto::aead::Aead;
 use neqo_crypto::hp::HpKey;
 use neqo_crypto::{
     hkdf, Agent, AntiReplay, Cipher, Epoch, RecordList, SymKey, TLS_AES_128_GCM_SHA256,
-    TLS_AES_256_GCM_SHA384, TLS_VERSION_1_3,
+    TLS_AES_256_GCM_SHA384, TLS_EPOCH_APPLICATION_DATA, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL,
+    TLS_EPOCH_ZERO_RTT, TLS_VERSION_1_3,
 };
 
 use crate::connection::Role;
 use crate::frame::{Frame, TxMode};
-use crate::packet::{CryptoCtx, PacketNumber};
+use crate::packet::{HeaderProtectionMask, PacketNumber, Protector, Unprotector};
 use crate::recovery::RecoveryToken;
 use crate::recv_stream::RxStreamOrderer;
 use crate::send_stream::TxBuffer;
@@ -31,7 +36,7 @@ const MAX_AUTH_TAG: usize = 32;
 pub struct Crypto {
     pub(crate) tls: Agent,
     pub(crate) streams: CryptoStreams,
-    pub(crate) states: [CryptoState; 4],
+    pub(crate) states: CryptoStates,
 }
 
 impl Crypto {
@@ -61,90 +66,90 @@ impl Crypto {
         })
     }
 
-    pub fn obtain(&mut self, role: Role, epoch: Epoch) -> Res<&mut CryptoState> {
-        // Try to get CryptoState if it is not initialized and we have keys.
-        self.try_to_get_crypto_state(role, epoch)?;
+    /// Enable 0-RTT and return `true` if it is enabled successfully.
+    pub fn enable_0rtt(&mut self, role: Role) -> Res<bool> {
+        let info = self.tls.preinfo()?;
+        // `info.early_data()` returns false for a server,
+        // so use `early_data_cipher()` to tell if 0-RTT is enabled.
+        let cipher = info.early_data_cipher();
+        if cipher.is_none() {
+            return Ok(false);
+        }
+        let (dir, secret) = match role {
+            Role::Client => (
+                CryptoDxDirection::Write,
+                self.tls.write_secret(TLS_EPOCH_ZERO_RTT),
+            ),
+            Role::Server => (
+                CryptoDxDirection::Read,
+                self.tls.read_secret(TLS_EPOCH_ZERO_RTT),
+            ),
+        };
+        let secret = secret.ok_or(Error::KeysNotFound)?;
+        self.states.set_0rtt_keys(dir, &secret, cipher.unwrap());
+        Ok(true)
+    }
 
-        if matches!(self.states[epoch as usize], CryptoState::Active{..}) {
-            Ok(&mut self.states[epoch as usize])
-        } else {
-            Err(Error::KeysNotFound)
+    pub fn install_keys(&mut self, role: Role) {
+        // There are no direct events to drive the installation of these keys, so we
+        // attempt to set them each time new CRYPTO frames arrive.
+        qtrace!([self], "Attempt to install keys");
+        if !self.tls.state().is_final() && self.states.handshake.is_none() {
+            if let Err(e) = self.set_handshake_keys() {
+                qdebug!([self], "unable to set handshake keys yet: {:?}", e);
+                return;
+            }
+        }
+        if role == Role::Server {
+            if let Err(e) = self.set_application_write_key() {
+                qdebug!([self], "unable to set application key yet: {:?}", e);
+            }
         }
     }
 
-    pub fn try_to_get_crypto_state(&mut self, role: Role, epoch: Epoch) -> Res<()> {
-        if !matches!(self.states[epoch as usize], CryptoState::NoInit) {
-            return Ok(());
-        }
-
-        #[cfg(debug_assertions)]
-        let label = format!("{}", self);
-        #[cfg(not(debug_assertions))]
-        let label = "";
-
-        qtrace!([label], "Build crypto state for epoch {}", epoch);
-        assert!(epoch != 0 && epoch != 1); // The state for 0 is made directly. The state for 1 is never used, it is handle differently.
-
+    fn set_handshake_keys(&mut self) -> Res<()> {
+        let write_secret = self
+            .tls
+            .write_secret(TLS_EPOCH_HANDSHAKE)
+            .ok_or(Error::KeysNotFound)?;
+        let read_secret = self
+            .tls
+            .read_secret(TLS_EPOCH_HANDSHAKE)
+            .ok_or(Error::KeysNotFound)?;
         let cipher = match self.tls.info() {
             None => self.tls.preinfo()?.cipher_suite(),
             Some(info) => Some(info.cipher_suite()),
         }
-        .ok_or_else(|| {
-            qdebug!([label], "cipher info not available yet");
-            Error::KeysNotFound
-        })?;
-
-        let rx = self
-            .tls
-            .read_secret(epoch)
-            .map(|rs| CryptoDxState::new(CryptoDxDirection::Read, epoch, rs, cipher));
-        let tx = self
-            .tls
-            .write_secret(epoch)
-            .map(|ws| CryptoDxState::new(CryptoDxDirection::Write, epoch, ws, cipher));
-
-        // Validate the key setup.
-        match (&rx, &tx, role, epoch) {
-            (Some(_), Some(_), _, _) => {}
-            (None, None, _, _) => {
-                qdebug!([label], "Keying material not available for epoch {}", epoch);
-                return Err(Error::KeysNotFound);
-            }
-            _ => panic!("bad configuration of keys"),
-        }
-
-        self.states[epoch as usize] = CryptoState::Active { rx, tx };
-        self.streams.streams[epoch as usize] = Some(Default::default());
+        .ok_or(Error::KeysNotFound)?;
+        self.states
+            .set_handshake_keys(&write_secret, &read_secret, cipher);
+        qdebug!([self], "handshake keys installed");
         Ok(())
     }
 
-    // Create the initial crypto state.
-    pub fn create_initial_state(&mut self, role: Role, dcid: &[u8]) {
-        const CLIENT_INITIAL_LABEL: &str = "client in";
-        const SERVER_INITIAL_LABEL: &str = "server in";
-
-        qinfo!(
-            [self],
-            "Creating initial cipher state role={:?} dcid={}",
-            role,
-            hex(dcid)
-        );
-
-        let (write_label, read_label) = match role {
-            Role::Client => (CLIENT_INITIAL_LABEL, SERVER_INITIAL_LABEL),
-            Role::Server => (SERVER_INITIAL_LABEL, CLIENT_INITIAL_LABEL),
-        };
-
-        if self.streams.streams[0].is_none() {
-            // If this is the first call create streams as well.
-            // For retry we do not want to create a new stream as well.
-            self.streams.streams[0] = Some(Default::default());
+    fn set_application_write_key(&mut self) -> Res<()> {
+        if self.states.app_write.is_none() {
+            let write_secret = self
+                .tls
+                .write_secret(TLS_EPOCH_APPLICATION_DATA)
+                .ok_or(Error::KeysNotFound)?;
+            self.states
+                .set_application_write_key(write_secret.clone())?;
         }
+        qdebug!([self], "application write key installed");
+        Ok(())
+    }
 
-        self.states[0] = CryptoState::Active {
-            tx: CryptoDxState::new_initial(CryptoDxDirection::Write, write_label, dcid),
-            rx: CryptoDxState::new_initial(CryptoDxDirection::Read, read_label, dcid),
-        };
+    pub fn set_application_keys(&mut self, expire_0rtt: Instant) -> Res<()> {
+        self.set_application_write_key()?;
+        let read_secret = self
+            .tls
+            .read_secret(TLS_EPOCH_APPLICATION_DATA)
+            .ok_or(Error::KeysNotFound)?;
+        self.states
+            .set_application_read_key(read_secret.clone(), expire_0rtt)?;
+        qdebug!([self], "application read keys installed");
+        Ok(())
     }
 
     /// Buffer crypto records for sending.
@@ -152,15 +157,14 @@ impl Crypto {
         for r in records {
             assert_eq!(r.ct, 22);
             qdebug!([self], "Adding CRYPTO data {:?}", r);
-            assert!(r.epoch != 1);
-            self.streams.send(r.epoch, &r.data);
+            self.streams.send(PNSpace::from(r.epoch), &r.data);
         }
     }
 
     pub fn acked(&mut self, token: CryptoRecoveryToken) {
         qinfo!(
-            "Acked crypto frame epoch={} offset={} length={}",
-            token.epoch,
+            "Acked crypto frame space={} offset={} length={}",
+            token.space,
             token.offset,
             token.length
         );
@@ -169,39 +173,17 @@ impl Crypto {
 
     pub fn lost(&mut self, token: &CryptoRecoveryToken) {
         qinfo!(
-            "Lost crypto frame epoch={} offset={} length={}",
-            token.epoch,
+            "Lost crypto frame space={} offset={} length={}",
+            token.space,
             token.offset,
             token.length
         );
         self.streams.lost(token);
     }
 
-    fn epoch(&self, pn_space: PNSpace) -> Epoch {
-        match pn_space {
-            PNSpace::Initial => 0,
-            PNSpace::Handshake => 2,
-            PNSpace::ApplicationData => 3, // 0RTT keys are stored differently, so this epoch will always be 3.
-        }
-    }
-
-    pub fn is_discarded(&self, pn_space: PNSpace) -> bool {
-        let epoch = self.epoch(pn_space);
-        assert!(
-            (matches!(
-                self.states[epoch as usize],
-                CryptoState::Discarded | CryptoState::NoInit
-            ) && self.streams.streams[epoch as usize].is_none())
-                || (matches!(self.states[epoch as usize], CryptoState::Active{..})
-                    && self.streams.streams[epoch as usize].is_some())
-        );
-        matches!(self.states[epoch as usize], CryptoState::Discarded)
-    }
-
-    pub fn discard(&mut self, pn_space: PNSpace) {
-        let epoch = self.epoch(pn_space);
-        self.states[epoch as usize] = CryptoState::Discarded;
-        self.streams.streams[epoch as usize] = None;
+    pub fn discard(&mut self, space: PNSpace) {
+        self.states.discard(space);
+        self.streams.discard(space);
     }
 }
 
@@ -211,7 +193,7 @@ impl ::std::fmt::Display for Crypto {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CryptoDxDirection {
     Read,
     Write,
@@ -219,10 +201,20 @@ pub enum CryptoDxDirection {
 
 #[derive(Debug)]
 pub struct CryptoDxState {
-    pub(crate) direction: CryptoDxDirection,
-    pub(crate) epoch: Epoch,
-    pub(crate) aead: Aead,
-    pub(crate) hpkey: HpKey,
+    direction: CryptoDxDirection,
+    /// The epoch of this crypto state.  This initially tracks TLS epochs
+    /// via DTLS: 0 = initial, 1 = 0-RTT, 2 = handshake, 3 = application.
+    /// But we don't need to keep that, and QUIC isn't limited in how
+    /// many times keys can be updated, so we don't use `u16` for this.
+    epoch: usize,
+    aead: Aead,
+    hpkey: HpKey,
+    /// This tracks the range of packet numbers that have been seen.  This allows
+    /// for verifying that packet numbers before a key update are strictly lower
+    /// than packet numbers after a key update.
+    used_pn: Range<PacketNumber>,
+    /// This is the minimum allowed.
+    min_pn: PacketNumber,
 }
 
 impl CryptoDxState {
@@ -240,13 +232,15 @@ impl CryptoDxState {
         );
         Self {
             direction,
-            epoch,
+            epoch: usize::from(epoch),
             aead: Aead::new(TLS_VERSION_1_3, cipher, secret, "quic ").unwrap(),
             hpkey: HpKey::extract(TLS_VERSION_1_3, cipher, secret, "quic hp").unwrap(),
+            used_pn: 0..0,
+            min_pn: 0,
         }
     }
 
-    pub fn new_initial(direction: CryptoDxDirection, label: &str, dcid: &[u8]) -> Option<Self> {
+    pub fn new_initial(direction: CryptoDxDirection, label: &str, dcid: &[u8]) -> Self {
         const INITIAL_SALT: &[u8] = &[
             0xc3, 0xee, 0xf7, 0x12, 0xc7, 0x2e, 0xbb, 0x5a, 0x11, 0xa7, 0xd2, 0x43, 0x2b, 0xb4,
             0x63, 0x65, 0xbe, 0xf9, 0xf5, 0x02,
@@ -269,34 +263,137 @@ impl CryptoDxState {
         let secret =
             hkdf::expand_label(TLS_VERSION_1_3, cipher, &initial_secret, &[], label).unwrap();
 
-        Some(Self::new(direction, 0, &secret, cipher))
+        Self::new(direction, TLS_EPOCH_INITIAL, &secret, cipher)
+    }
+
+    pub fn next(&self, next_secret: &SymKey, cipher: Cipher) -> Self {
+        let pn = self.next_pn();
+        Self {
+            direction: self.direction,
+            epoch: self.epoch + 1,
+            aead: Aead::new(TLS_VERSION_1_3, cipher, next_secret, "quic ").unwrap(),
+            hpkey: self.hpkey.clone(),
+            used_pn: pn..pn,
+            min_pn: pn,
+        }
+    }
+
+    #[must_use]
+    pub fn is_0rtt(&self) -> bool {
+        self.epoch == usize::from(TLS_EPOCH_ZERO_RTT)
+    }
+
+    #[must_use]
+    pub fn key_phase(&self) -> bool {
+        // Epoch 3 => 0, 4 => 1, 5 => 0, 6 => 1, ...
+        self.epoch & 1 != 1
+    }
+
+    #[must_use]
+    pub fn expansion(&self) -> usize {
+        self.aead.expansion()
+    }
+
+    /// This is a continuation of a previous, so adjust the range accordingly.
+    /// Fail if the two ranges overlap.  Do nothing if the directions don't match.
+    pub fn continuation(&mut self, prev: &Self) -> Res<()> {
+        debug_assert_eq!(self.direction, prev.direction);
+        let next = prev.next_pn();
+        self.min_pn = next;
+        // TODO(mt) use Range::is_empty() when available
+        if self.used_pn.start == self.used_pn.end {
+            self.used_pn = next..next;
+            Ok(())
+        } else if prev.used_pn.end > self.used_pn.start {
+            qdebug!(
+                [self],
+                "Found packet with too new packet number {} > {}, compared to {}",
+                self.used_pn.start,
+                prev.used_pn.end,
+                prev,
+            );
+            Err(Error::PacketNumberOverlap)
+        } else {
+            self.used_pn.start = next;
+            Ok(())
+        }
+    }
+
+    /// Mark a packet number as used.  If this is too low, reject it.
+    /// Note that this won't catch a value that is too high if packets protected with
+    /// old keys are received after a key update.  That needs to be caught elsewhere.
+    pub fn used(&mut self, pn: PacketNumber) -> Res<()> {
+        if pn < self.min_pn {
+            qdebug!(
+                [self],
+                "Found packet with too old packet number: {} < {}",
+                pn,
+                self.min_pn
+            );
+            return Err(Error::PacketNumberOverlap);
+        }
+        if self.used_pn.start == self.used_pn.end {
+            self.used_pn.start = pn;
+        }
+        self.used_pn.end = max(pn + 1, self.used_pn.end);
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn needs_update(&self) -> bool {
+        // Only initiate a key update if we have processed exactly one packet
+        // and we are in an epoch greater than 3.
+        self.used_pn.start + 1 == self.used_pn.end
+            && self.epoch > usize::from(TLS_EPOCH_APPLICATION_DATA)
+    }
+
+    #[must_use]
+    pub fn can_update(&self, largest_acknowledged: Option<PacketNumber>) -> bool {
+        if let Some(la) = largest_acknowledged {
+            self.used_pn.contains(&la)
+        } else {
+            // If we haven't received any acknowledgments, it's OK to update
+            // the first application data epoch.
+            self.epoch == usize::from(TLS_EPOCH_APPLICATION_DATA)
+        }
     }
 }
 
-impl CryptoCtx for CryptoDxState {
+impl HeaderProtectionMask for CryptoDxState {
     fn compute_mask(&self, sample: &[u8]) -> Res<Vec<u8>> {
         let mask = self.hpkey.mask(sample)?;
-        qdebug!("HP sample={} mask={}", hex(sample), hex(&mask));
+        qdebug!([self], "HP sample={} mask={}", hex(sample), hex(&mask));
         Ok(mask)
     }
 
-    fn aead_decrypt(&self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>> {
+    fn next_pn(&self) -> PacketNumber {
+        self.used_pn.end
+    }
+}
+
+impl Unprotector for CryptoDxState {
+    fn decrypt(&mut self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>> {
+        debug_assert_eq!(self.direction, CryptoDxDirection::Read);
         qinfo!(
             [self],
-            "aead_decrypt pn={} hdr={} body={}",
+            "decrypt pn={} hdr={} body={}",
             pn,
             hex(hdr),
             hex(body)
         );
         let mut out = vec![0; body.len()];
         let res = self.aead.decrypt(pn, hdr, body, &mut out)?;
+        self.used(pn)?;
         Ok(res.to_vec())
     }
+}
 
-    fn aead_encrypt(&self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>> {
+impl Protector for CryptoDxState {
+    fn encrypt(&mut self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>> {
+        debug_assert_eq!(self.direction, CryptoDxDirection::Write);
         qdebug!(
             [self],
-            "aead_encrypt pn={} hdr={} body={}",
+            "encrypt pn={} hdr={} body={}",
             pn,
             hex(hdr),
             hex(body)
@@ -306,8 +403,9 @@ impl CryptoCtx for CryptoDxState {
         let mut out = vec![0; size];
         let res = self.aead.encrypt(pn, hdr, body, &mut out)?;
 
-        qdebug!([self], "aead_encrypt ct={}", hex(res),);
-
+        qdebug!([self], "encrypt ct={}", hex(res));
+        debug_assert_eq!(pn, self.next_pn());
+        self.used(pn)?;
         Ok(res.to_vec())
     }
 }
@@ -319,124 +417,469 @@ impl std::fmt::Display for CryptoDxState {
 }
 
 #[derive(Debug)]
-pub enum CryptoState {
-    NoInit,
-    Active {
-        tx: Option<CryptoDxState>,
-        rx: Option<CryptoDxState>,
-    },
-    Discarded,
+pub struct CryptoState {
+    tx: CryptoDxState,
+    rx: CryptoDxState,
 }
 
-impl Default for CryptoState {
-    fn default() -> Self {
-        Self::NoInit
+impl Index<CryptoDxDirection> for CryptoState {
+    type Output = CryptoDxState;
+
+    fn index(&self, dir: CryptoDxDirection) -> &Self::Output {
+        match dir {
+            CryptoDxDirection::Read => &self.rx,
+            CryptoDxDirection::Write => &self.tx,
+        }
+    }
+}
+
+impl IndexMut<CryptoDxDirection> for CryptoState {
+    fn index_mut(&mut self, dir: CryptoDxDirection) -> &mut Self::Output {
+        match dir {
+            CryptoDxDirection::Read => &mut self.rx,
+            CryptoDxDirection::Write => &mut self.tx,
+        }
+    }
+}
+
+/// `CryptoDxAppData` wraps the state necessary for one direction of application data keys.
+/// This includes the secret needed to generate the next set of keys.
+#[derive(Debug)]
+struct CryptoDxAppData {
+    dx: CryptoDxState,
+    cipher: Cipher,
+    // Not the secret used to create `self.dx`, but the one needed for the next iteration.
+    next_secret: SymKey,
+}
+
+impl CryptoDxAppData {
+    pub fn new(dir: CryptoDxDirection, secret: SymKey, cipher: Cipher) -> Res<Self> {
+        Ok(Self {
+            dx: CryptoDxState::new(dir, TLS_EPOCH_APPLICATION_DATA, &secret, cipher),
+            cipher,
+            next_secret: Self::update_secret(cipher, &secret)?,
+        })
+    }
+
+    fn update_secret(cipher: Cipher, secret: &SymKey) -> Res<SymKey> {
+        let next = hkdf::expand_label(TLS_VERSION_1_3, cipher, secret, &[], "quic ku")?;
+        Ok(next)
+    }
+
+    pub fn next(&self) -> Res<Self> {
+        if self.dx.epoch == usize::max_value() {
+            // Guard against too many key updates.
+            return Err(Error::KeysNotFound);
+        }
+        let next_secret = Self::update_secret(self.cipher, &self.next_secret)?;
+        Ok(Self {
+            dx: self.dx.next(&next_secret, self.cipher),
+            cipher: self.cipher,
+            next_secret,
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct CryptoStates {
+    initial: Option<CryptoState>,
+    handshake: Option<CryptoState>,
+    zero_rtt: Option<CryptoDxState>, // One direction only!
+    cipher: Cipher,
+    app_write: Option<CryptoDxAppData>,
+    app_read: Option<CryptoDxAppData>,
+    app_read_next: Option<CryptoDxAppData>,
+    // If this is set, then we have noticed a genuine update.
+    // Once this time passes, we should switch in new keys.
+    read_update_time: Option<Instant>,
+}
+
+impl CryptoStates {
+    fn select_or_0rtt<'a>(
+        app: Option<&'a mut CryptoDxAppData>,
+        zero_rtt: Option<&'a mut CryptoDxState>,
+        dir: CryptoDxDirection,
+    ) -> Option<&'a mut CryptoDxState> {
+        app.map(|a| &mut a.dx)
+            .or_else(|| zero_rtt.filter(|z| z.direction == dir))
+    }
+
+    pub fn tx<'a>(&'a mut self, space: PNSpace) -> Option<&'a mut CryptoDxState> {
+        let tx = |x: &'a mut Option<CryptoState>| x.as_mut().map(|dx| &mut dx.tx);
+        match space {
+            PNSpace::Initial => tx(&mut self.initial),
+            PNSpace::Handshake => tx(&mut self.handshake),
+            PNSpace::ApplicationData => Self::select_or_0rtt(
+                self.app_write.as_mut(),
+                self.zero_rtt.as_mut(),
+                CryptoDxDirection::Write,
+            ),
+        }
+    }
+
+    pub fn rx_hp(&mut self, space: PNSpace) -> Option<&mut CryptoDxState> {
+        match space {
+            PNSpace::ApplicationData => Self::select_or_0rtt(
+                self.app_read.as_mut(),
+                self.zero_rtt.as_mut(),
+                CryptoDxDirection::Read,
+            ),
+            _ => self.rx(space, false),
+        }
+    }
+
+    pub fn rx<'a>(&'a mut self, space: PNSpace, key_phase: bool) -> Option<&'a mut CryptoDxState> {
+        let rx = |x: &'a mut Option<CryptoState>| x.as_mut().map(|dx| &mut dx.rx);
+        match space {
+            PNSpace::Initial => rx(&mut self.initial),
+            PNSpace::Handshake => rx(&mut self.handshake),
+            PNSpace::ApplicationData => {
+                let app = if let Some(arn) = &self.app_read_next {
+                    if arn.dx.key_phase() == key_phase {
+                        self.app_read_next.as_mut()
+                    } else {
+                        self.app_read.as_mut()
+                    }
+                } else {
+                    self.app_read.as_mut()
+                };
+                Self::select_or_0rtt(app, self.zero_rtt.as_mut(), CryptoDxDirection::Read)
+            }
+        }
+    }
+
+    /// Create the initial crypto state.
+    pub fn init(&mut self, role: Role, dcid: &[u8]) {
+        const CLIENT_INITIAL_LABEL: &str = "client in";
+        const SERVER_INITIAL_LABEL: &str = "server in";
+
+        qinfo!(
+            [self],
+            "Creating initial cipher state role={:?} dcid={}",
+            role,
+            hex(dcid)
+        );
+
+        let (write_label, read_label) = match role {
+            Role::Client => (CLIENT_INITIAL_LABEL, SERVER_INITIAL_LABEL),
+            Role::Server => (SERVER_INITIAL_LABEL, CLIENT_INITIAL_LABEL),
+        };
+
+        let mut initial = CryptoState {
+            tx: CryptoDxState::new_initial(CryptoDxDirection::Write, write_label, dcid),
+            rx: CryptoDxState::new_initial(CryptoDxDirection::Read, read_label, dcid),
+        };
+        if let Some(prev) = &self.initial {
+            qinfo!(
+                [self],
+                "Continue packet numbers for initial after retry (write is {:?})",
+                prev.rx.used_pn,
+            );
+            initial.tx.continuation(&prev.tx).unwrap();
+        }
+        self.initial = Some(initial);
+    }
+
+    pub fn set_0rtt_keys(&mut self, dir: CryptoDxDirection, secret: &SymKey, cipher: Cipher) {
+        self.zero_rtt = Some(CryptoDxState::new(dir, TLS_EPOCH_ZERO_RTT, secret, cipher));
+    }
+
+    pub fn discard(&mut self, space: PNSpace) {
+        match space {
+            PNSpace::Initial => self.initial = None,
+            PNSpace::Handshake => self.handshake = None,
+            PNSpace::ApplicationData => panic!("Can't drop application data keys"),
+        }
+    }
+
+    pub fn discard_0rtt_keys(&mut self) {
+        assert!(
+            self.app_read.is_none(),
+            "Can't discard 0-RTT after setting application keys"
+        );
+        self.zero_rtt = None;
+    }
+
+    pub fn set_handshake_keys(
+        &mut self,
+        write_secret: &SymKey,
+        read_secret: &SymKey,
+        cipher: Cipher,
+    ) {
+        self.cipher = cipher;
+        self.handshake = Some(CryptoState {
+            tx: CryptoDxState::new(
+                CryptoDxDirection::Write,
+                TLS_EPOCH_HANDSHAKE,
+                write_secret,
+                cipher,
+            ),
+            rx: CryptoDxState::new(
+                CryptoDxDirection::Read,
+                TLS_EPOCH_HANDSHAKE,
+                read_secret,
+                cipher,
+            ),
+        });
+    }
+
+    pub fn set_application_write_key(&mut self, secret: SymKey) -> Res<()> {
+        debug_assert!(self.app_write.is_none());
+        debug_assert_ne!(self.cipher, 0);
+        let mut app = CryptoDxAppData::new(CryptoDxDirection::Write, secret, self.cipher)?;
+        if let Some(z) = &self.zero_rtt {
+            if z.direction == CryptoDxDirection::Write {
+                app.dx.continuation(z)?;
+            }
+        }
+        self.zero_rtt = None;
+        self.app_write = Some(app);
+        Ok(())
+    }
+
+    pub fn set_application_read_key(&mut self, secret: SymKey, expire_0rtt: Instant) -> Res<()> {
+        debug_assert!(self.app_write.is_some(), "should have write keys installed");
+        debug_assert!(self.app_read.is_none());
+        let mut app = CryptoDxAppData::new(CryptoDxDirection::Read, secret, self.cipher)?;
+        if let Some(z) = &self.zero_rtt {
+            if z.direction == CryptoDxDirection::Read {
+                app.dx.continuation(z)?;
+            }
+            self.read_update_time = Some(expire_0rtt);
+        }
+        self.app_read_next = Some(app.next()?);
+        self.app_read = Some(app);
+        Ok(())
+    }
+
+    /// Update the write keys.
+    pub fn initiate_key_update(&mut self, largest_acknowledged: Option<PacketNumber>) -> Res<()> {
+        // Only update if we are able to. We can only do this if we have
+        // received an acknowledgement for a packet in the current phase.
+        // Also, skip this if we are waiting for read keys on the existing
+        // key update to be rolled over.
+        let write = &self.app_write.as_ref().unwrap().dx;
+        if write.can_update(largest_acknowledged) && self.read_update_time.is_none() {
+            // This call additionally checks that we don't advance to the next
+            // epoch while a key update is in progress.
+            if self.maybe_update_write()? {
+                Ok(())
+            } else {
+                qdebug!([self], "Write keys already updated");
+                Err(Error::KeyUpdateBlocked)
+            }
+        } else {
+            qdebug!([self], "Waiting for ACK or blocked on read key timer");
+            Err(Error::KeyUpdateBlocked)
+        }
+    }
+
+    /// Try to update, and return true if it happened.
+    fn maybe_update_write(&mut self) -> Res<bool> {
+        // Update write keys.  But only do so if the write keys are not already
+        // ahead of the read keys.  If we initiated the key update, the write keys
+        // will already be ahead.
+        debug_assert!(self.read_update_time.is_none());
+        let write = &self.app_write.as_ref().unwrap().dx;
+        let read = &self.app_read.as_ref().unwrap().dx;
+        if write.epoch == read.epoch {
+            qdebug!([self], "Updating write keys to epoch={}", write.epoch + 1);
+            self.app_write = Some(self.app_write.as_ref().unwrap().next()?);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn has_0rtt_read(&self) -> bool {
+        self.zero_rtt
+            .as_ref()
+            .filter(|z| z.direction == CryptoDxDirection::Read)
+            .is_some()
+    }
+
+    /// Prepare to update read keys.  This doesn't happen immediately as
+    /// we want to ensure that we can continue to receive any delayed
+    /// packets that use the old keys.  So we just set a timer.
+    pub fn key_update_received(&mut self, expiration: Instant) -> Res<()> {
+        // If we received a key update, then we assume that the peer has
+        // acknowledged a packet we sent in this epoch. It's OK to do that
+        // because they aren't allowed to update without first having received
+        // something from us. If the ACK isn't in the packet that triggered this
+        // key update, it must be in some other packet they have sent.
+        let _ = self.maybe_update_write()?;
+
+        // We shouldn't have 0-RTT keys at this point, but if we do, dump them.
+        debug_assert_eq!(self.read_update_time.is_some(), self.has_0rtt_read());
+        if self.has_0rtt_read() {
+            self.zero_rtt = None;
+        }
+        self.read_update_time = Some(expiration);
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn update_time(&self) -> Option<Instant> {
+        self.read_update_time
+    }
+
+    /// Check if time has passed for updating key update parameters.
+    /// If it has, then swap keys over and allow more key updates to be initiated.
+    /// This is also used to discard 0-RTT read keys at the server in the same way.
+    pub fn check_key_update(&mut self, now: Instant) -> Res<()> {
+        if let Some(expiry) = self.read_update_time {
+            // If enough time has passed, then install new keys and clear the timer.
+            if now >= expiry {
+                if self.has_0rtt_read() {
+                    qtrace!([self], "Discarding 0-RTT keys");
+                    self.zero_rtt = None;
+                } else {
+                    qtrace!([self], "Rotating read keys");
+                    mem::swap(&mut self.app_read, &mut self.app_read_next);
+                    self.app_read_next = Some(self.app_read.as_ref().unwrap().next()?);
+                }
+                self.read_update_time = None;
+            }
+        }
+        Ok(())
+    }
+
+    /// Get the current/highest epoch.  This returns (write, read) epochs.
+    #[cfg(test)]
+    pub fn get_epochs(&self) -> (Option<usize>, Option<usize>) {
+        let to_epoch = |app: &Option<CryptoDxAppData>| app.as_ref().map(|a| a.dx.epoch);
+        (to_epoch(&self.app_write), to_epoch(&self.app_read))
+    }
+
+    /// While we are awaiting the completion of a key update, we might receive
+    /// valid packets that are protected with old keys. We need to ensure that
+    /// these don't carry packet numbers higher than those in packets protected
+    /// with the newer keys.  To ensure that, this is called after every decryption.
+    pub fn check_pn_overlap(&mut self) -> Res<()> {
+        // We only need to do the check while we are waiting for read keys to be updated.
+        if self.read_update_time.is_some() {
+            qtrace!([self], "Checking for PN overlap");
+            let next_dx = &mut self.app_read_next.as_mut().unwrap().dx;
+            next_dx.continuation(&self.app_read.as_ref().unwrap().dx)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for CryptoStates {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "CryptoStates")
     }
 }
 
 #[derive(Debug, Default)]
 pub struct CryptoStream {
-    pub tx: TxBuffer,
-    pub rx: RxStreamOrderer,
+    tx: TxBuffer,
+    rx: RxStreamOrderer,
 }
 
-#[derive(Debug, Default)]
-pub struct CryptoStreams {
-    streams: [Option<CryptoStream>; 4],
+#[derive(Debug)]
+#[allow(dead_code)] // Suppress false positive: https://github.com/rust-lang/rust/issues/68408
+pub enum CryptoStreams {
+    Initial {
+        initial: CryptoStream,
+        handshake: CryptoStream,
+        application: CryptoStream,
+    },
+    Handshake {
+        handshake: CryptoStream,
+        application: CryptoStream,
+    },
+    ApplicationData {
+        application: CryptoStream,
+    },
 }
 
 impl CryptoStreams {
-    pub fn send(&mut self, epoch: u16, data: &[u8]) {
-        if let Some(stream) = &mut self.streams[epoch as usize] {
-            stream.tx.send(data);
-        } else {
-            debug_assert!(false);
+    pub fn discard(&mut self, space: PNSpace) {
+        match space {
+            PNSpace::Initial => {
+                if let Self::Initial {
+                    handshake,
+                    application,
+                    ..
+                } = self
+                {
+                    *self = Self::Handshake {
+                        handshake: mem::take(handshake),
+                        application: mem::take(application),
+                    };
+                }
+            }
+            PNSpace::Handshake => {
+                if let Self::Handshake { application, .. } = self {
+                    *self = Self::ApplicationData {
+                        application: mem::take(application),
+                    };
+                } else if matches!(self, Self::Initial {..}) {
+                    panic!("Discarding handshake before initial discarded");
+                }
+            }
+            PNSpace::ApplicationData => panic!("Discarding application data crypto streams"),
         }
     }
 
-    pub fn inbound_frame(&mut self, epoch: u16, offset: u64, data: Vec<u8>) -> Res<()> {
-        if let Some(stream) = &mut self.streams[epoch as usize] {
-            stream.rx.inbound_frame(offset, data)
-        } else {
-            debug_assert!(false);
-            Err(Error::KeysDiscarded)
-        }
+    pub fn send(&mut self, space: PNSpace, data: &[u8]) {
+        self[space].tx.send(data);
     }
 
-    pub fn data_ready(&self, epoch: u16) -> bool {
-        if let Some(stream) = &self.streams[epoch as usize] {
-            stream.rx.data_ready()
-        } else {
-            debug_assert!(false);
-            false
-        }
+    pub fn inbound_frame(&mut self, space: PNSpace, offset: u64, data: Vec<u8>) -> Res<()> {
+        self[space].rx.inbound_frame(offset, data)
     }
 
-    pub fn read_to_end(&mut self, epoch: u16, buf: &mut Vec<u8>) -> Res<u64> {
-        if let Some(stream) = &mut self.streams[epoch as usize] {
-            stream.rx.read_to_end(buf)
-        } else {
-            debug_assert!(false);
-            Err(Error::KeysDiscarded)
-        }
+    pub fn data_ready(&self, space: PNSpace) -> bool {
+        self[space].rx.data_ready()
+    }
+
+    pub fn read_to_end(&mut self, space: PNSpace, buf: &mut Vec<u8>) -> Res<u64> {
+        self[space].rx.read_to_end(buf)
     }
 
     pub fn acked(&mut self, token: CryptoRecoveryToken) {
-        if let Some(stream) = &mut self.streams[token.epoch as usize] {
-            stream.tx.mark_as_acked(token.offset, token.length);
-        } else {
-            debug_assert!(false);
-        }
+        self[token.space]
+            .tx
+            .mark_as_acked(token.offset, token.length)
     }
 
     pub fn lost(&mut self, token: &CryptoRecoveryToken) {
-        if let Some(stream) = &mut self.streams[token.epoch as usize] {
-            stream.tx.mark_as_lost(token.offset, token.length);
-        } else {
-            debug_assert!(false);
-        }
+        self[token.space]
+            .tx
+            .mark_as_lost(token.offset, token.length)
     }
 
-    pub fn sent(&mut self, epoch: u16, offset: u64, length: usize) {
-        if let Some(stream) = &mut self.streams[epoch as usize] {
-            stream.tx.mark_as_sent(offset, length);
-        } else {
-            debug_assert!(false);
-        }
+    pub fn sent(&mut self, space: PNSpace, offset: u64, length: usize) {
+        self[space].tx.mark_as_sent(offset, length)
     }
 
-    pub fn next_bytes(&self, epoch: u16, mode: TxMode) -> Option<(u64, &[u8])> {
-        if let Some(stream) = &self.streams[epoch as usize] {
-            stream.tx.next_bytes(mode)
-        } else {
-            debug_assert!(false);
-            None
-        }
+    pub fn next_bytes(&self, space: PNSpace, mode: TxMode) -> Option<(u64, &[u8])> {
+        self[space].tx.next_bytes(mode)
     }
 
     pub fn get_frame(
         &mut self,
-        epoch: u16,
+        space: PNSpace,
         mode: TxMode,
         remaining: usize,
     ) -> Option<(Frame, Option<RecoveryToken>)> {
-        if epoch == 1 {
-            // 0Rtt epoch does not have crypto streams
-            None
-        } else if let Some((offset, data)) = self.next_bytes(epoch, mode) {
+        if let Some((offset, data)) = self.next_bytes(space, mode) {
             let (frame, length) = Frame::new_crypto(offset, data, remaining);
-            self.sent(epoch, offset, length);
+            self.sent(space, offset, length);
 
             qdebug!(
-                "Emitting crypto frame epoch={}, offset={}, len={}",
-                epoch,
+                "Emitting crypto frame space={}, offset={}, len={}",
+                space,
                 offset,
                 length
             );
             Some((
                 frame,
                 Some(RecoveryToken::Crypto(CryptoRecoveryToken {
-                    epoch,
+                    space,
                     offset,
                     length,
                 })),
@@ -447,9 +890,64 @@ impl CryptoStreams {
     }
 }
 
+impl Default for CryptoStreams {
+    fn default() -> Self {
+        Self::Initial {
+            initial: CryptoStream::default(),
+            handshake: CryptoStream::default(),
+            application: CryptoStream::default(),
+        }
+    }
+}
+
+impl Index<PNSpace> for CryptoStreams {
+    type Output = CryptoStream;
+    fn index(&self, space: PNSpace) -> &Self::Output {
+        let (initial, hs, app) = match self {
+            Self::Initial {
+                initial,
+                handshake,
+                application,
+            } => (Some(initial), Some(handshake), application),
+            Self::Handshake {
+                handshake,
+                application,
+            } => (None, Some(handshake), application),
+            Self::ApplicationData { application } => (None, None, application),
+        };
+        match space {
+            PNSpace::Initial => initial.expect("Initial state dropped!"),
+            PNSpace::Handshake => hs.expect("Handshake state dropped!"),
+            PNSpace::ApplicationData => app,
+        }
+    }
+}
+
+impl IndexMut<PNSpace> for CryptoStreams {
+    fn index_mut(&mut self, space: PNSpace) -> &mut Self::Output {
+        let (initial, hs, app) = match self {
+            Self::Initial {
+                initial,
+                handshake,
+                application,
+            } => (Some(initial), Some(handshake), application),
+            Self::Handshake {
+                handshake,
+                application,
+            } => (None, Some(handshake), application),
+            Self::ApplicationData { application } => (None, None, application),
+        };
+        match space {
+            PNSpace::Initial => initial.expect("Initial state dropped!"),
+            PNSpace::Handshake => hs.expect("Handshake state dropped!"),
+            PNSpace::ApplicationData => app,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct CryptoRecoveryToken {
-    epoch: u16,
+    space: PNSpace,
     offset: u64,
     length: usize,
 }

--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -11,13 +11,13 @@ use std::collections::HashMap;
 use std::mem;
 
 use neqo_common::{qinfo, qtrace, qwarn, Encoder};
-use neqo_crypto::Epoch;
 
 use crate::frame::{Frame, StreamType};
 use crate::recovery::RecoveryToken;
 use crate::recv_stream::RecvStreams;
 use crate::send_stream::SendStreams;
 use crate::stream_id::{StreamId, StreamIndex, StreamIndexes};
+use crate::tracking::PNSpace;
 use crate::AppError;
 
 pub type FlowControlRecoveryToken = Frame;
@@ -291,10 +291,10 @@ impl FlowMgr {
 
     pub(crate) fn get_frame(
         &mut self,
-        epoch: Epoch,
+        space: PNSpace,
         remaining: usize,
     ) -> Option<(Frame, Option<RecoveryToken>)> {
-        if epoch != 3 {
+        if space != PNSpace::ApplicationData {
             return None;
         }
 

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -70,8 +70,14 @@ pub enum Error {
     InvalidResumptionToken,
     InvalidRetry,
     InvalidStreamId,
+    // Packet protection keys aren't available yet, or they have been discarded.
     KeysNotFound,
+    // An attempt to update keys can be blocked if
+    // a packet sent with the current keys hasn't been acknowledged.
+    KeyUpdateBlocked,
     NoMoreData,
+    NotConnected,
+    PacketNumberOverlap,
     PeerError(TransportError),
     TooMuchData,
     UnexpectedMessage,

--- a/neqo-transport/src/packet.rs
+++ b/neqo-transport/src/packet.rs
@@ -10,11 +10,11 @@
 #![allow(clippy::module_name_repetitions)]
 
 use neqo_common::{hex, matches, qtrace, Decoder, Encoder};
-use neqo_crypto::aead::Aead;
-use neqo_crypto::{random, Epoch};
+use neqo_crypto::random;
 
 use std::convert::{TryFrom, TryInto};
 
+use crate::tracking::PNSpace;
 use crate::{Error, Res};
 
 const PACKET_TYPE_INITIAL: u8 = 0x0;
@@ -32,7 +32,7 @@ const AUTH_TAG_LEN: usize = 16;
 
 #[derive(Debug, PartialEq)]
 pub enum PacketType {
-    Short,
+    Short(bool), // Includes whether the key phase is set
     ZeroRTT,
     Handshake,
     VN(Vec<Version>), // List of versions
@@ -40,13 +40,8 @@ pub enum PacketType {
     Retry { odcid: ConnectionId, token: Vec<u8> },
 }
 
-impl Default for PacketType {
-    fn default() -> Self {
-        Self::Short
-    }
-}
-
 impl PacketType {
+    #[must_use]
     fn code(&self) -> u8 {
         match self {
             Self::Initial(..) => PACKET_TYPE_INITIAL,
@@ -55,6 +50,27 @@ impl PacketType {
             Self::Retry { .. } => PACKET_TYPE_RETRY,
             _ => panic!("shouldn't be here"),
         }
+    }
+
+    #[must_use]
+    pub fn space(&self) -> PNSpace {
+        match self {
+            Self::Short(_) | Self::ZeroRTT => PNSpace::ApplicationData,
+            Self::Handshake => PNSpace::Handshake,
+            Self::Initial(_) => PNSpace::Initial,
+            _ => panic!("don't ask for the space when there isn't one"),
+        }
+    }
+
+    #[must_use]
+    pub fn key_phase(&self) -> bool {
+        matches!(self, Self::Short(true))
+    }
+}
+
+impl Default for PacketType {
+    fn default() -> Self {
+        Self::Short(false)
     }
 }
 
@@ -118,7 +134,6 @@ pub struct PacketHdr {
     pub dcid: ConnectionId,
     pub scid: Option<ConnectionId>,
     pub pn: PacketNumber,
-    pub epoch: Epoch,
     pub hdr_len: usize,
     body_len: usize,
 }
@@ -134,7 +149,6 @@ impl PacketHdr {
         dcid: ConnectionId,
         scid: Option<ConnectionId>,
         pn: PacketNumber,
-        epoch: Epoch,
     ) -> Self {
         Self {
             tbyte,
@@ -143,7 +157,6 @@ impl PacketHdr {
             dcid,
             scid,
             pn,
-            epoch,
             hdr_len: 0,
             body_len: 0,
         }
@@ -154,14 +167,14 @@ impl PacketHdr {
     }
 
     // header length plus auth tag
-    pub fn overhead(&self, aead: &Aead, pmtu: usize) -> usize {
+    pub fn overhead(&self, aead_expansion: usize, pmtu: usize) -> usize {
         match &self.tipe {
-            PacketType::Short => {
+            PacketType::Short(_) => {
                 // Leading byte.
                 let mut len = 1;
                 len += self.dcid.0.len();
                 len += pn_length(self.pn);
-                len + aead.expansion()
+                len + aead_expansion
             }
             PacketType::VN(_) => unimplemented!("Can't get overhead for VN"),
             PacketType::Retry { .. } => unimplemented!("Can't get overhead for Retry"),
@@ -181,45 +194,42 @@ impl PacketHdr {
                     len += token.len();
                 }
 
-                len += Encoder::varint_len((pnl + pmtu + aead.expansion()) as u64);
+                len += Encoder::varint_len((pnl + pmtu + aead_expansion) as u64);
                 len += pnl;
-                len + aead.expansion()
+                len + aead_expansion
             }
         }
     }
 }
 
-pub trait CryptoCtx {
+pub trait HeaderProtectionMask {
     fn compute_mask(&self, sample: &[u8]) -> Res<Vec<u8>>;
-    fn aead_decrypt(&self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>>;
-    fn aead_encrypt(&self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>>;
+    #[must_use]
+    fn next_pn(&self) -> PacketNumber;
 }
 
-pub struct PacketNumberDecoder {
-    expected: u64,
+pub trait Protector: HeaderProtectionMask {
+    fn encrypt(&mut self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>>;
 }
-impl PacketNumberDecoder {
-    pub fn new(largest_acknowledged: Option<u64>) -> Self {
-        Self {
-            expected: largest_acknowledged.map_or(0, |x| x + 1),
-        }
-    }
 
-    // TODO(mt) test this.  It's a strict implementation of the spec,
-    // but that doesn't mean we shouldn't test it.
-    fn decode_pn(&self, pn: u64, w: usize) -> PacketNumber {
-        let window = 1_u64 << (w * 8);
-        let candidate = (self.expected & !(window - 1)) | pn;
-        if candidate + (window / 2) <= self.expected {
-            candidate + window
-        } else if candidate > self.expected + (window / 2) {
-            match candidate.checked_sub(window) {
-                Some(pn_sub) => pn_sub,
-                None => candidate,
-            }
-        } else {
-            candidate
+pub trait Unprotector: HeaderProtectionMask {
+    fn decrypt(&mut self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>>;
+}
+
+// TODO(mt) test this.  It's a strict implementation of the spec,
+// but that doesn't mean we shouldn't test it.
+fn decode_pn(expected: PacketNumber, pn: u64, w: usize) -> PacketNumber {
+    let window = 1_u64 << (w * 8);
+    let candidate = (expected & !(window - 1)) | pn;
+    if candidate + (window / 2) <= expected {
+        candidate + window
+    } else if candidate > expected + (window / 2) {
+        match candidate.checked_sub(window) {
+            Some(pn_sub) => pn_sub,
+            None => candidate,
         }
+    } else {
+        candidate
     }
 }
 
@@ -333,12 +343,11 @@ pub fn decode_packet_hdr(cid_parser: &dyn ConnectionIdDecoder, pd: &[u8]) -> Res
         }
 
         // Short Header.
-        p.tipe = PacketType::Short;
+        p.tipe = PacketType::Short((p.tbyte & 4) != 0);
         let cid = d!(cid_parser.decode_cid(&mut d));
         p.dcid = ConnectionId(cid.to_vec()); // TODO(mt) unnecessary copy
         p.hdr_len = pd.len() - d.remaining();
         p.body_len = d.remaining();
-        p.epoch = 3; // TODO(ekr@rtfm.com): Decode key phase bits.
         return Ok(p);
     }
 
@@ -364,17 +373,10 @@ pub fn decode_packet_hdr(cid_parser: &dyn ConnectionIdDecoder, pd: &[u8]) -> Res
         p.tipe = match (p.tbyte >> 4) & 0x3 {
             // TODO(ekr@rtfm.com): Check the 0 bits.
             PACKET_TYPE_INITIAL => {
-                p.epoch = 0;
                 PacketType::Initial(d!(d.decode_vvec()).to_vec()) // TODO(mt) unnecessary copy
             }
-            PACKET_TYPE_0RTT => {
-                p.epoch = 1;
-                PacketType::ZeroRTT
-            }
-            PACKET_TYPE_HANDSHAKE => {
-                p.epoch = 2;
-                PacketType::Handshake
-            }
+            PACKET_TYPE_0RTT => PacketType::ZeroRTT,
+            PACKET_TYPE_HANDSHAKE => PacketType::Handshake,
             PACKET_TYPE_RETRY => {
                 let odcid = ConnectionId(d!(d.decode_vec(1)).to_vec()); // TODO(mt) unnecessary copy
                 let token = d.decode_remainder().to_vec(); // TODO(mt) unnecessary copy
@@ -394,64 +396,79 @@ pub fn decode_packet_hdr(cid_parser: &dyn ConnectionIdDecoder, pd: &[u8]) -> Res
     Ok(p)
 }
 
-pub fn decrypt_packet(
-    crypto: &dyn CryptoCtx,
-    pn: PacketNumberDecoder,
+pub fn decrypt_packet_hdr<'p>(
+    crypto: &mut dyn HeaderProtectionMask,
     hdr: &mut PacketHdr,
-    pkt: &[u8],
-) -> Res<Vec<u8>> {
+    pkt: &'p [u8],
+) -> Res<(Vec<u8>, &'p [u8])> {
     assert!(!matches!(
         hdr.tipe,
         PacketType::Retry{..} | PacketType::VN(_)
     ));
 
-    // First remove the header protection.
-    let payload = &pkt[hdr.hdr_len..];
+    qtrace!("unmask hdr={}", hex(&pkt[..hdr.hdr_len + 4]));
 
-    if payload.len() < (4 + SAMPLE_SIZE) {
-        return Err(Error::NoMoreData);
-    }
-    let mask = crypto.compute_mask(&payload[4..(SAMPLE_SIZE + 4)])?;
+    let sample_offset = hdr.hdr_len + 4;
+    let mask = if let Some(sample) = pkt.get(sample_offset..(sample_offset + SAMPLE_SIZE)) {
+        crypto.compute_mask(sample)
+    } else {
+        Err(Error::NoMoreData)
+    }?;
 
-    // Now put together a raw header to work on.
-    let pn_len = decode_pnl((hdr.tbyte ^ mask[0]) & 0x3);
-    let mut hdrbytes = pkt[0..(hdr.hdr_len + pn_len)].to_vec();
-
-    qtrace!("unmask hdr={}", hex(&hdrbytes));
     // Un-mask the leading byte.
-    hdrbytes[0] ^= mask[0]
+    debug_assert_eq!(hdr.tbyte, pkt[0]);
+    hdr.tbyte ^= mask[0]
         & match hdr.tipe {
-            PacketType::Short => 0x1f,
+            PacketType::Short(key_phase) => {
+                let flip = (mask[0] & 4) != 0;
+                hdr.tipe = PacketType::Short(key_phase ^ flip);
+                0x1f
+            }
             _ => 0x0f,
         };
+    let pn_len = decode_pnl(hdr.tbyte & 0x3);
 
-    // Now unmask the PN.
+    // Make a copy of the header to work on.
+    let mut hdrbytes = pkt[0..(hdr.hdr_len + pn_len)].to_vec();
+    hdrbytes[0] = hdr.tbyte;
+
+    // Unmask the PN.
     let mut pn_encoded: u64 = 0;
     for i in 0..pn_len {
         hdrbytes[hdr.hdr_len + i] ^= mask[1 + i];
         pn_encoded <<= 8;
         pn_encoded += u64::from(hdrbytes[hdr.hdr_len + i]);
     }
+
     qtrace!("unmasked hdr={}", hex(&hdrbytes));
     hdr.hdr_len += pn_len;
     hdr.body_len -= pn_len;
 
-    // Now call out to expand the PN.
-    hdr.pn = pn.decode_pn(pn_encoded, pn_len);
-
-    // Finally, decrypt.
-    Ok(crypto.aead_decrypt(
-        hdr.pn,
-        &hdrbytes,
-        &pkt[hdr.hdr_len..hdr.hdr_len + hdr.body_len()],
-    )?)
+    hdr.pn = decode_pn(crypto.next_pn(), pn_encoded, pn_len);
+    Ok((hdrbytes, &pkt[hdr.hdr_len..hdr.hdr_len + hdr.body_len]))
 }
 
-fn encode_packet_short(crypto: &dyn CryptoCtx, hdr: &PacketHdr, body: &[u8]) -> Vec<u8> {
+pub fn decrypt_packet_body(
+    crypto: &mut dyn Unprotector,
+    pn: PacketNumber,
+    hdrbytes: &[u8],
+    body: &[u8],
+) -> Res<Vec<u8>> {
+    Ok(crypto.decrypt(pn, hdrbytes, body)?)
+}
+
+fn encode_packet_short(
+    crypto: &mut dyn Protector,
+    hdr: &PacketHdr,
+    key_phase: bool,
+    body: &[u8],
+) -> Vec<u8> {
     let mut enc = Encoder::default();
     // Leading byte.
     let pnl = pn_length(hdr.pn);
-    enc.encode_byte(PACKET_BIT_SHORT | PACKET_BIT_FIXED_QUIC | encode_pnl(pnl));
+    enc.encode_byte(
+        PACKET_BIT_SHORT | PACKET_BIT_FIXED_QUIC | (u8::from(key_phase) << 2) | encode_pnl(pnl),
+    );
     enc.encode(&hdr.dcid.0);
     enc.encode_uint(pnl, hdr.pn);
 
@@ -476,7 +493,7 @@ pub fn encode_packet_vn(hdr: &PacketHdr) -> Vec<u8> {
 }
 
 /* Handle Initial, 0-RTT, Handshake. */
-fn encode_packet_long(crypto: &dyn CryptoCtx, hdr: &PacketHdr, body: &[u8]) -> Vec<u8> {
+fn encode_packet_long(crypto: &mut dyn Protector, hdr: &PacketHdr, body: &[u8]) -> Vec<u8> {
     let mut enc = Encoder::default();
 
     let pnl = pn_length(hdr.pn);
@@ -497,14 +514,14 @@ fn encode_packet_long(crypto: &dyn CryptoCtx, hdr: &PacketHdr, body: &[u8]) -> V
 }
 
 fn encrypt_packet(
-    crypto: &dyn CryptoCtx,
+    crypto: &mut dyn Protector,
     hdr: &PacketHdr,
     mut enc: Encoder,
     body: &[u8],
 ) -> Vec<u8> {
     let hdr_len = enc.len();
     // Encrypt the packet. This has too many copies.
-    let ct = crypto.aead_encrypt(hdr.pn, &enc, body).unwrap();
+    let ct = crypto.encrypt(hdr.pn, &enc, body).unwrap();
     enc.encode(&ct);
     qtrace!("mask hdr={}", hex(&enc[0..hdr_len]));
     let pn_start = hdr_len - pn_length(hdr.pn);
@@ -513,7 +530,7 @@ fn encrypt_packet(
         .unwrap();
     enc[0] ^= mask[0]
         & match hdr.tipe {
-            PacketType::Short => 0x1f,
+            PacketType::Short(_) => 0x1f,
             _ => 0x0f,
         };
     for i in 0..pn_length(hdr.pn) {
@@ -546,9 +563,9 @@ pub fn encode_retry(hdr: &PacketHdr) -> Vec<u8> {
     }
 }
 
-pub fn encode_packet(crypto: &dyn CryptoCtx, hdr: &PacketHdr, body: &[u8]) -> Vec<u8> {
+pub fn encode_packet(crypto: &mut dyn Protector, hdr: &PacketHdr, body: &[u8]) -> Vec<u8> {
     match &hdr.tipe {
-        PacketType::Short => encode_packet_short(crypto, hdr, body),
+        PacketType::Short(key_phase) => encode_packet_short(crypto, hdr, *key_phase, body),
         PacketType::VN(_) => encode_packet_vn(hdr),
         PacketType::Retry { .. } => encode_retry(hdr),
         PacketType::Initial(..) | PacketType::ZeroRTT | PacketType::Handshake => {
@@ -576,12 +593,19 @@ mod tests {
         }
     }
 
-    impl CryptoCtx for TestFixture {
+    impl HeaderProtectionMask for TestFixture {
         fn compute_mask(&self, sample: &[u8]) -> Res<Vec<u8>> {
-            Ok(vec![0xa5, 0xa5, 0xa5, 0xa5, 0xa5])
+            Ok(vec![0xa5; 5])
         }
 
-        fn aead_decrypt(&self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>> {
+        #[must_use]
+        fn next_pn(&self) -> PacketNumber {
+            0
+        }
+    }
+
+    impl Unprotector for TestFixture {
+        fn decrypt(&mut self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>> {
             let mut pt = body.to_vec();
 
             for i in &mut pt {
@@ -596,8 +620,10 @@ mod tests {
             }
             Ok(pt[0..pt_len].to_vec())
         }
+    }
 
-        fn aead_encrypt(&self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>> {
+    impl Protector for TestFixture {
+        fn encrypt(&mut self, pn: PacketNumber, hdr: &[u8], body: &[u8]) -> Res<Vec<u8>> {
             let tag = Self::auth_tag(hdr, body);
             let mut enc = Encoder::with_capacity(body.len() + tag.len());
             enc.encode(body);
@@ -619,12 +645,11 @@ mod tests {
     fn default_hdr() -> PacketHdr {
         PacketHdr {
             tbyte: 0,
-            tipe: PacketType::Short,
+            tipe: PacketType::Short(false),
             version: Some(31),
             dcid: ConnectionId(vec![1, 2, 3, 4, 5]),
             scid: None,
             pn: 0x0505,
-            epoch: 0,
             hdr_len: 0,
             body_len: 0,
         }
@@ -637,78 +662,79 @@ mod tests {
         assert_eq!(left.pn, right.pn);
     }
 
-    fn test_decrypt_packet(f: &TestFixture, packet: Vec<u8>) -> Res<(PacketHdr, Vec<u8>)> {
+    fn test_decrypt_packet(f: &mut TestFixture, packet: Vec<u8>) -> Res<(PacketHdr, Vec<u8>)> {
         let mut phdr = decode_packet_hdr(f, &packet)?;
-        let body = decrypt_packet(f, PacketNumberDecoder::new(Some(0)), &mut phdr, &packet)?;
-        Ok((phdr, body))
+        let (hdr, body) = decrypt_packet_hdr(f, &mut phdr, &packet)?;
+        let payload = decrypt_packet_body(f, phdr.pn, &hdr, body)?;
+        Ok((phdr, payload))
     }
 
-    fn test_encrypt_decrypt(f: &TestFixture, hdr: &mut PacketHdr, body: &[u8]) -> PacketHdr {
+    fn test_encrypt_decrypt(f: &mut TestFixture, hdr: &mut PacketHdr, body: &[u8]) -> PacketHdr {
         let packet = encode_packet(f, hdr, &TEST_BODY);
-        let res = test_decrypt_packet(&f, packet).unwrap();
-        assert_headers_equal(&hdr, &res.0);
-        assert_eq!(body.to_vec(), res.1);
-        res.0
+        let (dec_hdr, dec_body) = test_decrypt_packet(f, packet).unwrap();
+        assert_headers_equal(&hdr, &dec_hdr);
+        assert_eq!(body.to_vec(), dec_body);
+        dec_hdr
     }
 
     #[test]
     fn test_short_packet() {
-        let f = TestFixture {};
+        let mut f = TestFixture {};
         let mut hdr = default_hdr();
-        test_encrypt_decrypt(&f, &mut hdr, &TEST_BODY);
+        test_encrypt_decrypt(&mut f, &mut hdr, &TEST_BODY);
     }
 
     #[test]
     fn test_short_packet_damaged() {
-        let f = TestFixture {};
+        let mut f = TestFixture {};
         let hdr = default_hdr();
-        let mut packet = encode_packet(&f, &hdr, &TEST_BODY);
+        let mut packet = encode_packet(&mut f, &hdr, &TEST_BODY);
         let plen = packet.len();
         packet[plen - 1] ^= 0x7;
-        assert!(test_decrypt_packet(&f, packet).is_err());
+        assert!(test_decrypt_packet(&mut f, packet).is_err());
     }
 
     #[test]
     fn test_handshake_packet() {
-        let f = TestFixture {};
+        let mut f = TestFixture {};
         let mut hdr = default_hdr();
         hdr.tipe = PacketType::Handshake;
         hdr.scid = Some(ConnectionId(vec![9, 8, 7, 6, 5, 4, 3, 2]));
-        test_encrypt_decrypt(&f, &mut hdr, &TEST_BODY);
+        test_encrypt_decrypt(&mut f, &mut hdr, &TEST_BODY);
     }
 
     #[test]
     fn test_handshake_packet_damaged() {
-        let f = TestFixture {};
+        let mut f = TestFixture {};
         let mut hdr = default_hdr();
         hdr.tipe = PacketType::Handshake;
         hdr.scid = Some(ConnectionId(vec![9, 8, 7, 6, 5, 4, 3, 2]));
-        let mut packet = encode_packet(&f, &hdr, &TEST_BODY);
+        let mut packet = encode_packet(&mut f, &hdr, &TEST_BODY);
         let plen = packet.len();
         packet[plen - 1] ^= 0x7;
-        assert!(test_decrypt_packet(&f, packet).is_err());
+        assert!(test_decrypt_packet(&mut f, packet).is_err());
     }
 
     #[test]
     fn test_initial_packet() {
-        let f = TestFixture {};
+        let mut f = TestFixture {};
         let mut hdr = default_hdr();
         let tipe = PacketType::Initial(vec![0x0, 0x0, 0x0, 0x0]);
         hdr.tipe = tipe;
         hdr.scid = Some(ConnectionId(vec![9, 8, 7, 6, 5, 4, 3, 2]));
-        test_encrypt_decrypt(&f, &mut hdr, &TEST_BODY);
+        test_encrypt_decrypt(&mut f, &mut hdr, &TEST_BODY);
     }
 
     #[test]
     fn test_initial_packet_damaged() {
-        let f = TestFixture {};
+        let mut f = TestFixture {};
         let mut hdr = default_hdr();
         hdr.tipe = PacketType::Initial(vec![0x0, 0x0, 0x0, 0x0]);
         hdr.scid = Some(ConnectionId(vec![9, 8, 7, 6, 5, 4, 3, 2]));
-        let mut packet = encode_packet(&f, &hdr, &TEST_BODY);
+        let mut packet = encode_packet(&mut f, &hdr, &TEST_BODY);
         let plen = packet.len();
         packet[plen - 1] ^= 0x7;
-        assert!(test_decrypt_packet(&f, packet).is_err());
+        assert!(test_decrypt_packet(&mut f, packet).is_err());
     }
 
     #[test]

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -22,6 +22,7 @@ use crate::flow_mgr::FlowMgr;
 use crate::frame::{Frame, TxMode};
 use crate::recovery::RecoveryToken;
 use crate::stream_id::StreamId;
+use crate::tracking::PNSpace;
 use crate::{AppError, Error, Res};
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -743,11 +744,11 @@ impl SendStreams {
 
     pub(crate) fn get_frame(
         &mut self,
-        epoch: u16,
+        space: PNSpace,
         mode: TxMode,
         remaining: usize,
     ) -> Option<(Frame, Option<RecoveryToken>)> {
-        if epoch != 3 && epoch != 1 {
+        if space != PNSpace::ApplicationData {
             return None;
         }
 
@@ -758,11 +759,11 @@ impl SendStreams {
                     Frame::new_stream(stream_id.as_u64(), offset, data, complete, remaining)
                 {
                     qdebug!(
-                        "Stream {} sending bytes {}-{}, epoch {}, mode {:?}",
+                        "Stream {} sending bytes {}-{}, space {:?}, mode {:?}",
                         stream_id.as_u64(),
                         offset,
                         offset + length as u64,
-                        epoch,
+                        space,
                         mode,
                     );
                     let fin = complete && length == data.len();

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -244,7 +244,6 @@ impl Server {
             hdr.scid.as_ref().unwrap().clone(),
             Some(hdr.dcid.clone()),
             0, // unused
-            0, // unused
         ));
         Datagram::new(received.destination(), received.source(), vn)
     }
@@ -334,7 +333,6 @@ impl Server {
                     hdr.scid.as_ref().unwrap().clone(),
                     Some(self.cid_manager.borrow_mut().generate_cid()),
                     0, // Packet number
-                    0, // Epoch
                 ));
                 let retry = Datagram::new(dgram.destination(), dgram.source(), payload);
                 Some(retry)
@@ -394,7 +392,7 @@ impl Server {
             return self.process_connection(c, Some(dgram), now);
         }
 
-        if hdr.tipe == PacketType::Short {
+        if matches!(hdr.tipe, PacketType::Short(_)) {
             // TODO send a stateless reset here.
             qtrace!([self], "Short header packet for an unknown connection");
             return None;

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -10,11 +10,11 @@
 /// Connection statistics
 pub struct Stats {
     /// Total packets received
-    pub packets_rx: u64,
+    pub packets_rx: usize,
     /// Total packets sent
-    pub packets_tx: u64,
+    pub packets_tx: usize,
     /// Duplicate packets received
-    pub dups_rx: u64,
-    /// Dropped packets
-    pub dropped_rx: u64,
+    pub dups_rx: usize,
+    /// Dropped datagrams, or parts thereof
+    pub dropped_rx: usize,
 }

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -21,9 +21,9 @@ use crate::recovery::RecoveryToken;
 // TODO(mt) look at enabling EnumMap for this: https://stackoverflow.com/a/44905797/1375574
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PNSpace {
-    Initial = 0,
-    Handshake = 1,
-    ApplicationData = 2,
+    Initial,
+    Handshake,
+    ApplicationData,
 }
 
 #[allow(clippy::use_self)] // https://github.com/rust-lang/rust-clippy/issues/3410


### PR DESCRIPTION
This changes the code to operate on packet number spaces instead of
epochs.  That makes it slightly easier to manage in some places.

The major shift here is in how keys are made.  The current code just
tries to make every key when it is sending packets, iterating through
the epochs as it goes.  This code attempts to only create keys at the
right points in the state machine.  This is only really perfect for
application read keys, which are generated when the handshake is
complete.  Other keys it creates after processing CRYPTO frames.

A later change that might help is to propagate events from the TLS layer
about key availability, which would make this more precise, but this was
already getting big.

This doesn't do key discard, but it should be much easier to implement
now that keys won't be re-created every time.

This version is a draft that includes a bunch of changes in packages
other than transport, but I'll drop that once I can rebase it (and those
other PRs land).  I wanted to put this out there to get a little bit of
feedback.  Only the stuff in `neqo-transport` is relevant here.