### PR TITLE
Add grease frame type

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -363,6 +363,12 @@ impl Debug for Encoder {
     }
 }
 
+impl AsRef<[u8]> for Encoder {
+    fn as_ref(&self) -> &[u8] {
+        self.buf.as_ref()
+    }
+}
+
 impl<'a> From<Decoder<'a>> for Encoder {
     #[must_use]
     fn from(dec: Decoder<'a>) -> Self {

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -125,6 +125,7 @@ impl Http3Connection {
                 },
             ]),
         });
+        self.control_stream_local.queue_frame(&HFrame::Grease);
     }
 
     /// Save settings for adding to the session ticket.

--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -9,6 +9,7 @@ use neqo_common::{
     hex_with_len, qtrace, Decoder, Encoder, IncrementalDecoderBuffer, IncrementalDecoderIgnore,
     IncrementalDecoderUint,
 };
+use neqo_crypto::random;
 use neqo_transport::Connection;
 use std::convert::TryFrom;
 use std::mem;
@@ -53,6 +54,7 @@ pub(crate) enum HFrame {
     MaxPushId {
         push_id: u64,
     },
+    Grease,
 }
 
 impl HFrame {
@@ -65,6 +67,10 @@ impl HFrame {
             Self::PushPromise { .. } => H3_FRAME_TYPE_PUSH_PROMISE,
             Self::Goaway { .. } => H3_FRAME_TYPE_GOAWAY,
             Self::MaxPushId { .. } => H3_FRAME_TYPE_MAX_PUSH_ID,
+            Self::Grease => {
+                let r = random(7);
+                Decoder::from(&r).decode_uint(7).unwrap() * 0x1f + 0x21
+            }
         }
     }
 
@@ -104,6 +110,11 @@ impl HFrame {
                 enc.encode_vvec_with(|enc_inner| {
                     enc_inner.encode_varint(*push_id);
                 });
+            }
+            Self::Grease => {
+                // Encode some number of random bytes.
+                let r = random(8);
+                enc.encode_vvec(&r[1..usize::from(1 + (r[0] & 0x7))]);
             }
         }
     }
@@ -345,11 +356,11 @@ impl HFrameReader {
 
 #[cfg(test)]
 mod tests {
-    use super::{Encoder, Error, HFrame, HFrameReader, HSettings};
+    use super::{Decoder, Encoder, Error, HFrame, HFrameReader, HSettings};
     use crate::settings::{HSetting, HSettingType};
     use neqo_crypto::AuthenticationStatus;
     use neqo_transport::{Connection, StreamType};
-    use test_fixture::{connect, default_client, default_server, now};
+    use test_fixture::{connect, default_client, default_server, fixture_init, now};
 
     #[allow(clippy::many_single_char_names)]
     fn enc_dec(f: &HFrame, st: &str, remaining: usize) {
@@ -440,6 +451,25 @@ mod tests {
     fn test_max_push_id_frame4() {
         let f = HFrame::MaxPushId { push_id: 5 };
         enc_dec(&f, "0d0105", 0);
+    }
+
+    #[test]
+    fn grease() {
+        fn make_grease() -> u64 {
+            let mut enc = Encoder::default();
+            HFrame::Grease.encode(&mut enc);
+            let mut dec = Decoder::from(&enc);
+            let ft = dec.decode_varint().unwrap();
+            assert_eq!((ft - 0x21) % 0x1f, 0);
+            let body = dec.decode_vvec().unwrap();
+            assert!(body.len() <= 7);
+            ft
+        }
+
+        fixture_init();
+        let t1 = make_grease();
+        let t2 = make_grease();
+        assert_ne!(t1, t2);
     }
 
     struct HFrameReaderTest {


### PR DESCRIPTION
This isn't something I'm using right now, but I thought that I needed it
at one point.  It is fairly simple to add and doesn't cost that much.

It might help innoculate implementations against being too rigid.  Note
that I specifically did not add any parsing capability to HFrame::Grease
so that we use the usual extension handling to deal with what will
appear to be an unknown frame.