### PR TITLE
Don't cleanup bidi recv stream until send stream is done

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -2259,10 +2259,13 @@ impl Connection {
     }
 
     fn cleanup_streams(&mut self) {
+        self.send_streams.clear_terminal();
+
         let recv_to_remove = self
             .recv_streams
             .iter()
             .filter(|(_, stream)| stream.is_terminal())
+            .filter(|(id, _)| id.is_uni() || self.send_streams.get(**id).is_err())
             .map(|(id, _)| *id)
             .collect::<Vec<_>>();
 
@@ -2292,8 +2295,6 @@ impl Connection {
                 .borrow_mut()
                 .max_streams(self.indexes.local_max_stream_uni, StreamType::UniDi)
         }
-
-        self.send_streams.clear_terminal();
     }
 
     /// Get or make a stream, and implicitly open additional streams as

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -744,6 +744,10 @@ impl SendStreams {
         self.0.get_mut(&id).ok_or_else(|| Error::InvalidStreamId)
     }
 
+    pub fn exists(&self, id: StreamId) -> bool {
+        self.0.contains_key(&id)
+    }
+
     pub fn insert(&mut self, id: StreamId, stream: SendStream) {
         self.0.insert(id, stream);
     }


### PR DESCRIPTION
Currently, the client can have open streams exceeding MAX_STREAMS because we give them more streams credit when the recv stream is complete rather than when both the send and recv stream are complete.

Clear up terminal send streams first. Then, only remove bidi recv streams
if send stream is not present.

This keeps the recv stream hanging around longer than strictly necessary
but I think this is more straightforward than logic to remove it, and
then increase max_stream_bidi when the send stream is cleaned up.

fixes #871