### PR TITLE
Use consistent spacing in toml files

### DIFF
--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-neqo-crypto = { path = "./../neqo-crypto" }
-neqo-transport = { path = "./../neqo-transport" }
-neqo-common = { path="./../neqo-common" }
-neqo-http3 = { path = "./../neqo-http3" }
+neqo-crypto = {path = "./../neqo-crypto"}
+neqo-transport = {path = "./../neqo-transport"}
+neqo-common = {path="./../neqo-common"}
+neqo-http3 = {path = "./../neqo-http3"}
 structopt = "0.2.15"
 url = "1.7.2"
 

--- a/neqo-crypto/Cargo.toml
+++ b/neqo-crypto/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-neqo-common = { path = "../neqo-common" }
+neqo-common = {path = "../neqo-common"}
 log = {version = "0.4.0", default-features = false}
 
 [build-dependencies]
@@ -17,7 +17,7 @@ serde_derive = "1.0"
 toml = "0.4"
 
 [dev-dependencies]
-test-fixture = { path = "../test-fixture" }
+test-fixture = {path = "../test-fixture"}
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-http3-server/Cargo.toml
+++ b/neqo-http3-server/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-neqo-crypto = { path = "./../neqo-crypto" }
-neqo-transport = { path = "./../neqo-transport" }
-neqo-common = { path="./../neqo-common" }
-neqo-http3 = { path = "./../neqo-http3" }
+neqo-crypto = {path = "./../neqo-crypto"}
+neqo-transport = {path = "./../neqo-transport"}
+neqo-common = {path="./../neqo-common"}
+neqo-http3 = {path = "./../neqo-http3"}
 structopt = "0.2.15"
 mio = "0.6.17"
 mio-extras = "2.0.5"

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-neqo-common = { path = "./../neqo-common" }
-neqo-crypto = { path = "./../neqo-crypto" }
-neqo-transport = { path = "./../neqo-transport" }
-neqo-qpack = { path = "./../neqo-qpack" }
+neqo-common = {path = "./../neqo-common"}
+neqo-crypto = {path = "./../neqo-crypto"}
+neqo-transport = {path = "./../neqo-transport"}
+neqo-qpack = {path = "./../neqo-qpack"}
 num-traits = "0.2"
 log = {version = "0.4.0", default-features = false}
 smallvec = "1.0.0"
 
 [dev-dependencies]
-test-fixture = { path = "../test-fixture" }
+test-fixture = {path = "../test-fixture"}
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-interop/Cargo.toml
+++ b/neqo-interop/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-neqo-crypto = { path = "./../neqo-crypto" }
-neqo-transport = { path = "./../neqo-transport" }
-neqo-common = { path="./../neqo-common" }
-neqo-http3 = { path = "./../neqo-http3" }
+neqo-crypto = {path = "./../neqo-crypto"}
+neqo-transport = {path = "./../neqo-transport"}
+neqo-common = {path="./../neqo-common"}
+neqo-http3 = {path = "./../neqo-http3"}
 
 structopt = "0.2.15"
 lazy_static = "1.3.0"

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-neqo-common = { path = "./../neqo-common" }
-neqo-transport = { path = "./../neqo-transport" }
-neqo-crypto = { path = "./../neqo-crypto" }
+neqo-common = {path = "./../neqo-common"}
+neqo-transport = {path = "./../neqo-transport"}
+neqo-crypto = {path = "./../neqo-crypto"}
 log = {version = "0.4.0", default-features = false}
 
 [dev-dependencies]
-test-fixture = { path = "../test-fixture" }
+test-fixture = {path = "../test-fixture"}
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-server/Cargo.toml
+++ b/neqo-server/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-neqo-crypto = { path = "./../neqo-crypto" }
-neqo-transport = { path = "./../neqo-transport" }
-neqo-common = { path="./../neqo-common" }
+neqo-crypto = {path = "./../neqo-crypto"}
+neqo-transport = {path = "./../neqo-transport"}
+neqo-common = {path="./../neqo-common"}
 structopt = "0.2.15"
 regex = "1"
 

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-neqo-crypto = { path = "../neqo-crypto" }
-neqo-common = { path = "../neqo-common" }
+neqo-crypto = {path = "../neqo-crypto"}
+neqo-common = {path = "../neqo-common"}
 lazy_static = "1.3.0"
 log = {version = "0.4.0", default-features = false}
 smallvec = "1.0.0"
 
 [dev-dependencies]
-test-fixture = { path = "../test-fixture" }
+test-fixture = {path = "../test-fixture"}
 
 [features]
 default = ["deny-warnings"]

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-neqo-common = { path = "../neqo-common" }
-neqo-crypto = { path = "../neqo-crypto" }
-neqo-http3 = { path = "../neqo-http3" }
-neqo-transport = { path = "../neqo-transport" }
+neqo-common = {path = "../neqo-common"}
+neqo-crypto = {path = "../neqo-crypto"}
+neqo-http3 = {path = "../neqo-http3"}
+neqo-transport = {path = "../neqo-transport"}
 log = {version = "0.4.0", default-features = false}
 
 [features]


### PR DESCRIPTION
I have no idea how to enforce this on an ongoing basis, but having consistency now might help ensure that we keep consistency.