### PR TITLE
Remove unnecessary clippy instruction

### DIFF
--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -179,7 +179,6 @@ impl HFrameReader {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
     /// returns true if quic stream was closed.
     /// # Errors
     /// May return `HttpFrame` if a frame cannot be decoded.


### PR DESCRIPTION
The code has been refactor so the clippy instruction is not needed anymore.
Fixes #564 