### PR TITLE
Write ACK frames directly

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -226,6 +226,13 @@ impl Encoder {
         }
     }
 
+    /// Get the capacity of the underlying buffer: the number of bytes that can be
+    /// written without causing an allocation to occur.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.buf.capacity()
+    }
+
     /// Create a view of the current contents of the buffer.
     /// Note: for a view of a slice, use `Decoder::new(&enc[s..e])`
     #[must_use]

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1466,34 +1466,39 @@ impl Connection {
             false
         };
 
+        // Try to get a frame from all frame sources.
+        if let Some(t) = self.acks.write_frame(space, now, builder) {
+            tokens.push(t);
+        }
+
+        if profile.ack_only(space) {
+            return (tokens, ack_eliciting);
+        }
+
         // All useful frames are at least 2 bytes.
         while builder.len() + 2 < limit {
             let remaining = limit - builder.len();
-            // Try to get a frame from frame sources
-            let mut frame = self.acks.get_frame(now, space);
             // If we are CC limited we can only send acks!
-            if !profile.ack_only(space) {
-                if frame.is_none() && space == PNSpace::ApplicationData && self.role == Role::Server
-                {
-                    frame = self.state_signaling.send_done();
-                }
-                if frame.is_none() {
-                    frame = self.crypto.streams.get_frame(space, remaining)
-                }
-                if frame.is_none() {
-                    frame = self.flow_mgr.borrow_mut().get_frame(space, remaining);
-                }
-                if frame.is_none() {
-                    frame = self.send_streams.get_frame(space, remaining);
-                }
-                if frame.is_none() && space == PNSpace::ApplicationData {
-                    frame = self.new_token.get_frame(remaining);
-                }
+            let mut frame = None;
+            if space == PNSpace::ApplicationData && self.role == Role::Server {
+                frame = self.state_signaling.send_done();
+            }
+            if frame.is_none() {
+                frame = self.crypto.streams.get_frame(space, remaining)
+            }
+            if frame.is_none() {
+                frame = self.flow_mgr.borrow_mut().get_frame(space, remaining);
+            }
+            if frame.is_none() {
+                frame = self.send_streams.get_frame(space, remaining);
+            }
+            if frame.is_none() && space == PNSpace::ApplicationData {
+                frame = self.new_token.get_frame(remaining);
             }
 
             if let Some((frame, token)) = frame {
-                ack_eliciting |= frame.ack_eliciting();
-                debug_assert_ne!(frame, Frame::Padding);
+                ack_eliciting = true;
+                debug_assert!(frame.ack_eliciting());
                 frame.marshal(builder);
                 if let Some(t) = token {
                     tokens.push(t);

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1478,10 +1478,11 @@ impl Connection {
         while builder.remaining() >= 2 {
             let remaining = builder.remaining();
             // If we are CC limited we can only send acks!
-            let mut frame = None;
-            if space == PNSpace::ApplicationData && self.role == Role::Server {
-                frame = self.state_signaling.send_done();
-            }
+            let mut frame = if space == PNSpace::ApplicationData && self.role == Role::Server {
+                self.state_signaling.send_done()
+            } else {
+                None
+            };
             if frame.is_none() {
                 frame = self.crypto.streams.get_frame(space, remaining)
             }

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -22,7 +22,7 @@ pub type FrameType = u64;
 
 const FRAME_TYPE_PADDING: FrameType = 0x0;
 const FRAME_TYPE_PING: FrameType = 0x1;
-const FRAME_TYPE_ACK: FrameType = 0x2;
+pub const FRAME_TYPE_ACK: FrameType = 0x2;
 const FRAME_TYPE_ACK_ECN: FrameType = 0x3;
 const FRAME_TYPE_RST_STREAM: FrameType = 0x4;
 const FRAME_TYPE_STOP_SENDING: FrameType = 0x5;
@@ -338,21 +338,7 @@ impl Frame {
 
         match self {
             Self::Padding | Self::Ping => (),
-            Self::Ack {
-                largest_acknowledged,
-                ack_delay,
-                first_ack_range,
-                ack_ranges,
-            } => {
-                enc.encode_varint(*largest_acknowledged);
-                enc.encode_varint(*ack_delay);
-                enc.encode_varint(ack_ranges.len() as u64);
-                enc.encode_varint(*first_ack_range);
-                for r in ack_ranges {
-                    enc.encode_varint(r.gap);
-                    enc.encode_varint(r.range);
-                }
-            }
+            Self::Ack { .. } => unreachable!(),
             Self::ResetStream {
                 stream_id,
                 application_error_code,
@@ -746,16 +732,22 @@ impl Frame {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use neqo_common::hex;
+
+    fn just_dec(f: &Frame, s: &str) {
+        let encoded = Encoder::from_hex(s);
+        let decoded = Frame::decode(&mut encoded.as_decoder()).unwrap();
+        assert_eq!(*f, decoded);
+    }
 
     fn enc_dec(f: &Frame, s: &str) {
-        let mut d = Encoder::default();
+        let mut enc = Encoder::default();
+        let expected = Encoder::from_hex(s);
 
-        f.marshal(&mut d);
-        assert_eq!(d, Encoder::from_hex(s));
+        f.marshal(&mut enc);
+        assert_eq!(enc, expected);
 
-        let f2 = Frame::decode(&mut d.as_decoder()).unwrap();
-        assert_eq!(*f, f2);
+        let decoded = Frame::decode(&mut expected.as_decoder()).unwrap();
+        assert_eq!(*f, decoded);
     }
 
     #[test]
@@ -771,7 +763,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ack() {
+    fn ack() {
         let ar = vec![AckRange { gap: 1, range: 2 }, AckRange { gap: 3, range: 4 }];
 
         let f = Frame::Ack {
@@ -781,7 +773,7 @@ mod tests {
             ack_ranges: ar,
         };
 
-        enc_dec(&f, "025234523502523601020304");
+        just_dec(&f, "025234523502523601020304");
 
         // Try to parse ACK_ECN without ECN values
         let enc = Encoder::from_hex("035234523502523601020304");
@@ -1041,38 +1033,6 @@ mod tests {
         assert_eq!(f3, f4);
         assert_ne!(f3, f5);
         assert_ne!(f3, f6);
-    }
-
-    #[test]
-    fn encode_ack_frame() {
-        let ack_frame = Frame::Ack {
-            largest_acknowledged: 7,
-            ack_delay: 12_000,
-            first_ack_range: 2, // [7], 6, 5
-            ack_ranges: vec![AckRange {
-                gap: 0,   // 4
-                range: 1, // 3, 2
-            }],
-        };
-        let mut enc = Encoder::default();
-        ack_frame.marshal(&mut enc);
-        println!("Encoded ACK={}", hex(&enc[..]));
-
-        let f = Frame::decode(&mut enc.as_decoder()).unwrap();
-        if let Frame::Ack {
-            largest_acknowledged,
-            ack_delay,
-            first_ack_range,
-            ack_ranges,
-        } = f
-        {
-            assert_eq!(largest_acknowledged, 7);
-            assert_eq!(ack_delay, 12_000);
-            assert_eq!(first_ack_range, 2);
-            assert_eq!(ack_ranges.len(), 1);
-            assert_eq!(ack_ranges[0].gap, 0);
-            assert_eq!(ack_ranges[0].range, 1);
-        }
     }
 
     #[test]

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -146,16 +146,26 @@ pub struct PacketBuilder {
     pn: PacketNumber,
     header: Range<usize>,
     offsets: PacketBuilderOffsets,
+    limit: usize,
 }
 
 impl PacketBuilder {
+    fn infer_limit(encoder: &Encoder) -> usize {
+        if encoder.capacity() > 64 {
+            encoder.capacity()
+        } else {
+            2048
+        }
+    }
+
     /// Start building a short header packet.
     #[allow(clippy::unknown_clippy_lints)] // Until we require rust 1.45.
     #[allow(clippy::reversed_empty_ranges)]
-    pub fn short(mut encoder: Encoder, key_phase: bool, dcid: &ConnectionId) -> Self {
+    pub fn short(mut encoder: Encoder, key_phase: bool, dcid: impl AsRef<[u8]>) -> Self {
         let header_start = encoder.len();
         encoder.encode_byte(PACKET_BIT_SHORT | PACKET_BIT_FIXED_QUIC | (u8::from(key_phase) << 2));
-        encoder.encode(&dcid);
+        encoder.encode(dcid.as_ref());
+        let limit = Self::infer_limit(&encoder);
         Self {
             encoder,
             pn: u64::max_value(),
@@ -165,6 +175,7 @@ impl PacketBuilder {
                 pn: 0..0,
                 len: 0,
             },
+            limit,
         }
     }
 
@@ -177,14 +188,15 @@ impl PacketBuilder {
         mut encoder: Encoder,
         pt: PacketType,
         quic_version: QuicVersion,
-        dcid: &ConnectionId,
-        scid: &ConnectionId,
+        dcid: impl AsRef<[u8]>,
+        scid: impl AsRef<[u8]>,
     ) -> Self {
         let header_start = encoder.len();
         encoder.encode_byte(PACKET_BIT_LONG | PACKET_BIT_FIXED_QUIC | pt.code() << 4);
         encoder.encode_uint(4, quic_version.as_u32());
-        encoder.encode_vec(1, dcid);
-        encoder.encode_vec(1, scid);
+        encoder.encode_vec(1, dcid.as_ref());
+        encoder.encode_vec(1, scid.as_ref());
+        let limit = Self::infer_limit(&encoder);
         Self {
             encoder,
             pn: u64::max_value(),
@@ -194,11 +206,25 @@ impl PacketBuilder {
                 pn: 0..0,
                 len: 0,
             },
+            limit,
         }
     }
 
     fn is_long(&self) -> bool {
         self[self.header.start] & 0x80 == PACKET_BIT_LONG
+    }
+
+    /// This stores a value that can be used as a limit.  This does not cause
+    /// this limit to be enforced until encryption occurs.  Prior to that, it
+    /// is only used voluntarily by users of the builder, through `remaining()`.
+    pub fn set_limit(&mut self, limit: usize) {
+        self.limit = limit;
+    }
+
+    /// How many bytes remain against the size limit for the builder.
+    #[must_use]
+    pub fn remaining(&self) -> usize {
+        self.limit - self.encoder.len()
     }
 
     /// Add unpredictable values for unprotected parts of the packet.

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -154,7 +154,6 @@ impl PacketBuilder {
     #[allow(clippy::reversed_empty_ranges)]
     pub fn short(mut encoder: Encoder, key_phase: bool, dcid: &ConnectionId) -> Self {
         let header_start = encoder.len();
-        // TODO(mt) randomize the spin bit
         encoder.encode_byte(PACKET_BIT_SHORT | PACKET_BIT_FIXED_QUIC | (u8::from(key_phase) << 2));
         encoder.encode(&dcid);
         Self {


### PR DESCRIPTION
Rather than return `Frame::Ack` give the received packet tracker access to the write buffer and have it write directly.

This is step 1 of my plan to ensure that we send a PING occasionally alongside ACK.

It is also step 1 of a possible plan to avoid copying buffers when sending STREAM and CRYPTO frames.  A good potential alternative there is to change `Frame` so that it borrows rather than owns data, though that has the drawback that we can't represent the potentially fractured data we hold in our stream buffers (`VecDeque` can return two slices as data rolls around its circular buffer).

I don't know which of those follows on from this next.