### PR TITLE
Small changes:

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -157,7 +157,9 @@ impl Http3Client {
         qtrace!([self], "  settings {}", hex_with_len(&settings_slice));
         let mut dec_settings = Decoder::from(settings_slice);
         let mut settings = HSettings::default();
-        settings.decode_frame_contents(&mut dec_settings)?;
+        settings
+            .decode_frame_contents(&mut dec_settings)
+            .map_err(|_| Error::InvalidResumptionToken)?;
         let tok = dec.decode_remainder();
         qtrace!([self], "  Transport token {}", hex(&tok));
         self.conn.set_resumption_token(now, tok)?;

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -125,9 +125,9 @@ impl SendMessage {
     }
 
     pub fn send_body(&mut self, conn: &mut Connection, buf: &[u8]) -> Res<usize> {
-        qinfo!(
+        qtrace!(
             [self],
-            "send_request_body: state={:?} len={}",
+            "send_body: state={:?} len={}",
             self.state,
             buf.len()
         );


### PR DESCRIPTION
- Set Http3Connection to the ZeroRtt state only after the initialization is done, because the initialization may fail.
- Ignore InvalidStreamId error from the transport when trying to close a stream.
- If decoding settings in set_resumption_token fails map error to InvalidResumptionToken