### PR TITLE
neqo-client: Use h3-29 by default

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -62,7 +62,7 @@ type Res<T> = Result<T, ClientError>;
     about = "A basic QUIC HTTP/0.9 and HTTP3 client."
 )]
 pub struct Args {
-    #[structopt(short = "a", long, default_value = "h3-28")]
+    #[structopt(short = "a", long, default_value = "h3-29")]
     /// ALPN labels to negotiate.
     ///
     /// This client still only does HTTP/3 no matter what the ALPN says.


### PR DESCRIPTION
This will fix http3 test on interop runner