### PR TITLE
Trivial: SendStreams::get() and ::get_mut() should take &StreamId

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -2284,7 +2284,7 @@ impl Connection {
         }
 
         Ok((
-            self.send_streams.get_mut(stream_id).ok(),
+            self.send_streams.get_mut(&stream_id).ok(),
             self.recv_streams.get_mut(&stream_id),
         ))
     }
@@ -2411,7 +2411,7 @@ impl Connection {
     /// `InvalidInput` if length of `data` is zero,
     /// `FinalSizeError` if the stream has already been closed.
     pub fn stream_send(&mut self, stream_id: u64, data: &[u8]) -> Res<usize> {
-        self.send_streams.get_mut(stream_id.into())?.send(data)
+        self.send_streams.get_mut(&stream_id.into())?.send(data)
     }
 
     /// Send all data or nothing on a stream. May cause DATA_BLOCKED or
@@ -2424,7 +2424,7 @@ impl Connection {
     pub fn stream_send_atomic(&mut self, stream_id: u64, data: &[u8]) -> Res<bool> {
         let val = self
             .send_streams
-            .get_mut(stream_id.into())?
+            .get_mut(&stream_id.into())?
             .send_atomic(data);
         if let Ok(val) = val {
             debug_assert!(
@@ -2441,18 +2441,18 @@ impl Connection {
     /// i.e. that will not be blocked by flow credits or send buffer max
     /// capacity.
     pub fn stream_avail_send_space(&self, stream_id: u64) -> Res<usize> {
-        Ok(self.send_streams.get(stream_id.into())?.avail())
+        Ok(self.send_streams.get(&stream_id.into())?.avail())
     }
 
     /// Close the stream. Enqueued data will be sent.
     pub fn stream_close_send(&mut self, stream_id: u64) -> Res<()> {
-        self.send_streams.get_mut(stream_id.into())?.close();
+        self.send_streams.get_mut(&stream_id.into())?.close();
         Ok(())
     }
 
     /// Abandon transmission of in-flight and future stream data.
     pub fn stream_reset_send(&mut self, stream_id: u64, err: AppError) -> Res<()> {
-        self.send_streams.get_mut(stream_id.into())?.reset(err);
+        self.send_streams.get_mut(&stream_id.into())?.reset(err);
         Ok(())
     }
 
@@ -3470,7 +3470,7 @@ mod tests {
         let evts = client.events().collect::<Vec<_>>();
         assert_eq!(evts.len(), 2); // SendStreamWritable, StateChange(connected)
         assert_eq!(client.stream_send(stream_id, b"hello").unwrap(), 0);
-        let ss = client.send_streams.get_mut(stream_id.into()).unwrap();
+        let ss = client.send_streams.get_mut(&stream_id.into()).unwrap();
         ss.mark_as_sent(0, 4096, false);
         ss.mark_as_acked(0, 4096, false);
 

--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -220,7 +220,7 @@ impl FlowMgr {
                     application_error_code,
                     final_size
                 );
-                if send_streams.get(stream_id).is_ok() {
+                if send_streams.get(&stream_id).is_ok() {
                     self.stream_reset(stream_id, application_error_code, final_size);
                 }
             }
@@ -240,7 +240,7 @@ impl FlowMgr {
                 }
             }
             Frame::StreamDataBlocked { stream_id, .. } => {
-                if let Ok(ss) = send_streams.get(stream_id) {
+                if let Ok(ss) = send_streams.get(&stream_id) {
                     if ss.credit_avail() == 0 {
                         self.stream_data_blocked(stream_id, ss.max_stream_data())
                     }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -732,11 +732,11 @@ impl SendStream {
 pub(crate) struct SendStreams(HashMap<StreamId, SendStream>);
 
 impl SendStreams {
-    pub fn get(&self, id: StreamId) -> Res<&SendStream> {
+    pub fn get(&self, id: &StreamId) -> Res<&SendStream> {
         self.0.get(&id).ok_or_else(|| Error::InvalidStreamId)
     }
 
-    pub fn get_mut(&mut self, id: StreamId) -> Res<&mut SendStream> {
+    pub fn get_mut(&mut self, id: &StreamId) -> Res<&mut SendStream> {
         self.0.get_mut(&id).ok_or_else(|| Error::InvalidStreamId)
     }
 
@@ -1226,7 +1226,7 @@ mod tests {
         let f2 = ss.get_frame(PNSpace::ApplicationData, 100);
         assert!(matches!(f2, None));
 
-        ss.get_mut(0.into()).unwrap().close();
+        ss.get_mut(&0.into()).unwrap().close();
 
         let (_f2, f2_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
         assert!(matches!(&f2_token, Some(RecoveryToken::Stream(x)) if x.offset == 10));


### PR DESCRIPTION
These methods on collections typically take a ref to the key. This works
here because StreamId is Copy, but for consistency's sake with other
collections -- including RecvStreams! -- these should take a ref.