### PR TITLE
Added macro to implement Display trait

### DIFF
--- a/neqo-common/src/display.rs
+++ b/neqo-common/src/display.rs
@@ -1,0 +1,83 @@
+#[macro_export]
+macro_rules! display {
+
+    ($name: ident, $formatter: expr) => {
+        display!($name, self, $formatter,)
+    };
+
+    ($name: ident, $formatter: expr, $($arg: ident,)*) => {
+        display!($name, self, $formatter, $($arg),*)
+    };
+
+    ($name: ident, $formatter: expr, $($arg: ident),*) => {
+        display!($name, self, $formatter, $($arg),*)
+    };
+
+    ($name: ident, $self_: ident, $formatter: expr, $($arg: ident),*) => {
+        impl ::std::fmt::Display for $name {
+            fn fmt(&$self_, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                write!(f, $formatter, $($self_.$arg),*)
+            }
+        }
+    };
+
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+mod test {
+
+    #[test]
+    fn display_nofield() {
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        display!(Point, "point");
+        let origin = Point { x: 0, y: 0 };
+        assert_eq!(format!("The origin is: {}", origin), "The origin is: point");
+    }
+
+    #[test]
+    fn display_onefield() {
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        display!(Point, "({})", x);
+        let origin = Point { x: 0, y: 0 };
+        assert_eq!(format!("The origin is: {}", origin), "The origin is: (0)");
+    }
+
+    #[test]
+    fn display_twofield() {
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        display!(Point, "({}, {})", x, y);
+        let origin = Point { x: 0, y: 0 };
+        assert_eq!(
+            format!("The origin is: {}", origin),
+            "The origin is: (0, 0)"
+        );
+    }
+
+    #[test]
+    fn display_trailingcomma() {
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        display!(Point, "({}, {})", x, y,);
+        let origin = Point { x: 0, y: 0 };
+        assert_eq!(
+            format!("The origin is: {}", origin),
+            "The origin is: (0, 0)"
+        );
+    }
+}

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod codec;
 mod datagram;
+pub mod display;
 mod incrdecoder;
 pub mod log;
 pub mod qlog;


### PR DESCRIPTION
[Issue #672](https://github.com/mozilla/neqo/issues/672)

Added macro in neqo-common to implement `Display` trait. Usage for the macro is as follows:
1. Without any field
```rust
struct Point {
    x: i32,
    y: i32,
}
// Will always format point with a constant string
display!(Point, "point");
let origin = Point { x: 0, y: 0 };
// The origin is: point
format!("The origin is: {}", origin);
```
2. With one field
```rust
struct Point {
    x: i32,
    y: i32,
}
// Will format point with the provided field
display!(Point, "({})", x);
let origin = Point { x: 0, y: 0 };
// The origin is: (0)
format!("The origin is: {}", origin);
```
3. With multiple field
```rust
struct Point {
    x: i32,
    y: i32,
}
// Will format point with the provided fields
display!(Point, "({}, {})", x, y);
let origin = Point { x: 0, y: 0 };
// The origin is: (0, 0)
format!("The origin is: {}", origin);
```