### PR TITLE
Revert "Avoid usage of mem::take()"

### DIFF
--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -838,21 +838,17 @@ impl CryptoStreams {
                     ..
                 } = self
                 {
-                    // TODO: Use mem::take instead of mem::replace once 1.40+ is
-                    // usable in Firefox builds.
-                    let tmp_h = mem::replace(handshake, CryptoStream::default());
-                    let tmp_a = mem::replace(application, CryptoStream::default());
                     *self = Self::Handshake {
-                        handshake: tmp_h,
-                        application: tmp_a,
+                        handshake: mem::take(handshake),
+                        application: mem::take(application),
                     };
                 }
             }
             PNSpace::Handshake => {
                 if let Self::Handshake { application, .. } = self {
-                    // TODO: Same as above
-                    let tmp_a = mem::replace(application, CryptoStream::default());
-                    *self = Self::ApplicationData { application: tmp_a };
+                    *self = Self::ApplicationData {
+                        application: mem::take(application),
+                    };
                 } else if matches!(self, Self::Initial {..}) {
                     panic!("Discarding handshake before initial discarded");
                 }


### PR DESCRIPTION
This reverts commit e2b1faac522f74ca2e1d484a8faadd66786a1f1b.

We had to do this because Firefox was still on an older Rust compiler version, but now they've moved up so we can use the more natural mem::take method.