### PR TITLE
Factor more of the crypto handshake

### DIFF
--- a/neqo-crypto/src/agentio.rs
+++ b/neqo-crypto/src/agentio.rs
@@ -35,7 +35,7 @@ pub fn as_c_void<T: Unpin>(pin: &mut Pin<Box<T>>) -> *mut c_void {
 #[derive(Default, Debug)]
 struct RecordLength {
     epoch: Epoch,
-    ct: ssl::SSLContentType::Type,
+    ct: ContentType,
     len: usize,
 }
 
@@ -43,13 +43,13 @@ struct RecordLength {
 #[derive(Default)]
 pub struct Record {
     pub epoch: Epoch,
-    pub ct: ssl::SSLContentType::Type,
+    pub ct: ContentType,
     pub data: Vec<u8>,
 }
 
 impl Record {
     #[must_use]
-    pub fn new(epoch: Epoch, ct: ssl::SSLContentType::Type, data: &[u8]) -> Self {
+    pub fn new(epoch: Epoch, ct: ContentType, data: &[u8]) -> Self {
         Self {
             epoch,
             ct,
@@ -64,7 +64,7 @@ impl Record {
             ssl::SSL_RecordLayerData(
                 fd,
                 self.epoch,
-                self.ct,
+                ssl::SSLContentType::Type::from(self.ct),
                 self.data.as_ptr(),
                 c_uint::try_from(self.data.len())?,
             )
@@ -90,7 +90,7 @@ pub struct RecordList {
 }
 
 impl RecordList {
-    fn append(&mut self, epoch: Epoch, ct: ssl::SSLContentType::Type, data: &[u8]) {
+    fn append(&mut self, epoch: Epoch, ct: ContentType, data: &[u8]) {
         self.records.push(Record::new(epoch, ct, data));
     }
 
@@ -112,7 +112,7 @@ impl RecordList {
         let records = a.as_mut().unwrap();
 
         let slice = std::slice::from_raw_parts(data, len as usize);
-        records.append(epoch, ct, slice);
+        records.append(epoch, ContentType::try_from(ct).unwrap(), slice);
         ssl::SECSuccess
     }
 

--- a/neqo-crypto/src/constants.rs
+++ b/neqo-crypto/src/constants.rs
@@ -88,6 +88,16 @@ remap_enum! {
 }
 
 remap_enum! {
+    ContentType: u8 => ssl::SSLContentType {
+        TLS_CT_CHANGE_CIPHER_SPEC = ssl_ct_change_cipher_spec,
+        TLS_CT_ALERT = ssl_ct_alert,
+        TLS_CT_HANDSHAKE = ssl_ct_handshake,
+        TLS_CT_APPLICATION_DATA = ssl_ct_application_data,
+        TLS_CT_ACK = ssl_ct_ack,
+    }
+}
+
+remap_enum! {
     Extension: u16 => ssl::SSLExtensionType {
         TLS_EXT_SERVER_NAME = ssl_server_name_xtn,
         TLS_EXT_CERT_STATUS = ssl_cert_status_xtn,

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -15,9 +15,9 @@ use neqo_common::{hex, matches, qdebug, qerror, qinfo, qtrace, Role};
 use neqo_crypto::aead::Aead;
 use neqo_crypto::hp::HpKey;
 use neqo_crypto::{
-    hkdf, Agent, AntiReplay, Cipher, Epoch, RecordList, SymKey, TLS_AES_128_GCM_SHA256,
-    TLS_AES_256_GCM_SHA384, TLS_EPOCH_APPLICATION_DATA, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL,
-    TLS_EPOCH_ZERO_RTT, TLS_VERSION_1_3,
+    hkdf, Agent, AntiReplay, Cipher, Epoch, HandshakeState, Record, RecordList, SymKey,
+    TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CT_HANDSHAKE, TLS_EPOCH_APPLICATION_DATA,
+    TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL, TLS_EPOCH_ZERO_RTT, TLS_VERSION_1_3,
 };
 
 use crate::frame::Frame;
@@ -63,6 +63,42 @@ impl Crypto {
             streams: Default::default(),
             states: Default::default(),
         })
+    }
+
+    pub fn handshake(
+        &mut self,
+        now: Instant,
+        space: PNSpace,
+        data: Option<&[u8]>,
+    ) -> Res<&HandshakeState> {
+        let input = data.map(|d| {
+            qtrace!("Handshake record received {:0x?} ", d);
+            let epoch = match space {
+                PNSpace::Initial => TLS_EPOCH_INITIAL,
+                PNSpace::Handshake => TLS_EPOCH_HANDSHAKE,
+                // Our epoch progresses forward, but the TLS epoch is fixed to 3.
+                PNSpace::ApplicationData => TLS_EPOCH_APPLICATION_DATA,
+            };
+            Record {
+                ct: TLS_CT_HANDSHAKE,
+                epoch,
+                data: d.to_vec(),
+            }
+        });
+
+        match self.tls.handshake_raw(now, input) {
+            Ok(output) => {
+                self.buffer_records(output)?;
+                Ok(self.tls.state())
+            }
+            Err(e) => {
+                qinfo!("Handshake failed");
+                Err(match self.tls.alert() {
+                    Some(a) => Error::CryptoAlert(*a),
+                    _ => Error::CryptoError(e),
+                })
+            }
+        }
     }
 
     /// Enable 0-RTT and return `true` if it is enabled successfully.
@@ -154,12 +190,15 @@ impl Crypto {
     }
 
     /// Buffer crypto records for sending.
-    pub fn buffer_records(&mut self, records: RecordList) {
+    pub fn buffer_records(&mut self, records: RecordList) -> Res<()> {
         for r in records {
-            assert_eq!(r.ct, 22);
+            if r.ct != TLS_CT_HANDSHAKE {
+                return Err(Error::ProtocolViolation);
+            }
             qtrace!([self], "Adding CRYPTO data {:?}", r);
             self.streams.send(PNSpace::from(r.epoch), &r.data);
         }
+        Ok(())
     }
 
     pub fn acked(&mut self, token: CryptoRecoveryToken) {

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -13,7 +13,7 @@ use std::ops::{Index, IndexMut};
 use std::time::{Duration, Instant};
 
 use neqo_common::{qdebug, qinfo, qtrace, qwarn};
-use neqo_crypto::{Epoch, TLS_EPOCH_APPLICATION_DATA, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL};
+use neqo_crypto::{Epoch, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL};
 
 use crate::frame::{AckRange, Frame};
 use crate::packet::{PacketNumber, PacketType};
@@ -101,17 +101,6 @@ impl SentPacket {
         } else {
             self.pto = true;
             true
-        }
-    }
-}
-
-impl Into<Epoch> for PNSpace {
-    fn into(self) -> Epoch {
-        match self {
-            Self::Initial => TLS_EPOCH_INITIAL,
-            Self::Handshake => TLS_EPOCH_HANDSHAKE,
-            // Our epoch progresses forward, but the TLS epoch is fixed to 3.
-            Self::ApplicationData => TLS_EPOCH_APPLICATION_DATA,
         }
     }
 }


### PR DESCRIPTION
This moves the handshake stuff into crypto.rs.

I also added a proper constant for the content type, which we had fixed
to a literal 22 in a few places.

I removed the generic implementation of `Into<Epoch>` from PNSpace as that was very specific to the way that we are using this.  That is now part of the handshake method in crypto.rs.