### PR TITLE
Add APIs to get odcid to Connection and Http3Client

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -918,7 +918,7 @@ mod old {
             client.set_ciphers(&ciphers)?;
         }
 
-        client.set_qlog(qlog_new(args, origin, &client.odcid().as_ref().unwrap())?);
+        client.set_qlog(qlog_new(args, origin, &client.odcid().unwrap())?);
 
         let mut h = HandlerOld {
             streams: HashMap::new(),

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -20,8 +20,8 @@ use neqo_common::{
 use neqo_crypto::{agent::CertificateInfo, AuthenticationStatus, SecretAgentInfo};
 use neqo_qpack::{stats::Stats, QpackSettings};
 use neqo_transport::{
-    AppError, Connection, ConnectionEvent, ConnectionIdManager, Output, QuicVersion, StreamId,
-    StreamType, ZeroRttState,
+    AppError, Connection, ConnectionEvent, ConnectionId, ConnectionIdManager, Output, QuicVersion,
+    StreamId, StreamType, ZeroRttState,
 };
 use std::cell::RefCell;
 use std::fmt::Display;
@@ -142,6 +142,13 @@ impl Http3Client {
 
     pub fn set_qlog(&mut self, qlog: NeqoQlog) {
         self.conn.set_qlog(qlog);
+    }
+
+    /// Get the connection id, which is useful for disambiguating connections to
+    /// the same origin.
+    #[must_use]
+    pub fn connection_id(&self) -> &ConnectionId {
+        &self.conn.odcid().as_ref().expect("Client always has odcid")
     }
 
     /// Returns a resumption token if present.

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -148,7 +148,7 @@ impl Http3Client {
     /// the same origin.
     #[must_use]
     pub fn connection_id(&self) -> &ConnectionId {
-        &self.conn.odcid().as_ref().expect("Client always has odcid")
+        &self.conn.odcid().expect("Client always has odcid")
     }
 
     /// Returns a resumption token if present.

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -617,6 +617,13 @@ impl Connection {
         &mut self.qlog
     }
 
+    /// Get the original destination connection id for this connection. This
+    /// will always be present for Role::Client but not if Role::Server is in
+    /// State::Init.
+    pub fn odcid(&self) -> &Option<ConnectionId> {
+        &self.remote_original_destination_cid
+    }
+
     /// Set a local transport parameter, possibly overriding a default value.
     pub fn set_local_tparam(&self, tp: TransportParameterId, value: TransportParameter) -> Res<()> {
         if *self.state() == State::Init {

--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -620,8 +620,8 @@ impl Connection {
     /// Get the original destination connection id for this connection. This
     /// will always be present for Role::Client but not if Role::Server is in
     /// State::Init.
-    pub fn odcid(&self) -> &Option<ConnectionId> {
-        &self.remote_original_destination_cid
+    pub fn odcid(&self) -> Option<&ConnectionId> {
+        self.remote_original_destination_cid.as_ref()
     }
 
     /// Set a local transport parameter, possibly overriding a default value.


### PR DESCRIPTION
It's useful to have a tag that lets connections to the same host be
told apart. ODCID seems good for this purpose.

Make this available from Connection (as Option, because may not be set
for Role::Server) and Http3Client, where we know it must be set.

Change neqo-client to use new API rather than reaching into Connection
to get Path.