### PR TITLE
Allow base used in header block to be larger than number of inserts in the dynamic table.

### DIFF
--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -728,4 +728,31 @@ mod tests {
 
         decode_headers(&mut decoder, HEADER_BLOCK_2, &headers, 0);
     }
+
+    #[test]
+    fn test_base_larger_than_entry_count() {
+        // Test for issue https://github.com/mozilla/neqo/issues/533
+        // Send instruction that inserts 2 fields into the dynamic table and send a header that
+        // uses base larger than 2.
+        const ENCODER_INST: &[u8] = &[
+            0x4a, 0x6d, 0x79, 0x2d, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72, 0x61, 0x09, 0x6d, 0x79,
+            0x2d, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x61, 0x4a, 0x6d, 0x79, 0x2d, 0x68, 0x65, 0x61,
+            0x64, 0x65, 0x72, 0x62, 0x09, 0x6d, 0x79, 0x2d, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x62,
+        ];
+
+        const HEADER_BLOCK: &[u8] = &[0x03, 0x03, 0x83, 0x84];
+
+        let headers = vec![
+            (String::from("my-headerb"), String::from("my-valueb")),
+            (String::from("my-headera"), String::from("my-valuea")),
+        ];
+
+        let mut decoder = connect();
+
+        assert!(decoder.decoder.set_capacity(200).is_ok());
+
+        recv_instruction(&mut decoder, ENCODER_INST, &Ok(()));
+
+        decode_headers(&mut decoder, HEADER_BLOCK, &headers, 0);
+    }
 }

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -144,18 +144,17 @@ impl HeaderTable {
     }
 
     pub fn get_dynamic(&self, index: u64, base: u64, post: bool) -> Res<&DynamicTableEntry> {
-        let inx: u64;
-        if post {
+        let inx = if post {
             if self.base < (base + index + 1) {
                 return Err(Error::HeaderLookup);
             }
-            inx = self.base - (base + index + 1);
+            self.base - (base + index + 1)
         } else {
             if (self.base + index) < base {
                 return Err(Error::HeaderLookup);
             }
-            inx = (self.base + index) - base;
-        }
+            (self.base + index) - base
+        };
 
         self.get_dynamic_with_relative_index(inx)
     }

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -144,18 +144,17 @@ impl HeaderTable {
     }
 
     pub fn get_dynamic(&self, index: u64, base: u64, post: bool) -> Res<&DynamicTableEntry> {
-        if self.base < base {
-            return Err(Error::HeaderLookup);
-        }
         let inx: u64;
-        let base_rel = self.base - base;
         if post {
-            if base_rel <= index {
+            if self.base < (base + index + 1) {
                 return Err(Error::HeaderLookup);
             }
-            inx = base_rel - index - 1;
+            inx = self.base - (base + index + 1);
         } else {
-            inx = base_rel + index;
+            if (self.base + index) < base {
+                return Err(Error::HeaderLookup);
+            }
+            inx = (self.base + index) - base;
         }
 
         self.get_dynamic_with_relative_index(inx)


### PR DESCRIPTION
This is a fix for https://github.com/mozilla/neqo/issues/533