### PR TITLE
ConnectionEvent::NewStream now using StreamId

### DIFF
--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -121,17 +121,17 @@ impl Http3ServerHandler {
         while let Some(e) = conn.next_event() {
             qdebug!([self], "check_connection_events - event {:?}.", e);
             match e {
-                ConnectionEvent::NewStream {
-                    stream_id,
-                    stream_type,
-                } => match stream_type {
+                ConnectionEvent::NewStream { stream_id } => match stream_id.stream_type() {
                     StreamType::BiDi => self.base_handler.add_streams(
-                        stream_id,
-                        SendMessage::new(stream_id, Box::new(self.events.clone())),
-                        RecvMessage::new(stream_id, Box::new(self.events.clone()), None),
+                        stream_id.as_u64(),
+                        SendMessage::new(stream_id.as_u64(), Box::new(self.events.clone())),
+                        RecvMessage::new(stream_id.as_u64(), Box::new(self.events.clone()), None),
                     ),
                     StreamType::UniDi => {
-                        if self.base_handler.handle_new_unidi_stream(conn, stream_id)? {
+                        if self
+                            .base_handler
+                            .handle_new_unidi_stream(conn, stream_id.as_u64())?
+                        {
                             return Err(Error::HttpStreamCreation);
                         }
                     }

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -301,16 +301,13 @@ mod tests {
         let mut connected = false;
         while let Some(e) = neqo_trans_conn.next_event() {
             match e {
-                ConnectionEvent::NewStream {
-                    stream_id,
-                    stream_type,
-                } => {
+                ConnectionEvent::NewStream { stream_id } => {
                     assert!(
-                        (stream_id == SERVER_SIDE_CONTROL_STREAM_ID)
-                            || (stream_id == SERVER_SIDE_ENCODER_STREAM_ID)
-                            || (stream_id == SERVER_SIDE_DECODER_STREAM_ID)
+                        (stream_id.as_u64() == SERVER_SIDE_CONTROL_STREAM_ID)
+                            || (stream_id.as_u64() == SERVER_SIDE_ENCODER_STREAM_ID)
+                            || (stream_id.as_u64() == SERVER_SIDE_DECODER_STREAM_ID)
                     );
-                    assert_eq!(stream_type, StreamType::UniDi);
+                    assert_eq!(stream_id.stream_type(), StreamType::UniDi);
                 }
                 ConnectionEvent::RecvStreamReadable { stream_id } => {
                     if stream_id == CLIENT_SIDE_CONTROL_STREAM_ID

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -2801,17 +2801,17 @@ mod tests {
             _ => None,
         });
         let stream_id = stream_ids.next().expect("should have a new stream event");
-        let (received, fin) = server.stream_recv(stream_id, &mut buf).unwrap();
+        let (received, fin) = server.stream_recv(stream_id.as_u64(), &mut buf).unwrap();
         assert_eq!(received, 4000);
         assert_eq!(fin, false);
-        let (received, fin) = server.stream_recv(stream_id, &mut buf).unwrap();
+        let (received, fin) = server.stream_recv(stream_id.as_u64(), &mut buf).unwrap();
         assert_eq!(received, 140);
         assert_eq!(fin, false);
 
         let stream_id = stream_ids
             .next()
             .expect("should have a second new stream event");
-        let (received, fin) = server.stream_recv(stream_id, &mut buf).unwrap();
+        let (received, fin) = server.stream_recv(stream_id.as_u64(), &mut buf).unwrap();
         assert_eq!(received, 60);
         assert_eq!(fin, true);
     }
@@ -3074,7 +3074,7 @@ mod tests {
                 _ => None,
             })
             .expect("should have received a new stream event");
-        assert_eq!(client_stream_id, server_stream_id);
+        assert_eq!(client_stream_id, server_stream_id.as_u64());
     }
 
     #[test]
@@ -3105,11 +3105,11 @@ mod tests {
         let server_stream_id = server
             .events()
             .find_map(|evt| match evt {
-                ConnectionEvent::NewStream { stream_id, .. } => Some(stream_id),
+                ConnectionEvent::NewStream { stream_id } => Some(stream_id),
                 _ => None,
             })
             .expect("should have received a new stream event");
-        assert_eq!(client_stream_id, server_stream_id);
+        assert_eq!(client_stream_id, server_stream_id.as_u64());
     }
 
     #[test]

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -22,10 +22,7 @@ pub enum ConnectionEvent {
     /// Cert authentication needed
     AuthenticationNeeded,
     /// A new uni (read) or bidi stream has been opened by the peer.
-    NewStream {
-        stream_id: u64,
-        stream_type: StreamType,
-    },
+    NewStream { stream_id: StreamId },
     /// Space available in the buffer for an application write to succeed.
     SendStreamWritable { stream_id: u64 },
     /// New bytes available for reading.
@@ -58,10 +55,7 @@ impl ConnectionEvents {
     }
 
     pub fn new_stream(&self, stream_id: StreamId) {
-        self.insert(ConnectionEvent::NewStream {
-            stream_id: stream_id.as_u64(),
-            stream_type: stream_id.stream_type(),
-        });
+        self.insert(ConnectionEvent::NewStream { stream_id });
     }
 
     pub fn recv_stream_readable(&self, stream_id: StreamId) {


### PR DESCRIPTION
ConnectionEvent::NewStream should use StreamId
Issue : #717 

- [x] Added stream_id to NewStream instead of stream_id and stream_type
- [x] Added .as_u64() and .stream_type() function wherever necessary to match expected type.
