### PR TITLE
qlog: Refactor

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -454,7 +454,7 @@ fn client(
     );
 
     let qlog = qlog_new(args, hostname, client.conn())?;
-    client.set_qlog(qlog);
+    client.set_qlog(&qlog);
 
     let mut h = Handler {
         streams: HashMap::new(),
@@ -468,7 +468,7 @@ fn client(
     Ok(())
 }
 
-fn qlog_new(args: &Args, hostname: &str, conn: &Connection) -> Res<Option<NeqoQlog>> {
+fn qlog_new(args: &Args, hostname: &str, conn: &Connection) -> Res<NeqoQlog> {
     if let Some(qlog_dir) = &args.qlog_dir {
         let mut qlog_path = qlog_dir.to_path_buf();
         let filename = format!("{}-{}.qlog", hostname, conn.path().unwrap().remote_cid());
@@ -490,9 +490,9 @@ fn qlog_new(args: &Args, hostname: &str, conn: &Connection) -> Res<Option<NeqoQl
             Box::new(f),
         );
 
-        Ok(Some(NeqoQlog::new(streamer, qlog_path)?))
+        Ok(NeqoQlog::enabled(streamer, qlog_path)?)
     } else {
-        Ok(None)
+        Ok(NeqoQlog::disabled())
     }
 }
 
@@ -902,7 +902,7 @@ mod old {
             client.set_ciphers(&ciphers)?;
         }
 
-        client.set_qlog(qlog_new(args, origin, &client)?);
+        client.set_qlog(&qlog_new(args, origin, &client)?);
 
         let mut h = HandlerOld {
             streams: HashMap::new(),

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -454,7 +454,7 @@ fn client(
     );
 
     let qlog = qlog_new(args, hostname, client.conn())?;
-    client.set_qlog(&qlog);
+    client.set_qlog(qlog);
 
     let mut h = Handler {
         streams: HashMap::new(),
@@ -902,7 +902,7 @@ mod old {
             client.set_ciphers(&ciphers)?;
         }
 
-        client.set_qlog(&qlog_new(args, origin, &client)?);
+        client.set_qlog(qlog_new(args, origin, &client)?);
 
         let mut h = HandlerOld {
             streams: HashMap::new(),

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -120,7 +120,7 @@ impl Http3Client {
         self.conn.authenticated(status, now);
     }
 
-    pub fn set_qlog(&mut self, qlog: Option<NeqoQlog>) {
+    pub fn set_qlog(&mut self, qlog: &NeqoQlog) {
         self.conn.set_qlog(qlog);
     }
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -120,7 +120,7 @@ impl Http3Client {
         self.conn.authenticated(status, now);
     }
 
-    pub fn set_qlog(&mut self, qlog: &NeqoQlog) {
+    pub fn set_qlog(&mut self, qlog: NeqoQlog) {
         self.conn.set_qlog(qlog);
     }
 

--- a/neqo-http3/src/qlog.rs
+++ b/neqo-http3/src/qlog.rs
@@ -8,32 +8,30 @@ use std::convert::TryFrom;
 
 use qlog::{self, event::Event, H3DataRecipient};
 
-use neqo_common::qlog::{handle_qlog_result, NeqoQlog};
+use neqo_common::qlog::NeqoQlog;
 
-pub fn h3_data_moved_up(maybe_qlog: &mut Option<NeqoQlog>, stream_id: u64, amount: usize) {
-    if let Some(qlog) = maybe_qlog {
-        let res = qlog.stream().add_event(Event::h3_data_moved(
+pub fn h3_data_moved_up(qlog: &mut NeqoQlog, stream_id: u64, amount: usize) {
+    qlog.add_event(|| {
+        Some(Event::h3_data_moved(
             stream_id.to_string(),
             None,
             Some(u64::try_from(amount).unwrap()),
             Some(H3DataRecipient::Transport),
             Some(H3DataRecipient::Application),
             None,
-        ));
-        handle_qlog_result(maybe_qlog, res)
-    }
+        ))
+    })
 }
 
-pub fn h3_data_moved_down(maybe_qlog: &mut Option<NeqoQlog>, stream_id: u64, amount: usize) {
-    if let Some(qlog) = maybe_qlog {
-        let res = qlog.stream().add_event(Event::h3_data_moved(
+pub fn h3_data_moved_down(qlog: &mut NeqoQlog, stream_id: u64, amount: usize) {
+    qlog.add_event(|| {
+        Some(Event::h3_data_moved(
             stream_id.to_string(),
             None,
             Some(u64::try_from(amount).unwrap()),
             Some(H3DataRecipient::Application),
             Some(H3DataRecipient::Transport),
             None,
-        ));
-        handle_qlog_result(maybe_qlog, res)
-    }
+        ))
+    })
 }

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -183,11 +183,7 @@ impl RecvMessage {
                     let to_read = min(*remaining_data_len, buf.len() - written);
                     let (amount, fin) =
                         conn.stream_recv(self.stream_id, &mut buf[written..written + to_read])?;
-                    qlog::h3_data_moved_up(
-                        &mut conn.qlog_mut().borrow_mut(),
-                        self.stream_id,
-                        amount,
-                    );
+                    qlog::h3_data_moved_up(&mut conn.qlog_mut(), self.stream_id, amount);
 
                     debug_assert!(amount <= to_read);
                     *remaining_data_len -= amount;

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -183,7 +183,7 @@ impl RecvMessage {
                     let to_read = min(*remaining_data_len, buf.len() - written);
                     let (amount, fin) =
                         conn.stream_recv(self.stream_id, &mut buf[written..written + to_read])?;
-                    qlog::h3_data_moved_up(&mut conn.qlog_mut(), self.stream_id, amount);
+                    qlog::h3_data_moved_up(conn.qlog_mut(), self.stream_id, amount);
 
                     debug_assert!(amount <= to_read);
                     *remaining_data_len -= amount;

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -177,11 +177,7 @@ impl SendMessage {
                 }
                 match conn.stream_send(self.stream_id, &buf[..to_send]) {
                     Ok(sent) => {
-                        qlog::h3_data_moved_down(
-                            &mut conn.qlog_mut().borrow_mut(),
-                            self.stream_id,
-                            buf.len(),
-                        );
+                        qlog::h3_data_moved_down(&mut conn.qlog_mut(), self.stream_id, buf.len());
                         Ok(sent)
                     }
                     Err(e) => Err(Error::TransportError(e)),
@@ -240,7 +236,7 @@ impl SendMessage {
 
         if let SendMessageState::SendingInitialMessage { ref mut buf, fin } = self.state {
             let sent = conn.stream_send(self.stream_id, &buf)?;
-            qlog::h3_data_moved_down(&mut conn.qlog_mut().borrow_mut(), self.stream_id, buf.len());
+            qlog::h3_data_moved_down(&mut conn.qlog_mut(), self.stream_id, buf.len());
 
             qtrace!([label], "{} bytes sent", sent);
 

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -120,9 +120,7 @@ impl QPackEncoder {
         loop {
             let mut recv = ReceiverConnWrapper::new(conn, stream_id);
             match self.instruction_reader.read_instructions(&mut recv) {
-                Ok(instruction) => {
-                    self.call_instruction(instruction, &mut conn.qlog_mut().borrow_mut())?
-                }
+                Ok(instruction) => self.call_instruction(instruction, &mut conn.qlog_mut())?,
                 Err(Error::NeedMoreData) => break Ok(()),
                 Err(e) => break Err(e),
             }
@@ -193,7 +191,7 @@ impl QPackEncoder {
     fn call_instruction(
         &mut self,
         instruction: DecoderInstruction,
-        qlog: &mut Option<NeqoQlog>,
+        qlog: &mut NeqoQlog,
     ) -> Res<()> {
         qdebug!([self], "call intruction {:?}", instruction);
         match instruction {
@@ -202,7 +200,7 @@ impl QPackEncoder {
                     qlog,
                     increment,
                     &increment.to_be_bytes(),
-                )?;
+                );
 
                 self.insert_count_instruction(increment)
             }

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -6,28 +6,23 @@
 
 // Functions that handle capturing QLOG traces.
 
-use crate::Res;
 use neqo_common::hex;
-use neqo_common::qlog::{handle_qlog_result, NeqoQlog};
+use neqo_common::qlog::NeqoQlog;
 use qlog::{event::Event, QPackInstruction, QpackInstructionTypeName};
 
 pub fn qpack_read_insert_count_increment_instruction(
-    maybe_qlog: &mut Option<NeqoQlog>,
+    qlog: &mut NeqoQlog,
     increment: u64,
     data: &[u8],
-) -> Res<()> {
-    if let Some(qlog) = maybe_qlog {
-        let event = Event::qpack_instruction_received(
+) {
+    qlog.add_event(|| {
+        Some(Event::qpack_instruction_received(
             QPackInstruction::InsertCountIncrementInstruction {
                 instruction_type: QpackInstructionTypeName::InsertCountIncrementInstruction,
                 increment,
             },
             Some(8.to_string()),
             Some(hex(data)),
-        );
-
-        let res = qlog.stream().add_event(event);
-        handle_qlog_result(maybe_qlog, res);
-    }
-    Ok(())
+        ))
+    });
 }

--- a/neqo-transport/src/cc.rs
+++ b/neqo-transport/src/cc.rs
@@ -74,8 +74,8 @@ enum PacketState {
 }
 
 impl CongestionControl {
-    pub fn set_qlog(&mut self, qlog: &NeqoQlog) {
-        self.qlog = qlog.clone();
+    pub fn set_qlog(&mut self, qlog: NeqoQlog) {
+        self.qlog = qlog;
     }
 
     #[cfg(test)]

--- a/neqo-transport/src/cc.rs
+++ b/neqo-transport/src/cc.rs
@@ -6,10 +6,8 @@
 
 // Congestion control
 
-use std::cell::RefCell;
 use std::cmp::max;
 use std::fmt::{self, Display};
-use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use crate::pace::Pacer;
@@ -37,7 +35,7 @@ pub struct CongestionControl {
     ssthresh: usize,
     pacer: Option<Pacer>,
 
-    qlog: Rc<RefCell<Option<NeqoQlog>>>,
+    qlog: NeqoQlog,
     qlog_curr_cong_state: CongestionState,
 }
 
@@ -49,7 +47,7 @@ impl Default for CongestionControl {
             congestion_recovery_start_time: None,
             ssthresh: std::usize::MAX,
             pacer: None,
-            qlog: Rc::new(RefCell::new(None)),
+            qlog: NeqoQlog::disabled(),
             qlog_curr_cong_state: CongestionState::SlowStart,
         }
     }
@@ -76,8 +74,8 @@ enum PacketState {
 }
 
 impl CongestionControl {
-    pub fn set_qlog(&mut self, qlog: Rc<RefCell<Option<NeqoQlog>>>) {
-        self.qlog = qlog;
+    pub fn set_qlog(&mut self, qlog: &NeqoQlog) {
+        self.qlog = qlog.clone();
     }
 
     #[cfg(test)]
@@ -112,7 +110,7 @@ impl CongestionControl {
             if self.app_limited() {
                 // Do not increase congestion_window if application limited.
                 qlog::congestion_state_updated(
-                    &mut self.qlog.borrow_mut(),
+                    &mut self.qlog,
                     &mut self.qlog_curr_cong_state,
                     CongestionState::ApplicationLimited,
                 );
@@ -123,7 +121,7 @@ impl CongestionControl {
                 self.congestion_window += pkt.size;
                 qinfo!([self], "slow start");
                 qlog::congestion_state_updated(
-                    &mut self.qlog.borrow_mut(),
+                    &mut self.qlog,
                     &mut self.qlog_curr_cong_state,
                     CongestionState::SlowStart,
                 );
@@ -131,13 +129,13 @@ impl CongestionControl {
                 self.congestion_window += (MAX_DATAGRAM_SIZE * pkt.size) / self.congestion_window;
                 qinfo!([self], "congestion avoidance");
                 qlog::congestion_state_updated(
-                    &mut self.qlog.borrow_mut(),
+                    &mut self.qlog,
                     &mut self.qlog_curr_cong_state,
                     CongestionState::CongestionAvoidance,
                 );
             }
             qlog::metrics_updated(
-                &mut self.qlog.borrow_mut(),
+                &mut self.qlog,
                 &[
                     QlogMetric::CongestionWindow(self.congestion_window),
                     QlogMetric::BytesInFlight(self.bytes_in_flight),
@@ -162,7 +160,7 @@ impl CongestionControl {
             self.bytes_in_flight -= pkt.size;
         }
         qlog::metrics_updated(
-            &mut self.qlog.borrow_mut(),
+            &mut self.qlog,
             &[QlogMetric::BytesInFlight(self.bytes_in_flight)],
         );
 
@@ -190,7 +188,7 @@ impl CongestionControl {
             assert!(self.bytes_in_flight >= pkt.size);
             self.bytes_in_flight -= pkt.size;
             qlog::metrics_updated(
-                &mut self.qlog.borrow_mut(),
+                &mut self.qlog,
                 &[QlogMetric::BytesInFlight(self.bytes_in_flight)],
             );
             qtrace!([self], "Ignore pkt with size {}", pkt.size);
@@ -216,7 +214,7 @@ impl CongestionControl {
             self.congestion_window
         );
         qlog::metrics_updated(
-            &mut self.qlog.borrow_mut(),
+            &mut self.qlog,
             &[QlogMetric::BytesInFlight(self.bytes_in_flight)],
         );
 
@@ -231,10 +229,7 @@ impl CongestionControl {
                     true
                 } else {
                     if let PacketState::Acked = packet_state {
-                        qlog::metrics_updated(
-                            &mut self.qlog.borrow_mut(),
-                            &[QlogMetric::InRecovery(false)],
-                        );
+                        qlog::metrics_updated(&mut self.qlog, &[QlogMetric::InRecovery(false)]);
                         self.congestion_recovery_start_time = None;
                     }
                     false
@@ -259,14 +254,14 @@ impl CongestionControl {
                 self.ssthresh
             );
             qlog::metrics_updated(
-                &mut self.qlog.borrow_mut(),
+                &mut self.qlog,
                 &[
                     QlogMetric::SsThresh(self.ssthresh),
                     QlogMetric::InRecovery(true),
                 ],
             );
             qlog::congestion_state_updated(
-                &mut self.qlog.borrow_mut(),
+                &mut self.qlog,
                 &mut self.qlog_curr_cong_state,
                 CongestionState::Recovery,
             );

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -600,9 +600,9 @@ impl Connection {
     }
 
     /// Set or clear the qlog for this connection.
-    pub fn set_qlog(&mut self, qlog: &NeqoQlog) {
-        self.loss_recovery.set_qlog(qlog);
-        self.qlog = qlog.clone();
+    pub fn set_qlog(&mut self, qlog: NeqoQlog) {
+        self.loss_recovery.set_qlog(qlog.clone());
+        self.qlog = qlog;
     }
 
     /// Get the qlog (if any) for this connection.

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -519,9 +519,9 @@ impl LossRecovery {
         self.rtt_vals.pto(PNSpace::ApplicationData)
     }
 
-    pub fn set_qlog(&mut self, qlog: &NeqoQlog) {
-        self.qlog = qlog.clone();
-        self.cc.set_qlog(qlog)
+    pub fn set_qlog(&mut self, qlog: NeqoQlog) {
+        self.cc.set_qlog(qlog.clone());
+        self.qlog = qlog;
     }
 
     pub fn drop_0rtt(&mut self) -> Vec<SentPacket> {

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -8,10 +8,8 @@
 
 #![deny(clippy::pedantic)]
 
-use std::cell::RefCell;
 use std::cmp::{max, min};
 use std::collections::BTreeMap;
-use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use smallvec::{smallvec, SmallVec};
@@ -59,12 +57,7 @@ struct RttVals {
 }
 
 impl RttVals {
-    fn update_rtt(
-        &mut self,
-        qlog: &Rc<RefCell<Option<NeqoQlog>>>,
-        latest_rtt: Duration,
-        ack_delay: Duration,
-    ) {
+    fn update_rtt(&mut self, mut qlog: &mut NeqoQlog, latest_rtt: Duration, ack_delay: Duration) {
         self.latest_rtt = latest_rtt;
         // min_rtt ignores ack delay.
         self.min_rtt = min(self.min_rtt, self.latest_rtt);
@@ -92,7 +85,7 @@ impl RttVals {
             }
         }
         qlog::metrics_updated(
-            &mut qlog.borrow_mut(),
+            &mut qlog,
             &[
                 QlogMetric::LatestRtt(self.latest_rtt),
                 QlogMetric::MinRtt(self.min_rtt),
@@ -476,7 +469,7 @@ pub(crate) struct LossRecovery {
 
     spaces: LossRecoverySpaces,
 
-    qlog: Rc<RefCell<Option<NeqoQlog>>>,
+    qlog: NeqoQlog,
 }
 
 impl LossRecovery {
@@ -491,7 +484,7 @@ impl LossRecovery {
             pto_state: None,
             cc: CongestionControl::default(),
             spaces: LossRecoverySpaces::new(),
-            qlog: Rc::new(RefCell::new(None)),
+            qlog: NeqoQlog::disabled(),
         }
     }
 
@@ -526,7 +519,7 @@ impl LossRecovery {
         self.rtt_vals.pto(PNSpace::ApplicationData)
     }
 
-    pub fn set_qlog(&mut self, qlog: Rc<RefCell<Option<NeqoQlog>>>) {
+    pub fn set_qlog(&mut self, qlog: &NeqoQlog) {
         self.qlog = qlog.clone();
         self.cc.set_qlog(qlog)
     }
@@ -602,7 +595,8 @@ impl LossRecovery {
             space.largest_acked_sent_time = Some(largest_acked_pkt.time_sent);
             if any_ack_eliciting {
                 let latest_rtt = now - largest_acked_pkt.time_sent;
-                self.rtt_vals.update_rtt(&self.qlog, latest_rtt, ack_delay);
+                self.rtt_vals
+                    .update_rtt(&mut self.qlog, latest_rtt, ack_delay);
             }
         }
         self.cc.on_packets_acked(&acked_packets);
@@ -752,7 +746,7 @@ impl LossRecovery {
                 self.pto_state = Some(PtoState::new(pn_space));
             }
             qlog::metrics_updated(
-                &mut self.qlog.borrow_mut(),
+                &mut self.qlog,
                 &[QlogMetric::PtoCount(
                     self.pto_state.as_ref().unwrap().count(),
                 )],

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -351,7 +351,7 @@ impl Server {
         }
 
         if matches!(c.borrow().state(), State::Closed(_)) {
-            c.borrow_mut().set_qlog(None);
+            c.borrow_mut().set_qlog(&NeqoQlog::disabled());
             self.connections
                 .borrow_mut()
                 .retain(|_, v| !Rc::ptr_eq(v, &c));
@@ -435,7 +435,7 @@ impl Server {
         }
     }
 
-    fn create_qlog_trace(&self, attempt_key: &AttemptKey) -> Option<NeqoQlog> {
+    fn create_qlog_trace(&self, attempt_key: &AttemptKey) -> NeqoQlog {
         if let Some(qlog_dir) = &self.qlog_dir {
             let mut qlog_path = qlog_dir.to_path_buf();
 
@@ -460,13 +460,13 @@ impl Server {
                         common::qlog::new_trace(Role::Server),
                         Box::new(f),
                     );
-                    let n_qlog = NeqoQlog::new(streamer, qlog_path);
+                    let n_qlog = NeqoQlog::enabled(streamer, qlog_path);
                     match n_qlog {
-                        Ok(nql) => Some(nql),
+                        Ok(nql) => nql,
                         Err(e) => {
                             // Keep going but w/o qlogging
                             qerror!("NeqoQlog error: {}", e);
-                            None
+                            NeqoQlog::disabled()
                         }
                     }
                 }
@@ -476,11 +476,11 @@ impl Server {
                         qlog_path.display(),
                         e
                     );
-                    None
+                    NeqoQlog::disabled()
                 }
             }
         } else {
-            None
+            NeqoQlog::disabled()
         }
     }
 
@@ -519,7 +519,7 @@ impl Server {
                 // There was a retry, so set the connection IDs for.
                 c.set_retry_cids(odcid, initial.src_cid, initial.dst_cid);
             }
-            c.set_qlog(self.create_qlog_trace(&attempt_key));
+            c.set_qlog(&self.create_qlog_trace(&attempt_key));
             let c = Rc::new(RefCell::new(ServerConnectionState {
                 c,
                 last_timer: now,

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -351,7 +351,7 @@ impl Server {
         }
 
         if matches!(c.borrow().state(), State::Closed(_)) {
-            c.borrow_mut().set_qlog(&NeqoQlog::disabled());
+            c.borrow_mut().set_qlog(NeqoQlog::disabled());
             self.connections
                 .borrow_mut()
                 .retain(|_, v| !Rc::ptr_eq(v, &c));
@@ -519,7 +519,7 @@ impl Server {
                 // There was a retry, so set the connection IDs for.
                 c.set_retry_cids(odcid, initial.src_cid, initial.dst_cid);
             }
-            c.set_qlog(&self.create_qlog_trace(&attempt_key));
+            c.set_qlog(self.create_qlog_trace(&attempt_key));
             let c = Rc::new(RefCell::new(ServerConnectionState {
                 c,
                 last_timer: now,


### PR DESCRIPTION
Move handling of refcounting and enabled/disabled inside NeqoQlog struct.

Add add_event() and add_event_with_stream() methods to NeqoQlog that
handles enabled/disabled check, as well as disabling logging if an error
occurs.

add_event() is simpler and more commonly used. If enabled, the closure
is called, and may add 0 or 1 events. add_event_with_stream() is used when
a probe may need to add more than one event, or add frames to the event.

fixes #771