### PR TITLE
Suppress DataReadable events from end of stream

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -320,6 +320,7 @@ impl<'a> Handler<'a> {
                 true
             }
             e @ Err(Error::TransportError(TransportError::StreamLimitError))
+            | e @ Err(Error::StreamLimitError)
             | e @ Err(Error::Unavailable) => {
                 println!("Cannot create stream {:?}", e);
                 self.url_queue.push_front(url);


### PR DESCRIPTION
...when reading from the stream.  We suppress these otherwise, but not
if the DATA frame ends up being the last one.  Normally, this isn't an
issue as more data usually can't be read into the buffer when we don't
know how much we need, but this doesn't always happen and that leads to
extra events being left around after we told the calling code that the
stream was done.

Closes #968.