### PR TITLE
Use a default VecDeque for SendStream

### DIFF
--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -289,10 +289,7 @@ pub struct TxBuffer {
 
 impl TxBuffer {
     pub fn new() -> Self {
-        Self {
-            send_buf: VecDeque::with_capacity(SEND_BUFFER_SIZE),
-            ..Self::default()
-        }
+        Self::default()
     }
 
     /// Attempt to add some or all of the passed-in buffer to the TxBuffer.


### PR DESCRIPTION
Our current usage allocates a whole megabyte for every stream.  This
avoids additional allocations as new data is written to the stream, but
it is a grossly inefficient use of memory.  Most times we write much
less to streams.

VecDeque will start at 7 bytes and double its size as needed as new data
is read out.  If we manage to send in a single write, then it will
resize based on the size of new data.  Thus, the number of extra
allocations is likely to be small in most cases.  Lots of little writes
will cause this to allocate a few times, but we don't have many of
those, except where we really don't want to send very much.

This is intended to help with #923, but we should leave it open.  The true
cause of the OOM needs to be better understood.