### PR TITLE
Use display

### DIFF
--- a/neqo-common/src/display.rs
+++ b/neqo-common/src/display.rs
@@ -1,0 +1,83 @@
+#[macro_export]
+macro_rules! display {
+
+    ($name: ident, $formatter: expr) => {
+        display!($name, self, $formatter,)
+    };
+
+    ($name: ident, $formatter: expr, $($arg: ident,)*) => {
+        display!($name, self, $formatter, $($arg),*)
+    };
+
+    ($name: ident, $formatter: expr, $($arg: ident),*) => {
+        display!($name, self, $formatter, $($arg),*)
+    };
+
+    ($name: ident, $self_: ident, $formatter: expr, $($arg: ident),*) => {
+        impl ::std::fmt::Display for $name {
+            fn fmt(&$self_, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                write!(f, $formatter, $($self_.$arg),*)
+            }
+        }
+    };
+
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+mod test {
+
+    #[test]
+    fn display_nofield() {
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        display!(Point, "point");
+        let origin = Point { x: 0, y: 0 };
+        assert_eq!(format!("The origin is: {}", origin), "The origin is: point");
+    }
+
+    #[test]
+    fn display_onefield() {
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        display!(Point, "({})", x);
+        let origin = Point { x: 0, y: 0 };
+        assert_eq!(format!("The origin is: {}", origin), "The origin is: (0)");
+    }
+
+    #[test]
+    fn display_twofield() {
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        display!(Point, "({}, {})", x, y);
+        let origin = Point { x: 0, y: 0 };
+        assert_eq!(
+            format!("The origin is: {}", origin),
+            "The origin is: (0, 0)"
+        );
+    }
+
+    #[test]
+    fn display_trailingcomma() {
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        display!(Point, "({}, {})", x, y,);
+        let origin = Point { x: 0, y: 0 };
+        assert_eq!(
+            format!("The origin is: {}", origin),
+            "The origin is: (0, 0)"
+        );
+    }
+}

--- a/neqo-common/src/display.rs
+++ b/neqo-common/src/display.rs
@@ -1,30 +1,68 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Implement `std::fmt::Display` for a type.
+/// A single argument form displays the name of the type.
+/// A two argument form takes a fixed string as an argument.
+/// Adding identifiers for members of the type after the format string
+/// allows for those to be added to the format string.
+/// If more complex formatting is needed, then pass an identifier *before*
+/// the format string and then the trailing arguments can be expressions using
+/// that identifier, which will contain an immutable reference.
 #[macro_export]
 macro_rules! display {
-
-    ($name: ident, $formatter: expr) => {
-        display!($name, self, $formatter,)
+    ($name:ident $(< $($lt:tt),+ >)? $(,)?) => {
+        display!($name $(< $( $lt ),* >)?, stringify!($name),);
     };
 
-    ($name: ident, $formatter: expr, $($arg: ident,)*) => {
-        display!($name, self, $formatter, $($arg),*)
+    ($name:ident $(< $($lt:tt),+ >)?, $s:expr) => {
+        display!($name $(< $( $lt ),* >)?, $s,);
     };
 
-    ($name: ident, $formatter: expr, $($arg: ident),*) => {
-        display!($name, self, $formatter, $($arg),*)
+    ($name:ident $(< $($lt:tt),+ >)?, $format:expr, $($member:ident),* $(,)?) => {
+        display!($name $(< $( $lt ),* >)?, _v, $format, $(_v.$member),*);
     };
 
-    ($name: ident, $self_: ident, $formatter: expr, $($arg: ident),*) => {
-        impl ::std::fmt::Display for $name {
-            fn fmt(&$self_, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                write!(f, $formatter, $($self_.$arg),*)
+    ($name:ident $(< $($lt:tt),+ >)?, $v:ident, $format:expr, $($arg:expr),* $(,)?) => {
+        impl $(< $( $lt ),* >)? ::std::fmt::Display for $name $(< $( $lt ),* >)? {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                let $v = self;
+                write!(f, $format, $($arg),*)
+            }
+        }
+    };
+}
+
+/// `display_debug` implements `Display` for a type that already implements `Debug`.
+/// The `Display` implementation forwards to the `Debug` implementation.
+/// This version with a second argument adds that as a prefix,
+/// followed by ": " and the debug string.
+#[macro_export]
+macro_rules! display_debug {
+    ($name:ident $(< $($lt:tt),+ >)?) => {
+        impl $(< $( $lt ),* >)? ::std::fmt::Display for $name $(< $( $lt ),* >)? {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                ::std::fmt::Debug::fmt(self, f)
             }
         }
     };
 
+    ($name:ident $(< $($lt:tt),+ >)?, $prefix:expr) => {
+        impl $(< $( $lt ),* >)? ::std::fmt::Display for $name $(< $( $lt ),* >)? {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                f.write_str($prefix)?;
+                f.write_str(": ")?;
+                ::std::fmt::Debug::fmt(self, f)
+            }
+        }
+    };
 }
 
 #[cfg(test)]
-#[allow(dead_code)]
+#[allow(dead_code)] // Lots of unused fields in the structs we define.
 mod test {
 
     #[test]
@@ -35,7 +73,7 @@ mod test {
         }
 
         display!(Point, "point");
-        let origin = Point { x: 0, y: 0 };
+        let origin = Point { x: 1, y: 2 };
         assert_eq!(format!("The origin is: {}", origin), "The origin is: point");
     }
 
@@ -47,8 +85,8 @@ mod test {
         }
 
         display!(Point, "({})", x);
-        let origin = Point { x: 0, y: 0 };
-        assert_eq!(format!("The origin is: {}", origin), "The origin is: (0)");
+        let origin = Point { x: 1, y: 2 };
+        assert_eq!(format!("origin: {}", origin), "origin: (1)");
     }
 
     #[test]
@@ -59,11 +97,8 @@ mod test {
         }
 
         display!(Point, "({}, {})", x, y);
-        let origin = Point { x: 0, y: 0 };
-        assert_eq!(
-            format!("The origin is: {}", origin),
-            "The origin is: (0, 0)"
-        );
+        let origin = Point { x: 1, y: 2 };
+        assert_eq!(format!("origin: {}", origin), "origin: (1, 2)");
     }
 
     #[test]
@@ -74,10 +109,95 @@ mod test {
         }
 
         display!(Point, "({}, {})", x, y,);
-        let origin = Point { x: 0, y: 0 };
-        assert_eq!(
-            format!("The origin is: {}", origin),
-            "The origin is: (0, 0)"
-        );
+        let origin = Point { x: 1, y: 2 };
+        assert_eq!(format!("origin: {}", origin), "origin: (1, 2)");
+    }
+
+    #[test]
+    fn display_accessor() {
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+        impl Point {
+            fn x(&self) -> i32 {
+                self.x
+            }
+            fn y(&self) -> i32 {
+                self.y
+            }
+        }
+
+        display!(Point, v, "({}, {})", v.x(), v.y());
+        let origin = Point { x: 1, y: 2 };
+        assert_eq!(format!("origin: {}", origin), "origin: (1, 2)");
+    }
+
+    #[test]
+    fn display_complex() {
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+        display!(Point, v, "{}", v.x + v.y);
+        let origin = Point { x: 1, y: 2 };
+        assert_eq!(format!("{}", origin), "3");
+    }
+
+    #[test]
+    fn display_lifetime() {
+        struct S<'a> {
+            s: &'a str,
+        }
+        display!(S<'a>);
+        let v = S { s: "testing" };
+        assert_eq!(format!("{}", v), "S");
+    }
+
+    #[test]
+    fn display_lifetime_params() {
+        struct S<'a> {
+            s: &'a str,
+        }
+        display!(S<'a>, "S<'a> = {}", s);
+        let v = S { s: "testing" };
+        assert_eq!(format!("{}", v), "S<'a> = testing");
+    }
+
+    #[test]
+    fn display_debug() {
+        #[derive(Debug)]
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        display_debug!(Point);
+        let origin = Point { x: 1, y: 2 };
+        assert_eq!(format!("{}", origin), format!("{:?}", origin));
+    }
+
+    #[test]
+    fn display_debug_fmt() {
+        #[derive(Debug)]
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        display_debug!(Point, "Pt");
+        let origin = Point { x: 1, y: 2 };
+        assert_eq!(format!("{}", origin), format!("Pt: {:?}", origin));
+    }
+
+    #[test]
+    fn display_debug_lifetime() {
+        #[derive(Debug)]
+        struct S<'a> {
+            s: &'a str,
+        }
+        display_debug!(S<'a>);
+        let v = S { s: "testing" };
+        assert_eq!(format!("{}", v), format!("{:?}", v));
     }
 }

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -97,8 +97,4 @@ impl Role {
     }
 }
 
-impl ::std::fmt::Display for Role {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
+display_debug!(Role);

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod codec;
 mod datagram;
+pub mod display;
 mod incrdecoder;
 pub mod log;
 pub mod qlog;

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -21,7 +21,7 @@ use crate::secrets::SecretHolder;
 use crate::ssl::{self, PRBool};
 use crate::time::TimeHolder;
 
-use neqo_common::{hex_snip_middle, matches, qdebug, qinfo, qtrace, qwarn};
+use neqo_common::{display, hex_snip_middle, matches, qdebug, qinfo, qtrace, qwarn};
 use std::cell::RefCell;
 use std::convert::TryFrom;
 use std::ffi::CString;
@@ -677,11 +677,7 @@ impl Drop for SecretAgent {
     }
 }
 
-impl ::std::fmt::Display for SecretAgent {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Agent {:p}", self.fd)
-    }
-}
+display!(SecretAgent, "Agent {:p}", fd);
 
 /// A TLS Client.
 #[derive(Debug)]

--- a/neqo-crypto/src/agentio.rs
+++ b/neqo-crypto/src/agentio.rs
@@ -9,7 +9,7 @@ use crate::err::{nspr, Error, PR_SetError, Res};
 use crate::prio;
 use crate::ssl;
 
-use neqo_common::{hex, hex_with_len, qtrace};
+use neqo_common::{display, hex, hex_with_len, qtrace};
 use std::cmp::min;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -203,11 +203,7 @@ impl AgentIoInput {
     }
 }
 
-impl ::std::fmt::Display for AgentIoInput {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "AgentIoInput {:p}", self.input)
-    }
-}
+display!(AgentIoInput, "AgentIoInput {:p}", input);
 
 #[derive(Debug)]
 pub struct AgentIo {
@@ -253,11 +249,7 @@ impl AgentIo {
     }
 }
 
-impl ::std::fmt::Display for AgentIo {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "AgentIo")
-    }
-}
+display!(AgentIo);
 
 unsafe extern "C" fn agent_close(fd: PrFd) -> PrStatus {
     (*fd).secret = null_mut();

--- a/neqo-crypto/src/err.rs
+++ b/neqo-crypto/src/err.rs
@@ -6,9 +6,11 @@
 
 #![allow(dead_code)]
 
-use std::os::raw::c_char;
-
 use crate::ssl::{SECStatus, SECSuccess};
+
+use neqo_common::display_debug;
+
+use std::os::raw::c_char;
 
 include!(concat!(env!("OUT_DIR"), "/nspr_error.rs"));
 mod codes {
@@ -62,11 +64,7 @@ impl std::error::Error for Error {
     }
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "Error: {:?}", self)
-    }
-}
+display_debug!(Error, "Error");
 
 impl From<std::num::TryFromIntError> for Error {
     #[must_use]

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -13,7 +13,7 @@ use crate::hsettings_frame::{HSetting, HSettingType, HSettings};
 use crate::recv_message::RecvMessage;
 use crate::send_message::SendMessage;
 use crate::stream_type_reader::NewStreamTypeReader;
-use neqo_common::{matches, qdebug, qerror, qinfo, qtrace, qwarn};
+use neqo_common::{display, matches, qdebug, qerror, qinfo, qtrace, qwarn};
 use neqo_qpack::decoder::{QPackDecoder, QPACK_UNI_STREAM_TYPE_DECODER};
 use neqo_qpack::encoder::{QPackEncoder, QPACK_UNI_STREAM_TYPE_ENCODER};
 use neqo_qpack::QpackSettings;
@@ -72,11 +72,7 @@ pub(crate) struct Http3Connection {
     pub recv_streams: HashMap<u64, RecvMessage>,
 }
 
-impl ::std::fmt::Display for Http3Connection {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Http3 connection")
-    }
-}
+display!(Http3Connection);
 
 impl Http3Connection {
     /// Create a new connection.

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -13,8 +13,8 @@ use crate::recv_message::RecvMessage;
 use crate::send_message::{SendMessage, SendMessageEvents};
 use crate::Header;
 use neqo_common::{
-    hex, hex_with_len, matches, qdebug, qinfo, qlog::NeqoQlog, qtrace, Datagram, Decoder, Encoder,
-    Role,
+    display, hex, hex_with_len, matches, qdebug, qinfo, qlog::NeqoQlog, qtrace, Datagram, Decoder,
+    Encoder, Role,
 };
 use neqo_crypto::{agent::CertificateInfo, AuthenticationStatus, SecretAgentInfo};
 use neqo_qpack::QpackSettings;
@@ -52,11 +52,7 @@ pub struct Http3Client {
     push_handler: Rc<RefCell<PushController>>,
 }
 
-impl Display for Http3Client {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Http3 client")
-    }
-}
+display!(Http3Client);
 
 impl Http3Client {
     /// # Errors

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -10,7 +10,7 @@ use crate::recv_message::RecvMessage;
 use crate::send_message::SendMessage;
 use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents};
 use crate::{Error, Header, Res};
-use neqo_common::{matches, qdebug, qinfo, qtrace};
+use neqo_common::{display, matches, qdebug, qinfo, qtrace};
 use neqo_qpack::QpackSettings;
 use neqo_transport::{AppError, Connection, ConnectionEvent, StreamType};
 use std::time::Instant;
@@ -22,11 +22,7 @@ pub struct Http3ServerHandler {
     needs_processing: bool,
 }
 
-impl ::std::fmt::Display for Http3ServerHandler {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Http3 server connection")
-    }
-}
+display!(Http3ServerHandler);
 
 impl Http3ServerHandler {
     pub(crate) fn new(qpack_settings: QpackSettings) -> Self {

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -6,7 +6,7 @@
 
 use crate::hframe::HFrame;
 use crate::Res;
-use neqo_common::{qtrace, Encoder};
+use neqo_common::{display, qtrace, Encoder};
 use neqo_transport::{Connection, StreamType};
 
 pub const HTTP3_UNI_STREAM_TYPE_CONTROL: u64 = 0x0;
@@ -18,11 +18,7 @@ pub(crate) struct ControlStreamLocal {
     buf: Vec<u8>,
 }
 
-impl ::std::fmt::Display for ControlStreamLocal {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Local control stream {:?}", self.stream_id)
-    }
-}
+display!(ControlStreamLocal, "Local control {:?}", stream_id);
 
 impl ControlStreamLocal {
     /// Add a new frame that needs to be send.

--- a/neqo-http3/src/control_stream_remote.rs
+++ b/neqo-http3/src/control_stream_remote.rs
@@ -6,7 +6,7 @@
 
 use crate::hframe::{HFrame, HFrameReader};
 use crate::{Error, Res};
-use neqo_common::{qdebug, qinfo};
+use neqo_common::{display, qdebug, qinfo};
 use neqo_transport::Connection;
 
 /// The remote control stream is responsible only for reading frames. The frames are handled by `Http3Connection`.
@@ -17,11 +17,7 @@ pub(crate) struct ControlStreamRemote {
     fin: bool,
 }
 
-impl ::std::fmt::Display for ControlStreamRemote {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Http3 remote control stream {:?}", self.stream_id)
-    }
-}
+display!(ControlStreamRemote, "Remote control {:?}", stream_id);
 
 impl ControlStreamRemote {
     pub fn new() -> Self {

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -24,6 +24,7 @@ mod server_connection_events;
 mod server_events;
 mod stream_type_reader;
 
+use neqo_common::display_debug;
 use neqo_qpack::Error as QpackError;
 pub use neqo_transport::Output;
 use neqo_transport::{AppError, Error as TransportError};
@@ -148,8 +149,4 @@ impl ::std::error::Error for Error {
     }
 }
 
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "HTTP/3 error: {:?}", self)
-    }
-}
+display_debug!(Error, "HTTP/3 error");

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -5,26 +5,18 @@
 // except according to those terms.
 
 use crate::{Error, Res};
-use neqo_common::qtrace;
+use neqo_common::{display, qtrace};
 use std::fmt::Debug;
-use std::fmt::Display;
 
 #[derive(Debug)]
 pub(crate) struct PushController {}
 
+display!(PushController);
 impl PushController {
     pub fn new() -> Self {
         PushController {}
     }
-}
 
-impl Display for PushController {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Push controler")
-    }
-}
-
-impl PushController {
     #[allow(clippy::needless_pass_by_value)]
     pub fn new_push_promise(&self, push_id: u64, header_block: Vec<u8>) -> Res<()> {
         qtrace!(

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -7,7 +7,7 @@
 use crate::hframe::{HFrame, HFrameReader};
 use crate::push_controller::PushController;
 use crate::{Error, Header, Res};
-use neqo_common::{matches, qdebug, qinfo, qtrace};
+use neqo_common::{display, matches, qdebug, qinfo, qtrace};
 use neqo_qpack::decoder::QPackDecoder;
 use neqo_transport::Connection;
 use std::cell::RefCell;
@@ -57,11 +57,7 @@ pub(crate) struct RecvMessage {
     stream_id: u64,
 }
 
-impl ::std::fmt::Display for RecvMessage {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "RecvMessage stream_id:{}", self.stream_id)
-    }
-}
+display!(RecvMessage, "RecvMessage stream_id:{}", stream_id);
 
 impl RecvMessage {
     pub fn new(

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -7,7 +7,7 @@
 use crate::hframe::HFrame;
 use crate::Header;
 use crate::{Error, Res};
-use neqo_common::{matches, qdebug, qinfo, qtrace, Encoder};
+use neqo_common::{display, matches, qdebug, qinfo, qtrace, Encoder};
 use neqo_qpack::encoder::QPackEncoder;
 use neqo_transport::Connection;
 use std::cmp::min;
@@ -273,8 +273,4 @@ impl SendMessage {
     }
 }
 
-impl ::std::fmt::Display for SendMessage {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "SendMesage {}", self.stream_id)
-    }
-}
+display!(SendMessage, "SendMesage {}", stream_id);

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -11,7 +11,7 @@ use crate::connection_server::Http3ServerHandler;
 use crate::server_connection_events::Http3ServerConnEvent;
 use crate::server_events::{ClientRequestStream, Http3ServerEvent, Http3ServerEvents};
 use crate::Res;
-use neqo_common::{qtrace, Datagram};
+use neqo_common::{display, qtrace, Datagram};
 use neqo_crypto::AntiReplay;
 use neqo_qpack::QpackSettings;
 use neqo_transport::server::{ActiveConnectionRef, Server};
@@ -34,11 +34,7 @@ pub struct Http3Server {
     events: Http3ServerEvents,
 }
 
-impl ::std::fmt::Display for Http3Server {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Http3 server ")
-    }
-}
+display!(Http3Server);
 
 impl Http3Server {
     /// # Errors

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -9,9 +9,9 @@
 use crate::connection::Http3State;
 use crate::connection_server::Http3ServerHandler;
 use crate::{Header, Res};
-use neqo_common::{qdebug, qinfo};
+use neqo_common::{display, qdebug, qinfo};
 use neqo_transport::server::ActiveConnectionRef;
-use neqo_transport::{AppError, Connection};
+use neqo_transport::AppError;
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -24,16 +24,12 @@ pub struct ClientRequestStream {
     stream_id: u64,
 }
 
-impl ::std::fmt::Display for ClientRequestStream {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        let conn: &Connection = &self.conn.borrow();
-        write!(
-            f,
-            "Http3 server conn={:?} stream_id={}",
-            conn, self.stream_id
-        )
-    }
-}
+display!(
+    ClientRequestStream,
+    "ClientRequest conn={} stream_id={}",
+    conn,
+    stream_id
+);
 
 impl ClientRequestStream {
     pub(crate) fn new(

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -11,7 +11,7 @@ use crate::qpack_send_buf::QPData;
 use crate::reader::ReceiverConnWrapper;
 use crate::table::HeaderTable;
 use crate::{Error, Header, QpackSettings, Res};
-use neqo_common::qdebug;
+use neqo_common::{display, qdebug};
 use neqo_transport::Connection;
 use std::convert::TryInto;
 
@@ -231,11 +231,7 @@ impl QPackDecoder {
     }
 }
 
-impl ::std::fmt::Display for QPackDecoder {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "QPackDecoder {}", self.capacity())
-    }
-}
+display!(QPackDecoder, v, "QPackDecoder {}", v.capacity());
 
 fn map_error(err: &Error) -> Error {
     if *err == Error::ClosedCriticalStream {

--- a/neqo-qpack/src/decoder_instructions.rs
+++ b/neqo-qpack/src/decoder_instructions.rs
@@ -10,7 +10,7 @@ use crate::prefix::{
 use crate::qpack_send_buf::QPData;
 use crate::reader::{IntReader, ReadByte};
 use crate::Res;
-use neqo_common::{qdebug, qtrace};
+use neqo_common::{display, qdebug, qtrace};
 use std::mem;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -62,11 +62,7 @@ pub struct DecoderInstructionReader {
     instruction: DecoderInstruction,
 }
 
-impl ::std::fmt::Display for DecoderInstructionReader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "InstructionReader")
-    }
-}
+display!(DecoderInstructionReader);
 
 impl DecoderInstructionReader {
     pub fn new() -> Self {

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -13,7 +13,7 @@ use crate::reader::ReceiverConnWrapper;
 use crate::table::{HeaderTable, LookupResult, ADDITIONAL_TABLE_ENTRY_SIZE};
 use crate::Header;
 use crate::{Error, QpackSettings, Res};
-use neqo_common::{qdebug, qlog::NeqoQlog, qtrace};
+use neqo_common::{display, qdebug, qlog::NeqoQlog, qtrace};
 use neqo_transport::Connection;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryFrom;
@@ -428,11 +428,7 @@ impl QPackEncoder {
     }
 }
 
-impl ::std::fmt::Display for QPackEncoder {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "QPackEncoder")
-    }
-}
+display!(QPackEncoder);
 
 fn map_error(err: &Error) -> Error {
     if *err == Error::ClosedCriticalStream {

--- a/neqo-qpack/src/encoder_instructions.rs
+++ b/neqo-qpack/src/encoder_instructions.rs
@@ -11,7 +11,7 @@ use crate::prefix::{
 use crate::qpack_send_buf::QPData;
 use crate::reader::{IntReader, LiteralReader, ReadByte, Reader};
 use crate::Res;
-use neqo_common::{matches, qdebug, qtrace};
+use neqo_common::{display, matches, qdebug, qtrace};
 use std::mem;
 
 // The encoder only uses InsertWithNameLiteral, therefore clippy is complaining about dead_code.
@@ -107,15 +107,12 @@ pub struct EncoderInstructionReader {
     instruction: DecodedEncoderInstruction,
 }
 
-impl ::std::fmt::Display for EncoderInstructionReader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(
-            f,
-            "EncoderInstructionReader state={:?} instruction:{:?}",
-            self.state, self.instruction
-        )
-    }
-}
+display!(
+    EncoderInstructionReader,
+    "EncoderInstructionReader {:?} {:?}",
+    state,
+    instruction
+);
 
 impl EncoderInstructionReader {
     pub fn new() -> Self {

--- a/neqo-qpack/src/header_block.rs
+++ b/neqo-qpack/src/header_block.rs
@@ -15,7 +15,7 @@ use crate::reader::{to_string, ReceiverBufferWrapper};
 use crate::table::HeaderTable;
 use crate::Header;
 use crate::{Error, Res};
-use neqo_common::qtrace;
+use neqo_common::{display, qtrace};
 use std::ops::{Deref, Div};
 
 #[derive(Default, Debug, PartialEq)]
@@ -27,11 +27,7 @@ pub struct HeaderEncoder {
     max_dynamic_index_ref: Option<u64>,
 }
 
-impl ::std::fmt::Display for HeaderEncoder {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "HeaderEncoder")
-    }
-}
+display!(HeaderEncoder);
 
 impl HeaderEncoder {
     pub fn new(base: u64, use_huffman: bool, max_entries: u64) -> Self {
@@ -198,11 +194,7 @@ pub(crate) struct HeaderDecoder<'a> {
     req_insert_cnt: u64,
 }
 
-impl<'a> ::std::fmt::Display for HeaderDecoder<'a> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "HeaderDecoder")
-    }
-}
+display!(HeaderDecoder<'a>);
 
 #[derive(Debug, PartialEq)]
 pub enum HeaderDecoderResult {

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -26,6 +26,8 @@ pub mod reader;
 mod static_table;
 mod table;
 
+use neqo_common::display_debug;
+
 pub type Header = (String, String);
 type Res<T> = Result<T, Error>;
 
@@ -84,11 +86,7 @@ impl ::std::error::Error for Error {
     }
 }
 
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "QPACK error: {:?}", self)
-    }
-}
+display_debug!(Error, "QPACK error");
 
 impl From<neqo_transport::Error> for Error {
     fn from(err: neqo_transport::Error) -> Self {

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -6,7 +6,7 @@
 
 use crate::static_table::{StaticTableEntry, HEADER_STATIC_TABLE};
 use crate::{Error, Res};
-use neqo_common::qtrace;
+use neqo_common::{display, qtrace};
 use std::collections::VecDeque;
 use std::convert::TryFrom;
 
@@ -74,15 +74,13 @@ pub(crate) struct HeaderTable {
     acked_inserts_cnt: u64,
 }
 
-impl ::std::fmt::Display for HeaderTable {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(
-            f,
-            "HeaderTable for (base={} acked_inserts_cnt={} capacity={})",
-            self.base, self.acked_inserts_cnt, self.capacity
-        )
-    }
-}
+display!(
+    HeaderTable,
+    "HeaderTable base={} acked_inserts_cnt={} capacity={}",
+    base,
+    acked_inserts_cnt,
+    capacity
+);
 
 impl HeaderTable {
     pub fn new(encoder: bool) -> Self {

--- a/neqo-transport/src/cc.rs
+++ b/neqo-transport/src/cc.rs
@@ -7,13 +7,12 @@
 // Congestion control
 
 use std::cmp::max;
-use std::fmt::{self, Display};
 use std::time::{Duration, Instant};
 
 use crate::pace::Pacer;
 use crate::path::PATH_MTU_V6;
 use crate::tracking::SentPacket;
-use neqo_common::{const_max, const_min, qdebug, qinfo, qtrace};
+use neqo_common::{const_max, const_min, display, qdebug, qinfo, qtrace};
 
 pub const MAX_DATAGRAM_SIZE: usize = PATH_MTU_V6;
 pub const INITIAL_CWND_PKTS: usize = 10;
@@ -47,19 +46,18 @@ impl Default for CongestionControl {
     }
 }
 
-impl Display for CongestionControl {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "CongCtrl {}/{} ssthresh {}",
-            self.bytes_in_flight, self.congestion_window, self.ssthresh,
-        )?;
-        if let Some(p) = &self.pacer {
-            write!(f, " {}", p)?;
-        }
-        Ok(())
-    }
-}
+display!(
+    CongestionControl,
+    v,
+    "CongCtrl {}/{} ssthresh {}{}",
+    v.bytes_in_flight,
+    v.congestion_window,
+    v.ssthresh,
+    v.pacer
+        .as_ref()
+        .map(|p| format!(" {}", p))
+        .unwrap_or_else(|| String::from("")),
+);
 
 impl CongestionControl {
     #[cfg(test)]

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -6,7 +6,7 @@
 
 // Encoding and decoding packets off the wire.
 
-use neqo_common::{hex, hex_with_len, matches, Decoder};
+use neqo_common::{display, hex, hex_with_len, matches, Decoder};
 use neqo_crypto::random;
 
 use std::borrow::Borrow;
@@ -75,15 +75,11 @@ impl std::ops::Deref for ConnectionId {
     }
 }
 
+display!(ConnectionId, v, "{}", hex(&v.cid));
+
 impl ::std::fmt::Debug for ConnectionId {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "CID {}", hex_with_len(&self.cid))
-    }
-}
-
-impl ::std::fmt::Display for ConnectionId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}", hex(&self.cid))
     }
 }
 
@@ -104,11 +100,7 @@ impl<'a> ::std::fmt::Debug for ConnectionIdRef<'a> {
     }
 }
 
-impl<'a> ::std::fmt::Display for ConnectionIdRef<'a> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}", hex_with_len(&self.cid))
-    }
-}
+display!(ConnectionIdRef<'a>, v, "{}", hex(&v.cid));
 
 impl<'a> From<&'a [u8]> for ConnectionIdRef<'a> {
     fn from(cid: &'a [u8]) -> Self {

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -19,8 +19,8 @@ use std::time::{Duration, Instant};
 use smallvec::SmallVec;
 
 use neqo_common::{
-    hex, hex_snip_middle, matches, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn, Datagram,
-    Decoder, Encoder, Role,
+    display, hex, hex_snip_middle, matches, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn,
+    Datagram, Decoder, Encoder, Role,
 };
 use neqo_crypto::agent::CertificateInfo;
 use neqo_crypto::{
@@ -2485,11 +2485,7 @@ impl Connection {
     }
 }
 
-impl ::std::fmt::Display for Connection {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{:?} {:p}", self.role, self as *const Self)
-    }
-}
+display!(Connection, v, "{:?} {:p}", v.role, v as *const Self);
 
 #[cfg(test)]
 mod tests {

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -11,7 +11,7 @@ use std::ops::{Index, IndexMut, Range};
 use std::rc::Rc;
 use std::time::Instant;
 
-use neqo_common::{hex, matches, qdebug, qerror, qinfo, qtrace, Role};
+use neqo_common::{display, hex, matches, qdebug, qerror, qinfo, qtrace, Role};
 use neqo_crypto::aead::Aead;
 use neqo_crypto::hp::HpKey;
 use neqo_crypto::{
@@ -229,11 +229,7 @@ impl Crypto {
     }
 }
 
-impl ::std::fmt::Display for Crypto {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Crypto")
-    }
-}
+display!(Crypto);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CryptoDxDirection {
@@ -473,11 +469,7 @@ impl CryptoDxState {
     }
 }
 
-impl std::fmt::Display for CryptoDxState {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "epoch {} {:?}", self.epoch, self.direction)
-    }
-}
+display!(CryptoDxState, "epoch {} {:?}", epoch, direction);
 
 #[derive(Debug)]
 pub struct CryptoState {
@@ -859,11 +851,7 @@ impl CryptoStates {
     }
 }
 
-impl std::fmt::Display for CryptoStates {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "CryptoStates")
-    }
-}
+display!(CryptoStates);
 
 #[derive(Debug, Default)]
 pub struct CryptoStream {

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -38,6 +38,8 @@ pub use self::frame::StreamType;
 pub use self::packet::QuicVersion;
 pub use self::stream_id::StreamId;
 
+use neqo_common::display_debug;
+
 const LOCAL_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30); // 30 second
 
 type TransportError = u64;
@@ -146,11 +148,7 @@ impl ::std::error::Error for Error {
     }
 }
 
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Transport error: {:?}", self)
-    }
-}
+display_debug!(Error, "Transport error");
 
 pub type AppError = u64;
 

--- a/neqo-transport/src/pace.rs
+++ b/neqo-transport/src/pace.rs
@@ -7,11 +7,11 @@
 // Pacer
 #![deny(clippy::pedantic)]
 
-use neqo_common::qtrace;
+use neqo_common::{display, qtrace};
 
 use std::cmp::min;
 use std::convert::TryFrom;
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::time::{Duration, Instant};
 
 /// This value determines how much faster the pacer operates than the
@@ -103,11 +103,7 @@ impl Pacer {
     }
 }
 
-impl Display for Pacer {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "Pacer {}/{}", self.c, self.p)
-    }
-}
+display!(Pacer, "Pacer {}/{}", c, p);
 
 impl Debug for Pacer {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 
 use smallvec::{smallvec, SmallVec};
 
-use neqo_common::{qdebug, qinfo, qtrace, qwarn};
+use neqo_common::{display, qdebug, qinfo, qtrace, qwarn};
 
 use crate::cc::CongestionControl;
 use crate::crypto::CryptoRecoveryToken;
@@ -774,11 +774,7 @@ impl LossRecovery {
     }
 }
 
-impl ::std::fmt::Display for LossRecovery {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "LossRecovery")
-    }
-}
+display!(LossRecovery);
 
 #[cfg(test)]
 mod tests {

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -7,7 +7,7 @@
 // This file implements a server that can handle multiple connections.
 
 use neqo_common::{
-    self as common, hex, matches, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn,
+    self as common, display, hex, matches, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn,
     timer::Timer, Datagram, Decoder, Encoder, Role,
 };
 use neqo_crypto::{
@@ -67,6 +67,8 @@ impl DerefMut for ServerConnectionState {
         &mut self.c
     }
 }
+
+display!(ServerConnectionState, "{}", c);
 
 enum RetryTokenResult {
     Pass,
@@ -645,6 +647,8 @@ impl PartialEq for ActiveConnectionRef {
 
 impl Eq for ActiveConnectionRef {}
 
+display!(ActiveConnectionRef, "{:?}", c);
+
 struct ServerConnectionIdManager {
     c: Option<StateRef>,
     connections: ConnectionTableRef,
@@ -697,8 +701,4 @@ impl ConnectionIdManager for ServerConnectionIdManager {
     }
 }
 
-impl ::std::fmt::Display for Server {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Server")
-    }
-}
+display!(Server);

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -12,7 +12,7 @@ use std::collections::VecDeque;
 use std::convert::TryInto;
 use std::time::{Duration, Instant};
 
-use neqo_common::{qdebug, qinfo, qtrace, qwarn};
+use neqo_common::{display, qdebug, qinfo, qtrace, qwarn};
 use neqo_crypto::{Epoch, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL};
 
 use crate::frame::{AckRange, Frame};
@@ -38,6 +38,14 @@ impl PNSpace {
             PNSpace::ApplicationData,
         ];
         SPACES.iter()
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Initial => "in",
+            Self::Handshake => "hs",
+            Self::ApplicationData => "ap",
+        }
     }
 }
 
@@ -151,15 +159,7 @@ impl SentPacket {
     }
 }
 
-impl std::fmt::Display for PNSpace {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(match self {
-            Self::Initial => "in",
-            Self::Handshake => "hs",
-            Self::ApplicationData => "ap",
-        })
-    }
-}
+display!(PNSpace, v, "{}", v.as_str());
 
 #[derive(Clone, Debug, Default)]
 pub struct PacketRange {
@@ -233,11 +233,7 @@ impl PacketRange {
     }
 }
 
-impl ::std::fmt::Display for PacketRange {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{}->{}", self.largest, self.smallest)
-    }
-}
+display!(PacketRange, "{}->{}", largest, smallest);
 
 /// The ACK delay we use.
 pub const ACK_DELAY: Duration = Duration::from_millis(20); // 20ms
@@ -465,11 +461,7 @@ impl RecvdPackets {
     }
 }
 
-impl ::std::fmt::Display for RecvdPackets {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Recvd-{}", self.space)
-    }
-}
+display!(RecvdPackets, "Recvd-{}", space);
 
 #[derive(Debug)]
 pub struct AckTracker {


### PR DESCRIPTION
I started to use the code in #672 (which was great), but found that it needed a few tweaks to get into shape.  This is the conversion and the tweaks:

1. The type now accepts lifetime and type parameters.

2. More complex expressions are possible, not just member references.

3. I added a macro to forward to a `Debug` implementation, which we were using for `Error` implementations.

Closes #672 because it includes that code.