### PR TITLE
Make sure to initialize the fixture

### DIFF
--- a/neqo-crypto/tests/agent.rs
+++ b/neqo-crypto/tests/agent.rs
@@ -357,6 +357,7 @@ fn reject_zero_rtt() {
 
 #[test]
 fn close() {
+    fixture_init();
     let mut client = Client::new("server.example").expect("should create client");
     let mut server = Server::new(&["key"]).expect("should create server");
     connect(&mut client, &mut server);
@@ -366,6 +367,7 @@ fn close() {
 
 #[test]
 fn close_client_twice() {
+    fixture_init();
     let mut client = Client::new("server.example").expect("should create client");
     let mut server = Server::new(&["key"]).expect("should create server");
     connect(&mut client, &mut server);


### PR DESCRIPTION
Not sure why this didn't happen before now.

See https://app.circleci.com/pipelines/github/mozilla/neqo/1711/workflows/881ef5cc-8e15-47a9-8ce0-510d6246d7e7/jobs/1705/steps