### PR TITLE
Fix issue with packet containing MAX_STREAM_DATA being lost

### DIFF
--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -277,11 +277,9 @@ impl FlowMgr {
                 stream_id,
                 application_error_code,
             } => self.stop_sending(stream_id, application_error_code),
-            // Resend MaxStreamData if not SizeKnown
-            // (maybe_send_flowc_update() checks this.)
             Frame::MaxStreamData { stream_id, .. } => {
                 if let Some(rs) = recv_streams.get_mut(&stream_id) {
-                    rs.maybe_send_flowc_update()
+                    rs.flowc_lost()
                 }
             }
             Frame::PathResponse { .. } => qinfo!("Path Response lost, not re-sent"),


### PR DESCRIPTION
If a packet is lost, always requeue the flow control update for sending.

fixes #720