### PR TITLE
clippy pedantic enabled neqo-transport

### DIFF
--- a/neqo-transport/src/pace.rs
+++ b/neqo-transport/src/pace.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 // Pacer
-#![deny(clippy::pedantic)]
 
 use neqo_common::qtrace;
 

--- a/neqo-transport/src/packet/retry.rs
+++ b/neqo-transport/src/packet/retry.rs
@@ -4,7 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
 use crate::packet::QuicVersion;
 use crate::{Error, Res};
 

--- a/neqo-transport/src/packet/retry.rs
+++ b/neqo-transport/src/packet/retry.rs
@@ -4,7 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(clippy::pedantic)]
 
 use crate::packet::QuicVersion;
 use crate::{Error, Res};

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -6,7 +6,6 @@
 
 // Tracking of sent packets and detecting their loss.
 
-#![deny(clippy::pedantic)]
 
 use std::cmp::{max, min};
 use std::collections::BTreeMap;

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -6,7 +6,6 @@
 
 // Tracking of sent packets and detecting their loss.
 
-
 use std::cmp::{max, min};
 use std::collections::BTreeMap;
 use std::time::{Duration, Instant};

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -6,7 +6,6 @@
 
 // Tracking of received packets and generating acks thereof.
 
-#![deny(clippy::pedantic)]
 
 use std::collections::VecDeque;
 use std::convert::TryInto;

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -6,7 +6,6 @@
 
 // Tracking of received packets and generating acks thereof.
 
-
 use std::collections::VecDeque;
 use std::convert::TryInto;
 use std::rc::Rc;

--- a/neqo-transport/tests/conn_vectors.rs
+++ b/neqo-transport/tests/conn_vectors.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 // Tests with the test vectors from the spec.
-#![deny(clippy::pedantic)]
 
 use neqo_common::{Datagram, Encoder};
 use neqo_transport::{Connection, FixedConnectionIdManager, QuicVersion, State};

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
-#![warn(clippy::pedantic)]
 
 use neqo_common::{hex_with_len, matches, qdebug, qtrace, Datagram, Decoder, Encoder};
 use neqo_crypto::{


### PR DESCRIPTION
Removed `#![deny(clippy::pedantic)]` from neqo-transport files 
Issue : #553 
