### PR TITLE
Wrong check, we should check if a stream is already in he blocked list not if any stream <= streamId is in he list

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -5419,7 +5419,6 @@ mod tests {
 
         // Headers on the second request are blocked as well are blocked
         // waiting fro the encoder instructions.
-        let header_ready_event = |e| matches!(e, Http3ClientEvent::HeaderReady { .. });
         assert!(!client.events().any(header_ready_event));
 
         // Now read headers.

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -1119,10 +1119,12 @@ mod tests {
     // The data frame payload from HTTP_RESPONSE_2 is:
     const EXPECTED_RESPONSE_DATA_2_FRAME_1: &[u8] = &[0x61, 0x62, 0x63];
 
-    fn connect_and_send_request(close_sending_side: bool) -> (Http3Client, TestServer, u64) {
-        let (mut client, mut server) = connect();
-        let request_stream_id = make_request(&mut client, close_sending_side);
-        assert_eq!(request_stream_id, 0);
+    fn make_request_and_exchange_pkts(
+        client: &mut Http3Client,
+        server: &mut TestServer,
+        close_sending_side: bool,
+    ) -> u64 {
+        let request_stream_id = make_request(client, close_sending_side);
 
         let out = client.process(None, now());
         let _ = server.conn.process(out.dgram(), now());
@@ -1147,6 +1149,14 @@ mod tests {
         }
         let out = server.conn.process(None, now());
         client.process(out.dgram(), now());
+        request_stream_id
+    }
+
+    fn connect_and_send_request(close_sending_side: bool) -> (Http3Client, TestServer, u64) {
+        let (mut client, mut server) = connect();
+        let request_stream_id =
+            make_request_and_exchange_pkts(&mut client, &mut server, close_sending_side);
+        assert_eq!(request_stream_id, 0);
 
         (client, server, request_stream_id)
     }
@@ -5363,5 +5373,66 @@ mod tests {
             .encoder
             .recv_if_encoder_stream(&mut server.conn, CLIENT_SIDE_DECODER_STREAM_ID);
         assert_eq!(server.encoder.stats().stream_cancelled_recv, 0);
+    }
+
+    #[test]
+    fn multiple_streams_in_decoder_blocked_state() {
+        let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
+
+        setup_server_side_encoder(&mut client, &mut server);
+
+        let headers = vec![
+            (String::from(":status"), String::from("200")),
+            (String::from("my-header"), String::from("my-header")),
+            (String::from("content-length"), String::from("0")),
+        ];
+        let encoded_headers = server
+            .encoder
+            .encode_header_block(&mut server.conn, &headers, request_stream_id)
+            .unwrap();
+        let hframe = HFrame::Headers {
+            header_block: encoded_headers.to_vec(),
+        };
+
+        // Delay encoder instruction so that the stream will be blocked.
+        let encoder_insts = server.conn.process(None, now());
+
+        // Send response headers.
+        let mut d = Encoder::default();
+        hframe.encode(&mut d);
+        server_send_response_and_exchange_packet(
+            &mut client,
+            &mut server,
+            request_stream_id,
+            &d,
+            true,
+        );
+
+        // Headers are blocked waiting fro the encoder instructions.
+        let header_ready_event = |e| matches!(e, Http3ClientEvent::HeaderReady { .. });
+        assert!(!client.events().any(header_ready_event));
+
+        // Make another request.
+        let request2 = make_request_and_exchange_pkts(&mut client, &mut server, true);
+        // Send response headers.
+        server_send_response_and_exchange_packet(&mut client, &mut server, request2, &d, true);
+
+        // Headers on the second request are blocked as well are blocked
+        // waiting fro the encoder instructions.
+        let header_ready_event = |e| matches!(e, Http3ClientEvent::HeaderReady { .. });
+        assert!(!client.events().any(header_ready_event));
+
+        // Now read headers.
+        let _ = client.process(encoder_insts.dgram(), now());
+
+        // find the new request/response stream and send frame v on it.
+        let mut count_responses = 0;
+        while let Some(e) = client.next_event() {
+            if let Http3ClientEvent::HeaderReady { stream_id, .. } = e {
+                assert!((stream_id == request_stream_id) || (stream_id == request2));
+                count_responses += 1;
+            }
+        }
+        assert_eq!(count_responses, 2);
     }
 }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -5408,7 +5408,7 @@ mod tests {
             true,
         );
 
-        // Headers are blocked waiting fro the encoder instructions.
+        // Headers are blocked waiting for the encoder instructions.
         let header_ready_event = |e| matches!(e, Http3ClientEvent::HeaderReady { .. });
         assert!(!client.events().any(header_ready_event));
 
@@ -5418,13 +5418,13 @@ mod tests {
         server_send_response_and_exchange_packet(&mut client, &mut server, request2, &d, true);
 
         // Headers on the second request are blocked as well are blocked
-        // waiting fro the encoder instructions.
+        // waiting for the encoder instructions.
         assert!(!client.events().any(header_ready_event));
 
-        // Now read headers.
+        // Now make the encoder instructions available.
         let _ = client.process(encoder_insts.dgram(), now());
 
-        // find the new request/response stream and send frame v on it.
+        // Header blocks for both streams should be ready.
         let mut count_responses = 0;
         while let Some(e) = client.next_event() {
             if let Http3ClientEvent::HeaderReady { stream_id, .. } = e {

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -198,7 +198,7 @@ impl QPackDecoder {
                     let r = self
                         .blocked_streams
                         .iter()
-                        .filter_map(|(id, req)| if *id <= stream_id { Some(*req) } else { None })
+                        .filter_map(|(id, req)| if *id == stream_id { Some(*req) } else { None })
                         .collect::<Vec<_>>();
                     if !r.is_empty() {
                         debug_assert!(r.len() == 1);


### PR DESCRIPTION
We should not enter the same stream multiple times into the the block list. The check was wrong it should have checked whether the stream is in the list and not whether streams with id <= streamId are in the list.