### PR TITLE
Proposed fix to #585

### DIFF
--- a/neqo-transport/src/cc.rs
+++ b/neqo-transport/src/cc.rs
@@ -100,7 +100,7 @@ impl CongestionControl {
     pub fn on_packets_lost(
         &mut self,
         now: Instant,
-        largest_acked_sent: Option<Instant>,
+        prev_largest_acked_sent: Option<Instant>,
         pto: Duration,
         lost_packets: &[SentPacket],
     ) {
@@ -118,19 +118,17 @@ impl CongestionControl {
         let last_lost_pkt = lost_packets.last().unwrap();
         self.on_congestion_event(now, last_lost_pkt.time_sent);
 
-        let in_persistent_congestion = {
-            let congestion_period = pto * PERSISTENT_CONG_THRESH;
+        let congestion_period = pto * PERSISTENT_CONG_THRESH;
 
-            match largest_acked_sent {
-                Some(las) => las < last_lost_pkt.time_sent - congestion_period,
-                None => {
-                    // Nothing has ever been acked. Could still be PC.
-                    let first_lost_pkt_sent = lost_packets.first().unwrap().time_sent;
-                    last_lost_pkt.time_sent - first_lost_pkt_sent > congestion_period
-                }
-            }
-        };
-        if in_persistent_congestion {
+        let first_lost_pkt_after_largest_acked = lost_packets
+            .iter()
+            .find(|pkt| Some(pkt.time_sent) > prev_largest_acked_sent);
+
+        let starting_time_sent = first_lost_pkt_after_largest_acked
+            .unwrap_or_else(|| lost_packets.first().unwrap())
+            .time_sent;
+
+        if starting_time_sent < last_lost_pkt.time_sent - congestion_period {
             qinfo!([self], "persistent congestion");
             self.congestion_window = MIN_CONG_WINDOW;
         }


### PR DESCRIPTION
Instead of tracking largest acked sent time, track oldest lost packet
time. Compare against most recent lost packet

fixes #585