### PR TITLE
Use a reference-counted store of recovery tokens

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1535,7 +1535,7 @@ impl Connection {
             let sent = SentPacket::new(
                 now,
                 ack_eliciting,
-                tokens,
+                Rc::new(tokens),
                 encoder.len() - header_start,
                 in_flight,
             );
@@ -1990,7 +1990,7 @@ impl Connection {
     /// to retransmit the frame as needed.
     fn handle_lost_packets(&mut self, lost_packets: &[SentPacket]) {
         for lost in lost_packets {
-            for token in &lost.tokens {
+            for token in lost.tokens.as_ref() {
                 qdebug!([self], "Lost: {:?}", token);
                 match token {
                     RecoveryToken::Ack(_) => {}
@@ -2036,10 +2036,10 @@ impl Connection {
             now,
         );
         for acked in acked_packets {
-            for token in acked.tokens {
+            for token in acked.tokens.as_ref() {
                 match token {
-                    RecoveryToken::Ack(at) => self.acks.acked(&at),
-                    RecoveryToken::Stream(st) => self.send_streams.acked(&st),
+                    RecoveryToken::Ack(at) => self.acks.acked(at),
+                    RecoveryToken::Stream(st) => self.send_streams.acked(st),
                     RecoveryToken::Crypto(ct) => self.crypto.acked(ct),
                     RecoveryToken::Flow(ft) => {
                         self.flow_mgr.borrow_mut().acked(ft, &mut self.send_streams)

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -201,7 +201,7 @@ impl Crypto {
         Ok(())
     }
 
-    pub fn acked(&mut self, token: CryptoRecoveryToken) {
+    pub fn acked(&mut self, token: &CryptoRecoveryToken) {
         qinfo!(
             "Acked crypto frame space={} offset={} length={}",
             token.space,
@@ -933,7 +933,7 @@ impl CryptoStreams {
         self.get_mut(space).unwrap().rx.read_to_end(buf)
     }
 
-    pub fn acked(&mut self, token: CryptoRecoveryToken) {
+    pub fn acked(&mut self, token: &CryptoRecoveryToken) {
         self.get_mut(token.space)
             .unwrap()
             .tx

--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -176,41 +176,27 @@ impl FlowMgr {
 
     pub(crate) fn acked(
         &mut self,
-        token: FlowControlRecoveryToken,
+        token: &FlowControlRecoveryToken,
         send_streams: &mut SendStreams,
     ) {
-        if let Frame::ResetStream {
-            stream_id,
-            application_error_code,
-            final_size,
-        } = token
-        {
-            qinfo!(
-                "Reset received stream={} err={} final_size={}",
-                stream_id.as_u64(),
-                application_error_code,
-                final_size
-            );
+        const RESET_STREAM: &Frame = &Frame::ResetStream {
+            stream_id: StreamId::new(0),
+            application_error_code: 0,
+            final_size: 0,
+        };
+
+        if let Frame::ResetStream { stream_id, .. } = token {
+            qinfo!("Reset received stream={}", stream_id.as_u64());
 
             if self
                 .from_streams
-                .remove(&(
-                    stream_id,
-                    mem::discriminant(&Frame::ResetStream {
-                        stream_id,
-                        application_error_code,
-                        final_size,
-                    }),
-                ))
+                .remove(&(*stream_id, mem::discriminant(RESET_STREAM)))
                 .is_some()
             {
-                qinfo!(
-                    "Queued ResetStream for {} removed because previous ResetStream was acked",
-                    stream_id.as_u64()
-                );
+                qinfo!("Removed RESET_STREAM frame for {}", stream_id.as_u64());
             }
 
-            send_streams.reset_acked(stream_id);
+            send_streams.reset_acked(*stream_id);
         }
     }
 

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -784,6 +784,7 @@ impl ::std::fmt::Display for LossRecovery {
 mod tests {
     use super::{LossRecovery, LossRecoverySpace, PNSpace, SentPacket};
     use std::convert::TryInto;
+    use std::rc::Rc;
     use std::time::{Duration, Instant};
     use test_fixture::now;
 
@@ -862,7 +863,7 @@ mod tests {
             lr.on_packet_sent(
                 PNSpace::ApplicationData,
                 pn,
-                SentPacket::new(pn_time(pn), true, Vec::new(), ON_SENT_SIZE, true),
+                SentPacket::new(pn_time(pn), true, Rc::default(), ON_SENT_SIZE, true),
             );
         }
     }
@@ -983,7 +984,7 @@ mod tests {
         lr.on_packet_sent(
             PNSpace::ApplicationData,
             0,
-            SentPacket::new(pn_time(0), true, Vec::new(), ON_SENT_SIZE, true),
+            SentPacket::new(pn_time(0), true, Rc::default(), ON_SENT_SIZE, true),
         );
         lr.on_packet_sent(
             PNSpace::ApplicationData,
@@ -991,7 +992,7 @@ mod tests {
             SentPacket::new(
                 pn_time(0) + INITIAL_RTT / 4,
                 true,
-                Vec::new(),
+                Rc::default(),
                 ON_SENT_SIZE,
                 true,
             ),
@@ -1093,21 +1094,21 @@ mod tests {
         lr.on_packet_sent(
             PNSpace::Initial,
             0,
-            SentPacket::new(pn_time(0), true, Vec::new(), ON_SENT_SIZE, true),
+            SentPacket::new(pn_time(0), true, Rc::default(), ON_SENT_SIZE, true),
         );
         lr.on_packet_sent(
             PNSpace::Handshake,
             0,
-            SentPacket::new(pn_time(1), true, Vec::new(), ON_SENT_SIZE, true),
+            SentPacket::new(pn_time(1), true, Rc::default(), ON_SENT_SIZE, true),
         );
         lr.on_packet_sent(
             PNSpace::ApplicationData,
             0,
-            SentPacket::new(pn_time(2), true, Vec::new(), ON_SENT_SIZE, true),
+            SentPacket::new(pn_time(2), true, Rc::default(), ON_SENT_SIZE, true),
         );
 
         // Now put all spaces on the LR timer so we can see them.
-        let pkt = SentPacket::new(pn_time(3), true, vec![], ON_SENT_SIZE, true);
+        let pkt = SentPacket::new(pn_time(3), true, Rc::default(), ON_SENT_SIZE, true);
         for sp in PNSpace::iter() {
             lr.on_packet_sent(*sp, 1, pkt.clone());
             lr.on_ack_received(*sp, 1, vec![(1, 1)], Duration::from_secs(0), pn_time(3));
@@ -1127,10 +1128,10 @@ mod tests {
 
         // There are cases where we send a packet that is not subsequently tracked.
         // So check that this works.
-        lr.on_packet_sent(
+        lr.on_packet_sent( 
             PNSpace::Initial,
             0,
-            SentPacket::new(pn_time(3), true, Vec::new(), ON_SENT_SIZE, true),
+            SentPacket::new(pn_time(3), true, Rc::default(), ON_SENT_SIZE, true),
         );
         assert_sent_times(&lr, None, None, Some(pn_time(2)));
     }

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -1128,7 +1128,7 @@ mod tests {
 
         // There are cases where we send a packet that is not subsequently tracked.
         // So check that this works.
-        lr.on_packet_sent( 
+        lr.on_packet_sent(
             PNSpace::Initial,
             0,
             SentPacket::new(pn_time(3), true, Rc::default(), ON_SENT_SIZE, true),

--- a/neqo-transport/src/stream_id.rs
+++ b/neqo-transport/src/stream_id.rs
@@ -43,6 +43,10 @@ impl StreamIndexes {
 pub struct StreamId(u64);
 
 impl StreamId {
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+
     pub fn is_bidi(self) -> bool {
         self.0 & 0x02 == 0
     }
@@ -102,7 +106,7 @@ impl StreamId {
 
 impl From<u64> for StreamId {
     fn from(val: u64) -> Self {
-        Self(val)
+        Self::new(val)
     }
 }
 

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -10,8 +10,8 @@
 
 use std::collections::VecDeque;
 use std::convert::TryInto;
-use std::time::{Duration, Instant};
 use std::rc::Rc;
+use std::time::{Duration, Instant};
 
 use neqo_common::{qdebug, qinfo, qtrace, qwarn};
 use neqo_crypto::{Epoch, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL};

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -11,6 +11,7 @@
 use std::collections::VecDeque;
 use std::convert::TryInto;
 use std::time::{Duration, Instant};
+use std::rc::Rc;
 
 use neqo_common::{qdebug, qinfo, qtrace, qwarn};
 use neqo_crypto::{Epoch, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL};
@@ -66,7 +67,7 @@ impl From<PacketType> for PNSpace {
 pub struct SentPacket {
     ack_eliciting: bool,
     pub time_sent: Instant,
-    pub tokens: Vec<RecoveryToken>,
+    pub tokens: Rc<Vec<RecoveryToken>>,
 
     time_declared_lost: Option<Instant>,
     /// After a PTO, the packet has been released.
@@ -80,7 +81,7 @@ impl SentPacket {
     pub fn new(
         time_sent: Instant,
         ack_eliciting: bool,
-        tokens: Vec<RecoveryToken>,
+        tokens: Rc<Vec<RecoveryToken>>,
         size: usize,
         in_flight: bool,
     ) -> Self {


### PR DESCRIPTION
We clone these enough times to make sharing the memory worth the
overhead of the reference count.

Closes #622.