### PR TITLE
Ack frequency extension

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -2689,7 +2689,7 @@ mod tests {
     use crate::recovery::ACK_ONLY_SIZE_LIMIT;
     use crate::recovery::PTO_PACKET_COUNT;
     use crate::send_stream::SEND_BUFFER_SIZE;
-    use crate::tracking::DEFAULT_ACK_PACKET_THRESHOLD;
+    use crate::tracking::{DEFAULT_ACK_DELAY, DEFAULT_ACK_PACKET_THRESHOLD};
     use std::convert::TryInto;
 
     use neqo_crypto::{constants::TLS_CHACHA20_POLY1305_SHA256, AllowZeroRtt};
@@ -4180,15 +4180,19 @@ mod tests {
 
         now += Duration::from_millis(10);
         // Client receive ack for the first packet
-        let dgram = client.process(pkt, now).dgram();
-        // The PTO included a PING, so we acknowledge immediately.
-        assert!(dgram.is_some());
+        let cb = client.process(pkt, now).callback();
+        // Ack delay timer for the packet carrying HANDSHAKE_DONE.
+        assert_eq!(cb, DEFAULT_ACK_DELAY);
 
+        // Let the ack timer expire.
+        now += cb;
+        let out = client.process(None, now).dgram();
+        assert!(out.is_some());
         let cb = client.process(None, now).callback();
         // The handshake keys are discarded, but now we're back to the idle timeout.
         // We don't send another PING because the handshake space is done and there
         // is nothing to probe for.
-        assert_eq!(cb, LOCAL_IDLE_TIMEOUT);
+        assert_eq!(cb, LOCAL_IDLE_TIMEOUT - DEFAULT_ACK_DELAY);
     }
 
     /// Test that PTO in the Handshake space contains the right frames.

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -464,6 +464,7 @@ fn frame_to_qlogframe(frame: &Frame) -> QuicFrame {
             Some(frame_type.to_string()),
         ),
         Frame::HandshakeDone => QuicFrame::handshake_done(),
+        Frame::AckFrequency { .. } => QuicFrame::unknown(frame.get_type()),
     }
 }
 

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -44,6 +44,7 @@ tpids! {
     ACTIVE_CONNECTION_ID_LIMIT = 0x0e,
     INITIAL_SOURCE_CONNECTION_ID = 0x0f,
     RETRY_SOURCE_CONNECTION_ID = 0x10,
+    MIN_ACK_DELAY = 0xaf,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -188,6 +189,7 @@ impl TransportParameters {
             ACK_DELAY_EXPONENT => 3,
             MAX_ACK_DELAY => 25,
             ACTIVE_CONNECTION_ID_LIMIT => 2,
+            MIN_ACK_DELAY => 0,
             _ => panic!("Transport parameter not known or not an Integer"),
         };
         match self.params.get(&tp) {
@@ -210,7 +212,8 @@ impl TransportParameters {
             | MAX_UDP_PAYLOAD_SIZE
             | ACK_DELAY_EXPONENT
             | MAX_ACK_DELAY
-            | ACTIVE_CONNECTION_ID_LIMIT => {
+            | ACTIVE_CONNECTION_ID_LIMIT
+            | MIN_ACK_DELAY => {
                 self.set(tp, TransportParameter::Integer(value));
             }
             _ => panic!("Transport parameter not known"),

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -44,7 +44,7 @@ tpids! {
     ACTIVE_CONNECTION_ID_LIMIT = 0x0e,
     INITIAL_SOURCE_CONNECTION_ID = 0x0f,
     RETRY_SOURCE_CONNECTION_ID = 0x10,
-    MIN_ACK_DELAY = 0xaf,
+    MIN_ACK_DELAY = 0xde1a,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -451,12 +451,15 @@ impl RecvdPackets {
 
     /// Add the packet to the tracked set.
     pub fn set_received(&mut self, now: Instant, pn: PacketNumber, ack_eliciting: bool) {
+        let largest = self.ranges.front().map_or(0, |r| r.largest);
+        qdebug!([self], "received {}, largest: {}", pn, largest);
+
         self.add(pn);
         self.trim_ranges();
 
         // The new addition is the new largest acknowledged, so an immediate ACK
         // might be needed.
-        let immediate_ack = if pn >= self.next_unacknowledged {
+        let immediate_ack = if pn >= largest {
             self.largest_pn_time = Some(now);
 
             if self.space != PNSpace::ApplicationData {


### PR DESCRIPTION
Tests are WIP, plus we shouldn't land this while the spec is unstable, because this will advertise support and we might choke on badly formed frames.

This assumes a structure to the ACK_FREQUENCY frame that doesn't exist in the draft, specifically:

```
ACK_FREQUENCY Frame {
  Type (i) = 0xaf,
  Sequence Number (i),
  Ack Delay (i),
  Packet Threshold (i),
  Loss Threshold (i),
}
```

This PR needs to sit until that discussion stabilizes a little more.  Shipping this would be irresponsible.

(One thing we might consider taking from this in the meantime is the code that advertises the MAX_ACK_DELAY transport parameter.)