### PR TITLE
Fix server Initial padding

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -368,6 +368,13 @@ impl Encoder {
     pub fn truncate(&mut self, len: usize) {
         self.buf.truncate(len);
     }
+
+    /// Pad the buffer to `len` with bytes set to `v`.
+    pub fn pad_to(&mut self, len: usize, v: u8) {
+        if len > self.buf.len() {
+            self.buf.resize(len, v);
+        }
+    }
 }
 
 impl Debug for Encoder {
@@ -776,5 +783,16 @@ mod tests {
         let mut enc = Encoder::from_hex("010234");
         enc[0] = 0xff;
         assert_eq!(enc, Encoder::from_hex("ff0234"));
+    }
+
+    #[test]
+    fn pad() {
+        let mut enc = Encoder::from_hex("010234");
+        enc.pad_to(5, 0);
+        assert_eq!(enc, Encoder::from_hex("0102340000"));
+        enc.pad_to(4, 0);
+        assert_eq!(enc, Encoder::from_hex("0102340000"));
+        enc.pad_to(7, 0xc2);
+        assert_eq!(enc, Encoder::from_hex("0102340000c2c2"));
     }
 }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1647,7 +1647,11 @@ impl Connection {
                 initial_sent = Some(sent);
                 needs_padding = true;
             } else {
-                if pt != PacketType::ZeroRtt && self.role == Role::Client {
+                if pt == PacketType::Short
+                    || (pt == PacketType::Handshake && self.role == Role::Client)
+                {
+                    // TODO(mt) we still need to pad Initial packets from the server when
+                    // sending 1-RTT packets, but we can't do that with the current padding scheme.
                     needs_padding = false;
                 }
                 self.loss_recovery.on_packet_sent(sent);

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -227,6 +227,11 @@ impl PacketBuilder {
         self.limit - self.encoder.len()
     }
 
+    /// Pad with "PADDING" frames.
+    pub fn pad(&mut self) {
+        self.encoder.pad_to(self.limit, 0);
+    }
+
     /// Add unpredictable values for unprotected parts of the packet.
     pub fn scramble(&mut self, quic_bit: bool) {
         let mask = if quic_bit { PACKET_BIT_FIXED_QUIC } else { 0 }


### PR DESCRIPTION
Padding server Initial packets turns out to be tricky.  This fixes that
problem by adding PADDING frames if padding is needed.

This partly retains the odd padding scheme that has caused so many
problems in other implementations.  It turns out that it is convenient
to only add PADDING frames to ApplicationData packets.  This means that
we will use PADDING frames for 0-RTT and 1-RTT packets if we have
determined that padding is needed.  We'll keep the quirky padding when
neither of those packets is being coalesced.

(This should also for padding PATH_CHALLENGE and PATH_RESPONSE when
those come along.)

Closes #1020.