### PR TITLE
Probes don't cause more probes

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -2181,7 +2181,7 @@ mod tests {
     use crate::frame::{CloseError, StreamType};
     use crate::path::PATH_MTU_V6;
     use crate::recovery::PTO_PACKET_COUNT;
-    use crate::tracking::MAX_UNACKED_PKTS;
+    use crate::tracking::{ACK_DELAY, MAX_UNACKED_PKTS};
     use std::convert::TryInto;
 
     use neqo_common::matches;
@@ -3549,8 +3549,8 @@ mod tests {
         let mut server = default_server();
 
         let pkt = client.process(None, now).dgram();
-        let out = client.process(None, now);
-        assert_eq!(out, Output::Callback(Duration::from_millis(120)));
+        let cb = client.process(None, now).callback();
+        assert_eq!(cb, Duration::from_millis(120));
 
         now += Duration::from_millis(10);
         let pkt = server.process(pkt, now).dgram();
@@ -3558,8 +3558,8 @@ mod tests {
         now += Duration::from_millis(10);
         let pkt = client.process(pkt, now).dgram();
 
-        let out = client.process(None, now);
-        assert_eq!(out, Output::Callback(LOCAL_IDLE_TIMEOUT));
+        let cb = client.process(None, now).callback();
+        assert_eq!(cb, LOCAL_IDLE_TIMEOUT);
 
         now += Duration::from_millis(10);
         let pkt = server.process(pkt, now).dgram();
@@ -3572,8 +3572,8 @@ mod tests {
         let pkt1 = client.process(None, now).dgram();
         assert!(pkt1.is_some());
 
-        let out = client.process(None, now);
-        assert_eq!(out, Output::Callback(Duration::from_millis(60)));
+        let cb = client.process(None, now).callback();
+        assert_eq!(cb, Duration::from_millis(60));
 
         // Wait for PTO to expire and resend a handshake packet
         now += Duration::from_millis(60);
@@ -3585,8 +3585,8 @@ mod tests {
         assert!(pkt3.is_some());
 
         // PTO has been doubled.
-        let out = client.process(None, now);
-        assert_eq!(out, Output::Callback(Duration::from_millis(120)));
+        let cb = client.process(None, now).callback();
+        assert_eq!(cb, Duration::from_millis(120));
 
         now += Duration::from_millis(10);
         // Server receives the first packet.
@@ -3601,40 +3601,28 @@ mod tests {
         let dropped_before = server.stats().dropped_rx;
         let frames = server.test_process_input(pkt2.unwrap(), now);
         assert_eq!(1, server.stats().dropped_rx - dropped_before);
-        assert!(matches!(frames[0], (Frame::Ping, PNSpace::ApplicationData)));
+        assert_eq!(frames[0], (Frame::Ping, PNSpace::ApplicationData));
 
         let dropped_before = server.stats().dropped_rx;
         let frames = server.test_process_input(pkt3.unwrap(), now);
         assert_eq!(1, server.stats().dropped_rx - dropped_before);
-        assert!(matches!(frames[0], (Frame::Ping, PNSpace::ApplicationData)));
+        assert_eq!(frames[0], (Frame::Ping, PNSpace::ApplicationData));
 
         now += Duration::from_millis(10);
         // Client receive ack for the first packet
-        let out = client.process(pkt, now);
+        let cb = client.process(pkt, now).callback();
         // Ack delay timer for the packet carrying HANDSHAKE_DONE.
-        assert_eq!(out, Output::Callback(Duration::from_millis(20)));
+        assert_eq!(cb, ACK_DELAY);
 
         // Let the ack timer expire.
-        now += Duration::from_millis(20);
+        now += cb;
         let out = client.process(None, now).dgram();
         assert!(out.is_some());
-        let out = client.process(None, now);
-        // The handshake keys are discarded
-        // Return PTO timer for an app pn space packet (when the Handshake PTO timer has expired,
-        // a PING in the app pn space has been send as well).
-        // pto=142.5ms, the PTO packet was sent 40ms ago. The timer will be 102.5ms.
-        assert_eq!(out, Output::Callback(Duration::from_micros(102_500)));
-
-        // Let PTO expire. We will send a PING only in the APP pn space, the client has discarded
-        // Handshshake keys.
-        now += Duration::from_micros(102_500);
-        let out = client.process(None, now).dgram();
-        assert!(out.is_some());
-
-        now += Duration::from_millis(10);
-        let frames = server.test_process_input(out.unwrap(), now);
-
-        assert_eq!(frames[0], (Frame::Ping, PNSpace::ApplicationData));
+        let cb = client.process(None, now).callback();
+        // The handshake keys are discarded, but now we're back to the idle timeout.
+        // We don't send another PING because the handshake space is done and there
+        // is nothing to probe for.
+        assert_eq!(cb, LOCAL_IDLE_TIMEOUT - ACK_DELAY);
     }
 
     #[test]

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -161,7 +161,7 @@ impl LossRecoverySpace {
             .take(count)
     }
 
-    pub fn pto_time(&self) -> Option<Instant> {
+    pub fn pto_base_time(&self) -> Option<Instant> {
         if self.in_flight_outstanding() {
             debug_assert!(self.pto_base_time.is_some());
             self.pto_base_time
@@ -603,7 +603,7 @@ impl LossRecovery {
     // Calculate PTO time for the given space.
     fn pto_time(&self, pn_space: PNSpace) -> Option<Instant> {
         if let Some(space) = self.spaces.get(pn_space) {
-            space.pto_time().map(|t| {
+            space.pto_base_time().map(|t| {
                 t + self
                     .rtt_vals
                     .pto(pn_space)

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -102,8 +102,14 @@ pub(crate) struct LossRecoverySpace {
     space: PNSpace,
     largest_acked: Option<u64>,
     largest_acked_sent_time: Option<Instant>,
-    time_of_last_sent_ack_eliciting_packet: Option<Instant>,
-    ack_eliciting_outstanding: u64,
+    /// The time used to calculate the PTO timer for this space.
+    /// This is the time that the last ACK-eliciting packet in this space
+    /// was sent.  This might be the time that a probe was sent.
+    pto_base_time: Option<Instant>,
+    /// The number of outstanding packets in this space that are in flight.
+    /// This might be less than the number of ACK-eliciting packets,
+    /// because PTO packets don't count.
+    in_flight_outstanding: u64,
     sent_packets: BTreeMap<u64, SentPacket>,
     /// The time that the first out-of-order packet was sent.
     /// This is `None` if there were no out-of-order packets detected.
@@ -117,8 +123,8 @@ impl LossRecoverySpace {
             space,
             largest_acked: None,
             largest_acked_sent_time: None,
-            time_of_last_sent_ack_eliciting_packet: None,
-            ack_eliciting_outstanding: 0,
+            pto_base_time: None,
+            in_flight_outstanding: 0,
             sent_packets: BTreeMap::default(),
             first_ooo_time: None,
         }
@@ -137,8 +143,8 @@ impl LossRecoverySpace {
         self.first_ooo_time
     }
 
-    pub fn ack_eliciting_outstanding(&self) -> bool {
-        self.ack_eliciting_outstanding > 0
+    pub fn in_flight_outstanding(&self) -> bool {
+        self.in_flight_outstanding > 0
     }
 
     pub fn pto_packets(&mut self, count: usize) -> impl Iterator<Item = &SentPacket> {
@@ -155,28 +161,30 @@ impl LossRecoverySpace {
             .take(count)
     }
 
-    pub fn time_of_last_sent_ack_eliciting_packet(&self) -> Option<Instant> {
-        if self.ack_eliciting_outstanding() {
-            debug_assert!(self.time_of_last_sent_ack_eliciting_packet.is_some());
-            self.time_of_last_sent_ack_eliciting_packet
+    pub fn pto_time(&self) -> Option<Instant> {
+        if self.in_flight_outstanding() {
+            debug_assert!(self.pto_base_time.is_some());
+            self.pto_base_time
         } else {
             None
         }
     }
 
     pub fn on_packet_sent(&mut self, packet_number: u64, sent_packet: SentPacket) {
-        if sent_packet.ack_eliciting {
-            self.time_of_last_sent_ack_eliciting_packet = Some(sent_packet.time_sent);
-            self.ack_eliciting_outstanding += 1;
+        if sent_packet.ack_eliciting() {
+            self.pto_base_time = Some(sent_packet.time_sent);
+            if sent_packet.cc_in_flight() {
+                self.in_flight_outstanding += 1;
+            }
         }
         self.sent_packets.insert(packet_number, sent_packet);
     }
 
     pub fn remove_packet(&mut self, pn: u64) -> Option<SentPacket> {
         if let Some(sent) = self.sent_packets.remove(&pn) {
-            if sent.ack_eliciting {
-                debug_assert!(self.ack_eliciting_outstanding > 0);
-                self.ack_eliciting_outstanding -= 1;
+            if sent.cc_in_flight() {
+                debug_assert!(self.in_flight_outstanding > 0);
+                self.in_flight_outstanding -= 1;
             }
             Some(sent)
         } else {
@@ -194,7 +202,7 @@ impl LossRecoverySpace {
             for pn in start..=end {
                 if let Some(sent) = self.remove_packet(pn) {
                     qdebug!("acked={}", pn);
-                    eliciting |= sent.ack_eliciting;
+                    eliciting |= sent.ack_eliciting();
                     acked_packets.insert(pn, sent);
                 }
             }
@@ -209,7 +217,7 @@ impl LossRecoverySpace {
     /// This is called by a client when 0-RTT packets are dropped, when a Retry is received
     /// and when keys are dropped.
     fn remove_ignored(&mut self) -> impl Iterator<Item = SentPacket> {
-        self.ack_eliciting_outstanding = 0;
+        self.in_flight_outstanding = 0;
         std::mem::take(&mut self.sent_packets)
             .into_iter()
             .map(|(_, v)| v)
@@ -595,7 +603,7 @@ impl LossRecovery {
     // Calculate PTO time for the given space.
     fn pto_time(&self, pn_space: PNSpace) -> Option<Instant> {
         if let Some(space) = self.spaces.get(pn_space) {
-            space.time_of_last_sent_ack_eliciting_packet().map(|t| {
+            space.pto_time().map(|t| {
                 t + self
                     .rtt_vals
                     .pto(pn_space)

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -64,7 +64,7 @@ impl From<PacketType> for PNSpace {
 
 #[derive(Debug, Clone)]
 pub struct SentPacket {
-    pub ack_eliciting: bool,
+    ack_eliciting: bool,
     pub time_sent: Instant,
     pub tokens: Vec<RecoveryToken>,
 
@@ -93,6 +93,11 @@ impl SentPacket {
             size,
             in_flight,
         }
+    }
+
+    /// Returns `true` if the packet will elicit an ACK.
+    pub fn ack_eliciting(&self) -> bool {
+        self.ack_eliciting
     }
 
     /// Returns `true` if the packet counts requires congestion control accounting.
@@ -235,7 +240,7 @@ impl ::std::fmt::Display for PacketRange {
 }
 
 /// The ACK delay we use.
-const ACK_DELAY: Duration = Duration::from_millis(20); // 20ms
+pub const ACK_DELAY: Duration = Duration::from_millis(20); // 20ms
 pub const MAX_UNACKED_PKTS: u64 = 1;
 const MAX_TRACKED_RANGES: usize = 32;
 const MAX_ACKS_PER_FRAME: usize = 32;


### PR DESCRIPTION
In #647 I discovered that we generate probes when probes go missing.

The problem was that we were setting a PTO timer if there were
ack-eliciting packets outstanding.  What we should have been doing was
sending probes only if the congestion controller considers them to be in
flight.  The difference is subtle, but it means that PTO packets don't
count as being in flight.

This changes a few names.  I'm happier with the names, because they are
much less of a mouthful, but I think that they could be improved
further.  Suggestions for improvements are very welcome.

Closes #647.