### PR TITLE
Enforce maximum values for stream offsets and stream ID limits

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -126,7 +126,7 @@ impl<'a> Decoder<'a> {
         res
     }
 
-    pub fn decode_checked(&mut self, n: Option<u64>) -> Option<&'a [u8]> {
+    fn decode_checked(&mut self, n: Option<u64>) -> Option<&'a [u8]> {
         let len = match n {
             Some(l) => l,
             _ => return None,

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -126,7 +126,7 @@ impl<'a> Decoder<'a> {
         res
     }
 
-    fn decode_checked(&mut self, n: Option<u64>) -> Option<&'a [u8]> {
+    pub fn decode_checked(&mut self, n: Option<u64>) -> Option<&'a [u8]> {
         let len = match n {
             Some(l) => l,
             _ => return None,

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -596,7 +596,7 @@ impl Frame {
                 let o = dv!(dec);
                 let l = dv!(dec);
                 if (o + l) > (1 << 62 - 1) {
-                    return Err(Error::FrameEncodingError)
+                    return Err(Error::FrameEncodingError);
                 }
                 let len = Some(l);
                 Ok(Self::Crypto {
@@ -625,7 +625,7 @@ impl Frame {
                     let l = dv!(dec);
 
                     if (o + l) > (1 << 62 - 1) {
-                        return Err(Error::FrameEncodingError)
+                        return Err(Error::FrameEncodingError);
                     }
                     let len = Some(l);
                     d!(dec.decode_checked(len))
@@ -648,13 +648,13 @@ impl Frame {
             FRAME_TYPE_MAX_STREAMS_BIDI | FRAME_TYPE_MAX_STREAMS_UNIDI => {
                 let m = dv!(dec);
                 if m > (1 << 60) {
-                        return Err(Error::StreamLimitError)
+                    return Err(Error::StreamLimitError);
                 }
                 Ok(Self::MaxStreams {
                     stream_type: StreamType::from_type_bit(t),
                     maximum_streams: StreamIndex::new(m),
                 })
-            },
+            }
             FRAME_TYPE_DATA_BLOCKED => Ok(Self::DataBlocked {
                 data_limit: dv!(dec),
             }),

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -595,7 +595,7 @@ impl Frame {
             FRAME_TYPE_CRYPTO => {
                 let o = dv!(dec);
                 let l = dv!(dec);
-                if (o + l) > (1 << 62 - 1) {
+                if (o + l) > ((1 << 62) - 1) {
                     return Err(Error::FrameEncodingError);
                 }
                 let len = Some(l);
@@ -624,7 +624,7 @@ impl Frame {
                     qtrace!("STREAM frame, with length");
                     let l = dv!(dec);
 
-                    if (o + l) > (1 << 62 - 1) {
+                    if (o + l) > ((1 << 62) - 1) {
                         return Err(Error::FrameEncodingError);
                     }
                     let len = Some(l);

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -645,11 +645,16 @@ impl Frame {
                 stream_id: dv!(dec).into(),
                 maximum_stream_data: dv!(dec),
             }),
-            FRAME_TYPE_MAX_STREAMS_BIDI | FRAME_TYPE_MAX_STREAMS_UNIDI => Ok(Self::MaxStreams {
-                stream_type: StreamType::from_type_bit(t),
-                maximum_streams: StreamIndex::new(dv!(dec)),
-            }),
-
+            FRAME_TYPE_MAX_STREAMS_BIDI | FRAME_TYPE_MAX_STREAMS_UNIDI => {
+                let m = dv!(dec);
+                if m > (1 << 60) {
+                        return Err(Error::StreamLimitError)
+                }
+                Ok(Self::MaxStreams {
+                    stream_type: StreamType::from_type_bit(t),
+                    maximum_streams: StreamIndex::new(m),
+                })
+            },
             FRAME_TYPE_DATA_BLOCKED => Ok(Self::DataBlocked {
                 data_limit: dv!(dec),
             }),

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -97,8 +97,7 @@ impl TransportParameter {
                 None => return Err(Error::TransportParameterError),
             },
 
-            INITIAL_MAX_STREAMS_BIDI
-            | INITIAL_MAX_STREAMS_UNI => match d.decode_varint() {
+            INITIAL_MAX_STREAMS_BIDI | INITIAL_MAX_STREAMS_UNI => match d.decode_varint() {
                 Some(v) if v <= (1 << 60) => Self::Integer(v),
                 _ => return Err(Error::StreamLimitError),
             },

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -92,11 +92,15 @@ impl TransportParameter {
             | INITIAL_MAX_STREAM_DATA_BIDI_LOCAL
             | INITIAL_MAX_STREAM_DATA_BIDI_REMOTE
             | INITIAL_MAX_STREAM_DATA_UNI
-            | INITIAL_MAX_STREAMS_BIDI
-            | INITIAL_MAX_STREAMS_UNI
             | MAX_ACK_DELAY => match d.decode_varint() {
                 Some(v) => Self::Integer(v),
                 None => return Err(Error::TransportParameterError),
+            },
+
+            INITIAL_MAX_STREAMS_BIDI
+            | INITIAL_MAX_STREAMS_UNI => match d.decode_varint() {
+                Some(v) if v <= (1 << 60) => Self::Integer(v),
+                _ => return Err(Error::StreamLimitError),
             },
 
             MAX_PACKET_SIZE => match d.decode_varint() {


### PR DESCRIPTION
Enforce maximum values for stream offsets and stream ID limits

As requested in #546, to make the implementation better comply with the protocol.