### PR TITLE
Update version to draft-25

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -28,7 +28,7 @@ use url::Url;
     about = "A basic QUIC HTTP/0.9 and HTTP3 client."
 )]
 pub struct Args {
-    #[structopt(short = "a", long, default_value = "h3-24")]
+    #[structopt(short = "a", long, default_value = "h3-25")]
     /// ALPN labels to negotiate.
     ///
     /// This client still only does HTTP3 no matter what the ALPN says.

--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -50,7 +50,7 @@ struct Args {
     /// Name of key from NSS database.
     key: String,
 
-    #[structopt(short = "a", long, default_value = "h3-24")]
+    #[structopt(short = "a", long, default_value = "h3-25")]
     /// ALPN labels to negotiate.
     ///
     /// This server still only does HTTP3 no matter what the ALPN says.

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -373,8 +373,8 @@ enum Test {
 impl Test {
     fn alpn(&self) -> Vec<String> {
         match self {
-            Self::H3 => vec![String::from("h3-24")],
-            _ => vec![String::from("hq-24")],
+            Self::H3 => vec![String::from("h3-25")],
+            _ => vec![String::from("hq-25")],
         }
     }
 
@@ -493,7 +493,7 @@ impl Handler for VnHandler {
 fn test_vn(nctx: &NetworkCtx, peer: &Peer) -> Result<Connection, String> {
     let mut client = Connection::new_client(
         peer.host,
-        &["hq-22"],
+        &["hq-25"],
         Rc::new(RefCell::new(FixedConnectionIdManager::new(0))),
         nctx.local_addr,
         nctx.remote_addr,

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -36,7 +36,7 @@ pub use self::frame::StreamType;
 pub use self::tparams::{tp_constants, TransportParameter};
 
 /// The supported version of the QUIC protocol.
-pub const QUIC_VERSION: u32 = 0xff00_0018;
+pub const QUIC_VERSION: u32 = 0xff00_0000 + 25;
 
 type TransportError = u64;
 

--- a/neqo-transport/tests/conn_vectors.rs
+++ b/neqo-transport/tests/conn_vectors.rs
@@ -12,7 +12,7 @@ use neqo_common::{Datagram, Encoder};
 use neqo_transport::State;
 use test_fixture::*;
 
-const INITIAL_PACKET: &str = "c0ff000018088394c8f03e5157080000\
+const INITIAL_PACKET: &str = "c0ff000019088394c8f03e5157080000\
                               449e3b343aa8535064a4268a0d9d7b1c\
                               9d250ae355162276e9b1e3011ef6bbc0\
                               ab48ad5bcc2681e953857ca62becd752\
@@ -86,7 +86,7 @@ const INITIAL_PACKET: &str = "c0ff000018088394c8f03e5157080000\
                               d2bee680d8f41a597c262648bb18bcfc\
                               13c8b3d97b1a77b2ac3af745d61a34cc\
                               4709865bac824a94bb19058015e4e42d\
-                              0488c1b9a230f7c894193cbb54ae795e";
+                              aebe13f98ec51170a4aad0a8324bb768";
 
 #[test]
 fn process_client_initial() {


### PR DESCRIPTION
This doesn't do any of the concrete things we need for compatibility,
but it changes the version numbers.

I have three things that we need to do at the transport layer (aside from stuff we already don't do):

* HANDSHAKE_DONE (I have a start with #407)
* Retry integrity
* Symmetric idle timeout