### PR TITLE
QNS client: Re-add sleep to client runs

### DIFF
--- a/neqo-qns/run_endpoint.sh
+++ b/neqo-qns/run_endpoint.sh
@@ -13,6 +13,7 @@ if [ "$ROLE" == "client" ]; then
     echo "Starting Neqo client ..."
     echo "CLIENT_PARAMS: ${CLIENT_PARAMS[*]}"
     echo "REQUESTS: $REQUESTS"
+    sleep 5
     RUST_LOG=debug RUST_BACKTRACE=1 ./target/neqo-client "${CLIENT_PARAMS[@]}" $REQUESTS
 elif [ "$ROLE" == "server" ]; then
     RUST_LOG=info RUST_BACKTRACE=1 ./target/neqo-http3-server "${SERVER_PARAMS[@]}"


### PR DESCRIPTION
We're seeing "connection refused" errors. wait-for-it doesn't seem to ever
be waiting.

We need to re-add the sleep for now.