### PR TITLE
No Issue: Add method to indicate server(s) is/are listening

### DIFF
--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -205,23 +205,20 @@ fn main() -> Result<(), io::Error> {
             PollOpt::edge(),
         )?;
         sockets.push(socket);
-        servers.insert(
-            local_addr,
-            (
-                Http3Server::new(
-                    Instant::now(),
-                    &[args.key.clone()],
-                    &[args.alpn.clone()],
-                    AntiReplay::new(Instant::now(), Duration::from_secs(10), 7, 14)
-                        .expect("unable to setup anti-replay"),
-                    Rc::new(RefCell::new(FixedConnectionIdManager::new(10))),
-                    args.max_table_size,
-                    args.max_blocked_streams,
-                )
-                .expect("We cannot make a server!"),
-                None,
-            ),
-        );
+        let http3_server = Http3Server::new(
+            Instant::now(),
+            &[args.key.clone()],
+            &[args.alpn.clone()],
+            AntiReplay::new(Instant::now(), Duration::from_secs(10), 7, 14)
+                .expect("unable to setup anti-replay"),
+            Rc::new(RefCell::new(FixedConnectionIdManager::new(10))),
+            args.max_table_size,
+            args.max_blocked_streams,
+        )
+        .expect("We cannot make a server!");
+        http3_server.listen();
+
+        servers.insert(local_addr, (http3_server, None));
     }
 
     let buf = &mut [0u8; 2048];

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -53,6 +53,11 @@ impl Http3Server {
         })
     }
 
+    pub fn listen(&self) {
+        qtrace!([self], "Listening for client connections");
+        self.server.listen();
+    }
+
     pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
         qtrace!([self], "Process.");
         let out = self.server.process(dgram, now);

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -438,6 +438,10 @@ impl Server {
         }
     }
 
+    pub fn listen(&self) {
+        qtrace!([self], "Listening for client connections");
+    }
+
     pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
         let out = if let Some(d) = dgram {
             self.process_input(d, now)


### PR DESCRIPTION
As a UDP-based protocol with an event-driven implementation,
there's no real reason for a having a special method to tell a
server to start started listening for connections. However,
the qlog specification has a "server listening" event. Provide
a method for the server user to indicate that the server is
listening. Once qlog implementation progresses, this is the
method where neqo will log the server listening event.