### PR TITLE
Add error documentation to crypto functions.

### DIFF
--- a/neqo-crypto/src/aead.rs
+++ b/neqo-crypto/src/aead.rs
@@ -56,6 +56,10 @@ pub struct Aead {
 // TODO(mt) move unused_self once https://github.com/rust-lang/rust-clippy/issues/5053 is fixed
 #[allow(clippy::unused_self)]
 impl Aead {
+    /// Create a new AEAD based on the indicated TLS version and cipher suite.
+    ///
+    /// # Errors
+    /// Returns `Error` when the supporting NSS functions fail.
     pub fn new(version: Version, cipher: Cipher, secret: &SymKey, prefix: &str) -> Res<Self> {
         let s: *mut PK11SymKey = **secret;
         unsafe { Self::from_raw(version, cipher, s, prefix) }
@@ -94,6 +98,9 @@ impl Aead {
     ///
     /// The space provided in `output` needs to be larger than `input` by
     /// the value provided in `Aead::expansion`.
+    ///
+    /// # Errors
+    /// If the input can't be protected or any input is too large for NSS.
     pub fn encrypt<'a>(
         &self,
         count: u64,
@@ -123,6 +130,9 @@ impl Aead {
     /// Note that NSS insists upon having extra space available for decryption, so
     /// the buffer for `output` should be the same length as `input`, even though
     /// the final result will be shorter.
+    ///
+    /// # Errors
+    /// If the input isn't authenticated or any input is too large for NSS.
     pub fn decrypt<'a>(
         &self,
         count: u64,

--- a/neqo-crypto/src/ext.rs
+++ b/neqo-crypto/src/ext.rs
@@ -118,11 +118,14 @@ impl ExtensionTracker {
     }
 
     /// Use the provided handler to manage an extension.  This is quite unsafe.
-    /// # Safety
     ///
+    /// # Safety
     /// The holder of this `ExtensionTracker` needs to ensure that it lives at
     /// least as long as the file descriptor, as NSS provides no way to remove
     /// an extension handler once it is configured.
+    ///
+    /// # Errors
+    /// If the underlying NSS API fails to register a handler.
     pub unsafe fn new(
         fd: *mut PRFileDesc,
         extension: Extension,

--- a/neqo-crypto/src/hkdf.rs
+++ b/neqo-crypto/src/hkdf.rs
@@ -45,11 +45,18 @@ fn key_size(version: Version, cipher: Cipher) -> Res<usize> {
     })
 }
 
+/// Generate a random key of the right size for the given suite.
+///
+/// # Errors
+/// Only if NSS fails.
 pub fn generate_key(version: Version, cipher: Cipher) -> Res<SymKey> {
     import_key(version, cipher, &random(key_size(version, cipher)?))
 }
 
 /// Import a symmetric key for use with HKDF.
+///
+/// # Errors
+/// Errors returned if the key buffer is an incompatible size or the NSS functions fail.
 pub fn import_key(version: Version, cipher: Cipher, buf: &[u8]) -> Res<SymKey> {
     if version != TLS_VERSION_1_3 {
         return Err(Error::UnsupportedVersion);
@@ -86,6 +93,9 @@ pub fn import_key(version: Version, cipher: Cipher, buf: &[u8]) -> Res<SymKey> {
 }
 
 /// Extract a PRK from the given salt and IKM using the algorithm defined in RFC 5869.
+///
+/// # Errors
+/// Errors returned if inputs are too large or the NSS functions fail.
 pub fn extract(
     version: Version,
     cipher: Cipher,
@@ -105,6 +115,9 @@ pub fn extract(
 }
 
 /// Expand a PRK using the HKDF-Expand-Label function defined in RFC 8446.
+///
+/// # Errors
+/// Errors returned if inputs are too large or the NSS functions fail.
 pub fn expand_label(
     version: Version,
     cipher: Cipher,

--- a/neqo-crypto/src/hp.rs
+++ b/neqo-crypto/src/hp.rs
@@ -40,6 +40,9 @@ impl Debug for HpKey {
 
 impl HpKey {
     /// QUIC-specific API for extracting a header-protection key.
+    ///
+    /// # Errors
+    /// Errors if HKDF fails or if the label is too long to fit in a `c_uint`.
     pub fn extract(version: Version, cipher: Cipher, prk: &SymKey, label: &str) -> Res<Self> {
         let l = label.as_bytes();
         let mut secret: *mut PK11SymKey = null_mut();
@@ -74,6 +77,10 @@ impl HpKey {
     }
 
     /// Generate a header protection mask for QUIC.
+    ///
+    /// # Errors
+    /// An error is returned if the NSS functions fail; a sample of the
+    /// wrong size is the obvious cause.
     #[allow(clippy::cast_sign_loss)]
     pub fn mask(&self, sample: &[u8]) -> Res<Vec<u8>> {
         let k: *mut PK11SymKey = *self.0;

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -67,6 +67,9 @@ scoped_ptr!(Slot, PK11SlotInfo, PK11_FreeSlot);
 
 impl SymKey {
     /// You really don't want to use this.
+    ///
+    /// # Errors
+    /// Internal errors in case of failures in NSS.
     pub fn as_bytes<'a>(&'a self) -> Res<&'a [u8]> {
         secstatus_to_res(unsafe { PK11_ExtractKeyValue(self.ptr) })?;
 

--- a/neqo-crypto/src/replay.rs
+++ b/neqo-crypto/src/replay.rs
@@ -49,6 +49,10 @@ pub struct AntiReplay {
 impl AntiReplay {
     /// Make a new anti-replay context.
     /// See the documentation in NSS for advice on how to set these values.
+    ///
+    /// # Errors
+    /// Returns an error if `now` is in the past relative to our baseline or
+    /// NSS is unable to generate an anti-replay context.
     pub fn new(now: Instant, window: Duration, k: usize, bits: usize) -> Res<Self> {
         let mut ctx: *mut SSLAntiReplayContext = null_mut();
         unsafe {


### PR DESCRIPTION
Clippy in 1.41 has a new lint.