### PR TITLE
Better Pin handling

### DIFF
--- a/neqo-crypto/src/agentio.rs
+++ b/neqo-crypto/src/agentio.rs
@@ -26,6 +26,11 @@ type PrStatus = prio::PRStatus::Type;
 const PR_SUCCESS: PrStatus = prio::PRStatus::PR_SUCCESS;
 const PR_FAILURE: PrStatus = prio::PRStatus::PR_FAILURE;
 
+/// Convert a pinned, boxed object into a void pointer.
+pub fn as_c_void<T: Unpin>(pin: &mut Pin<Box<T>>) -> *mut c_void {
+    Pin::into_inner(pin.as_mut()) as *mut T as *mut c_void
+}
+
 // This holds the length of the slice, not the slice itself.
 #[derive(Default, Debug)]
 struct RecordLength {
@@ -112,9 +117,9 @@ impl RecordList {
 
     /// Create a new record list.
     pub(crate) fn setup(fd: *mut ssl::PRFileDesc) -> Res<Pin<Box<Self>>> {
-        let mut records = Pin::new(Box::new(Self::default()));
-        let records_ptr = &mut *records as *mut Self as *mut c_void;
-        unsafe { ssl::SSL_RecordLayerWriteCallback(fd, Some(Self::ingest), records_ptr) }?;
+        let mut records = Box::pin(Self::default());
+        let p = as_c_void(&mut records);
+        unsafe { ssl::SSL_RecordLayerWriteCallback(fd, Some(Self::ingest), p) }?;
         Ok(records)
     }
 }

--- a/neqo-crypto/src/ext.rs
+++ b/neqo-crypto/src/ext.rs
@@ -140,16 +140,17 @@ impl ExtensionTracker {
         // This way, only this "outer" code deals with the reference count.
         let mut tracker = Self {
             extension,
-            handler: Pin::new(Box::new(Box::new(handler))),
+            handler: Box::pin(Box::new(handler)),
         };
-        let p = &mut *tracker.handler as *mut BoxedExtensionHandler as *mut c_void;
+        let pin = Pin::as_mut(&mut tracker.handler);
+        let ptr = Pin::get_unchecked_mut(pin) as *mut BoxedExtensionHandler as *mut c_void;
         SSL_InstallExtensionHooks(
             fd,
             extension,
             Some(Self::extension_writer),
-            p,
+            ptr,
             Some(Self::extension_handler),
-            p,
+            ptr,
         )?;
         Ok(tracker)
     }

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -3748,7 +3748,7 @@ mod tests {
         // We will check this by processing init_pkt_s a second time.
         // The initial packet should be dropped. The packet contains a Handshake packet as well, which
         // will be marked as dup.
-        check_discarded(&mut client, init_pkt_s.clone(), 1, 1);
+        check_discarded(&mut client, init_pkt_s, 1, 1);
 
         assert!(maybe_authenticate(&mut client));
 


### PR DESCRIPTION
Our current code was taking pinned objects and just casting them to the
requisite types.  This works, but I think that it was by accident more
than design.  I believe that what was happening was that `Pin<Box<T>`,
`Box<T>`, and `*mut T` are all effectively the same value once all the
rust compiler decorations are erased. So a cast to a pointer from any of
these does work.  However, this is not something the API guarantees.
Though `Pin` and `Box` are both annotated with `#[repr(transparent)]`,
this is not a promise of a particular layout, but a hint.

The correct way to handle these cases is to use `Pin::as_mut()` to get a
`Pin<&mut T>` and then use the unsafe method `Pin::as_unchecked_mut()`
on that to get a mutable reference to the memory.

This pinning stuff is a little hard to grok still, but my understanding
is that using `Box` consistently, as we do, ensures that we don't have a
problem unless we try to move the object that the `Box` points at.
Using `Pin` is supposed to help with that, but this code is so littered
with `unsafe` blocks, we will probably just have to be vigilant.