### PR TITLE
Checkout specific tags of NSS and NSPR

### DIFF
--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -99,6 +99,13 @@ fn nss_dir() -> PathBuf {
                 ])
                 .status()
                 .expect("can't clone nss");
+            let orig_dir = env::current_dir().unwrap();
+            env::set_current_dir(&dir).unwrap();
+            Command::new("hg")
+                .args(&["up", "NSS_3_50_RTM"])
+                .status()
+                .expect("can't update to tag for NSS");
+            env::set_current_dir(&orig_dir).unwrap();
         }
         let nspr_dir = Path::new(&out_dir).join("nspr");
         if !nspr_dir.exists() {
@@ -110,6 +117,13 @@ fn nss_dir() -> PathBuf {
                 ])
                 .status()
                 .expect("can't clone nspr");
+            let orig_dir = env::current_dir().unwrap();
+            env::set_current_dir(&nspr_dir).unwrap();
+            Command::new("hg")
+                .args(&["up", "NSPR_4_25_RTM"])
+                .status()
+                .expect("can't update to tag for NSPR");
+            env::set_current_dir(&orig_dir).unwrap();
         }
         dir.to_path_buf()
     };


### PR DESCRIPTION
Checking out the tip of these, NSS especially, can cause mysterious
breakage that's not our fault. Instead of the tip, check out recent RTM
tags.

