### PR TITLE
http3 client: Fold calls to process_http3 into other process_ methods

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -134,7 +134,6 @@ fn process_loop(
                 }
             }
         }
-        client.process_http3(Instant::now());
 
         if exiting {
             return Ok(client.state());
@@ -157,7 +156,6 @@ fn process_loop(
                 if sz > 0 {
                     let d = Datagram::new(*remote_addr, *local_addr, &buf[..sz]);
                     client.process_input(d, Instant::now());
-                    client.process_http3(Instant::now());
                 }
             }
         };
@@ -184,7 +182,6 @@ struct PostConnectHandler {
 impl Handler for PostConnectHandler {
     fn handle(&mut self, args: &Args, client: &mut Http3Client) -> Res<bool> {
         let mut data = vec![0; 4000];
-        client.process_http3(Instant::now());
         while let Some(event) = client.next_event() {
             match event {
                 Http3ClientEvent::HeaderReady { stream_id } => match self.streams.get(&stream_id) {

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -311,7 +311,6 @@ fn process_loop_h3(nctx: &NetworkCtx, handler: &mut H3Handler) -> Result<State, 
 impl H3Handler {
     fn handle(&mut self) -> bool {
         let mut data = vec![0; 4000];
-        self.h3.process_http3(Instant::now());
         while let Some(event) = self.h3.next_event() {
             match event {
                 Http3ClientEvent::HeaderReady { stream_id } => {
@@ -484,7 +483,6 @@ fn test_h3(nctx: &NetworkCtx, peer: &Peer, client: Connection) -> Result<(), Str
         host: String::from(peer.host),
         path: String::from("/"),
     };
-    hc.h3.process_http3(Instant::now());
     let client_stream_id = hc
         .h3
         .fetch("GET", "https", &hc.host, &hc.path, &[])


### PR DESCRIPTION
Instead of making users of this code know that they need to call
process_http3() before or after calling other process_() methods,
call it from within those.

Make process_http3() no longer a public method.

NOTE: This will require changes to glue code when/if merged into Gecko.