### PR TITLE
Added must_use annotation to process

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -907,7 +907,7 @@ mod tests {
     fn send_and_receive_client_settings(client: &mut Http3Client, server: &mut TestServer) {
         // send and receive client settings
         let out = client.process(None, now());
-        server.conn.process(out.dgram(), now());
+        let _ = server.conn.process(out.dgram(), now());
         server.check_client_control_qpack_streams_no_resumption();
     }
 
@@ -1015,7 +1015,7 @@ mod tests {
         assert_eq!(request_stream_id, 0);
 
         let out = client.process(None, now());
-        server.conn.process(out.dgram(), now());
+        let _ = server.conn.process(out.dgram(), now());
 
         // find the new request/response stream and send frame v on it.
         while let Some(e) = server.conn.next_event() {
@@ -1226,7 +1226,7 @@ mod tests {
             .stream_send(new_stream_id, &[0x41, 0x19, 0x4, 0x4, 0x6, 0x0, 0x8, 0x0]);
         let out = server.conn.process(None, now());
         let out = client.process(out.dgram(), now());
-        server.conn.process(out.dgram(), now());
+        let _ = server.conn.process(out.dgram(), now());
 
         // check for stop-sending with Error::HttpStreamCreation.
         let mut stop_sending_event_found = false;
@@ -1255,7 +1255,7 @@ mod tests {
         let _ = server.conn.stream_send(push_stream_id, PUSH_STREAM_DATA);
         let out = server.conn.process(None, now());
         let out = client.process(out.dgram(), now());
-        server.conn.process(out.dgram(), now());
+        let _ = server.conn.process(out.dgram(), now());
 
         assert_closed(&client, &Error::HttpId);
     }
@@ -1492,7 +1492,7 @@ mod tests {
         let _ = client.stream_close_send(request_stream_id);
 
         let out = client.process(None, now());
-        server.conn.process(out.dgram(), now());
+        let _ = server.conn.process(out.dgram(), now());
 
         // find the new request/response stream and send response on it.
         while let Some(e) = server.conn.next_event() {
@@ -2167,7 +2167,7 @@ mod tests {
         assert_eq!(request_stream_id_3, 8);
 
         let out = client.process(None, now());
-        server.conn.process(out.dgram(), now());
+        let _ = server.conn.process(out.dgram(), now());
 
         let _ = server
             .conn
@@ -2241,7 +2241,7 @@ mod tests {
         assert_eq!(request_stream_id_3, 8);
 
         let out = client.process(None, now());
-        server.conn.process(out.dgram(), now());
+        let _ = server.conn.process(out.dgram(), now());
 
         // First send a Goaway frame with an higher number
         let _ = server
@@ -3647,7 +3647,7 @@ mod tests {
 
         let request_stream_id = make_request(&mut client, true);
         let out = client.process(None, now());
-        server.conn.process(out.dgram(), now());
+        let _ = server.conn.process(out.dgram(), now());
 
         server.encoder.set_max_capacity(100).unwrap();
         server.encoder.set_max_blocked_streams(100).unwrap();

--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -377,10 +377,10 @@ mod tests {
         let out = conn_c.process(None, now());
         let out = conn_s.process(out.dgram(), now());
         let out = conn_c.process(out.dgram(), now());
-        conn_s.process(out.dgram(), now());
+        let _ = conn_s.process(out.dgram(), now());
         conn_c.authenticated(AuthenticationStatus::Ok, now());
         let out = conn_c.process(None, now());
-        conn_s.process(out.dgram(), now());
+        let _ = conn_s.process(out.dgram(), now());
 
         // create a stream
         let stream_id = conn_s.stream_create(StreamType::BiDi).unwrap();
@@ -399,7 +399,7 @@ mod tests {
         }
         conn_s.stream_send(stream_id, &buf).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
 
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
@@ -482,32 +482,32 @@ mod tests {
         // Send and read settings frame 040406040804
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x6]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x8]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         assert!(fr.done());
@@ -534,47 +534,47 @@ mod tests {
         // Read settings frame 400406064004084100
         conn_s.stream_send(stream_id, &[0x40]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x6]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x6]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x40]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x4]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x8]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x41]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x0]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         assert!(fr.done());
@@ -601,24 +601,24 @@ mod tests {
         // Read pushpromise frame 05054101010203
         conn_s.stream_send(stream_id, &[0x5]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x5]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s.stream_send(stream_id, &[0x41]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         conn_s
             .stream_send(stream_id, &[0x1, 0x1, 0x2, 0x3])
             .unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         // headers are still on the stream.
@@ -657,7 +657,7 @@ mod tests {
             .stream_send(stream_id, &[0x0, 0x3, 0x1, 0x2, 0x3])
             .unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         // payloead is still on the stream.
@@ -696,13 +696,13 @@ mod tests {
         buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
         conn_s.stream_send(stream_id, &buf).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         // now receive a CANCEL_PUSH fram to see that frame reader is ok.
         conn_s.stream_send(stream_id, &[0x03, 0x01, 0x05]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
         assert_eq!(Ok(false), fr.receive(&mut conn_c, stream_id));
 
         assert!(fr.done());
@@ -745,12 +745,12 @@ mod tests {
         }
 
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
 
         if let FrameReadingTestSend::DataThenFin = test_to_send {
             conn_s.stream_close_send(stream_id).unwrap();
             let out = conn_s.process(None, now());
-            conn_c.process(out.dgram(), now());
+            let _ = conn_c.process(out.dgram(), now());
         }
 
         let mut fr = HFrameReader::new();
@@ -973,12 +973,12 @@ mod tests {
         let stream_id = conn_s.stream_create(StreamType::BiDi).unwrap();
         conn_s.stream_send(stream_id, &[0x00]).unwrap();
         let out = conn_s.process(None, now());
-        conn_c.process(out.dgram(), now());
+        let _ = conn_c.process(out.dgram(), now());
 
         let mut fr: HFrameReader = HFrameReader::new();
         assert_eq!(Ok(()), conn_c.stream_close_send(stream_id));
         let out = conn_c.process(None, now());
-        conn_s.process(out.dgram(), now());
+        let _ = conn_s.process(out.dgram(), now());
         assert_eq!(Ok(true), fr.receive(&mut conn_s, stream_id));
     }
 }

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -296,7 +296,7 @@ mod tests {
         let out = neqo_trans_conn.process(None, now());
         let out = hconn.process(out.dgram(), now());
         assert_connected(&mut hconn);
-        neqo_trans_conn.process(out.dgram(), now());
+        let _ = neqo_trans_conn.process(out.dgram(), now());
 
         let mut connected = false;
         while let Some(e) = neqo_trans_conn.next_event() {
@@ -397,7 +397,7 @@ mod tests {
         assert_eq!(sent, Ok(1));
         let out1 = neqo_trans_conn.process(None, now());
         let out2 = hconn.process(out1.dgram(), now());
-        neqo_trans_conn.process(out2.dgram(), now());
+        let _ = neqo_trans_conn.process(out2.dgram(), now());
 
         // assert no error occured.
         assert_not_closed(&mut hconn);
@@ -503,9 +503,9 @@ mod tests {
             .stream_send(new_stream_id, &[0x41, 0x19, 0x4, 0x4, 0x6, 0x0, 0x8, 0x0]);
         let out = peer_conn.conn.process(None, now());
         let out = hconn.process(out.dgram(), now());
-        peer_conn.conn.process(out.dgram(), now());
+        let _ = peer_conn.conn.process(out.dgram(), now());
         let out = hconn.process(None, now());
-        peer_conn.conn.process(out.dgram(), now());
+        let _ = peer_conn.conn.process(out.dgram(), now());
 
         // check for stop-sending with Error::HttpStreamCreation.
         let mut stop_sending_event_found = false;
@@ -534,7 +534,7 @@ mod tests {
         let _ = peer_conn.conn.stream_send(push_stream_id, &[0x1]);
         let out = peer_conn.conn.process(None, now());
         let out = hconn.process(out.dgram(), now());
-        peer_conn.conn.process(out.dgram(), now());
+        let _ = peer_conn.conn.process(out.dgram(), now());
         assert_closed(&mut hconn, &Error::HttpStreamCreation);
     }
 

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -303,7 +303,7 @@ mod tests {
             .peer_conn
             .stream_send(decoder.recv_stream_id, encoder_instruction);
         let out = decoder.peer_conn.process(None, now());
-        decoder.conn.process(out.dgram(), now());
+        let _ = decoder.conn.process(out.dgram(), now());
         assert_eq!(
             decoder
                 .decoder
@@ -315,7 +315,7 @@ mod tests {
     fn send_instructions_and_check(decoder: &mut TestDecoder, decoder_instruction: &[u8]) {
         decoder.decoder.send(&mut decoder.conn).unwrap();
         let out = decoder.conn.process(None, now());
-        decoder.peer_conn.process(out.dgram(), now());
+        let _ = decoder.peer_conn.process(out.dgram(), now());
         let mut buf = [0_u8; 100];
         let (amount, fin) = decoder
             .peer_conn

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -524,7 +524,7 @@ mod tests {
         encoder.encoder.send(&mut encoder.conn).unwrap();
         let out = encoder.conn.process(None, now());
         let out2 = encoder.peer_conn.process(out.dgram(), now());
-        encoder.conn.process(out2.dgram(), now());
+        let _ = encoder.conn.process(out2.dgram(), now());
         let mut buf = [0_u8; 100];
         let (amount, fin) = encoder
             .peer_conn
@@ -540,7 +540,7 @@ mod tests {
             .stream_send(encoder.recv_stream_id, decoder_instruction)
             .unwrap();
         let out = encoder.peer_conn.process(None, now());
-        encoder.conn.process(out.dgram(), now());
+        let _ = encoder.conn.process(out.dgram(), now());
         assert!(encoder
             .encoder
             .read_instructions(&mut encoder.conn, encoder.recv_stream_id)
@@ -1589,7 +1589,7 @@ mod tests {
 
         encoder.encoder.send(&mut encoder.conn).unwrap();
         let out = encoder.conn.process(None, now());
-        encoder.peer_conn.process(out.dgram(), now());
+        let _ = encoder.peer_conn.process(out.dgram(), now());
         // receive an insert count increment.
         recv_instruction(&mut encoder, &[0x01]);
 


### PR DESCRIPTION
Added must_use annotation to process.
Issue : #721 
- [x] Annotated Connection::process. Annotations for Output::dgram and Output::callback already present there.
- [x] Fixed tests by adding ``let _ =``. 