### PR TITLE
Implement Drop for SecretAgent

### DIFF
--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -645,6 +645,10 @@ impl SecretAgent {
     }
 
     pub fn close(&mut self) {
+        // It should be safe to close multiple times.
+        if self.fd.is_null() {
+            return;
+        }
         if let Some(true) = self.raw {
             // Need to hold the record list in scope until the close is done.
             let _records = self.setup_raw().expect("Can only close");

--- a/neqo-crypto/tests/agent.rs
+++ b/neqo-crypto/tests/agent.rs
@@ -353,3 +353,21 @@ fn reject_zero_rtt() {
     assert!(!client.info().unwrap().early_data_accepted());
     assert!(!server.info().unwrap().early_data_accepted());
 }
+
+#[test]
+fn close() {
+    let mut client = Client::new("server.example").expect("should create client");
+    let mut server = Server::new(&["key"]).expect("should create server");
+    connect(&mut client, &mut server);
+    client.close();
+    server.close();
+}
+
+#[test]
+fn close_client_twice() {
+    let mut client = Client::new("server.example").expect("should create client");
+    let mut server = Server::new(&["key"]).expect("should create server");
+    connect(&mut client, &mut server);
+    client.close();
+    client.close(); // Should be a noop.
+}


### PR DESCRIPTION
The current code doesn't ever close the socket, which means that the TLS
code leaks a LOT.  That's bad.  Implement Drop and add a function that
closes the socket.