### PR TITLE
Ignore VersionNegotiation containing reserved values and the value of the used QUIC version

### DIFF
--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -24,7 +24,7 @@ const PACKET_TYPE_0RTT: u8 = 0x01;
 const PACKET_TYPE_HANDSHAKE: u8 = 0x2;
 const PACKET_TYPE_RETRY: u8 = 0x03;
 
-const PACKET_BIT_LONG: u8 = 0x80;
+pub const PACKET_BIT_LONG: u8 = 0x80;
 const PACKET_BIT_SHORT: u8 = 0x00;
 const PACKET_BIT_KEY_PHASE: u8 = 0x04;
 const PACKET_BIT_FIXED_QUIC: u8 = 0x40;
@@ -639,6 +639,17 @@ impl<'a> PublicPacket<'a> {
         } else {
             Err(Error::DecryptError)
         }
+    }
+
+    pub fn supported_versions(&self) -> Res<Vec<Version>> {
+        assert_eq!(self.packet_type, PacketType::VersionNegotiation);
+        let mut decoder = Decoder::new(&self.data[self.header_len..]);
+        let mut res = Vec::new();
+        while decoder.remaining() > 0 {
+            let version = Version::try_from(Self::opt(decoder.decode_uint(4))?)?;
+            res.push(version);
+        }
+        Ok(res)
     }
 }
 

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -717,14 +717,10 @@ fn version_negotiation() {
     }
     assert!(found, "valid version not found");
 
+    // Client ignores VN packet that contain negotiated version.
     let res = client.process(Some(vn), now());
-    assert_eq!(res, Output::None);
-    match client.state() {
-        State::Closed(err) => {
-            assert_eq!(*err, ConnectionError::Transport(Error::VersionNegotiation))
-        }
-        _ => panic!("Invalid client state"),
-    }
+    assert!(res.callback() > Duration::new(0, 120));
+    assert_eq!(client.state(), &State::WaitInitial);
 }
 
 #[test]


### PR DESCRIPTION

fixes #675

This also add test server_receive_unknow_first_packet which was crashing when trying to get timers (I have accidentally made a wrong test that revealed the issue)