### PR TITLE
Encode packet numbers shorter

### DIFF
--- a/neqo-crypto/src/hp.rs
+++ b/neqo-crypto/src/hp.rs
@@ -78,17 +78,25 @@ impl HpKey {
         }
     }
 
+    /// Get the sample size, which is also the output size.
+    #[allow(clippy::cast_sign_loss)]
+    #[must_use]
+    pub fn sample_size(&self) -> usize {
+        let k: *mut PK11SymKey = *self.0;
+        let mech = unsafe { PK11_GetMechanism(k) };
+        // Cast is safe because block size is always greater than or equal to 0
+        (unsafe { PK11_GetBlockSize(mech, null_mut()) }) as usize
+    }
+
     /// Generate a header protection mask for QUIC.
     ///
     /// # Errors
     /// An error is returned if the NSS functions fail; a sample of the
     /// wrong size is the obvious cause.
-    #[allow(clippy::cast_sign_loss)]
     pub fn mask(&self, sample: &[u8]) -> Res<Vec<u8>> {
         let k: *mut PK11SymKey = *self.0;
         let mech = unsafe { PK11_GetMechanism(k) };
-        // Cast is safe because block size is always greater than or equal to 0
-        let block_size = unsafe { PK11_GetBlockSize(mech, null_mut()) } as usize;
+        let block_size = self.sample_size();
 
         let mut output = vec![0_u8; block_size];
         let output_slice = &mut output[..];

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -591,6 +591,15 @@ impl CryptoDxState {
             CLIENT_CID,
         )
     }
+
+    /// Get the amount of extra padding packets protected with this profile need.
+    /// This is the difference between the size of the header protection sample
+    /// and the AEAD expansion.
+    pub fn extra_padding(&self) -> usize {
+        self.hpkey
+            .sample_size()
+            .saturating_sub(self.aead.expansion())
+    }
 }
 
 impl std::fmt::Display for CryptoDxState {

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -12,6 +12,7 @@ use crate::{Error, Res};
 use neqo_common::{hex, hex_with_len, qtrace, Decoder, Encoder};
 use neqo_crypto::random;
 
+use std::cmp::min;
 use std::convert::TryFrom;
 use std::fmt;
 use std::iter::ExactSizeIterator;
@@ -34,6 +35,7 @@ const PACKET_HP_MASK_SHORT: u8 = 0x1f;
 
 const SAMPLE_SIZE: usize = 16;
 const SAMPLE_OFFSET: usize = 4;
+const MAX_PACKET_NUMBER_LEN: usize = 4;
 
 mod retry;
 
@@ -259,14 +261,17 @@ impl PacketBuilder {
             self.offsets.len = self.encoder.len();
             self.encoder.encode(&[0; 2]);
         }
+
+        // This allows the input to be >4, which is absurd, but we can eat that.
+        let pn_len = min(MAX_PACKET_NUMBER_LEN, pn_len);
+        debug_assert_ne!(pn_len, 0);
         // Encode the packet number and save its offset.
-        debug_assert!(pn_len <= 4 && pn_len > 0);
         let pn_offset = self.encoder.len();
         self.encoder.encode_uint(pn_len, pn);
         self.offsets.pn = pn_offset..self.encoder.len();
 
         // Now encode the packet number length and save the header length.
-        self.encoder[self.header.start] |= (pn_len - 1) as u8;
+        self.encoder[self.header.start] |= u8::try_from(pn_len - 1).unwrap();
         self.header.end = self.encoder.len();
         self.pn = pn;
     }
@@ -277,11 +282,25 @@ impl PacketBuilder {
         self.encoder[self.offsets.len + 1] = (len & 0xff) as u8;
     }
 
+    fn pad_for_crypto(&mut self, crypto: &mut CryptoDxState) {
+        // Make sure that there is enough data in the packet.
+        // The length of the packet number plus the payload length needs to
+        // be at least 4 (MAX_PACKET_NUMBER_LEN) plus any amount by which
+        // the header protection sample exceeds the AEAD expansion.
+        let crypto_pad = crypto.extra_padding();
+        self.encoder.pad_to(
+            self.offsets.pn.start + MAX_PACKET_NUMBER_LEN + crypto_pad,
+            0,
+        );
+    }
+
     /// Build the packet and return the encoder.
     pub fn build(mut self, crypto: &mut CryptoDxState) -> Res<Encoder> {
+        self.pad_for_crypto(crypto);
         if self.offsets.len > 0 {
             self.write_len(crypto.expansion());
         }
+
         let hdr = &self.encoder[self.header.clone()];
         let body = &self.encoder[self.header.end..];
         qtrace!(
@@ -656,7 +675,7 @@ impl<'a> PublicPacket<'a> {
 
         // Unmask the PN.
         let mut pn_encoded: u64 = 0;
-        for i in 0..4 {
+        for i in 0..MAX_PACKET_NUMBER_LEN {
             hdrbytes[self.header_len + i] ^= mask[1 + i];
             pn_encoded <<= 8;
             pn_encoded += u64::from(hdrbytes[self.header_len + i]);
@@ -665,7 +684,7 @@ impl<'a> PublicPacket<'a> {
         // Now decode the packet number length and apply it, hopefully in constant time.
         let pn_len = usize::from((first_byte & 0x3) + 1);
         hdrbytes.truncate(self.header_len + pn_len);
-        pn_encoded >>= 8 * (4 - pn_len);
+        pn_encoded >>= 8 * (MAX_PACKET_NUMBER_LEN - pn_len);
 
         qtrace!("unmasked hdr={}", hex(&hdrbytes));
 

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -22,6 +22,7 @@ use crate::cc::CongestionControlAlgorithm;
 use crate::connection::LOCAL_IDLE_TIMEOUT;
 use crate::crypto::CryptoRecoveryToken;
 use crate::flow_mgr::FlowControlRecoveryToken;
+use crate::packet::PacketNumber;
 use crate::qlog::{self, QlogMetric};
 use crate::send_stream::StreamRecoveryToken;
 use crate::stats::{Stats, StatsCell};
@@ -225,7 +226,7 @@ impl SendProfile {
 #[derive(Debug)]
 pub(crate) struct LossRecoverySpace {
     space: PNSpace,
-    largest_acked: Option<u64>,
+    largest_acked: Option<PacketNumber>,
     largest_acked_sent_time: Option<Instant>,
     /// The time used to calculate the PTO timer for this space.
     /// This is the time that the last ACK-eliciting packet in this space
@@ -637,7 +638,7 @@ impl LossRecovery {
         self.packet_sender.cwnd_avail()
     }
 
-    pub fn largest_acknowledged_pn(&self, pn_space: PNSpace) -> Option<u64> {
+    pub fn largest_acknowledged_pn(&self, pn_space: PNSpace) -> Option<PacketNumber> {
         self.spaces.get(pn_space).and_then(|sp| sp.largest_acked)
     }
 


### PR DESCRIPTION
As we were debating the implementation of this in the spec, I decided
that it was worth doing in our implementation too.  In a lot of cases we
will waste fewer bytes this way.

This isn't ideal as it doesn't yet account for the potential for the
send rate to increase, but it's a pretty good algorithm, I think.

I've been extra cautious and I've adjusted for the header protection
sample size and the AEAD expansion, even though those are both 16
currently and this is in effect a no-op.