### PR TITLE
Use less wrapping in build.rs

### DIFF
--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -21,25 +21,31 @@ const BINDINGS_CONFIG: &str = "bindings.toml";
 // This is the format of a single section of the configuration file.
 #[derive(Deserialize)]
 struct Bindings {
-    // types that are explicitly included
-    types: Option<Vec<String>>,
-    // functions that are explicitly included
-    functions: Option<Vec<String>>,
-    // variables (and `#define`s) that are explicitly included
-    variables: Option<Vec<String>>,
-    // types that should be explicitly marked as opaque
-    opaque: Option<Vec<String>>,
-    // enumerations that are turned into a module (without this, the enum is
-    // mapped using the default, which means that the individual values are
-    // formed with an underscore as <enum_type>_<enum_value_name>).
-    enums: Option<Vec<String>>,
+    /// types that are explicitly included
+    #[serde(default)]
+    types: Vec<String>,
+    /// functions that are explicitly included
+    #[serde(default)]
+    functions: Vec<String>,
+    /// variables (and `#define`s) that are explicitly included
+    #[serde(default)]
+    variables: Vec<String>,
+    /// types that should be explicitly marked as opaque
+    #[serde(default)]
+    opaque: Vec<String>,
+    /// enumerations that are turned into a module (without this, the enum is
+    /// mapped using the default, which means that the individual values are
+    /// formed with an underscore as <enum_type>_<enum_value_name>).
+    #[serde(default)]
+    enums: Vec<String>,
 
-    // Any item that is specifically excluded; if none of the types, functions,
-    // or variables fields are specified, everything defined will be mapped,
-    // so this can be used to limit that.
-    exclude: Option<Vec<String>>,
+    /// Any item that is specifically excluded; if none of the types, functions,
+    /// or variables fields are specified, everything defined will be mapped,
+    /// so this can be used to limit that.
+    #[serde(default)]
+    exclude: Vec<String>,
 
-    // Whether the file is to be interpreted as C++
+    /// Whether the file is to be interpreted as C++
     #[serde(default)]
     cplusplus: bool,
 }
@@ -253,23 +259,22 @@ fn build_bindings(base: &str, bindings: &Bindings, flags: &[String], gecko: bool
     builder = builder.clang_args(flags);
 
     // Apply the configuration.
-    let empty: Vec<String> = vec![];
-    for v in bindings.types.as_ref().unwrap_or_else(|| &empty).iter() {
+    for v in &bindings.types {
         builder = builder.whitelist_type(v);
     }
-    for v in bindings.functions.as_ref().unwrap_or_else(|| &empty).iter() {
+    for v in &bindings.functions {
         builder = builder.whitelist_function(v);
     }
-    for v in bindings.variables.as_ref().unwrap_or_else(|| &empty).iter() {
+    for v in &bindings.variables {
         builder = builder.whitelist_var(v);
     }
-    for v in bindings.exclude.as_ref().unwrap_or_else(|| &empty).iter() {
+    for v in &bindings.exclude {
         builder = builder.blacklist_item(v);
     }
-    for v in bindings.opaque.as_ref().unwrap_or_else(|| &empty).iter() {
+    for v in &bindings.opaque {
         builder = builder.opaque_type(v);
     }
-    for v in bindings.enums.as_ref().unwrap_or_else(|| &empty).iter() {
+    for v in &bindings.enums {
         builder = builder.constified_enum_module(v);
     }
 


### PR DESCRIPTION
Using `#[serde(default)]` avoids some of the extra unwrapping and
simplifies the code considerably.