### PR TITLE
The qpack encoder should write all instructions directly into a transport stream

### DIFF
--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -171,7 +171,9 @@ impl Http3Connection {
         }
         self.qpack_decoder.send(conn)?;
         match self.qpack_encoder.send(conn) {
-            Ok(()) | Err(neqo_qpack::Error::EncoderStreamBlocked) => {}
+            Ok(())
+            | Err(neqo_qpack::Error::EncoderStreamBlocked)
+            | Err(neqo_qpack::Error::DynamicTableFull) => {}
             Err(e) => return Err(Error::QpackError(e)),
         }
         Ok(())

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -170,7 +170,11 @@ impl Http3Connection {
             }
         }
         self.qpack_decoder.send(conn)?;
-        self.qpack_encoder.send(conn)?;
+        match self.qpack_encoder.send(conn) {
+            Ok(()) => {}
+            Err(neqo_qpack::Error::EncoderStreamBlocked) => {}
+            Err(e) => return Err(Error::QpackError(e)),
+        }
         Ok(())
     }
 

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -171,8 +171,7 @@ impl Http3Connection {
         }
         self.qpack_decoder.send(conn)?;
         match self.qpack_encoder.send(conn) {
-            Ok(()) => {}
-            Err(neqo_qpack::Error::EncoderStreamBlocked) => {}
+            Ok(()) | Err(neqo_qpack::Error::EncoderStreamBlocked) => {}
             Err(e) => return Err(Error::QpackError(e)),
         }
         Ok(())

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -286,7 +286,7 @@ impl QPackEncoder {
     fn maybe_send_change_capacity(
         &mut self,
         conn: &mut Connection,
-        stream_id: &StreamId,
+        stream_id: StreamId,
     ) -> Res<()> {
         if let Some(cap) = self.next_capacity {
             // Check if it is possible to reduce the capacity, e.g. if enough space can be make free for the reduction.
@@ -327,10 +327,10 @@ impl QPackEncoder {
                     return Err(Error::EncoderStreamBlocked);
                 }
                 self.local_stream = LocalStreamState::Initialized(stream_id);
-                self.maybe_send_change_capacity(conn, &stream_id)
+                self.maybe_send_change_capacity(conn, stream_id)
             }
             LocalStreamState::Initialized(stream_id) => {
-                self.maybe_send_change_capacity(conn, &stream_id)
+                self.maybe_send_change_capacity(conn, stream_id)
             }
         }
     }
@@ -473,7 +473,7 @@ impl QPackEncoder {
 
     #[must_use]
     pub fn local_stream_id(&self) -> Option<u64> {
-        self.local_stream.stream_id().map(|s| s.as_u64())
+        self.local_stream.stream_id().map(StreamId::as_u64)
     }
 
     #[must_use]

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -289,8 +289,8 @@ impl QPackEncoder {
         stream_id: &StreamId,
     ) -> Res<()> {
         if let Some(cap) = self.next_capacity {
-            // Check if itt is possible to reduce the capacity, e.g. if enough space can be make free for the reduction.
-            if cap < self.table.capacity() && !self.table.test_evict_to(cap) {
+            // Check if it is possible to reduce the capacity, e.g. if enough space can be make free for the reduction.
+            if cap < self.table.capacity() && !self.table.can_evict_to(cap) {
                 return Err(Error::DynamicTableFull);
             }
             let mut buf = QPData::default();
@@ -301,7 +301,7 @@ impl QPackEncoder {
             if self.table.set_capacity(cap).is_err() {
                 debug_assert!(
                     false,
-                    "test_evict_to should have checked and make sure this operation is possible"
+                    "can_evict_to should have checked and make sure this operation is possible"
                 );
                 return Err(Error::InternalError);
             }

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -21,14 +21,29 @@ use std::convert::TryFrom;
 
 pub const QPACK_UNI_STREAM_TYPE_ENCODER: u64 = 0x2;
 
+#[derive(Debug, PartialEq)]
+enum LocalStreamState {
+    NoStream,
+    Uninitialized(u64),
+    Initialized(u64),
+}
+
+impl LocalStreamState {
+    pub fn stream_id(&self) -> Option<u64> {
+        match self {
+            Self::NoStream => None,
+            Self::Uninitialized(stream_id) | Self::Initialized(stream_id) => Some(*stream_id),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct QPackEncoder {
     table: HeaderTable,
-    send_buf: QPData,
     max_table_size: u64,
     max_entries: u64,
     instruction_reader: DecoderInstructionReader,
-    local_stream_id: Option<u64>,
+    local_stream: LocalStreamState,
     remote_stream_id: Option<u64>,
     max_blocked_streams: u16,
     // Remember header blocks that are referring to dynamic table.
@@ -38,6 +53,7 @@ pub struct QPackEncoder {
     unacked_header_blocks: HashMap<u64, VecDeque<HashSet<u64>>>,
     blocked_stream_cnt: u16,
     use_huffman: bool,
+    change_capacity: Option<u64>,
     stats: Stats,
 }
 
@@ -46,16 +62,16 @@ impl QPackEncoder {
     pub fn new(qpack_settings: QpackSettings, use_huffman: bool) -> Self {
         Self {
             table: HeaderTable::new(true),
-            send_buf: QPData::default(),
             max_table_size: qpack_settings.max_table_size_encoder,
             max_entries: 0,
             instruction_reader: DecoderInstructionReader::new(),
-            local_stream_id: None,
+            local_stream: LocalStreamState::NoStream,
             remote_stream_id: None,
             max_blocked_streams: 0,
             unacked_header_blocks: HashMap::new(),
             blocked_stream_cnt: 0,
             use_huffman,
+            change_capacity: None,
             stats: Stats::default(),
         }
     }
@@ -84,7 +100,8 @@ impl QPackEncoder {
         let new_cap = std::cmp::min(self.max_table_size, cap);
         self.max_entries = new_cap / 32;
         // we also set our table to the max allowed.
-        self.change_capacity(new_cap)
+        self.change_capacity(new_cap);
+        Ok(())
     }
 
     /// This function is use for setting encoders max blocked streams. The value is received as
@@ -229,9 +246,6 @@ impl QPackEncoder {
     ) -> Res<u64> {
         qdebug!([self], "insert {:?} {:?}.", name, value);
         self.send(conn)?;
-        if self.send_buf.len() != 0 {
-            return Err(Error::EncoderStreamBlocked);
-        }
 
         let entry_size = name.len() + value.len() + ADDITIONAL_TABLE_ENTRY_SIZE;
 
@@ -246,7 +260,7 @@ impl QPackEncoder {
         }
         .marshal(&mut buf, self.use_huffman);
 
-        let stream_id = self.local_stream_id.ok_or(Error::Internal)?;
+        let stream_id = self.local_stream.stream_id().ok_or(Error::Internal)?;
 
         let sent = conn.stream_send_atomic(stream_id, &buf)?;
         if !sent {
@@ -264,10 +278,21 @@ impl QPackEncoder {
         }
     }
 
-    fn change_capacity(&mut self, value: u64) -> Res<()> {
+    fn change_capacity(&mut self, value: u64) {
         qdebug!([self], "change capacity: {}", value);
-        self.table.set_capacity(value)?;
-        EncoderInstruction::Capacity { value }.marshal(&mut self.send_buf, self.use_huffman);
+        self.change_capacity = Some(value);
+    }
+
+    fn maybe_send_change_capacity(&mut self, conn: &mut Connection, stream_id: u64) -> Res<()> {
+        if let Some(cap) = self.change_capacity {
+            let mut buf = QPData::default();
+            EncoderInstruction::Capacity { value: cap }.marshal(&mut buf, self.use_huffman);
+            if !conn.stream_send_atomic(stream_id, &buf)? {
+                return Err(Error::EncoderStreamBlocked);
+            }
+            self.table.set_capacity(cap)?;
+            self.change_capacity = None;
+        }
         Ok(())
     }
 
@@ -275,17 +300,20 @@ impl QPackEncoder {
     /// # Errors
     ///   returns `EncoderStream` in case of an error.
     pub fn send(&mut self, conn: &mut Connection) -> Res<()> {
-        if self.send_buf.is_empty() {
-            Ok(())
-        } else if let Some(stream_id) = self.local_stream_id {
-            let r = conn
-                .stream_send(stream_id, &self.send_buf[..])
-                .map_err(|_| Error::EncoderStream)?;
-            qdebug!([self], "{} bytes sent.", r);
-            self.send_buf.read(r as usize);
-            Ok(())
-        } else {
-            Ok(())
+        match self.local_stream {
+            LocalStreamState::NoStream => Ok(()),
+            LocalStreamState::Uninitialized(stream_id) => {
+                let mut buf = QPData::default();
+                buf.encode_varint(QPACK_UNI_STREAM_TYPE_ENCODER);
+                if !conn.stream_send_atomic(stream_id, &buf[..])? {
+                    return Err(Error::EncoderStreamBlocked);
+                }
+                self.local_stream = LocalStreamState::Initialized(stream_id);
+                self.maybe_send_change_capacity(conn, stream_id)
+            }
+            LocalStreamState::Initialized(stream_id) => {
+                self.maybe_send_change_capacity(conn, stream_id)
+            }
         }
     }
 
@@ -401,11 +429,11 @@ impl QPackEncoder {
 
     /// Encoder stream has been created. Add the stream id.
     pub fn add_send_stream(&mut self, stream_id: u64) {
-        if self.local_stream_id.is_some() {
+        if self.local_stream == LocalStreamState::NoStream {
+            self.local_stream = LocalStreamState::Uninitialized(stream_id);
+        } else {
             panic!("Adding multiple local streams");
         }
-        self.local_stream_id = Some(stream_id);
-        self.send_buf.encode_varint(QPACK_UNI_STREAM_TYPE_ENCODER);
     }
 
     /// We have received a remote decoder stream. Remember its stream id.
@@ -427,7 +455,7 @@ impl QPackEncoder {
 
     #[must_use]
     pub fn local_stream_id(&self) -> Option<u64> {
-        self.local_stream_id
+        self.local_stream.stream_id()
     }
 
     #[must_use]
@@ -457,7 +485,7 @@ fn map_error(err: &Error) -> Error {
 
 #[cfg(test)]
 mod tests {
-    use super::{Connection, Error, Header, QPackEncoder};
+    use super::{Connection, Error, Header, QPackEncoder, Res};
     use crate::QpackSettings;
     use neqo_transport::tparams::{self, TransportParameter};
     use neqo_transport::StreamType;
@@ -520,6 +548,12 @@ mod tests {
 
             handshake(client, server);
         })
+    }
+
+    fn change_capacity(encoder: &mut TestEncoder, capacity: u64) -> Res<()> {
+        encoder.encoder.set_max_capacity(capacity).unwrap();
+        // We will try to really change the table only when we send the change capacity instruction.
+        encoder.encoder.send(&mut encoder.conn)
     }
 
     fn send_instructions(encoder: &mut TestEncoder, encoder_instruction: &[u8]) {
@@ -1349,19 +1383,19 @@ mod tests {
         assert_is_index_to_dynamic(&buf);
 
         // trying to evict the entry will failed.
-        assert!(encoder.encoder.set_max_capacity(10).is_err());
+        assert!(change_capacity(&mut encoder, 10).is_err());
 
         // receive an Insert Count Increment for the entry.
         recv_instruction(&mut encoder, &[0x01]);
 
         // trying to evict the entry will failed. The stream is still referring to it.
-        assert!(encoder.encoder.set_max_capacity(10).is_err());
+        assert!(change_capacity(&mut encoder, 10).is_err());
 
         // receive a header_ack for the header block.
         recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_1);
 
         // now entry can be evicted.
-        assert!(encoder.encoder.set_max_capacity(10).is_ok());
+        assert!(change_capacity(&mut encoder, 10).is_ok());
     }
 
     #[test]
@@ -1396,19 +1430,19 @@ mod tests {
         assert_is_index_to_dynamic(&buf);
 
         // trying to evict the entry will failed.
-        assert!(encoder.encoder.set_max_capacity(10).is_err());
+        assert!(change_capacity(&mut encoder, 10).is_err());
 
         // receive an Insert Count Increment for the entry.
         recv_instruction(&mut encoder, &[0x01]);
 
         // trying to evict the entry will failed. The stream is still referring to it.
-        assert!(encoder.encoder.set_max_capacity(10).is_err());
+        assert!(change_capacity(&mut encoder, 10).is_err());
 
         // receive a stream cancelled.
         recv_instruction(&mut encoder, STREAM_CANCELED_ID_1);
 
         // now entry can be evicted.
-        assert!(encoder.encoder.set_max_capacity(10).is_ok());
+        assert!(change_capacity(&mut encoder, 10).is_ok());
     }
 
     #[test]
@@ -1432,13 +1466,13 @@ mod tests {
         send_instructions(&mut encoder, HEADER_CONTENT_LENGTH_VALUE_1_NAME_LITERAL);
 
         // trying to evict the entry will failed, because the entry is not acked.
-        assert!(encoder.encoder.set_max_capacity(10).is_err());
+        assert!(change_capacity(&mut encoder, 10).is_err());
 
         // receive an Insert Count Increment for the entry.
         recv_instruction(&mut encoder, &[0x01]);
 
         // now entry can be evicted.
-        assert!(encoder.encoder.set_max_capacity(10).is_ok());
+        assert!(change_capacity(&mut encoder, 10).is_ok());
     }
 
     #[test]
@@ -1474,13 +1508,13 @@ mod tests {
 
         // trying to evict the entry will failed. The stream is still referring to it and
         // entry is not acked.
-        assert!(encoder.encoder.set_max_capacity(10).is_err());
+        assert!(change_capacity(&mut encoder, 10).is_err());
 
         // receive a header_ack for the header block. This will also ack the instruction.
         recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_1);
 
         // now entry can be evicted.
-        assert!(encoder.encoder.set_max_capacity(10).is_ok());
+        assert!(change_capacity(&mut encoder, 10).is_ok());
     }
 
     #[test]
@@ -1582,7 +1616,7 @@ mod tests {
         let mut encoder = connect(false);
 
         encoder.encoder.set_max_blocked_streams(20).unwrap();
-        assert!(encoder.encoder.set_max_capacity(50).is_ok());
+        assert!(change_capacity(&mut encoder, 50).is_ok());
 
         encoder
             .encoder

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -43,6 +43,7 @@ pub enum Error {
     EncoderStream,
     DecoderStream,
     ClosedCriticalStream,
+    InternalError,
 
     // These are internal errors, they will be transformed into one of the above.
     NeedMoreData, // Return when an input stream does not have more data that a decoder needs.(It does not mean that a stream is closed.)

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -246,7 +246,7 @@ impl HeaderTable {
         self.evict_to_internal(reduce, false)
     }
 
-    pub fn test_evict_to(&mut self, reduce: u64) -> bool {
+    pub fn can_evict_to(&mut self, reduce: u64) -> bool {
         self.evict_to_internal(reduce, true)
     }
 
@@ -276,7 +276,7 @@ impl HeaderTable {
 
     pub fn insert_possible(&mut self, size: usize) -> bool {
         u64::try_from(size).unwrap() <= self.capacity
-            && self.test_evict_to(self.capacity - u64::try_from(size).unwrap())
+            && self.can_evict_to(self.capacity - u64::try_from(size).unwrap())
     }
 
     /// Insert a new entry.

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -246,7 +246,7 @@ impl HeaderTable {
         self.evict_to_internal(reduce, false)
     }
 
-    fn test_evict_to(&mut self, reduce: u64) -> bool {
+    pub fn test_evict_to(&mut self, reduce: u64) -> bool {
         self.evict_to_internal(reduce, true)
     }
 


### PR DESCRIPTION

Probably this is all that is needed for #655 