### PR TITLE
Write frames directly

### DIFF
--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -13,7 +13,7 @@ use neqo_crypto::{
 };
 
 use crate::cid::ConnectionId;
-use crate::frame::Frame;
+use crate::packet::PacketBuilder;
 use crate::recovery::RecoveryToken;
 use crate::Res;
 
@@ -349,11 +349,9 @@ impl NewTokenState {
 
     /// If this is a server, maybe send a frame.
     /// If this is a client, do nothing.
-    pub fn get_frame(&mut self, space: usize) -> Option<(Frame, Option<RecoveryToken>)> {
+    pub fn write_frames(&mut self, builder: &mut PacketBuilder, tokens: &mut Vec<RecoveryToken>) {
         if let Self::Server(ref mut sender) = self {
-            sender.get_frame(space)
-        } else {
-            None
+            sender.write_frames(builder, tokens);
         }
     }
 
@@ -421,19 +419,17 @@ impl NewTokenSender {
         self.next_seqno += 1;
     }
 
-    pub fn get_frame(&mut self, space: usize) -> Option<(Frame, Option<RecoveryToken>)> {
+    pub fn write_frames(&mut self, builder: &mut PacketBuilder, tokens: &mut Vec<RecoveryToken>) {
         for t in self.tokens.iter_mut() {
-            if t.needs_sending && t.fits(space) {
+            if t.needs_sending && t.fits(builder.remaining()) {
                 t.needs_sending = false;
-                return Some((
-                    Frame::NewToken {
-                        token: t.token.clone(),
-                    },
-                    Some(RecoveryToken::NewToken(t.seqno)),
-                ));
+
+                builder.encode_varint(crate::frame::FRAME_TYPE_NEW_TOKEN);
+                builder.encode_vvec(&t.token);
+
+                tokens.push(RecoveryToken::NewToken(t.seqno));
             }
         }
-        None
     }
 
     pub fn lost(&mut self, seqno: usize) {

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1536,6 +1536,7 @@ impl Connection {
         }
 
         // All useful frames are at least 2 bytes.
+<<<<<<< HEAD
         while builder.remaining() >= 2 {
             let remaining = builder.remaining();
             // If we are CC limited we can only send acks!
@@ -1544,6 +1545,15 @@ impl Connection {
             } else {
                 None
             };
+=======
+        while builder.len() + 2 < limit {
+            let remaining = limit - builder.len();
+            // If we are CC limited we can only send acks!
+            let mut frame = None;
+            if space == PNSpace::ApplicationData && self.role == Role::Server {
+                frame = self.state_signaling.send_done();
+            }
+>>>>>>> Write ACK frames directly
             if frame.is_none() {
                 frame = self.crypto.streams.get_frame(space, remaining)
             }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1541,14 +1541,15 @@ impl Connection {
                 tokens.push(t);
             }
         }
+        if let Some(t) = self.crypto.streams.write_frame(space, builder) {
+            ack_eliciting = true;
+            tokens.push(t);
+        }
 
         // All useful frames are at least 2 bytes.
         while builder.remaining() >= 2 {
             let remaining = builder.remaining();
-            let mut frame = self.crypto.streams.get_frame(space, remaining);
-            if frame.is_none() {
-                frame = self.flow_mgr.borrow_mut().get_frame(space, remaining);
-            }
+            let mut frame = self.flow_mgr.borrow_mut().get_frame(space, remaining);
             if frame.is_none() {
                 frame = self.send_streams.get_frame(space, remaining);
             }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1545,14 +1545,14 @@ impl Connection {
             ack_eliciting = true;
             tokens.push(t);
         }
+        self.flow_mgr
+            .borrow_mut()
+            .write_frames(space, builder, &mut tokens);
 
         // All useful frames are at least 2 bytes.
         while builder.remaining() >= 2 {
             let remaining = builder.remaining();
-            let mut frame = self.flow_mgr.borrow_mut().get_frame(space, remaining);
-            if frame.is_none() {
-                frame = self.send_streams.get_frame(space, remaining);
-            }
+            let mut frame = self.send_streams.get_frame(space, remaining);
             if frame.is_none() && space == PNSpace::ApplicationData {
                 frame = self.new_token.get_frame(remaining);
             }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1536,7 +1536,6 @@ impl Connection {
         }
 
         // All useful frames are at least 2 bytes.
-<<<<<<< HEAD
         while builder.remaining() >= 2 {
             let remaining = builder.remaining();
             // If we are CC limited we can only send acks!
@@ -1545,15 +1544,6 @@ impl Connection {
             } else {
                 None
             };
-=======
-        while builder.len() + 2 < limit {
-            let remaining = limit - builder.len();
-            // If we are CC limited we can only send acks!
-            let mut frame = None;
-            if space == PNSpace::ApplicationData && self.role == Role::Server {
-                frame = self.state_signaling.send_done();
-            }
->>>>>>> Write ACK frames directly
             if frame.is_none() {
                 frame = self.crypto.streams.get_frame(space, remaining)
             }

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -255,8 +255,8 @@ fn idle_caching() {
     let (initial, _) = split_datagram(&dgram.unwrap());
     let frames = client.test_process_input(initial, middle);
     assert_eq!(frames.len(), 2);
-    assert_eq!(frames[0], (Frame::Ping, PNSpace::Initial));
-    assert!(matches!(frames[1], (Frame::Ack { .. }, PNSpace::Initial)));
+    assert!(matches!(frames[0], (Frame::Ack { .. }, PNSpace::Initial)));
+    assert_eq!(frames[1], (Frame::Ping, PNSpace::Initial));
 
     let end = start + LOCAL_IDLE_TIMEOUT + (AT_LEAST_PTO / 2);
     // Now let the server Initial through, with the CRYPTO frame.

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -5,7 +5,8 @@
 // except according to those terms.
 
 use std::cell::RefCell;
-use std::cmp::max;
+use std::cmp::{max, min};
+use std::convert::TryFrom;
 use std::mem;
 use std::ops::{Index, IndexMut, Range};
 use std::rc::Rc;
@@ -20,8 +21,7 @@ use neqo_crypto::{
     TLS_VERSION_1_3,
 };
 
-use crate::frame::Frame;
-use crate::packet::{PacketNumber, QuicVersion};
+use crate::packet::{PacketBuilder, PacketNumber, QuicVersion};
 use crate::recovery::RecoveryToken;
 use crate::recv_stream::RxStreamOrderer;
 use crate::send_stream::TxBuffer;
@@ -1225,30 +1225,38 @@ impl CryptoStreams {
         }
     }
 
-    pub fn get_frame(
+    pub fn write_frame(
         &mut self,
         space: PNSpace,
-        remaining: usize,
-    ) -> Option<(Frame, Option<RecoveryToken>)> {
+        builder: &mut PacketBuilder,
+    ) -> Option<RecoveryToken> {
         let cs = self.get_mut(space).unwrap();
         if let Some((offset, data)) = cs.tx.next_bytes() {
-            let (frame, length) = Frame::new_crypto(offset, data, remaining);
+            let mut header_len = 1 + Encoder::varint_len(offset) + 1;
+
+            // Don't bother if there isn't room for the header and some data.
+            if builder.remaining() < header_len + 1 {
+                return None;
+            }
+            // Calculate length of data based on the minimum of:
+            // - available data
+            // - remaining space, less the header, which counts only one byte
+            //   for the length at first to avoid underestimating length
+            let length = min(data.len(), builder.remaining() - header_len);
+            header_len += Encoder::varint_len(u64::try_from(length).unwrap()) - 1;
+            let length = min(data.len(), builder.remaining() - header_len);
+
+            builder.encode_varint(crate::frame::FRAME_TYPE_CRYPTO);
+            builder.encode_varint(offset);
+            builder.encode_vvec(&data[..length]);
             cs.tx.mark_as_sent(offset, length);
 
-            qdebug!(
-                "Emitting crypto frame space={}, offset={}, len={}",
+            qdebug!("CRYPTO for {} offset={}, len={}", space, offset, length);
+            Some(RecoveryToken::Crypto(CryptoRecoveryToken {
                 space,
                 offset,
-                length
-            );
-            Some((
-                frame,
-                Some(RecoveryToken::Crypto(CryptoRecoveryToken {
-                    space,
-                    offset,
-                    length,
-                })),
-            ))
+                length,
+            }))
         } else {
             None
         }

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -315,7 +315,7 @@ impl PacketBuilder {
 
     /// Work out if nothing was added after the header.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub fn packet_empty(&self) -> bool {
         self.encoder.len() == self.header.end
     }
 

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -16,14 +16,14 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 use smallvec::SmallVec;
 
-use neqo_common::{qdebug, qerror, qinfo, qtrace};
+use neqo_common::{qdebug, qerror, qinfo, qtrace, Encoder};
 
 use crate::events::ConnectionEvents;
 use crate::flow_mgr::FlowMgr;
 use crate::frame::Frame;
+use crate::packet::PacketBuilder;
 use crate::recovery::RecoveryToken;
 use crate::stream_id::StreamId;
-use crate::tracking::PNSpace;
 use crate::{AppError, Error, Res};
 
 pub const SEND_BUFFER_SIZE: usize = 0x10_0000; // 1 MiB
@@ -511,6 +511,80 @@ impl SendStream {
         }
     }
 
+    /// Calculate how many bytes (length) can fit into available space and whether
+    /// the remainder of the space can be filled (or if a length field is needed).
+    fn length_and_fill(data_len: usize, space: usize) -> (usize, bool) {
+        if data_len >= space {
+            // Either more data than space allows, or an exact fit.
+            qtrace!("SendStream::length_and_fill fill {}", space);
+            return (space, true);
+        }
+
+        // Estimate size of the length field based on the available space,
+        // less 1, which is the worst case.
+        let length = min(space.saturating_sub(1), data_len);
+        let length_len = Encoder::varint_len(u64::try_from(length).unwrap());
+        if length_len > space {
+            qtrace!(
+                "SendStream::length_and_fill no room for length of {} in {}",
+                length,
+                space
+            );
+            return (0, false);
+        }
+
+        let length = min(data_len, space - length_len);
+        qtrace!("SendStream::length_and_fill {} in {}", length, space);
+        (length, false)
+    }
+
+    pub fn write_frame(&mut self, builder: &mut PacketBuilder) -> Option<RecoveryToken> {
+        let id = self.stream_id;
+        let final_size = self.final_size();
+        if let Some((offset, data)) = self.next_bytes() {
+            let overhead = 1 // Frame type
+                + Encoder::varint_len(id.as_u64())
+                + if offset > 0 {
+                    Encoder::varint_len(offset)
+                } else {
+                    0
+                };
+            if overhead > builder.remaining() {
+                qtrace!("SendStream::write_frame no space for header");
+                return None;
+            }
+
+            let (length, fill) = Self::length_and_fill(data.len(), builder.remaining() - overhead);
+            let fin = final_size.map_or(false, |fs| fs == offset + u64::try_from(length).unwrap());
+            if length == 0 && !fin {
+                qtrace!("SendStream::write_frame no data, no fin");
+                return None;
+            }
+
+            // Write the stream out.
+            builder.encode_varint(Frame::stream_type(fin, offset > 0, fill));
+            builder.encode_varint(id.as_u64());
+            if offset > 0 {
+                builder.encode_varint(offset);
+            }
+            if fill {
+                builder.encode(&data[..length]);
+            } else {
+                builder.encode_vvec(&data[..length]);
+            }
+
+            self.mark_as_sent(offset, length, fin);
+            Some(RecoveryToken::Stream(StreamRecoveryToken {
+                id,
+                offset,
+                length,
+                fin,
+            }))
+        } else {
+            None
+        }
+    }
+
     pub fn mark_as_sent(&mut self, offset: u64, len: usize, fin: bool) {
         if let Some(buf) = self.state.tx_buf_mut() {
             buf.mark_as_sent(offset, len);
@@ -791,49 +865,16 @@ impl SendStreams {
         self.0.retain(|_, stream| !stream.is_terminal())
     }
 
-    pub(crate) fn get_frame(
+    pub(crate) fn write_frames(
         &mut self,
-        space: PNSpace,
-        remaining: usize,
-    ) -> Option<(Frame, Option<RecoveryToken>)> {
-        if space != PNSpace::ApplicationData {
-            return None;
-        }
-
-        for (stream_id, stream) in self {
-            let final_size = stream.final_size();
-            if let Some((offset, data)) = stream.next_bytes() {
-                let data_len = u64::try_from(data.len()).unwrap();
-                let range_has_fin = final_size
-                    .map(|fs| fs == offset + data_len)
-                    .unwrap_or(false);
-                if let Some((frame, length)) =
-                    Frame::new_stream(stream_id.as_u64(), offset, data, range_has_fin, remaining)
-                {
-                    qdebug!(
-                        "Stream {} sending bytes {}-{}, space {:?}",
-                        stream_id.as_u64(),
-                        offset,
-                        offset + length as u64,
-                        space,
-                    );
-                    let fin = range_has_fin && length == data.len();
-                    debug_assert!(!fin || matches!(frame, Frame::Stream{fin: true, .. }));
-                    stream.mark_as_sent(offset, length, fin);
-
-                    return Some((
-                        frame,
-                        Some(RecoveryToken::Stream(StreamRecoveryToken {
-                            id: *stream_id,
-                            offset,
-                            length,
-                            fin,
-                        })),
-                    ));
-                }
+        builder: &mut PacketBuilder,
+        tokens: &mut Vec<RecoveryToken>,
+    ) {
+        for (_, stream) in self {
+            if let Some(t) = stream.write_frame(builder) {
+                tokens.push(t);
             }
         }
-        None
     }
 }
 
@@ -859,7 +900,7 @@ mod tests {
     use super::*;
 
     use crate::events::ConnectionEvent;
-    use neqo_common::event::Provider;
+    use neqo_common::{event::Provider, hex_with_len, qtrace};
 
     #[test]
     fn test_mark_range() {
@@ -1266,39 +1307,65 @@ mod tests {
         s.close();
 
         let mut ss = SendStreams::default();
-        ss.insert(0.into(), s);
+        ss.insert(StreamId::from(0), s);
 
-        let (_f1, f1_token) = ss.get_frame(PNSpace::ApplicationData, 6).unwrap();
-        assert!(matches!(&f1_token, Some(RecoveryToken::Stream(x)) if !x.fin));
-        let (_f2, f2_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(&f2_token, Some(RecoveryToken::Stream(x)) if x.fin));
+        let mut tokens = Vec::new();
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
 
-        // Should be no more data to frame
-        let f3 = ss.get_frame(PNSpace::ApplicationData, 100);
-        assert!(matches!(f3, None));
+        // Write a small frame: no fin.
+        let written = builder.len();
+        builder.set_limit(written + 6);
+        ss.write_frames(&mut builder, &mut tokens);
+        assert_eq!(builder.len(), written + 6);
+        assert_eq!(tokens.len(), 1);
+        let f1_token = tokens.remove(0);
+        assert!(matches!(&f1_token, RecoveryToken::Stream(x) if !x.fin));
+
+        // Write the rest: fin.
+        let written = builder.len();
+        builder.set_limit(written + 200);
+        ss.write_frames(&mut builder, &mut tokens);
+        assert_eq!(builder.len(), written + 10);
+        assert_eq!(tokens.len(), 1);
+        let f2_token = tokens.remove(0);
+        assert!(matches!(&f2_token, RecoveryToken::Stream(x) if x.fin));
+
+        // Should be no more data to frame.
+        let written = builder.len();
+        ss.write_frames(&mut builder, &mut tokens);
+        assert_eq!(builder.len(), written);
+        assert!(tokens.is_empty());
 
         // Mark frame 1 as lost
-        let f1_token = match f1_token {
-            Some(RecoveryToken::Stream(rt)) => rt,
-            _ => panic!(),
-        };
-        ss.lost(&f1_token);
+        if let RecoveryToken::Stream(rt) = f1_token {
+            ss.lost(&rt);
+        } else {
+            panic!();
+        }
 
         // Next frame should not set fin even though stream has fin but frame
         // does not include end of stream
-        let (_f4, f4_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(f4_token, Some(RecoveryToken::Stream(x)) if !x.fin));
+        let written = builder.len();
+        ss.write_frames(&mut builder, &mut tokens);
+        assert_eq!(builder.len(), written + 7); // Needs a length this time.
+        assert_eq!(tokens.len(), 1);
+        let f4_token = tokens.remove(0);
+        assert!(matches!(&f4_token, RecoveryToken::Stream(x) if !x.fin));
 
         // Mark frame 2 as lost
-        let f2_token = match f2_token {
-            Some(RecoveryToken::Stream(rt)) => rt,
-            _ => panic!(),
-        };
-        ss.lost(&f2_token);
+        if let RecoveryToken::Stream(rt) = f2_token {
+            ss.lost(&rt);
+        } else {
+            panic!();
+        }
 
         // Next frame should set fin because it includes end of stream
-        let (_f5, f5_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(f5_token, Some(RecoveryToken::Stream(x)) if x.fin));
+        let written = builder.len();
+        ss.write_frames(&mut builder, &mut tokens);
+        assert_eq!(builder.len(), written + 10);
+        assert_eq!(tokens.len(), 1);
+        let f5_token = tokens.remove(0);
+        assert!(matches!(&f5_token, RecoveryToken::Stream(x) if x.fin));
     }
 
     #[test]
@@ -1313,49 +1380,55 @@ mod tests {
         s.send(&[0; 10]).unwrap();
 
         let mut ss = SendStreams::default();
-        ss.insert(0.into(), s);
+        ss.insert(StreamId::from(0), s);
 
-        let (_f1, f1_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(&f1_token, Some(RecoveryToken::Stream(x)) if x.offset == 0));
-        assert!(matches!(&f1_token, Some(RecoveryToken::Stream(x)) if x.length == 10));
-        assert!(matches!(&f1_token, Some(RecoveryToken::Stream(x)) if !x.fin));
+        let mut tokens = Vec::new();
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        ss.write_frames(&mut builder, &mut tokens);
+        let f1_token = tokens.remove(0);
+        assert!(matches!(&f1_token, RecoveryToken::Stream(x) if x.offset == 0));
+        assert!(matches!(&f1_token, RecoveryToken::Stream(x) if x.length == 10));
+        assert!(matches!(&f1_token, RecoveryToken::Stream(x) if !x.fin));
 
         // Should be no more data to frame
-        let f2 = ss.get_frame(PNSpace::ApplicationData, 100);
-        assert!(matches!(f2, None));
+        ss.write_frames(&mut builder, &mut tokens);
+        assert!(tokens.is_empty());
 
-        ss.get_mut(0.into()).unwrap().close();
+        ss.get_mut(StreamId::from(0)).unwrap().close();
 
-        let (_f2, f2_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(&f2_token, Some(RecoveryToken::Stream(x)) if x.offset == 10));
-        assert!(matches!(&f2_token, Some(RecoveryToken::Stream(x)) if x.length == 0));
-        assert!(matches!(&f2_token, Some(RecoveryToken::Stream(x)) if x.fin));
+        ss.write_frames(&mut builder, &mut tokens);
+        let f2_token = tokens.remove(0);
+        assert!(matches!(&f2_token, RecoveryToken::Stream(x) if x.offset == 10));
+        assert!(matches!(&f2_token, RecoveryToken::Stream(x) if x.length == 0));
+        assert!(matches!(&f2_token, RecoveryToken::Stream(x) if x.fin));
 
         // Mark frame 2 as lost
-        let f2_token = match f2_token {
-            Some(RecoveryToken::Stream(rt)) => rt,
-            _ => panic!(),
-        };
-        ss.lost(&f2_token);
+        if let RecoveryToken::Stream(rt) = f2_token {
+            ss.lost(&rt);
+        } else {
+            panic!();
+        }
 
         // Next frame should set fin
-        let (_f3, f3_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(&f3_token, Some(RecoveryToken::Stream(x)) if x.offset == 10));
-        assert!(matches!(&f3_token, Some(RecoveryToken::Stream(x)) if x.length == 0));
-        assert!(matches!(&f3_token, Some(RecoveryToken::Stream(x)) if x.fin));
+        ss.write_frames(&mut builder, &mut tokens);
+        let f3_token = tokens.remove(0);
+        assert!(matches!(&f3_token, RecoveryToken::Stream(x) if x.offset == 10));
+        assert!(matches!(&f3_token, RecoveryToken::Stream(x) if x.length == 0));
+        assert!(matches!(&f3_token, RecoveryToken::Stream(x) if x.fin));
 
         // Mark frame 1 as lost
-        let f1_token = match f1_token {
-            Some(RecoveryToken::Stream(rt)) => rt,
-            _ => panic!(),
-        };
-        ss.lost(&f1_token);
+        if let RecoveryToken::Stream(rt) = f1_token {
+            ss.lost(&rt);
+        } else {
+            panic!();
+        }
 
         // Next frame should set fin and include all data
-        let (_f4, f4_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(&f4_token, Some(RecoveryToken::Stream(x)) if x.offset == 0));
-        assert!(matches!(&f4_token, Some(RecoveryToken::Stream(x)) if x.length == 10));
-        assert!(matches!(&f4_token, Some(RecoveryToken::Stream(x)) if x.fin));
+        ss.write_frames(&mut builder, &mut tokens);
+        let f4_token = tokens.remove(0);
+        assert!(matches!(&f4_token, RecoveryToken::Stream(x) if x.offset == 0));
+        assert!(matches!(&f4_token, RecoveryToken::Stream(x) if x.length == 10));
+        assert!(matches!(&f4_token, RecoveryToken::Stream(x) if x.fin));
     }
 
     #[test]
@@ -1364,7 +1437,8 @@ mod tests {
         flow_mgr.borrow_mut().conn_increase_max_credit(5);
         let conn_events = ConnectionEvents::default();
 
-        let mut s = SendStream::new(4.into(), 0, Rc::clone(&flow_mgr), conn_events);
+        let stream_id = StreamId::from(4);
+        let mut s = SendStream::new(stream_id, 0, Rc::clone(&flow_mgr), conn_events);
         s.set_max_stream_data(2);
 
         // Stream is initially blocked (conn:5, stream:2)
@@ -1375,7 +1449,7 @@ mod tests {
         assert_eq!(
             flow_mgr.borrow_mut().next().unwrap(),
             Frame::StreamDataBlocked {
-                stream_id: 4.into(),
+                stream_id,
                 stream_data_limit: 0x2
             }
         );
@@ -1391,7 +1465,7 @@ mod tests {
         assert_eq!(
             flow_mgr.borrow_mut().next().unwrap(),
             Frame::StreamDataBlocked {
-                stream_id: 4.into(),
+                stream_id,
                 stream_data_limit: 0x2
             }
         );
@@ -1457,12 +1531,12 @@ mod tests {
         const MESSAGE: &[u8] = b"hello";
         let len_u64 = u64::try_from(MESSAGE.len()).unwrap();
 
-        let flow_mgr = Rc::new(RefCell::new(FlowMgr::default()));
-        flow_mgr.borrow_mut().conn_increase_max_credit(len_u64);
+        let mut flow_mgr = FlowMgr::default();
+        flow_mgr.conn_increase_max_credit(len_u64);
         let conn_events = ConnectionEvents::default();
 
         let id = StreamId::new(100);
-        let mut s = SendStream::new(id, 0, Rc::clone(&flow_mgr), conn_events);
+        let mut s = SendStream::new(id, 0, Rc::new(RefCell::new(flow_mgr)), conn_events);
         s.set_max_stream_data(len_u64);
 
         // Send all the data, then the fin.
@@ -1476,8 +1550,197 @@ mod tests {
         s.mark_as_lost(len_u64, 0, true);
 
         // No frame should be sent here.
-        let mut builder = SendStreams(IndexMap::default());
-        builder.insert(id, s);
-        assert!(builder.get_frame(PNSpace::ApplicationData, 1000).is_none());
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        assert!(s.write_frame(&mut builder).is_none());
+    }
+
+    /// Create a `SendStream` and force it into a state where it believes that
+    /// `offset` bytes have already been sent and acknowledged.
+    fn stream_with_sent(stream: u64, offset: usize) -> SendStream {
+        const MAX_VARINT: u64 = (1 << 62) - 1;
+
+        let mut flow_mgr = FlowMgr::default();
+        flow_mgr.conn_increase_max_credit(MAX_VARINT);
+
+        let mut s = SendStream::new(
+            StreamId::from(stream),
+            MAX_VARINT,
+            Rc::new(RefCell::new(flow_mgr)),
+            ConnectionEvents::default(),
+        );
+
+        let mut send_buf = TxBuffer::new();
+        send_buf.retired = u64::try_from(offset).unwrap();
+        send_buf.ranges.mark_range(0, offset, RangeState::Acked);
+        s.state = SendStreamState::Send { send_buf };
+        s
+    }
+
+    fn frame_sent_sid(stream: u64, offset: usize, len: usize, fin: bool, space: usize) -> bool {
+        const BUF: &[u8] = &[0x42; 128];
+        let mut s = stream_with_sent(stream, offset);
+
+        // Now write out the proscribed data and maybe close.
+        if len > 0 {
+            s.send(&BUF[..len]).unwrap();
+        }
+        if fin {
+            s.close();
+        }
+
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        let header_len = builder.len();
+        builder.set_limit(header_len + space);
+        let token = s.write_frame(&mut builder);
+        qtrace!("STREAM frame: {}", hex_with_len(&builder[header_len..]));
+        token.is_some()
+    }
+
+    fn frame_sent(offset: usize, len: usize, fin: bool, space: usize) -> bool {
+        frame_sent_sid(0, offset, len, fin, space)
+    }
+
+    #[test]
+    fn stream_frame_empty() {
+        // Stream frames with empty data and no fin never work.
+        assert!(!frame_sent(10, 0, false, 2));
+        assert!(!frame_sent(10, 0, false, 3));
+        assert!(!frame_sent(10, 0, false, 4));
+        assert!(!frame_sent(10, 0, false, 5));
+        assert!(!frame_sent(10, 0, false, 100));
+
+        // Empty data with fin is only a problem if there is no space.
+        assert!(!frame_sent(0, 0, true, 1));
+        assert!(frame_sent(0, 0, true, 2));
+        assert!(!frame_sent(10, 0, true, 2));
+        assert!(frame_sent(10, 0, true, 3));
+        assert!(frame_sent(10, 0, true, 4));
+        assert!(frame_sent(10, 0, true, 5));
+        assert!(frame_sent(10, 0, true, 100));
+    }
+
+    #[test]
+    fn stream_frame_minimum() {
+        // Add minimum data
+        assert!(!frame_sent(10, 1, false, 3));
+        assert!(!frame_sent(10, 1, true, 3));
+        assert!(frame_sent(10, 1, false, 4));
+        assert!(frame_sent(10, 1, true, 4));
+        assert!(frame_sent(10, 1, false, 5));
+        assert!(frame_sent(10, 1, true, 5));
+        assert!(frame_sent(10, 1, false, 100));
+        assert!(frame_sent(10, 1, true, 100));
+    }
+
+    #[test]
+    fn stream_frame_more() {
+        // Try more data
+        assert!(!frame_sent(10, 100, false, 3));
+        assert!(!frame_sent(10, 100, true, 3));
+        assert!(frame_sent(10, 100, false, 4));
+        assert!(frame_sent(10, 100, true, 4));
+        assert!(frame_sent(10, 100, false, 5));
+        assert!(frame_sent(10, 100, true, 5));
+        assert!(frame_sent(10, 100, false, 100));
+        assert!(frame_sent(10, 100, true, 100));
+
+        assert!(frame_sent(10, 100, false, 1000));
+        assert!(frame_sent(10, 100, true, 1000));
+    }
+
+    #[test]
+    fn stream_frame_big_id() {
+        // A value that encodes to the largest varint.
+        const BIG: u64 = 1 << 30;
+        const BIGSZ: usize = 1 << 30;
+
+        assert!(!frame_sent_sid(BIG, BIGSZ, 0, false, 16));
+        assert!(!frame_sent_sid(BIG, BIGSZ, 0, true, 16));
+        assert!(!frame_sent_sid(BIG, BIGSZ, 0, false, 17));
+        assert!(frame_sent_sid(BIG, BIGSZ, 0, true, 17));
+        assert!(!frame_sent_sid(BIG, BIGSZ, 0, false, 18));
+        assert!(frame_sent_sid(BIG, BIGSZ, 0, true, 18));
+
+        assert!(!frame_sent_sid(BIG, BIGSZ, 1, false, 17));
+        assert!(!frame_sent_sid(BIG, BIGSZ, 1, true, 17));
+        assert!(frame_sent_sid(BIG, BIGSZ, 1, false, 18));
+        assert!(frame_sent_sid(BIG, BIGSZ, 1, true, 18));
+        assert!(frame_sent_sid(BIG, BIGSZ, 1, false, 19));
+        assert!(frame_sent_sid(BIG, BIGSZ, 1, true, 19));
+        assert!(frame_sent_sid(BIG, BIGSZ, 1, false, 100));
+        assert!(frame_sent_sid(BIG, BIGSZ, 1, true, 100));
+    }
+
+    #[test]
+    fn stream_frame_16384() {
+        const DATA16384: &[u8] = &[0x43; 16384];
+
+        // 16383/16384 is an odd boundary in STREAM frame construction.
+        // That is the boundary where a length goes from 2 bytes to 4 bytes.
+        // If the data fits in the available space, then it is simple:
+        let mut s = stream_with_sent(0, 0);
+        s.send(DATA16384).unwrap();
+        s.close();
+
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        let header_len = builder.len();
+        builder.set_limit(header_len + DATA16384.len() + 2);
+        let token = s.write_frame(&mut builder);
+        assert!(token.is_some());
+        // Expect STREAM + FIN only.
+        assert_eq!(&builder[header_len..header_len + 2], &[0b1001, 0]);
+        assert_eq!(&builder[header_len + 2..], DATA16384);
+
+        s.mark_as_lost(0, DATA16384.len(), true);
+
+        // However, if there is one extra byte of space, we will try to add a length.
+        // That length will then make the frame to be too large and the data will be
+        // truncated.  The frame could carry one more byte of data, but it's a corner
+        // case we don't want to address as it should be rare (if not impossible).
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        let header_len = builder.len();
+        builder.set_limit(header_len + DATA16384.len() + 3);
+        let token = s.write_frame(&mut builder);
+        assert!(token.is_some());
+        // Expect STREAM + LEN + FIN.
+        assert_eq!(
+            &builder[header_len..header_len + 4],
+            &[0b1010, 0, 0x7f, 0xfd]
+        );
+        assert_eq!(
+            &builder[header_len + 4..],
+            &DATA16384[..DATA16384.len() - 3]
+        );
+    }
+
+    #[test]
+    fn stream_frame_64() {
+        const DATA64: &[u8] = &[0x43; 64];
+
+        // Unlike 16383/16384, the boundary at 63/64 is easy because the difference
+        // is just one byte.  We lose just the last byte when there is more space.
+        let mut s = stream_with_sent(0, 0);
+        s.send(DATA64).unwrap();
+        s.close();
+
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        let header_len = builder.len();
+        builder.set_limit(header_len + 66);
+        let token = s.write_frame(&mut builder);
+        assert!(token.is_some());
+        // Expect STREAM + FIN only.
+        assert_eq!(&builder[header_len..header_len + 2], &[0b1001, 0]);
+        assert_eq!(&builder[header_len + 2..], DATA64);
+
+        s.mark_as_lost(0, DATA64.len(), true);
+
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        let header_len = builder.len();
+        builder.set_limit(header_len + 67);
+        let token = s.write_frame(&mut builder);
+        assert!(token.is_some());
+        // Expect STREAM + LEN, not FIN.
+        assert_eq!(&builder[header_len..header_len + 3], &[0b1010, 0, 63]);
+        assert_eq!(&builder[header_len + 3..], &DATA64[..63]);
     }
 }

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -15,7 +15,7 @@ use std::ops::{Index, IndexMut};
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use neqo_common::{qdebug, qinfo, qtrace, qwarn, Encoder};
+use neqo_common::{qdebug, qinfo, qtrace, qwarn};
 use neqo_crypto::{Epoch, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL};
 
 use crate::packet::{PacketBuilder, PacketNumber, PacketType};

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -15,7 +15,7 @@ use std::ops::{Index, IndexMut};
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use neqo_common::{qdebug, qinfo, qtrace, qwarn};
+use neqo_common::{qdebug, qinfo, qtrace, qwarn, Encoder};
 use neqo_crypto::{Epoch, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL};
 
 use crate::packet::{PacketBuilder, PacketNumber, PacketType};


### PR DESCRIPTION
OK, first, I have to apologize for how big this is.  It's largely mechanical, but it doesn't look that way.

The individual commits should be fairly clear, because I did this almost a frame at a time.

Each source of frames now writes directly.  So the code from `Frame::marshal` and related functions are moved.  Rather than making a frame it just writes the data out after working out if there is space.

This is less architecturally pure in the sense that there is no single place where all the frame writing occurs, and it means that we have less direct testing of this code, but we now have plenty of testing elsewhere.

The biggest change here is moving all of the STREAM frame stuff from frame.rs to send_stream.rs.  I had to refactor the code a lot.  Same for the tests, though all the existing tests are still there, just with different fixtures.

(The next step is to make `Frame` borrow buffers rather than taking copies.  That turns out to be less of a big win, but it saves a bit of extra copying in a few narrow cases.)