### PR TITLE
neqo-client: fix QNS compliance check

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -78,7 +78,6 @@ pub struct Args {
     /// This client still only does HTTP/3 no matter what the ALPN says.
     alpn: String,
 
-    #[structopt(required = true, min_values = 1)]
     urls: Vec<Url>,
 
     #[structopt(short = "m", default_value = "GET")]


### PR DESCRIPTION
When QNS image is checked for compliance no URL is passed to the binary.