### PR TITLE
Centralize logging of dropped received packets

### DIFF
--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -6,9 +6,13 @@
 
 // Tracking of some useful statistics.
 
+use neqo_common::qwarn;
+
 #[derive(Default, Debug)]
 /// Connection statistics
 pub struct Stats {
+    conn_display_info: String,
+
     /// Total packets received
     pub packets_rx: usize,
     /// Total packets sent
@@ -17,6 +21,22 @@ pub struct Stats {
     pub dups_rx: usize,
     /// Dropped datagrams, or parts thereof
     pub dropped_rx: usize,
-    /// resumsion used
+    /// resumption used
     pub resumed: bool,
+}
+
+impl Stats {
+    pub fn init(&mut self, conn_info: String) {
+        self.conn_display_info = conn_info;
+    }
+
+    pub fn pkt_dropped(&mut self, reason: impl AsRef<str>) {
+        self.dropped_rx += 1;
+        qwarn!(
+            [self.conn_display_info],
+            "Dropped received packet: {}; Total: {}",
+            reason.as_ref(),
+            self.dropped_rx
+        )
+    }
 }


### PR DESCRIPTION
Add a method to `Stats` that increments dropped_rx and prints a message, instead of
incrementing at each drop site.

We really need this to be a method on Stats rather than Connection to
avoid borrowck hell, but we also really want Connection's Display in the
log message. Can't pass it in b/c borrowck. Instead, capture it in
Connection::new().