### PR TITLE
Use inspect rather than map

### DIFF
--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -324,10 +324,7 @@ impl LossRecovery {
             .is_none());
         self.spaces[PNSpace::ApplicationData]
             .remove_ignored()
-            .map(|p| {
-                self.cc.discard(&p);
-                p
-            })
+            .inspect(|p| self.cc.discard(&p))
             .collect()
     }
 
@@ -424,10 +421,7 @@ impl LossRecovery {
         self.spaces
             .iter_mut()
             .flat_map(|spc| spc.remove_ignored())
-            .map(|p| {
-                cc.discard(&p);
-                p
-            })
+            .inspect(|p| cc.discard(&p))
             .collect()
     }
 


### PR DESCRIPTION
`map(|x| { do_something(&x); x })` can be replaced with
`inspect(|x| do_something(&x)`.  There is probably a lint for that, but
we don't have all the lints on yet.