### PR TITLE
Make Frame borrow for its buffers

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -165,7 +165,7 @@ impl<'a> Deref for Decoder<'a> {
 
 impl<'a> Debug for Decoder<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(&hex_with_len(self))
+        f.write_str(&hex_with_len(&self[..]))
     }
 }
 

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -25,17 +25,18 @@ pub use self::incrdecoder::{
 extern crate lazy_static;
 
 #[must_use]
-pub fn hex(buf: &[u8]) -> String {
-    let mut ret = String::with_capacity(buf.len() * 2);
-    for b in buf {
+pub fn hex(buf: impl AsRef<[u8]>) -> String {
+    let mut ret = String::with_capacity(buf.as_ref().len() * 2);
+    for b in buf.as_ref() {
         ret.push_str(&format!("{:02x}", b));
     }
     ret
 }
 
 #[must_use]
-pub fn hex_snip_middle(buf: &[u8]) -> String {
+pub fn hex_snip_middle(buf: impl AsRef<[u8]>) -> String {
     const SHOW_LEN: usize = 8;
+    let buf = buf.as_ref();
     if buf.len() <= SHOW_LEN * 2 {
         hex_with_len(buf)
     } else {
@@ -53,7 +54,8 @@ pub fn hex_snip_middle(buf: &[u8]) -> String {
 }
 
 #[must_use]
-pub fn hex_with_len(buf: &[u8]) -> String {
+pub fn hex_with_len(buf: impl AsRef<[u8]>) -> String {
+    let buf = buf.as_ref();
     let mut ret = String::with_capacity(10 + buf.len() * 2);
     ret.push_str(&format!("[{}]: ", buf.len()));
     for b in buf {

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -13,7 +13,7 @@ use neqo_crypto::{
 };
 
 use crate::cid::ConnectionId;
-use crate::frame::Frame;
+use crate::packet::PacketBuilder;
 use crate::recovery::RecoveryToken;
 use crate::Res;
 
@@ -349,11 +349,9 @@ impl NewTokenState {
 
     /// If this is a server, maybe send a frame.
     /// If this is a client, do nothing.
-    pub fn get_frame(&mut self, space: usize) -> Option<(Frame, Option<RecoveryToken>)> {
+    pub fn write_frames(&mut self, builder: &mut PacketBuilder, tokens: &mut Vec<RecoveryToken>) {
         if let Self::Server(ref mut sender) = self {
-            sender.get_frame(space)
-        } else {
-            None
+            sender.write_frames(builder, tokens);
         }
     }
 
@@ -421,19 +419,17 @@ impl NewTokenSender {
         self.next_seqno += 1;
     }
 
-    pub fn get_frame(&mut self, space: usize) -> Option<(Frame, Option<RecoveryToken>)> {
+    pub fn write_frames(&mut self, builder: &mut PacketBuilder, tokens: &mut Vec<RecoveryToken>) {
         for t in self.tokens.iter_mut() {
-            if t.needs_sending && t.fits(space) {
+            if t.needs_sending && t.fits(builder.remaining()) {
                 t.needs_sending = false;
-                return Some((
-                    Frame::NewToken {
-                        token: t.token.clone(),
-                    },
-                    Some(RecoveryToken::NewToken(t.seqno)),
-                ));
+
+                builder.encode_varint(crate::frame::FRAME_TYPE_NEW_TOKEN);
+                builder.encode_vvec(&t.token);
+
+                tokens.push(RecoveryToken::NewToken(t.seqno));
             }
         }
-        None
     }
 
     pub fn lost(&mut self, seqno: usize) {

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -274,7 +274,7 @@ pub struct Connection {
     pub(crate) acks: AckTracker,
     idle_timeout: IdleTimeout,
     pub(crate) indexes: StreamIndexes,
-    connection_ids: HashMap<u64, (Vec<u8>, [u8; 16])>, // (sequence number, (connection id, reset token))
+    connection_ids: HashMap<u64, (ConnectionId, [u8; 16])>, // (sequence number, (connection id, reset token))
     pub(crate) send_streams: SendStreams,
     pub(crate) recv_streams: RecvStreams,
     pub(crate) flow_mgr: Rc<RefCell<FlowMgr>>,
@@ -836,16 +836,6 @@ impl Connection {
         self.cleanup_streams();
     }
 
-    /// Just like above but returns frames parsed from the datagram
-    #[cfg(test)]
-    #[must_use]
-    pub fn test_process_input(&mut self, dgram: Datagram, now: Instant) -> Vec<(Frame, PNSpace)> {
-        let res = self.input(dgram, now);
-        let frames = self.absorb_error(now, res).unwrap_or_default();
-        self.cleanup_streams();
-        frames
-    }
-
     /// Get the time that we next need to be called back, relative to `now`.
     fn next_delay(&mut self, now: Instant, paced: bool) -> Duration {
         qtrace!([self], "Get callback delay {:?}", now);
@@ -1200,9 +1190,8 @@ impl Connection {
     }
 
     /// Take a datagram as input.  This reports an error if the packet was bad.
-    fn input(&mut self, d: Datagram, now: Instant) -> Res<Vec<(Frame, PNSpace)>> {
+    fn input(&mut self, d: Datagram, now: Instant) -> Res<()> {
         let mut slc = &d[..];
-        let mut frames = Vec::new();
         let mut dcid = None;
 
         qtrace!([self], "input {}", hex(&**d));
@@ -1223,7 +1212,7 @@ impl Connection {
             match self.preprocess(&packet, dcid.as_ref(), now)? {
                 PreprocessResult::Continue => (),
                 PreprocessResult::Next => break,
-                PreprocessResult::End => return Ok(frames),
+                PreprocessResult::End => return Ok(()),
             }
 
             qtrace!([self], "Received unverified packet {:?}", packet);
@@ -1251,7 +1240,7 @@ impl Connection {
                         self.remote_initial_source_cid = Some(ConnectionId::from(packet.scid()));
                         self.initialize_path(d.destination(), d.source());
                     }
-                    frames.extend(res?);
+                    res?;
                     if self.state == State::WaitInitial {
                         self.start_handshake(&packet, &d)?;
                     }
@@ -1264,7 +1253,7 @@ impl Connection {
                             // Don't check this packet for a stateless reset, just return.
                             let remaining = slc.len();
                             self.save_datagram(cspace, d, remaining, now);
-                            return Ok(frames);
+                            return Ok(());
                         }
                         Error::KeysExhausted => {
                             // Exhausting read keys is fatal.
@@ -1284,14 +1273,10 @@ impl Connection {
             dcid = Some(ConnectionId::from(packet.dcid()));
         }
         self.check_stateless_reset(&d, dcid.is_none(), now)?;
-        Ok(frames)
+        Ok(())
     }
 
-    fn process_packet(
-        &mut self,
-        packet: &DecryptedPacket,
-        now: Instant,
-    ) -> Res<Vec<(Frame, PNSpace)>> {
+    fn process_packet(&mut self, packet: &DecryptedPacket, now: Instant) -> Res<()> {
         // TODO(ekr@rtfm.com): Have the server blow away the initial
         // crypto state if this fails? Otherwise, we will get a panic
         // on the assert for doesn't exist.
@@ -1301,14 +1286,12 @@ impl Connection {
         if self.acks.get_mut(space).unwrap().is_duplicate(packet.pn()) {
             qdebug!([self], "Duplicate packet from {} pn={}", space, packet.pn());
             self.stats.borrow_mut().dups_rx += 1;
-            return Ok(vec![]);
+            return Ok(());
         }
 
         let mut ack_eliciting = false;
         let mut d = Decoder::from(&packet[..]);
         let mut consecutive_padding = 0;
-        #[allow(unused_mut)]
-        let mut frames = Vec::new();
         while d.remaining() > 0 {
             let mut f = Frame::decode(&mut d)?;
 
@@ -1326,9 +1309,6 @@ impl Connection {
                 consecutive_padding = 0;
             }
 
-            if cfg!(test) {
-                frames.push((f.clone(), space));
-            }
             ack_eliciting |= f.ack_eliciting();
             let t = f.get_type();
             let res = self.input_frame(packet.packet_type(), f, now);
@@ -1339,7 +1319,7 @@ impl Connection {
             .unwrap()
             .set_received(now, packet.pn(), ack_eliciting);
 
-        Ok(frames)
+        Ok(())
     }
 
     fn initialize_path(&mut self, local_addr: SocketAddr, remote_addr: SocketAddr) {
@@ -1531,8 +1511,9 @@ impl Connection {
         now: Instant,
     ) -> (Vec<RecoveryToken>, bool) {
         let mut tokens = Vec::new();
+        let stats = &mut self.stats.borrow_mut().frame_tx;
 
-        let ack_token = self.acks.write_frame(space, now, builder);
+        let ack_token = self.acks.write_frame(space, now, builder, stats);
 
         if profile.ack_only(space) {
             // If we are CC limited we can only send acks!
@@ -1545,20 +1526,22 @@ impl Connection {
         if space == PNSpace::ApplicationData && self.role == Role::Server {
             if let Some(t) = self.state_signaling.write_done(builder) {
                 tokens.push(t);
+                stats.handshake_done += 1;
             }
         }
 
         if let Some(t) = self.crypto.streams.write_frame(space, builder) {
             tokens.push(t);
+            stats.crypto += 1;
         }
 
         if space == PNSpace::ApplicationData {
             self.flow_mgr
                 .borrow_mut()
-                .write_frames(builder, &mut tokens);
+                .write_frames(builder, &mut tokens, stats);
 
-            self.send_streams.write_frames(builder, &mut tokens);
-            self.new_token.write_frames(builder, &mut tokens);
+            self.send_streams.write_frames(builder, &mut tokens, stats);
+            self.new_token.write_frames(builder, &mut tokens, stats);
         }
 
         // Anything - other than ACK - that registered a token wants an acknowledgment.
@@ -1567,6 +1550,8 @@ impl Connection {
                 // Nothing ack-eliciting and we need to probe; send PING.
                 debug_assert_ne!(builder.remaining(), 0);
                 builder.encode_varint(crate::frame::FRAME_TYPE_PING);
+                stats.ping += 1;
+                stats.all += 1;
                 true
             } else {
                 false
@@ -1575,6 +1560,7 @@ impl Connection {
         if let Some(t) = ack_token {
             tokens.push(t);
         }
+        stats.all += tokens.len();
         (tokens, ack_eliciting)
     }
 
@@ -1930,14 +1916,17 @@ impl Connection {
             qerror!("frame not allowed: {:?} {:?}", frame, ptype);
             return Err(Error::ProtocolViolation);
         }
+        self.stats.borrow_mut().frame_rx.all += 1;
         let space = PNSpace::from(ptype);
         match frame {
             Frame::Padding => {
-                // Ignore
+                // Note: This counts contiguous padding as a single frame.
+                self.stats.borrow_mut().frame_rx.padding += 1;
             }
             Frame::Ping => {
                 // If we get a PING and there are outstanding CRYPTO frames,
                 // prepare to resend them.
+                self.stats.borrow_mut().frame_rx.ping += 1;
                 self.crypto.resend_unacked(space);
             }
             Frame::Ack {
@@ -1961,6 +1950,7 @@ impl Connection {
                 ..
             } => {
                 // TODO(agrover@mozilla.com): use final_size for connection MaxData calc
+                self.stats.borrow_mut().frame_rx.reset_stream += 1;
                 if let (_, Some(rs)) = self.obtain_stream(stream_id)? {
                     rs.reset(application_error_code);
                 }
@@ -1969,6 +1959,7 @@ impl Connection {
                 stream_id,
                 application_error_code,
             } => {
+                self.stats.borrow_mut().frame_rx.stop_sending += 1;
                 self.events
                     .send_stream_stop_sending(stream_id, application_error_code);
                 if let (Some(ss), _) = self.obtain_stream(stream_id)? {
@@ -1983,6 +1974,7 @@ impl Connection {
                     offset,
                     &data
                 );
+                self.stats.borrow_mut().frame_rx.crypto += 1;
                 self.crypto.streams.inbound_frame(space, offset, data)?;
                 if self.crypto.streams.data_ready(space) {
                     let mut buf = Vec::new();
@@ -1996,7 +1988,8 @@ impl Connection {
                 }
             }
             Frame::NewToken { token } => {
-                self.new_token.save_token(token);
+                self.stats.borrow_mut().frame_rx.new_token += 1;
+                self.new_token.save_token(token.to_vec());
                 self.create_resumption_token(now);
             }
             Frame::Stream {
@@ -2006,15 +1999,20 @@ impl Connection {
                 data,
                 ..
             } => {
+                self.stats.borrow_mut().frame_rx.stream += 1;
                 if let (_, Some(rs)) = self.obtain_stream(stream_id)? {
                     rs.inbound_stream_frame(fin, offset, data)?;
                 }
             }
-            Frame::MaxData { maximum_data } => self.handle_max_data(maximum_data),
+            Frame::MaxData { maximum_data } => {
+                self.stats.borrow_mut().frame_rx.max_data += 1;
+                self.handle_max_data(maximum_data);
+            }
             Frame::MaxStreamData {
                 stream_id,
                 maximum_stream_data,
             } => {
+                self.stats.borrow_mut().frame_rx.max_stream_data += 1;
                 if let (Some(ss), _) = self.obtain_stream(stream_id)? {
                     ss.set_max_stream_data(maximum_stream_data);
                 }
@@ -2023,6 +2021,7 @@ impl Connection {
                 stream_type,
                 maximum_streams,
             } => {
+                self.stats.borrow_mut().frame_rx.max_streams += 1;
                 let remote_max = match stream_type {
                     StreamType::BiDi => &mut self.indexes.remote_max_stream_bidi,
                     StreamType::UniDi => &mut self.indexes.remote_max_stream_uni,
@@ -2040,6 +2039,7 @@ impl Connection {
                     "Received DataBlocked with data limit {}",
                     data_limit
                 );
+                self.stats.borrow_mut().frame_rx.data_blocked += 1;
                 // But if it does, open it up all the way
                 self.flow_mgr.borrow_mut().max_data(LOCAL_MAX_DATA);
             }
@@ -2047,6 +2047,7 @@ impl Connection {
                 stream_id,
                 stream_data_limit,
             } => {
+                self.stats.borrow_mut().frame_rx.stream_data_blocked += 1;
                 // Terminate connection with STREAM_STATE_ERROR if send-only
                 // stream (-transport 19.13)
                 if stream_id.is_send_only(self.role()) {
@@ -2069,6 +2070,7 @@ impl Connection {
                 }
             }
             Frame::StreamsBlocked { stream_type, .. } => {
+                self.stats.borrow_mut().frame_rx.streams_blocked += 1;
                 let local_max = match stream_type {
                     StreamType::BiDi => &mut self.indexes.local_max_stream_bidi,
                     StreamType::UniDi => &mut self.indexes.local_max_stream_uni,
@@ -2084,23 +2086,31 @@ impl Connection {
                 stateless_reset_token,
                 ..
             } => {
-                self.connection_ids
-                    .insert(sequence_number, (connection_id, stateless_reset_token));
+                self.stats.borrow_mut().frame_rx.new_connection_id += 1;
+                let cid = ConnectionId::from(connection_id);
+                let srt = stateless_reset_token.to_owned();
+                self.connection_ids.insert(sequence_number, (cid, srt));
             }
             Frame::RetireConnectionId { sequence_number } => {
+                self.stats.borrow_mut().frame_rx.retire_connection_id += 1;
                 self.connection_ids.remove(&sequence_number);
             }
-            Frame::PathChallenge { data } => self.flow_mgr.borrow_mut().path_response(data),
+            Frame::PathChallenge { data } => {
+                self.stats.borrow_mut().frame_rx.path_challenge += 1;
+                self.flow_mgr.borrow_mut().path_response(data);
+            }
             Frame::PathResponse { .. } => {
                 // Should never see this, we don't support migration atm and
                 // do not send path challenges
                 qwarn!([self], "Received Path Response");
+                self.stats.borrow_mut().frame_rx.path_response += 1;
             }
             Frame::ConnectionClose {
                 error_code,
                 frame_type,
                 reason_phrase,
             } => {
+                self.stats.borrow_mut().frame_rx.connection_close += 1;
                 let reason_phrase = String::from_utf8_lossy(&reason_phrase);
                 qinfo!(
                     [self],
@@ -2130,6 +2140,7 @@ impl Connection {
                 });
             }
             Frame::HandshakeDone => {
+                self.stats.borrow_mut().frame_rx.handshake_done += 1;
                 if self.role == Role::Server || !self.state.connected() {
                     return Err(Error::ProtocolViolation);
                 }
@@ -2219,6 +2230,9 @@ impl Connection {
         }
         self.handle_lost_packets(&lost_packets);
         qlog::packets_lost(&mut self.qlog, &lost_packets);
+        let stats = &mut self.stats.borrow_mut().frame_rx;
+        stats.ack += 1;
+        stats.largest_acknowledged = max(stats.largest_acknowledged, largest_acknowledged);
         Ok(())
     }
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1536,6 +1536,7 @@ impl Connection {
         }
 
         // All useful frames are at least 2 bytes.
+<<<<<<< HEAD
         while builder.remaining() >= 2 {
             let remaining = builder.remaining();
             // If we are CC limited we can only send acks!
@@ -1544,6 +1545,15 @@ impl Connection {
             } else {
                 None
             };
+=======
+        while builder.len() + 2 < limit {
+            let remaining = limit - builder.len();
+            // If we are CC limited we can only send acks!
+            let mut frame = None;
+            if space == PNSpace::ApplicationData && self.role == Role::Server {
+                frame = self.state_signaling.send_done();
+            }
+>>>>>>> Write ACK frames directly
             if frame.is_none() {
                 frame = self.crypto.streams.get_frame(space, remaining)
             }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1541,14 +1541,15 @@ impl Connection {
                 tokens.push(t);
             }
         }
+        if let Some(t) = self.crypto.streams.write_frame(space, builder) {
+            ack_eliciting = true;
+            tokens.push(t);
+        }
 
         // All useful frames are at least 2 bytes.
         while builder.remaining() >= 2 {
             let remaining = builder.remaining();
-            let mut frame = self.crypto.streams.get_frame(space, remaining);
-            if frame.is_none() {
-                frame = self.flow_mgr.borrow_mut().get_frame(space, remaining);
-            }
+            let mut frame = self.flow_mgr.borrow_mut().get_frame(space, remaining);
             if frame.is_none() {
                 frame = self.send_streams.get_frame(space, remaining);
             }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1545,14 +1545,14 @@ impl Connection {
             ack_eliciting = true;
             tokens.push(t);
         }
+        self.flow_mgr
+            .borrow_mut()
+            .write_frames(space, builder, &mut tokens);
 
         // All useful frames are at least 2 bytes.
         while builder.remaining() >= 2 {
             let remaining = builder.remaining();
-            let mut frame = self.flow_mgr.borrow_mut().get_frame(space, remaining);
-            if frame.is_none() {
-                frame = self.send_streams.get_frame(space, remaining);
-            }
+            let mut frame = self.send_streams.get_frame(space, remaining);
             if frame.is_none() && space == PNSpace::ApplicationData {
                 frame = self.new_token.get_frame(remaining);
             }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1536,7 +1536,6 @@ impl Connection {
         }
 
         // All useful frames are at least 2 bytes.
-<<<<<<< HEAD
         while builder.remaining() >= 2 {
             let remaining = builder.remaining();
             // If we are CC limited we can only send acks!
@@ -1545,15 +1544,6 @@ impl Connection {
             } else {
                 None
             };
-=======
-        while builder.len() + 2 < limit {
-            let remaining = limit - builder.len();
-            // If we are CC limited we can only send acks!
-            let mut frame = None;
-            if space == PNSpace::ApplicationData && self.role == Role::Server {
-                frame = self.state_signaling.send_done();
-            }
->>>>>>> Write ACK frames directly
             if frame.is_none() {
                 frame = self.crypto.streams.get_frame(space, remaining)
             }

--- a/neqo-transport/src/connection/state.rs
+++ b/neqo-transport/src/connection/state.rs
@@ -71,6 +71,8 @@ impl PartialOrd for State {
     }
 }
 
+type ClosingFrame = Frame<'static>;
+
 /// `StateSignaling` manages whether we need to send HANDSHAKE_DONE and CONNECTION_CLOSE.
 /// Valid state transitions are:
 /// * Idle -> HandshakeDone: at the server when the handshake completes
@@ -84,11 +86,11 @@ pub enum StateSignaling {
     Idle,
     HandshakeDone,
     /// These states save the frame that needs to be sent.
-    Closing(Frame),
-    Draining(Frame),
+    Closing(ClosingFrame),
+    Draining(ClosingFrame),
     /// This state saves the frame that might need to be sent again.
     /// If it is `None`, then we are draining and don't send.
-    CloseSent(Option<Frame>),
+    CloseSent(Option<ClosingFrame>),
     Reset,
 }
 
@@ -115,7 +117,7 @@ impl StateSignaling {
         error: ConnectionError,
         frame_type: FrameType,
         message: impl AsRef<str>,
-    ) -> Frame {
+    ) -> ClosingFrame {
         let reason_phrase = message.as_ref().as_bytes().to_owned();
         Frame::ConnectionClose {
             error_code: CloseError::from(error),
@@ -147,7 +149,7 @@ impl StateSignaling {
     }
 
     /// If a close is pending, take a frame.
-    pub fn close_frame(&mut self) -> Option<Frame> {
+    pub fn close_frame(&mut self) -> Option<ClosingFrame> {
         match self {
             Self::Closing(frame) => {
                 // When we are closing, we might need to send the close frame again.

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -255,8 +255,8 @@ fn idle_caching() {
     let (initial, _) = split_datagram(&dgram.unwrap());
     let frames = client.test_process_input(initial, middle);
     assert_eq!(frames.len(), 2);
-    assert_eq!(frames[0], (Frame::Ping, PNSpace::Initial));
-    assert!(matches!(frames[1], (Frame::Ack { .. }, PNSpace::Initial)));
+    assert!(matches!(frames[0], (Frame::Ack { .. }, PNSpace::Initial)));
+    assert_eq!(frames[1], (Frame::Ping, PNSpace::Initial));
 
     let end = start + LOCAL_IDLE_TIMEOUT + (AT_LEAST_PTO / 2);
     // Now let the server Initial through, with the CRYPTO frame.

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -10,12 +10,12 @@ use super::{
     default_server, fill_cwnd, maybe_authenticate, send_and_receive, send_something, AT_LEAST_PTO,
     POST_HANDSHAKE_CWND,
 };
-use crate::frame::{Frame, StreamType};
+use crate::frame::StreamType;
 use crate::path::PATH_MTU_V6;
 use crate::recovery::PTO_PACKET_COUNT;
 use crate::stats::MAX_PTO_COUNTS;
 use crate::tparams::TransportParameter;
-use crate::tracking::{PNSpace, ACK_DELAY};
+use crate::tracking::ACK_DELAY;
 
 use neqo_common::qdebug;
 use neqo_crypto::AuthenticationStatus;
@@ -54,15 +54,9 @@ fn pto_works_basic() {
     now += AT_LEAST_PTO;
     let out = client.process(None, now);
 
-    let frames = server.test_process_input(out.dgram().unwrap(), now);
-
-    assert!(frames.iter().all(|(_, sp)| *sp == PNSpace::ApplicationData));
-    assert!(frames
-        .iter()
-        .any(|(f, _)| matches!(f, Frame::Stream { stream_id, .. } if stream_id.as_u64() == 2)));
-    assert!(frames
-        .iter()
-        .any(|(f, _)| matches!(f, Frame::Stream { stream_id, .. } if stream_id.as_u64() == 6)));
+    let stream_before = server.stats().frame_rx.stream;
+    server.process_input(out.dgram().unwrap(), now);
+    assert_eq!(server.stats().frame_rx.stream, stream_before + 2);
 }
 
 #[test]
@@ -82,20 +76,16 @@ fn pto_works_full_cwnd() {
     neqo_common::qwarn!("waiting over");
     // Fill the CWND after waiting for a PTO.
     let (dgrams, now) = fill_cwnd(&mut client, 2, now + AT_LEAST_PTO);
-    assert_eq!(dgrams.len(), 2); // Two packets in the PTO.
-                                 // The first should be full sized; the second might be small.
+    // Two packets in the PTO.
+    // The first should be full sized; the second might be small.
+    assert_eq!(dgrams.len(), 2);
     assert_eq!(dgrams[0].len(), PATH_MTU_V6);
 
-    // All (2) datagrams contain a STREAM frame.
+    // Both datagrams contain a STREAM frame.
     for d in dgrams {
-        let frames = server.test_process_input(d, now);
-        assert_eq!(
-            frames
-                .iter()
-                .filter(|i| matches!(i, (Frame::Stream { .. }, PNSpace::ApplicationData)))
-                .count(),
-            1
-        );
+        let stream_before = server.stats().frame_rx.stream;
+        server.process_input(d, now);
+        assert_eq!(server.stats().frame_rx.stream, stream_before + 1);
     }
 }
 
@@ -182,12 +172,12 @@ fn pto_works_ping() {
         now + Duration::from_secs(10) + Duration::from_millis(110),
     );
 
-    let frames = server.test_process_input(
+    let ping_before = server.stats().frame_rx.ping;
+    server.process_input(
         pkt6.dgram().unwrap(),
         now + Duration::from_secs(10) + Duration::from_millis(110),
     );
-
-    assert_eq!(frames[0], (Frame::Ping, PNSpace::ApplicationData));
+    assert_eq!(server.stats().frame_rx.ping, ping_before + 1);
 }
 
 #[test]
@@ -307,14 +297,15 @@ fn pto_handshake_complete() {
     // Check that the PTO packets (pkt2, pkt3) are Handshake packets.
     // The server discarded the Handshake keys already, therefore they are dropped.
     let dropped_before1 = server.stats().dropped_rx;
-    let frames = server.test_process_input(pkt2.unwrap(), now);
+    let frames_before = server.stats().frame_rx.all;
+    server.process_input(pkt2.unwrap(), now);
     assert_eq!(1, server.stats().dropped_rx - dropped_before1);
-    assert!(frames.is_empty());
+    assert_eq!(server.stats().frame_rx.all, frames_before);
 
     let dropped_before2 = server.stats().dropped_rx;
-    let frames = server.test_process_input(pkt3.unwrap(), now);
+    server.process_input(pkt3.unwrap(), now);
     assert_eq!(1, server.stats().dropped_rx - dropped_before2);
-    assert!(frames.is_empty());
+    assert_eq!(server.stats().frame_rx.all, frames_before);
 
     now += Duration::from_millis(10);
     // Client receive ack for the first packet
@@ -375,13 +366,9 @@ fn pto_handshake_frames() {
     assert!(pkt2.is_some());
 
     now += Duration::from_millis(10);
-    let frames = server.test_process_input(pkt2.unwrap(), now);
-
-    assert_eq!(frames.len(), 1);
-    assert!(matches!(
-        frames[0],
-        (Frame::Crypto { .. }, PNSpace::Handshake)
-    ));
+    let crypto_before = server.stats().frame_rx.crypto;
+    server.process_input(pkt2.unwrap(), now);
+    assert_eq!(server.stats().frame_rx.crypto, crypto_before + 1)
 }
 
 /// In the case that the Handshake takes too many packets, the server might
@@ -425,8 +412,9 @@ fn handshake_ack_pto() {
     assert!(c3.is_some());
 
     now += RTT / 2;
-    let frames = server.test_process_input(c3.unwrap(), now);
-    assert_eq!(frames, vec![(Frame::Ping, PNSpace::Handshake)]);
+    let ping_before = server.stats().frame_rx.ping;
+    server.process_input(c3.unwrap(), now);
+    assert_eq!(server.stats().frame_rx.ping, ping_before + 1);
 
     pto_counts[0] = 1;
     assert_eq!(client.stats.borrow().pto_counts, pto_counts);
@@ -507,13 +495,12 @@ fn ack_after_pto() {
     let ack = client.process(Some(dgram), now).dgram();
     assert!(ack.is_some());
 
-    // Make sure that the packet only contained ACK frames.
-    let frames = server.test_process_input(ack.unwrap(), now);
-    assert_eq!(frames.len(), 1);
-    for (frame, space) in frames {
-        assert_eq!(space, PNSpace::ApplicationData);
-        assert!(matches!(frame, Frame::Ack { .. }));
-    }
+    // Make sure that the packet only contained an ACK frame.
+    let all_frames_before = server.stats().frame_rx.all;
+    let ack_before = server.stats().frame_rx.ack;
+    server.process_input(ack.unwrap(), now);
+    assert_eq!(server.stats().frame_rx.all, all_frames_before + 1);
+    assert_eq!(server.stats().frame_rx.ack, ack_before + 1);
 }
 
 /// When we declare a packet as lost, we keep it around for a while for another loss period.

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -1149,7 +1149,7 @@ impl CryptoStreams {
         self.get_mut(space).unwrap().tx.send(data);
     }
 
-    pub fn inbound_frame(&mut self, space: PNSpace, offset: u64, data: Vec<u8>) -> Res<()> {
+    pub fn inbound_frame(&mut self, space: PNSpace, offset: u64, data: &[u8]) -> Res<()> {
         self.get_mut(space).unwrap().rx.inbound_frame(offset, data)
     }
 

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -5,7 +5,8 @@
 // except according to those terms.
 
 use std::cell::RefCell;
-use std::cmp::max;
+use std::cmp::{max, min};
+use std::convert::TryFrom;
 use std::mem;
 use std::ops::{Index, IndexMut, Range};
 use std::rc::Rc;
@@ -20,8 +21,7 @@ use neqo_crypto::{
     TLS_VERSION_1_3,
 };
 
-use crate::frame::Frame;
-use crate::packet::{PacketNumber, QuicVersion};
+use crate::packet::{PacketBuilder, PacketNumber, QuicVersion};
 use crate::recovery::RecoveryToken;
 use crate::recv_stream::RxStreamOrderer;
 use crate::send_stream::TxBuffer;
@@ -1225,30 +1225,38 @@ impl CryptoStreams {
         }
     }
 
-    pub fn get_frame(
+    pub fn write_frame(
         &mut self,
         space: PNSpace,
-        remaining: usize,
-    ) -> Option<(Frame, Option<RecoveryToken>)> {
+        builder: &mut PacketBuilder,
+    ) -> Option<RecoveryToken> {
         let cs = self.get_mut(space).unwrap();
         if let Some((offset, data)) = cs.tx.next_bytes() {
-            let (frame, length) = Frame::new_crypto(offset, data, remaining);
+            let mut header_len = 1 + Encoder::varint_len(offset) + 1;
+
+            // Don't bother if there isn't room for the header and some data.
+            if builder.remaining() < header_len + 1 {
+                return None;
+            }
+            // Calculate length of data based on the minimum of:
+            // - available data
+            // - remaining space, less the header, which counts only one byte
+            //   for the length at first to avoid underestimating length
+            let length = min(data.len(), builder.remaining() - header_len);
+            header_len += Encoder::varint_len(u64::try_from(length).unwrap()) - 1;
+            let length = min(data.len(), builder.remaining() - header_len);
+
+            builder.encode_varint(crate::frame::FRAME_TYPE_CRYPTO);
+            builder.encode_varint(offset);
+            builder.encode_vvec(&data[..length]);
             cs.tx.mark_as_sent(offset, length);
 
-            qdebug!(
-                "Emitting crypto frame space={}, offset={}, len={}",
+            qdebug!("CRYPTO for {} offset={}, len={}", space, offset, length);
+            Some(RecoveryToken::Crypto(CryptoRecoveryToken {
                 space,
                 offset,
-                length
-            );
-            Some((
-                frame,
-                Some(RecoveryToken::Crypto(CryptoRecoveryToken {
-                    space,
-                    offset,
-                    length,
-                })),
-            ))
+                length,
+            }))
         } else {
             None
         }

--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -18,23 +18,25 @@ use crate::packet::PacketBuilder;
 use crate::recovery::RecoveryToken;
 use crate::recv_stream::RecvStreams;
 use crate::send_stream::SendStreams;
+use crate::stats::FrameStats;
 use crate::stream_id::{StreamId, StreamIndex, StreamIndexes};
 use crate::AppError;
 
-pub type FlowControlRecoveryToken = Frame;
+type FlowFrame = Frame<'static>;
+pub type FlowControlRecoveryToken = FlowFrame;
 
 #[derive(Debug, Default)]
 pub struct FlowMgr {
     // Discriminant as key ensures only 1 of every frame type will be queued.
-    from_conn: HashMap<mem::Discriminant<Frame>, Frame>,
+    from_conn: HashMap<mem::Discriminant<FlowFrame>, FlowFrame>,
 
     // (id, discriminant) as key ensures only 1 of every frame type per stream
     // will be queued.
-    from_streams: HashMap<(StreamId, mem::Discriminant<Frame>), Frame>,
+    from_streams: HashMap<(StreamId, mem::Discriminant<FlowFrame>), FlowFrame>,
 
     // (stream_type, discriminant) as key ensures only 1 of every frame type
     // per stream type will be queued.
-    from_stream_types: HashMap<(StreamType, mem::Discriminant<Frame>), Frame>,
+    from_stream_types: HashMap<(StreamType, mem::Discriminant<FlowFrame>), FlowFrame>,
 
     used_data: u64,
     max_data: u64,
@@ -54,10 +56,10 @@ impl FlowMgr {
 
     /// Returns whether max credit was actually increased.
     pub fn conn_increase_max_credit(&mut self, new: u64) -> bool {
+        const DB_FRAME: FlowFrame = Frame::DataBlocked { data_limit: 0 };
+
         if new > self.max_data {
             self.max_data = new;
-
-            const DB_FRAME: Frame = Frame::DataBlocked { data_limit: 0 };
             self.from_conn.remove(&mem::discriminant(&DB_FRAME));
 
             true
@@ -280,6 +282,7 @@ impl FlowMgr {
         &mut self,
         builder: &mut PacketBuilder,
         tokens: &mut Vec<RecoveryToken>,
+        stats: &mut FrameStats,
     ) {
         while let Some(frame) = self.peek() {
             // All these frames are bags of varints, so we can just extract the
@@ -289,34 +292,59 @@ impl FlowMgr {
                     stream_id,
                     application_error_code,
                     final_size,
-                } => smallvec![stream_id.as_u64(), *application_error_code, *final_size],
+                } => {
+                    stats.reset_stream += 1;
+                    smallvec![stream_id.as_u64(), *application_error_code, *final_size]
+                }
                 Frame::StopSending {
                     stream_id,
                     application_error_code,
-                } => smallvec![stream_id.as_u64(), *application_error_code],
+                } => {
+                    stats.stop_sending += 1;
+                    smallvec![stream_id.as_u64(), *application_error_code]
+                }
 
                 Frame::MaxStreams {
                     maximum_streams, ..
-                } => smallvec![maximum_streams.as_u64()],
-                Frame::StreamsBlocked { stream_limit, .. } => smallvec![stream_limit.as_u64()],
+                } => {
+                    stats.max_streams += 1;
+                    smallvec![maximum_streams.as_u64()]
+                }
+                Frame::StreamsBlocked { stream_limit, .. } => {
+                    stats.streams_blocked += 1;
+                    smallvec![stream_limit.as_u64()]
+                }
 
-                Frame::MaxData { maximum_data } => smallvec![*maximum_data],
-                Frame::DataBlocked { data_limit } => smallvec![*data_limit],
+                Frame::MaxData { maximum_data } => {
+                    stats.max_data += 1;
+                    smallvec![*maximum_data]
+                }
+                Frame::DataBlocked { data_limit } => {
+                    stats.data_blocked += 1;
+                    smallvec![*data_limit]
+                }
 
                 Frame::MaxStreamData {
                     stream_id,
                     maximum_stream_data,
-                } => smallvec![stream_id.as_u64(), *maximum_stream_data],
+                } => {
+                    stats.max_stream_data += 1;
+                    smallvec![stream_id.as_u64(), *maximum_stream_data]
+                }
                 Frame::StreamDataBlocked {
                     stream_id,
                     stream_data_limit,
-                } => smallvec![stream_id.as_u64(), *stream_data_limit],
+                } => {
+                    stats.stream_data_blocked += 1;
+                    smallvec![stream_id.as_u64(), *stream_data_limit]
+                }
 
                 // A special case, just write it out and move on..
                 Frame::PathResponse { data } => {
-                    if builder.remaining() < 1 + 8 {
+                    stats.path_response += 1;
+                    if builder.remaining() < 1 + data.len() {
                         builder.encode_varint(frame.get_type());
-                        builder.encode(&data[..]);
+                        builder.encode(data);
                         tokens.push(RecoveryToken::Flow(self.next().unwrap()));
                         continue;
                     } else {
@@ -342,9 +370,10 @@ impl FlowMgr {
 }
 
 impl Iterator for FlowMgr {
-    type Item = Frame;
+    type Item = FlowFrame;
+
     /// Used by generator to get a flow control frame.
-    fn next(&mut self) -> Option<Frame> {
+    fn next(&mut self) -> Option<Self::Item> {
         let first_key = self.from_conn.keys().next();
         if let Some(&first_key) = first_key {
             return self.from_conn.remove(&first_key);

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -315,7 +315,7 @@ impl PacketBuilder {
 
     /// Work out if nothing was added after the header.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub fn packet_empty(&self) -> bool {
         self.encoder.len() == self.header.end
     }
 

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -16,14 +16,14 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 use smallvec::SmallVec;
 
-use neqo_common::{qdebug, qerror, qinfo, qtrace};
+use neqo_common::{qdebug, qerror, qinfo, qtrace, Encoder};
 
 use crate::events::ConnectionEvents;
 use crate::flow_mgr::FlowMgr;
 use crate::frame::Frame;
+use crate::packet::PacketBuilder;
 use crate::recovery::RecoveryToken;
 use crate::stream_id::StreamId;
-use crate::tracking::PNSpace;
 use crate::{AppError, Error, Res};
 
 pub const SEND_BUFFER_SIZE: usize = 0x10_0000; // 1 MiB
@@ -511,6 +511,80 @@ impl SendStream {
         }
     }
 
+    /// Calculate how many bytes (length) can fit into available space and whether
+    /// the remainder of the space can be filled (or if a length field is needed).
+    fn length_and_fill(data_len: usize, space: usize) -> (usize, bool) {
+        if data_len >= space {
+            // Either more data than space allows, or an exact fit.
+            qtrace!("SendStream::length_and_fill fill {}", space);
+            return (space, true);
+        }
+
+        // Estimate size of the length field based on the available space,
+        // less 1, which is the worst case.
+        let length = min(space.saturating_sub(1), data_len);
+        let length_len = Encoder::varint_len(u64::try_from(length).unwrap());
+        if length_len > space {
+            qtrace!(
+                "SendStream::length_and_fill no room for length of {} in {}",
+                length,
+                space
+            );
+            return (0, false);
+        }
+
+        let length = min(data_len, space - length_len);
+        qtrace!("SendStream::length_and_fill {} in {}", length, space);
+        (length, false)
+    }
+
+    pub fn write_frame(&mut self, builder: &mut PacketBuilder) -> Option<RecoveryToken> {
+        let id = self.stream_id;
+        let final_size = self.final_size();
+        if let Some((offset, data)) = self.next_bytes() {
+            let overhead = 1 // Frame type
+                + Encoder::varint_len(id.as_u64())
+                + if offset > 0 {
+                    Encoder::varint_len(offset)
+                } else {
+                    0
+                };
+            if overhead > builder.remaining() {
+                qtrace!("SendStream::write_frame no space for header");
+                return None;
+            }
+
+            let (length, fill) = Self::length_and_fill(data.len(), builder.remaining() - overhead);
+            let fin = final_size.map_or(false, |fs| fs == offset + u64::try_from(length).unwrap());
+            if length == 0 && !fin {
+                qtrace!("SendStream::write_frame no data, no fin");
+                return None;
+            }
+
+            // Write the stream out.
+            builder.encode_varint(Frame::stream_type(fin, offset > 0, fill));
+            builder.encode_varint(id.as_u64());
+            if offset > 0 {
+                builder.encode_varint(offset);
+            }
+            if fill {
+                builder.encode(&data[..length]);
+            } else {
+                builder.encode_vvec(&data[..length]);
+            }
+
+            self.mark_as_sent(offset, length, fin);
+            Some(RecoveryToken::Stream(StreamRecoveryToken {
+                id,
+                offset,
+                length,
+                fin,
+            }))
+        } else {
+            None
+        }
+    }
+
     pub fn mark_as_sent(&mut self, offset: u64, len: usize, fin: bool) {
         if let Some(buf) = self.state.tx_buf_mut() {
             buf.mark_as_sent(offset, len);
@@ -791,49 +865,16 @@ impl SendStreams {
         self.0.retain(|_, stream| !stream.is_terminal())
     }
 
-    pub(crate) fn get_frame(
+    pub(crate) fn write_frames(
         &mut self,
-        space: PNSpace,
-        remaining: usize,
-    ) -> Option<(Frame, Option<RecoveryToken>)> {
-        if space != PNSpace::ApplicationData {
-            return None;
-        }
-
-        for (stream_id, stream) in self {
-            let final_size = stream.final_size();
-            if let Some((offset, data)) = stream.next_bytes() {
-                let data_len = u64::try_from(data.len()).unwrap();
-                let range_has_fin = final_size
-                    .map(|fs| fs == offset + data_len)
-                    .unwrap_or(false);
-                if let Some((frame, length)) =
-                    Frame::new_stream(stream_id.as_u64(), offset, data, range_has_fin, remaining)
-                {
-                    qdebug!(
-                        "Stream {} sending bytes {}-{}, space {:?}",
-                        stream_id.as_u64(),
-                        offset,
-                        offset + length as u64,
-                        space,
-                    );
-                    let fin = range_has_fin && length == data.len();
-                    debug_assert!(!fin || matches!(frame, Frame::Stream{fin: true, .. }));
-                    stream.mark_as_sent(offset, length, fin);
-
-                    return Some((
-                        frame,
-                        Some(RecoveryToken::Stream(StreamRecoveryToken {
-                            id: *stream_id,
-                            offset,
-                            length,
-                            fin,
-                        })),
-                    ));
-                }
+        builder: &mut PacketBuilder,
+        tokens: &mut Vec<RecoveryToken>,
+    ) {
+        for (_, stream) in self {
+            if let Some(t) = stream.write_frame(builder) {
+                tokens.push(t);
             }
         }
-        None
     }
 }
 
@@ -859,7 +900,7 @@ mod tests {
     use super::*;
 
     use crate::events::ConnectionEvent;
-    use neqo_common::event::Provider;
+    use neqo_common::{event::Provider, hex_with_len, qtrace};
 
     #[test]
     fn test_mark_range() {
@@ -1266,39 +1307,65 @@ mod tests {
         s.close();
 
         let mut ss = SendStreams::default();
-        ss.insert(0.into(), s);
+        ss.insert(StreamId::from(0), s);
 
-        let (_f1, f1_token) = ss.get_frame(PNSpace::ApplicationData, 6).unwrap();
-        assert!(matches!(&f1_token, Some(RecoveryToken::Stream(x)) if !x.fin));
-        let (_f2, f2_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(&f2_token, Some(RecoveryToken::Stream(x)) if x.fin));
+        let mut tokens = Vec::new();
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
 
-        // Should be no more data to frame
-        let f3 = ss.get_frame(PNSpace::ApplicationData, 100);
-        assert!(matches!(f3, None));
+        // Write a small frame: no fin.
+        let written = builder.len();
+        builder.set_limit(written + 6);
+        ss.write_frames(&mut builder, &mut tokens);
+        assert_eq!(builder.len(), written + 6);
+        assert_eq!(tokens.len(), 1);
+        let f1_token = tokens.remove(0);
+        assert!(matches!(&f1_token, RecoveryToken::Stream(x) if !x.fin));
+
+        // Write the rest: fin.
+        let written = builder.len();
+        builder.set_limit(written + 200);
+        ss.write_frames(&mut builder, &mut tokens);
+        assert_eq!(builder.len(), written + 10);
+        assert_eq!(tokens.len(), 1);
+        let f2_token = tokens.remove(0);
+        assert!(matches!(&f2_token, RecoveryToken::Stream(x) if x.fin));
+
+        // Should be no more data to frame.
+        let written = builder.len();
+        ss.write_frames(&mut builder, &mut tokens);
+        assert_eq!(builder.len(), written);
+        assert!(tokens.is_empty());
 
         // Mark frame 1 as lost
-        let f1_token = match f1_token {
-            Some(RecoveryToken::Stream(rt)) => rt,
-            _ => panic!(),
-        };
-        ss.lost(&f1_token);
+        if let RecoveryToken::Stream(rt) = f1_token {
+            ss.lost(&rt);
+        } else {
+            panic!();
+        }
 
         // Next frame should not set fin even though stream has fin but frame
         // does not include end of stream
-        let (_f4, f4_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(f4_token, Some(RecoveryToken::Stream(x)) if !x.fin));
+        let written = builder.len();
+        ss.write_frames(&mut builder, &mut tokens);
+        assert_eq!(builder.len(), written + 7); // Needs a length this time.
+        assert_eq!(tokens.len(), 1);
+        let f4_token = tokens.remove(0);
+        assert!(matches!(&f4_token, RecoveryToken::Stream(x) if !x.fin));
 
         // Mark frame 2 as lost
-        let f2_token = match f2_token {
-            Some(RecoveryToken::Stream(rt)) => rt,
-            _ => panic!(),
-        };
-        ss.lost(&f2_token);
+        if let RecoveryToken::Stream(rt) = f2_token {
+            ss.lost(&rt);
+        } else {
+            panic!();
+        }
 
         // Next frame should set fin because it includes end of stream
-        let (_f5, f5_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(f5_token, Some(RecoveryToken::Stream(x)) if x.fin));
+        let written = builder.len();
+        ss.write_frames(&mut builder, &mut tokens);
+        assert_eq!(builder.len(), written + 10);
+        assert_eq!(tokens.len(), 1);
+        let f5_token = tokens.remove(0);
+        assert!(matches!(&f5_token, RecoveryToken::Stream(x) if x.fin));
     }
 
     #[test]
@@ -1313,49 +1380,55 @@ mod tests {
         s.send(&[0; 10]).unwrap();
 
         let mut ss = SendStreams::default();
-        ss.insert(0.into(), s);
+        ss.insert(StreamId::from(0), s);
 
-        let (_f1, f1_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(&f1_token, Some(RecoveryToken::Stream(x)) if x.offset == 0));
-        assert!(matches!(&f1_token, Some(RecoveryToken::Stream(x)) if x.length == 10));
-        assert!(matches!(&f1_token, Some(RecoveryToken::Stream(x)) if !x.fin));
+        let mut tokens = Vec::new();
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        ss.write_frames(&mut builder, &mut tokens);
+        let f1_token = tokens.remove(0);
+        assert!(matches!(&f1_token, RecoveryToken::Stream(x) if x.offset == 0));
+        assert!(matches!(&f1_token, RecoveryToken::Stream(x) if x.length == 10));
+        assert!(matches!(&f1_token, RecoveryToken::Stream(x) if !x.fin));
 
         // Should be no more data to frame
-        let f2 = ss.get_frame(PNSpace::ApplicationData, 100);
-        assert!(matches!(f2, None));
+        ss.write_frames(&mut builder, &mut tokens);
+        assert!(tokens.is_empty());
 
-        ss.get_mut(0.into()).unwrap().close();
+        ss.get_mut(StreamId::from(0)).unwrap().close();
 
-        let (_f2, f2_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(&f2_token, Some(RecoveryToken::Stream(x)) if x.offset == 10));
-        assert!(matches!(&f2_token, Some(RecoveryToken::Stream(x)) if x.length == 0));
-        assert!(matches!(&f2_token, Some(RecoveryToken::Stream(x)) if x.fin));
+        ss.write_frames(&mut builder, &mut tokens);
+        let f2_token = tokens.remove(0);
+        assert!(matches!(&f2_token, RecoveryToken::Stream(x) if x.offset == 10));
+        assert!(matches!(&f2_token, RecoveryToken::Stream(x) if x.length == 0));
+        assert!(matches!(&f2_token, RecoveryToken::Stream(x) if x.fin));
 
         // Mark frame 2 as lost
-        let f2_token = match f2_token {
-            Some(RecoveryToken::Stream(rt)) => rt,
-            _ => panic!(),
-        };
-        ss.lost(&f2_token);
+        if let RecoveryToken::Stream(rt) = f2_token {
+            ss.lost(&rt);
+        } else {
+            panic!();
+        }
 
         // Next frame should set fin
-        let (_f3, f3_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(&f3_token, Some(RecoveryToken::Stream(x)) if x.offset == 10));
-        assert!(matches!(&f3_token, Some(RecoveryToken::Stream(x)) if x.length == 0));
-        assert!(matches!(&f3_token, Some(RecoveryToken::Stream(x)) if x.fin));
+        ss.write_frames(&mut builder, &mut tokens);
+        let f3_token = tokens.remove(0);
+        assert!(matches!(&f3_token, RecoveryToken::Stream(x) if x.offset == 10));
+        assert!(matches!(&f3_token, RecoveryToken::Stream(x) if x.length == 0));
+        assert!(matches!(&f3_token, RecoveryToken::Stream(x) if x.fin));
 
         // Mark frame 1 as lost
-        let f1_token = match f1_token {
-            Some(RecoveryToken::Stream(rt)) => rt,
-            _ => panic!(),
-        };
-        ss.lost(&f1_token);
+        if let RecoveryToken::Stream(rt) = f1_token {
+            ss.lost(&rt);
+        } else {
+            panic!();
+        }
 
         // Next frame should set fin and include all data
-        let (_f4, f4_token) = ss.get_frame(PNSpace::ApplicationData, 100).unwrap();
-        assert!(matches!(&f4_token, Some(RecoveryToken::Stream(x)) if x.offset == 0));
-        assert!(matches!(&f4_token, Some(RecoveryToken::Stream(x)) if x.length == 10));
-        assert!(matches!(&f4_token, Some(RecoveryToken::Stream(x)) if x.fin));
+        ss.write_frames(&mut builder, &mut tokens);
+        let f4_token = tokens.remove(0);
+        assert!(matches!(&f4_token, RecoveryToken::Stream(x) if x.offset == 0));
+        assert!(matches!(&f4_token, RecoveryToken::Stream(x) if x.length == 10));
+        assert!(matches!(&f4_token, RecoveryToken::Stream(x) if x.fin));
     }
 
     #[test]
@@ -1364,7 +1437,8 @@ mod tests {
         flow_mgr.borrow_mut().conn_increase_max_credit(5);
         let conn_events = ConnectionEvents::default();
 
-        let mut s = SendStream::new(4.into(), 0, Rc::clone(&flow_mgr), conn_events);
+        let stream_id = StreamId::from(4);
+        let mut s = SendStream::new(stream_id, 0, Rc::clone(&flow_mgr), conn_events);
         s.set_max_stream_data(2);
 
         // Stream is initially blocked (conn:5, stream:2)
@@ -1375,7 +1449,7 @@ mod tests {
         assert_eq!(
             flow_mgr.borrow_mut().next().unwrap(),
             Frame::StreamDataBlocked {
-                stream_id: 4.into(),
+                stream_id,
                 stream_data_limit: 0x2
             }
         );
@@ -1391,7 +1465,7 @@ mod tests {
         assert_eq!(
             flow_mgr.borrow_mut().next().unwrap(),
             Frame::StreamDataBlocked {
-                stream_id: 4.into(),
+                stream_id,
                 stream_data_limit: 0x2
             }
         );
@@ -1457,12 +1531,12 @@ mod tests {
         const MESSAGE: &[u8] = b"hello";
         let len_u64 = u64::try_from(MESSAGE.len()).unwrap();
 
-        let flow_mgr = Rc::new(RefCell::new(FlowMgr::default()));
-        flow_mgr.borrow_mut().conn_increase_max_credit(len_u64);
+        let mut flow_mgr = FlowMgr::default();
+        flow_mgr.conn_increase_max_credit(len_u64);
         let conn_events = ConnectionEvents::default();
 
         let id = StreamId::new(100);
-        let mut s = SendStream::new(id, 0, Rc::clone(&flow_mgr), conn_events);
+        let mut s = SendStream::new(id, 0, Rc::new(RefCell::new(flow_mgr)), conn_events);
         s.set_max_stream_data(len_u64);
 
         // Send all the data, then the fin.
@@ -1476,8 +1550,197 @@ mod tests {
         s.mark_as_lost(len_u64, 0, true);
 
         // No frame should be sent here.
-        let mut builder = SendStreams(IndexMap::default());
-        builder.insert(id, s);
-        assert!(builder.get_frame(PNSpace::ApplicationData, 1000).is_none());
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        assert!(s.write_frame(&mut builder).is_none());
+    }
+
+    /// Create a `SendStream` and force it into a state where it believes that
+    /// `offset` bytes have already been sent and acknowledged.
+    fn stream_with_sent(stream: u64, offset: usize) -> SendStream {
+        const MAX_VARINT: u64 = (1 << 62) - 1;
+
+        let mut flow_mgr = FlowMgr::default();
+        flow_mgr.conn_increase_max_credit(MAX_VARINT);
+
+        let mut s = SendStream::new(
+            StreamId::from(stream),
+            MAX_VARINT,
+            Rc::new(RefCell::new(flow_mgr)),
+            ConnectionEvents::default(),
+        );
+
+        let mut send_buf = TxBuffer::new();
+        send_buf.retired = u64::try_from(offset).unwrap();
+        send_buf.ranges.mark_range(0, offset, RangeState::Acked);
+        s.state = SendStreamState::Send { send_buf };
+        s
+    }
+
+    fn frame_sent_sid(stream: u64, offset: usize, len: usize, fin: bool, space: usize) -> bool {
+        const BUF: &[u8] = &[0x42; 128];
+        let mut s = stream_with_sent(stream, offset);
+
+        // Now write out the proscribed data and maybe close.
+        if len > 0 {
+            s.send(&BUF[..len]).unwrap();
+        }
+        if fin {
+            s.close();
+        }
+
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        let header_len = builder.len();
+        builder.set_limit(header_len + space);
+        let token = s.write_frame(&mut builder);
+        qtrace!("STREAM frame: {}", hex_with_len(&builder[header_len..]));
+        token.is_some()
+    }
+
+    fn frame_sent(offset: usize, len: usize, fin: bool, space: usize) -> bool {
+        frame_sent_sid(0, offset, len, fin, space)
+    }
+
+    #[test]
+    fn stream_frame_empty() {
+        // Stream frames with empty data and no fin never work.
+        assert!(!frame_sent(10, 0, false, 2));
+        assert!(!frame_sent(10, 0, false, 3));
+        assert!(!frame_sent(10, 0, false, 4));
+        assert!(!frame_sent(10, 0, false, 5));
+        assert!(!frame_sent(10, 0, false, 100));
+
+        // Empty data with fin is only a problem if there is no space.
+        assert!(!frame_sent(0, 0, true, 1));
+        assert!(frame_sent(0, 0, true, 2));
+        assert!(!frame_sent(10, 0, true, 2));
+        assert!(frame_sent(10, 0, true, 3));
+        assert!(frame_sent(10, 0, true, 4));
+        assert!(frame_sent(10, 0, true, 5));
+        assert!(frame_sent(10, 0, true, 100));
+    }
+
+    #[test]
+    fn stream_frame_minimum() {
+        // Add minimum data
+        assert!(!frame_sent(10, 1, false, 3));
+        assert!(!frame_sent(10, 1, true, 3));
+        assert!(frame_sent(10, 1, false, 4));
+        assert!(frame_sent(10, 1, true, 4));
+        assert!(frame_sent(10, 1, false, 5));
+        assert!(frame_sent(10, 1, true, 5));
+        assert!(frame_sent(10, 1, false, 100));
+        assert!(frame_sent(10, 1, true, 100));
+    }
+
+    #[test]
+    fn stream_frame_more() {
+        // Try more data
+        assert!(!frame_sent(10, 100, false, 3));
+        assert!(!frame_sent(10, 100, true, 3));
+        assert!(frame_sent(10, 100, false, 4));
+        assert!(frame_sent(10, 100, true, 4));
+        assert!(frame_sent(10, 100, false, 5));
+        assert!(frame_sent(10, 100, true, 5));
+        assert!(frame_sent(10, 100, false, 100));
+        assert!(frame_sent(10, 100, true, 100));
+
+        assert!(frame_sent(10, 100, false, 1000));
+        assert!(frame_sent(10, 100, true, 1000));
+    }
+
+    #[test]
+    fn stream_frame_big_id() {
+        // A value that encodes to the largest varint.
+        const BIG: u64 = 1 << 30;
+        const BIGSZ: usize = 1 << 30;
+
+        assert!(!frame_sent_sid(BIG, BIGSZ, 0, false, 16));
+        assert!(!frame_sent_sid(BIG, BIGSZ, 0, true, 16));
+        assert!(!frame_sent_sid(BIG, BIGSZ, 0, false, 17));
+        assert!(frame_sent_sid(BIG, BIGSZ, 0, true, 17));
+        assert!(!frame_sent_sid(BIG, BIGSZ, 0, false, 18));
+        assert!(frame_sent_sid(BIG, BIGSZ, 0, true, 18));
+
+        assert!(!frame_sent_sid(BIG, BIGSZ, 1, false, 17));
+        assert!(!frame_sent_sid(BIG, BIGSZ, 1, true, 17));
+        assert!(frame_sent_sid(BIG, BIGSZ, 1, false, 18));
+        assert!(frame_sent_sid(BIG, BIGSZ, 1, true, 18));
+        assert!(frame_sent_sid(BIG, BIGSZ, 1, false, 19));
+        assert!(frame_sent_sid(BIG, BIGSZ, 1, true, 19));
+        assert!(frame_sent_sid(BIG, BIGSZ, 1, false, 100));
+        assert!(frame_sent_sid(BIG, BIGSZ, 1, true, 100));
+    }
+
+    #[test]
+    fn stream_frame_16384() {
+        const DATA16384: &[u8] = &[0x43; 16384];
+
+        // 16383/16384 is an odd boundary in STREAM frame construction.
+        // That is the boundary where a length goes from 2 bytes to 4 bytes.
+        // If the data fits in the available space, then it is simple:
+        let mut s = stream_with_sent(0, 0);
+        s.send(DATA16384).unwrap();
+        s.close();
+
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        let header_len = builder.len();
+        builder.set_limit(header_len + DATA16384.len() + 2);
+        let token = s.write_frame(&mut builder);
+        assert!(token.is_some());
+        // Expect STREAM + FIN only.
+        assert_eq!(&builder[header_len..header_len + 2], &[0b1001, 0]);
+        assert_eq!(&builder[header_len + 2..], DATA16384);
+
+        s.mark_as_lost(0, DATA16384.len(), true);
+
+        // However, if there is one extra byte of space, we will try to add a length.
+        // That length will then make the frame to be too large and the data will be
+        // truncated.  The frame could carry one more byte of data, but it's a corner
+        // case we don't want to address as it should be rare (if not impossible).
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        let header_len = builder.len();
+        builder.set_limit(header_len + DATA16384.len() + 3);
+        let token = s.write_frame(&mut builder);
+        assert!(token.is_some());
+        // Expect STREAM + LEN + FIN.
+        assert_eq!(
+            &builder[header_len..header_len + 4],
+            &[0b1010, 0, 0x7f, 0xfd]
+        );
+        assert_eq!(
+            &builder[header_len + 4..],
+            &DATA16384[..DATA16384.len() - 3]
+        );
+    }
+
+    #[test]
+    fn stream_frame_64() {
+        const DATA64: &[u8] = &[0x43; 64];
+
+        // Unlike 16383/16384, the boundary at 63/64 is easy because the difference
+        // is just one byte.  We lose just the last byte when there is more space.
+        let mut s = stream_with_sent(0, 0);
+        s.send(DATA64).unwrap();
+        s.close();
+
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        let header_len = builder.len();
+        builder.set_limit(header_len + 66);
+        let token = s.write_frame(&mut builder);
+        assert!(token.is_some());
+        // Expect STREAM + FIN only.
+        assert_eq!(&builder[header_len..header_len + 2], &[0b1001, 0]);
+        assert_eq!(&builder[header_len + 2..], DATA64);
+
+        s.mark_as_lost(0, DATA64.len(), true);
+
+        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+        let header_len = builder.len();
+        builder.set_limit(header_len + 67);
+        let token = s.write_frame(&mut builder);
+        assert!(token.is_some());
+        // Expect STREAM + LEN, not FIN.
+        assert_eq!(&builder[header_len..header_len + 3], &[0b1010, 0, 63]);
+        assert_eq!(&builder[header_len + 3..], &DATA64[..63]);
     }
 }

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -7,6 +7,7 @@
 // Tracking of some useful statistics.
 #![deny(clippy::pedantic)]
 
+use crate::packet::PacketNumber;
 use neqo_common::qinfo;
 use std::cell::RefCell;
 use std::fmt::{self, Debug};
@@ -14,6 +15,39 @@ use std::ops::Deref;
 use std::rc::Rc;
 
 pub(crate) const MAX_PTO_COUNTS: usize = 16;
+
+#[derive(Default, Clone)]
+#[allow(clippy::module_name_repetitions)]
+pub struct FrameStats {
+    pub all: usize,
+    pub ack: usize,
+    pub largest_acknowledged: PacketNumber,
+
+    pub crypto: usize,
+    pub stream: usize,
+    pub reset_stream: usize,
+    pub stop_sending: usize,
+
+    pub ping: usize,
+    pub padding: usize,
+
+    pub max_streams: usize,
+    pub streams_blocked: usize,
+    pub max_data: usize,
+    pub data_blocked: usize,
+    pub max_stream_data: usize,
+    pub stream_data_blocked: usize,
+
+    pub new_connection_id: usize,
+    pub retire_connection_id: usize,
+
+    pub path_challenge: usize,
+    pub path_response: usize,
+
+    pub connection_close: usize,
+    pub handshake_done: usize,
+    pub new_token: usize,
+}
 
 /// Connection statistics
 #[derive(Default, Clone)]
@@ -46,6 +80,11 @@ pub struct Stats {
     /// Count PTOs. Single PTOs, 2 PTOs in a row, 3 PTOs in row, etc. are counted
     /// separately.
     pub pto_counts: [usize; MAX_PTO_COUNTS],
+
+    /// Count frames received.
+    pub frame_rx: FrameStats,
+    /// Count frames sent.
+    pub frame_tx: FrameStats,
 }
 
 impl Stats {

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -15,7 +15,7 @@ use std::ops::{Index, IndexMut};
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use neqo_common::{qdebug, qinfo, qtrace, qwarn, Encoder};
+use neqo_common::{qdebug, qinfo, qtrace, qwarn};
 use neqo_crypto::{Epoch, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL};
 
 use crate::packet::{PacketBuilder, PacketNumber, PacketType};

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -15,7 +15,7 @@ use std::ops::{Index, IndexMut};
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use neqo_common::{qdebug, qinfo, qtrace, qwarn};
+use neqo_common::{qdebug, qinfo, qtrace, qwarn, Encoder};
 use neqo_crypto::{Epoch, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL};
 
 use crate::packet::{PacketBuilder, PacketNumber, PacketType};


### PR DESCRIPTION
This is built on #1010....  It's just one commit extra, albeit a big one.  Look at the last one.

Mostly.  I've kept the CONNECTION_CLOSE reason phrase owned.  Changing
this would mean hitting a whole different piece of code and this is
already too large.

The main effect here is on receive streams, which have to deal with
receiving slices rather than `Vec<u8>`.

There is another casualty of this change, which is
`Connection::test_process_input`.  I never liked that solution and this
validates that choice.  There was no way to preserve this as the frames
that would have been returned refer to the contents of the temporary
buffer we decrypt into.

To replace `Connection::test_process_input`, new stats have been added.
These record the number of frames that are sent, both in total and for
each type.  Aside from a minor infidelity in that PADDING is counted
only once if there is a contiguous block of padding, this worked nicely.
I don't think the PADDING thing is worth fixing.

In terms of practical effect this is likely minor.  New data we receive
is copied into receive buffers anyway.  However, we no longer allocate
for any duplicate data that is received, we only allocate what is
necessary.

I want to iterate on this further; we currently allocate when we receive
data that is adjacent to existing data.  That's suboptimal and we could
just use extend_from_slice here.