### PR TITLE
Update env_logger dependency

### DIFF
--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 log = {version = "0.4.0", default-features = false}
-env_logger = "0.6.1"
+env_logger = "0.7.1"
 lazy_static = "1.3.0"
 qlog = "0.3.0"
 chrono = "0.4.10"


### PR DESCRIPTION
This way, we have one fewer version to deal with.  This is the later of
the two versions we already have to pull in.  It won't fix gecko (which
has lots of use of 0.6.2), but we can help out.