### PR TITLE
Do not send MAX_STREAM_DATA if stream is no longer in Recv state

### DIFF
--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -122,6 +122,16 @@ impl FlowMgr {
             .insert((stream_id, mem::discriminant(&frame)), frame);
     }
 
+    /// Don't send stream data updates if no more data is coming
+    pub fn clear_max_stream_data(&mut self, stream_id: StreamId) {
+        let frame = Frame::MaxStreamData {
+            stream_id,
+            maximum_stream_data: 0,
+        };
+        self.from_streams
+            .remove(&(stream_id, mem::discriminant(&frame)));
+    }
+
     /// Indicate to receiving remote we need more credits
     pub fn stream_data_blocked(&mut self, stream_id: StreamId, stream_data_limit: u64) {
         let frame = Frame::StreamDataBlocked {

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -356,6 +356,10 @@ impl RecvStream {
     }
 
     fn set_state(&mut self, new_state: RecvStreamState) {
+        assert_ne!(
+            mem::discriminant(&self.state),
+            mem::discriminant(&new_state)
+        );
         qtrace!(
             "RecvStream {} state {} -> {}",
             self.stream_id.as_u64(),

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -356,7 +356,7 @@ impl RecvStream {
     }
 
     fn set_state(&mut self, new_state: RecvStreamState) {
-        assert_ne!(
+        debug_assert_ne!(
             mem::discriminant(&self.state),
             mem::discriminant(&new_state)
         );

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -29,7 +29,7 @@ pub(crate) type RecvStreams = BTreeMap<StreamId, RecvStream>;
 
 /// Holds data not yet read by application. Orders and dedupes data ranges
 /// from incoming STREAM frames.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default)]
 pub struct RxStreamOrderer {
     data_ranges: BTreeMap<u64, Vec<u8>>, // (start_offset, data)
     retired: u64,                        // Number of bytes the application has read
@@ -274,7 +274,7 @@ impl RxStreamOrderer {
 }
 
 /// QUIC receiving states, based on -transport 3.2.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 #[allow(dead_code)]
 // Because a dead_code warning is easier than clippy::unused_self, see https://github.com/rust-lang/rust/issues/68408
 enum RecvStreamState {


### PR DESCRIPTION
Previously, we would no longer enqueue MAX_STREAM_DATA frames but we
did not remove an already enqueued frame. This fixes that by adding
a clear_max_stream_data method to FlowMgr, which is called when a
RecvStream transitions out of Recv state.

Refactor SendStream: Move RecvStreamState::transition() to
RecvStream::set_state().

fixes #435