### PR TITLE
Drop handshake space when all handshake data acked

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -1666,8 +1666,9 @@ impl Connection {
                 if self.role == Role::Client {
                     // Client can send Handshake packets -> discard Initial keys and states
                     self.discard_keys(PNSpace::Initial, now);
-                } else if self.state == State::Confirmed {
-                    // We could discard handshake keys in set_state, but wait until after sending an ACK.
+                } else if self.crypto.streams.all_data_acked(PNSpace::Handshake) {
+                    // We could discard handshake keys in set_state, but wait
+                    // until after sending an ACK.
                     self.discard_keys(PNSpace::Handshake, now);
                 }
             }

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -1024,6 +1024,13 @@ impl CryptoStreams {
         }
     }
 
+    pub fn all_data_acked(&self, space: PNSpace) -> bool {
+        match self.get(space) {
+            Some(cs) => cs.tx.buffered() == 0,
+            None => true,
+        }
+    }
+
     fn get(&self, space: PNSpace) -> Option<&CryptoStream> {
         let (initial, hs, app) = match self {
             Self::Initial {

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -369,7 +369,7 @@ impl TxBuffer {
         self.buffered() as u64 + self.retired
     }
 
-    fn buffered(&self) -> usize {
+    pub fn buffered(&self) -> usize {
         self.send_buf.len()
     }
 


### PR DESCRIPTION
Instead of dropping when client receives HandshakeDone, drop when
handshake crypto bytes are acked by server. This is when the server may
have dropped their hs keys, so further transmissions are not useful.
This is especially bad when the 1RTT packet containing the HandshakeDone
frame is lost. Our hs PTOs are not readable, but we only send hs PTOs
until HandshakeDone is received.