### PR TITLE
Allow ACK after PTO

### DIFF
--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -29,7 +29,7 @@ const INITIAL_RTT: Duration = Duration::from_millis(100);
 const PACKET_THRESHOLD: u64 = 3;
 /// The number of packets we send on a PTO.
 /// And the number to declare lost when the PTO timer is hit.
-const PTO_PACKET_COUNT: usize = 2;
+pub const PTO_PACKET_COUNT: usize = 2;
 
 #[derive(Debug, Clone)]
 pub enum RecoveryToken {


### PR DESCRIPTION
In testing with Google's implementation, I found that they were not
sending any of the usual frames that allow us to clear the PTO timer.
Mostly this was ACK, but it also included HANDSHAKE_DONE.  We still got
packets though and those cause us to get into a bind.

What happened was that we set the delayed ACK timer, which eventually
expired.  But we would not send any packets when that expired because we
had exhausted our budget of PTO packets.  The result was that we were
not sending an ACK and clearing the delayed ACK timer, so that timer
remained set in the past.

We would subsequently report a negative delay, which was clamped to
zero.  The calling code then crashed trying to set a zero-delay timeout
on the socket.

Allowing ACKs to be sent after a PTO has fired avoids the problem.

This doesn't completely solve the problem in #177.  I know that we also
might have timers stuck in the past when we are in the closing state.  But this should avoid the worst cases.