### PR TITLE
Factor some of the ChaCha20 stuff

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -401,7 +401,7 @@ fn client(
     )?;
     let ciphers = args.get_ciphers();
     if !ciphers.is_empty() {
-        transport.enable_ciphers(&ciphers)?;
+        transport.set_ciphers(&ciphers)?;
     }
     let mut client = Http3Client::new_with_conn(
         transport,

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -2529,6 +2529,7 @@ mod tests {
     use std::convert::TryInto;
 
     use neqo_common::matches;
+    use neqo_crypto::constants::TLS_CHACHA20_POLY1305_SHA256;
     use std::mem;
     use test_fixture::{self, assertions, fixture_init, loopback, now};
 
@@ -5351,6 +5352,25 @@ mod tests {
             now(),
         );
         assert_eq!(1, client.stats().dropped_rx);
+    }
+
+    /// Run a single ChaCha20-Poly1305 test and get a PTO.
+    #[test]
+    fn chacha20poly1305() {
+        let mut server = default_server();
+        let mut client = Connection::new_client(
+            test_fixture::DEFAULT_SERVER_NAME,
+            test_fixture::DEFAULT_ALPN,
+            Rc::new(RefCell::new(FixedConnectionIdManager::new(0))),
+            loopback(),
+            loopback(),
+            QuicVersion::default(),
+        )
+        .expect("create a default client");
+        client
+            .enable_ciphers(&[TLS_CHACHA20_POLY1305_SHA256])
+            .unwrap();
+        connect_force_idle(&mut client, &mut server);
     }
 
     /// Test that a client can handle a stateless reset correctly.

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -5367,9 +5367,7 @@ mod tests {
             QuicVersion::default(),
         )
         .expect("create a default client");
-        client
-            .enable_ciphers(&[TLS_CHACHA20_POLY1305_SHA256])
-            .unwrap();
+        client.set_ciphers(&[TLS_CHACHA20_POLY1305_SHA256]).unwrap();
         connect_force_idle(&mut client, &mut server);
     }
 

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -16,8 +16,9 @@ use neqo_crypto::aead::Aead;
 use neqo_crypto::hp::HpKey;
 use neqo_crypto::{
     hkdf, Agent, AntiReplay, Cipher, Epoch, HandshakeState, Record, RecordList, SymKey,
-    TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CT_HANDSHAKE, TLS_EPOCH_APPLICATION_DATA,
-    TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL, TLS_EPOCH_ZERO_RTT, TLS_VERSION_1_3,
+    TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256, TLS_CT_HANDSHAKE,
+    TLS_EPOCH_APPLICATION_DATA, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL, TLS_EPOCH_ZERO_RTT,
+    TLS_VERSION_1_3,
 };
 
 use crate::frame::Frame;
@@ -46,7 +47,11 @@ impl Crypto {
         anti_replay: Option<&AntiReplay>,
     ) -> Res<Self> {
         agent.set_version_range(TLS_VERSION_1_3, TLS_VERSION_1_3)?;
-        agent.set_ciphers(&[TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384])?;
+        agent.set_ciphers(&[
+            TLS_AES_128_GCM_SHA256,
+            TLS_AES_256_GCM_SHA384,
+            TLS_CHACHA20_POLY1305_SHA256,
+        ])?;
         agent.set_alpn(protocols)?;
         agent.disable_end_of_early_data()?;
         match &mut agent {
@@ -851,6 +856,51 @@ impl CryptoStates {
             handshake: None,
             zero_rtt: None,
             cipher: TLS_AES_128_GCM_SHA256,
+            app_write: None,
+            app_read: Some(app_read()),
+            app_read_next: Some(app_read()),
+            read_update_time: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_chacha() -> Self {
+        const SECRET: &[u8] = &[
+            0x9a, 0xc3, 0x12, 0xa7, 0xf8, 0x77, 0x46, 0x8e, 0xbe, 0x69, 0x42, 0x27, 0x48, 0xad,
+            0x00, 0xa1, 0x54, 0x43, 0xf1, 0x82, 0x03, 0xa0, 0x7d, 0x60, 0x60, 0xf6, 0x88, 0xf3,
+            0x0f, 0x21, 0x63, 0x2b,
+        ];
+        let secret =
+            hkdf::import_key(TLS_VERSION_1_3, TLS_CHACHA20_POLY1305_SHA256, SECRET).unwrap();
+        let app_read = || CryptoDxAppData {
+            dx: CryptoDxState {
+                direction: CryptoDxDirection::Read,
+                epoch: 0,
+                aead: Aead::new(
+                    TLS_VERSION_1_3,
+                    TLS_CHACHA20_POLY1305_SHA256,
+                    &secret,
+                    "quic ",
+                )
+                .unwrap(),
+                hpkey: HpKey::extract(
+                    TLS_VERSION_1_3,
+                    TLS_CHACHA20_POLY1305_SHA256,
+                    &secret,
+                    "quic hp",
+                )
+                .unwrap(),
+                used_pn: 0..645_971_972,
+                min_pn: 0,
+            },
+            cipher: TLS_CHACHA20_POLY1305_SHA256,
+            next_secret: secret.clone(),
+        };
+        Self {
+            initial: None,
+            handshake: None,
+            zero_rtt: None,
+            cipher: TLS_CHACHA20_POLY1305_SHA256,
             app_write: None,
             app_read: Some(app_read()),
             app_read_next: Some(app_read()),

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -1092,4 +1092,22 @@ mod tests {
             0x4000_0000_0000_0002
         );
     }
+
+    #[test]
+    fn chacha20_sample() {
+        const PACKET: &[u8] = &[
+            0x4c, 0xfe, 0x41, 0x89, 0x65, 0x5e, 0x5c, 0xd5, 0x5c, 0x41, 0xf6, 0x90, 0x80, 0x57,
+            0x5d, 0x79, 0x99, 0xc2, 0x5a, 0x5b, 0xfb,
+        ];
+        fixture_init();
+        let (packet, slice) =
+            PublicPacket::decode(PACKET, &FixedConnectionIdManager::new(0)).unwrap();
+        assert!(slice.is_empty());
+        let decrypted = packet
+            .decrypt(&mut CryptoStates::test_chacha(), now())
+            .unwrap();
+        assert_eq!(decrypted.packet_type(), PacketType::Short);
+        assert_eq!(decrypted.pn(), 654_360_564);
+        assert_eq!(&decrypted[..], &[0x01]);
+    }
 }


### PR DESCRIPTION
Mainly this was so that I could construct a sample ChaCha20 header
protection example for the spec, but I think that this is cleaner
overall, and more usable.

There are some improvements to the neqo-client interface as well.