### PR TITLE
Add an encoder's max_table_size.

### DIFF
--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -12,6 +12,7 @@ neqo-crypto = { path = "./../neqo-crypto" }
 neqo-transport = { path = "./../neqo-transport" }
 neqo-common = { path="./../neqo-common" }
 neqo-http3 = { path = "./../neqo-http3" }
+neqo-qpack = { path = "./../neqo-qpack" }
 structopt = "0.3.7"
 url = "1.7.2"
 qlog = "0.2.0"

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -12,6 +12,7 @@ use qlog::QlogStreamer;
 use neqo_common::{self as common, hex, matches, qlog::NeqoQlog, Datagram, Role};
 use neqo_crypto::{init, AuthenticationStatus};
 use neqo_http3::{self, Header, Http3Client, Http3ClientEvent, Http3State, Output};
+use neqo_qpack::QpackSettings;
 use neqo_transport::FixedConnectionIdManager;
 
 use std::cell::RefCell;
@@ -75,8 +76,11 @@ pub struct Args {
     #[structopt(short = "h", long, number_of_values = 2)]
     header: Vec<String>,
 
-    #[structopt(name = "max-table-size", short = "t", long, default_value = "128")]
-    max_table_size: u64,
+    #[structopt(name = "encoder-table-size", short = "e", long, default_value = "128")]
+    max_table_size_encoder: u64,
+
+    #[structopt(name = "decoder-table-size", short = "d", long, default_value = "128")]
+    max_table_size_decoder: u64,
 
     #[structopt(name = "max-blocked-streams", short = "b", long, default_value = "128")]
     max_blocked_streams: u16,
@@ -341,8 +345,11 @@ fn client(
         Rc::new(RefCell::new(FixedConnectionIdManager::new(0))),
         local_addr,
         remote_addr,
-        args.max_table_size,
-        args.max_blocked_streams,
+        QpackSettings {
+            max_table_size_encoder: args.max_table_size_encoder,
+            max_table_size_decoder: args.max_table_size_decoder,
+            max_blocked_streams: args.max_blocked_streams,
+        },
     )
     .expect("must succeed");
     client.set_qlog(qlog_new(args, origin)?);

--- a/neqo-http3-server/Cargo.toml
+++ b/neqo-http3-server/Cargo.toml
@@ -10,6 +10,7 @@ neqo-crypto = { path = "./../neqo-crypto" }
 neqo-transport = { path = "./../neqo-transport" }
 neqo-common = { path="./../neqo-common" }
 neqo-http3 = { path = "./../neqo-http3" }
+neqo-qpack = { path = "./../neqo-qpack" }
 structopt = "0.3.7"
 mio = "0.6.17"
 mio-extras = "2.0.5"

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -10,6 +10,7 @@ use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvent
 use crate::transaction_server::TransactionServer;
 use crate::{Error, Header, Res};
 use neqo_common::{qdebug, qinfo, qtrace};
+use neqo_qpack::QpackSettings;
 use neqo_transport::{AppError, Connection, ConnectionEvent, StreamType};
 use std::time::Instant;
 
@@ -27,9 +28,9 @@ impl ::std::fmt::Display for Http3ServerHandler {
 }
 
 impl Http3ServerHandler {
-    pub(crate) fn new(max_table_size: u64, max_blocked_streams: u16) -> Self {
+    pub(crate) fn new(qpack_settings: QpackSettings) -> Self {
         Self {
-            base_handler: Http3Connection::new(max_table_size, max_blocked_streams),
+            base_handler: Http3Connection::new(qpack_settings),
             events: Http3ServerConnEvents::default(),
             needs_processing: false,
         }

--- a/neqo-interop/Cargo.toml
+++ b/neqo-interop/Cargo.toml
@@ -10,6 +10,7 @@ neqo-crypto = { path = "./../neqo-crypto" }
 neqo-transport = { path = "./../neqo-transport" }
 neqo-common = { path="./../neqo-common" }
 neqo-http3 = { path = "./../neqo-http3" }
+neqo-qpack = { path = "./../neqo-qpack" }
 
 structopt = "0.3.7"
 lazy_static = "1.3.0"

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -10,6 +10,7 @@
 use neqo_common::{hex, matches, Datagram};
 use neqo_crypto::{init, AuthenticationStatus};
 use neqo_http3::{Header, Http3Client, Http3ClientEvent};
+use neqo_qpack::QpackSettings;
 use neqo_transport::{
     Connection, ConnectionError, ConnectionEvent, Error, FixedConnectionIdManager, Output, State,
     StreamType,
@@ -480,7 +481,14 @@ fn test_h9(nctx: &NetworkCtx, client: &mut Connection) -> Result<(), String> {
 fn test_h3(nctx: &NetworkCtx, peer: &Peer, client: Connection) -> Result<(), String> {
     let mut hc = H3Handler {
         streams: HashSet::new(),
-        h3: Http3Client::new_with_conn(client, 128, 128),
+        h3: Http3Client::new_with_conn(
+            client,
+            QpackSettings {
+                max_table_size_encoder: 128,
+                max_table_size_decoder: 128,
+                max_blocked_streams: 128,
+            },
+        ),
         host: String::from(peer.host),
         path: String::from("/"),
     };

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -29,6 +29,13 @@ mod table;
 pub type Header = (String, String);
 type Res<T> = Result<T, Error>;
 
+#[derive(Debug, PartialEq, PartialOrd, Ord, Eq, Clone, Copy)]
+pub struct QpackSettings {
+    pub max_table_size_decoder: u64,
+    pub max_table_size_encoder: u64,
+    pub max_blocked_streams: u16,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {
     DecompressionFailed,

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT/Apache-2.0"
 neqo-common = { path = "../neqo-common" }
 neqo-crypto = { path = "../neqo-crypto" }
 neqo-http3 = { path = "../neqo-http3" }
+neqo-qpack = { path = "../neqo-qpack" }
 neqo-transport = { path = "../neqo-transport" }
 log = {version = "0.4.0", default-features = false}
 lazy_static = "1.3.0"

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -10,6 +10,7 @@
 use neqo_common::matches;
 use neqo_crypto::{init_db, AntiReplay, AuthenticationStatus};
 use neqo_http3::{Http3Client, Http3Server};
+use neqo_qpack::QpackSettings;
 use neqo_transport::{Connection, ConnectionEvent, FixedConnectionIdManager, State};
 
 use std::cell::RefCell;
@@ -143,8 +144,11 @@ pub fn default_http3_client() -> Http3Client {
         Rc::new(RefCell::new(FixedConnectionIdManager::new(3))),
         loopback(),
         loopback(),
-        100,
-        100,
+        QpackSettings {
+            max_table_size_encoder: 100,
+            max_table_size_decoder: 100,
+            max_blocked_streams: 100,
+        },
     )
     .expect("create a default client")
 }
@@ -159,8 +163,11 @@ pub fn default_http3_server() -> Http3Server {
         DEFAULT_ALPN,
         anti_replay(),
         Rc::new(RefCell::new(FixedConnectionIdManager::new(5))),
-        100,
-        100,
+        QpackSettings {
+            max_table_size_encoder: 100,
+            max_table_size_decoder: 100,
+            max_blocked_streams: 100,
+        },
     )
     .expect("create a default server")
 }


### PR DESCRIPTION
Currently we were using the any size a peer was returning in the SETTINGS_QPACK_MAX_TABLE_CAPACITY.