### PR TITLE
Defer processing of saved datagrams

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1041,12 +1041,11 @@ impl Connection {
     fn process_saved(&mut self, now: Instant) {
         while let Some(cspace) = self.saved_datagrams.available() {
             qdebug!([self], "process saved for space {:?}", cspace);
-            if self.crypto.states.rx_hp(cspace).is_some() {
-                for saved in self.saved_datagrams.take_saved() {
-                    qtrace!([self], "input saved @{:?}: {:?}", saved.t, saved.d);
-                    let res = self.input(saved.d, saved.t);
-                    self.absorb_error(now, res);
-                }
+            debug_assert!(self.crypto.states.rx_hp(cspace).is_some());
+            for saved in self.saved_datagrams.take_saved() {
+                qtrace!([self], "input saved @{:?}: {:?}", saved.t, saved.d);
+                let res = self.input(saved.d, saved.t);
+                self.absorb_error(now, res);
             }
         }
     }

--- a/neqo-transport/src/connection/saved.rs
+++ b/neqo-transport/src/connection/saved.rs
@@ -29,6 +29,7 @@ pub struct SavedDatagram {
 pub struct SavedDatagrams {
     handshake: Vec<SavedDatagram>,
     application_data: Vec<SavedDatagram>,
+    available: Option<CryptoSpace>,
 }
 
 impl SavedDatagrams {
@@ -51,7 +52,21 @@ impl SavedDatagrams {
         }
     }
 
-    pub fn take_saved(&mut self, cspace: CryptoSpace) -> Vec<SavedDatagram> {
-        mem::take(self.store(cspace))
+    pub fn make_available(&mut self, cspace: CryptoSpace) {
+        debug_assert_ne!(cspace, CryptoSpace::ZeroRtt);
+        debug_assert_ne!(cspace, CryptoSpace::Initial);
+        if !self.store(cspace).is_empty() {
+            self.available = Some(cspace);
+        }
+    }
+
+    pub fn available(&self) -> Option<CryptoSpace> {
+        self.available
+    }
+
+    pub fn take_saved(&mut self) -> Vec<SavedDatagram> {
+        self.available
+            .take()
+            .map_or_else(Vec::new, |cspace| mem::take(self.store(cspace)))
     }
 }


### PR DESCRIPTION
This ensures that we don't jump into handling Handshake packets before
we have finished processing the current datagram.

This doesn't do much, but the moved assertion in start_handshake()
should highlight why this was not great.  Without the changes, that
assertion fails.