### PR TITLE
Support the new chacha20 test for the server

### DIFF
--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -13,7 +13,7 @@ use crate::server_events::{ClientRequestStream, Http3ServerEvent, Http3ServerEve
 use crate::settings::HttpZeroRttChecker;
 use crate::Res;
 use neqo_common::{qtrace, Datagram};
-use neqo_crypto::AntiReplay;
+use neqo_crypto::{AntiReplay, Cipher};
 use neqo_qpack::QpackSettings;
 use neqo_transport::server::{ActiveConnectionRef, Server, ValidateAddress};
 use neqo_transport::{ConnectionIdManager, Output};
@@ -74,6 +74,10 @@ impl Http3Server {
 
     pub fn set_validation(&mut self, v: ValidateAddress) {
         self.server.set_validation(v);
+    }
+
+    pub fn set_ciphers(&mut self, ciphers: impl AsRef<[Cipher]>) {
+        self.server.set_ciphers(ciphers);
     }
 
     pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {

--- a/neqo-server/src/old_https.rs
+++ b/neqo-server/src/old_https.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 use regex::Regex;
 
 use neqo_common::Datagram;
-use neqo_crypto::{AllowZeroRtt, AntiReplay};
+use neqo_crypto::{AllowZeroRtt, AntiReplay, Cipher};
 use neqo_http3::Error;
 use neqo_transport::server::{ActiveConnectionRef, Server, ValidateAddress};
 use neqo_transport::{ConnectionEvent, ConnectionIdManager, Output, State};
@@ -190,6 +190,10 @@ impl HttpServer for Http09Server {
 
     fn validate_address(&mut self, v: ValidateAddress) {
         self.server.set_validation(v);
+    }
+
+    fn set_ciphers(&mut self, ciphers: &[Cipher]) {
+        self.server.set_ciphers(ciphers);
     }
 }
 

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -10,7 +10,7 @@ use neqo_common::{
     self as common, hex, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn, timer::Timer,
     Datagram, Decoder, Role,
 };
-use neqo_crypto::{AntiReplay, ZeroRttCheckResult, ZeroRttChecker};
+use neqo_crypto::{AntiReplay, Cipher, ZeroRttCheckResult, ZeroRttChecker};
 
 pub use crate::addr_valid::ValidateAddress;
 use crate::addr_valid::{AddressValidation, AddressValidationResult};
@@ -121,6 +121,8 @@ pub struct Server {
     certs: Vec<String>,
     /// The ALPN values that the server supports.
     protocols: Vec<String>,
+    /// The cipher suites that the server supports.
+    ciphers: Vec<Cipher>,
     /// Anti-replay configuration for 0-RTT.
     anti_replay: AntiReplay,
     /// A function for determining if 0-RTT can be accepted.
@@ -168,6 +170,7 @@ impl Server {
         Ok(Self {
             certs: certs.iter().map(|x| String::from(x.as_ref())).collect(),
             protocols: protocols.iter().map(|x| String::from(x.as_ref())).collect(),
+            ciphers: Vec::new(),
             anti_replay,
             zero_rtt_checker: ServerZeroRttChecker::new(zero_rtt_checker),
             cid_manager,
@@ -189,6 +192,12 @@ impl Server {
     /// Set the policy for address validation.
     pub fn set_validation(&mut self, v: ValidateAddress) {
         self.address_validation.borrow_mut().set_validation(v);
+    }
+
+    /// Set the cipher suites that should be used.  Set an empty value to use
+    /// default values.
+    pub fn set_ciphers(&mut self, ciphers: impl AsRef<[Cipher]>) {
+        self.ciphers = Vec::from(ciphers.as_ref());
     }
 
     fn remove_timer(&mut self, c: &StateRef) {


### PR DESCRIPTION
Right now, we support chacha20, but the QNS tests don't know that.  They
assumed that every server would support it.  But mvfst spoiled it for
everyone by not supporting it.  So we need to have explicit support for
this test on the server side.

Is it worth moving the duplicated code to neqo-crypto?  A `TryFrom<AsRef<str>>` implementation on Cipher isn't crazy.  That could be integrated into the macro definition.  That might be a tiny bit more work than is ideal though.  Maybe a separate issue once this lands.