### PR TITLE
transport: Fix issues in TxBuffer::next_bytes()

### DIFF
--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -340,6 +340,7 @@ impl TxBuffer {
 
         // We can drop contig acked range from the buffer
         let new_retirable = self.ranges.acked_from_zero() - self.retired;
+        debug_assert!(new_retirable <= self.buffered() as u64);
         let keep_len =
             self.buffered() - usize::try_from(new_retirable).expect("should fit in usize");
 

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -895,12 +895,13 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cognitive_complexity)]
     fn tx_buffer_next_bytes_1() {
         let mut txb = TxBuffer::new();
 
         assert_eq!(txb.avail(), 65535);
 
-        assert_eq!(txb.send(&[1; 100000]), TxBuffer::BUFFER_SIZE);
+        assert_eq!(txb.send(&[1; 100_000]), TxBuffer::BUFFER_SIZE);
         assert!(matches!(txb.next_bytes(), Some((0, x)) if x.len()==65535));
 
         txb.mark_as_sent(0, 65534);
@@ -932,7 +933,7 @@ mod tests {
 
         assert_eq!(txb.avail(), 65535);
 
-        assert_eq!(txb.send(&[1; 100000]), TxBuffer::BUFFER_SIZE);
+        assert_eq!(txb.send(&[1; 100_000]), TxBuffer::BUFFER_SIZE);
         assert!(matches!(txb.next_bytes(), Some((0, x)) if x.len()==65535));
 
         txb.mark_as_acked(0, 65500);


### PR DESCRIPTION
Added a test to reproduce the issue reported in:
https://bugzilla.mozilla.org/show_bug.cgi?id=1622237 .
    
Also another test for a different issue. The conversion to using VecDeque was making some bad assumptions that resulted in bugs when the first slice returned from VecDeque::as_slices() was empty but the second had some data.

