### PR TITLE
Check header fields

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -6002,57 +6002,60 @@ mod tests {
 
     #[test]
     fn malformed_response_pseudo_header_after_regular_header() {
-        let headers = vec![
+        do_malformed_response_test(&[
             (String::from("content-type"), String::from("text/plain")),
-            (String::from(":status"), String::from("200")),
-        ];
-        do_malformed_response_test(&headers);
+            (String::from(":status"), String::from("100")),
+        ]);
     }
 
     #[test]
     fn malformed_response_undefined_pseudo_header() {
-        let headers = vec![
+        do_malformed_response_test(&[
+            (String::from(":status"), String::from("200")),
             (String::from(":cheese"), String::from("200")),
-            (String::from("content-type"), String::from("text/plain")),
-        ];
-        do_malformed_response_test(&headers);
+        ]);
     }
 
     #[test]
     fn malformed_response_duplicate_pseudo_header() {
-        let headers = vec![
+        do_malformed_response_test(&[
             (String::from(":status"), String::from("200")),
             (String::from(":status"), String::from("100")),
             (String::from("content-type"), String::from("text/plain")),
-        ];
-        do_malformed_response_test(&headers);
+        ]);
     }
 
     #[test]
     fn malformed_response_uppercase_header() {
-        let headers = vec![
+        do_malformed_response_test(&[
             (String::from(":status"), String::from("200")),
             (String::from("content-Type"), String::from("text/plain")),
-        ];
-        do_malformed_response_test(&headers);
+        ]);
     }
 
     #[test]
     fn malformed_response_excluded_header() {
-        let headers = vec![
+        do_malformed_response_test(&[
             (String::from(":status"), String::from("200")),
             (String::from("content-type"), String::from("text/plain")),
             (String::from("connection"), String::from("close")),
-        ];
-        do_malformed_response_test(&headers);
+        ]);
     }
 
     #[test]
     fn malformed_response_excluded_byte_in_header() {
-        let headers = vec![
+        do_malformed_response_test(&[
             (String::from(":status"), String::from("200")),
             (String::from("content:type"), String::from("text/plain")),
-        ];
-        do_malformed_response_test(&headers);
+        ]);
+    }
+
+    #[test]
+    fn malformed_response_request_header_in_response() {
+        do_malformed_response_test(&[
+            (String::from(":status"), String::from("200")),
+            (String::from(":method"), String::from("GET")),
+            (String::from("content-type"), String::from("text/plain")),
+        ]);
     }
 }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -5795,7 +5795,7 @@ mod tests {
             e,
             Http3ClientEvent::Reset {
                 stream_id: request_stream_id,
-                error: Error::HttpInvalidHeader.code(),
+                error: Error::InvalidHeader.code(),
                 local: true,
             }
         );
@@ -5808,7 +5808,7 @@ mod tests {
             matches!(e, ConnectionEvent::SendStreamStopSending {
             stream_id,
             app_error
-        } if stream_id == request_stream_id && app_error == Error::HttpInvalidHeader.code())
+        } if stream_id == request_stream_id && app_error == Error::InvalidHeader.code())
         };
         assert!(server.conn.events().any(stop_sending_event));
 
@@ -5928,7 +5928,7 @@ mod tests {
             matches!(e, Http3ClientEvent::PushReset {
             push_id,
             error,
-        } if push_id == FIRST_PUSH_ID && error == Error::HttpInvalidHeader.code())
+        } if push_id == FIRST_PUSH_ID && error == Error::InvalidHeader.code())
         };
 
         assert!(client.events().any(push_reset_event));
@@ -5941,7 +5941,7 @@ mod tests {
             matches!(e, ConnectionEvent::SendStreamStopSending {
             stream_id,
             app_error
-        } if stream_id == push_stream_id && app_error == Error::HttpInvalidHeader.code())
+        } if stream_id == push_stream_id && app_error == Error::InvalidHeader.code())
         };
         assert!(server.conn.events().any(stop_sending_event));
     }
@@ -5994,7 +5994,7 @@ mod tests {
             e,
             Http3ClientEvent::Reset {
                 stream_id: request_stream_id,
-                error: Error::HttpInvalidHeader.code(),
+                error: Error::InvalidHeader.code(),
                 local: true,
             }
         );

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -5970,7 +5970,6 @@ mod tests {
         handshake_client_error(&mut client, &mut server, &Error::StreamLimitError);
     }
 
-    #[test]
     fn do_malformed_response_test(headers: &[Header]) {
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -5795,7 +5795,7 @@ mod tests {
             e,
             Http3ClientEvent::Reset {
                 stream_id: request_stream_id,
-                error: Error::HttpGeneralProtocolStream.code(),
+                error: Error::HttpInvalidHeader.code(),
                 local: true,
             }
         );
@@ -5808,7 +5808,7 @@ mod tests {
             matches!(e, ConnectionEvent::SendStreamStopSending {
             stream_id,
             app_error
-        } if stream_id == request_stream_id && app_error == Error::HttpGeneralProtocolStream.code())
+        } if stream_id == request_stream_id && app_error == Error::HttpInvalidHeader.code())
         };
         assert!(server.conn.events().any(stop_sending_event));
 
@@ -5928,7 +5928,7 @@ mod tests {
             matches!(e, Http3ClientEvent::PushReset {
             push_id,
             error,
-        } if push_id == FIRST_PUSH_ID && error == Error::HttpGeneralProtocol.code())
+        } if push_id == FIRST_PUSH_ID && error == Error::HttpInvalidHeader.code())
         };
 
         assert!(client.events().any(push_reset_event));
@@ -5941,7 +5941,7 @@ mod tests {
             matches!(e, ConnectionEvent::SendStreamStopSending {
             stream_id,
             app_error
-        } if stream_id == push_stream_id && app_error == Error::HttpGeneralProtocolStream.code())
+        } if stream_id == push_stream_id && app_error == Error::HttpInvalidHeader.code())
         };
         assert!(server.conn.events().any(stop_sending_event));
     }
@@ -5994,7 +5994,7 @@ mod tests {
             e,
             Http3ClientEvent::Reset {
                 stream_id: request_stream_id,
-                error: Error::HttpGeneralProtocolStream.code(),
+                error: Error::HttpInvalidHeader.code(),
                 local: true,
             }
         );

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -62,7 +62,6 @@ pub enum Error {
     HttpRequestIncomplete,
     HttpConnect,
     HttpVersionFallback,
-    HttpInvalidHeader,
     QpackError(neqo_qpack::Error),
 
     // Internal errors from here.
@@ -83,6 +82,7 @@ pub enum Error {
     TransportStreamDoesNotExist,
     InvalidInput,
     FatalError,
+    InvalidHeader,
 }
 
 impl Error {
@@ -105,7 +105,6 @@ impl Error {
             Self::HttpRequestIncomplete => 0x10d,
             Self::HttpConnect => 0x10f,
             Self::HttpVersionFallback => 0x110,
-            Self::HttpInvalidHeader => 0x111,
             Self::QpackError(e) => e.code(),
             // These are all internal errors.
             _ => 3,
@@ -133,10 +132,7 @@ impl Error {
 
     #[must_use]
     pub fn stream_reset_error(&self) -> bool {
-        matches!(
-            self,
-            Self::HttpGeneralProtocolStream | Self::HttpInvalidHeader
-        )
+        matches!(self, Self::HttpGeneralProtocolStream | Self::InvalidHeader)
     }
 
     #[must_use]

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -90,7 +90,9 @@ impl Error {
     pub fn code(&self) -> AppError {
         match self {
             Self::HttpNoError => 0x100,
-            Self::HttpGeneralProtocol | Self::HttpGeneralProtocolStream => 0x101,
+            Self::HttpGeneralProtocol | Self::HttpGeneralProtocolStream | Self::InvalidHeader => {
+                0x101
+            }
             Self::HttpInternal => 0x102,
             Self::HttpStreamCreation => 0x103,
             Self::HttpClosedCriticalStream => 0x104,

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -62,6 +62,7 @@ pub enum Error {
     HttpRequestIncomplete,
     HttpConnect,
     HttpVersionFallback,
+    HttpInvalidHeader,
     QpackError(neqo_qpack::Error),
 
     // Internal errors from here.
@@ -104,6 +105,7 @@ impl Error {
             Self::HttpRequestIncomplete => 0x10d,
             Self::HttpConnect => 0x10f,
             Self::HttpVersionFallback => 0x110,
+            Self::HttpInvalidHeader => 0x111,
             Self::QpackError(e) => e.code(),
             // These are all internal errors.
             _ => 3,
@@ -131,7 +133,10 @@ impl Error {
 
     #[must_use]
     pub fn stream_reset_error(&self) -> bool {
-        matches!(self, Self::HttpGeneralProtocolStream)
+        matches!(
+            self,
+            Self::HttpGeneralProtocolStream | Self::HttpInvalidHeader
+        )
     }
 
     #[must_use]


### PR DESCRIPTION
Fix #753 

Implement some checks against response headers.
1. Pseudo header fields shoud not after fields.
2. Contains no uppercase characters in field names.
3. Have undefined or excluded header.