### PR TITLE
HFrame::Header should contain header_block and make the receive side of transaction simpler

### DIFF
--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -32,14 +32,14 @@ pub enum HStreamType {
     Push,
 }
 
-// data for DATA and header blocks for HEADERS anf PUSH_PROMISE are not read into HFrame.
+// data for DATA frame is not read into HFrame::Data.
 #[derive(PartialEq, Debug)]
 pub enum HFrame {
     Data {
         len: u64, // length of the data
     },
     Headers {
-        len: u64, // length of the header block
+        header_block: Vec<u8>,
     },
     CancelPush {
         push_id: u64,
@@ -80,9 +80,12 @@ impl HFrame {
         enc.encode_varint(self.get_type());
 
         match self {
-            Self::Data { len } | Self::Headers { len } => {
-                // DATA and HEADERS frames only encode the length here.
+            Self::Data { len } => {
+                // DATA frame only encode the length here.
                 enc.encode_varint(*len);
+            }
+            Self::Headers { header_block } => {
+                enc.encode_vvec(header_block);
             }
             Self::CancelPush { push_id } => {
                 enc.encode_vvec_with(|enc_inner| {
@@ -235,10 +238,8 @@ impl HFrameReader {
                             );
                             self.hframe_len = len;
                             self.state = match self.hframe_type {
-                                // DATA and HEADERS payload are left on the quic stream and picked up separately
-                                H3_FRAME_TYPE_DATA | H3_FRAME_TYPE_HEADERS => {
-                                    HFrameReaderState::Done
-                                }
+                                // DATA payload are left on the quic stream and picked up separately
+                                H3_FRAME_TYPE_DATA => HFrameReaderState::Done,
 
                                 // for other frames get all data before decoding.
                                 H3_FRAME_TYPE_CANCEL_PUSH
@@ -246,7 +247,8 @@ impl HFrameReader {
                                 | H3_FRAME_TYPE_GOAWAY
                                 | H3_FRAME_TYPE_MAX_PUSH_ID
                                 | H3_FRAME_TYPE_DUPLICATE_PUSH
-                                | H3_FRAME_TYPE_PUSH_PROMISE => {
+                                | H3_FRAME_TYPE_PUSH_PROMISE
+                                | H3_FRAME_TYPE_HEADERS => {
                                     if len == 0 {
                                         HFrameReaderState::Done
                                     } else {
@@ -329,7 +331,7 @@ impl HFrameReader {
                 len: self.hframe_len,
             },
             H3_FRAME_TYPE_HEADERS => HFrame::Headers {
-                len: self.hframe_len,
+                header_block: dec.decode_remainder().to_vec(),
             },
             H3_FRAME_TYPE_CANCEL_PUSH => HFrame::CancelPush {
                 push_id: match dec.decode_varint() {
@@ -448,8 +450,10 @@ mod tests {
 
     #[test]
     fn test_headers_frame() {
-        let f = HFrame::Headers { len: 3 };
-        enc_dec(&f, "0103010203", 3);
+        let f = HFrame::Headers {
+            header_block: vec![0x01, 0x02, 0x03],
+        };
+        enc_dec(&f, "0103010203", 0);
     }
 
     #[test]
@@ -493,10 +497,9 @@ mod tests {
         enc_dec(&f, "0e0105", 0);
     }
 
-    // We have 3 code paths in frame_reader:
-    // 1) All frames except DATA, HEADERES and PUSH_PROMISE (here we test SETTING and SETTINGS with larger varints)
-    // 2) PUSH_PROMISE and
-    // 1) DATA and HEADERS frame (for this we will test DATA)
+    // We have 2 code paths in frame_reader:
+    // 1) All frames except DATA (here we test SETTING and SETTINGS with larger varints and PUSH_PROMISE)
+    // 1) DATA
 
     // Test SETTINGS
     #[test]
@@ -914,6 +917,7 @@ mod tests {
     #[test]
     fn test_complete_and_incomplete_frames() {
         const FRAME_LEN: usize = 10;
+        const HEADER_BLOCK: &[u8] = &[0x01, 0x02, 0x03, 0x04];
 
         // H3_FRAME_TYPE_DATA len=0
         let f = HFrame::Data { len: 0 };
@@ -932,22 +936,23 @@ mod tests {
         buf.resize(FRAME_LEN + buf.len(), 0);
         test_complete_and_incomplete_frame(&buf, 2);
 
-        // H3_FRAME_TYPE_HEADERS len=0
-        let f = HFrame::Data { len: 0 };
-        let mut enc = Encoder::with_capacity(2);
+        // H3_FRAME_TYPE_HEADERS empty header block
+        let f = HFrame::Headers {
+            header_block: Vec::new(),
+        };
+        let mut enc = Encoder::default();
         f.encode(&mut enc);
         let buf: Vec<_> = enc.into();
         test_complete_and_incomplete_frame(&buf, 2);
 
-        // H3_FRAME_TYPE_HEADERS len=FRAME_LEN
+        // H3_FRAME_TYPE_HEADERS
         let f = HFrame::Headers {
-            len: FRAME_LEN as u64,
+            header_block: HEADER_BLOCK.to_vec(),
         };
-        let mut enc = Encoder::with_capacity(2);
+        let mut enc = Encoder::default();
         f.encode(&mut enc);
-        let mut buf: Vec<_> = enc.into();
-        buf.resize(FRAME_LEN + buf.len(), 0);
-        test_complete_and_incomplete_frame(&buf, 2);
+        let buf: Vec<_> = enc.into();
+        test_complete_and_incomplete_frame(&buf, buf.len());
 
         // H3_FRAME_TYPE_CANCEL_PUSH
         let f = HFrame::CancelPush { push_id: 5 };
@@ -968,7 +973,7 @@ mod tests {
         // H3_FRAME_TYPE_PUSH_PROMISE
         let f = HFrame::PushPromise {
             push_id: 4,
-            header_block: vec![0x01, 0x02, 0x03, 0x04],
+            header_block: HEADER_BLOCK.to_vec(),
         };
         let mut enc = Encoder::default();
         f.encode(&mut enc);

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -15,6 +15,7 @@ mod control_stream_local;
 mod control_stream_remote;
 pub mod hframe;
 mod hsettings_frame;
+mod response_stream;
 pub mod server;
 mod server_connection_events;
 mod server_events;

--- a/neqo-http3/src/response_stream.rs
+++ b/neqo-http3/src/response_stream.rs
@@ -7,7 +7,7 @@
 use crate::client_events::Http3ClientEvents;
 use crate::hframe::{HFrame, HFrameReader};
 use crate::{Error, Header, Res};
-use neqo_common::{qdebug, qinfo, qtrace};
+use neqo_common::{matches, qdebug, qinfo, qtrace};
 use neqo_qpack::decoder::QPackDecoder;
 use neqo_transport::Connection;
 use std::mem;
@@ -16,18 +16,14 @@ use std::mem;
  * Response stream state:
  *    WaitingForResponseHeaders : we wait for headers. in this state we can
  *                                also get a PUSH_PROMISE frame.
- *    ReadingHeaders : we have HEADERS frame and now we are reading header
- *                     block. This may block on encoder instructions. In this
- *                     state we do no read from the stream.
- *    BlockedDecodingHeaders : Decoding headers is blocked on encoder
- *                             instructions.
+ *    DecodingHeaders : In this step the headers will be decoded. The stream
+ *                      may be blocked in this state on encoder instructions.
  *    WaitingForData : we got HEADERS, we are waiting for one or more data
  *                     frames. In this state we can receive one or more
  *                     PUSH_PROMIS frames or a HEADERS frame carrying trailers.
  *    ReadingData : we got a DATA frame, now we letting the app read payload.
  *                  From here we will go back to WaitingForData state to wait
  *                  for more data frames or to CLosed state
- *    ReadingTrailers : reading trailers.
  *    ClosePending : waiting for app to pick up data, after that we can delete
  * the TransactionClient.
  *    Closed
@@ -35,11 +31,10 @@ use std::mem;
 #[derive(PartialEq, Debug)]
 enum ResponseStreamState {
     WaitingForResponseHeaders,
-    ReadingHeaders { buf: Vec<u8>, offset: usize },
-    BlockedDecodingHeaders { buf: Vec<u8>, fin: bool },
+    DecodingHeaders { header_block: Vec<u8>, fin: bool },
     WaitingForData,
     ReadingData { remaining_data_len: usize },
-    //    ReadingTrailers,
+    WaitingForFinAfterTrailers,
     ClosePending, // Close must first be read by application
     Closed,
 }
@@ -62,17 +57,13 @@ pub(crate) struct ResponseStream {
 
 impl ::std::fmt::Display for ResponseStream {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(
-            f,
-            "ResponseStream stream_id:{}",
-            self.stream_id
-        )
+        write!(f, "ResponseStream stream_id:{}", self.stream_id)
     }
 }
 
 impl ResponseStream {
     pub fn new(stream_id: u64, conn_events: Http3ClientEvents) -> Self {
-        ResponseStream {
+        Self {
             state: ResponseStreamState::WaitingForResponseHeaders,
             frame_reader: HFrameReader::new(),
             response_headers_state: ResponseHeadersState::NoHeaders,
@@ -81,67 +72,53 @@ impl ResponseStream {
         }
     }
 
-    fn handle_frame_in_state_waiting_for_headers(&mut self, frame: HFrame, fin: bool) -> Res<()> {
-        qinfo!(
-            [self],
-            "A new frame has been received: {:?}; state={:?}",
-            frame,
-            self.state
-        );
-        match frame {
-            HFrame::Headers { len } => self.handle_headers_frame(len, fin),
-            HFrame::PushPromise { .. } => Err(Error::HttpIdError),
-            _ => Err(Error::HttpFrameUnexpected),
-        }
-    }
-
-    fn handle_frame_in_state_waiting_for_data(&mut self, frame: HFrame, fin: bool) -> Res<()> {
-        qinfo!(
-            [self],
-            "A new frame has been received: {:?}; state={:?}",
-            frame,
-            self.state
-        );
-        match frame {
-            HFrame::Data { len } => self.handle_data_frame(len, fin),
-            HFrame::PushPromise { .. } => Err(Error::HttpIdError),
-            HFrame::Headers { .. } => {
-                // TODO implement trailers!
-                Err(Error::HttpFrameUnexpected)
+    fn handle_headers_frame(&mut self, header_block: Vec<u8>, fin: bool) -> Res<()> {
+        match self.state {
+            ResponseStreamState::WaitingForResponseHeaders => {
+                if header_block.is_empty() {
+                    self.add_headers(None)?;
+                } else {
+                    self.state = ResponseStreamState::DecodingHeaders { header_block, fin };
+                }
+             }
+            ResponseStreamState::WaitingForData => {
+                // TODO implement trailers, for now just ignore them.
+                self.state = ResponseStreamState::WaitingForFinAfterTrailers;
             }
-            _ => Err(Error::HttpFrameUnexpected),
-        }
-    }
-
-    fn handle_headers_frame(&mut self, len: u64, fin: bool) -> Res<()> {
-        if len == 0 {
-            self.add_headers(None)
-        } else {
-            if fin {
-                return Err(Error::HttpFrameError);
+            ResponseStreamState::WaitingForFinAfterTrailers => {
+                return Err(Error::HttpFrameUnexpected);
             }
-            self.state = ResponseStreamState::ReadingHeaders {
-                buf: vec![0; len as usize],
-                offset: 0,
-            };
-            Ok(())
-        }
+            _ => unreachable!("This functions is only called in WaitingForResponseHeaders | WaitingForData | WaitingForFinAfterTrailers state.")
+         }
+        Ok(())
     }
 
     fn handle_data_frame(&mut self, len: u64, fin: bool) -> Res<()> {
-        if len > 0 {
-            if fin {
-                return Err(Error::HttpFrameError);
+        match self.state {
+            ResponseStreamState::WaitingForResponseHeaders | ResponseStreamState::WaitingForFinAfterTrailers => {
+                return Err(Error::HttpFrameUnexpected);
             }
-            self.state = ResponseStreamState::ReadingData {
-                remaining_data_len: len as usize,
-            };
+            ResponseStreamState::WaitingForData => {
+                if len > 0 {
+                    if fin {
+                        return Err(Error::HttpFrameError);
+                    }
+                    self.state = ResponseStreamState::ReadingData {
+                        remaining_data_len: len as usize,
+                    };
+                }
+            }
+            _ => unreachable!("This functions is only called in WaitingForResponseHeaders | WaitingForData | WaitingForFinAfterTrailers state.")
         }
         Ok(())
     }
 
     fn add_headers(&mut self, headers: Option<Vec<Header>>) -> Res<()> {
         if self.response_headers_state != ResponseHeadersState::NoHeaders {
+            debug_assert!(
+                false,
+                "self.response_headers_state must be in state ResponseHeadersState::NoHeaders."
+            );
             return Err(Error::HttpInternalError);
         }
         self.response_headers_state = ResponseHeadersState::Ready(headers);
@@ -153,7 +130,7 @@ impl ResponseStream {
     fn set_state_to_close_pending(&mut self) {
         // Stream has received fin. Depending on headers state set header_ready
         // or data_readable event so that app can pick up the fin.
-        qdebug!(
+        qtrace!(
             [self],
             "set_state_to_close_pending:  response_headers_state={:?}",
             self.response_headers_state
@@ -171,73 +148,14 @@ impl ResponseStream {
         self.state = ResponseStreamState::ClosePending;
     }
 
-    fn recv_frame_header(&mut self, conn: &mut Connection) -> Res<Option<(HFrame, bool)>> {
+    fn recv_frame(&mut self, conn: &mut Connection) -> Res<(Option<HFrame>, bool)> {
         qtrace!([self], "receiving frame header");
         let fin = self.frame_reader.receive(conn, self.stream_id)?;
         if !self.frame_reader.done() {
-            if fin {
-                //we have received stream fin while waiting for a frame.
-                // !self.frame_reader.done() means that we do not have a new
-                // frame at all. Set state to ClosePending and waith for app
-                // to pick up fin.
-                self.set_state_to_close_pending();
-            }
-            Ok(None)
+            Ok((None, fin))
         } else {
             qdebug!([self], "A new frame has been received.");
-            Ok(Some((self.frame_reader.get_frame()?, fin)))
-        }
-    }
-
-    fn read_headers_frame_body(
-        &mut self,
-        conn: &mut Connection,
-        decoder: &mut QPackDecoder,
-    ) -> Res<bool> {
-        let label = if ::log::log_enabled!(::log::Level::Debug) {
-            format!("{}", self)
-        } else {
-            String::new()
-        };
-        if let ResponseStreamState::ReadingHeaders {
-            ref mut buf,
-            ref mut offset,
-        } = self.state
-        {
-            let (amount, fin) = conn.stream_recv(self.stream_id, &mut buf[*offset..])?;
-            qdebug!([label], "read_headers: read {} bytes fin={}.", amount, fin);
-            *offset += amount as usize;
-            if *offset < buf.len() {
-                if fin {
-                    // Malformated frame
-                    return Err(Error::HttpFrameError);
-                }
-                return Ok(true);
-            }
-
-            // we have read the headers, try decoding them.
-            qinfo!(
-                [label],
-                "read_headers: read all headers, try decoding them."
-            );
-            match decoder.decode_header_block(buf, self.stream_id)? {
-                Some(headers) => {
-                    self.add_headers(Some(headers))?;
-                    if fin {
-                        self.set_state_to_close_pending();
-                    }
-                    Ok(fin)
-                }
-                None => {
-                    let mut tmp: Vec<u8> = Vec::new();
-                    mem::swap(&mut tmp, buf);
-                    self.state =
-                        ResponseStreamState::BlockedDecodingHeaders { buf: tmp, fin };
-                    Ok(true)
-                }
-            }
-        } else {
-            panic!("This is only called when state is ReadingHeaders.");
+            Ok((Some(self.frame_reader.get_frame()?), fin))
         }
     }
 
@@ -303,61 +221,64 @@ impl ResponseStream {
             String::new()
         };
         loop {
-            qdebug!(
-                [label],
-                "state={:?}.",
-                self.state
-            );
+            qdebug!([label], "state={:?}.", self.state);
             match self.state {
-                ResponseStreamState::WaitingForResponseHeaders => {
-                    match self.recv_frame_header(conn)? {
-                        None => break Ok(()),
-                        Some((f, fin)) => {
-                            self.handle_frame_in_state_waiting_for_headers(f, fin)?;
-                            if fin {
+                // In the following 3 states we need to read frames.
+                ResponseStreamState::WaitingForResponseHeaders
+                | ResponseStreamState::WaitingForData
+                | ResponseStreamState::WaitingForFinAfterTrailers => {
+                    match self.recv_frame(conn)? {
+                        (None, true) => {
+                            self.set_state_to_close_pending();
+                            break Ok(());
+                        }
+                        (None, false) => break Ok(()),
+                        (Some(frame), fin) => {
+                            qinfo!(
+                                [self],
+                                "A new frame has been received: {:?}; state={:?}",
+                                frame,
+                                self.state
+                            );
+                            match frame {
+                                HFrame::Headers { header_block } => {
+                                    self.handle_headers_frame(header_block, fin)?
+                                }
+                                HFrame::Data { len } => self.handle_data_frame(len, fin)?,
+                                HFrame::PushPromise { .. } | HFrame::DuplicatePush { .. } => {
+                                    break Err(Error::HttpIdError)
+                                }
+                                _ => break Err(Error::HttpFrameUnexpected),
+                            }
+                            if fin
+                                && !matches!(self.state, ResponseStreamState::DecodingHeaders{..})
+                            {
                                 self.set_state_to_close_pending();
                                 break Ok(());
                             }
                         }
                     };
                 }
-                ResponseStreamState::ReadingHeaders { .. } => {
-                    if self.read_headers_frame_body(conn, decoder)? {
-                        break Ok(());
-                    }
-                }
-                ResponseStreamState::BlockedDecodingHeaders { ref buf, fin } => {
-                    match decoder.decode_header_block(buf, self.stream_id)? {
-                        Some(headers) => {
-                            self.add_headers(Some(headers))?;
-                            if fin {
-                                self.set_state_to_close_pending();
-                                break Ok(());
-                            }
-                        }
-                        None => {
-                            qinfo!([self], "decoding header is blocked.");
+                ResponseStreamState::DecodingHeaders {
+                    ref header_block,
+                    fin,
+                } => match decoder.decode_header_block(header_block, self.stream_id)? {
+                    Some(headers) => {
+                        self.add_headers(Some(headers))?;
+                        if fin {
+                            self.set_state_to_close_pending();
                             break Ok(());
                         }
                     }
-                }
-                ResponseStreamState::WaitingForData => {
-                    match self.recv_frame_header(conn)? {
-                        None => break Ok(()),
-                        Some((f, fin)) => {
-                            self.handle_frame_in_state_waiting_for_data(f, fin)?;
-                            if fin {
-                                self.set_state_to_close_pending();
-                                break Ok(());
-                            }
-                        }
-                    };
-                }
+                    None => {
+                        qinfo!([self], "decoding header is blocked.");
+                        break Ok(());
+                    }
+                },
                 ResponseStreamState::ReadingData { .. } => {
                     self.conn_events.data_readable(self.stream_id);
                     break Ok(());
                 }
-                // ResponseStreamState::ReadingTrailers => break Ok(()),
                 ResponseStreamState::ClosePending => {
                     panic!("Stream readable after being closed!");
                 }

--- a/neqo-http3/src/response_stream.rs
+++ b/neqo-http3/src/response_stream.rs
@@ -1,0 +1,378 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::client_events::Http3ClientEvents;
+use crate::hframe::{HFrame, HFrameReader};
+use crate::{Error, Header, Res};
+use neqo_common::{qdebug, qinfo, qtrace};
+use neqo_qpack::decoder::QPackDecoder;
+use neqo_transport::Connection;
+use std::mem;
+
+/*
+ * Response stream state:
+ *    WaitingForResponseHeaders : we wait for headers. in this state we can
+ *                                also get a PUSH_PROMISE frame.
+ *    ReadingHeaders : we have HEADERS frame and now we are reading header
+ *                     block. This may block on encoder instructions. In this
+ *                     state we do no read from the stream.
+ *    BlockedDecodingHeaders : Decoding headers is blocked on encoder
+ *                             instructions.
+ *    WaitingForData : we got HEADERS, we are waiting for one or more data
+ *                     frames. In this state we can receive one or more
+ *                     PUSH_PROMIS frames or a HEADERS frame carrying trailers.
+ *    ReadingData : we got a DATA frame, now we letting the app read payload.
+ *                  From here we will go back to WaitingForData state to wait
+ *                  for more data frames or to CLosed state
+ *    ReadingTrailers : reading trailers.
+ *    ClosePending : waiting for app to pick up data, after that we can delete
+ * the TransactionClient.
+ *    Closed
+ */
+#[derive(PartialEq, Debug)]
+enum ResponseStreamState {
+    WaitingForResponseHeaders,
+    ReadingHeaders { buf: Vec<u8>, offset: usize },
+    BlockedDecodingHeaders { buf: Vec<u8>, fin: bool },
+    WaitingForData,
+    ReadingData { remaining_data_len: usize },
+    //    ReadingTrailers,
+    ClosePending, // Close must first be read by application
+    Closed,
+}
+
+#[derive(Debug, PartialEq)]
+enum ResponseHeadersState {
+    NoHeaders,
+    Ready(Option<Vec<Header>>),
+    Read,
+}
+
+#[derive(Debug)]
+pub(crate) struct ResponseStream {
+    state: ResponseStreamState,
+    frame_reader: HFrameReader,
+    response_headers_state: ResponseHeadersState,
+    conn_events: Http3ClientEvents,
+    stream_id: u64,
+}
+
+impl ::std::fmt::Display for ResponseStream {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(
+            f,
+            "ResponseStream stream_id:{}",
+            self.stream_id
+        )
+    }
+}
+
+impl ResponseStream {
+    pub fn new(stream_id: u64, conn_events: Http3ClientEvents) -> Self {
+        ResponseStream {
+            state: ResponseStreamState::WaitingForResponseHeaders,
+            frame_reader: HFrameReader::new(),
+            response_headers_state: ResponseHeadersState::NoHeaders,
+            conn_events,
+            stream_id,
+        }
+    }
+
+    fn handle_frame_in_state_waiting_for_headers(&mut self, frame: HFrame, fin: bool) -> Res<()> {
+        qinfo!(
+            [self],
+            "A new frame has been received: {:?}; state={:?}",
+            frame,
+            self.state
+        );
+        match frame {
+            HFrame::Headers { len } => self.handle_headers_frame(len, fin),
+            HFrame::PushPromise { .. } => Err(Error::HttpIdError),
+            _ => Err(Error::HttpFrameUnexpected),
+        }
+    }
+
+    fn handle_frame_in_state_waiting_for_data(&mut self, frame: HFrame, fin: bool) -> Res<()> {
+        qinfo!(
+            [self],
+            "A new frame has been received: {:?}; state={:?}",
+            frame,
+            self.state
+        );
+        match frame {
+            HFrame::Data { len } => self.handle_data_frame(len, fin),
+            HFrame::PushPromise { .. } => Err(Error::HttpIdError),
+            HFrame::Headers { .. } => {
+                // TODO implement trailers!
+                Err(Error::HttpFrameUnexpected)
+            }
+            _ => Err(Error::HttpFrameUnexpected),
+        }
+    }
+
+    fn handle_headers_frame(&mut self, len: u64, fin: bool) -> Res<()> {
+        if len == 0 {
+            self.add_headers(None)
+        } else {
+            if fin {
+                return Err(Error::HttpFrameError);
+            }
+            self.state = ResponseStreamState::ReadingHeaders {
+                buf: vec![0; len as usize],
+                offset: 0,
+            };
+            Ok(())
+        }
+    }
+
+    fn handle_data_frame(&mut self, len: u64, fin: bool) -> Res<()> {
+        if len > 0 {
+            if fin {
+                return Err(Error::HttpFrameError);
+            }
+            self.state = ResponseStreamState::ReadingData {
+                remaining_data_len: len as usize,
+            };
+        }
+        Ok(())
+    }
+
+    fn add_headers(&mut self, headers: Option<Vec<Header>>) -> Res<()> {
+        if self.response_headers_state != ResponseHeadersState::NoHeaders {
+            return Err(Error::HttpInternalError);
+        }
+        self.response_headers_state = ResponseHeadersState::Ready(headers);
+        self.conn_events.header_ready(self.stream_id);
+        self.state = ResponseStreamState::WaitingForData;
+        Ok(())
+    }
+
+    fn set_state_to_close_pending(&mut self) {
+        // Stream has received fin. Depending on headers state set header_ready
+        // or data_readable event so that app can pick up the fin.
+        qdebug!(
+            [self],
+            "set_state_to_close_pending:  response_headers_state={:?}",
+            self.response_headers_state
+        );
+        match self.response_headers_state {
+            ResponseHeadersState::NoHeaders => {
+                self.conn_events.header_ready(self.stream_id);
+                self.response_headers_state = ResponseHeadersState::Ready(None);
+            }
+            // In Ready state we are already waiting for app to pick up headers
+            // it can also pick up fin, so we do not need a new event.
+            ResponseHeadersState::Ready(..) => {}
+            ResponseHeadersState::Read => self.conn_events.data_readable(self.stream_id),
+        }
+        self.state = ResponseStreamState::ClosePending;
+    }
+
+    fn recv_frame_header(&mut self, conn: &mut Connection) -> Res<Option<(HFrame, bool)>> {
+        qtrace!([self], "receiving frame header");
+        let fin = self.frame_reader.receive(conn, self.stream_id)?;
+        if !self.frame_reader.done() {
+            if fin {
+                //we have received stream fin while waiting for a frame.
+                // !self.frame_reader.done() means that we do not have a new
+                // frame at all. Set state to ClosePending and waith for app
+                // to pick up fin.
+                self.set_state_to_close_pending();
+            }
+            Ok(None)
+        } else {
+            qdebug!([self], "A new frame has been received.");
+            Ok(Some((self.frame_reader.get_frame()?, fin)))
+        }
+    }
+
+    fn read_headers_frame_body(
+        &mut self,
+        conn: &mut Connection,
+        decoder: &mut QPackDecoder,
+    ) -> Res<bool> {
+        let label = if ::log::log_enabled!(::log::Level::Debug) {
+            format!("{}", self)
+        } else {
+            String::new()
+        };
+        if let ResponseStreamState::ReadingHeaders {
+            ref mut buf,
+            ref mut offset,
+        } = self.state
+        {
+            let (amount, fin) = conn.stream_recv(self.stream_id, &mut buf[*offset..])?;
+            qdebug!([label], "read_headers: read {} bytes fin={}.", amount, fin);
+            *offset += amount as usize;
+            if *offset < buf.len() {
+                if fin {
+                    // Malformated frame
+                    return Err(Error::HttpFrameError);
+                }
+                return Ok(true);
+            }
+
+            // we have read the headers, try decoding them.
+            qinfo!(
+                [label],
+                "read_headers: read all headers, try decoding them."
+            );
+            match decoder.decode_header_block(buf, self.stream_id)? {
+                Some(headers) => {
+                    self.add_headers(Some(headers))?;
+                    if fin {
+                        self.set_state_to_close_pending();
+                    }
+                    Ok(fin)
+                }
+                None => {
+                    let mut tmp: Vec<u8> = Vec::new();
+                    mem::swap(&mut tmp, buf);
+                    self.state =
+                        ResponseStreamState::BlockedDecodingHeaders { buf: tmp, fin };
+                    Ok(true)
+                }
+            }
+        } else {
+            panic!("This is only called when state is ReadingHeaders.");
+        }
+    }
+
+    pub fn read_response_headers(&mut self) -> Res<(Vec<Header>, bool)> {
+        if let ResponseHeadersState::Ready(ref mut headers) = self.response_headers_state {
+            let mut tmp = Vec::new();
+            if let Some(ref mut hdrs) = headers {
+                mem::swap(&mut tmp, hdrs);
+            }
+            self.response_headers_state = ResponseHeadersState::Read;
+            let mut fin = false;
+            if self.state == ResponseStreamState::ClosePending {
+                fin = true;
+                self.state = ResponseStreamState::Closed;
+            }
+            Ok((tmp, fin))
+        } else {
+            Err(Error::Unavailable)
+        }
+    }
+
+    pub fn read_response_data(
+        &mut self,
+        conn: &mut Connection,
+        buf: &mut [u8],
+    ) -> Res<(usize, bool)> {
+        match self.state {
+            ResponseStreamState::ReadingData {
+                ref mut remaining_data_len,
+            } => {
+                let to_read = if *remaining_data_len > buf.len() {
+                    buf.len()
+                } else {
+                    *remaining_data_len
+                };
+                let (amount, fin) = conn.stream_recv(self.stream_id, &mut buf[..to_read])?;
+                debug_assert!(amount <= to_read);
+                *remaining_data_len -= amount;
+
+                if fin {
+                    if *remaining_data_len > 0 {
+                        return Err(Error::HttpFrameError);
+                    }
+                    self.state = ResponseStreamState::Closed;
+                } else if *remaining_data_len == 0 {
+                    self.state = ResponseStreamState::WaitingForData;
+                }
+
+                Ok((amount, fin))
+            }
+            ResponseStreamState::ClosePending => {
+                self.state = ResponseStreamState::Closed;
+                Ok((0, true))
+            }
+            _ => Ok((0, false)),
+        }
+    }
+
+    pub fn receive(&mut self, conn: &mut Connection, decoder: &mut QPackDecoder) -> Res<()> {
+        let label = if ::log::log_enabled!(::log::Level::Debug) {
+            format!("{}", self)
+        } else {
+            String::new()
+        };
+        loop {
+            qdebug!(
+                [label],
+                "state={:?}.",
+                self.state
+            );
+            match self.state {
+                ResponseStreamState::WaitingForResponseHeaders => {
+                    match self.recv_frame_header(conn)? {
+                        None => break Ok(()),
+                        Some((f, fin)) => {
+                            self.handle_frame_in_state_waiting_for_headers(f, fin)?;
+                            if fin {
+                                self.set_state_to_close_pending();
+                                break Ok(());
+                            }
+                        }
+                    };
+                }
+                ResponseStreamState::ReadingHeaders { .. } => {
+                    if self.read_headers_frame_body(conn, decoder)? {
+                        break Ok(());
+                    }
+                }
+                ResponseStreamState::BlockedDecodingHeaders { ref buf, fin } => {
+                    match decoder.decode_header_block(buf, self.stream_id)? {
+                        Some(headers) => {
+                            self.add_headers(Some(headers))?;
+                            if fin {
+                                self.set_state_to_close_pending();
+                                break Ok(());
+                            }
+                        }
+                        None => {
+                            qinfo!([self], "decoding header is blocked.");
+                            break Ok(());
+                        }
+                    }
+                }
+                ResponseStreamState::WaitingForData => {
+                    match self.recv_frame_header(conn)? {
+                        None => break Ok(()),
+                        Some((f, fin)) => {
+                            self.handle_frame_in_state_waiting_for_data(f, fin)?;
+                            if fin {
+                                self.set_state_to_close_pending();
+                                break Ok(());
+                            }
+                        }
+                    };
+                }
+                ResponseStreamState::ReadingData { .. } => {
+                    self.conn_events.data_readable(self.stream_id);
+                    break Ok(());
+                }
+                // ResponseStreamState::ReadingTrailers => break Ok(()),
+                ResponseStreamState::ClosePending => {
+                    panic!("Stream readable after being closed!");
+                }
+                ResponseStreamState::Closed => {
+                    panic!("Stream readable after being closed!");
+                }
+            };
+        }
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.state == ResponseStreamState::Closed
+    }
+
+    pub fn close(&mut self) {
+        self.state = ResponseStreamState::Closed;
+    }
+}

--- a/neqo-http3/src/transaction_client.rs
+++ b/neqo-http3/src/transaction_client.rs
@@ -4,10 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::hframe::{HFrame, HFrameReader};
+use crate::hframe::HFrame;
 
 use crate::client_events::Http3ClientEvents;
 use crate::connection::Http3Transaction;
+use crate::response_stream::ResponseStream;
 use crate::Header;
 use neqo_common::{qdebug, qinfo, qtrace, qwarn, Encoder};
 use neqo_qpack::decoder::QPackDecoder;
@@ -16,7 +17,6 @@ use neqo_transport::Connection;
 
 use crate::{Error, Res};
 use std::cmp::min;
-use std::mem;
 
 const MAX_DATA_HEADER_SIZE_2: usize = (1 << 6) - 1; // Maximal amount of data with DATA frame header size 2
 const MAX_DATA_HEADER_SIZE_2_LIMIT: usize = MAX_DATA_HEADER_SIZE_2 + 3; // 63 + 3 (size of the next buffer data frame header)
@@ -121,53 +121,12 @@ enum TransactionSendState {
     Closed,
 }
 
-/*
- * Transaction receive state:
- *    WaitingForResponseHeaders : we wait for headers. in this state we can
- *                                also get a PUSH_PROMISE frame.
- *    ReadingHeaders : we have HEADERS frame and now we are reading header
- *                     block. This may block on encoder instructions. In this
- *                     state we do no read from the stream.
- *    BlockedDecodingHeaders : Decoding headers is blocked on encoder
- *                             instructions.
- *    WaitingForData : we got HEADERS, we are waiting for one or more data
- *                     frames. In this state we can receive one or more
- *                     PUSH_PROMIS frames or a HEADERS frame carrying trailers.
- *    ReadingData : we got a DATA frame, now we letting the app read payload.
- *                  From here we will go back to WaitingForData state to wait
- *                  for more data frames or to CLosed state
- *    ReadingTrailers : reading trailers.
- *    ClosePending : waiting for app to pick up data, after that we can delete
- * the TransactionClient.
- *    Closed
- */
-#[derive(PartialEq, Debug)]
-enum TransactionRecvState {
-    WaitingForResponseHeaders,
-    ReadingHeaders { buf: Vec<u8>, offset: usize },
-    BlockedDecodingHeaders { buf: Vec<u8>, fin: bool },
-    WaitingForData,
-    ReadingData { remaining_data_len: usize },
-    //    ReadingTrailers,
-    ClosePending, // Close must first be read by application
-    Closed,
-}
-
-#[derive(Debug, PartialEq)]
-enum ResponseHeadersState {
-    NoHeaders,
-    Ready(Option<Vec<Header>>),
-    Read,
-}
-
 //  This is used for normal request/responses.
 #[derive(Debug)]
 pub struct TransactionClient {
     send_state: TransactionSendState,
-    recv_state: TransactionRecvState,
+    response_stream: ResponseStream,
     stream_id: u64,
-    frame_reader: HFrameReader,
-    response_headers_state: ResponseHeadersState,
     conn_events: Http3ClientEvents,
 }
 
@@ -187,10 +146,8 @@ impl TransactionClient {
                 request: Request::new(method, scheme, host, path, headers),
                 fin: false,
             },
-            recv_state: TransactionRecvState::WaitingForResponseHeaders,
+            response_stream: ResponseStream::new(stream_id, conn_events.clone()),
             stream_id,
-            response_headers_state: ResponseHeadersState::NoHeaders,
-            frame_reader: HFrameReader::new(),
             conn_events,
         }
     }
@@ -250,167 +207,6 @@ impl TransactionClient {
         }
     }
 
-    fn handle_frame_in_state_waiting_for_headers(&mut self, frame: HFrame, fin: bool) -> Res<()> {
-        qinfo!(
-            [self],
-            "A new frame has been received: {:?}; state={:?}",
-            frame,
-            self.recv_state
-        );
-        match frame {
-            HFrame::Headers { len } => self.handle_headers_frame(len, fin),
-            HFrame::PushPromise { .. } => Err(Error::HttpIdError),
-            _ => Err(Error::HttpFrameUnexpected),
-        }
-    }
-
-    fn handle_headers_frame(&mut self, len: u64, fin: bool) -> Res<()> {
-        if len == 0 {
-            self.add_headers(None)
-        } else {
-            if fin {
-                return Err(Error::HttpFrameError);
-            }
-            self.recv_state = TransactionRecvState::ReadingHeaders {
-                buf: vec![0; len as usize],
-                offset: 0,
-            };
-            Ok(())
-        }
-    }
-
-    fn handle_frame_in_state_waiting_for_data(&mut self, frame: HFrame, fin: bool) -> Res<()> {
-        qinfo!(
-            [self],
-            "A new frame has been received: {:?}; state={:?}",
-            frame,
-            self.recv_state
-        );
-        match frame {
-            HFrame::Data { len } => self.handle_data_frame(len, fin),
-            HFrame::PushPromise { .. } => Err(Error::HttpIdError),
-            HFrame::Headers { .. } => {
-                // TODO implement trailers!
-                qwarn!([self], "Received trailers");
-                Err(Error::HttpFrameUnexpected)
-            }
-            _ => Err(Error::HttpFrameUnexpected),
-        }
-    }
-
-    fn handle_data_frame(&mut self, len: u64, fin: bool) -> Res<()> {
-        if len > 0 {
-            if fin {
-                return Err(Error::HttpFrameError);
-            }
-            self.recv_state = TransactionRecvState::ReadingData {
-                remaining_data_len: len as usize,
-            };
-        }
-        Ok(())
-    }
-
-    fn add_headers(&mut self, headers: Option<Vec<Header>>) -> Res<()> {
-        if self.response_headers_state != ResponseHeadersState::NoHeaders {
-            return Err(Error::HttpInternalError);
-        }
-        self.response_headers_state = ResponseHeadersState::Ready(headers);
-        self.conn_events.header_ready(self.stream_id);
-        self.recv_state = TransactionRecvState::WaitingForData;
-        Ok(())
-    }
-
-    fn set_state_to_close_pending(&mut self) {
-        // Stream has received fin. Depending on headers state set header_ready
-        // or data_readable event so that app can pick up the fin.
-        qdebug!(
-            [self],
-            "set_state_to_close_pending:  response_headers_state={:?}",
-            self.response_headers_state
-        );
-        match self.response_headers_state {
-            ResponseHeadersState::NoHeaders => {
-                self.conn_events.header_ready(self.stream_id);
-                self.response_headers_state = ResponseHeadersState::Ready(None);
-            }
-            // In Ready state we are already waiting for app to pick up headers
-            // it can also pick up fin, so we do not need a new event.
-            ResponseHeadersState::Ready(..) => {}
-            ResponseHeadersState::Read => self.conn_events.data_readable(self.stream_id),
-        }
-        self.recv_state = TransactionRecvState::ClosePending;
-    }
-
-    fn recv_frame_header(&mut self, conn: &mut Connection) -> Res<Option<(HFrame, bool)>> {
-        qtrace!([self], "receiving frame header");
-        let fin = self.frame_reader.receive(conn, self.stream_id)?;
-        if !self.frame_reader.done() {
-            if fin {
-                //we have received stream fin while waiting for a frame.
-                // !self.frame_reader.done() means that we do not have a new
-                // frame at all. Set state to ClosePending and waith for app
-                // to pick up fin.
-                self.set_state_to_close_pending();
-            }
-            Ok(None)
-        } else {
-            qdebug!([self], "A new frame has been received.");
-            Ok(Some((self.frame_reader.get_frame()?, fin)))
-        }
-    }
-
-    fn read_headers_frame_body(
-        &mut self,
-        conn: &mut Connection,
-        decoder: &mut QPackDecoder,
-    ) -> Res<bool> {
-        let label = if ::log::log_enabled!(::log::Level::Debug) {
-            format!("{}", self)
-        } else {
-            String::new()
-        };
-        if let TransactionRecvState::ReadingHeaders {
-            ref mut buf,
-            ref mut offset,
-        } = self.recv_state
-        {
-            let (amount, fin) = conn.stream_recv(self.stream_id, &mut buf[*offset..])?;
-            qdebug!([label], "read_headers: read {} bytes fin={}.", amount, fin);
-            *offset += amount as usize;
-            if *offset < buf.len() {
-                if fin {
-                    // Malformated frame
-                    return Err(Error::HttpFrameError);
-                }
-                return Ok(true);
-            }
-
-            // we have read the headers, try decoding them.
-            qinfo!(
-                [label],
-                "read_headers: read all headers, try decoding them."
-            );
-            match decoder.decode_header_block(buf, self.stream_id)? {
-                Some(headers) => {
-                    self.add_headers(Some(headers))?;
-                    if fin {
-                        self.set_state_to_close_pending();
-                    }
-                    Ok(fin)
-                }
-                None => {
-                    let mut tmp: Vec<u8> = Vec::new();
-                    mem::swap(&mut tmp, buf);
-                    self.recv_state =
-                        TransactionRecvState::BlockedDecodingHeaders { buf: tmp, fin };
-                    Ok(true)
-                }
-            }
-        } else {
-            panic!("This is only called when recv_state is ReadingHeaders.");
-        }
-    }
-
     pub fn is_sending_closed(&self) -> bool {
         match self.send_state {
             TransactionSendState::SendingHeaders { fin, .. } => fin,
@@ -420,21 +216,7 @@ impl TransactionClient {
     }
 
     pub fn read_response_headers(&mut self) -> Res<(Vec<Header>, bool)> {
-        if let ResponseHeadersState::Ready(ref mut headers) = self.response_headers_state {
-            let mut tmp = Vec::new();
-            if let Some(ref mut hdrs) = headers {
-                mem::swap(&mut tmp, hdrs);
-            }
-            self.response_headers_state = ResponseHeadersState::Read;
-            let mut fin = false;
-            if self.recv_state == TransactionRecvState::ClosePending {
-                fin = true;
-                self.recv_state = TransactionRecvState::Closed;
-            }
-            Ok((tmp, fin))
-        } else {
-            Err(Error::Unavailable)
-        }
+        self.response_stream.read_response_headers()
     }
 
     pub fn read_response_data(
@@ -442,36 +224,7 @@ impl TransactionClient {
         conn: &mut Connection,
         buf: &mut [u8],
     ) -> Res<(usize, bool)> {
-        match self.recv_state {
-            TransactionRecvState::ReadingData {
-                ref mut remaining_data_len,
-            } => {
-                let to_read = if *remaining_data_len > buf.len() {
-                    buf.len()
-                } else {
-                    *remaining_data_len
-                };
-                let (amount, fin) = conn.stream_recv(self.stream_id, &mut buf[..to_read])?;
-                debug_assert!(amount <= to_read);
-                *remaining_data_len -= amount;
-
-                if fin {
-                    if *remaining_data_len > 0 {
-                        return Err(Error::HttpFrameError);
-                    }
-                    self.recv_state = TransactionRecvState::Closed;
-                } else if *remaining_data_len == 0 {
-                    self.recv_state = TransactionRecvState::WaitingForData;
-                }
-
-                Ok((amount, fin))
-            }
-            TransactionRecvState::ClosePending => {
-                self.recv_state = TransactionRecvState::Closed;
-                Ok((0, true))
-            }
-            _ => Ok((0, false)),
-        }
+        self.response_stream.read_response_data(conn, buf)
     }
 
     pub fn is_state_sending_data(&self) -> bool {
@@ -512,77 +265,12 @@ impl Http3Transaction for TransactionClient {
         Ok(())
     }
 
-    fn receive(&mut self, conn: &mut Connection, decoder: &mut QPackDecoder) -> Res<()> {
-        let label = if ::log::log_enabled!(::log::Level::Debug) {
-            format!("{}", self)
-        } else {
-            String::new()
-        };
-        loop {
-            qdebug!(
-                [label],
-                "send_state={:?} recv_state={:?}.",
-                self.send_state,
-                self.recv_state
-            );
-            match self.recv_state {
-                TransactionRecvState::WaitingForResponseHeaders => {
-                    match self.recv_frame_header(conn)? {
-                        None => break Ok(()),
-                        Some((f, fin)) => {
-                            self.handle_frame_in_state_waiting_for_headers(f, fin)?;
-                            if fin {
-                                self.set_state_to_close_pending();
-                                break Ok(());
-                            }
-                        }
-                    };
-                }
-                TransactionRecvState::ReadingHeaders { .. } => {
-                    if self.read_headers_frame_body(conn, decoder)? {
-                        break Ok(());
-                    }
-                }
-                TransactionRecvState::BlockedDecodingHeaders { ref buf, fin } => {
-                    match decoder.decode_header_block(buf, self.stream_id)? {
-                        Some(headers) => {
-                            self.add_headers(Some(headers))?;
-                            if fin {
-                                self.set_state_to_close_pending();
-                                break Ok(());
-                            }
-                        }
-                        None => {
-                            qinfo!([self], "decoding header is blocked.");
-                            break Ok(());
-                        }
-                    }
-                }
-                TransactionRecvState::WaitingForData => {
-                    match self.recv_frame_header(conn)? {
-                        None => break Ok(()),
-                        Some((f, fin)) => {
-                            self.handle_frame_in_state_waiting_for_data(f, fin)?;
-                            if fin {
-                                self.set_state_to_close_pending();
-                                break Ok(());
-                            }
-                        }
-                    };
-                }
-                TransactionRecvState::ReadingData { .. } => {
-                    self.conn_events.data_readable(self.stream_id);
-                    break Ok(());
-                }
-                // TransactionRecvState::ReadingTrailers => break Ok(()),
-                TransactionRecvState::ClosePending => {
-                    panic!("Stream readable after being closed!");
-                }
-                TransactionRecvState::Closed => {
-                    panic!("Stream readable after being closed!");
-                }
-            };
-        }
+    fn receive(
+        &mut self,
+        conn: &mut Connection,
+        decoder: &mut QPackDecoder,
+    ) -> Res<()> {
+        self.response_stream.receive(conn, decoder)
     }
 
     fn has_data_to_send(&self) -> bool {
@@ -594,7 +282,7 @@ impl Http3Transaction for TransactionClient {
     }
 
     fn reset_receiving_side(&mut self) {
-        self.recv_state = TransactionRecvState::Closed;
+        self.response_stream.close();
     }
 
     fn stop_sending(&mut self) {
@@ -602,8 +290,7 @@ impl Http3Transaction for TransactionClient {
     }
 
     fn done(&self) -> bool {
-        self.send_state == TransactionSendState::Closed
-            && self.recv_state == TransactionRecvState::Closed
+        self.send_state == TransactionSendState::Closed && self.response_stream.is_closed()
     }
 
     fn close_send(&mut self, conn: &mut Connection) -> Res<()> {


### PR DESCRIPTION
Fixes #344     
Furthermore:
    - Move response part of the client transaction into a separate file
    - do not return an error if trailers are received (Fixes #437 #264 ).