### PR TITLE
No Issue: Refactor QPACK instruction types

### DIFF
--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -10,19 +10,13 @@ use crate::huffman::encode_huffman;
 use crate::qpack_helper::read_prefixed_encoded_int_with_connection;
 use crate::qpack_send_buf::QPData;
 use crate::table::HeaderTable;
+use crate::DecoderInstructions;
 use crate::Header;
 use crate::{Error, Res};
 use neqo_common::{qdebug, qtrace};
 use neqo_transport::Connection;
 
 pub const QPACK_UNI_STREAM_TYPE_ENCODER: u64 = 0x2;
-
-#[derive(Debug)]
-enum DecoderInstructions {
-    InsertCountIncrement,
-    HeaderAck,
-    StreamCancellation,
-}
 
 fn get_instruction(b: u8) -> DecoderInstructions {
     if (b & 0xc0) == 0 {

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -26,6 +26,29 @@ enum QPackSide {
     Decoder,
 }
 
+// Will be used by qlog code.
+#[allow(dead_code)]
+pub enum QpackInstructions {
+    Decoder(DecoderInstructions),
+    Encoder(EncoderInstructions),
+}
+#[derive(Debug)]
+pub enum DecoderInstructions {
+    InsertCountIncrement,
+    HeaderAck,
+    StreamCancellation,
+}
+
+// Will be used by qlog code.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum EncoderInstructions {
+    SetDynamicTableCapacity,
+    InsertWithNameReference,
+    InsertWithoutNameReference,
+    Duplicate,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {
     DecompressionFailed,


### PR DESCRIPTION
Refactor QPACK instruction types to the crate for use later by qlog.