### PR TITLE
Enforce a correct stream id in a GOAWAY frame

### DIFF
--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -57,7 +57,7 @@ pub enum Http3State {
     Initializing,
     ZeroRtt,
     Connected,
-    GoingAway,
+    GoingAway(u64),
     Closing(CloseError),
     Closed(CloseError),
 }
@@ -618,7 +618,7 @@ impl<T: Http3Transaction> Http3Connection<T> {
     }
 
     fn state_active(&self) -> bool {
-        matches!(self.state, Http3State::Connected | Http3State::GoingAway)
+        matches!(self.state, Http3State::Connected | Http3State::GoingAway(_))
     }
 
     fn state_zero_rtt(&self) -> bool {

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -16,7 +16,7 @@ use neqo_common::{
 };
 use neqo_crypto::{agent::CertificateInfo, AuthenticationStatus, SecretAgentInfo};
 use neqo_transport::{
-    AppError, Connection, ConnectionEvent, ConnectionIdManager, Output, StreamType,
+    AppError, Connection, ConnectionEvent, ConnectionIdManager, Output, StreamId, StreamType,
 };
 use std::cell::RefCell;
 use std::net::SocketAddr;
@@ -167,7 +167,7 @@ impl Http3Client {
         );
         // Requests cannot be created when a connection is in states: Initializing, GoingAway, Closing and Closed.
         match self.base_handler.state() {
-            Http3State::GoingAway | Http3State::Closing(..) | Http3State::Closed(..) => {
+            Http3State::GoingAway(..) | Http3State::Closing(..) | Http3State::Closed(..) => {
                 return Err(Error::AlreadyClosed)
             }
             Http3State::Initializing => return Err(Error::Unavailable),
@@ -301,7 +301,7 @@ impl Http3Client {
     fn process_http3(&mut self, now: Instant) {
         qtrace!([self], "Process http3 internal.");
         match self.base_handler.state() {
-            Http3State::ZeroRtt | Http3State::Connected | Http3State::GoingAway => {
+            Http3State::ZeroRtt | Http3State::Connected | Http3State::GoingAway(..) => {
                 let res = self.check_connection_events();
                 if self.check_result(now, &res) {
                     return;
@@ -337,6 +337,15 @@ impl Http3Client {
     // An error results in closing the connection.
     fn check_result<ERR>(&mut self, now: Instant, res: &Res<ERR>) -> bool {
         match &res {
+            Err(Error::HttpGoaway) => {
+                qinfo!([self], "Connection error: goaway stream_id increased.");
+                self.close(
+                    now,
+                    Error::HttpGeneralProtocol.code(),
+                    "Connection error: goaway stream_id increased",
+                );
+                true
+            }
             Err(e) => {
                 qinfo!([self], "Connection error: {}.", e);
                 self.close(now, e.code(), &format!("{}", e));
@@ -472,7 +481,27 @@ impl Http3Client {
     }
 
     fn handle_goaway(&mut self, goaway_stream_id: u64) -> Res<()> {
-        qinfo!([self], "handle_goaway");
+        qinfo!([self], "handle_goaway {}", goaway_stream_id);
+
+        let id = StreamId::from(goaway_stream_id);
+        if id.is_uni() || id.is_server_initiated() {
+            return Err(Error::HttpId);
+        }
+
+        match self.base_handler.state {
+            Http3State::Connected => {
+                self.base_handler.state = Http3State::GoingAway(goaway_stream_id);
+            }
+            Http3State::GoingAway(ref mut stream_id) => {
+                if goaway_stream_id > *stream_id {
+                    return Err(Error::HttpGoaway);
+                }
+                *stream_id = goaway_stream_id;
+            }
+            Http3State::Closing(..) | Http3State::Closed(..) => {}
+            _ => unreachable!("Should not receive Goaway frame in this state."),
+        }
+
         // Issue reset events for streams >= goaway stream id
         for id in self.base_handler.transactions.iter().filter_map(|(id, _)| {
             if *id >= goaway_stream_id {
@@ -490,9 +519,6 @@ impl Http3Client {
             .transactions
             .retain(|id, _| *id < goaway_stream_id);
 
-        if self.base_handler.state == Http3State::Connected {
-            self.base_handler.state = Http3State::GoingAway;
-        }
         Ok(())
     }
 }
@@ -1941,7 +1967,7 @@ mod tests {
         }
 
         assert!(stream_reset);
-        assert_eq!(client.state(), Http3State::GoingAway);
+        assert_eq!(client.state(), Http3State::GoingAway(8));
 
         // Check that a new request cannot be made.
         assert_eq!(
@@ -1950,6 +1976,129 @@ mod tests {
         );
 
         client.close(now(), 0, "");
+    }
+
+    #[test]
+    fn multiple_goaways() {
+        let (mut client, mut server) = connect();
+        let request_stream_id_1 = make_request(&mut client, false);
+        assert_eq!(request_stream_id_1, 0);
+        let request_stream_id_2 = make_request(&mut client, false);
+        assert_eq!(request_stream_id_2, 4);
+        let request_stream_id_3 = make_request(&mut client, false);
+        assert_eq!(request_stream_id_3, 8);
+
+        let out = client.process(None, now());
+        server.conn.process(out.dgram(), now());
+
+        // First send a Goaway frame with an higher number
+        let _ = server
+            .conn
+            .stream_send(server.control_stream_id.unwrap(), &[0x7, 0x1, 0x8]);
+
+        let out = server.conn.process(None, now());
+        client.process(out.dgram(), now());
+
+        // Check that there is one reset for stream_id 8
+        let mut stream_reset_1 = 0;
+        while let Some(e) = client.next_event() {
+            if let Http3ClientEvent::Reset { stream_id, error } = e {
+                assert_eq!(stream_id, request_stream_id_3);
+                assert_eq!(error, Error::HttpRequestRejected.code());
+                stream_reset_1 += 1;
+            }
+        }
+
+        assert_eq!(stream_reset_1, 1);
+        assert_eq!(client.state(), Http3State::GoingAway(8));
+
+        // Server sends another GOAWAY frame
+        let _ = server
+            .conn
+            .stream_send(server.control_stream_id.unwrap(), &[0x7, 0x1, 0x4]);
+
+        // Send response for stream 0
+        let _ = server
+            .conn
+            .stream_send(request_stream_id_1, HTTP_RESPONSE_1);
+        server.conn.stream_close_send(request_stream_id_1).unwrap();
+
+        let out = server.conn.process(None, now());
+        client.process(out.dgram(), now());
+
+        let mut stream_reset_2 = 0;
+        while let Some(e) = client.next_event() {
+            match e {
+                Http3ClientEvent::HeaderReady { headers, fin, .. } => {
+                    check_response_header_1(&headers.unwrap());
+                    assert_eq!(fin, false);
+                }
+                Http3ClientEvent::DataReadable { stream_id } => {
+                    assert!(stream_id == request_stream_id_1);
+                    let mut buf = [0_u8; 100];
+                    assert_eq!(
+                        (EXPECTED_RESPONSE_DATA_1.len(), true),
+                        client
+                            .read_response_data(now(), stream_id, &mut buf)
+                            .unwrap()
+                    );
+                }
+                Http3ClientEvent::Reset { stream_id, error } => {
+                    assert_eq!(stream_id, request_stream_id_2);
+                    assert_eq!(error, Error::HttpRequestRejected.code());
+                    stream_reset_2 += 1;
+                }
+                _ => {}
+            }
+        }
+
+        assert_eq!(stream_reset_2, 1);
+        assert_eq!(client.state(), Http3State::GoingAway(4));
+    }
+
+    #[test]
+    fn multiple_goaways_stream_id_increased() {
+        let (mut client, mut server) = connect();
+        let request_stream_id_1 = make_request(&mut client, false);
+        assert_eq!(request_stream_id_1, 0);
+        let request_stream_id_2 = make_request(&mut client, false);
+        assert_eq!(request_stream_id_2, 4);
+        let request_stream_id_3 = make_request(&mut client, false);
+        assert_eq!(request_stream_id_3, 8);
+
+        // First send a Goaway frame with a smaller number
+        let _ = server
+            .conn
+            .stream_send(server.control_stream_id.unwrap(), &[0x7, 0x1, 0x4]);
+
+        let out = server.conn.process(None, now());
+        client.process(out.dgram(), now());
+
+        assert_eq!(client.state(), Http3State::GoingAway(4));
+
+        // Now send a Goaway frame with an higher number
+        let _ = server
+            .conn
+            .stream_send(server.control_stream_id.unwrap(), &[0x7, 0x1, 0x8]);
+
+        let out = server.conn.process(None, now());
+        client.process(out.dgram(), now());
+
+        assert_closed(&client, &Error::HttpGeneralProtocol);
+    }
+
+    #[test]
+    fn goaway_wrong_stream_id() {
+        let (mut client, mut server) = connect();
+
+        let _ = server
+            .conn
+            .stream_send(server.control_stream_id.unwrap(), &[0x7, 0x1, 0x9]);
+
+        let out = server.conn.process(None, now());
+        client.process(out.dgram(), now());
+
+        assert_closed(&client, &Error::HttpId);
     }
 
     // Close stream before headers.

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -69,7 +69,7 @@ impl Http3ServerHandler {
     pub fn process_http3(&mut self, conn: &mut Connection, now: Instant) {
         qtrace!([self], "Process http3 internal.");
         match self.base_handler.state() {
-            Http3State::Connected | Http3State::GoingAway => {
+            Http3State::Connected | Http3State::GoingAway(..) => {
                 let res = self.check_connection_events(conn);
                 if self.check_result(conn, now, &res) {
                     return;

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -69,6 +69,7 @@ pub enum Error {
     Unavailable,
     Unexpected,
     InvalidResumptionToken,
+    HttpGoaway,
 }
 
 impl Error {

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -35,6 +35,7 @@ pub use self::connection::{Connection, FixedConnectionIdManager, Output, State};
 pub use self::events::{ConnectionEvent, ConnectionEvents};
 pub use self::frame::CloseError;
 pub use self::frame::StreamType;
+pub use self::stream_id::StreamId;
 
 /// The supported version of the QUIC protocol.
 pub type Version = u32;


### PR DESCRIPTION
 Ensure GOAWAY frame stream_id is not increasing
 the stream_id must be a bidi client-initiated stream