### PR TITLE
Better version negotiation filtering 

### DIFF
--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -7,7 +7,7 @@
 use super::super::{Connection, FixedConnectionIdManager, Output, State, LOCAL_IDLE_TIMEOUT};
 use super::{
     assert_error, connect_force_idle, connect_with_rtt, default_client, default_server, get_tokens,
-    handshake, maybe_authenticate, send_something, split_datagram, AT_LEAST_PTO,
+    handshake, maybe_authenticate, send_something, split_datagram, AT_LEAST_PTO, DEFAULT_RTT,
     DEFAULT_STREAM_DATA,
 };
 use crate::connection::AddressValidation;
@@ -479,10 +479,11 @@ fn reorder_handshake() {
     let (_, s_hs) = split_datagram(&s1.unwrap());
     assert!(s_hs.is_some());
 
-    // Pass just the handshake packet in and the client can't handle it.
+    // Pass just the handshake packet in and the client can't handle it yet.
+    // It can only send another Initial packet.
     now += RTT / 2;
-    let res = client.process(s_hs, now);
-    assert_ne!(res.callback(), Duration::new(0, 0));
+    let dgram = client.process(s_hs, now).dgram();
+    assertions::assert_initial(&dgram.as_ref().unwrap(), false);
     assert_eq!(client.stats().saved_datagrams, 1);
     assert_eq!(client.stats().packets_rx, 1);
 
@@ -632,4 +633,75 @@ fn verify_pkt_honors_mtu() {
     let pkt0 = client.process(None, now);
     assert!(matches!(pkt0, Output::Datagram(_)));
     assert_eq!(pkt0.as_dgram_ref().unwrap().len(), PATH_MTU_V6);
+}
+
+#[test]
+fn extra_initial_hs() {
+    let mut client = default_client();
+    let mut server = default_server();
+    let mut now = now();
+
+    let c_init = client.process(None, now).dgram();
+    assert!(c_init.is_some());
+    now += DEFAULT_RTT / 2;
+    let s_init = server.process(c_init, now).dgram();
+    assert!(s_init.is_some());
+    now += DEFAULT_RTT / 2;
+
+    // Drop the Initial packet, keep only the Handshake.
+    let (_, undecryptable) = split_datagram(&s_init.unwrap());
+    assert!(undecryptable.is_some());
+
+    // Feed the same undecryptable packet into the client a few times.
+    // Do that EXTRA_INITIALS times and each time the client will emit
+    // another Initial packet.
+    for _ in 0..=super::super::EXTRA_INITIALS {
+        let c_init = client.process(undecryptable.clone(), now).dgram();
+        assertions::assert_initial(&c_init.as_ref().unwrap(), false);
+        now += DEFAULT_RTT / 10;
+    }
+
+    // After EXTRA_INITIALS, the client stops sending Initial packets.
+    let nothing = client.process(undecryptable, now).dgram();
+    assert!(nothing.is_none());
+
+    // Until PTO, where another Initial can be used to complete the handshake.
+    now += AT_LEAST_PTO;
+    let c_init = client.process(None, now).dgram();
+    assertions::assert_initial(c_init.as_ref().unwrap(), false);
+    now += DEFAULT_RTT / 2;
+    let s_init = server.process(c_init, now).dgram();
+    now += DEFAULT_RTT / 2;
+    client.process_input(s_init.unwrap(), now);
+    maybe_authenticate(&mut client);
+    let c_fin = client.process_output(now).dgram();
+    assert_eq!(*client.state(), State::Connected);
+    now += DEFAULT_RTT / 2;
+    server.process_input(c_fin.unwrap(), now);
+    assert_eq!(*server.state(), State::Confirmed);
+}
+
+#[test]
+fn extra_initial_invalid_cid() {
+    let mut client = default_client();
+    let mut server = default_server();
+    let mut now = now();
+
+    let c_init = client.process(None, now).dgram();
+    assert!(c_init.is_some());
+    now += DEFAULT_RTT / 2;
+    let s_init = server.process(c_init, now).dgram();
+    assert!(s_init.is_some());
+    now += DEFAULT_RTT / 2;
+
+    // If the client receives a packet that contains the wrong connection
+    // ID, it won't send another Initial.
+    let (_, hs) = split_datagram(&s_init.unwrap());
+    let hs = hs.unwrap();
+    let mut copy = hs.to_vec();
+    assert_ne!(copy[5], 0); // The DCID should be non-zero length.
+    copy[6] ^= 0xc4;
+    let dgram_copy = Datagram::new(hs.destination(), hs.source(), copy);
+    let nothing = client.process(Some(dgram_copy), now).dgram();
+    assert!(nothing.is_none());
 }

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -572,7 +572,7 @@ impl<'a> PublicPacket<'a> {
         self.quic_version
     }
 
-    pub fn packet_len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.data.len()
     }
 

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -545,7 +545,7 @@ impl<'a> PublicPacket<'a> {
 
     pub fn is_valid_initial(&self) -> bool {
         // Packet has to be an initial, with a DCID of 8 bytes, or a token.
-        // Assume that the Server class validates the token.
+        // Note: the Server class validates the token and checks the length.
         self.packet_type == PacketType::Initial
             && (self.dcid().len() >= 8 || !self.token.is_empty())
     }

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -169,7 +169,7 @@ pub fn packet_dropped(qlog: &mut NeqoQlog, payload: &PublicPacket) {
     qlog.add_event(|| {
         Some(Event::packet_dropped(
             Some(to_qlog_pkt_type(payload.packet_type())),
-            Some(u64::try_from(payload.packet_len()).unwrap()),
+            Some(u64::try_from(payload.len()).unwrap()),
             None,
         ))
     })
@@ -202,7 +202,7 @@ pub fn packet_received(
             to_qlog_pkt_type(payload.packet_type()),
             PacketHeader::new(
                 payload.pn(),
-                Some(u64::try_from(public_packet.packet_len()).unwrap()),
+                Some(u64::try_from(public_packet.len()).unwrap()),
                 None,
                 None,
                 None,

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -20,7 +20,7 @@ use neqo_transport::{
     Connection, ConnectionError, ConnectionEvent, Error, FixedConnectionIdManager, Output,
     QuicVersion, State, StreamType,
 };
-use test_fixture::{self, assertions, default_client, now};
+use test_fixture::{self, assertions, default_client, loopback, now};
 
 use std::cell::RefCell;
 use std::convert::TryFrom;
@@ -572,6 +572,36 @@ fn retry_after_pto() {
 
     let ci2 = client.process(retry, now).dgram();
     assert!(ci2.unwrap().len() >= 1200);
+}
+
+#[test]
+fn vn_after_retry() {
+    let mut server = default_server();
+    server.set_validation(ValidateAddress::Always);
+    let mut client = default_client();
+
+    let dgram = client.process(None, now()).dgram(); // Initial
+    assert!(dgram.is_some());
+    let dgram = server.process(dgram, now()).dgram(); // Retry
+    assert!(dgram.is_some());
+
+    assertions::assert_retry(&dgram.as_ref().unwrap());
+
+    let dgram = client.process(dgram, now()).dgram(); // Initial w/token
+    assert!(dgram.is_some());
+
+    let mut encoder = Encoder::default();
+    encoder.encode_byte(0x80);
+    encoder.encode(&[0; 4]); // Zero version == VN.
+    encoder.encode_vec(1, &client.odcid().unwrap()[..]);
+    encoder.encode_vec(1, &[]);
+    encoder.encode_uint(4, 0x5a5a_6a6a_u64);
+    let vn = Datagram::new(loopback(), loopback(), encoder);
+
+    assert_ne!(
+        client.process(Some(vn), now()).callback(),
+        Duration::from_secs(0)
+    );
 }
 
 // Generate an AEAD and header protection object for a client Initial.


### PR DESCRIPTION
Right now, we accept a version negotiation if the destination connection
ID doesn't match or after receiving a Retry packet.  That isn't good.

This is built on top of #991 because I touched the same code (I only noticed the bug because I touched the code).  Just look at the last commit to understand this one.  I can backport it, but it shouldn't make a difference.

