### PR TITLE
Disable default-features for the log crate to reduce binary size

### DIFF
--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 num-traits = "0.2"
-log = "0.4.0"
+log = {version = "0.4.0", default-features = false}
 env_logger = "0.6.1"
 lazy_static = "1.3.0"
 

--- a/neqo-crypto/Cargo.toml
+++ b/neqo-crypto/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 neqo-common = { path = "../neqo-common" }
-log = "0.4.0"
+log = {version = "0.4.0", default-features = false}
 
 [build-dependencies]
 bindgen = {version = "0.53.2", default-features = false}

--- a/neqo-http3-server/Cargo.toml
+++ b/neqo-http3-server/Cargo.toml
@@ -13,7 +13,7 @@ neqo-http3 = { path = "./../neqo-http3" }
 structopt = "0.2.15"
 mio = "0.6.17"
 mio-extras = "2.0.5"
-log = "0.4.0"
+log = {version = "0.4.0", default-features = false}
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -11,7 +11,7 @@ neqo-crypto = { path = "./../neqo-crypto" }
 neqo-transport = { path = "./../neqo-transport" }
 neqo-qpack = { path = "./../neqo-qpack" }
 num-traits = "0.2"
-log = "0.4.0"
+log = {version = "0.4.0", default-features = false}
 smallvec = "1.0.0"
 
 [dev-dependencies]

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 neqo-common = { path = "./../neqo-common" }
 neqo-transport = { path = "./../neqo-transport" }
 neqo-crypto = { path = "./../neqo-crypto" }
-log = "0.4.0"
+log = {version = "0.4.0", default-features = false}
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 neqo-crypto = { path = "../neqo-crypto" }
 neqo-common = { path = "../neqo-common" }
 lazy_static = "1.3.0"
-log = "0.4.0"
+log = {version = "0.4.0", default-features = false}
 smallvec = "1.0.0"
 
 [dev-dependencies]

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -10,7 +10,7 @@ neqo-common = { path = "../neqo-common" }
 neqo-crypto = { path = "../neqo-crypto" }
 neqo-http3 = { path = "../neqo-http3" }
 neqo-transport = { path = "../neqo-transport" }
-log = "0.4.0"
+log = {version = "0.4.0", default-features = false}
 
 [features]
 default = ["deny-warnings"]


### PR DESCRIPTION
This should cut down on total code size as well.