### PR TITLE
[WIP] Replace u64 for stream id with StreamId

### DIFF
--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -7,14 +7,14 @@
 use crate::hframe::HFrame;
 use crate::Res;
 use neqo_common::{qtrace, Encoder};
-use neqo_transport::{Connection, StreamType};
+use neqo_transport::{Connection, StreamId, StreamType};
 
 pub const HTTP3_UNI_STREAM_TYPE_CONTROL: u64 = 0x0;
 
 // The local control stream, responsible for encoding frames and sending them
 #[derive(Default, Debug)]
 pub struct ControlStreamLocal {
-    stream_id: Option<u64>,
+    stream_id: Option<StreamId>,
     buf: Vec<u8>,
 }
 
@@ -49,7 +49,7 @@ impl ControlStreamLocal {
 
     pub fn create(&mut self, conn: &mut Connection) -> Res<()> {
         qtrace!([self], "Create a control stream.");
-        self.stream_id = Some(conn.stream_create(StreamType::UniDi)?);
+        self.stream_id = Some(conn.stream_create(StreamType::UniDi)?.into());
         let mut enc = Encoder::default();
         enc.encode_varint(HTTP3_UNI_STREAM_TYPE_CONTROL as u64);
         self.buf.append(&mut enc.into());

--- a/neqo-http3/src/response_stream.rs
+++ b/neqo-http3/src/response_stream.rs
@@ -9,7 +9,7 @@ use crate::hframe::{HFrame, HFrameReader};
 use crate::{Error, Header, Res};
 use neqo_common::{matches, qdebug, qinfo, qtrace};
 use neqo_qpack::decoder::QPackDecoder;
-use neqo_transport::Connection;
+use neqo_transport::{Connection, StreamId};
 use std::cmp::min;
 use std::mem;
 
@@ -53,7 +53,7 @@ pub(crate) struct ResponseStream {
     frame_reader: HFrameReader,
     response_headers_state: ResponseHeadersState,
     conn_events: Http3ClientEvents,
-    stream_id: u64,
+    stream_id: StreamId,
 }
 
 impl ::std::fmt::Display for ResponseStream {
@@ -63,7 +63,7 @@ impl ::std::fmt::Display for ResponseStream {
 }
 
 impl ResponseStream {
-    pub fn new(stream_id: u64, conn_events: Http3ClientEvents) -> Self {
+    pub fn new(stream_id: StreamId, conn_events: Http3ClientEvents) -> Self {
         Self {
             state: ResponseStreamState::WaitingForResponseHeaders,
             frame_reader: HFrameReader::new(),

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -294,7 +294,7 @@ mod tests {
 
     struct PeerConnection {
         conn: Connection,
-        control_stream_id: u64,
+        control_stream_id: StreamId,
     }
 
     // Connect transport, send and receive settings.
@@ -735,7 +735,7 @@ mod tests {
         // Send only request headers for now.
         peer_conn
             .conn
-            .stream_send(request_stream_id, &REQUEST_WITH_BODY[..20])
+            .stream_send(request_stream_id.into(), &REQUEST_WITH_BODY[..20])
             .unwrap();
 
         let out = peer_conn.conn.process(None, now());

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -9,7 +9,7 @@ use crate::connection_server::Http3ServerHandler;
 use crate::{Header, Res};
 use neqo_common::{qdebug, qinfo};
 use neqo_transport::server::ActiveConnectionRef;
-use neqo_transport::{AppError, Connection};
+use neqo_transport::{AppError, Connection, StreamId};
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -19,7 +19,7 @@ use std::rc::Rc;
 pub struct ClientRequestStream {
     conn: ActiveConnectionRef,
     handler: Rc<RefCell<Http3ServerHandler>>,
-    stream_id: u64,
+    stream_id: StreamId,
 }
 
 impl ::std::fmt::Display for ClientRequestStream {
@@ -37,7 +37,7 @@ impl ClientRequestStream {
     pub fn new(
         conn: ActiveConnectionRef,
         handler: Rc<RefCell<Http3ServerHandler>>,
-        stream_id: u64,
+        stream_id: StreamId,
     ) -> Self {
         Self {
             conn,

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 
 use neqo_common::{qdebug, Decoder, IncrementalDecoder, IncrementalDecoderResult};
-use neqo_transport::Connection;
+use neqo_transport::{Connection, StreamId};
 
 #[derive(Debug)]
 pub struct NewStreamTypeReader {
@@ -20,7 +20,7 @@ impl NewStreamTypeReader {
             fin: false,
         }
     }
-    pub fn get_type(&mut self, conn: &mut Connection, stream_id: u64) -> Option<u64> {
+    pub fn get_type(&mut self, conn: &mut Connection, stream_id: StreamId) -> Option<u64> {
         // On any error we will only close this stream!
         loop {
             let to_read = self.reader.min_remaining();

--- a/neqo-http3/src/transaction_client.rs
+++ b/neqo-http3/src/transaction_client.rs
@@ -13,7 +13,7 @@ use crate::Header;
 use neqo_common::{qinfo, Encoder};
 use neqo_qpack::decoder::QPackDecoder;
 use neqo_qpack::encoder::QPackEncoder;
-use neqo_transport::Connection;
+use neqo_transport::{Connection, StreamId};
 
 use crate::{Error, Res};
 use std::cmp::min;
@@ -53,7 +53,7 @@ impl Request {
         r
     }
 
-    pub fn ensure_encoded(&mut self, encoder: &mut QPackEncoder, stream_id: u64) {
+    pub fn ensure_encoded(&mut self, encoder: &mut QPackEncoder, stream_id: StreamId) {
         if self.buf.is_some() {
             return;
         }
@@ -72,7 +72,7 @@ impl Request {
         &mut self,
         conn: &mut Connection,
         encoder: &mut QPackEncoder,
-        stream_id: u64,
+        stream_id: StreamId,
     ) -> Res<bool> {
         let label = if ::log::log_enabled!(::log::Level::Debug) {
             format!("{}", self)
@@ -125,13 +125,13 @@ enum TransactionSendState {
 pub struct TransactionClient {
     send_state: TransactionSendState,
     response_stream: ResponseStream,
-    stream_id: u64,
+    stream_id: StreamId,
     conn_events: Http3ClientEvents,
 }
 
 impl TransactionClient {
     pub fn new(
-        stream_id: u64,
+        stream_id: StreamId,
         method: &str,
         scheme: &str,
         host: &str,

--- a/neqo-http3/src/transaction_server.rs
+++ b/neqo-http3/src/transaction_server.rs
@@ -12,7 +12,7 @@ use crate::{Error, Res};
 use neqo_common::{matches, qdebug, qinfo, qtrace, Encoder};
 use neqo_qpack::decoder::QPackDecoder;
 use neqo_qpack::encoder::QPackEncoder;
-use neqo_transport::Connection;
+use neqo_transport::{Connection, StreamId};
 use std::mem;
 
 #[derive(PartialEq, Debug)]
@@ -35,13 +35,13 @@ enum TransactionSendState {
 pub struct TransactionServer {
     recv_state: TransactionRecvState,
     send_state: TransactionSendState,
-    stream_id: u64,
+    stream_id: StreamId,
     frame_reader: HFrameReader,
     conn_events: Http3ServerConnEvents,
 }
 
 impl TransactionServer {
-    pub fn new(stream_id: u64, conn_events: Http3ServerConnEvents) -> Self {
+    pub fn new(stream_id: StreamId, conn_events: Http3ServerConnEvents) -> Self {
         qinfo!("Create a request stream_id={}", stream_id);
         Self {
             recv_state: TransactionRecvState::WaitingForHeaders,

--- a/neqo-qpack/src/decoder_instructions.rs
+++ b/neqo-qpack/src/decoder_instructions.rs
@@ -24,9 +24,13 @@ pub enum DecoderInstruction {
 impl DecoderInstruction {
     fn get_instruction(b: u8) -> Self {
         if DECODER_HEADER_ACK.cmp_prefix(b) {
-            Self::HeaderAck { stream_id: 0 }
+            Self::HeaderAck {
+                stream_id: 0,
+            }
         } else if DECODER_STREAM_CANCELLATION.cmp_prefix(b) {
-            Self::StreamCancellation { stream_id: 0 }
+            Self::StreamCancellation {
+                stream_id: 0,
+            }
         } else if DECODER_INSERT_COUNT_INCREMENT.cmp_prefix(b) {
             Self::InsertCountIncrement { increment: 0 }
         } else {
@@ -153,11 +157,19 @@ mod test {
         test_encoding_decoding(DecoderInstruction::InsertCountIncrement { increment: 1 });
         test_encoding_decoding(DecoderInstruction::InsertCountIncrement { increment: 10_000 });
 
-        test_encoding_decoding(DecoderInstruction::HeaderAck { stream_id: 1 });
-        test_encoding_decoding(DecoderInstruction::HeaderAck { stream_id: 10_000 });
+        test_encoding_decoding(DecoderInstruction::HeaderAck {
+            stream_id: 1,
+        });
+        test_encoding_decoding(DecoderInstruction::HeaderAck {
+            stream_id: 10_000,
+        });
 
-        test_encoding_decoding(DecoderInstruction::StreamCancellation { stream_id: 1 });
-        test_encoding_decoding(DecoderInstruction::StreamCancellation { stream_id: 10_000 });
+        test_encoding_decoding(DecoderInstruction::StreamCancellation {
+            stream_id: 1,
+        });
+        test_encoding_decoding(DecoderInstruction::StreamCancellation {
+            stream_id: 10_000,
+        });
     }
 
     fn test_encoding_decoding_slow_reader(instruction: DecoderInstruction) {
@@ -187,9 +199,11 @@ mod test {
         test_encoding_decoding_slow_reader(DecoderInstruction::InsertCountIncrement {
             increment: 10_000,
         });
-        test_encoding_decoding_slow_reader(DecoderInstruction::HeaderAck { stream_id: 10_000 });
+        test_encoding_decoding_slow_reader(DecoderInstruction::HeaderAck {
+            stream_id: StreamId(10_000),
+        });
         test_encoding_decoding_slow_reader(DecoderInstruction::StreamCancellation {
-            stream_id: 10_000,
+            stream_id: StreamId(10_000),
         });
     }
 

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -9,6 +9,7 @@ use crate::prefix::Prefix;
 use crate::{Error, Res};
 use neqo_common::{qdebug, qerror};
 use neqo_transport::Connection;
+use neqo_transport::StreamId;
 use std::convert::TryInto;
 use std::mem;
 use std::str;
@@ -23,7 +24,7 @@ pub trait Reader {
 
 pub(crate) struct ReceiverConnWrapper<'a> {
     conn: &'a mut Connection,
-    stream_id: u64,
+    stream_id: StreamId,
 }
 
 impl<'a> ReadByte for ReceiverConnWrapper<'a> {
@@ -47,7 +48,7 @@ impl<'a> Reader for ReceiverConnWrapper<'a> {
 }
 
 impl<'a> ReceiverConnWrapper<'a> {
-    pub fn new(conn: &'a mut Connection, stream_id: u64) -> Self {
+    pub fn new(conn: &'a mut Connection, stream_id: StreamId) -> Self {
         Self { conn, stream_id }
     }
 }

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -9,7 +9,7 @@
 
 use neqo_common::Datagram;
 use neqo_crypto::{init_db, AntiReplay};
-use neqo_transport::{Connection, ConnectionEvent, FixedConnectionIdManager, State};
+use neqo_transport::{Connection, ConnectionEvent, FixedConnectionIdManager, State, StreamId};
 use regex::Regex;
 
 use std::cell::RefCell;
@@ -85,7 +85,7 @@ impl ToSocketAddrs for Args {
 // World's dumbest HTTP 0.9 server. Assumes that the whole request is
 // in a single write.
 // TODO(ekr@rtfm.com): One imagines we could fix this.
-fn http_serve(server: &mut Connection, stream: u64) {
+fn http_serve(server: &mut Connection, stream: StreamId) {
     println!("Stream ID {}", stream);
     let mut data = vec![0; 4000];
     server

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -23,19 +23,25 @@ pub enum ConnectionEvent {
     AuthenticationNeeded,
     /// A new uni (read) or bidi stream has been opened by the peer.
     NewStream {
-        stream_id: u64,
+        stream_id: StreamId,
         stream_type: StreamType,
     },
     /// Space available in the buffer for an application write to succeed.
-    SendStreamWritable { stream_id: u64 },
+    SendStreamWritable { stream_id: StreamId },
     /// New bytes available for reading.
-    RecvStreamReadable { stream_id: u64 },
+    RecvStreamReadable { stream_id: StreamId },
     /// Peer reset the stream.
-    RecvStreamReset { stream_id: u64, app_error: AppError },
+    RecvStreamReset {
+        stream_id: StreamId,
+        app_error: AppError,
+    },
     /// Peer has sent STOP_SENDING
-    SendStreamStopSending { stream_id: u64, app_error: AppError },
+    SendStreamStopSending {
+        stream_id: StreamId,
+        app_error: AppError,
+    },
     /// Peer has acked everything sent on the stream.
-    SendStreamComplete { stream_id: u64 },
+    SendStreamComplete { stream_id: StreamId },
     /// Peer increased MAX_STREAMS
     SendStreamCreatable { stream_type: StreamType },
     /// Connection state change.
@@ -59,50 +65,50 @@ impl ConnectionEvents {
 
     pub fn new_stream(&self, stream_id: StreamId) {
         self.insert(ConnectionEvent::NewStream {
-            stream_id: stream_id.as_u64(),
+            stream_id: stream_id,
             stream_type: stream_id.stream_type(),
         });
     }
 
     pub fn recv_stream_readable(&self, stream_id: StreamId) {
         self.insert(ConnectionEvent::RecvStreamReadable {
-            stream_id: stream_id.as_u64(),
+            stream_id: stream_id,
         });
     }
 
     pub fn recv_stream_reset(&self, stream_id: StreamId, app_error: AppError) {
         // If reset, no longer readable.
-        self.remove(|evt| matches!(evt, ConnectionEvent::RecvStreamReadable { stream_id: x } if *x == stream_id.as_u64()));
+        self.remove(|evt| matches!(evt, ConnectionEvent::RecvStreamReadable { stream_id: x } if *x == stream_id));
 
         self.insert(ConnectionEvent::RecvStreamReset {
-            stream_id: stream_id.as_u64(),
+            stream_id: stream_id,
             app_error,
         });
     }
 
     pub fn send_stream_writable(&self, stream_id: StreamId) {
         self.insert(ConnectionEvent::SendStreamWritable {
-            stream_id: stream_id.as_u64(),
+            stream_id: stream_id,
         });
     }
 
     pub fn send_stream_stop_sending(&self, stream_id: StreamId, app_error: AppError) {
         // If stopped, no longer writable.
-        self.remove(|evt| matches!(evt, ConnectionEvent::SendStreamWritable { stream_id: x } if *x == stream_id.as_u64()));
+        self.remove(|evt| matches!(evt, ConnectionEvent::SendStreamWritable { stream_id: x } if *x == stream_id));
 
         self.insert(ConnectionEvent::SendStreamStopSending {
-            stream_id: stream_id.as_u64(),
+            stream_id: stream_id,
             app_error,
         });
     }
 
     pub fn send_stream_complete(&self, stream_id: StreamId) {
-        self.remove(|evt| matches!(evt, ConnectionEvent::SendStreamWritable { stream_id: x } if *x == stream_id.as_u64()));
+        self.remove(|evt| matches!(evt, ConnectionEvent::SendStreamWritable { stream_id: x } if *x == stream_id));
 
-        self.remove(|evt| matches!(evt, ConnectionEvent::SendStreamStopSending { stream_id: x, .. } if *x == stream_id.as_u64()));
+        self.remove(|evt| matches!(evt, ConnectionEvent::SendStreamStopSending { stream_id: x, .. } if *x == stream_id));
 
         self.insert(ConnectionEvent::SendStreamComplete {
-            stream_id: stream_id.as_u64(),
+            stream_id: stream_id,
         });
     }
 
@@ -204,7 +210,7 @@ mod tests {
         assert_eq!(
             events[0],
             ConnectionEvent::SendStreamStopSending {
-                stream_id: 8,
+                stream_id: 8.into(),
                 app_error: 55
             }
         );

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -261,13 +261,13 @@ impl Frame {
     /// Create a STREAM frame that fits the available space.
     /// Return a tuple of a frame and the amount of data it carries.
     pub fn new_stream(
-        stream_id: u64,
+        stream_id: StreamId,
         offset: u64,
         data: &[u8],
         fin: bool,
         space: usize,
     ) -> Option<(Self, usize)> {
-        let mut overhead = 1 + Encoder::varint_len(stream_id);
+        let mut overhead = 1 + Encoder::varint_len(stream_id.as_u64());
         if offset > 0 {
             overhead += Encoder::varint_len(offset);
         }

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -34,6 +34,7 @@ pub use self::connection::{Connection, FixedConnectionIdManager, Output, Role, S
 pub use self::events::{ConnectionEvent, ConnectionEvents};
 pub use self::frame::CloseError;
 pub use self::frame::StreamType;
+pub use self::stream_id::StreamId;
 
 /// The supported version of the QUIC protocol.
 pub type Version = u32;

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -760,7 +760,7 @@ impl SendStreams {
                     .map(|fs| fs == offset + data_len)
                     .unwrap_or(false);
                 if let Some((frame, length)) =
-                    Frame::new_stream(stream_id.as_u64(), offset, data, range_has_fin, remaining)
+                    Frame::new_stream(stream_id.clone(), offset, data, range_has_fin, remaining)
                 {
                     qdebug!(
                         "Stream {} sending bytes {}-{}, space {:?}",

--- a/neqo-transport/src/stream_id.rs
+++ b/neqo-transport/src/stream_id.rs
@@ -10,6 +10,7 @@ use std::ops::AddAssign;
 
 use crate::connection::{Role, LOCAL_STREAM_LIMIT_BIDI, LOCAL_STREAM_LIMIT_UNI};
 use crate::frame::StreamType;
+use std::fmt;
 
 pub struct StreamIndexes {
     pub local_max_stream_uni: StreamIndex,
@@ -139,5 +140,11 @@ impl From<StreamId> for StreamIndex {
 impl AddAssign<u64> for StreamIndex {
     fn add_assign(&mut self, other: u64) {
         *self = Self::new(self.as_u64() + other)
+    }
+}
+
+impl fmt::Display for StreamId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.as_u64())
     }
 }


### PR DESCRIPTION
@agrover @martinthomson 
I tried to solve this issue #346 , but either I have changed too much or not enough.
Could you please look through? 

For example, there are places where it looks like the type should be StreamId: like this [Result](https://github.com/mozilla/neqo/blob/master/neqo-transport/src/connection.rs#L1936) or maybe even in some fields of this struct [Http3Connection](https://github.com/mozilla/neqo/blob/master/neqo-http3/src/connection.rs#L64)

I haven't touched tests yet. They are failing cause stream_id is expected to be u64. 