### PR TITLE
Fix panic on QNS when using 0.9 server

### DIFF
--- a/neqo-http3-server/src/old_https.rs
+++ b/neqo-http3-server/src/old_https.rs
@@ -92,7 +92,11 @@ impl Http09Server {
                 }
             }
         };
-        let conn_state = self.conn_state.get_mut(&(conn.clone(), stream_id)).unwrap();
+
+        let conn_state = self
+            .conn_state
+            .entry((conn.clone(), stream_id))
+            .or_default();
         conn_state.data_to_send = resp.map(|r| (r, 0));
         if conn_state.writable {
             self.stream_writable(stream_id, &mut conn);


### PR DESCRIPTION
Do no assume NewStream event is before StreamWritable event.

fixes #846