### PR TITLE
Improve the feedback from the pre-commit hook

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -26,5 +26,11 @@ fi
 # Check formatting.
 trap 'git stash pop -q' EXIT
 git stash push -k -u -q -m "pre-commit stash"
-cargo fmt -- --check -l
-exit $?
+if ! errors=($(cargo fmt -- --check -l)); then
+    echo "Formatting errors found."
+    echo "Run \`cargo fmt\` to fix the following files:"
+    for err in "${errors[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi


### PR DESCRIPTION
This has been bugging me for a while now.  This is much nicer...

```
$ git commit -m test neqo-crypto/tests/ext.rs
Formatting errors found.
Run `cargo fmt` to fix the following files:
  /home/martin/code/neqo/neqo-crypto/tests/ext.rs
$ echo $?
1
```