### PR TITLE
Don't subtract discarded pkts from BIF if previously deemed lost

### DIFF
--- a/neqo-transport/src/cc.rs
+++ b/neqo-transport/src/cc.rs
@@ -141,7 +141,7 @@ impl CongestionControl {
     }
 
     pub fn discard(&mut self, pkt: &SentPacket) {
-        if pkt.in_flight {
+        if pkt.in_flight && pkt.time_declared_lost.is_none() {
             assert!(self.bytes_in_flight >= pkt.size);
             self.bytes_in_flight -= pkt.size;
             qtrace!([self], "Ignore pkt with size {}", pkt.size);


### PR DESCRIPTION
This is basically the same bug as #365.

We keep SentPackets that were deemed lost around for a bit longer, just
in case they get acked then we win. But, they're subtracted from BIF when
deemed lost. When they are actually removed from sent_packets they
should not be subtracted again.

see https://bugzilla.mozilla.org/show_bug.cgi?id=1616009