### PR TITLE
Set granularity of the server timer to 1ms.

### DIFF
--- a/neqo-http3-server/src/main.rs
+++ b/neqo-http3-server/src/main.rs
@@ -372,7 +372,9 @@ fn main() -> Result<(), io::Error> {
 
     let (poll, mut sockets, mut servers) = init_poll(&hosts, &args)?;
 
-    let mut timer = Builder::default().build::<usize>();
+    let mut timer = Builder::default()
+        .tick_duration(Duration::from_millis(1))
+        .build::<usize>();
     poll.register(&timer, TIMER_TOKEN, Ready::readable(), PollOpt::edge())?;
 
     let buf = &mut [0u8; 2048];


### PR DESCRIPTION
The default granularity is 100ms. 