### PR TITLE
Better tracking

### DIFF
--- a/neqo-transport/src/cc.rs
+++ b/neqo-transport/src/cc.rs
@@ -155,7 +155,7 @@ impl CongestionControl {
             return;
         }
 
-        for pkt in lost_packets.iter().filter(|pkt| pkt.cc_in_flight()) {
+        for pkt in lost_packets.iter().filter(|pkt| pkt.ack_eliciting()) {
             assert!(self.bytes_in_flight >= pkt.size);
             self.bytes_in_flight -= pkt.size;
         }
@@ -201,7 +201,7 @@ impl CongestionControl {
             .unwrap()
             .spend(pkt.time_sent, rtt, self.congestion_window, pkt.size);
 
-        if !pkt.cc_in_flight() {
+        if !pkt.ack_eliciting() {
             return;
         }
 
@@ -217,8 +217,6 @@ impl CongestionControl {
             &mut self.qlog,
             &[QlogMetric::BytesInFlight(self.bytes_in_flight)],
         );
-
-        debug_assert!(self.bytes_in_flight <= self.congestion_window);
     }
 
     #[must_use]

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -10,18 +10,19 @@
 
 use std::cmp::{max, min};
 use std::collections::BTreeMap;
+use std::mem;
 use std::time::{Duration, Instant};
 
 use smallvec::{smallvec, SmallVec};
 
-use neqo_common::{qdebug, qinfo, qlog::NeqoQlog, qtrace, qwarn};
+use neqo_common::{qdebug, qinfo, qlog::NeqoQlog, qtrace};
 
 use crate::cc::CongestionControl;
 use crate::crypto::CryptoRecoveryToken;
 use crate::flow_mgr::FlowControlRecoveryToken;
 use crate::qlog::{self, QlogMetric};
 use crate::send_stream::StreamRecoveryToken;
-use crate::tracking::{AckToken, PNSpace, SentPacket};
+use crate::tracking::{AckToken, PNSpace, PNSpaceSet, SentPacket};
 use crate::LOCAL_IDLE_TIMEOUT;
 
 pub const GRANULARITY: Duration = Duration::from_millis(20);
@@ -147,6 +148,7 @@ impl Default for RttVals {
 pub struct SendProfile {
     limit: usize,
     pto: Option<PNSpace>,
+    probe: PNSpaceSet,
     paced: bool,
 }
 
@@ -158,6 +160,7 @@ impl SendProfile {
         Self {
             limit: max(ACK_ONLY_SIZE_LIMIT - 1, limit),
             pto: None,
+            probe: PNSpaceSet::default(),
             paced: false,
         }
     }
@@ -167,27 +170,33 @@ impl SendProfile {
         Self {
             limit: ACK_ONLY_SIZE_LIMIT - 1,
             pto: None,
+            probe: PNSpaceSet::default(),
             paced: true,
         }
     }
 
-    pub fn new_pto(pn_space: PNSpace, mtu: usize) -> Self {
+    pub fn new_pto(pn_space: PNSpace, mtu: usize, probe: PNSpaceSet) -> Self {
         debug_assert!(mtu > ACK_ONLY_SIZE_LIMIT);
+        debug_assert!(probe[pn_space]);
         Self {
             limit: mtu,
             pto: Some(pn_space),
+            probe,
             paced: false,
         }
     }
 
-    pub fn pto(&self) -> bool {
-        self.pto.is_some()
+    /// Whether probing this space is helpful.  This isn't necessarily the space
+    /// that caused the timer to pop, but it is helpful to send a PING in a space
+    /// that has the PTO timer armed.
+    pub fn should_probe(&self, space: PNSpace) -> bool {
+        self.probe[space]
     }
 
     /// Determine whether an ACK-only packet should be sent for the given packet
     /// number space.
     /// Send only ACKs either: when the space available is too small, or when a PTO
-    /// exists for a later packet number space (which could use extra space for data).
+    /// exists for a later packet number space (which should get the most space).
     pub fn ack_only(&self, space: PNSpace) -> bool {
         self.limit < ACK_ONLY_SIZE_LIMIT || self.pto.map_or(false, |sp| space < sp)
     }
@@ -289,9 +298,7 @@ impl LossRecoverySpace {
     pub fn on_packet_sent(&mut self, sent_packet: SentPacket) {
         if sent_packet.ack_eliciting() {
             self.pto_base_time = Some(sent_packet.time_sent);
-            if sent_packet.cc_in_flight() {
-                self.in_flight_outstanding += 1;
-            }
+            self.in_flight_outstanding += 1;
         } else if self.space != PNSpace::ApplicationData && self.pto_base_time.is_none() {
             // For Initial and Handshake spaces, make sure that we have a PTO baseline
             // always. See `LossRecoverySpace::pto_base_time()` for details.
@@ -300,15 +307,14 @@ impl LossRecoverySpace {
         self.sent_packets.insert(sent_packet.pn, sent_packet);
     }
 
-    pub fn remove_packet(&mut self, pn: u64) -> Option<SentPacket> {
-        if let Some(sent) = self.sent_packets.remove(&pn) {
-            if sent.cc_in_flight() {
-                debug_assert!(self.in_flight_outstanding > 0);
-                self.in_flight_outstanding -= 1;
+    fn remove_packet(&mut self, p: &SentPacket) {
+        if p.ack_eliciting() {
+            debug_assert!(self.in_flight_outstanding > 0);
+            self.in_flight_outstanding -= 1;
+            if self.in_flight_outstanding == 0 {
+                qtrace!("remove_packet outstanding == 0");
+                self.pto_base_time = None;
             }
-            Some(sent)
-        } else {
-            None
         }
     }
 
@@ -320,8 +326,8 @@ impl LossRecoverySpace {
         for (end, start) in acked_ranges {
             // ^^ Notabug: see Frame::decode_ack_frame()
             for pn in start..=end {
-                if let Some(sent) = self.remove_packet(pn) {
-                    qtrace!([self.space], "acked={}", pn);
+                if let Some(sent) = self.sent_packets.remove(&pn) {
+                    self.remove_packet(&sent);
                     eliciting |= sent.ack_eliciting();
                     acked_packets.insert(pn, sent);
                 }
@@ -338,17 +344,49 @@ impl LossRecoverySpace {
     /// and when keys are dropped.
     fn remove_ignored(&mut self) -> impl Iterator<Item = SentPacket> {
         self.in_flight_outstanding = 0;
-        std::mem::take(&mut self.sent_packets)
+        mem::take(&mut self.sent_packets)
             .into_iter()
             .map(|(_, v)| v)
     }
 
+    /// Remove old packets that we've been tracking in case they get acknowledged.
+    /// We try to keep these around until a probe is sent for them, so it is
+    /// important that `cd` is set to at least the current PTO time; otherwise we
+    /// might remove all in-flight packets and stop sending probes.
+    fn remove_old_lost(&mut self, now: Instant, cd: Duration) {
+        let mut it = self.sent_packets.iter();
+        // If the first item is not expired, do nothing.
+        if it.next().map_or(false, |(_, p)| p.expired(now, cd)) {
+            // Find the index of the first unexpired packet.
+            let to_remove = if let Some(first_keep) =
+                it.find_map(|(i, p)| if p.expired(now, cd) { None } else { Some(*i) })
+            {
+                // Some packets haven't expired, so keep those.
+                let keep = self.sent_packets.split_off(&first_keep);
+                mem::replace(&mut self.sent_packets, keep)
+            } else {
+                // All packets are expired.
+                mem::take(&mut self.sent_packets)
+            };
+            for (_, p) in to_remove {
+                self.remove_packet(&p);
+            }
+        }
+    }
+
+    /// Detect lost packets.
+    /// `loss_delay` is the time we will wait before declaring something lost.
+    /// `cleanup_delay` is the time we will wait before cleaning up a lost packet.
     pub fn detect_lost_packets(
         &mut self,
         now: Instant,
         loss_delay: Duration,
+        cleanup_delay: Duration,
         lost_packets: &mut Vec<SentPacket>,
     ) {
+        // Housekeeping.
+        self.remove_old_lost(now, cleanup_delay);
+
         // Packets sent before this time are deemed lost.
         let lost_deadline = now - loss_delay;
         qtrace!(
@@ -364,9 +402,6 @@ impl LossRecoverySpace {
 
         // Lost for retrans/CC purposes
         let mut lost_pns = SmallVec::<[_; 8]>::new();
-
-        // Lost for we-can-actually-forget-about-it purposes
-        let mut really_lost_pns = SmallVec::<[_; 8]>::new();
 
         for (pn, packet) in self
             .sent_packets
@@ -396,13 +431,7 @@ impl LossRecoverySpace {
 
             if packet.declare_lost(now) {
                 lost_pns.push(*pn);
-            } else if packet.expired(now, loss_delay * 2) {
-                really_lost_pns.push(*pn);
             }
-        }
-
-        for pn in really_lost_pns {
-            self.remove_packet(pn).expect("lost packet missing");
         }
 
         lost_packets.extend(lost_pns.iter().map(|pn| self.sent_packets[pn].clone()));
@@ -474,24 +503,32 @@ impl LossRecoverySpaces {
 
 #[derive(Debug)]
 struct PtoState {
+    /// The packet number space that caused the PTO to fire.
     space: PNSpace,
+    /// The number of probes that we have sent.
     count: usize,
     packets: usize,
+    /// The complete set of packet number spaces that can have probes sent.
+    probe: PNSpaceSet,
 }
 
 impl PtoState {
-    pub fn new(space: PNSpace) -> Self {
+    pub fn new(space: PNSpace, probe: PNSpaceSet) -> Self {
+        debug_assert!(probe[space]);
         Self {
             space,
             count: 1,
             packets: PTO_PACKET_COUNT,
+            probe,
         }
     }
 
-    pub fn pto(&mut self, space: PNSpace) {
+    pub fn pto(&mut self, space: PNSpace, probe: PNSpaceSet) {
+        debug_assert!(probe[space]);
         self.space = space;
         self.count += 1;
         self.packets = PTO_PACKET_COUNT;
+        self.probe = probe;
     }
 
     pub fn count(&self) -> usize {
@@ -503,7 +540,7 @@ impl PtoState {
     pub fn send_profile(&mut self, mtu: usize) -> SendProfile {
         if self.packets > 0 {
             self.packets -= 1;
-            SendProfile::new_pto(self.space, mtu)
+            SendProfile::new_pto(self.space, mtu, self.probe)
         } else {
             SendProfile::new_limited(0)
         }
@@ -559,10 +596,6 @@ impl LossRecovery {
 
     pub fn largest_acknowledged_pn(&self, pn_space: PNSpace) -> Option<u64> {
         self.spaces.get(pn_space).and_then(|sp| sp.largest_acked)
-    }
-
-    pub fn pto(&self) -> Duration {
-        self.rtt_vals.pto(PNSpace::ApplicationData)
     }
 
     pub fn set_qlog(&mut self, qlog: NeqoQlog) {
@@ -631,7 +664,7 @@ impl LossRecovery {
         }
 
         // Track largest PN acked per space
-        let prev_largest_acked_sent_time = space.largest_acked_sent_time;
+        let prev_largest_acked = space.largest_acked_sent_time;
         if Some(largest_acked) > space.largest_acked {
             space.largest_acked = Some(largest_acked);
 
@@ -647,24 +680,29 @@ impl LossRecovery {
         }
         self.cc.on_packets_acked(&acked_packets);
 
+        // Perform loss detection.
+        // PTO is used to remove lost packets from in-flight accounting.
+        // We need to ensure that we have sent any PTO probes before they are removed
+        // as we rely on the count of in-flight packets to determine whether to send
+        // another probe.  Removing them too soon would result in not sending on PTO.
         let loss_delay = self.loss_delay();
-        let mut lost_packets = Vec::new();
-        self.spaces.get_mut(pn_space).unwrap().detect_lost_packets(
-            now,
-            loss_delay,
-            &mut lost_packets,
-        );
-        // TODO Process ECN information if present.
-        self.cc.on_packets_lost(
-            now,
-            prev_largest_acked_sent_time,
-            self.rtt_vals.pto(pn_space),
-            &lost_packets,
-        );
+        let cleanup = self.pto_period(pn_space);
+        let mut lost = Vec::new();
+        self.spaces
+            .get_mut(pn_space)
+            .unwrap()
+            .detect_lost_packets(now, loss_delay, cleanup, &mut lost);
+
+        // Tell the congestion controller about any lost packets.
+        // The PTO for congestion control is the raw number, without exponential
+        // backoff, so that we can determine persistent congestion.
+        let pto_raw = self.pto_raw(pn_space);
+        self.cc
+            .on_packets_lost(now, prev_largest_acked, pto_raw, &lost);
 
         self.pto_state = None;
 
-        (acked_packets, lost_packets)
+        (acked_packets, lost)
     }
 
     fn loss_delay(&self) -> Duration {
@@ -694,7 +732,8 @@ impl LossRecovery {
         // So maybe fire a PTO.
         if let Some(pto) = self.pto_time(PNSpace::ApplicationData) {
             if pto < now {
-                self.fire_pto(PNSpace::ApplicationData);
+                let probes = PNSpaceSet::from(&[PNSpace::ApplicationData]);
+                self.fire_pto(PNSpace::ApplicationData, probes);
             }
         }
     }
@@ -743,11 +782,37 @@ impl LossRecovery {
             .map(|val| val + self.loss_delay())
     }
 
+    // The borrow checker is a harsh mistress.
+    // It's important that calls to `RttVals::pto()` are routed through a central point
+    // because that ensures consistency, but we often have a mutable borrow on other
+    // pieces of `self` that prevents that.
+    // An associated function avoids another borrow on `&self`.
+    fn pto_raw_inner(rtt_vals: &RttVals, space: PNSpace) -> Duration {
+        rtt_vals.pto(space)
+    }
+
+    // Borrow checker hack, see above.
+    fn pto_period_inner(
+        rtt_vals: &RttVals,
+        pto_state: &Option<PtoState>,
+        pn_space: PNSpace,
+    ) -> Duration {
+        Self::pto_raw_inner(rtt_vals, pn_space)
+            .checked_mul(1 << pto_state.as_ref().map_or(0, |p| p.count))
+            .unwrap_or(LOCAL_IDLE_TIMEOUT * 2)
+    }
+
     /// Get the Base PTO value, which is derived only from the `RTT` and `RTTvar` values.
     /// This is for those cases where you need a value for the time you might sensibly
-    /// wait for a packet to propagate.  Using `3*raw_pto()` is common.
-    pub fn raw_pto(&self) -> Duration {
-        self.rtt_vals.pto(PNSpace::ApplicationData)
+    /// wait for a packet to propagate.  Using `3*pto_raw(..)` is common.
+    pub fn pto_raw(&self, space: PNSpace) -> Duration {
+        Self::pto_raw_inner(&self.rtt_vals, space)
+    }
+
+    /// Get the current PTO period for the given packet number space.
+    /// Unlike `pto_raw`, this includes calculation for the exponential backoff.
+    fn pto_period(&self, pn_space: PNSpace) -> Duration {
+        Self::pto_period_inner(&self.rtt_vals, &self.pto_state, pn_space)
     }
 
     // Calculate PTO time for the given space.
@@ -755,13 +820,7 @@ impl LossRecovery {
         if self.confirmed_time.is_none() && pn_space == PNSpace::ApplicationData {
             None
         } else if let Some(space) = self.spaces.get(pn_space) {
-            space.pto_base_time().map(|t| {
-                t + self
-                    .rtt_vals
-                    .pto(pn_space)
-                    .checked_mul(1 << self.pto_state.as_ref().map_or(0, |p| p.count))
-                    .unwrap_or(LOCAL_IDLE_TIMEOUT * 2)
-            })
+            space.pto_base_time().map(|t| t + self.pto_period(pn_space))
         } else {
             None
         }
@@ -781,11 +840,11 @@ impl LossRecovery {
         }
     }
 
-    fn fire_pto(&mut self, pn_space: PNSpace) {
+    fn fire_pto(&mut self, pn_space: PNSpace, allow_probes: PNSpaceSet) {
         if let Some(st) = &mut self.pto_state {
-            st.pto(pn_space);
+            st.pto(pn_space, allow_probes);
         } else {
-            self.pto_state = Some(PtoState::new(pn_space));
+            self.pto_state = Some(PtoState::new(pn_space, allow_probes));
         }
         qlog::metrics_updated(
             &mut self.qlog,
@@ -801,26 +860,26 @@ impl LossRecovery {
     /// we have to clone the `SentPacket` instance.
     fn maybe_fire_pto(&mut self, now: Instant, lost: &mut Vec<SentPacket>) {
         let mut pto_space = None;
+        // The spaces in which we will allow probing.
+        let mut allow_probes = PNSpaceSet::default();
         for pn_space in PNSpace::iter() {
-            // Skip early packet number spaces where the PTO timer hasn't fired.
-            // Once the timer for one space has fired, include higher spaces. Declaring more
-            // data as "lost" makes it more likely that PTO packets will include useful data.
-            if pto_space.is_none() && self.pto_time(*pn_space).map_or(true, |t| t > now) {
-                continue;
-            }
-            qdebug!([self], "PTO timer fired for {}", pn_space);
-            if let Some(space) = self.spaces.get_mut(*pn_space) {
-                pto_space = pto_space.or(Some(*pn_space));
-                lost.extend(space.pto_packets(PTO_PACKET_COUNT).cloned());
-            } else {
-                qwarn!([self], "PTO timer for dropped space {}", pn_space);
+            if let Some(t) = self.pto_time(*pn_space) {
+                allow_probes[*pn_space] = true;
+                if t <= now {
+                    qdebug!([self], "PTO timer fired for {}", pn_space);
+                    let space = self.spaces.get_mut(*pn_space).unwrap();
+                    lost.extend(space.pto_packets(PTO_PACKET_COUNT).cloned());
+
+                    pto_space = pto_space.or(Some(*pn_space));
+                }
             }
         }
 
         // This has to happen outside the loop. Increasing the PTO count here causes the
         // pto_time to increase which might cause PTO for later packet number spaces to not fire.
         if let Some(pn_space) = pto_space {
-            self.fire_pto(pn_space);
+            qtrace!([self], "PTO {}, probing {:?}", pn_space, allow_probes);
+            self.fire_pto(pn_space, allow_probes);
         }
     }
 
@@ -831,11 +890,12 @@ impl LossRecovery {
         let mut lost_packets = Vec::new();
         for space in self.spaces.iter_mut() {
             let first = lost_packets.len(); // The first packet lost in this space.
-            space.detect_lost_packets(now, loss_delay, &mut lost_packets);
+            let pto = Self::pto_period_inner(&self.rtt_vals, &self.pto_state, space.space());
+            space.detect_lost_packets(now, loss_delay, pto, &mut lost_packets);
             self.cc.on_packets_lost(
                 now,
                 space.largest_acked_sent_time,
-                self.rtt_vals.pto(space.space()),
+                Self::pto_raw_inner(&self.rtt_vals, space.space()),
                 &lost_packets[first..],
             )
         }
@@ -969,7 +1029,6 @@ mod tests {
                 true,
                 Rc::default(),
                 ON_SENT_SIZE,
-                true,
             ));
         }
     }
@@ -1088,7 +1147,6 @@ mod tests {
             true,
             Rc::default(),
             ON_SENT_SIZE,
-            true,
         ));
         lr.on_packet_sent(SentPacket::new(
             PacketType::Short,
@@ -1097,7 +1155,6 @@ mod tests {
             true,
             Rc::default(),
             ON_SENT_SIZE,
-            true,
         ));
         let (_, lost) = lr.on_ack_received(
             PNSpace::ApplicationData,
@@ -1141,7 +1198,7 @@ mod tests {
         let packets = lr.timeout(pn1_loss_time);
         assert_eq!(packets.len(), 1);
         // Checking for expiration with zero delay lets us check the loss time.
-        assert!(packets[0].expired(pn1_loss_time, Duration::from_secs(0)));
+        assert!(packets[0].expired(pn1_loss_time, Duration::new(0, 0)));
         assert_no_sent_times(&lr);
     }
 
@@ -1200,7 +1257,6 @@ mod tests {
             true,
             Rc::default(),
             ON_SENT_SIZE,
-            true,
         ));
         lr.on_packet_sent(SentPacket::new(
             PacketType::Handshake,
@@ -1209,7 +1265,6 @@ mod tests {
             true,
             Rc::default(),
             ON_SENT_SIZE,
-            true,
         ));
         lr.on_packet_sent(SentPacket::new(
             PacketType::Short,
@@ -1218,7 +1273,6 @@ mod tests {
             true,
             Rc::default(),
             ON_SENT_SIZE,
-            true,
         ));
 
         // Now put all spaces on the LR timer so we can see them.
@@ -1227,8 +1281,7 @@ mod tests {
             PacketType::Handshake,
             PacketType::Short,
         ] {
-            let sent_pkt =
-                SentPacket::new(*sp, 1, pn_time(3), true, Rc::default(), ON_SENT_SIZE, true);
+            let sent_pkt = SentPacket::new(*sp, 1, pn_time(3), true, Rc::default(), ON_SENT_SIZE);
             let pn_space = PNSpace::from(sent_pkt.pt);
             lr.on_packet_sent(sent_pkt);
             lr.on_ack_received(
@@ -1242,6 +1295,7 @@ mod tests {
             lr.spaces.get_mut(pn_space).unwrap().detect_lost_packets(
                 pn_time(3),
                 TEST_RTT,
+                TEST_RTT * 3, // unused
                 &mut lost,
             );
             assert!(lost.is_empty());
@@ -1262,7 +1316,6 @@ mod tests {
             true,
             Rc::default(),
             ON_SENT_SIZE,
-            true,
         ));
         assert_sent_times(&lr, None, None, Some(pn_time(2)));
     }
@@ -1278,7 +1331,6 @@ mod tests {
             true,
             Rc::default(),
             ON_SENT_SIZE,
-            true,
         ));
         lr.on_packet_sent(SentPacket::new(
             PacketType::Short,
@@ -1287,7 +1339,6 @@ mod tests {
             true,
             Rc::default(),
             ON_SENT_SIZE,
-            true,
         ));
 
         assert_eq!(lr.pto_time(PNSpace::ApplicationData), None);
@@ -1299,6 +1350,9 @@ mod tests {
         let expected_pto = pn_time(2) + (INITIAL_RTT * 3) + MAX_ACK_DELAY;
         lr.discard(PNSpace::Handshake, expected_pto);
         let profile = lr.send_profile(expected_pto, 10000);
-        assert!(profile.pto());
+        assert!(profile.pto.is_some());
+        assert!(!profile.should_probe(PNSpace::Initial));
+        assert!(!profile.should_probe(PNSpace::Handshake));
+        assert!(profile.should_probe(PNSpace::ApplicationData));
     }
 }


### PR DESCRIPTION
This improves tracking of in-flight packets.  Most importantly, it
removes the distinction we were using for PTO packets that was flat-out
incorrect (my bad).

In addition to that, there are several other tweaks.

1. Remove SentPacket::cc_in_flight()

2. Allow in flight bytes to exceed the congestion window.  The only
change here is to remove a debug assertion; once we started counting PTO
packets properly, this was the only other thing that was standing in the
way of this accounting being better.

3. Change the way we probe so that we don't probe spaces that don't
require a PTO.  Part of the reason we had infinite loops in the past is
that we were sending a PING in ApplicationData without needing to.  This
is achieved by recording which spaces have an active PTO timer when
processing the PTO timer.  We will only send a PING for those spaces.
Note that we will still send outstanding data for a space if there is a
PTO on an earlier space, but only if there is room left for that.

4. Change the way we acquire the PTO timer and associated values.  We
use the raw PTO value in some places and the exponentiated value in
other places.  Make separate functions so that this is clearer.  There
are some awkward hacks involved so that everything routes through
the same functions without invoking the wrath of the borrow checker
here.

5. Change the way we stop tracking old lost packets.  The code before
included that in the main detect_lost_packets loop, but that was never
necessary.  This now uses BTreeMap::split_off, which should be a little
faster.

6. Track old lost packets for much longer.  This now uses the *current*
PTO timer, which should ensure that they stick around for ages.  The
problem with dropping lost packets earlier than one PTO is that we were
dropping the number of in-flight packets back to zero in some cases.
That would result in us no longer probing, even though there could be
unacknowledged ack-eliciting packets.  As the timer was 3x the loss
recovery timer, this is likely to be larger than one PTO, but if there
are multiple losses or low rttvar, it is possible that we would stop
sending altogether before even one PTO.  (This was compounded by the
fact that we didn't consider probes to be outstanding, so we stopped
retransmissions after a single probe in most cases.)

Of these, number 5 is separable, but the changes are fairly simple
to review alongside the other changes.

Closes #835.

Note: this is built on top of #833.