### PR TITLE
Enforce tighter bounds on CONNECTION_CLOSE packets

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1945,7 +1945,7 @@ impl Connection {
 
     fn input_frame(&mut self, ptype: PacketType, frame: Frame, now: Instant) -> Res<()> {
         if !frame.is_allowed(ptype) {
-            qerror!("frame not allowed: {:?} {:?}", frame, ptype);
+            qinfo!("frame not allowed: {:?} {:?}", frame, ptype);
             return Err(Error::ProtocolViolation);
         }
         self.stats.borrow_mut().frame_rx.all += 1;


### PR DESCRIPTION
When I started changing the connection ID generator for testing, it
caused this test to fail.  By breaking the datagram up, the test can be
better.