### PR TITLE
QNS: Support server for http3 test

### DIFF
--- a/neqo-qns/Dockerfile
+++ b/neqo-qns/Dockerfile
@@ -45,6 +45,7 @@ RUN cd neqo && cargo build && cp target/debug/neqo-client target && cp target/de
 FROM martenseemann/quic-network-simulator-endpoint:latest
 ENV LD_LIBRARY_PATH=$HOME/dist/Debug/lib
 COPY --from=buildimage /neqo/target /neqo/target
+COPY --from=buildimage /neqo/test-fixture/db /neqo/test-fixture/db
 COPY --from=buildimage $HOME/dist/Debug/lib/*.so $HOME/dist/Debug/lib/
 COPY run_endpoint.sh .
 RUN chmod +x run_endpoint.sh

--- a/neqo-qns/run_endpoint.sh
+++ b/neqo-qns/run_endpoint.sh
@@ -6,7 +6,7 @@
 cd neqo
 
 CLIENT_PARAMS="--qns-mode --output-dir /downloads"
-SERVER_PARAMS=""
+SERVER_PARAMS="--qns-mode 0.0.0.0:443"
 
 if [ "$ROLE" == "client" ]; then
     echo "Starting Neqo client ..."
@@ -15,5 +15,5 @@ if [ "$ROLE" == "client" ]; then
     sleep 5
     RUST_LOG=debug RUST_BACKTRACE=1 ./target/neqo-client $CLIENT_PARAMS $REQUESTS
 elif [ "$ROLE" == "server" ]; then
-    exit 127
+    RUST_LOG=info RUST_BACKTRACE=1 ./target/neqo-http3-server $SERVER_PARAMS
 fi


### PR DESCRIPTION
server qns-mode hardcodes /www as the directory to serve files from.

Also, change neqo-http3-server alpn default to h3-29.

This doesn't quite fix #676 because it's not the right test, but it's s start. To get other transfer tests working we will probably want to do what we did with client -- merge H/0.9 and H/3 into one program -- rather than maintaining them separately. `neqo-http3-server` is in a lot better shape than `neqo-server`, which is "World's dumbest HTTP 0.9 server".