### PR TITLE
Use wait-for-it

### DIFF
--- a/neqo-qns/run_endpoint.sh
+++ b/neqo-qns/run_endpoint.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
 # Set up the routing needed for the simulation.
-./setup.sh
+/setup.sh
 
 cd neqo
 
-CLIENT_PARAMS="--qns-mode --output-dir /downloads"
-SERVER_PARAMS="--qns-mode 0.0.0.0:443"
+CLIENT_PARAMS=(--qns-mode --output-dir /downloads)
+SERVER_PARAMS=(--qns-mode 0.0.0.0:443)
 
 if [ "$ROLE" == "client" ]; then
+    /wait-for-it.sh sim:57832 -s -t 30
     echo "Starting Neqo client ..."
-    echo "CLIENT_PARAMS:" $CLIENT_PARAMS
-    echo "REQUESTS:" $REQUESTS
-    sleep 5
-    RUST_LOG=debug RUST_BACKTRACE=1 ./target/neqo-client $CLIENT_PARAMS $REQUESTS
+    echo "CLIENT_PARAMS: ${CLIENT_PARAMS[*]}"
+    echo "REQUESTS: $REQUESTS"
+    RUST_LOG=debug RUST_BACKTRACE=1 ./target/neqo-client "${CLIENT_PARAMS[@]}" $REQUESTS
 elif [ "$ROLE" == "server" ]; then
-    RUST_LOG=info RUST_BACKTRACE=1 ./target/neqo-http3-server $SERVER_PARAMS
+    RUST_LOG=info RUST_BACKTRACE=1 ./target/neqo-http3-server "${SERVER_PARAMS@]}"
 fi


### PR DESCRIPTION
This might help with simulation setup.  ngtcp2 in particular fails
consistently, and the main difference I can see is that those that don't
fail include wait-for-it in their endpoint script.

This also cleans up quoting for arguments.