### PR TITLE
Do not allow initial packet to exceed cwnd in persistent congestion

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1673,9 +1673,10 @@ impl Connection {
             let mut packets: Vec<u8> = encoder.into();
             if let Some(mut initial) = initial_sent.take() {
                 if needs_padding {
-                    qdebug!([self], "pad Initial to path MTU {}", path.mtu());
-                    initial.size += path.mtu() - packets.len();
-                    packets.resize(path.mtu(), 0);
+                    let limit = profile.limit();
+                    qdebug!([self], "pad Initial to {}", limit);
+                    initial.size += limit - packets.len();
+                    packets.resize(limit, 0);
                 }
                 self.loss_recovery.on_packet_sent(initial);
             }


### PR DESCRIPTION
When in persistent congestion, we set cwnd to MAX_DATAGRAM_SIZE * 2, where
MAX_DATAGRAM_SIZE is equal to PATH_MTU_V6. Thus, on a IPv4 path, cwnd is
slightly too small to send two max-size datagrams.

If the second datagram needs padding after a max-size first dgram then
using path.mtu() will cause bytes_in_flight to exceed cwnd and
generate an assert. To fix this, use profile.limit() for padding instead
of path.mtu(). limit() in this case will be min(mtu, cwnd) which is what
we want.