### PR TITLE
Factor SSL option handling

### DIFF
--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -400,9 +400,7 @@ impl SecretAgent {
     /// # Errors
     /// Returns an error if the option or option value is invalid; i.e., never.
     pub fn set_option(&mut self, opt: ssl::Opt, value: bool) -> Res<()> {
-        secstatus_to_res(unsafe {
-            ssl::SSL_OptionSet(self.fd, opt.as_int(), opt.map_enabled(value))
-        })
+        opt.set(self.fd, value)
     }
 
     /// Enable 0-RTT.

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -39,13 +39,14 @@ pub use self::agent::{
     Agent, Client, HandshakeState, Record, RecordList, SecretAgent, SecretAgentInfo,
     SecretAgentPreInfo, Server, ZeroRttCheckResult, ZeroRttChecker,
 };
+pub use self::auth::AuthenticationStatus;
 pub use self::constants::*;
 pub use self::err::{Error, PRErrorCode, Res};
 pub use self::ext::{ExtensionHandler, ExtensionHandlerResult, ExtensionWriterResult};
 pub use self::p11::{random, SymKey};
 pub use self::replay::AntiReplay;
 pub use self::secrets::SecretDirection;
-pub use auth::AuthenticationStatus;
+pub use self::ssl::Opt;
 
 use self::once::OnceResult;
 


### PR DESCRIPTION
This makes the setting of options available to other crates.  That will
make it possible to run some tests later.