### PR TITLE
Use a generic event provider

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -9,7 +9,7 @@
 
 use qlog::QlogStreamer;
 
-use neqo_common::{self as common, hex, qlog::NeqoQlog, Datagram, Role};
+use neqo_common::{self as common, event::Provider, hex, qlog::NeqoQlog, Datagram, Role};
 use neqo_crypto::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256},
     init, AuthenticationStatus, Cipher, ResumptionToken,
@@ -718,7 +718,7 @@ mod old {
 
     use super::{qlog_new, KeyUpdateState, Res};
 
-    use neqo_common::Datagram;
+    use neqo_common::{event::Provider, Datagram};
     use neqo_crypto::{AuthenticationStatus, ResumptionToken};
     use neqo_transport::{
         Connection, ConnectionEvent, Error, FixedConnectionIdManager, Output, QuicVersion, State,

--- a/neqo-common/src/event.rs
+++ b/neqo-common/src/event.rs
@@ -8,13 +8,15 @@ use std::iter::Iterator;
 use std::marker::PhantomData;
 
 /// An event provider is able to generate a stream of events.
-pub trait Provider: Sized {
+pub trait Provider {
     type Event;
 
     /// Get the next event.
+    #[must_use]
     fn next_event(&mut self) -> Option<Self::Event>;
 
     /// Determine whether there are pending events.
+    #[must_use]
     fn has_events(&self) -> bool;
 
     /// Construct an iterator that produces all events.
@@ -23,16 +25,19 @@ pub trait Provider: Sized {
     }
 }
 
-pub struct Iter<'a, P, E> {
+pub struct Iter<'a, P, E>
+where
+    P: ?Sized,
+{
     p: &'a mut P,
     _e: PhantomData<E>,
 }
 
 impl<'a, P, E> Iter<'a, P, E>
 where
-    P: Provider<Event = E>,
+    P: Provider<Event = E> + ?Sized,
 {
-    pub fn new(p: &'a mut P) -> Self {
+    fn new(p: &'a mut P) -> Self {
         Self { p, _e: PhantomData }
     }
 }

--- a/neqo-common/src/event.rs
+++ b/neqo-common/src/event.rs
@@ -1,0 +1,48 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::iter::Iterator;
+use std::marker::PhantomData;
+
+/// An event provider is able to generate a stream of events.
+pub trait Provider: Sized {
+    type Event;
+
+    /// Get the next event.
+    fn next_event(&mut self) -> Option<Self::Event>;
+
+    /// Determine whether there are pending events.
+    fn has_events(&self) -> bool;
+
+    /// Construct an iterator that produces all events.
+    fn events(&'_ mut self) -> Iter<'_, Self, Self::Event> {
+        Iter::new(self)
+    }
+}
+
+pub struct Iter<'a, P, E> {
+    p: &'a mut P,
+    _e: PhantomData<E>,
+}
+
+impl<'a, P, E> Iter<'a, P, E>
+where
+    P: Provider<Event = E>,
+{
+    pub fn new(p: &'a mut P) -> Self {
+        Self { p, _e: PhantomData }
+    }
+}
+
+impl<'a, P, E> Iterator for Iter<'a, P, E>
+where
+    P: Provider<Event = E>,
+{
+    type Item = E;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.p.next_event()
+    }
+}

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod codec;
 mod datagram;
+pub mod event;
 mod incrdecoder;
 pub mod log;
 pub mod qlog;

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -10,7 +10,7 @@ use crate::recv_message::RecvMessage;
 use crate::send_message::SendMessage;
 use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents};
 use crate::{Error, Header, Res};
-use neqo_common::{qdebug, qinfo, qtrace};
+use neqo_common::{event::Provider, qdebug, qinfo, qtrace};
 use neqo_qpack::QpackSettings;
 use neqo_transport::{AppError, Connection, ConnectionEvent, StreamType};
 use std::time::Instant;

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -222,6 +222,7 @@ fn prepare_data(
 mod tests {
     use super::{Http3Server, Http3ServerEvent, Http3State, Rc, RefCell};
     use crate::{Error, Header};
+    use neqo_common::event::Provider;
     use neqo_crypto::AuthenticationStatus;
     use neqo_qpack::encoder::QPackEncoder;
     use neqo_qpack::QpackSettings;

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused_assignments)]
 
-use neqo_common::Datagram;
+use neqo_common::{event::Provider, Datagram};
 use neqo_crypto::AuthenticationStatus;
 use neqo_http3::{Http3Client, Http3ClientEvent, Http3Server, Http3ServerEvent, Http3State};
 use test_fixture::*;

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::use_self)]
 
-use neqo_common::{hex, Datagram};
+use neqo_common::{event::Provider, hex, Datagram};
 use neqo_crypto::{init, AuthenticationStatus, ResumptionToken};
 use neqo_http3::{Header, Http3Client, Http3ClientEvent, Http3Parameters, Http3State};
 use neqo_qpack::QpackSettings;

--- a/neqo-server/src/old_https.rs
+++ b/neqo-server/src/old_https.rs
@@ -16,7 +16,7 @@ use std::time::Instant;
 
 use regex::Regex;
 
-use neqo_common::Datagram;
+use neqo_common::{event::Provider, Datagram};
 use neqo_crypto::{AllowZeroRtt, AntiReplay};
 use neqo_http3::Error;
 use neqo_transport::server::{ActiveConnectionRef, Server, ValidateAddress};

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -22,7 +22,7 @@ use std::mem;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use neqo_common::{qdebug, qtrace, Datagram, Decoder};
+use neqo_common::{event::Provider, qdebug, qtrace, Datagram, Decoder};
 use neqo_crypto::{AllowZeroRtt, AuthenticationStatus, ResumptionToken};
 use test_fixture::{self, fixture_init, loopback, now};
 

--- a/neqo-transport/src/connection/tests/zerortt.rs
+++ b/neqo-transport/src/connection/tests/zerortt.rs
@@ -10,6 +10,7 @@ use crate::events::ConnectionEvent;
 use crate::frame::StreamType;
 use crate::{Error, QuicVersion};
 
+use neqo_common::event::Provider;
 use neqo_crypto::{AllowZeroRtt, AntiReplay};
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -842,6 +842,7 @@ mod tests {
     use super::*;
 
     use crate::events::ConnectionEvent;
+    use neqo_common::event::Provider;
 
     #[test]
     fn test_mark_range() {
@@ -1161,7 +1162,7 @@ mod tests {
     fn send_stream_writable_event_gen() {
         let flow_mgr = Rc::new(RefCell::new(FlowMgr::default()));
         flow_mgr.borrow_mut().conn_increase_max_credit(2);
-        let conn_events = ConnectionEvents::default();
+        let mut conn_events = ConnectionEvents::default();
 
         let mut s = SendStream::new(4.into(), 0, Rc::clone(&flow_mgr), conn_events.clone());
 
@@ -1225,7 +1226,7 @@ mod tests {
     fn send_stream_writable_event_new_stream() {
         let flow_mgr = Rc::new(RefCell::new(FlowMgr::default()));
         flow_mgr.borrow_mut().conn_increase_max_credit(2);
-        let conn_events = ConnectionEvents::default();
+        let mut conn_events = ConnectionEvents::default();
 
         let _s = SendStream::new(4.into(), 100, flow_mgr, conn_events.clone());
 

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -7,8 +7,8 @@
 // This file implements a server that can handle multiple connections.
 
 use neqo_common::{
-    self as common, hex, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn, timer::Timer,
-    Datagram, Decoder, Role,
+    self as common, event::Provider, hex, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn,
+    timer::Timer, Datagram, Decoder, Role,
 };
 use neqo_crypto::{AntiReplay, ZeroRttCheckResult, ZeroRttChecker};
 

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::pedantic)]
 
-use neqo_common::{hex_with_len, qdebug, qtrace, Datagram, Decoder, Encoder};
+use neqo_common::{event::Provider, hex_with_len, qdebug, qtrace, Datagram, Decoder, Encoder};
 use neqo_crypto::{
     aead::Aead,
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},

--- a/neqo-transport/tests/sim/connection.rs
+++ b/neqo-transport/tests/sim/connection.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 use super::{Node, Rng};
-use neqo_common::{qdebug, qtrace, Datagram};
+use neqo_common::{event::Provider, qdebug, qtrace, Datagram};
 use neqo_crypto::AuthenticationStatus;
 use neqo_transport::{Connection, ConnectionEvent, Output, State, StreamId, StreamType};
 use std::cmp::min;

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::pedantic)]
 
+use neqo_common::event::Provider;
 use neqo_crypto::{init_db, AllowZeroRtt, AntiReplay, AuthenticationStatus};
 use neqo_http3::{Http3Client, Http3Parameters, Http3Server};
 use neqo_qpack::QpackSettings;


### PR DESCRIPTION
This doesn't really reduce code size much, but it unifies the interface
somewhat.  It also makes the iterator cleaner for those cases where it
is used.  As it now takes a mutable borrow, it is also safer to use.
Previously, the events that were retrieved could be out of date.

I did run into #973 when working on this.  `Iterator::any` stops when it
hits the first success and there were multiple DataReadable events
queued.  I've flagged that in the code.  It should be easy to fix up
when it comes time (what is hard is getting the function signatures
right; `Iterator::any` takes a value, `Iterator::filter` takes a
reference.

Closes #934.