### PR TITLE
HTTP 0.9 fixes

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -562,10 +562,10 @@ mod old {
                             .expect("Read should succeed");
 
                         let mut have_out_file = false;
-                        if let Some(out_file) = out_file {
+                        if let Some(Some(out_file)) = out_file {
                             have_out_file = true;
                             if sz > 0 {
-                                out_file.as_ref().unwrap().write_all(&data[..sz])?;
+                                out_file.write_all(&data[..sz])?;
                             }
                         } else if !args.output_read_data {
                             println!("READ[{}]: {} bytes", stream_id, sz);

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -40,7 +40,7 @@ struct Args {
     /// Name of keys from NSS database.
     key: Vec<String>,
 
-    #[structopt(short = "a", long, default_value = "http/0.9")]
+    #[structopt(short = "a", long, default_value = "hq-27")]
     /// ALPN labels to negotiate.
     ///
     /// This server still only does HTTP/0.9 no matter what the ALPN says.


### PR DESCRIPTION
* neqo-client: Fix logic in HandlerOld::handle() 
* neqo-server: Update ALPN for 0.9 server