### PR TITLE
Avoid usage of mem::take()

### DIFF
--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -838,17 +838,21 @@ impl CryptoStreams {
                     ..
                 } = self
                 {
+                    // TODO: Use mem::take instead of mem::replace once 1.40+ is
+                    // usable in Firefox builds.
+                    let tmp_h = mem::replace(handshake, CryptoStream::default());
+                    let tmp_a = mem::replace(application, CryptoStream::default());
                     *self = Self::Handshake {
-                        handshake: mem::take(handshake),
-                        application: mem::take(application),
+                        handshake: tmp_h,
+                        application: tmp_a,
                     };
                 }
             }
             PNSpace::Handshake => {
                 if let Self::Handshake { application, .. } = self {
-                    *self = Self::ApplicationData {
-                        application: mem::take(application),
-                    };
+                    // TODO: Same as above
+                    let tmp_a = mem::replace(application, CryptoStream::default());
+                    *self = Self::ApplicationData { application: tmp_a };
                 } else if matches!(self, Self::Initial {..}) {
                     panic!("Discarding handshake before initial discarded");
                 }


### PR DESCRIPTION
This was first available in Rust 1.40, which unfortunately is not yet
used for Firefox builds, so we need to avoid for the moment.