### PR TITLE
Factoring of ACK tracking

### DIFF
--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -223,6 +223,13 @@ impl std::fmt::Display for PNSpace {
     }
 }
 
+/// `InsertionResult` tracks whether something was inserted for `PacketRange::add()`.
+pub enum InsertionResult {
+    Largest,
+    Smallest,
+    NotInserted,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct PacketRange {
     largest: PacketNumber,
@@ -232,7 +239,7 @@ pub struct PacketRange {
 
 impl PacketRange {
     /// Make a single packet range.
-    pub fn new(pn: u64) -> Self {
+    pub fn new(pn: PacketNumber) -> Self {
         Self {
             largest: pn,
             smallest: pn,
@@ -251,36 +258,38 @@ impl PacketRange {
     }
 
     /// Return whether the given number is in the range.
-    pub fn contains(&self, pn: u64) -> bool {
+    pub fn contains(&self, pn: PacketNumber) -> bool {
         (pn >= self.smallest) && (pn <= self.largest)
     }
 
-    /// Maybe add a packet number to the range.  Returns true if it was added.
-    pub fn add(&mut self, pn: u64) -> bool {
+    /// Maybe add a packet number to the range.  Returns true if it was added
+    /// at the small end (which indicates that this might need merging with a
+    /// preceding range).
+    pub fn add(&mut self, pn: PacketNumber) -> InsertionResult {
         assert!(!self.contains(pn));
         // Only insert if this is adjacent the current range.
         if (self.largest + 1) == pn {
             qtrace!([self], "Adding largest {}", pn);
             self.largest += 1;
             self.ack_needed = true;
-            true
+            InsertionResult::Largest
         } else if self.smallest == (pn + 1) {
             qtrace!([self], "Adding smallest {}", pn);
             self.smallest -= 1;
             self.ack_needed = true;
-            true
+            InsertionResult::Smallest
         } else {
-            false
+            InsertionResult::NotInserted
         }
     }
 
-    /// Maybe merge a lower-numbered range into this.
-    pub fn merge_smaller(&mut self, other: &Self) {
+    /// Maybe merge a higher-numbered range into this.
+    fn merge_larger(&mut self, other: &Self) {
         qinfo!([self], "Merging {}", other);
         // This only works if they are immediately adjacent.
-        assert_eq!(self.smallest - 1, other.largest);
+        assert_eq!(self.largest + 1, other.smallest);
 
-        self.smallest = other.smallest;
+        self.largest = other.largest;
         self.ack_needed = self.ack_needed || other.ack_needed;
     }
 
@@ -357,37 +366,31 @@ impl RecvdPackets {
     // A simple addition of a packet number to the tracked set.
     // This doesn't do a binary search on the assumption that
     // new packets will generally be added to the start of the list.
-    fn add(&mut self, pn: u64) -> usize {
+    fn add(&mut self, pn: PacketNumber) {
         for i in 0..self.ranges.len() {
-            if self.ranges[i].add(pn) {
-                // Maybe merge two ranges.
-                let nxt = i + 1;
-                if (nxt < self.ranges.len()) && (pn - 1 == self.ranges[nxt].largest) {
-                    let smaller = self.ranges.remove(nxt).unwrap();
-                    self.ranges[i].merge_smaller(&smaller);
+            match self.ranges[i].add(pn) {
+                InsertionResult::Largest => return,
+                InsertionResult::Smallest => {
+                    // If this was the smallest, it might have filled a gap.
+                    let nxt = i + 1;
+                    if (nxt < self.ranges.len()) && (pn - 1 == self.ranges[nxt].largest) {
+                        let larger = self.ranges.remove(i).unwrap();
+                        self.ranges[i].merge_larger(&larger);
+                    }
+                    return;
                 }
-                return i;
-            }
-            if self.ranges[i].largest < pn {
-                self.ranges.insert(i, PacketRange::new(pn));
-                return i;
+                InsertionResult::NotInserted => {
+                    if self.ranges[i].largest < pn {
+                        self.ranges.insert(i, PacketRange::new(pn));
+                        return;
+                    }
+                }
             }
         }
         self.ranges.push_back(PacketRange::new(pn));
-        self.ranges.len() - 1
     }
 
-    /// Add the packet to the tracked set.
-    pub fn set_received(&mut self, now: Instant, pn: u64, ack_eliciting: bool) {
-        let next_in_order_pn = self.ranges.front().map_or(0, |pr| pr.largest + 1);
-        qdebug!([self], "next in order pn: {}", next_in_order_pn);
-        let i = self.add(pn);
-
-        // The new addition was the largest, so update the time we use for calculating ACK delay.
-        if i == 0 && pn == self.ranges[0].largest {
-            self.largest_pn_time = Some(now);
-        }
-
+    fn trim_ranges(&mut self) {
         // Limit the number of ranges that are tracked to MAX_TRACKED_RANGES.
         if self.ranges.len() > MAX_TRACKED_RANGES {
             let oldest = self.ranges.pop_back().unwrap();
@@ -398,6 +401,20 @@ impl RecvdPackets {
                 qdebug!([self], "Drop ACK range: {}", oldest);
             }
             self.min_tracked = oldest.largest + 1;
+        }
+    }
+
+    /// Add the packet to the tracked set.
+    pub fn set_received(&mut self, now: Instant, pn: u64, ack_eliciting: bool) {
+        let next_in_order_pn = self.ranges.front().map_or(0, |pr| pr.largest + 1);
+        qdebug!([self], "received {}, next in order pn: {}", pn, next_in_order_pn);
+
+        self.add(pn);
+        self.trim_ranges();
+
+        // The new addition was the largest, so update the time we use for calculating ACK delay.
+        if pn >= next_in_order_pn {
+            self.largest_pn_time = Some(now);
         }
 
         if ack_eliciting {

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -407,7 +407,12 @@ impl RecvdPackets {
     /// Add the packet to the tracked set.
     pub fn set_received(&mut self, now: Instant, pn: u64, ack_eliciting: bool) {
         let next_in_order_pn = self.ranges.front().map_or(0, |pr| pr.largest + 1);
-        qdebug!([self], "received {}, next in order pn: {}", pn, next_in_order_pn);
+        qdebug!(
+            [self],
+            "received {}, next in order pn: {}",
+            pn,
+            next_in_order_pn
+        );
 
         self.add(pn);
         self.trim_ranges();


### PR DESCRIPTION
We attempt to merge ACK ranges in one case that was unnecessary.
Remove that by extending the interface.

When merging, remove the largest ACK range rather than the next one.  On
the assumption that most cases where we fill gaps are near the most
recent packet, this will result in dropping the head of the list rather
than a range in the middle of the list.

Finally, simplify the logic that determines whether this is the largest
acknowledged.