### PR TITLE
Drop ack ranges

### DIFF
--- a/neqo-transport/src/cc.rs
+++ b/neqo-transport/src/cc.rs
@@ -74,10 +74,7 @@ impl CongestionControl {
 
     // Multi-packet version of OnPacketAckedCC
     pub fn on_packets_acked(&mut self, acked_pkts: &[SentPacket]) {
-        for pkt in acked_pkts
-            .iter()
-            .filter(|pkt| pkt.cc_outstanding())
-        {
+        for pkt in acked_pkts.iter().filter(|pkt| pkt.cc_outstanding()) {
             assert!(self.bytes_in_flight >= pkt.size);
             self.bytes_in_flight -= pkt.size;
 

--- a/neqo-transport/src/cc.rs
+++ b/neqo-transport/src/cc.rs
@@ -76,8 +76,7 @@ impl CongestionControl {
     pub fn on_packets_acked(&mut self, acked_pkts: &[SentPacket]) {
         for pkt in acked_pkts
             .iter()
-            .filter(|pkt| pkt.in_flight)
-            .filter(|pkt| pkt.time_declared_lost.is_none())
+            .filter(|pkt| pkt.cc_outstanding())
         {
             assert!(self.bytes_in_flight >= pkt.size);
             self.bytes_in_flight -= pkt.size;
@@ -112,7 +111,7 @@ impl CongestionControl {
             return;
         }
 
-        for pkt in lost_packets.iter().filter(|pkt| pkt.in_flight) {
+        for pkt in lost_packets.iter().filter(|pkt| pkt.cc_in_flight()) {
             assert!(self.bytes_in_flight >= pkt.size);
             self.bytes_in_flight -= pkt.size;
         }
@@ -141,7 +140,7 @@ impl CongestionControl {
     }
 
     pub fn discard(&mut self, pkt: &SentPacket) {
-        if pkt.in_flight && pkt.time_declared_lost.is_none() {
+        if pkt.cc_outstanding() {
             assert!(self.bytes_in_flight >= pkt.size);
             self.bytes_in_flight -= pkt.size;
             qtrace!([self], "Ignore pkt with size {}", pkt.size);
@@ -149,7 +148,7 @@ impl CongestionControl {
     }
 
     pub fn on_packet_sent(&mut self, pkt: &SentPacket) {
-        if !pkt.in_flight {
+        if !pkt.cc_in_flight() {
             return;
         }
 

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -665,11 +665,11 @@ impl Connection {
 
     pub fn process_timer(&mut self, now: Instant) {
         if matches!(self.state(), State::Closing{..} | State::Closed{..}) {
-            qinfo!("Timer fired while closing/closed");
+            qinfo!([self], "Timer fired while closing/closed");
             return;
         }
         if self.idle_timeout.expired(now, self.loss_recovery.raw_pto()) {
-            qinfo!("idle timeout expired");
+            qinfo!([self], "idle timeout expired");
             self.set_state(State::Closed(ConnectionError::Transport(
                 Error::IdleTimeout,
             )));
@@ -744,6 +744,7 @@ impl Connection {
     /// Returns datagrams to send, and how long to wait before calling again
     /// even if no incoming packets.
     pub fn process_output(&mut self, now: Instant) -> Output {
+        qtrace!([self], "process_output {:?}", now);
         self.process_timer(now);
         let pkt = match &self.state {
             State::Init => {
@@ -1039,6 +1040,7 @@ impl Connection {
     }
 
     fn output(&mut self, now: Instant) -> Option<Datagram> {
+        qtrace!([self], "output {:?}", now);
         if let Some(mut path) = self.path.take() {
             let res = match &self.state {
                 State::Init

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -957,7 +957,7 @@ impl Connection {
         // OK, we have a valid packet.
 
         let space = PNSpace::from(packet.packet_type());
-        if self.acks.get(space).unwrap().is_duplicate(packet.pn()) {
+        if self.acks.get_mut(space).unwrap().is_duplicate(packet.pn()) {
             qdebug!([self], "Duplicate packet from {} pn={}", space, packet.pn());
             self.stats.dups_rx += 1;
             return Ok(vec![]);
@@ -990,7 +990,7 @@ impl Connection {
             self.capture_error(now, t, res)?;
         }
         self.acks
-            .get(space)
+            .get_mut(space)
             .unwrap()
             .set_received(now, packet.pn(), ack_eliciting);
 

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -602,7 +602,7 @@ impl LossRecovery {
         let loss_delay = self.loss_delay();
         let mut lost_packets = Vec::new();
         for &sp in PNSpace::iter() {
-            let first = lost_packets.len();  // The first packet lost in this space.
+            let first = lost_packets.len(); // The first packet lost in this space.
             self.spaces[sp].detect_lost_packets(now, loss_delay, &mut lost_packets);
             self.cc.on_packets_lost(
                 now,

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -497,7 +497,9 @@ impl AckTracker {
         now: Instant,
         pn_space: PNSpace,
     ) -> Option<(Frame, Option<RecoveryToken>)> {
-        self.get(pn_space).map(|space| space.get_frame(now)).flatten()
+        self.get(pn_space)
+            .map(|space| space.get_frame(now))
+            .flatten()
     }
 }
 
@@ -650,16 +652,25 @@ mod tests {
     fn aggregate_ack_time() {
         let mut tracker = AckTracker::default();
         // This packet won't trigger an ACK.
-        tracker.get(PNSpace::Handshake).unwrap().set_received(*NOW, 0, false);
+        tracker
+            .get(PNSpace::Handshake)
+            .unwrap()
+            .set_received(*NOW, 0, false);
         assert_eq!(None, tracker.ack_time());
 
         // This should be delayed.
-        tracker.get(PNSpace::ApplicationData).unwrap().set_received(*NOW, 0, true);
+        tracker
+            .get(PNSpace::ApplicationData)
+            .unwrap()
+            .set_received(*NOW, 0, true);
         assert_eq!(Some(*NOW + ACK_DELAY), tracker.ack_time());
 
         // This should move the time forward.
         let later = *NOW + ACK_DELAY.checked_div(2).unwrap();
-        tracker.get(PNSpace::Initial).unwrap().set_received(later, 0, true);
+        tracker
+            .get(PNSpace::Initial)
+            .unwrap()
+            .set_received(later, 0, true);
         assert_eq!(Some(later), tracker.ack_time());
     }
 }

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -354,6 +354,7 @@ impl RecvdPackets {
             } else {
                 self.ack_time = Some(now);
             }
+            qdebug!([self], "Set ACK timer to {:?}", self.ack_time);
         }
     }
 


### PR DESCRIPTION
When we are dropping keys, we don't need to keep tracking ACKs for the
same packet number space, so drop all state entirely.

I don't know, but I think that this pattern works reasonably well.  We
might be able to use this pattern more broadly.

I need to test this, but it would be good to get feedback.

Closes #513.

This is incremental on #583, so it will appear to have all those changes.

