### PR TITLE
Faster ACK processing

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -2967,6 +2967,7 @@ mod tests {
             let output = a.process(input, now).dgram();
             assert!(had_input || output.is_some());
             input = output;
+            qtrace!("t += {:?}", rtt / 2);
             now += rtt / 2;
             mem::swap(&mut a, &mut b);
         }


### PR DESCRIPTION
This improves performance by an absurd amount.  Transferring 100M with this implementation of ACK processing takes 2.3s (approximately) of wall clock time on my old machine.  Before the change it took 15.7s.

The flamegraphs show this clearly as well.

Before:
![image](https://user-images.githubusercontent.com/67641/88513082-fbcde500-d02a-11ea-8cbc-6019ed09cdd0.png)

After:
![image](https://user-images.githubusercontent.com/67641/88513094-00929900-d02b-11ea-9449-9342f26d163d.png)

Clearly we have a way to go before our performance is *good*, but this should help a lot.


