### PR TITLE
A transaction should try to read the next frame when it is done reading a data frame

### DIFF
--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -153,14 +153,4 @@ impl Http3ClientEvents {
                 | Http3ClientEvent::StopSending { stream_id: x, .. } if *x == stream_id)
         });
     }
-
-    /// Remove header/data ready events for a stream
-    pub(crate) fn remove_data_ready_events_for_stream_id(&self, stream_id: u64) {
-        self.remove(|evt| {
-            matches!(evt,
-                Http3ClientEvent::HeaderReady { stream_id: x }
-                | Http3ClientEvent::DataReadable { stream_id: x }
-                | Http3ClientEvent::NewPushStream { stream_id: x } if *x == stream_id)
-        });
-    }
 }

--- a/neqo-http3/src/response_stream.rs
+++ b/neqo-http3/src/response_stream.rs
@@ -186,37 +186,48 @@ impl ResponseStream {
     pub fn read_response_data(
         &mut self,
         conn: &mut Connection,
+        decoder: &mut QPackDecoder,
         buf: &mut [u8],
     ) -> Res<(usize, bool)> {
-        match self.state {
-            ResponseStreamState::ReadingData {
-                ref mut remaining_data_len,
-            } => {
-                let to_read = min(*remaining_data_len, buf.len());
-                let (amount, fin) = conn.stream_recv(self.stream_id, &mut buf[..to_read])?;
-                debug_assert!(amount <= to_read);
-                *remaining_data_len -= amount;
+        let mut written = 0;
+        loop {
+            match self.state {
+                ResponseStreamState::ReadingData {
+                    ref mut remaining_data_len,
+                } => {
+                    let to_read = min(*remaining_data_len, buf.len() - written);
+                    let (amount, fin) =
+                        conn.stream_recv(self.stream_id, &mut buf[written..written + to_read])?;
+                    debug_assert!(amount <= to_read);
+                    *remaining_data_len -= amount;
+                    written += amount;
 
-                if fin {
-                    if *remaining_data_len > 0 {
-                        return Err(Error::HttpFrame);
+                    if fin {
+                        if *remaining_data_len > 0 {
+                            return Err(Error::HttpFrame);
+                        }
+                        self.state = ResponseStreamState::Closed;
+                        break Ok((written, fin));
+                    } else if *remaining_data_len == 0 {
+                        self.state = ResponseStreamState::WaitingForData;
+                        self.receive(conn, decoder, false)?;
                     }
-                    self.state = ResponseStreamState::Closed;
-                } else if *remaining_data_len == 0 {
-                    self.state = ResponseStreamState::WaitingForData;
                 }
-
-                Ok((amount, fin))
+                ResponseStreamState::ClosePending => {
+                    self.state = ResponseStreamState::Closed;
+                    break Ok((written, true));
+                }
+                _ => break Ok((written, false)),
             }
-            ResponseStreamState::ClosePending => {
-                self.state = ResponseStreamState::Closed;
-                Ok((0, true))
-            }
-            _ => Ok((0, false)),
         }
     }
 
-    pub fn receive(&mut self, conn: &mut Connection, decoder: &mut QPackDecoder) -> Res<()> {
+    pub fn receive(
+        &mut self,
+        conn: &mut Connection,
+        decoder: &mut QPackDecoder,
+        post_readable_event: bool,
+    ) -> Res<()> {
         let label = if ::log::log_enabled!(::log::Level::Debug) {
             format!("{}", self)
         } else {
@@ -279,7 +290,9 @@ impl ResponseStream {
                     }
                 }
                 ResponseStreamState::ReadingData { .. } => {
-                    self.conn_events.data_readable(self.stream_id);
+                    if post_readable_event {
+                        self.conn_events.data_readable(self.stream_id);
+                    }
                     break Ok(());
                 }
                 ResponseStreamState::ClosePending | ResponseStreamState::Closed => {

--- a/neqo-http3/src/transaction_client.rs
+++ b/neqo-http3/src/transaction_client.rs
@@ -223,9 +223,10 @@ impl TransactionClient {
     pub fn read_response_data(
         &mut self,
         conn: &mut Connection,
+        decoder: &mut QPackDecoder,
         buf: &mut [u8],
     ) -> Res<(usize, bool)> {
-        self.response_stream.read_response_data(conn, buf)
+        self.response_stream.read_response_data(conn, decoder, buf)
     }
 
     pub fn is_state_sending_data(&self) -> bool {
@@ -267,7 +268,7 @@ impl Http3Transaction for TransactionClient {
     }
 
     fn receive(&mut self, conn: &mut Connection, decoder: &mut QPackDecoder) -> Res<()> {
-        self.response_stream.receive(conn, decoder)
+        self.response_stream.receive(conn, decoder, true)
     }
 
     // TransactionClient owns headers and sends them. This method returns if


### PR DESCRIPTION
fixes #568 