### PR TITLE
Qlog 0 2 mystery

### DIFF
--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -14,6 +14,9 @@ neqo-common = { path="./../neqo-common" }
 neqo-http3 = { path = "./../neqo-http3" }
 structopt = "0.3.7"
 url = "1.7.2"
+qlog = "0.1.0"
+serde = "1"
+serde_json = "1"
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -14,7 +14,7 @@ neqo-common = { path="./../neqo-common" }
 neqo-http3 = { path = "./../neqo-http3" }
 structopt = "0.3.7"
 url = "1.7.2"
-qlog = "0.1.0"
+qlog = "0.2.0"
 serde = "1"
 serde_json = "1"
 

--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -12,7 +12,7 @@ neqo-crypto = { path = "./../neqo-crypto" }
 neqo-transport = { path = "./../neqo-transport" }
 neqo-common = { path="./../neqo-common" }
 neqo-http3 = { path = "./../neqo-http3" }
-structopt = "0.2.15"
+structopt = "0.3.7"
 url = "1.7.2"
 
 [features]

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -10,7 +10,7 @@ num-traits = "0.2"
 log = {version = "0.4.0", default-features = false}
 env_logger = "0.6.1"
 lazy_static = "1.3.0"
-qlog = "0.1.0"
+qlog = "0.2.0"
 chrono = "0.4.10"
 
 [features]

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -10,6 +10,8 @@ num-traits = "0.2"
 log = {version = "0.4.0", default-features = false}
 env_logger = "0.6.1"
 lazy_static = "1.3.0"
+qlog = "0.1.0"
+chrono = "0.4.10"
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -11,11 +11,13 @@ mod codec;
 mod datagram;
 mod incrdecoder;
 pub mod log;
+pub mod qlog;
 pub mod timer;
 
 pub use self::codec::{Decoder, Encoder};
 pub use self::datagram::Datagram;
 pub use self::incrdecoder::{IncrementalDecoder, IncrementalDecoderResult};
+pub use self::log::NeqoQlogRef;
 
 #[macro_use]
 extern crate lazy_static;
@@ -48,4 +50,27 @@ pub const fn const_max(a: usize, b: usize) -> usize {
 #[must_use]
 pub const fn const_min(a: usize, b: usize) -> usize {
     [a, b][(a >= b) as usize]
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+/// Client or Server.
+pub enum Role {
+    Client,
+    Server,
+}
+
+impl Role {
+    #[must_use]
+    pub fn remote(self) -> Self {
+        match self {
+            Self::Client => Self::Server,
+            Self::Server => Self::Client,
+        }
+    }
+}
+
+impl ::std::fmt::Display for Role {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -4,10 +4,31 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use env_logger::Builder;
+use std::cell::RefCell;
 use std::io::Write;
+use std::rc::Rc;
 use std::sync::Once;
 use std::time::Instant;
+
+use env_logger::Builder;
+use qlog::Trace;
+
+pub struct NeqoQlog {
+    pub trace: Trace,
+    pub zero_time: Instant,
+}
+
+impl NeqoQlog {
+    #[must_use]
+    pub fn new(now: Instant, trace: Trace) -> Self {
+        Self {
+            trace,
+            zero_time: now,
+        }
+    }
+}
+
+pub type NeqoQlogRef = Rc<RefCell<NeqoQlog>>;
 
 static INIT_ONCE: Once = Once::new();
 
@@ -38,7 +59,7 @@ pub fn init() {
 }
 
 #[macro_export]
-macro_rules! qlog {
+macro_rules! log_invoke {
     ($lvl:expr, $ctx:expr, $($arg:tt)*) => ( {
         ::neqo_common::log::init();
         ::log::log!($lvl, "[{}] {}", $ctx, format!($($arg)*));
@@ -46,26 +67,26 @@ macro_rules! qlog {
 }
 #[macro_export]
 macro_rules! qerror {
-    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Error, $ctx, $($arg)*););
+    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Error, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Error, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qwarn {
-    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Warn, $ctx, $($arg)*););
+    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Warn, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Warn, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qinfo {
-    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Info, $ctx, $($arg)*););
+    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Info, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Info, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qdebug {
-    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Debug, $ctx, $($arg)*););
+    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Debug, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Debug, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qtrace {
-    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::qlog!(::log::Level::Trace, $ctx, $($arg)*););
+    ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Trace, $ctx, $($arg)*););
     ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Trace, $($arg)*); } );
 }

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -5,6 +5,7 @@
 // except according to those terms.
 
 use std::cell::RefCell;
+use std::fmt;
 use std::io::Write;
 use std::rc::Rc;
 use std::sync::Once;
@@ -25,6 +26,12 @@ impl NeqoQlog {
             trace,
             zero_time: now,
         }
+    }
+}
+
+impl fmt::Debug for NeqoQlog {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "NeqoQlog with zero time of {:?}", self.zero_time)
     }
 }
 

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -1,0 +1,52 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use chrono::{DateTime, Utc};
+
+use std::time::SystemTime;
+
+use qlog::{CommonFields, Configuration, TimeUnits, Trace, VantagePoint, VantagePointType};
+
+use crate::Role;
+
+#[must_use]
+pub fn new_trace(role: Role) -> qlog::Trace {
+    let role_str = match role {
+        Role::Client => "client",
+        Role::Server => "server",
+    };
+
+    Trace {
+        vantage_point: VantagePoint {
+            name: Some(format!("neqo-{}", role_str)),
+            ty: VantagePointType::Server,
+            flow: None,
+        },
+        title: Some(format!("neqo-{} trace", role_str)),
+        description: Some("Example qlog trace description".to_string()),
+        configuration: Some(Configuration {
+            time_offset: Some("0".into()),
+            time_units: Some(TimeUnits::Us),
+            original_uris: None,
+        }),
+        common_fields: Some(CommonFields {
+            group_id: None,
+            protocol_type: None,
+            reference_time: Some({
+                let system_time = SystemTime::now();
+                let datetime: DateTime<Utc> = system_time.into();
+                datetime.to_rfc3339()
+            }),
+        }),
+        event_fields: vec![
+            "relative_time".to_string(),
+            "category".to_string(),
+            "event".to_string(),
+            "data".to_string(),
+        ],
+        events: Vec::new(),
+    }
+}

--- a/neqo-http3-server/Cargo.toml
+++ b/neqo-http3-server/Cargo.toml
@@ -14,7 +14,7 @@ structopt = "0.3.7"
 mio = "0.6.17"
 mio-extras = "2.0.5"
 log = {version = "0.4.0", default-features = false}
-qlog = "0.1.0"
+qlog = "0.2.0"
 serde = "1"
 serde_json = "1"
 

--- a/neqo-http3-server/Cargo.toml
+++ b/neqo-http3-server/Cargo.toml
@@ -10,7 +10,7 @@ neqo-crypto = { path = "./../neqo-crypto" }
 neqo-transport = { path = "./../neqo-transport" }
 neqo-common = { path="./../neqo-common" }
 neqo-http3 = { path = "./../neqo-http3" }
-structopt = "0.2.15"
+structopt = "0.3.7"
 mio = "0.6.17"
 mio-extras = "2.0.5"
 log = {version = "0.4.0", default-features = false}

--- a/neqo-http3-server/Cargo.toml
+++ b/neqo-http3-server/Cargo.toml
@@ -14,6 +14,9 @@ structopt = "0.3.7"
 mio = "0.6.17"
 mio-extras = "2.0.5"
 log = {version = "0.4.0", default-features = false}
+qlog = "0.1.0"
+serde = "1"
+serde_json = "1"
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -95,8 +95,8 @@ impl<T: Http3Transaction> Http3Connection<T> {
             control_stream_local: ControlStreamLocal::default(),
             control_stream_remote: ControlStreamRemote::new(),
             new_streams: HashMap::new(),
-            qpack_encoder: QPackEncoder::new(true),
-            qpack_decoder: QPackDecoder::new(max_table_size, max_blocked_streams),
+            qpack_encoder: QPackEncoder::new(true, log.clone()),
+            qpack_decoder: QPackDecoder::new(max_table_size, max_blocked_streams, log.clone()),
             settings_state: Http3RemoteSettingsState::NotReceived,
             streams_have_data_to_send: BTreeSet::new(),
             transactions: HashMap::new(),
@@ -382,10 +382,11 @@ impl<T: Http3Transaction> Http3Connection<T> {
             self.control_stream_local = ControlStreamLocal::default();
             self.control_stream_remote = ControlStreamRemote::new();
             self.new_streams.clear();
-            self.qpack_encoder = QPackEncoder::new(true);
+            self.qpack_encoder = QPackEncoder::new(true, self.log.clone());
             self.qpack_decoder = QPackDecoder::new(
                 self.local_settings.max_table_size,
                 self.local_settings.max_blocked_streams,
+                self.log.clone(),
             );
             self.settings_state = Http3RemoteSettingsState::NotReceived;
             self.streams_have_data_to_send.clear();

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -9,7 +9,7 @@ use crate::control_stream_remote::ControlStreamRemote;
 use crate::hframe::HFrame;
 use crate::hsettings_frame::{HSetting, HSettingType, HSettings};
 use crate::stream_type_reader::NewStreamTypeReader;
-use neqo_common::{matches, qdebug, qerror, qinfo, qtrace, qwarn};
+use neqo_common::{log::NeqoQlogRef, matches, qdebug, qerror, qinfo, qtrace, qwarn};
 use neqo_qpack::decoder::{QPackDecoder, QPACK_UNI_STREAM_TYPE_DECODER};
 use neqo_qpack::encoder::{QPackEncoder, QPACK_UNI_STREAM_TYPE_ENCODER};
 use neqo_transport::{AppError, CloseError, Connection, State, StreamType};
@@ -72,6 +72,7 @@ pub struct Http3Connection<T: Http3Transaction> {
     settings_state: Http3RemoteSettingsState,
     streams_have_data_to_send: BTreeSet<u64>,
     pub transactions: HashMap<u64, T>,
+    log: Option<NeqoQlogRef>,
 }
 
 impl<T: Http3Transaction> ::std::fmt::Display for Http3Connection<T> {
@@ -81,7 +82,7 @@ impl<T: Http3Transaction> ::std::fmt::Display for Http3Connection<T> {
 }
 
 impl<T: Http3Transaction> Http3Connection<T> {
-    pub fn new(max_table_size: u32, max_blocked_streams: u16) -> Self {
+    pub fn new(max_table_size: u32, max_blocked_streams: u16, log: Option<NeqoQlogRef>) -> Self {
         if max_table_size > (1 << 30) - 1 {
             panic!("Wrong max_table_size");
         }
@@ -99,6 +100,7 @@ impl<T: Http3Transaction> Http3Connection<T> {
             settings_state: Http3RemoteSettingsState::NotReceived,
             streams_have_data_to_send: BTreeSet::new(),
             transactions: HashMap::new(),
+            log,
         }
     }
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -550,7 +550,7 @@ mod tests {
             },
             conn: default_server(),
             control_stream_id: None,
-            encoder: QPackEncoder::new(true),
+            encoder: QPackEncoder::new(true, None),
         }
     }
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -55,17 +55,23 @@ impl Http3Client {
                 cid_manager,
                 local_addr,
                 remote_addr,
-                log,
+                log.clone(),
             )?,
             max_table_size,
             max_blocked_streams,
+            log,
         ))
     }
 
-    pub fn new_with_conn(c: Connection, max_table_size: u32, max_blocked_streams: u16) -> Self {
+    pub fn new_with_conn(
+        c: Connection,
+        max_table_size: u32,
+        max_blocked_streams: u16,
+        log: Option<NeqoQlogRef>,
+    ) -> Self {
         Self {
             conn: c,
-            base_handler: Http3Connection::new(max_table_size, max_blocked_streams),
+            base_handler: Http3Connection::new(max_table_size, max_blocked_streams, log),
             events: Http3ClientEvents::default(),
         }
     }

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -9,7 +9,7 @@ use crate::hframe::HFrame;
 use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents};
 use crate::transaction_server::TransactionServer;
 use crate::{Error, Header, Res};
-use neqo_common::{qdebug, qinfo, qtrace};
+use neqo_common::{log::NeqoQlogRef, qdebug, qinfo, qtrace};
 use neqo_transport::{AppError, Connection, ConnectionEvent, StreamType};
 use std::time::Instant;
 
@@ -27,9 +27,9 @@ impl ::std::fmt::Display for Http3ServerHandler {
 }
 
 impl Http3ServerHandler {
-    pub fn new(max_table_size: u32, max_blocked_streams: u16) -> Self {
+    pub fn new(max_table_size: u32, max_blocked_streams: u16, log: Option<NeqoQlogRef>) -> Self {
         Self {
-            base_handler: Http3Connection::new(max_table_size, max_blocked_streams),
+            base_handler: Http3Connection::new(max_table_size, max_blocked_streams, log),
             events: Http3ServerConnEvents::default(),
             needs_processing: false,
         }

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -9,6 +9,7 @@ use crate::connection_server::Http3ServerHandler;
 use crate::server_connection_events::Http3ServerConnEvent;
 use crate::server_events::{ClientRequestStream, Http3ServerEvent, Http3ServerEvents};
 use crate::Res;
+use neqo_common::log::NeqoQlogRef;
 use neqo_common::{qtrace, Datagram};
 use neqo_crypto::AntiReplay;
 use neqo_transport::server::{ActiveConnectionRef, Server};
@@ -35,6 +36,7 @@ impl ::std::fmt::Display for Http3Server {
 }
 
 impl Http3Server {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         now: Instant,
         certs: &[impl AsRef<str>],
@@ -43,9 +45,10 @@ impl Http3Server {
         cid_manager: Rc<RefCell<dyn ConnectionIdManager>>,
         max_table_size: u32,
         max_blocked_streams: u16,
+        qlog: Option<NeqoQlogRef>,
     ) -> Res<Self> {
         Ok(Self {
-            server: Server::new(now, certs, protocols, anti_replay, cid_manager)?,
+            server: Server::new(now, certs, protocols, anti_replay, cid_manager, qlog)?,
             max_table_size,
             max_blocked_streams,
             http3_handlers: HashMap::new(),
@@ -180,6 +183,7 @@ mod tests {
             Rc::new(RefCell::new(FixedConnectionIdManager::new(5))),
             100,
             100,
+            None,
         )
         .expect("create a default server")
     }

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -314,7 +314,7 @@ mod tests {
             &[0x0, 0x4, 0x6, 0x1, 0x40, 0x64, 0x7, 0x40, 0x64],
         );
         assert_eq!(sent, Ok(9));
-        let mut encoder = QPackEncoder::new(true);
+        let mut encoder = QPackEncoder::new(true, None);
         encoder.add_send_stream(neqo_trans_conn.stream_create(StreamType::UniDi).unwrap());
         encoder.send(&mut neqo_trans_conn).unwrap();
         let decoder_stream = neqo_trans_conn.stream_create(StreamType::UniDi).unwrap();

--- a/neqo-interop/Cargo.toml
+++ b/neqo-interop/Cargo.toml
@@ -11,8 +11,8 @@ neqo-transport = { path = "./../neqo-transport" }
 neqo-common = { path="./../neqo-common" }
 neqo-http3 = { path = "./../neqo-http3" }
 
-structopt = "0.2.15"
-lazy_static = "1.3.0"
+structopt = "0.3.7"
+lazy_static = "1.4.0"
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -435,6 +435,7 @@ fn test_connect(nctx: &NetworkCtx, test: &Test, peer: &Peer) -> Result<Connectio
         Rc::new(RefCell::new(FixedConnectionIdManager::new(0))),
         nctx.local_addr,
         nctx.remote_addr,
+        None,
     )
     .expect("must succeed");
     // Temporary here to help out the type inference engine
@@ -524,6 +525,7 @@ fn test_vn(nctx: &NetworkCtx, peer: &Peer) -> Result<Connection, String> {
         Rc::new(RefCell::new(FixedConnectionIdManager::new(0))),
         nctx.local_addr,
         nctx.remote_addr,
+        None,
     )
     .expect("must succeed");
     // Temporary here to help out the type inference engine

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -481,7 +481,7 @@ fn test_h9(nctx: &NetworkCtx, client: &mut Connection) -> Result<(), String> {
 fn test_h3(nctx: &NetworkCtx, peer: &Peer, client: Connection) -> Result<(), String> {
     let mut hc = H3Handler {
         streams: HashSet::new(),
-        h3: Http3Client::new_with_conn(client, 128, 128),
+        h3: Http3Client::new_with_conn(client, 128, 128, None),
         host: String::from(peer.host),
         path: String::from("/"),
     };

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -11,7 +11,7 @@ neqo-transport = { path = "./../neqo-transport" }
 neqo-crypto = { path = "./../neqo-crypto" }
 log = {version = "0.4.0", default-features = false}
 static_assertions = "1.1.0"
-qlog = "0.1.0"
+qlog = "0.2.0"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -11,6 +11,7 @@ neqo-transport = { path = "./../neqo-transport" }
 neqo-crypto = { path = "./../neqo-crypto" }
 log = {version = "0.4.0", default-features = false}
 static_assertions = "1.1.0"
+qlog = "0.1.0"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -7,6 +7,7 @@
 use crate::decoder_instructions::{DecoderInstruction, DecoderInstructionReader};
 use crate::encoder_instructions::EncoderInstruction;
 use crate::header_block::HeaderEncoder;
+use crate::qlog;
 use crate::qpack_send_buf::QPData;
 use crate::reader::ReceiverConnWrapper;
 use crate::table::{HeaderTable, LookupResult};
@@ -16,6 +17,7 @@ use neqo_common::{log::NeqoQlogRef, qdebug, qtrace};
 use neqo_transport::Connection;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryInto;
+use std::time::Instant;
 
 pub const QPACK_UNI_STREAM_TYPE_ENCODER: u64 = 0x2;
 
@@ -165,6 +167,13 @@ impl QPackEncoder {
         qdebug!([self], "call intruction {:?}", instruction);
         match instruction {
             DecoderInstruction::InsertCountIncrement { increment } => {
+                qlog::qpack_read_insert_count_increment_instruction(
+                    &self.log,
+                    Instant::now(),
+                    increment,
+                    &increment.to_be_bytes(),
+                );
+
                 self.insert_count_instruction(increment)
             }
             DecoderInstruction::HeaderAck { stream_id } => self.header_ack(stream_id),

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -12,7 +12,7 @@ use crate::reader::ReceiverConnWrapper;
 use crate::table::{HeaderTable, LookupResult};
 use crate::Header;
 use crate::{Error, Res};
-use neqo_common::{qdebug, qtrace};
+use neqo_common::{log::NeqoQlogRef, qdebug, qtrace};
 use neqo_transport::Connection;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryInto;
@@ -35,10 +35,11 @@ pub struct QPackEncoder {
     unacked_header_blocks: HashMap<u64, VecDeque<HashSet<u64>>>,
     blocked_stream_cnt: u16,
     use_huffman: bool,
+    log: Option<NeqoQlogRef>,
 }
 
 impl QPackEncoder {
-    pub fn new(use_huffman: bool) -> Self {
+    pub fn new(use_huffman: bool, log: Option<NeqoQlogRef>) -> Self {
         Self {
             table: HeaderTable::new(true),
             send_buf: QPData::default(),
@@ -50,6 +51,7 @@ impl QPackEncoder {
             unacked_header_blocks: HashMap::new(),
             blocked_stream_cnt: 0,
             use_huffman,
+            log,
         }
     }
 
@@ -400,7 +402,7 @@ mod tests {
         let send_stream_id = conn.stream_create(StreamType::UniDi).unwrap();
 
         // create an encoder
-        let mut encoder = QPackEncoder::new(huffman);
+        let mut encoder = QPackEncoder::new(huffman, None);
         encoder.add_send_stream(send_stream_id);
 
         TestEncoder {

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -16,6 +16,7 @@ pub mod huffman;
 mod huffman_decode_helper;
 pub mod huffman_table;
 mod prefix;
+mod qlog;
 mod qpack_send_buf;
 pub mod reader;
 mod static_table;

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -14,6 +14,8 @@ use qlog::{
 use std::fmt::LowerHex;
 use std::time::Instant;
 
+// TODO(hawkinsw@obs.cr): There is a copy of this in neqo-transports/src/qlog.rs.
+// Refactor both uses into something in neqo-common.
 fn slice_to_hex_string<T: LowerHex>(slice: &[T]) -> String {
     if slice.is_empty() {
         "0x0".to_string()
@@ -54,11 +56,11 @@ mod tests {
     use super::*;
     #[test]
     fn test_slice_to_hex_string() {
-        let s = slice_to_hex_string(&vec![10, 9, 8]);
+        let s = slice_to_hex_string(&[10, 9, 8]);
         assert_eq!(r#"0xa98"#, s);
         let s = slice_to_hex_string(&Vec::<u8>::new());
         assert_eq!(r#"0x0"#, s);
-        let s = slice_to_hex_string(&vec![128]);
+        let s = slice_to_hex_string(&[128]);
         assert_eq!(r#"0x80"#, s);
     }
 }

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Functions that handle capturing QLOG traces.
+
+use std::time::Instant;
+
+use neqo_common::NeqoQlogRef;
+use qlog::{
+    EventCategory, EventData::QpackInstructionReceived, EventField,
+    QPackInstruction::InsertCountIncrementInstruction, QpackInstructionTypeName,
+};
+
+fn slice_to_string<T: ToString>(slice: &[T]) -> String {
+    slice
+        .iter()
+        .fold("".to_string(), |acc, x| acc + &x.to_string())
+}
+
+pub fn qpack_read_insert_count_increment_instruction(
+    qlog: &Option<NeqoQlogRef>,
+    now: Instant,
+    increment: u64,
+    data: &[u8],
+) {
+    if let Some(qlog) = qlog {
+        let mut qlog = qlog.borrow_mut();
+        let elapsed = now.duration_since(qlog.zero_time);
+        let instruction_received_data = QpackInstructionReceived {
+            instruction: InsertCountIncrementInstruction {
+                instruction_type: QpackInstructionTypeName::InsertCountIncrementInstruction,
+                increment,
+            },
+            byte_length: Some(8.to_string()),
+            raw: Some(slice_to_string(data)),
+        };
+        qlog.trace.events.push(vec![
+            EventField::Category(EventCategory::Qpack),
+            EventField::RelativeTime(format!("{}", elapsed.as_micros())),
+            EventField::Data(instruction_received_data),
+        ]);
+    }
+}

--- a/neqo-server/Cargo.toml
+++ b/neqo-server/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 neqo-crypto = { path = "./../neqo-crypto" }
 neqo-transport = { path = "./../neqo-transport" }
 neqo-common = { path="./../neqo-common" }
-structopt = "0.2.15"
+structopt = "0.3.7"
 regex = "1"
 
 [features]

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -157,6 +157,7 @@ fn main() {
                 &args.alpn,
                 &anti_replay,
                 Rc::new(RefCell::new(FixedConnectionIdManager::new(10))),
+                None,
             )
             .expect("can't create connection")
         });

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -11,7 +11,7 @@ neqo-common = { path = "../neqo-common" }
 lazy_static = "1.3.0"
 log = {version = "0.4.0", default-features = false}
 smallvec = "1.0.0"
-qlog = "0.1.0"
+qlog = "0.2.0"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -11,6 +11,7 @@ neqo-common = { path = "../neqo-common" }
 lazy_static = "1.3.0"
 log = {version = "0.4.0", default-features = false}
 smallvec = "1.0.0"
+qlog = "0.1.0"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1438,11 +1438,13 @@ impl Connection {
                 unreachable!("Crypto state should not be new or failed after successful handshake")
             }
         }
+
         // There is a chance that this could be called less often, but getting the
         // conditions right is a little tricky, so call it on every  CRYPTO frame.
         if try_update {
             self.crypto.install_keys(self.role);
         }
+
         Ok(())
     }
 
@@ -1738,6 +1740,8 @@ impl Connection {
             // Remove the randomized client CID from the list of acceptable CIDs.
             assert_eq!(1, self.valid_cids.len());
             self.valid_cids.clear();
+            // Generate a qlog event that the server connection started.
+            qlog::server_connection_started(&self.qlog, now, self.path.as_ref().unwrap());
         } else {
             self.zero_rtt_state = if self.crypto.tls.info().unwrap().early_data_accepted() {
                 ZeroRttState::AcceptedClient

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1762,6 +1762,7 @@ impl Connection {
             self.set_state(State::Confirmed);
         }
         qinfo!([self], "Connection established");
+        qlog::connection_tparams_set(&self.qlog, now, &*self.tps.borrow());
         Ok(())
     }
 

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -11,7 +11,7 @@ use std::ops::{Index, IndexMut, Range};
 use std::rc::Rc;
 use std::time::Instant;
 
-use neqo_common::{hex, matches, qdebug, qerror, qinfo, qtrace};
+use neqo_common::{hex, matches, qdebug, qerror, qinfo, qtrace, Role};
 use neqo_crypto::aead::Aead;
 use neqo_crypto::hp::HpKey;
 use neqo_crypto::{
@@ -20,7 +20,6 @@ use neqo_crypto::{
     TLS_EPOCH_ZERO_RTT, TLS_VERSION_1_3,
 };
 
-use crate::connection::Role;
 use crate::frame::Frame;
 use crate::packet::PacketNumber;
 use crate::recovery::RecoveryToken;

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -95,7 +95,7 @@ impl CloseError {
         }
     }
 
-    fn code(&self) -> u64 {
+    pub fn code(&self) -> u64 {
         match self {
             Self::Transport(c) | Self::Application(c) => *c,
         }

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -20,6 +20,7 @@ mod flow_mgr;
 mod frame;
 mod packet;
 mod path;
+mod qlog;
 mod recovery;
 mod recv_stream;
 mod send_stream;
@@ -29,8 +30,8 @@ mod stream_id;
 pub mod tparams;
 mod tracking;
 
-pub use self::cid::ConnectionIdManager;
-pub use self::connection::{Connection, FixedConnectionIdManager, Output, Role, State};
+pub use self::cid::{ConnectionId, ConnectionIdManager};
+pub use self::connection::{Connection, FixedConnectionIdManager, Output, State};
 pub use self::events::{ConnectionEvent, ConnectionEvents};
 pub use self::frame::CloseError;
 pub use self::frame::StreamType;

--- a/neqo-transport/src/packet.rs
+++ b/neqo-transport/src/packet.rs
@@ -721,7 +721,7 @@ mod tests {
         padded.extend_from_slice(EXTRA);
         let (packet, remainder) = PublicPacket::decode(&padded, &cid_mgr()).unwrap();
         assert_eq!(packet.packet_type(), PacketType::Initial);
-        assert_eq!(&packet.dcid()[..], &[]);
+        assert_eq!(&packet.dcid()[..], &[] as &[u8]);
         assert_eq!(&packet.scid()[..], SERVER_CID);
         assert!(packet.token().is_empty());
         assert_eq!(remainder, EXTRA);

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -94,4 +94,14 @@ impl Path {
     pub fn datagram<V: Into<Vec<u8>>>(&self, payload: V) -> Datagram {
         Datagram::new(self.local, self.remote, payload)
     }
+
+    /// Get local socketaddr
+    pub fn local_sock(&self) -> &SocketAddr {
+        &self.local
+    }
+
+    /// Get remote socketaddr
+    pub fn remote_sock(&self) -> &SocketAddr {
+        &self.remote
+    }
 }

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -19,7 +19,96 @@ use neqo_common::{hex, qinfo, Decoder, NeqoQlogRef};
 use crate::frame::{self, Frame};
 use crate::packet::{DecryptedPacket, PacketNumber, PacketType};
 use crate::path::Path;
+use crate::tparams::{self, TransportParametersHandler};
 use crate::QUIC_VERSION;
+use std::fmt::LowerHex;
+
+// TODO(hawkinsw@obs.cr): This is copied verbatim from neqo-qpack/src/qlog.rs where
+// it has appropriate tests. Refactor both uses into something in neqo-common.
+fn slice_to_hex_string<T: LowerHex>(slice: &[T]) -> String {
+    if slice.is_empty() {
+        "0x0".to_string()
+    } else {
+        slice
+            .iter()
+            .fold("0x".to_string(), |acc, x| acc + &format!("{:x}", x))
+    }
+}
+
+pub fn connection_tparams_set(
+    qlog: &Option<NeqoQlogRef>,
+    now: Instant,
+    tph: &TransportParametersHandler,
+) {
+    if let Some(qlog) = qlog {
+        let mut qlog = qlog.borrow_mut();
+        let elapsed = now.duration_since(qlog.zero_time);
+        let remote = tph.remote();
+        let data = EventData::TransportParametersSet {
+            owner: None,
+            resumption_allowed: None,
+            early_data_enabled: None,
+            alpn: None,
+            version: None,
+            tls_cipher: None,
+            original_connection_id: if let Some(ocid) =
+                remote.get_bytes(tparams::ORIGINAL_CONNECTION_ID)
+            {
+                // Cannot use packet::ConnectionId's Display trait implementation
+                // because it does not include the 0x prefix.
+                Some(slice_to_hex_string(&ocid))
+            } else {
+                None
+            },
+            stateless_reset_token: if let Some(srt) =
+                remote.get_bytes(tparams::STATELESS_RESET_TOKEN)
+            {
+                Some(slice_to_hex_string(&srt))
+            } else {
+                None
+            },
+            disable_active_migration: if remote.get_empty(tparams::DISABLE_MIGRATION).is_some() {
+                Some(true)
+            } else {
+                None
+            },
+            idle_timeout: Some(remote.get_integer(tparams::IDLE_TIMEOUT)),
+            max_packet_size: Some(remote.get_integer(tparams::MAX_PACKET_SIZE)),
+            ack_delay_exponent: Some(remote.get_integer(tparams::ACK_DELAY_EXPONENT)),
+            max_ack_delay: Some(remote.get_integer(tparams::MAX_ACK_DELAY)),
+            // TODO(hawkinsw@obs.cr): We do not yet handle ACTIVE_CONNECTION_ID_LIMIT in tparams yet.
+            active_connection_id_limit: None,
+            initial_max_data: Some(format!("{}", remote.get_integer(tparams::INITIAL_MAX_DATA))),
+            initial_max_stream_data_bidi_local: Some(format!(
+                "{}",
+                remote.get_integer(tparams::INITIAL_MAX_STREAM_DATA_BIDI_LOCAL)
+            )),
+            initial_max_stream_data_bidi_remote: Some(format!(
+                "{}",
+                remote.get_integer(tparams::INITIAL_MAX_STREAM_DATA_BIDI_REMOTE)
+            )),
+            initial_max_stream_data_uni: Some(format!(
+                "{}",
+                remote.get_integer(tparams::INITIAL_MAX_STREAM_DATA_UNI)
+            )),
+            initial_max_streams_bidi: Some(format!(
+                "{}",
+                remote.get_integer(tparams::INITIAL_MAX_STREAMS_BIDI)
+            )),
+            initial_max_streams_uni: Some(format!(
+                "{}",
+                remote.get_integer(tparams::INITIAL_MAX_STREAMS_UNI)
+            )),
+            // TODO(hawkinsw@obs.cr): We do not yet handle PREFERRED_ADDRESS in tparams yet.
+            preferred_address: None,
+        };
+        qlog.trace.push_transport_event(
+            format!("{}", elapsed.as_micros()),
+            TransportEventType::ParametersSet,
+            data,
+        );
+    }
+}
 
 pub fn server_connection_started(qlog: &Option<NeqoQlogRef>, now: Instant, path: &Path) {
     connection_started(qlog, now, path)

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -1,0 +1,308 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Functions that handle capturing QLOG traces.
+
+use std::string::String;
+use std::time::Instant;
+
+use qlog::{
+    self, ConnectivityEventType, EventData, PacketHeader, QuicFrame, QuicFrameTypeName,
+    TransportEventType,
+};
+
+use neqo_common::{hex, qinfo, Decoder, NeqoQlogRef};
+
+use crate::frame::{self, Frame};
+use crate::packet::{DecryptedPacket, PacketNumber, PacketType};
+use crate::path::Path;
+use crate::QUIC_VERSION;
+
+pub fn client_connection_started(qlog: &Option<NeqoQlogRef>, now: Instant, path: &Path) {
+    if let Some(qlog) = qlog {
+        let mut qlog = qlog.borrow_mut();
+        let elapsed = now.duration_since(qlog.zero_time);
+
+        qlog.trace.push_connectivity_event(
+            format!("{}", elapsed.as_micros()),
+            ConnectivityEventType::ConnectionStarted,
+            EventData::ConnectionStarted {
+                ip_version: if path.local_sock().ip().is_ipv4() {
+                    "ipv4".into()
+                } else {
+                    "ipv6".into()
+                },
+                src_ip: format!("{}", path.local_sock().ip()),
+                dst_ip: format!("{}", path.remote_sock().ip()),
+                protocol: Some("QUIC".into()),
+                src_port: path.local_sock().port().into(),
+                dst_port: path.remote_sock().port().into(),
+                quic_version: Some(format!("{:x}", QUIC_VERSION)),
+                src_cid: Some(format!("{}", path.local_cid())),
+                dst_cid: Some(format!("{}", path.remote_cid())),
+            },
+        )
+    }
+}
+
+pub fn packet_sent(
+    qlog: &Option<NeqoQlogRef>,
+    now: Instant,
+    pt: PacketType,
+    pn: PacketNumber,
+    body: &[u8],
+) {
+    if let Some(qlog) = qlog {
+        let mut qlog = qlog.borrow_mut();
+        let elapsed = now.duration_since(qlog.zero_time);
+
+        let mut frames = Vec::new();
+        let mut d = Decoder::from(body);
+
+        while d.remaining() > 0 {
+            match Frame::decode(&mut d) {
+                Ok(f) => frames.push(frame_to_qlogframe(&f)),
+                Err(_) => {
+                    qinfo!("qlog: invalid frame");
+                    break;
+                }
+            }
+        }
+
+        let packet_type = pkt_type_to_qlog_pkt_type(pt);
+
+        qlog.trace.push_transport_event(
+            format!("{}", elapsed.as_micros()),
+            TransportEventType::PacketSent,
+            EventData::PacketSent {
+                packet_type,
+                header: PacketHeader {
+                    packet_number: pn.to_string(),
+                    packet_size: None,
+                    payload_length: None,
+                    version: None,
+                    scil: None,
+                    dcil: None,
+                    scid: None,
+                    dcid: None,
+                },
+                frames: Some(frames),
+                is_coalesced: None,
+                raw_encrypted: None,
+                raw_decrypted: None,
+            },
+        )
+    }
+}
+
+pub fn packet_received(qlog: &Option<NeqoQlogRef>, now: Instant, payload: &DecryptedPacket) {
+    if let Some(qlog) = qlog {
+        let mut qlog = qlog.borrow_mut();
+        let elapsed = now.duration_since(qlog.zero_time);
+
+        let mut frames = Vec::new();
+        let mut d = Decoder::from(&payload[..]);
+
+        while d.remaining() > 0 {
+            match Frame::decode(&mut d) {
+                Ok(f) => frames.push(frame_to_qlogframe(&f)),
+                Err(_) => {
+                    qinfo!("qlog: invalid frame");
+                    break;
+                }
+            }
+        }
+
+        let packet_type = pkt_type_to_qlog_pkt_type(payload.packet_type());
+
+        qlog.trace.push_transport_event(
+            format!("{}", elapsed.as_micros()),
+            TransportEventType::PacketReceived,
+            EventData::PacketReceived {
+                packet_type,
+                header: PacketHeader {
+                    packet_number: payload.pn().to_string(),
+                    packet_size: None,
+                    payload_length: None,
+                    version: None,
+                    scil: None,
+                    dcil: None,
+                    scid: None,
+                    dcid: None,
+                },
+                frames: Some(frames),
+                is_coalesced: None,
+                raw_encrypted: None,
+                raw_decrypted: None,
+            },
+        )
+    }
+}
+
+// Helper functions
+
+fn frame_to_qlogframe(frame: &Frame) -> QuicFrame {
+    match frame {
+        Frame::Padding => QuicFrame::Padding {
+            frame_type: QuicFrameTypeName::Padding,
+        },
+        Frame::Ping => QuicFrame::Ping {
+            frame_type: QuicFrameTypeName::Ping,
+        },
+        Frame::Ack { ack_delay, .. } => QuicFrame::Ack {
+            frame_type: QuicFrameTypeName::Ack,
+            ack_delay: Some(ack_delay.to_string()),
+            acked_ranges: None,
+            ect1: None,
+            ect0: None,
+            ce: None,
+        },
+        Frame::ResetStream {
+            stream_id,
+            application_error_code,
+            final_size,
+        } => QuicFrame::ResetStream {
+            frame_type: QuicFrameTypeName::ResetStream,
+            stream_id: stream_id.as_u64().to_string(),
+            error_code: *application_error_code,
+            final_size: final_size.to_string(),
+        },
+        Frame::StopSending {
+            stream_id,
+            application_error_code,
+        } => QuicFrame::StopSending {
+            frame_type: QuicFrameTypeName::StopSending,
+            stream_id: stream_id.as_u64().to_string(),
+            error_code: *application_error_code,
+        },
+        Frame::Crypto { offset, data } => QuicFrame::Crypto {
+            frame_type: QuicFrameTypeName::Crypto,
+            offset: offset.to_string(),
+            length: data.len().to_string(),
+        },
+        Frame::NewToken { token } => QuicFrame::NewToken {
+            frame_type: QuicFrameTypeName::NewToken,
+            length: token.len().to_string(),
+            token: hex(&token),
+        },
+        Frame::Stream {
+            fin,
+            stream_id,
+            offset,
+            data,
+            ..
+        } => QuicFrame::Stream {
+            frame_type: QuicFrameTypeName::Stream,
+            stream_id: stream_id.as_u64().to_string(),
+            offset: offset.to_string(),
+            length: data.len().to_string(),
+            fin: *fin,
+            raw: None,
+        },
+        Frame::MaxData { maximum_data } => QuicFrame::MaxData {
+            frame_type: QuicFrameTypeName::MaxData,
+            maximum: maximum_data.to_string(),
+        },
+        Frame::MaxStreamData {
+            stream_id,
+            maximum_stream_data,
+        } => QuicFrame::MaxStreamData {
+            frame_type: QuicFrameTypeName::MaxStreamData,
+            stream_id: stream_id.as_u64().to_string(),
+            maximum: maximum_stream_data.to_string(),
+        },
+        Frame::MaxStreams {
+            stream_type,
+            maximum_streams,
+        } => QuicFrame::MaxStreams {
+            frame_type: QuicFrameTypeName::MaxData,
+            stream_type: match stream_type {
+                frame::StreamType::BiDi => qlog::StreamType::Bidirectional,
+                frame::StreamType::UniDi => qlog::StreamType::Unidirectional,
+            },
+            maximum: maximum_streams.as_u64().to_string(),
+        },
+        Frame::DataBlocked { data_limit } => QuicFrame::DataBlocked {
+            frame_type: QuicFrameTypeName::DataBlocked,
+            limit: data_limit.to_string(),
+        },
+        Frame::StreamDataBlocked {
+            stream_id,
+            stream_data_limit,
+        } => QuicFrame::StreamDataBlocked {
+            frame_type: QuicFrameTypeName::StreamDataBlocked,
+            stream_id: stream_id.as_u64().to_string(),
+            limit: stream_data_limit.to_string(),
+        },
+        Frame::StreamsBlocked {
+            stream_type,
+            stream_limit,
+        } => QuicFrame::StreamsBlocked {
+            frame_type: QuicFrameTypeName::StreamsBlocked,
+            stream_type: match stream_type {
+                frame::StreamType::BiDi => qlog::StreamType::Bidirectional,
+                frame::StreamType::UniDi => qlog::StreamType::Unidirectional,
+            },
+            limit: stream_limit.as_u64().to_string(),
+        },
+        Frame::NewConnectionId {
+            sequence_number,
+            retire_prior,
+            connection_id,
+            stateless_reset_token,
+        } => QuicFrame::NewConnectionId {
+            frame_type: QuicFrameTypeName::NewConnectionId,
+            sequence_number: sequence_number.to_string(),
+            retire_prior_to: retire_prior.to_string(),
+            length: connection_id.len() as u64,
+            connection_id: hex(&connection_id),
+            reset_token: hex(stateless_reset_token),
+        },
+        Frame::RetireConnectionId { sequence_number } => QuicFrame::RetireConnectionId {
+            frame_type: QuicFrameTypeName::RetireConnectionId,
+            sequence_number: sequence_number.to_string(),
+        },
+        Frame::PathChallenge { data } => QuicFrame::PathChallenge {
+            frame_type: QuicFrameTypeName::PathChallenge,
+            data: Some(hex(data)),
+        },
+        Frame::PathResponse { data } => QuicFrame::PathResponse {
+            frame_type: QuicFrameTypeName::PathResponse,
+            data: Some(hex(data)),
+        },
+        Frame::ConnectionClose {
+            error_code,
+            frame_type,
+            reason_phrase,
+        } => QuicFrame::ConnectionClose {
+            frame_type: QuicFrameTypeName::ConnectionClose,
+            error_space: match error_code {
+                frame::CloseError::Transport(_) => qlog::ErrorSpace::TransportError,
+                frame::CloseError::Application(_) => qlog::ErrorSpace::ApplicationError,
+            },
+            error_code: error_code.code(),
+            raw_error_code: 0,
+            reason: String::from_utf8_lossy(&reason_phrase).to_string(),
+            trigger_frame_type: Some(frame_type.to_string()),
+        },
+        Frame::HandshakeDone => QuicFrame::Unknown {
+            frame_type: QuicFrameTypeName::Unknown,
+            raw_frame_type: 0x1e,
+        },
+    }
+}
+
+fn pkt_type_to_qlog_pkt_type(ptype: PacketType) -> qlog::PacketType {
+    match ptype {
+        PacketType::Initial => qlog::PacketType::Initial,
+        PacketType::Handshake => qlog::PacketType::Handshake,
+        PacketType::ZeroRtt => qlog::PacketType::ZeroRtt,
+        PacketType::Short => qlog::PacketType::OneRtt,
+        PacketType::Retry => qlog::PacketType::Retry,
+        PacketType::VersionNegotiation => qlog::PacketType::VersionNegotiation,
+        PacketType::OtherVersion => qlog::PacketType::Unknown,
+    }
+}

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -21,31 +21,12 @@ use crate::packet::{DecryptedPacket, PacketNumber, PacketType};
 use crate::path::Path;
 use crate::QUIC_VERSION;
 
-pub fn client_connection_started(qlog: &Option<NeqoQlogRef>, now: Instant, path: &Path) {
-    if let Some(qlog) = qlog {
-        let mut qlog = qlog.borrow_mut();
-        let elapsed = now.duration_since(qlog.zero_time);
+pub fn server_connection_started(qlog: &Option<NeqoQlogRef>, now: Instant, path: &Path) {
+    connection_started(qlog, now, path)
+}
 
-        qlog.trace.push_connectivity_event(
-            format!("{}", elapsed.as_micros()),
-            ConnectivityEventType::ConnectionStarted,
-            EventData::ConnectionStarted {
-                ip_version: if path.local_sock().ip().is_ipv4() {
-                    "ipv4".into()
-                } else {
-                    "ipv6".into()
-                },
-                src_ip: format!("{}", path.local_sock().ip()),
-                dst_ip: format!("{}", path.remote_sock().ip()),
-                protocol: Some("QUIC".into()),
-                src_port: path.local_sock().port().into(),
-                dst_port: path.remote_sock().port().into(),
-                quic_version: Some(format!("{:x}", QUIC_VERSION)),
-                src_cid: Some(format!("{}", path.local_cid())),
-                dst_cid: Some(format!("{}", path.remote_cid())),
-            },
-        )
-    }
+pub fn client_connection_started(qlog: &Option<NeqoQlogRef>, now: Instant, path: &Path) {
+    connection_started(qlog, now, path);
 }
 
 pub fn packet_sent(
@@ -304,5 +285,32 @@ fn pkt_type_to_qlog_pkt_type(ptype: PacketType) -> qlog::PacketType {
         PacketType::Retry => qlog::PacketType::Retry,
         PacketType::VersionNegotiation => qlog::PacketType::VersionNegotiation,
         PacketType::OtherVersion => qlog::PacketType::Unknown,
+    }
+}
+
+fn connection_started(qlog: &Option<NeqoQlogRef>, now: Instant, path: &Path) {
+    if let Some(qlog) = qlog {
+        let mut qlog = qlog.borrow_mut();
+        let elapsed = now.duration_since(qlog.zero_time);
+
+        qlog.trace.push_connectivity_event(
+            format!("{}", elapsed.as_micros()),
+            ConnectivityEventType::ConnectionStarted,
+            EventData::ConnectionStarted {
+                ip_version: if path.local_sock().ip().is_ipv4() {
+                    "ipv4".into()
+                } else {
+                    "ipv6".into()
+                },
+                src_ip: format!("{}", path.local_sock().ip()),
+                dst_ip: format!("{}", path.remote_sock().ip()),
+                protocol: Some("QUIC".into()),
+                src_port: path.local_sock().port().into(),
+                dst_port: path.remote_sock().port().into(),
+                quic_version: Some(format!("{:x}", QUIC_VERSION)),
+                src_cid: Some(format!("{}", path.local_cid())),
+                dst_cid: Some(format!("{}", path.remote_cid())),
+            },
+        )
     }
 }

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -9,10 +9,7 @@
 use std::string::String;
 use std::time::Instant;
 
-use qlog::{
-    self, ConnectivityEventType, EventData, PacketHeader, QuicFrame, QuicFrameTypeName,
-    TransportEventType,
-};
+use qlog::{self, event::Event, PacketHeader, QuicFrame};
 
 use neqo_common::{hex, qinfo, Decoder, NeqoQlogRef};
 
@@ -44,69 +41,62 @@ pub fn connection_tparams_set(
         let mut qlog = qlog.borrow_mut();
         let elapsed = now.duration_since(qlog.zero_time);
         let remote = tph.remote();
-        let data = EventData::TransportParametersSet {
-            owner: None,
-            resumption_allowed: None,
-            early_data_enabled: None,
-            alpn: None,
-            version: None,
-            tls_cipher: None,
-            original_connection_id: if let Some(ocid) =
-                remote.get_bytes(tparams::ORIGINAL_CONNECTION_ID)
-            {
+        let event = Event::transport_parameters_set(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            if let Some(ocid) = remote.get_bytes(tparams::ORIGINAL_CONNECTION_ID) {
                 // Cannot use packet::ConnectionId's Display trait implementation
                 // because it does not include the 0x prefix.
                 Some(slice_to_hex_string(&ocid))
             } else {
                 None
             },
-            stateless_reset_token: if let Some(srt) =
-                remote.get_bytes(tparams::STATELESS_RESET_TOKEN)
-            {
+            if let Some(srt) = remote.get_bytes(tparams::STATELESS_RESET_TOKEN) {
                 Some(slice_to_hex_string(&srt))
             } else {
                 None
             },
-            disable_active_migration: if remote.get_empty(tparams::DISABLE_MIGRATION).is_some() {
+            if remote.get_empty(tparams::DISABLE_MIGRATION).is_some() {
                 Some(true)
             } else {
                 None
             },
-            idle_timeout: Some(remote.get_integer(tparams::IDLE_TIMEOUT)),
-            max_packet_size: Some(remote.get_integer(tparams::MAX_PACKET_SIZE)),
-            ack_delay_exponent: Some(remote.get_integer(tparams::ACK_DELAY_EXPONENT)),
-            max_ack_delay: Some(remote.get_integer(tparams::MAX_ACK_DELAY)),
+            Some(remote.get_integer(tparams::IDLE_TIMEOUT)),
+            Some(remote.get_integer(tparams::MAX_PACKET_SIZE)),
+            Some(remote.get_integer(tparams::ACK_DELAY_EXPONENT)),
+            Some(remote.get_integer(tparams::MAX_ACK_DELAY)),
             // TODO(hawkinsw@obs.cr): We do not yet handle ACTIVE_CONNECTION_ID_LIMIT in tparams yet.
-            active_connection_id_limit: None,
-            initial_max_data: Some(format!("{}", remote.get_integer(tparams::INITIAL_MAX_DATA))),
-            initial_max_stream_data_bidi_local: Some(format!(
+            None,
+            Some(format!("{}", remote.get_integer(tparams::INITIAL_MAX_DATA))),
+            Some(format!(
                 "{}",
                 remote.get_integer(tparams::INITIAL_MAX_STREAM_DATA_BIDI_LOCAL)
             )),
-            initial_max_stream_data_bidi_remote: Some(format!(
+            Some(format!(
                 "{}",
                 remote.get_integer(tparams::INITIAL_MAX_STREAM_DATA_BIDI_REMOTE)
             )),
-            initial_max_stream_data_uni: Some(format!(
+            Some(format!(
                 "{}",
                 remote.get_integer(tparams::INITIAL_MAX_STREAM_DATA_UNI)
             )),
-            initial_max_streams_bidi: Some(format!(
+            Some(format!(
                 "{}",
                 remote.get_integer(tparams::INITIAL_MAX_STREAMS_BIDI)
             )),
-            initial_max_streams_uni: Some(format!(
+            Some(format!(
                 "{}",
                 remote.get_integer(tparams::INITIAL_MAX_STREAMS_UNI)
             )),
             // TODO(hawkinsw@obs.cr): We do not yet handle PREFERRED_ADDRESS in tparams yet.
-            preferred_address: None,
-        };
-        qlog.trace.push_transport_event(
-            format!("{}", elapsed.as_micros()),
-            TransportEventType::ParametersSet,
-            data,
+            None,
         );
+
+        qlog.trace.push_event(elapsed, event);
     }
 }
 
@@ -144,27 +134,14 @@ pub fn packet_sent(
 
         let packet_type = pkt_type_to_qlog_pkt_type(pt);
 
-        qlog.trace.push_transport_event(
-            format!("{}", elapsed.as_micros()),
-            TransportEventType::PacketSent,
-            EventData::PacketSent {
+        qlog.trace.push_event(
+            elapsed,
+            Event::packet_sent_min(
                 packet_type,
-                header: PacketHeader {
-                    packet_number: pn.to_string(),
-                    packet_size: None,
-                    payload_length: None,
-                    version: None,
-                    scil: None,
-                    dcil: None,
-                    scid: None,
-                    dcid: None,
-                },
-                frames: Some(frames),
-                is_coalesced: None,
-                raw_encrypted: None,
-                raw_decrypted: None,
-            },
-        )
+                PacketHeader::new(pn, None, None, None, None, None),
+                Some(frames),
+            ),
+        );
     }
 }
 
@@ -188,27 +165,17 @@ pub fn packet_received(qlog: &Option<NeqoQlogRef>, now: Instant, payload: &Decry
 
         let packet_type = pkt_type_to_qlog_pkt_type(payload.packet_type());
 
-        qlog.trace.push_transport_event(
-            format!("{}", elapsed.as_micros()),
-            TransportEventType::PacketReceived,
-            EventData::PacketReceived {
+        qlog.trace.push_event(
+            elapsed,
+            Event::packet_received(
                 packet_type,
-                header: PacketHeader {
-                    packet_number: payload.pn().to_string(),
-                    packet_size: None,
-                    payload_length: None,
-                    version: None,
-                    scil: None,
-                    dcil: None,
-                    scid: None,
-                    dcid: None,
-                },
-                frames: Some(frames),
-                is_coalesced: None,
-                raw_encrypted: None,
-                raw_decrypted: None,
-            },
-        )
+                PacketHeader::new(payload.pn(), None, None, None, None, None),
+                Some(frames),
+                None,
+                None,
+                None,
+            ),
+        );
     }
 }
 
@@ -216,152 +183,109 @@ pub fn packet_received(qlog: &Option<NeqoQlogRef>, now: Instant, payload: &Decry
 
 fn frame_to_qlogframe(frame: &Frame) -> QuicFrame {
     match frame {
-        Frame::Padding => QuicFrame::Padding {
-            frame_type: QuicFrameTypeName::Padding,
-        },
-        Frame::Ping => QuicFrame::Ping {
-            frame_type: QuicFrameTypeName::Ping,
-        },
-        Frame::Ack { ack_delay, .. } => QuicFrame::Ack {
-            frame_type: QuicFrameTypeName::Ack,
-            ack_delay: Some(ack_delay.to_string()),
-            acked_ranges: None,
-            ect1: None,
-            ect0: None,
-            ce: None,
-        },
+        Frame::Padding => QuicFrame::padding(),
+        Frame::Ping => QuicFrame::ping(),
+        Frame::Ack { ack_delay, .. } => {
+            QuicFrame::ack(Some(ack_delay.to_string()), None, None, None, None)
+        }
         Frame::ResetStream {
             stream_id,
             application_error_code,
             final_size,
-        } => QuicFrame::ResetStream {
-            frame_type: QuicFrameTypeName::ResetStream,
-            stream_id: stream_id.as_u64().to_string(),
-            error_code: *application_error_code,
-            final_size: final_size.to_string(),
-        },
+        } => QuicFrame::reset_stream(
+            stream_id.as_u64().to_string(),
+            *application_error_code,
+            final_size.to_string(),
+        ),
         Frame::StopSending {
             stream_id,
             application_error_code,
-        } => QuicFrame::StopSending {
-            frame_type: QuicFrameTypeName::StopSending,
-            stream_id: stream_id.as_u64().to_string(),
-            error_code: *application_error_code,
-        },
-        Frame::Crypto { offset, data } => QuicFrame::Crypto {
-            frame_type: QuicFrameTypeName::Crypto,
-            offset: offset.to_string(),
-            length: data.len().to_string(),
-        },
-        Frame::NewToken { token } => QuicFrame::NewToken {
-            frame_type: QuicFrameTypeName::NewToken,
-            length: token.len().to_string(),
-            token: hex(&token),
-        },
+        } => QuicFrame::stop_sending(stream_id.as_u64().to_string(), *application_error_code),
+        Frame::Crypto { offset, data } => {
+            QuicFrame::crypto(offset.to_string(), data.len().to_string())
+        }
+        Frame::NewToken { token } => QuicFrame::new_token(token.len().to_string(), hex(&token)),
         Frame::Stream {
             fin,
             stream_id,
             offset,
             data,
             ..
-        } => QuicFrame::Stream {
-            frame_type: QuicFrameTypeName::Stream,
-            stream_id: stream_id.as_u64().to_string(),
-            offset: offset.to_string(),
-            length: data.len().to_string(),
-            fin: *fin,
-            raw: None,
-        },
-        Frame::MaxData { maximum_data } => QuicFrame::MaxData {
-            frame_type: QuicFrameTypeName::MaxData,
-            maximum: maximum_data.to_string(),
-        },
+        } => QuicFrame::stream(
+            stream_id.as_u64().to_string(),
+            offset.to_string(),
+            data.len().to_string(),
+            *fin,
+            None,
+        ),
+        Frame::MaxData { maximum_data } => QuicFrame::max_data(maximum_data.to_string()),
         Frame::MaxStreamData {
             stream_id,
             maximum_stream_data,
-        } => QuicFrame::MaxStreamData {
-            frame_type: QuicFrameTypeName::MaxStreamData,
-            stream_id: stream_id.as_u64().to_string(),
-            maximum: maximum_stream_data.to_string(),
-        },
+        } => QuicFrame::max_stream_data(
+            stream_id.as_u64().to_string(),
+            maximum_stream_data.to_string(),
+        ),
         Frame::MaxStreams {
             stream_type,
             maximum_streams,
-        } => QuicFrame::MaxStreams {
-            frame_type: QuicFrameTypeName::MaxData,
-            stream_type: match stream_type {
+        } => QuicFrame::max_streams(
+            match stream_type {
                 frame::StreamType::BiDi => qlog::StreamType::Bidirectional,
                 frame::StreamType::UniDi => qlog::StreamType::Unidirectional,
             },
-            maximum: maximum_streams.as_u64().to_string(),
-        },
-        Frame::DataBlocked { data_limit } => QuicFrame::DataBlocked {
-            frame_type: QuicFrameTypeName::DataBlocked,
-            limit: data_limit.to_string(),
-        },
+            maximum_streams.as_u64().to_string(),
+        ),
+        Frame::DataBlocked { data_limit } => QuicFrame::data_blocked(data_limit.to_string()),
         Frame::StreamDataBlocked {
             stream_id,
             stream_data_limit,
-        } => QuicFrame::StreamDataBlocked {
-            frame_type: QuicFrameTypeName::StreamDataBlocked,
-            stream_id: stream_id.as_u64().to_string(),
-            limit: stream_data_limit.to_string(),
-        },
+        } => QuicFrame::stream_data_blocked(
+            stream_id.as_u64().to_string(),
+            stream_data_limit.to_string(),
+        ),
         Frame::StreamsBlocked {
             stream_type,
             stream_limit,
-        } => QuicFrame::StreamsBlocked {
-            frame_type: QuicFrameTypeName::StreamsBlocked,
-            stream_type: match stream_type {
+        } => QuicFrame::streams_blocked(
+            match stream_type {
                 frame::StreamType::BiDi => qlog::StreamType::Bidirectional,
                 frame::StreamType::UniDi => qlog::StreamType::Unidirectional,
             },
-            limit: stream_limit.as_u64().to_string(),
-        },
+            stream_limit.as_u64().to_string(),
+        ),
         Frame::NewConnectionId {
             sequence_number,
             retire_prior,
             connection_id,
             stateless_reset_token,
-        } => QuicFrame::NewConnectionId {
-            frame_type: QuicFrameTypeName::NewConnectionId,
-            sequence_number: sequence_number.to_string(),
-            retire_prior_to: retire_prior.to_string(),
-            length: connection_id.len() as u64,
-            connection_id: hex(&connection_id),
-            reset_token: hex(stateless_reset_token),
-        },
-        Frame::RetireConnectionId { sequence_number } => QuicFrame::RetireConnectionId {
-            frame_type: QuicFrameTypeName::RetireConnectionId,
-            sequence_number: sequence_number.to_string(),
-        },
-        Frame::PathChallenge { data } => QuicFrame::PathChallenge {
-            frame_type: QuicFrameTypeName::PathChallenge,
-            data: Some(hex(data)),
-        },
-        Frame::PathResponse { data } => QuicFrame::PathResponse {
-            frame_type: QuicFrameTypeName::PathResponse,
-            data: Some(hex(data)),
-        },
+        } => QuicFrame::new_connection_id(
+            sequence_number.to_string(),
+            retire_prior.to_string(),
+            connection_id.len() as u64,
+            hex(&connection_id),
+            hex(stateless_reset_token),
+        ),
+        Frame::RetireConnectionId { sequence_number } => {
+            QuicFrame::retire_connection_id(sequence_number.to_string())
+        }
+        Frame::PathChallenge { data } => QuicFrame::path_challenge(Some(hex(data))),
+        Frame::PathResponse { data } => QuicFrame::path_response(Some(hex(data))),
         Frame::ConnectionClose {
             error_code,
             frame_type,
             reason_phrase,
-        } => QuicFrame::ConnectionClose {
-            frame_type: QuicFrameTypeName::ConnectionClose,
-            error_space: match error_code {
+        } => QuicFrame::connection_close(
+            match error_code {
                 frame::CloseError::Transport(_) => qlog::ErrorSpace::TransportError,
                 frame::CloseError::Application(_) => qlog::ErrorSpace::ApplicationError,
             },
-            error_code: error_code.code(),
-            raw_error_code: 0,
-            reason: String::from_utf8_lossy(&reason_phrase).to_string(),
-            trigger_frame_type: Some(frame_type.to_string()),
-        },
-        Frame::HandshakeDone => QuicFrame::Unknown {
-            frame_type: QuicFrameTypeName::Unknown,
-            raw_frame_type: 0x1e,
-        },
+            error_code.code(),
+            0,
+            String::from_utf8_lossy(&reason_phrase).to_string(),
+            Some(frame_type.to_string()),
+        ),
+        Frame::HandshakeDone => QuicFrame::unknown(0x1e),
     }
 }
 
@@ -382,24 +306,23 @@ fn connection_started(qlog: &Option<NeqoQlogRef>, now: Instant, path: &Path) {
         let mut qlog = qlog.borrow_mut();
         let elapsed = now.duration_since(qlog.zero_time);
 
-        qlog.trace.push_connectivity_event(
-            format!("{}", elapsed.as_micros()),
-            ConnectivityEventType::ConnectionStarted,
-            EventData::ConnectionStarted {
-                ip_version: if path.local_sock().ip().is_ipv4() {
+        qlog.trace.push_event(
+            elapsed,
+            Event::connection_started(
+                if path.local_sock().ip().is_ipv4() {
                     "ipv4".into()
                 } else {
                     "ipv6".into()
                 },
-                src_ip: format!("{}", path.local_sock().ip()),
-                dst_ip: format!("{}", path.remote_sock().ip()),
-                protocol: Some("QUIC".into()),
-                src_port: path.local_sock().port().into(),
-                dst_port: path.remote_sock().port().into(),
-                quic_version: Some(format!("{:x}", QUIC_VERSION)),
-                src_cid: Some(format!("{}", path.local_cid())),
-                dst_cid: Some(format!("{}", path.remote_cid())),
-            },
-        )
+                format!("{}", path.local_sock().ip()),
+                format!("{}", path.remote_sock().ip()),
+                Some("QUIC".into()),
+                path.local_sock().port().into(),
+                path.remote_sock().port().into(),
+                Some(format!("{:x}", QUIC_VERSION)),
+                Some(format!("{}", path.local_cid())),
+                Some(format!("{}", path.remote_cid())),
+            ),
+        );
     }
 }

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -335,6 +335,7 @@ impl Server {
             &self.protocols,
             &self.anti_replay,
             cid_mgr.clone(),
+            None,
         );
         if let Ok(mut c) = sconn {
             if let Some(odcid) = odcid {

--- a/neqo-transport/src/stream_id.rs
+++ b/neqo-transport/src/stream_id.rs
@@ -8,7 +8,9 @@
 
 use std::ops::AddAssign;
 
-use crate::connection::{Role, LOCAL_STREAM_LIMIT_BIDI, LOCAL_STREAM_LIMIT_UNI};
+use neqo_common::Role;
+
+use crate::connection::{LOCAL_STREAM_LIMIT_BIDI, LOCAL_STREAM_LIMIT_UNI};
 use crate::frame::StreamType;
 
 pub struct StreamIndexes {

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -233,6 +233,18 @@ impl TransportParameters {
         }
     }
 
+    pub fn get_empty(&self, tipe: TransportParameterId) -> Option<TransportParameter> {
+        let default = match tipe {
+            DISABLE_MIGRATION => None,
+            _ => panic!("Transport parameter not known or not an Empty"),
+        };
+        match self.params.get(&tipe) {
+            None => default,
+            Some(TransportParameter::Empty) => Some(TransportParameter::Empty),
+            _ => panic!("Internal error"),
+        }
+    }
+
     /// Return true if the remembered transport parameters are OK for 0-RTT.
     /// Generally this means that any value that is currently in effect is greater than
     /// or equal to the promised value.

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -36,6 +36,7 @@ fn default_server() -> Server {
         test_fixture::DEFAULT_ALPN,
         test_fixture::anti_replay(),
         Rc::new(RefCell::new(FixedConnectionIdManager::new(9))),
+        None,
     )
     .expect("should create a server")
 }

--- a/test-fixture/src/assertions.rs
+++ b/test-fixture/src/assertions.rs
@@ -7,7 +7,7 @@
 use std::convert::TryInto;
 
 use neqo_common::Decoder;
-use neqo_transport::QUIC_VERSION;
+use neqo_transport::{Version, QUIC_VERSION};
 
 // Do a simple decode of the datagram to verify that it is coalesced.
 pub fn assert_coalesced_0rtt(payload: &[u8]) {
@@ -15,8 +15,8 @@ pub fn assert_coalesced_0rtt(payload: &[u8]) {
     let mut dec = Decoder::from(payload);
     let initial_type = dec.decode_byte().unwrap(); // Initial
     assert_eq!(initial_type & 0b1111_0000, 0b1100_0000);
-    let version = dec.decode_uint(4).unwrap();
-    assert_eq!(version, QUIC_VERSION.into());
+    let version: Version = dec.decode_uint(4).unwrap().try_into().unwrap();
+    assert_eq!(version, QUIC_VERSION);
     dec.skip_vec(1); // DCID
     dec.skip_vec(1); // SCID
     dec.skip_vvec();

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -81,6 +81,7 @@ pub fn default_client() -> Connection {
         Rc::new(RefCell::new(FixedConnectionIdManager::new(3))),
         loopback(),
         loopback(),
+        None,
     )
     .expect("create a default client")
 }
@@ -94,6 +95,7 @@ pub fn default_server() -> Connection {
         DEFAULT_ALPN,
         &anti_replay(),
         Rc::new(RefCell::new(FixedConnectionIdManager::new(5))),
+        None,
     )
     .expect("create a default server")
 }
@@ -145,6 +147,7 @@ pub fn default_http3_client() -> Http3Client {
         loopback(),
         100,
         100,
+        None,
     )
     .expect("create a default client")
 }

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -164,6 +164,7 @@ pub fn default_http3_server() -> Http3Server {
         Rc::new(RefCell::new(FixedConnectionIdManager::new(5))),
         100,
         100,
+        None,
     )
     .expect("create a default server")
 }


### PR DESCRIPTION
I have been working on rebasing our in-progress qlog PR (473) and also moving to qlog 0.2.0 crate version. In doing so I'm having some extreme weirdness. The changes needed for qlog 0.2 are nothing special, but for some reason cause two other, seemingly-unrelated spots of our code to start throwing errors! 

* Build this PR, including last commit that fixes other spots: Compiles.
* Build this PR minus the top commit. Doesn't compile.
* Build this PR minus the top two commits, the second-from-top commit encompassing the changes for qlog 0.2: Compiles

What's going on here?