### PR TITLE
Enable SSLTRACE for debugging

### DIFF
--- a/neqo-crypto/bindings/bindings.toml
+++ b/neqo-crypto/bindings/bindings.toml
@@ -39,6 +39,7 @@ functions = [
     "SSL_ImportFD",
     "SSL_NamedGroupConfig",
     "SSL_OptionSet",
+    "SSL_OptionGetDefault",
     "SSL_PeerCertificate",
     "SSL_PeerCertificateChain",
     "SSL_PeerSignedCertTimestamps",

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -104,6 +104,18 @@ pub fn init() {
     }
 }
 
+/// This enables SSLTRACE by calling a simple, harmless function to trigger its
+/// side effects.  SSLTRACE is not enabled in NSS until a socket is made or
+/// global options are accessed.  Reading an option is the least impact approach.
+/// This allows us to use SSLTRACE in all of our unit tests and programs.
+#[cfg(debug_assertions)]
+fn enable_ssl_trace() {
+    let opt = ssl::Opt::Locking.as_int();
+    let mut _v: ::std::os::raw::c_int = 0;
+    secstatus_to_res(unsafe { ssl::SSL_OptionGetDefault(opt, &mut _v) })
+        .expect("SSL_OptionGetDefault failed");
+}
+
 pub fn init_db<P: Into<PathBuf>>(dir: P) {
     time::init();
     unsafe {
@@ -134,6 +146,9 @@ pub fn init_db<P: Into<PathBuf>>(dir: P) {
                 dircstr.as_ptr(),
             ))
             .expect("SSL_ConfigServerSessionIDCache failed");
+
+            #[cfg(debug_assertions)]
+            enable_ssl_trace();
 
             NssLoaded::Db(path.into_boxed_path())
         });


### PR DESCRIPTION
It turns out that NSS doesn't always do this and it is a little
distracting if you want to use SSLTRACE to debug certain functions.