### PR TITLE
Let HKDF work out the size of its own keys

### DIFF
--- a/neqo-crypto/src/hkdf.rs
+++ b/neqo-crypto/src/hkdf.rs
@@ -34,7 +34,7 @@ experimental_api!(SSL_HkdfExpandLabel(
     secret: *mut *mut PK11SymKey,
 ));
 
-pub fn key_size(version: Version, cipher: Cipher) -> Res<usize> {
+fn key_size(version: Version, cipher: Cipher) -> Res<usize> {
     if version != TLS_VERSION_1_3 {
         return Err(Error::UnsupportedVersion);
     }
@@ -45,8 +45,8 @@ pub fn key_size(version: Version, cipher: Cipher) -> Res<usize> {
     })
 }
 
-pub fn generate_key(version: Version, cipher: Cipher, size: usize) -> Res<SymKey> {
-    import_key(version, cipher, &random(size))
+pub fn generate_key(version: Version, cipher: Cipher) -> Res<SymKey> {
+    import_key(version, cipher, &random(key_size(version, cipher)?))
 }
 
 /// Import a symmetric key for use with HKDF.

--- a/neqo-crypto/src/selfencrypt.rs
+++ b/neqo-crypto/src/selfencrypt.rs
@@ -28,8 +28,7 @@ impl SelfEncrypt {
     const SALT_LENGTH: usize = 16;
 
     pub fn new(version: Version, cipher: Cipher) -> Res<Self> {
-        let sz = hkdf::key_size(version, cipher)?;
-        let key = hkdf::generate_key(version, cipher, sz)?;
+        let key = hkdf::generate_key(version, cipher)?;
         Ok(Self {
             version,
             cipher,
@@ -48,8 +47,7 @@ impl SelfEncrypt {
 
     /// Rotate keys.  This causes any previous key that is being held to be replaced by the current key.
     pub fn rotate(&mut self) -> Res<()> {
-        let sz = hkdf::key_size(self.version, self.cipher)?;
-        let new_key = hkdf::generate_key(self.version, self.cipher, sz)?;
+        let new_key = hkdf::generate_key(self.version, self.cipher)?;
         self.old_key = Some(mem::replace(&mut self.key, new_key));
         let (kid, _) = self.key_id.overflowing_add(1);
         self.key_id = kid;


### PR DESCRIPTION
We don't need the flexibility implied by passing a size parameter to
generate_key().  Worse, this could be abused to create bad keys.  So
just call key_size() internally, and stop exporting it.