### PR TITLE
Revert move to bindgen 52

### DIFF
--- a/neqo-crypto/Cargo.toml
+++ b/neqo-crypto/Cargo.toml
@@ -11,7 +11,7 @@ neqo-common = { path = "../neqo-common" }
 log = "0.4.0"
 
 [build-dependencies]
-bindgen = {version = "0.52", default-features = false}
+bindgen = {version = "0.51", default-features = false}
 serde = "1.0"
 serde_derive = "1.0"
 toml = "0.4"

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -226,6 +226,7 @@ fn build_bindings(base: &str, bindings: &Bindings, flags: &[String], gecko: bool
 
     let mut builder = Builder::default().header(header);
     builder = builder.generate_comments(false);
+    builder = builder.derive_debug(false); // https://github.com/rust-lang/rust-bindgen/issues/372
 
     builder = builder.clang_arg("-v");
 


### PR DESCRIPTION
Unfortunately Gecko is not cool with bindgen 52.