### PR TITLE
More neqo-client fixes for QNS

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -382,14 +382,14 @@ fn main() -> Res<()> {
             };
             out_path.push(url_path);
 
-            eprintln!("Saving {} to {:?}", url.clone().into_string(), dir);
+            eprintln!("Saving {} to {:?}", url.clone().into_string(), out_path);
 
             Some(
                 OpenOptions::new()
                     .write(true)
                     .create(true)
                     .truncate(true)
-                    .open(&dir)?,
+                    .open(&out_path)?,
             )
         } else {
             None


### PR DESCRIPTION
These let neqo-client be used for the quic-network-sim (QNS) "http3" test.