### PR TITLE
Reduce strictness of assertions while closing

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1821,7 +1821,7 @@ impl Connection {
                 _ => {}
             }
             self.events.connection_state_change(state);
-        } else if mem::discriminant(state) != mem::discriminant(self.state) {
+        } else if mem::discriminant(&state) != mem::discriminant(&self.state) {
             // Only tolerate a regression in state if the new state is closing
             // and the connection is already closed.
             debug_assert!(matches!(state, State::Closing { .. }));


### PR DESCRIPTION
This patches over the assertion, essentially allowing us to mark something as closing.  I don't know if this is the best strategy, but it does stop a crash that is fairly reproducible from the server end.

The alternative is to try to find why things are attempting to set a closing state after going to closed.  If you think that is better, then I'm OK with deferring this and doing the analysis.  I'm just recording what I did to remove a road block.