### PR TITLE
Invert map and filter_map usage

### DIFF
--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -611,14 +611,10 @@ impl LossRecovery {
         }
 
         PNSpace::iter()
-            .map(|spc| (*spc, self.spaces[*spc].earliest_sent_time()))
-            .filter_map(|(spc, time)| {
-                // None is ordered less than Some(_). Bad. Filter them out.
-                if let Some(time) = time {
-                    Some((spc, time))
-                } else {
-                    None
-                }
+            .filter_map(|&spc| {
+                self.spaces[spc]
+                    .earliest_sent_time()
+                    .map(|time| (spc, time))
             })
             .min_by_key(|&(_, time)| time)
             .map(|(spc, val)| (spc, val + self.loss_delay()))


### PR DESCRIPTION
This changes the code to use filter_map and map in a different order to
reduce the amount of line noise.  It's slightly less clear, but a lot
less weird.