### PR TITLE
Create an active method on Http3State

### DIFF
--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -74,12 +74,7 @@ impl Http3ServerHandler {
         }
 
         let res = self.check_connection_events(conn);
-        if !self.check_result(conn, now, &res)
-            && matches!(
-                self.base_handler.state(),
-                Http3State::Connected | Http3State::GoingAway(..)
-            )
-        {
+        if !self.check_result(conn, now, &res) && self.base_handler.state().active() {
             let res = self.base_handler.process_sending(conn);
             self.check_result(conn, now, &res);
         }


### PR DESCRIPTION
... and use it more consistently.

This should avoid problems where something happens and the state is
wrong.

I also removed a bunch of assertions that were wrong for the server when
it accepts 0-RTT.  A server is "Initializing" when it receives new
streams.  We can rely on the transport enforcing the rules for this.
If we were building a fully-fledged server, we might be more concerned
about the potential to serve content prior to handshake completion
(doing the whole idempotency check and whatnot) but I will just create
an issue for that rather than try to fix it here.