### PR TITLE
Use rustc version matching minimum Gecko version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.40.0
+    RUST_VERSION=1.41.1
 
 RUN set -eux; \
     curl -sSLf "https://static.rust-lang.org/rustup/archive/1.20.2/x86_64-unknown-linux-gnu/rustup-init" -o rustup-init; \


### PR DESCRIPTION
see https://bugzilla.mozilla.org/show_bug.cgi?id=1615003

It's ok if we don't exactly track Gecko's rust version, but we shouldn't
get ahead of it. I think we want 1.41 to use the new lockfile format.