### PR TITLE
Remove reference cycle in server

### DIFF
--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -474,12 +474,11 @@ impl Server {
             saved_cids: Vec::new(),
         }));
 
-        let cid_mgr_dyn = Rc::clone(&cid_mgr); // Temporary for tricking type coercion.
         let sconn = Connection::new_server(
             &self.certs,
             &self.protocols,
             &self.anti_replay,
-            cid_mgr_dyn,
+            Rc::clone(&cid_mgr) as _,
             initial.quic_version,
         );
 


### PR DESCRIPTION
This uses `Weak` rather than `Rc` because the loop was holding
connections open.

In other news, Rust doesn't fix memory leaks arising from thoughtless
use of Rc.

Closes #523.