### PR TITLE
Handshake recovery fixes

### DIFF
--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -780,7 +780,7 @@ impl DerefMut for Client {
 /// `ZeroRttCheckResult` encapsulates the options for handling a `ClientHello`.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ZeroRttCheckResult {
-    /// Accept 0-RTT; the default.
+    /// Accept 0-RTT.
     Accept,
     /// Reject 0-RTT, but continue the handshake normally.
     Reject,

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1911,7 +1911,7 @@ impl Connection {
             Frame::Ping => {
                 // If we get a PING and there are outstanding CRYPTO frames,
                 // prepare to resend them.
-                self.crypto.resend_frames(space);
+                self.crypto.resend_unacked(space);
             }
             Frame::Ack {
                 largest_acknowledged,
@@ -1964,7 +1964,7 @@ impl Connection {
                     self.handshake(now, space, Some(&buf))?;
                 } else {
                     // If we get a useless CRYPTO frame send outstanding CRYPTO frames again.
-                    self.crypto.resend_frames(space);
+                    self.crypto.resend_unacked(space);
                 }
             }
             Frame::NewToken { token } => self.token = Some(token),

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -235,6 +235,12 @@ impl Crypto {
         self.streams.lost(token);
     }
 
+    /// Mark any outstanding frames in the indicated space as "lost" so
+    /// that they can be sent again.
+    pub fn resend_frames(&mut self, space: PNSpace) {
+        self.streams.resend(space);
+    }
+
     /// Discard state for a packet number space and return true
     /// if something was discarded.
     pub fn discard(&mut self, space: PNSpace) -> bool {
@@ -996,13 +1002,23 @@ impl CryptoStreams {
         self.get_mut(token.space)
             .unwrap()
             .tx
-            .mark_as_acked(token.offset, token.length)
+            .mark_as_acked(token.offset, token.length);
     }
 
     pub fn lost(&mut self, token: &CryptoRecoveryToken) {
         // See BZ 1624800, ignore lost packets in spaces we've dropped keys
         if let Some(cs) = self.get_mut(token.space) {
-            cs.tx.mark_as_lost(token.offset, token.length)
+            cs.tx.mark_as_lost(token.offset, token.length);
+        }
+    }
+
+    /// Resend any Initial or Handshake CRYPTO frames that might be outstanding.
+    /// This can help speed up handshake times.
+    pub fn resend(&mut self, space: PNSpace) {
+        if space != PNSpace::ApplicationData {
+            if let Some(cs) = self.get_mut(space) {
+                cs.tx.unmark_sent();
+            }
         }
     }
 

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -237,8 +237,8 @@ impl Crypto {
 
     /// Mark any outstanding frames in the indicated space as "lost" so
     /// that they can be sent again.
-    pub fn resend_frames(&mut self, space: PNSpace) {
-        self.streams.resend(space);
+    pub fn resend_unacked(&mut self, space: PNSpace) {
+        self.streams.resend_unacked(space);
     }
 
     /// Discard state for a packet number space and return true
@@ -1014,7 +1014,7 @@ impl CryptoStreams {
 
     /// Resend any Initial or Handshake CRYPTO frames that might be outstanding.
     /// This can help speed up handshake times.
-    pub fn resend(&mut self, space: PNSpace) {
+    pub fn resend_unacked(&mut self, space: PNSpace) {
         if space != PNSpace::ApplicationData {
             if let Some(cs) = self.get_mut(space) {
                 cs.tx.unmark_sent();

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -290,7 +290,7 @@ impl LossRecoverySpace {
             if sent_packet.cc_in_flight() {
                 self.in_flight_outstanding += 1;
             }
-        } else if self.space != PNSpace::ApplicationData {
+        } else if self.space != PNSpace::ApplicationData && self.pto_base_time.is_none() {
             // For Initial and Handshake spaces, make sure that we have a PTO baseline
             // always. See `LossRecoverySpace::pto_base_time()` for details.
             self.pto_base_time = Some(sent_packet.time_sent);

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -208,11 +208,11 @@ impl RangeTracker {
 
     fn unmark_range(&mut self, off: u64, len: usize) {
         if len == 0 {
-            qinfo!("unmark 0-length range at {}", off);
+            qdebug!("unmark 0-length range at {}", off);
             return;
         }
 
-        let len = len as u64;
+        let len = u64::try_from(len).unwrap();
         let end_off = off + len;
 
         let mut to_remove = SmallVec::<[_; 8]>::new();
@@ -225,7 +225,7 @@ impl RangeTracker {
                 // Check for overlap
                 if *cur_off + *cur_len > off {
                     if *cur_state == RangeState::Acked {
-                        qinfo!(
+                        qdebug!(
                             "Attempted to unmark Acked range {}-{} with unmark_range {}-{}",
                             cur_off,
                             cur_len,
@@ -240,7 +240,7 @@ impl RangeTracker {
             }
 
             if *cur_state == RangeState::Acked {
-                qinfo!(
+                qdebug!(
                     "Attempted to unmark Acked range {}-{} with unmark_range {}-{}",
                     cur_off,
                     cur_len,
@@ -274,15 +274,7 @@ impl RangeTracker {
 
     /// Unmark all sent ranges.
     pub fn unmark_sent(&mut self) {
-        let mut to_remove = SmallVec::<[_; 8]>::new();
-        for (off, (_, state)) in self.used.iter() {
-            if *state != RangeState::Acked {
-                to_remove.push(*off);
-            }
-        }
-        for r in to_remove {
-            self.used.remove(&r);
-        }
+        self.unmark_range(0, usize::try_from(self.highest_offset()).unwrap());
     }
 }
 


### PR DESCRIPTION
There are two main changes here:

1. Keep the PTO timer armed for the Initial and Handshake packet number spaces.

This is based on the spec, which says that clients need to keep these armed, even if they haven't sent anything that is "in flight".  Doing this avoids a handshake deadlock when the server hasn't got its own PTO timer armed.  The server can't arm the PTO timer when it hasn't validated the client's address.

Note that we don't implement the anti-amplification limit, so our server doesn't really do this.  It arms the PTO timer when it shouldn't and ignores limits.  This is something we might need to fix eventually.

The other limitation here is that the PTO is armed past the point where it should be.  The spec says that the client can stop after the server has acknowledged Handshake or 1-RTT packets; or after the handshake is confirmed.  Not stopping means that there are some crazy corner cases where we'll keep probing in these spaces, but the impact should be limited.

(It would be good if you could also go through these corner cases and see if you could find one that is worth caring about.  I couldn't.)

2. Resend CRYPTO frames in Initial and Handshake packet number spaces if a useless CRYPTO frame is received (i.e., one that doesn't make more data available).  Also, if a PING is received in these spaces, do the same.

The CRYPTO frame thing is close to what is recommended in the spec, noting that this doesn't strictly adhere to the spec.  The spec says that only CRYPTO frames containing redundant data cause retransmission; this change causes any CRYPTO frame that doesn't make new data available.  This means that out-of-order CRYPTO frames will cause us to send more CRYPTO frames.  This could be a little wasteful. 

Assuming that we do this, it's probably worth opening an issue to look into making this a little less aggressive about re-sending.  As it is, this might eat a little of our congestion window if we get an out-of-order packet AND we don't receive an ACK for outstanding CRYPTO data (which is likely, as ACKs tend to be put with the first CRYPTO frames).  Fixing this might help with wastage, but then it might not depending on how often apparent out-of-order packets are a consequence of loss - re-sending immediately is good if the out-of-order packet really is an indication that the other data was lost.

The PING frame is another digression from spec, but it recognizes that a PING, sent on PTO in Handshake packets, is equivalent to receiving useless CRYPTO data.  If a PING is sent in Handshake or Initial packets, it means that the other side is probing (and likely can't send CRYPTO). Interpreting that as equivalent to a useless CRYPTO frame is safe and likely a good optimization for the case where server Handshake packets are lost.

---
I was planning to split this into two, and I could still do so, but the test that I wrote for the first bit didn't properly complete the handshake until I did the second part.  The problem there was that we were sending PING frames at the client when the Handshake PTO expired.  This elicited an ACK from the server, but the server didn't re-send CRYPTO frames.  The result was that we would have stalled until the server hit a PTO.  So I gave you both fixes.  Each is fairly distinct in the code.

Read the second commit for commentary about the tricky test.

There are some changes to logging that I found useful here as well, but none of those should really interfere.