### PR TITLE
Qlog filenames

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -453,12 +453,8 @@ fn client(
         },
     );
 
-    let qlog_filename = format!(
-        "{}-{}",
-        hostname,
-        client.conn().path().unwrap().remote_cid()
-    );
-    client.set_qlog(qlog_new(args, &qlog_filename)?);
+    let qlog = qlog_new(args, hostname, client.conn())?;
+    client.set_qlog(qlog);
 
     let mut h = Handler {
         streams: HashMap::new(),
@@ -472,10 +468,11 @@ fn client(
     Ok(())
 }
 
-fn qlog_new(args: &Args, filename: &str) -> Res<Option<NeqoQlog>> {
+fn qlog_new(args: &Args, hostname: &str, conn: &Connection) -> Res<Option<NeqoQlog>> {
     if let Some(qlog_dir) = &args.qlog_dir {
         let mut qlog_path = qlog_dir.to_path_buf();
-        qlog_path.push(format!("{}.qlog", filename));
+        let filename = format!("{}-{}.qlog", hostname, conn.path().unwrap().remote_cid());
+        qlog_path.push(filename);
 
         let f = OpenOptions::new()
             .write(true)
@@ -905,10 +902,7 @@ mod old {
             client.set_ciphers(&ciphers)?;
         }
 
-        client.set_qlog(qlog_new(
-            args,
-            &format!("{}-{}", origin, client.path().unwrap().remote_cid()),
-        )?);
+        client.set_qlog(qlog_new(args, origin, &client)?);
 
         let mut h = HandlerOld {
             streams: HashMap::new(),

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -452,7 +452,13 @@ fn client(
             max_blocked_streams: args.max_blocked_streams,
         },
     );
-    client.set_qlog(qlog_new(args, hostname)?);
+
+    let qlog_filename = format!(
+        "{}-{}",
+        hostname,
+        client.conn().path().unwrap().remote_cid()
+    );
+    client.set_qlog(qlog_new(args, &qlog_filename)?);
 
     let mut h = Handler {
         streams: HashMap::new(),
@@ -466,10 +472,10 @@ fn client(
     Ok(())
 }
 
-fn qlog_new(args: &Args, origin: &str) -> Res<Option<NeqoQlog>> {
+fn qlog_new(args: &Args, filename: &str) -> Res<Option<NeqoQlog>> {
     if let Some(qlog_dir) = &args.qlog_dir {
         let mut qlog_path = qlog_dir.to_path_buf();
-        qlog_path.push(format!("{}.qlog", origin));
+        qlog_path.push(format!("{}.qlog", filename));
 
         let f = OpenOptions::new()
             .write(true)
@@ -899,7 +905,10 @@ mod old {
             client.set_ciphers(&ciphers)?;
         }
 
-        client.set_qlog(qlog_new(args, origin)?);
+        client.set_qlog(qlog_new(
+            args,
+            &format!("{}-{}", origin, client.path().unwrap().remote_cid()),
+        )?);
 
         let mut h = HandlerOld {
             streams: HashMap::new(),

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -439,14 +439,13 @@ impl Server {
         if let Some(qlog_dir) = &self.qlog_dir {
             let mut qlog_path = qlog_dir.to_path_buf();
 
-            // TODO(mt) - the original DCID is not really unique, which means that attackers
-            // can cause us to overwrite our own logs.  That's not ideal.
             qlog_path.push(format!("{}.qlog", attempt_key.odcid));
 
+            // The original DCID is chosen by the client. Using create_new()
+            // prevents attackers from overwriting existing logs.
             match OpenOptions::new()
                 .write(true)
-                .create(true)
-                .truncate(true)
+                .create_new(true)
                 .open(&qlog_path)
             {
                 Ok(f) => {


### PR DESCRIPTION
For client, append dcid to qlog filename for uniqueness.

For server, open qlog file ensuing it does not overwrite an existing log file.