### PR TITLE
Allow passing of String to close()

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -138,7 +138,7 @@ impl Http3Client {
     /// This is call to close a connection.
     pub fn close<S>(&mut self, now: Instant, error: AppError, msg: S)
     where
-        S: Into<String> + Display,
+        S: AsRef<str> + Display,
     {
         qinfo!([self], "Close the connection error={} msg={}.", error, msg);
         if !matches!(self.base_handler.state, Http3State::Closing(_)| Http3State::Closed(_)) {

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -19,6 +19,7 @@ use neqo_transport::{
     AppError, Connection, ConnectionEvent, ConnectionIdManager, Output, StreamId, StreamType,
 };
 use std::cell::RefCell;
+use std::fmt::Display;
 use std::net::SocketAddr;
 use std::rc::Rc;
 use std::time::Instant;
@@ -31,7 +32,7 @@ pub struct Http3Client {
     events: Http3ClientEvents,
 }
 
-impl ::std::fmt::Display for Http3Client {
+impl Display for Http3Client {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "Http3 client")
     }
@@ -135,7 +136,10 @@ impl Http3Client {
     }
 
     /// This is call to close a connection.
-    pub fn close(&mut self, now: Instant, error: AppError, msg: &str) {
+    pub fn close<S>(&mut self, now: Instant, error: AppError, msg: S)
+    where
+        S: Into<String> + Display,
+    {
         qinfo!([self], "Close the connection error={} msg={}.", error, msg);
         if !matches!(self.base_handler.state, Http3State::Closing(_)| Http3State::Closed(_)) {
             self.conn.close(now, error, msg);

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1383,7 +1383,10 @@ impl Connection {
     }
 
     /// Close the connection.
-    pub fn close(&mut self, now: Instant, error: AppError, msg: &str) {
+    pub fn close<S>(&mut self, now: Instant, error: AppError, msg: S)
+    where
+        S: Into<String>,
+    {
         self.set_state(State::Closing {
             error: ConnectionError::Application(error),
             frame_type: 0,


### PR DESCRIPTION
This turns the close() function into a template so that we can accept
owned strings.  This doesn't change usage at all.

From #558.