### PR TITLE
Revert "use std::matches"

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -9,7 +9,7 @@
 
 use qlog::QlogStreamer;
 
-use neqo_common::{self as common, hex, qlog::NeqoQlog, Datagram, Role};
+use neqo_common::{self as common, hex, matches, qlog::NeqoQlog, Datagram, Role};
 use neqo_crypto::{init, AuthenticationStatus, Cipher, TLS_CHACHA20_POLY1305_SHA256};
 use neqo_http3::{self, Header, Http3Client, Http3ClientEvent, Http3State, Output};
 use neqo_qpack::QpackSettings;
@@ -603,7 +603,7 @@ mod old {
 
     use super::{qlog_new, Res};
 
-    use neqo_common::Datagram;
+    use neqo_common::{matches, Datagram};
     use neqo_crypto::{AuthenticationStatus, Cipher};
     use neqo_transport::{
         Connection, ConnectionEvent, Error, FixedConnectionIdManager, Output, QuicVersion, State,

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -21,6 +21,17 @@ pub use self::incrdecoder::{IncrementalDecoder, IncrementalDecoderResult};
 #[macro_use]
 extern crate lazy_static;
 
+// Cribbed from the |matches| crate, for simplicity.
+#[macro_export]
+macro_rules! matches {
+    ($expression:expr, $($pattern:tt)+) => {
+        match $expression {
+            $($pattern)+ => true,
+            _ => false
+        }
+    }
+}
+
 #[must_use]
 pub fn hex(buf: &[u8]) -> String {
     let mut ret = String::with_capacity(buf.len() * 2);

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -21,7 +21,7 @@ use crate::secrets::SecretHolder;
 use crate::ssl::{self, PRBool};
 use crate::time::TimeHolder;
 
-use neqo_common::{hex_snip_middle, qdebug, qinfo, qtrace, qwarn};
+use neqo_common::{hex_snip_middle, matches, qdebug, qinfo, qtrace, qwarn};
 use std::cell::RefCell;
 use std::convert::TryFrom;
 use std::ffi::CString;

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -10,6 +10,7 @@ use crate::connection::Http3State;
 use crate::recv_message::RecvMessageEvents;
 use crate::send_message::SendMessageEvents;
 use crate::Header;
+use neqo_common::matches;
 use neqo_transport::{AppError, StreamType};
 
 use std::cell::RefCell;

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -13,7 +13,7 @@ use crate::hsettings_frame::{HSetting, HSettingType, HSettings};
 use crate::recv_message::RecvMessage;
 use crate::send_message::SendMessage;
 use crate::stream_type_reader::NewStreamTypeReader;
-use neqo_common::{qdebug, qerror, qinfo, qtrace, qwarn};
+use neqo_common::{matches, qdebug, qerror, qinfo, qtrace, qwarn};
 use neqo_qpack::decoder::{QPackDecoder, QPACK_UNI_STREAM_TYPE_DECODER};
 use neqo_qpack::encoder::{QPackEncoder, QPACK_UNI_STREAM_TYPE_ENCODER};
 use neqo_qpack::QpackSettings;

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -13,7 +13,8 @@ use crate::recv_message::RecvMessage;
 use crate::send_message::{SendMessage, SendMessageEvents};
 use crate::Header;
 use neqo_common::{
-    hex, hex_with_len, qdebug, qinfo, qlog::NeqoQlog, qtrace, Datagram, Decoder, Encoder, Role,
+    hex, hex_with_len, matches, qdebug, qinfo, qlog::NeqoQlog, qtrace, Datagram, Decoder, Encoder,
+    Role,
 };
 use neqo_crypto::{agent::CertificateInfo, AuthenticationStatus, SecretAgentInfo};
 use neqo_qpack::QpackSettings;
@@ -599,7 +600,7 @@ mod tests {
     };
     use crate::hframe::HFrame;
     use crate::hsettings_frame::{HSetting, HSettingType};
-    use neqo_common::Encoder;
+    use neqo_common::{matches, Encoder};
     use neqo_crypto::AntiReplay;
     use neqo_qpack::encoder::QPackEncoder;
     use neqo_transport::{

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -10,7 +10,7 @@ use crate::recv_message::RecvMessage;
 use crate::send_message::SendMessage;
 use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents};
 use crate::{Error, Header, Res};
-use neqo_common::{qdebug, qinfo, qtrace};
+use neqo_common::{matches, qdebug, qinfo, qtrace};
 use neqo_qpack::QpackSettings;
 use neqo_transport::{AppError, Connection, ConnectionEvent, StreamType};
 use std::time::Instant;

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -7,7 +7,7 @@
 use crate::hframe::{HFrame, HFrameReader};
 use crate::push_controller::PushController;
 use crate::{Error, Header, Res};
-use neqo_common::{qdebug, qinfo, qtrace};
+use neqo_common::{matches, qdebug, qinfo, qtrace};
 use neqo_qpack::decoder::QPackDecoder;
 use neqo_transport::Connection;
 use std::cell::RefCell;

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -7,7 +7,7 @@
 use crate::hframe::HFrame;
 use crate::Header;
 use crate::{Error, Res};
-use neqo_common::{qdebug, qinfo, qtrace, Encoder};
+use neqo_common::{matches, qdebug, qinfo, qtrace, Encoder};
 use neqo_qpack::encoder::QPackEncoder;
 use neqo_transport::Connection;
 use std::cmp::min;

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -210,6 +210,7 @@ fn prepare_data(
 mod tests {
     use super::{Http3Server, Http3ServerEvent, Http3State, Rc, RefCell};
     use crate::{Error, Header};
+    use neqo_common::matches;
     use neqo_crypto::AuthenticationStatus;
     use neqo_qpack::encoder::QPackEncoder;
     use neqo_qpack::QpackSettings;

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -8,6 +8,7 @@ use crate::connection::Http3State;
 use crate::recv_message::RecvMessageEvents;
 use crate::send_message::SendMessageEvents;
 use crate::Header;
+use neqo_common::matches;
 
 use std::cell::RefCell;
 use std::collections::VecDeque;

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused_assignments)]
 
-use neqo_common::Datagram;
+use neqo_common::{matches, Datagram};
 use neqo_crypto::AuthenticationStatus;
 use neqo_http3::{Http3Client, Http3ClientEvent, Http3Server, Http3ServerEvent, Http3State};
 use test_fixture::*;

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::use_self)]
 
-use neqo_common::{hex, Datagram};
+use neqo_common::{hex, matches, Datagram};
 use neqo_crypto::{init, AuthenticationStatus};
 use neqo_http3::{Header, Http3Client, Http3ClientEvent, Http3State};
 use neqo_qpack::QpackSettings;

--- a/neqo-qpack/src/encoder_instructions.rs
+++ b/neqo-qpack/src/encoder_instructions.rs
@@ -11,7 +11,7 @@ use crate::prefix::{
 use crate::qpack_send_buf::QPData;
 use crate::reader::{IntReader, LiteralReader, ReadByte, Reader};
 use crate::Res;
-use neqo_common::{qdebug, qtrace};
+use neqo_common::{matches, qdebug, qtrace};
 use std::mem;
 
 // The encoder only uses InsertWithNameLiteral, therefore clippy is complaining about dead_code.

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -6,7 +6,7 @@
 
 // Encoding and decoding packets off the wire.
 
-use neqo_common::{hex, hex_with_len, Decoder};
+use neqo_common::{hex, hex_with_len, matches, Decoder};
 use neqo_crypto::random;
 
 use std::borrow::Borrow;
@@ -142,6 +142,7 @@ pub trait ConnectionIdManager: ConnectionIdDecoder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use neqo_common::matches;
     use test_fixture::fixture_init;
 
     #[test]

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -19,8 +19,8 @@ use std::time::{Duration, Instant};
 use smallvec::SmallVec;
 
 use neqo_common::{
-    hex, hex_snip_middle, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn, Datagram, Decoder,
-    Encoder, Role,
+    hex, hex_snip_middle, matches, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn, Datagram,
+    Decoder, Encoder, Role,
 };
 use neqo_crypto::agent::CertificateInfo;
 use neqo_crypto::{
@@ -2501,6 +2501,7 @@ mod tests {
     use crate::tracking::{ACK_DELAY, MAX_UNACKED_PKTS};
     use std::convert::TryInto;
 
+    use neqo_common::matches;
     use std::mem;
     use test_fixture::{self, assertions, fixture_init, loopback, now};
 

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -11,7 +11,7 @@ use std::ops::{Index, IndexMut, Range};
 use std::rc::Rc;
 use std::time::Instant;
 
-use neqo_common::{hex, qdebug, qerror, qinfo, qtrace, Role};
+use neqo_common::{hex, matches, qdebug, qerror, qinfo, qtrace, Role};
 use neqo_crypto::aead::Aead;
 use neqo_crypto::hp::HpKey;
 use neqo_crypto::{

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -10,6 +10,8 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
+use neqo_common::matches;
+
 use crate::connection::State;
 use crate::frame::StreamType;
 use crate::stream_id::StreamId;

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -6,7 +6,7 @@
 
 // Directly relating to QUIC frames.
 
-use neqo_common::{qdebug, qtrace, Decoder, Encoder};
+use neqo_common::{matches, qdebug, qtrace, Decoder, Encoder};
 
 use crate::cid::MAX_CONNECTION_ID_LEN;
 use crate::packet::PacketType;

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -21,7 +21,7 @@ use crate::events::ConnectionEvents;
 use crate::flow_mgr::FlowMgr;
 use crate::stream_id::StreamId;
 use crate::{AppError, Error, Res};
-use neqo_common::qtrace;
+use neqo_common::{matches, qtrace};
 
 pub const RX_STREAM_DATA_WINDOW: u64 = 0xFFFF; // 64 KiB
 
@@ -550,6 +550,7 @@ impl RecvStream {
 mod tests {
     use super::*;
     use crate::frame::Frame;
+    use neqo_common::matches;
 
     #[test]
     fn test_stream_rx() {

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -15,7 +15,7 @@ use std::rc::Rc;
 
 use smallvec::SmallVec;
 
-use neqo_common::{qdebug, qerror, qinfo, qtrace};
+use neqo_common::{matches, qdebug, qerror, qinfo, qtrace};
 
 use crate::events::ConnectionEvents;
 use crate::flow_mgr::FlowMgr;
@@ -836,6 +836,8 @@ pub struct StreamRecoveryToken {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use neqo_common::matches;
 
     use crate::events::ConnectionEvent;
 

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -7,8 +7,8 @@
 // This file implements a server that can handle multiple connections.
 
 use neqo_common::{
-    self as common, hex, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn, timer::Timer,
-    Datagram, Decoder, Encoder, Role,
+    self as common, hex, matches, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn,
+    timer::Timer, Datagram, Decoder, Encoder, Role,
 };
 use neqo_crypto::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -8,7 +8,7 @@
 
 #![allow(dead_code)]
 use crate::{Error, Res};
-use neqo_common::{hex, qdebug, qinfo, qtrace, Decoder, Encoder};
+use neqo_common::{hex, matches, qdebug, qinfo, qtrace, Decoder, Encoder};
 use neqo_crypto::constants::{TLS_HS_CLIENT_HELLO, TLS_HS_ENCRYPTED_EXTENSIONS};
 use neqo_crypto::ext::{ExtensionHandler, ExtensionHandlerResult, ExtensionWriterResult};
 use neqo_crypto::{HandshakeMessage, ZeroRttCheckResult, ZeroRttChecker};

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::pedantic)]
 
-use neqo_common::{hex_with_len, qdebug, qtrace, Datagram, Decoder, Encoder};
+use neqo_common::{hex_with_len, matches, qdebug, qtrace, Datagram, Decoder, Encoder};
 use neqo_crypto::{
     aead::Aead,
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::pedantic)]
 
+use neqo_common::matches;
 use neqo_crypto::{init_db, AntiReplay, AuthenticationStatus};
 use neqo_http3::{Http3Client, Http3Server};
 use neqo_qpack::QpackSettings;


### PR DESCRIPTION
Well I need to place a paper bag on my head in shame over this, but moving Neqo to 1.43 was based on Firefox moving to at least that version, and they have not. Firefox's minimum rustc version is still 1.41.

Note to self: A commit in mozilla-central that the builders have updated to 1.43 does not mean the minimum rustc version has been changed. For this the authoritative value is `rustc_min_version` in build/moz.configure/rust.configure.

Clearly I'm enthusiastic about using `std::matches`, so once Firefox ACTUALLY moves to 1.42+ then we can rebase and apply #728. Hopefully it won't be too long from now, but who can say.

Reverts mozilla/neqo#728