### PR TITLE
Display the connection ID in logs

### DIFF
--- a/neqo-transport/src/connection.rs
+++ b/neqo-transport/src/connection.rs
@@ -2673,7 +2673,12 @@ impl Connection {
 
 impl ::std::fmt::Display for Connection {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "{:?} {:p}", self.role, self as *const Self)
+        write!(f, "{:?} ", self.role)?;
+        if let Some(cid) = self.odcid() {
+            std::fmt::Display::fmt(&cid, f)
+        } else {
+            write!(f, "...")
+        }
     }
 }
 


### PR DESCRIPTION
Using the pointer seems to result in the same value from being used multiple times as the same memory location appears to be reused for holding different connections, so let's avoid doing that for connections at least.