### PR TITLE
Export constants for send and recv buffer sizes

### DIFF
--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -39,6 +39,8 @@ pub use self::packet::QuicVersion;
 pub use self::stream_id::StreamId;
 
 const LOCAL_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30); // 30 second
+pub use self::recv_stream::RECV_BUFFER_SIZE;
+pub use self::send_stream::SEND_BUFFER_SIZE;
 
 type TransportError = u64;
 const ERROR_APPLICATION_CLOSE: TransportError = 12;

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -23,7 +23,10 @@ use crate::stream_id::StreamId;
 use crate::{AppError, Error, Res};
 use neqo_common::qtrace;
 
-pub const RX_STREAM_DATA_WINDOW: u64 = 0x10_0000; // 1MiB
+const RX_STREAM_DATA_WINDOW: u64 = 0x10_0000; // 1MiB
+
+// Export as usize for consistency with SEND_BUFFER_SIZE
+pub const RECV_BUFFER_SIZE: usize = RX_STREAM_DATA_WINDOW as usize;
 
 pub(crate) type RecvStreams = BTreeMap<StreamId, RecvStream>;
 


### PR DESCRIPTION
Followup to #806, this is simpler than const methods on Connection.

Note that while we can change these constants now, setting them to
different values will cause some tests to fail. Spending time to fix
tests for different const values is not justified yet.