### PR TITLE
Fix error handling in read_response_data

### DIFF
--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -169,7 +169,8 @@ impl HFrameReader {
     #[allow(clippy::too_many_lines)]
     /// returns true if quic stream was closed.
     /// # Errors
-    /// returns an error if frame is not complete.
+    /// May return `HttpFrame` if a frame cannot be decoded.
+    /// and `TransportStreamDoesNotExist` if `stream_recv` fails.
     pub fn receive(
         &mut self,
         conn: &mut Connection,
@@ -178,7 +179,10 @@ impl HFrameReader {
         loop {
             let to_read = std::cmp::min(self.min_remaining(), MAX_READ_SIZE);
             let mut buf = vec![0; to_read];
-            let (output, read, fin) = match conn.stream_recv(stream_id, &mut buf)? {
+            let (output, read, fin) = match conn
+                .stream_recv(stream_id, &mut buf)
+                .map_err(|e| Error::map_stream_recv_errors(&e))?
+            {
                 (0, f) => (None, false, f),
                 (amount, f) => {
                     qtrace!(
@@ -210,6 +214,8 @@ impl HFrameReader {
         }
     }
 
+    /// # Errors
+    /// May return `HttpFrame` if a frame cannot be decoded.
     fn consume(&mut self, mut input: Decoder) -> Res<Option<HFrame>> {
         match &mut self.state {
             HFrameReaderState::GetType { decoder } => {
@@ -290,7 +296,7 @@ impl HFrameReader {
     }
 
     /// # Errors
-    /// May return `NotEnoughData` if frame is not completely read.
+    /// May return `HttpFrame` if a frame cannot be decoded.
     fn get_frame(&mut self) -> Res<HFrame> {
         let payload = mem::replace(&mut self.payload, Vec::new());
         let mut dec = Decoder::from(&payload[..]);

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -137,6 +137,23 @@ impl Error {
             }
         }
     }
+
+    #[must_use]
+    pub fn map_stream_recv_errors(err: &TransportError) -> Self {
+        match err {
+            TransportError::NoMoreData => {
+                debug_assert!(
+                    false,
+                    "Do not call stream_recv if FIN has been previously read"
+                );
+            }
+            TransportError::InvalidStreamId => {}
+            _ => {
+                debug_assert!(false, "Unexpected error");
+            }
+        };
+        Error::TransportStreamDoesNotExist
+    }
 }
 
 impl From<TransportError> for Error {

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -340,8 +340,9 @@ impl RecvStream for RecvMessage {
                     ref mut remaining_data_len,
                 } => {
                     let to_read = min(*remaining_data_len, buf.len() - written);
-                    let (amount, fin) =
-                        conn.stream_recv(self.stream_id, &mut buf[written..written + to_read])?;
+                    let (amount, fin) = conn
+                        .stream_recv(self.stream_id, &mut buf[written..written + to_read])
+                        .map_err(|e| Error::map_stream_recv_errors(&e))?;
                     qlog::h3_data_moved_up(conn.qlog_mut(), self.stream_id, amount);
 
                     debug_assert!(amount <= to_read);


### PR DESCRIPTION
Executing read_response_data may return errors that are fatal and will terminate a HTTP3 connection and errors that only mean that the stream has been closed and the application is still not aware of the situation or the application has used a wrong stream id.

An application read HTTP3 connection events to find out if a stream has been closed, therefore if the application has not read all events it may happen that a stream is closed, but the application is not aware of it.

Also HTTP3  connection needs to read transport events to find out that transport streams are closed. This is done in the function process_output, therefore it may happen that an application calls read_response_data and gets a TransportStreamDoesNotExist if process_output has not called when it has needed to be called. The HTTP3 stream will not be terminated when this error is caught, HTTP3 will wait for process_output to be called and the transport events to be handled.