### PR TITLE
Don't save datagrams with a bad connection ID

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1255,8 +1255,10 @@ impl Connection {
                         Error::KeysPending(cspace) => {
                             // This packet can't be decrypted because we don't have the keys yet.
                             // Don't check this packet for a stateless reset, just return.
-                            let remaining = slc.len();
-                            self.save_datagram(cspace, d, remaining, now);
+                            if self.is_valid_cid(&packet.dcid()) {
+                                let remaining = slc.len();
+                                self.save_datagram(cspace, d, remaining, now);
+                            }
                             return Ok(frames);
                         }
                         Error::KeysExhausted => {

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -612,7 +612,7 @@ fn corrupted_initial() {
     // the first should be dropped, the second saved.
     assert_eq!(server.stats().packets_rx, 2);
     assert_eq!(server.stats().dropped_rx, 1);
-    assert_eq!(server.stats().saved_datagrams, 1);
+    assert_eq!(server.stats().saved_datagrams, 0);
 }
 
 #[test]


### PR DESCRIPTION
Our funny padding means that we get a lot of packets that look like they
might be 1-RTT packets.  We save that padding.

We probably shouldn't.  A simple way we can avoid that is to check that
the connection ID is right.