### PR TITLE
trivial: SendStream::send_internal() does not need to be pub

### DIFF
--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -629,7 +629,7 @@ impl SendStream {
         }
     }
 
-    pub fn send_internal(&mut self, buf: &[u8], atomic: bool) -> Res<usize> {
+    fn send_internal(&mut self, buf: &[u8], atomic: bool) -> Res<usize> {
         if buf.is_empty() {
             qerror!("zero-length send on stream {}", self.stream_id.as_u64());
             return Err(Error::InvalidInput);


### PR DESCRIPTION
Sorry I should've noticed this in the review but I didn't.