### PR TITLE
Implement more qlog traces: CC and Recovery state

### DIFF
--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use chrono::{DateTime, Utc};
@@ -25,12 +25,15 @@ impl NeqoQlog {
     /// # Errors
     ///
     /// Will return `qlog::Error` if cannot write to the new log.
-    pub fn new(mut streamer: QlogStreamer, qlog_path: PathBuf) -> Result<Self, qlog::Error> {
+    pub fn new(
+        mut streamer: QlogStreamer,
+        qlog_path: impl AsRef<Path>,
+    ) -> Result<Self, qlog::Error> {
         streamer.start_log()?;
 
         Ok(Self {
             streamer,
-            qlog_path,
+            qlog_path: qlog_path.as_ref().to_owned(),
         })
     }
 

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -53,6 +53,17 @@ impl Drop for NeqoQlog {
     }
 }
 
+pub fn handle_qlog_result<T>(qlog: &mut Option<NeqoQlog>, result: Result<T, qlog::Error>) {
+    if let Err(e) = result {
+        crate::do_log!(
+            ::log::Level::Error,
+            "Qlog streaming failed with error {}; closing qlog.",
+            e
+        );
+        *qlog = None;
+    }
+}
+
 #[must_use]
 pub fn new_trace(role: Role) -> qlog::Trace {
     Trace {

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -15,6 +15,7 @@ use qlog::{
 };
 
 use crate::Role;
+
 #[allow(clippy::module_name_repetitions)]
 pub struct NeqoQlog {
     qlog_path: PathBuf,

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -13,6 +13,7 @@ neqo-qpack = { path = "./../neqo-qpack" }
 num-traits = "0.2"
 log = {version = "0.4.0", default-features = false}
 smallvec = "1.0.0"
+qlog = "0.3.0"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -17,6 +17,7 @@ mod control_stream_remote;
 pub mod hframe;
 mod hsettings_frame;
 mod push_controller;
+mod qlog;
 mod recv_message;
 mod send_message;
 pub mod server;

--- a/neqo-http3/src/qlog.rs
+++ b/neqo-http3/src/qlog.rs
@@ -1,0 +1,39 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::convert::TryFrom;
+
+use qlog::{self, event::Event, H3DataRecipient};
+
+use neqo_common::qlog::{handle_qlog_result, NeqoQlog};
+
+pub fn h3_data_moved_up(maybe_qlog: &mut Option<NeqoQlog>, stream_id: u64, amount: usize) {
+    if let Some(qlog) = maybe_qlog {
+        let res = qlog.stream().add_event(Event::h3_data_moved(
+            stream_id.to_string(),
+            None,
+            Some(u64::try_from(amount).unwrap()),
+            Some(H3DataRecipient::Transport),
+            Some(H3DataRecipient::Application),
+            None,
+        ));
+        handle_qlog_result(maybe_qlog, res)
+    }
+}
+
+pub fn h3_data_moved_down(maybe_qlog: &mut Option<NeqoQlog>, stream_id: u64, amount: usize) {
+    if let Some(qlog) = maybe_qlog {
+        let res = qlog.stream().add_event(Event::h3_data_moved(
+            stream_id.to_string(),
+            None,
+            Some(u64::try_from(amount).unwrap()),
+            Some(H3DataRecipient::Application),
+            Some(H3DataRecipient::Transport),
+            None,
+        ));
+        handle_qlog_result(maybe_qlog, res)
+    }
+}

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -5,8 +5,10 @@
 // except according to those terms.
 
 use crate::hframe::HFrame;
+use crate::qlog;
 use crate::Header;
 use crate::{Error, Res};
+
 use neqo_common::{matches, qdebug, qinfo, qtrace, Encoder};
 use neqo_qpack::encoder::QPackEncoder;
 use neqo_transport::Connection;
@@ -174,7 +176,14 @@ impl SendMessage {
                     Err(e) => return Err(Error::TransportError(e)),
                 }
                 match conn.stream_send(self.stream_id, &buf[..to_send]) {
-                    Ok(sent) => Ok(sent),
+                    Ok(sent) => {
+                        qlog::h3_data_moved_down(
+                            &mut conn.qlog_mut().borrow_mut(),
+                            self.stream_id,
+                            buf.len(),
+                        );
+                        Ok(sent)
+                    }
                     Err(e) => Err(Error::TransportError(e)),
                 }
             }
@@ -231,6 +240,8 @@ impl SendMessage {
 
         if let SendMessageState::SendingInitialMessage { ref mut buf, fin } = self.state {
             let sent = conn.stream_send(self.stream_id, &buf)?;
+            qlog::h3_data_moved_down(&mut conn.qlog_mut().borrow_mut(), self.stream_id, buf.len());
+
             qtrace!([label], "{} bytes sent", sent);
 
             if sent == buf.len() {

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -120,7 +120,9 @@ impl QPackEncoder {
         loop {
             let mut recv = ReceiverConnWrapper::new(conn, stream_id);
             match self.instruction_reader.read_instructions(&mut recv) {
-                Ok(instruction) => self.call_instruction(instruction, conn.qlog_mut())?,
+                Ok(instruction) => {
+                    self.call_instruction(instruction, &mut conn.qlog_mut().borrow_mut())?
+                }
                 Err(Error::NeedMoreData) => break Ok(()),
                 Err(e) => break Err(e),
             }

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -8,15 +8,15 @@
 
 use crate::Res;
 use neqo_common::hex;
-use neqo_common::qlog::NeqoQlog;
+use neqo_common::qlog::{handle_qlog_result, NeqoQlog};
 use qlog::{event::Event, QPackInstruction, QpackInstructionTypeName};
 
 pub fn qpack_read_insert_count_increment_instruction(
-    qlog: &mut Option<NeqoQlog>,
+    maybe_qlog: &mut Option<NeqoQlog>,
     increment: u64,
     data: &[u8],
 ) -> Res<()> {
-    if let Some(qlog) = qlog {
+    if let Some(qlog) = maybe_qlog {
         let event = Event::qpack_instruction_received(
             QPackInstruction::InsertCountIncrementInstruction {
                 instruction_type: QpackInstructionTypeName::InsertCountIncrementInstruction,
@@ -26,7 +26,8 @@ pub fn qpack_read_insert_count_increment_instruction(
             Some(hex(data)),
         );
 
-        qlog.stream().add_event(event)?;
+        let res = qlog.stream().add_event(event);
+        handle_qlog_result(maybe_qlog, res);
     }
     Ok(())
 }

--- a/neqo-transport/src/cc.rs
+++ b/neqo-transport/src/cc.rs
@@ -109,18 +109,27 @@ impl CongestionControl {
             }
             if self.app_limited() {
                 // Do not increase congestion_window if application limited.
-                qlog::congestion_state_updated(&mut self.qlog.borrow_mut(), "application_limited");
+                qlog::congestion_state_updated(
+                    &mut self.qlog.borrow_mut(),
+                    qlog::CongestionState::ApplicationLimited,
+                );
                 continue;
             }
 
             if self.congestion_window < self.ssthresh {
                 self.congestion_window += pkt.size;
                 qinfo!([self], "slow start");
-                qlog::congestion_state_updated(&mut self.qlog.borrow_mut(), "slow_start");
+                qlog::congestion_state_updated(
+                    &mut self.qlog.borrow_mut(),
+                    qlog::CongestionState::SlowStart,
+                );
             } else {
                 self.congestion_window += (MAX_DATAGRAM_SIZE * pkt.size) / self.congestion_window;
                 qinfo!([self], "congestion avoidance");
-                qlog::congestion_state_updated(&mut self.qlog.borrow_mut(), "congestion_avoidance");
+                qlog::congestion_state_updated(
+                    &mut self.qlog.borrow_mut(),
+                    qlog::CongestionState::CongestionAvoidance,
+                );
             }
             qlog::metrics_updated(
                 &mut self.qlog.borrow_mut(),
@@ -251,7 +260,10 @@ impl CongestionControl {
                     QlogMetric::InRecovery(true),
                 ],
             );
-            qlog::congestion_state_updated(&mut self.qlog.borrow_mut(), "recovery");
+            qlog::congestion_state_updated(
+                &mut self.qlog.borrow_mut(),
+                qlog::CongestionState::Recovery,
+            );
         } else {
             qdebug!([self], "Cong event but already in recovery");
         }

--- a/neqo-transport/src/cc.rs
+++ b/neqo-transport/src/cc.rs
@@ -103,24 +103,18 @@ impl CongestionControl {
             }
             if self.app_limited() {
                 // Do not increase congestion_window if application limited.
-                let _ = qlog::congestion_state_updated(
-                    &mut self.qlog.borrow_mut(),
-                    "application_limited",
-                );
+                qlog::congestion_state_updated(&mut self.qlog.borrow_mut(), "application_limited");
                 continue;
             }
 
             if self.congestion_window < self.ssthresh {
                 self.congestion_window += pkt.size;
                 qinfo!([self], "slow start");
-                let _ = qlog::congestion_state_updated(&mut self.qlog.borrow_mut(), "slow_start");
+                qlog::congestion_state_updated(&mut self.qlog.borrow_mut(), "slow_start");
             } else {
                 self.congestion_window += (MAX_DATAGRAM_SIZE * pkt.size) / self.congestion_window;
                 qinfo!([self], "congestion avoidance");
-                let _ = qlog::congestion_state_updated(
-                    &mut self.qlog.borrow_mut(),
-                    "congestion_avoidance",
-                );
+                qlog::congestion_state_updated(&mut self.qlog.borrow_mut(), "congestion_avoidance");
             }
         }
     }
@@ -210,7 +204,7 @@ impl CongestionControl {
                 self.congestion_window,
                 self.ssthresh
             );
-            let _ = qlog::congestion_state_updated(&mut self.qlog.borrow_mut(), "recovery");
+            qlog::congestion_state_updated(&mut self.qlog.borrow_mut(), "recovery");
         } else {
             qdebug!([self], "Cong event but already in recovery");
         }

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1267,6 +1267,7 @@ impl Connection {
                     // the rest of the datagram on the floor, but don't generate an error.
                     self.check_stateless_reset(&d, slc, now)?;
                     self.stats.pkt_dropped("Decryption failure");
+                    qlog::packet_dropped(&mut self.qlog, &packet)?;
                 }
             }
             slc = remainder;

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -457,7 +457,7 @@ pub struct Connection {
     events: ConnectionEvents,
     token: Option<Vec<u8>>,
     stats: Stats,
-    qlog: Option<NeqoQlog>,
+    qlog: Rc<RefCell<Option<NeqoQlog>>>,
 
     quic_version: QuicVersion,
 }
@@ -582,7 +582,7 @@ impl Connection {
             events: ConnectionEvents::default(),
             token: None,
             stats: Stats::default(),
-            qlog: None,
+            qlog: Rc::new(RefCell::new(None)),
             quic_version,
         };
         c.stats.init(format!("{}", c));
@@ -596,12 +596,14 @@ impl Connection {
 
     /// Set or clear the qlog for this connection.
     pub fn set_qlog(&mut self, qlog: Option<NeqoQlog>) {
-        self.qlog = qlog;
+        let conn_ql = Rc::new(RefCell::new(qlog));
+        self.loss_recovery.set_qlog(conn_ql.clone());
+        self.qlog = conn_ql;
     }
 
     /// Get the qlog (if any) for this connection.
-    pub fn qlog_mut(&mut self) -> &mut Option<NeqoQlog> {
-        &mut self.qlog
+    pub fn qlog_mut(&mut self) -> Rc<RefCell<Option<NeqoQlog>>> {
+        self.qlog.clone()
     }
 
     /// Set a local transport parameter, possibly overriding a default value.
@@ -1243,7 +1245,7 @@ impl Connection {
                         payload.pn(),
                         &payload[..],
                     );
-                    qlog::packet_received(&mut self.qlog, &payload)?;
+                    qlog::packet_received(&mut self.qlog.borrow_mut(), &payload)?;
                     let res = self.process_packet(&payload, now);
                     if res.is_err() && self.path.is_none() {
                         // We need to make a path for sending an error message.
@@ -1267,7 +1269,7 @@ impl Connection {
                     // the rest of the datagram on the floor, but don't generate an error.
                     self.check_stateless_reset(&d, slc, now)?;
                     self.stats.pkt_dropped("Decryption failure");
-                    qlog::packet_dropped(&mut self.qlog, &packet)?;
+                    qlog::packet_dropped(&mut self.qlog.borrow_mut(), &packet)?;
                 }
             }
             slc = remainder;
@@ -1598,7 +1600,12 @@ impl Connection {
             }
 
             dump_packet(self, "TX ->", pt, pn, &builder[payload_start..]);
-            qlog::packet_sent(&mut self.qlog, pt, pn, &builder[payload_start..])?;
+            qlog::packet_sent(
+                &mut self.qlog.borrow_mut(),
+                pt,
+                pn,
+                &builder[payload_start..],
+            )?;
 
             self.stats.packets_tx += 1;
             encoder = builder.build(self.crypto.states.tx(*space).unwrap())?;
@@ -1678,7 +1685,7 @@ impl Connection {
     fn client_start(&mut self, now: Instant) -> Res<()> {
         qinfo!([self], "client_start");
         debug_assert_eq!(self.role, Role::Client);
-        qlog::client_connection_started(&mut self.qlog, self.path.as_ref().unwrap())?;
+        qlog::client_connection_started(&mut self.qlog.borrow_mut(), self.path.as_ref().unwrap())?;
         self.loss_recovery.start_pacer(now);
 
         self.handshake(now, PNSpace::Initial, None)?;
@@ -2177,7 +2184,10 @@ impl Connection {
             debug_assert_eq!(1, self.valid_cids.len());
             self.valid_cids.clear();
             // Generate a qlog event that the server connection started.
-            qlog::server_connection_started(&mut self.qlog, self.path.as_ref().unwrap())?;
+            qlog::server_connection_started(
+                &mut self.qlog.borrow_mut(),
+                self.path.as_ref().unwrap(),
+            )?;
         } else {
             self.zero_rtt_state = if self.crypto.tls.info().unwrap().early_data_accepted() {
                 ZeroRttState::AcceptedClient
@@ -2198,7 +2208,7 @@ impl Connection {
             self.set_state(State::Confirmed);
         }
         qinfo!([self], "Connection established");
-        qlog::connection_tparams_set(&mut self.qlog, &*self.tps.borrow())?;
+        qlog::connection_tparams_set(&mut self.qlog.borrow_mut(), &*self.tps.borrow())?;
         Ok(())
     }
 

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1245,7 +1245,7 @@ impl Connection {
                         payload.pn(),
                         &payload[..],
                     );
-                    qlog::packet_received(&mut self.qlog.borrow_mut(), &payload)?;
+                    qlog::packet_received(&mut self.qlog.borrow_mut(), &payload);
                     let res = self.process_packet(&payload, now);
                     if res.is_err() && self.path.is_none() {
                         // We need to make a path for sending an error message.
@@ -1269,7 +1269,7 @@ impl Connection {
                     // the rest of the datagram on the floor, but don't generate an error.
                     self.check_stateless_reset(&d, slc, now)?;
                     self.stats.pkt_dropped("Decryption failure");
-                    qlog::packet_dropped(&mut self.qlog.borrow_mut(), &packet)?;
+                    qlog::packet_dropped(&mut self.qlog.borrow_mut(), &packet);
                 }
             }
             slc = remainder;
@@ -1605,7 +1605,7 @@ impl Connection {
                 pt,
                 pn,
                 &builder[payload_start..],
-            )?;
+            );
 
             self.stats.packets_tx += 1;
             encoder = builder.build(self.crypto.states.tx(*space).unwrap())?;
@@ -1685,7 +1685,7 @@ impl Connection {
     fn client_start(&mut self, now: Instant) -> Res<()> {
         qinfo!([self], "client_start");
         debug_assert_eq!(self.role, Role::Client);
-        qlog::client_connection_started(&mut self.qlog.borrow_mut(), self.path.as_ref().unwrap())?;
+        qlog::client_connection_started(&mut self.qlog.borrow_mut(), self.path.as_ref().unwrap());
         self.loss_recovery.start_pacer(now);
 
         self.handshake(now, PNSpace::Initial, None)?;
@@ -2187,7 +2187,7 @@ impl Connection {
             qlog::server_connection_started(
                 &mut self.qlog.borrow_mut(),
                 self.path.as_ref().unwrap(),
-            )?;
+            );
         } else {
             self.zero_rtt_state = if self.crypto.tls.info().unwrap().early_data_accepted() {
                 ZeroRttState::AcceptedClient
@@ -2208,7 +2208,7 @@ impl Connection {
             self.set_state(State::Confirmed);
         }
         qinfo!([self], "Connection established");
-        qlog::connection_tparams_set(&mut self.qlog.borrow_mut(), &*self.tps.borrow())?;
+        qlog::connection_tparams_set(&mut self.qlog.borrow_mut(), &*self.tps.borrow());
         Ok(())
     }
 

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -535,6 +535,10 @@ impl<'a> PublicPacket<'a> {
         self.quic_version
     }
 
+    pub fn packet_len(&self) -> usize {
+        self.data.len()
+    }
+
     fn decode_pn(expected: PacketNumber, pn: u64, w: usize) -> PacketNumber {
         let window = 1_u64 << (w * 8);
         let candidate = (expected & !(window - 1)) | pn;

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -8,13 +8,15 @@
 
 #![deny(clippy::pedantic)]
 
+use std::cell::RefCell;
 use std::cmp::{max, min};
 use std::collections::BTreeMap;
+use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use smallvec::{smallvec, SmallVec};
 
-use neqo_common::{qdebug, qinfo, qtrace, qwarn};
+use neqo_common::{qdebug, qinfo, qlog::NeqoQlog, qtrace, qwarn};
 
 use crate::cc::CongestionControl;
 use crate::crypto::CryptoRecoveryToken;
@@ -501,6 +503,10 @@ impl LossRecovery {
 
     pub fn pto(&self) -> Duration {
         self.rtt_vals.pto(PNSpace::ApplicationData)
+    }
+
+    pub fn set_qlog(&mut self, qlog: Rc<RefCell<Option<NeqoQlog>>>) {
+        self.cc.set_qlog(qlog)
     }
 
     pub fn drop_0rtt(&mut self) -> Vec<SentPacket> {

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -65,6 +65,8 @@ impl From<PacketType> for PNSpace {
 
 #[derive(Debug, Clone)]
 pub struct SentPacket {
+    pub pt: PacketType,
+    pub pn: u64,
     ack_eliciting: bool,
     pub time_sent: Instant,
     pub tokens: Rc<Vec<RecoveryToken>>,
@@ -79,6 +81,8 @@ pub struct SentPacket {
 
 impl SentPacket {
     pub fn new(
+        pt: PacketType,
+        pn: u64,
         time_sent: Instant,
         ack_eliciting: bool,
         tokens: Rc<Vec<RecoveryToken>>,
@@ -86,6 +90,8 @@ impl SentPacket {
         in_flight: bool,
     ) -> Self {
         Self {
+            pt,
+            pn,
             time_sent,
             ack_eliciting,
             tokens,


### PR DESCRIPTION
More interesting values, such as from congestion control and recovery.

The early commits in this PR stick with allowing qlog tracing functions to return `Res`, but this is converted later to handling qlog errors internally (response: emit a logmessage and close the log) rather than imposing error-handling on calling functions.

One burden calling functions *do* have to bear is ensuring the `NeqoQlog` is in scope. It's refcounted so that helps, but it does require a couple additional `set_qlog` methods.