### PR TITLE
Add connection to active connection list when data sent

### DIFF
--- a/neqo-http3-server/src/old_https.rs
+++ b/neqo-http3-server/src/old_https.rs
@@ -131,6 +131,7 @@ impl Http09Server {
                         .unwrap();
                     eprintln!("Wrote {}", sent);
                     *offset += sent;
+                    self.server.add_to_waiting(conn.clone());
                     if *offset == data.len() {
                         eprintln!("Sent {} on {}, closing", sent, stream_id);
                         conn.borrow_mut().stream_close_send(stream_id).unwrap();


### PR DESCRIPTION
We are queueing up data to send but it's not being sent because the
connection has fallen off the active connection queue in Server, and so
never gets polled for packets.

Testing locally, this gets us passing QNS M as server for all except 2
clients (ngtcp2 and mvfst), so is a step towards resolving #911.