### PR TITLE
Large transport bufs

### DIFF
--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -23,7 +23,7 @@ use crate::stream_id::StreamId;
 use crate::{AppError, Error, Res};
 use neqo_common::{matches, qtrace};
 
-pub const RX_STREAM_DATA_WINDOW: u64 = 0xFFFF; // 64 KiB
+pub const RX_STREAM_DATA_WINDOW: u64 = 0x10_0000; // 1MiB
 
 pub(crate) type RecvStreams = BTreeMap<StreamId, RecvStream>;
 

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -280,7 +280,7 @@ pub struct TxBuffer {
 }
 
 impl TxBuffer {
-    const BUFFER_SIZE: usize = 0xFFFF; // 64 KiB
+    pub const BUFFER_SIZE: usize = 0xFFFF; // 64 KiB
 
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
Increase transport send & recv bufs from 64K to 1M. Most of this PR is updating tests in http3 and transport to not depend on buffers being a certain size.