### PR TITLE
Use the minimum idle_timeout value from both peers

### DIFF
--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -429,6 +429,13 @@ impl LossRecovery {
         max(rtt * 9 / 8, GRANULARITY)
     }
 
+    /// Get the Base PTO value, which is derived only from the RTT and RTTvar values.
+    /// This is for those cases where you need a value for the time you might sensibly
+    /// wait for a packet to propagate.  Using `3*raw_pto()` is common.
+    pub fn raw_pto(&self) -> Duration {
+        self.rtt_vals.pto(PNSpace::ApplicationData)
+    }
+
     // Calculate PTO duration
     fn pto_timeout(&self, pn_space: PNSpace) -> Duration {
         self.rtt_vals


### PR DESCRIPTION
We have a fixed idle timeout, but we aren't using the value from the
peer to set our actual timeout.

This does that.  It chooses the minimum value from both endpoints.  But
it also is careful not to go lower than 3x the current PTO, which might
otherwise cause things to go pear-shaped.