### PR TITLE
Add new macro that logs in all circumstances

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -76,13 +76,13 @@ pub struct Args {
     #[structopt(short = "h", long, number_of_values = 2)]
     header: Vec<String>,
 
-    #[structopt(name = "encoder-table-size", short = "e", long, default_value = "128")]
+    #[structopt(name = "encoder-table-size", short = "e", long, default_value = "16384")]
     max_table_size_encoder: u64,
 
-    #[structopt(name = "decoder-table-size", short = "d", long, default_value = "128")]
+    #[structopt(name = "decoder-table-size", short = "f", long, default_value = "16384")]
     max_table_size_decoder: u64,
 
-    #[structopt(name = "max-blocked-streams", short = "b", long, default_value = "128")]
+    #[structopt(name = "max-blocked-streams", short = "b", long, default_value = "10")]
     max_blocked_streams: u16,
 
     #[structopt(name = "use-old-http", short = "o", long)]

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -76,10 +76,20 @@ pub struct Args {
     #[structopt(short = "h", long, number_of_values = 2)]
     header: Vec<String>,
 
-    #[structopt(name = "encoder-table-size", short = "e", long, default_value = "16384")]
+    #[structopt(
+        name = "encoder-table-size",
+        short = "e",
+        long,
+        default_value = "16384"
+    )]
     max_table_size_encoder: u64,
 
-    #[structopt(name = "decoder-table-size", short = "f", long, default_value = "16384")]
+    #[structopt(
+        name = "decoder-table-size",
+        short = "f",
+        long,
+        default_value = "16384"
+    )]
     max_table_size_decoder: u64,
 
     #[structopt(name = "max-blocked-streams", short = "b", long, default_value = "10")]

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -7,7 +7,6 @@
 use std::io::Write;
 use std::sync::Once;
 use std::time::Instant;
-extern crate log;
 
 #[macro_export]
 macro_rules! do_log {
@@ -24,12 +23,11 @@ macro_rules! do_log {
     ($lvl:expr, $($arg:tt)+) => ($crate::do_log!(target: ::log::__log_module_path!(), $lvl, $($arg)+))
 }
 
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! log_enabled {
     (target: $target:expr, $lvl:expr) => {{
         let lvl = $lvl;
-        lvl <= ::log::max_level()
-            && ::log::__private_api_enabled(lvl, $target)
+        lvl <= ::log::max_level() && ::log::__private_api_enabled(lvl, $target)
     }};
     ($lvl:expr) => {
         $crate::log_enabled!(target: ::log::__log_module_path!(), $lvl)

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -24,14 +24,14 @@ macro_rules! do_log {
 }
 
 #[macro_export]
-macro_rules! log_enabled {
-    (target: $target:expr, $lvl:expr) => {{
-        let lvl = $lvl;
-        lvl <= ::log::max_level() && ::log::__private_api_enabled(lvl, $target)
+macro_rules! log_subject {
+    ($lvl:expr, $subject:expr) => {{
+        if $lvl <= ::log::max_level() {
+            format!("{}", $subject)
+        } else {
+            String::new()
+        }
     }};
-    ($lvl:expr) => {
-        $crate::log_enabled!(target: ::log::__log_module_path!(), $lvl)
-    };
 }
 
 use env_logger::Builder;

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -7,6 +7,34 @@
 use std::io::Write;
 use std::sync::Once;
 use std::time::Instant;
+extern crate log;
+
+#[macro_export]
+macro_rules! do_log {
+    (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
+        let lvl = $lvl;
+        if lvl <= ::log::max_level() {
+            ::log::__private_api_log(
+                ::log::__log_format_args!($($arg)+),
+                lvl,
+                &($target, ::log::__log_module_path!(), ::log::__log_file!(), ::log::__log_line!()),
+            );
+        }
+    });
+    ($lvl:expr, $($arg:tt)+) => ($crate::do_log!(target: ::log::__log_module_path!(), $lvl, $($arg)+))
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! log_enabled {
+    (target: $target:expr, $lvl:expr) => {{
+        let lvl = $lvl;
+        lvl <= ::log::max_level()
+            && ::log::__private_api_enabled(lvl, $target)
+    }};
+    ($lvl:expr) => {
+        $crate::log_enabled!(target: ::log::__log_module_path!(), $lvl)
+    };
+}
 
 use env_logger::Builder;
 
@@ -31,9 +59,9 @@ pub fn init() {
             )
         });
         if let Err(e) = builder.try_init() {
-            ::log::log!(::log::Level::Info, "Logging initialization error {:?}", e);
+            do_log!(::log::Level::Info, "Logging initialization error {:?}", e);
         } else {
-            ::log::log!(::log::Level::Info, "Logging initialized");
+            do_log!(::log::Level::Info, "Logging initialized");
         }
     });
 }
@@ -42,31 +70,31 @@ pub fn init() {
 macro_rules! log_invoke {
     ($lvl:expr, $ctx:expr, $($arg:tt)*) => ( {
         ::neqo_common::log::init();
-        ::log::log!($lvl, "[{}] {}", $ctx, format!($($arg)*));
+        ::neqo_common::do_log!($lvl, "[{}] {}", $ctx, format!($($arg)*));
     } )
 }
 #[macro_export]
 macro_rules! qerror {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Error, $ctx, $($arg)*););
-    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Error, $($arg)*); } );
+    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::neqo_common::do_log!(::log::Level::Error, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qwarn {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Warn, $ctx, $($arg)*););
-    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Warn, $($arg)*); } );
+    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::neqo_common::do_log!(::log::Level::Warn, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qinfo {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Info, $ctx, $($arg)*););
-    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Info, $($arg)*); } );
+    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::neqo_common::do_log!(::log::Level::Info, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qdebug {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Debug, $ctx, $($arg)*););
-    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Debug, $($arg)*); } );
+    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::neqo_common::do_log!(::log::Level::Debug, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qtrace {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Trace, $ctx, $($arg)*););
-    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::log::log!(::log::Level::Trace, $($arg)*); } );
+    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::neqo_common::do_log!(::log::Level::Trace, $($arg)*); } );
 }

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -15,7 +15,6 @@ use qlog::{
 };
 
 use crate::Role;
-
 #[allow(clippy::module_name_repetitions)]
 pub struct NeqoQlog {
     qlog_path: PathBuf,
@@ -49,7 +48,7 @@ impl fmt::Debug for NeqoQlog {
 impl Drop for NeqoQlog {
     fn drop(&mut self) {
         if let Err(e) = self.streamer.finish_log() {
-            ::log::log!(::log::Level::Error, "Error dropping NeqoQlog: {}", e)
+            crate::do_log!(::log::Level::Error, "Error dropping NeqoQlog: {}", e)
         }
     }
 }

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -21,7 +21,7 @@ use crate::secrets::SecretHolder;
 use crate::ssl::{self, PRBool};
 use crate::time::TimeHolder;
 
-use neqo_common::{matches, qdebug, qinfo, qtrace, qwarn};
+use neqo_common::{hex, matches, qdebug, qinfo, qtrace, qwarn};
 use std::cell::RefCell;
 use std::convert::TryFrom;
 use std::ffi::CString;
@@ -749,7 +749,7 @@ impl Client {
         let resumption = resumption_ptr.as_mut().unwrap();
         let mut v = Vec::with_capacity(len as usize);
         v.extend_from_slice(std::slice::from_raw_parts(token, len as usize));
-        qdebug!([format!("{:p}", fd)], "Got resumption token");
+        qinfo!([format!("{:p}", fd)], "Got resumption token {}", hex(&v));
         *resumption = Some(v);
         ssl::SECSuccess
     }

--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -36,13 +36,23 @@ struct Args {
     #[structopt(default_value = "[::]:4433")]
     hosts: Vec<String>,
 
-    #[structopt(name = "encoder-table-size", short = "e", long, default_value = "128")]
+    #[structopt(
+        name = "encoder-table-size",
+        short = "e",
+        long,
+        default_value = "16384"
+    )]
     max_table_size_encoder: u64,
 
-    #[structopt(name = "decoder-table-size", short = "d", long, default_value = "128")]
+    #[structopt(
+        name = "decoder-table-size",
+        short = "f",
+        long,
+        default_value = "16384"
+    )]
     max_table_size_decoder: u64,
 
-    #[structopt(short = "b", long, default_value = "128")]
+    #[structopt(short = "b", long, default_value = "10")]
     max_blocked_streams: u16,
 
     #[structopt(

--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -45,7 +45,12 @@ struct Args {
     #[structopt(short = "b", long, default_value = "128")]
     max_blocked_streams: u16,
 
-    #[structopt(short = "d", long, default_value = "./db", parse(from_os_str))]
+    #[structopt(
+        short = "d",
+        long,
+        default_value = "./test-fixture/db",
+        parse(from_os_str)
+    )]
     /// NSS database directory.
     db: PathBuf,
 

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -233,7 +233,7 @@ impl<T: Http3Transaction> Http3Connection<T> {
     ) -> Res<HandleReadableOutput> {
         qtrace!([self], "Readable stream {}.", stream_id);
 
-        let label = if ::log::log_enabled!(::log::Level::Debug) {
+        let label = if ::neqo_common::log_enabled!(::log::Level::Debug) {
             format!("{}", self)
         } else {
             String::new()
@@ -414,7 +414,7 @@ impl<T: Http3Transaction> Http3Connection<T> {
     }
 
     fn handle_read_stream(&mut self, conn: &mut Connection, stream_id: u64) -> Res<bool> {
-        let label = if ::log::log_enabled!(::log::Level::Debug) {
+        let label = if ::neqo_common::log_enabled!(::log::Level::Debug) {
             format!("{}", self)
         } else {
             String::new()

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -414,11 +414,7 @@ impl<T: Http3Transaction> Http3Connection<T> {
     }
 
     fn handle_read_stream(&mut self, conn: &mut Connection, stream_id: u64) -> Res<bool> {
-        let label = if ::neqo_common::log_enabled!(::log::Level::Debug) {
-            format!("{}", self)
-        } else {
-            String::new()
-        };
+        let label = ::neqo_common::log_subject!(::log::Level::Info, self);
 
         let t = self.transactions.get_mut(&stream_id);
         if t.is_none() {

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -233,12 +233,7 @@ impl<T: Http3Transaction> Http3Connection<T> {
     ) -> Res<HandleReadableOutput> {
         qtrace!([self], "Readable stream {}.", stream_id);
 
-        let label = if ::neqo_common::log_enabled!(::log::Level::Debug) {
-            format!("{}", self)
-        } else {
-            String::new()
-        };
-
+        let label = ::neqo_common::log_subject!(::log::Level::Debug, self);
         if self.handle_read_stream(conn, stream_id)? {
             qdebug!([label], "Request/response stream {} read.", stream_id);
             Ok(HandleReadableOutput::NoOutput)

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -169,20 +169,12 @@ impl<T: Http3Transaction> Http3Connection<T> {
     }
 
     /// We have a resumption token which remembers previous settings. Update the setting.
-    pub fn set_resumption_settings(
-        &mut self,
-        conn: &mut Connection,
-        settings: HSettings,
-    ) -> Res<()> {
-        if let Http3State::Initializing = &self.state {
-            self.state = Http3State::ZeroRtt;
-            self.initialize_http3_connection(conn)?;
-            self.set_qpack_settings(&settings)?;
-            self.settings_state = Http3RemoteSettingsState::ZeroRtt(settings);
-            Ok(())
-        } else {
-            Err(Error::Unexpected)
-        }
+    pub fn set_0rtt_settings(&mut self, conn: &mut Connection, settings: HSettings) -> Res<()> {
+        self.state = Http3State::ZeroRtt;
+        self.initialize_http3_connection(conn)?;
+        self.set_qpack_settings(&settings)?;
+        self.settings_state = Http3RemoteSettingsState::ZeroRtt(settings);
+        Ok(())
     }
 
     /// Returns the settings for a connection. This is used for creating a resumption token.

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -74,12 +74,7 @@ impl Http3ServerHandler {
         }
 
         let res = self.check_connection_events(conn);
-        if !self.check_result(conn, now, &res)
-            && matches!(
-                self.base_handler.state(),
-                Http3State::Connected | Http3State::GoingAway(..)
-            )
-        {
+        if !self.check_result(conn, now, &res) && self.base_handler.state().active() {
             let res = self.base_handler.process_sending(conn);
             self.check_result(conn, now, &res);
         }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -62,14 +62,15 @@ pub enum Error {
     // Internal errors from here.
     AlreadyClosed,
     DecodingFrame,
+    HttpGoaway,
+    InvalidResumptionToken,
     InvalidStreamId,
+    InvalidState,
     NoMoreData,
     NotEnoughData,
     TransportError(TransportError),
     Unavailable,
     Unexpected,
-    InvalidResumptionToken,
-    HttpGoaway,
 }
 
 impl Error {

--- a/neqo-http3/src/response_stream.rs
+++ b/neqo-http3/src/response_stream.rs
@@ -200,11 +200,7 @@ impl ResponseStream {
         decoder: &mut QPackDecoder,
         post_readable_event: bool,
     ) -> Res<()> {
-        let label = if ::log::log_enabled!(::log::Level::Debug) {
-            format!("{}", self)
-        } else {
-            String::new()
-        };
+        let label = ::neqo_common::log_subject!(::log::Level::Debug, self);
         loop {
             qdebug!([label], "state={:?}.", self.state);
             match self.state {

--- a/neqo-http3/src/transaction_client.rs
+++ b/neqo-http3/src/transaction_client.rs
@@ -81,11 +81,7 @@ impl Request {
         encoder: &mut QPackEncoder,
         stream_id: u64,
     ) -> Res<bool> {
-        let label = if ::neqo_common::log_enabled!(::log::Level::Debug) {
-            format!("{}", self)
-        } else {
-            String::new()
-        };
+        let label = ::neqo_common::log_subject!(::log::Level::Info, self);
         self.encode(conn, encoder, stream_id)?;
         if let Some(buf) = &mut self.buf {
             let sent = conn.stream_send(stream_id, &buf)?;
@@ -244,11 +240,7 @@ impl ::std::fmt::Display for TransactionClient {
 
 impl Http3Transaction for TransactionClient {
     fn send(&mut self, conn: &mut Connection, encoder: &mut QPackEncoder) -> Res<()> {
-        let label = if ::neqo_common::log_enabled!(::log::Level::Debug) {
-            format!("{}", self)
-        } else {
-            String::new()
-        };
+        let label = ::neqo_common::log_subject!(::log::Level::Info, self);
         if let TransactionSendState::SendingHeaders {
             ref mut request,
             fin,

--- a/neqo-http3/src/transaction_client.rs
+++ b/neqo-http3/src/transaction_client.rs
@@ -81,7 +81,7 @@ impl Request {
         encoder: &mut QPackEncoder,
         stream_id: u64,
     ) -> Res<bool> {
-        let label = if ::log::log_enabled!(::log::Level::Debug) {
+        let label = if ::neqo_common::log_enabled!(::log::Level::Debug) {
             format!("{}", self)
         } else {
             String::new()
@@ -244,7 +244,7 @@ impl ::std::fmt::Display for TransactionClient {
 
 impl Http3Transaction for TransactionClient {
     fn send(&mut self, conn: &mut Connection, encoder: &mut QPackEncoder) -> Res<()> {
-        let label = if ::log::log_enabled!(::log::Level::Debug) {
+        let label = if ::neqo_common::log_enabled!(::log::Level::Debug) {
             format!("{}", self)
         } else {
             String::new()

--- a/neqo-http3/src/transaction_server.rs
+++ b/neqo-http3/src/transaction_server.rs
@@ -130,7 +130,7 @@ impl Http3Transaction for TransactionServer {
     fn send(&mut self, conn: &mut Connection, encoder: &mut QPackEncoder) -> Res<()> {
         self.ensure_response_encoded(conn, encoder)?;
         qtrace!([self], "Sending response.");
-        let label = if ::log::log_enabled!(::log::Level::Debug) {
+        let label = if ::neqo_common::log_enabled!(::log::Level::Debug) {
             format!("{}", self)
         } else {
             String::new()
@@ -153,7 +153,7 @@ impl Http3Transaction for TransactionServer {
 
     #[allow(clippy::too_many_lines)]
     fn receive(&mut self, conn: &mut Connection, decoder: &mut QPackDecoder) -> Res<()> {
-        let label = if ::log::log_enabled!(::log::Level::Debug) {
+        let label = if ::neqo_common::log_enabled!(::log::Level::Debug) {
             format!("{}", self)
         } else {
             String::new()

--- a/neqo-http3/src/transaction_server.rs
+++ b/neqo-http3/src/transaction_server.rs
@@ -130,11 +130,7 @@ impl Http3Transaction for TransactionServer {
     fn send(&mut self, conn: &mut Connection, encoder: &mut QPackEncoder) -> Res<()> {
         self.ensure_response_encoded(conn, encoder)?;
         qtrace!([self], "Sending response.");
-        let label = if ::neqo_common::log_enabled!(::log::Level::Debug) {
-            format!("{}", self)
-        } else {
-            String::new()
-        };
+        let label = ::neqo_common::log_subject!(::log::Level::Info, self);
         if let TransactionSendState::SendingResponse { ref mut buf } = self.send_state {
             let sent = conn.stream_send(self.stream_id, &buf[..])?;
             qinfo!([label], "{} bytes sent", sent);
@@ -153,11 +149,7 @@ impl Http3Transaction for TransactionServer {
 
     #[allow(clippy::too_many_lines)]
     fn receive(&mut self, conn: &mut Connection, decoder: &mut QPackDecoder) -> Res<()> {
-        let label = if ::neqo_common::log_enabled!(::log::Level::Debug) {
-            format!("{}", self)
-        } else {
-            String::new()
-        };
+        let label = ::neqo_common::log_subject!(::log::Level::Trace, self);
 
         loop {
             qtrace!(

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -484,9 +484,9 @@ fn test_h3(nctx: &NetworkCtx, peer: &Peer, client: Connection) -> Result<(), Str
         h3: Http3Client::new_with_conn(
             client,
             QpackSettings {
-                max_table_size_encoder: 128,
-                max_table_size_decoder: 128,
-                max_blocked_streams: 128,
+                max_table_size_encoder: 16384,
+                max_table_size_decoder: 16384,
+                max_blocked_streams: 10,
             },
         ),
         host: String::from(peer.host),

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -33,7 +33,12 @@ struct Args {
     /// A resource to request.
     request: Vec<String>,
 
-    #[structopt(short = "d", long, default_value = "./db", parse(from_os_str))]
+    #[structopt(
+        short = "d",
+        long,
+        default_value = "./test-fixture/db",
+        parse(from_os_str)
+    )]
     /// NSS database directory.
     db: PathBuf,
     #[structopt(short = "k", long, default_value = "key")]

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1562,7 +1562,7 @@ impl Connection {
                 self.crypto.streams.inbound_frame(space, offset, data)?;
                 if self.crypto.streams.data_ready(space) {
                     let mut buf = Vec::new();
-                    let read = self.crypto.streams.read_to_end(space, &mut buf)?;
+                    let read = self.crypto.streams.read_to_end(space, &mut buf);
                     qdebug!("Read {} bytes", read);
                     self.handshake(now, space, Some(&buf))?;
                 }

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -105,8 +105,8 @@ impl PartialOrd for State {
     }
 }
 
-#[derive(Debug)]
-enum ZeroRttState {
+#[derive(Debug, PartialEq, Eq)]
+pub enum ZeroRttState {
     Init,
     Sending,
     AcceptedClient,
@@ -513,7 +513,7 @@ impl Connection {
 
     /// Access the latest resumption token on the connection.
     pub fn resumption_token(&self) -> Option<Vec<u8>> {
-        if !self.state.connected() {
+        if self.state < State::Connected {
             return None;
         }
         match self.crypto.tls {
@@ -628,6 +628,11 @@ impl Connection {
     /// Get the state of the connection.
     pub fn state(&self) -> &State {
         &self.state
+    }
+
+    /// Get the 0-RTT state of the connection.
+    pub fn zero_rtt_state(&self) -> &ZeroRttState {
+        &self.zero_rtt_state
     }
 
     /// Get collected statistics.
@@ -854,7 +859,7 @@ impl Connection {
                 match PublicPacket::decode(slc, self.cid_manager.borrow().as_decoder()) {
                     Ok((packet, remainder)) => (packet, remainder),
                     Err(e) => {
-                        qinfo!([self], "Garbage packet: {} {}", e, hex(slc));
+                        qdebug!([self], "Garbage packet: {} {}", e, hex(slc));
                         self.stats.dropped_rx += 1;
                         return Ok(frames);
                     }
@@ -1112,7 +1117,6 @@ impl Connection {
         };
         if pt == PacketType::Initial {
             builder.initial_token(if let Some(info) = retry_info {
-                qtrace!("Initial token {}", hex(&info.token));
                 &info.token
             } else {
                 &[]

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -910,7 +910,7 @@ impl CryptoStreams {
         self.get(space).map_or(false, |cs| cs.rx.data_ready())
     }
 
-    pub fn read_to_end(&mut self, space: PNSpace, buf: &mut Vec<u8>) -> Res<u64> {
+    pub fn read_to_end(&mut self, space: PNSpace, buf: &mut Vec<u8>) -> Res<usize> {
         self.get_mut(space).unwrap().rx.read_to_end(buf)
     }
 

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -910,7 +910,7 @@ impl CryptoStreams {
         self.get(space).map_or(false, |cs| cs.rx.data_ready())
     }
 
-    pub fn read_to_end(&mut self, space: PNSpace, buf: &mut Vec<u8>) -> Res<usize> {
+    pub fn read_to_end(&mut self, space: PNSpace, buf: &mut Vec<u8>) -> usize {
         self.get_mut(space).unwrap().rx.read_to_end(buf)
     }
 

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -30,7 +30,7 @@ pub mod tparams;
 mod tracking;
 
 pub use self::cid::{ConnectionId, ConnectionIdManager};
-pub use self::connection::{Connection, FixedConnectionIdManager, Output, State};
+pub use self::connection::{Connection, FixedConnectionIdManager, Output, State, ZeroRttState};
 pub use self::events::{ConnectionEvent, ConnectionEvents};
 pub use self::frame::CloseError;
 pub use self::frame::StreamType;

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -10,7 +10,7 @@
 use std::cell::RefCell;
 use std::cmp::{max, min};
 use std::collections::BTreeMap;
-use std::convert::TryInto;
+use std::convert::TryFrom;
 use std::mem;
 use std::ops::Bound::{Included, Unbounded};
 use std::rc::Rc;
@@ -219,9 +219,9 @@ impl RxStreamOrderer {
     }
 
     /// Copy received data (if any) into the buffer. Returns bytes copied.
-    fn read(&mut self, buf: &mut [u8]) -> Res<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> usize {
         qtrace!("Reading {} bytes, {} available", buf.len(), self.buffered());
-        let mut buf_remaining = buf.len() as usize;
+        let mut buf_remaining = buf.len();
         let mut copied = 0;
 
         for (&range_start, range_data) in &mut self.data_ranges {
@@ -230,7 +230,8 @@ impl RxStreamOrderer {
 
                 // Convert to offset into data vec and move past bytes we
                 // already have
-                let copy_offset = (max(range_start, self.retired) - range_start).try_into()?;
+                let copy_offset =
+                    usize::try_from(max(range_start, self.retired) - range_start).unwrap();
                 let copy_bytes = min(range_data.len() - copy_offset, buf_remaining);
                 let copy_slc = &mut range_data[copy_offset..copy_offset + copy_bytes];
                 buf[copied..copied + copy_bytes].copy_from_slice(copy_slc);
@@ -253,11 +254,11 @@ impl RxStreamOrderer {
             self.data_ranges.remove(&key);
         }
 
-        Ok(copied)
+        copied
     }
 
     /// Extend the given Vector with any available data.
-    pub fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Res<usize> {
+    pub fn read_to_end(&mut self, buf: &mut Vec<u8>) -> usize {
         let orig_len = buf.len();
         buf.resize(orig_len + self.bytes_ready(), 0);
         self.read(&mut buf[orig_len..])
@@ -504,9 +505,9 @@ impl RecvStream {
     pub fn read(&mut self, buf: &mut [u8]) -> Res<(usize, bool)> {
         let res = match &mut self.state {
             RecvStreamState::Recv { recv_buf, .. }
-            | RecvStreamState::SizeKnown { recv_buf, .. } => Ok((recv_buf.read(buf)?, false)),
+            | RecvStreamState::SizeKnown { recv_buf, .. } => Ok((recv_buf.read(buf), false)),
             RecvStreamState::DataRecvd { recv_buf } => {
-                let bytes_read = recv_buf.read(buf)?;
+                let bytes_read = recv_buf.read(buf);
                 let fin_read = recv_buf.buffered() == 0;
                 if fin_read {
                     self.set_state(RecvStreamState::DataRead)
@@ -703,7 +704,10 @@ mod tests {
         s.inbound_stream_frame(false, 0, frame1).unwrap();
         s.maybe_send_flowc_update();
         assert_eq!(s.flow_mgr.borrow().peek(), None);
-        assert_eq!(s.read(&mut buf).unwrap(), (RX_STREAM_DATA_WINDOW, false));
+        assert_eq!(
+            s.read(&mut buf).unwrap(),
+            (RX_STREAM_DATA_WINDOW as usize, false)
+        );
         assert_eq!(s.data_ready(), false);
         s.maybe_send_flowc_update();
 
@@ -750,7 +754,7 @@ mod tests {
         assert_eq!(rx_ord.buffered(), 6);
         assert_eq!(rx_ord.retired(), 0);
         // read some so there's an offset into the first frame
-        rx_ord.read(&mut buf[..2]).unwrap();
+        rx_ord.read(&mut buf[..2]);
         assert_eq!(rx_ord.bytes_ready(), 4);
         assert_eq!(rx_ord.buffered(), 4);
         assert_eq!(rx_ord.retired(), 2);

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -219,7 +219,7 @@ impl RxStreamOrderer {
     }
 
     /// Copy received data (if any) into the buffer. Returns bytes copied.
-    fn read(&mut self, buf: &mut [u8]) -> Res<u64> {
+    fn read(&mut self, buf: &mut [u8]) -> Res<usize> {
         qtrace!("Reading {} bytes, {} available", buf.len(), self.buffered());
         let mut buf_remaining = buf.len() as usize;
         let mut copied = 0;
@@ -253,11 +253,11 @@ impl RxStreamOrderer {
             self.data_ranges.remove(&key);
         }
 
-        Ok(copied as u64)
+        Ok(copied)
     }
 
     /// Extend the given Vector with any available data.
-    pub fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Res<u64> {
+    pub fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Res<usize> {
         let orig_len = buf.len();
         buf.resize(orig_len + self.bytes_ready(), 0);
         self.read(&mut buf[orig_len..])
@@ -501,7 +501,7 @@ impl RecvStream {
             .map_or(false, RxStreamOrderer::data_ready)
     }
 
-    pub fn read(&mut self, buf: &mut [u8]) -> Res<(u64, bool)> {
+    pub fn read(&mut self, buf: &mut [u8]) -> Res<(usize, bool)> {
         let res = match &mut self.state {
             RecvStreamState::Recv { recv_buf, .. }
             | RecvStreamState::SizeKnown { recv_buf, .. } => Ok((recv_buf.read(buf)?, false)),


### PR DESCRIPTION
I've been looking into bug [1611990](https://bugzilla.mozilla.org/show_bug.cgi?id=1611990) but there doesn't seem to be an easy way to make all logging happen regardless if `release_max_level_info` is set.

Instead, it seems we can replace the [log!](https://github.com/rust-lang/log/blob/4fb398b68ea43f5317e6e0f04b5eacaa9e679218/src/macros.rs#L34) logging macro with do_log! that does pretty much the same but does not respect `STATIC_MAX_LEVEL`