### PR TITLE
Add a new http3 test server that always rejects zero rtt

### DIFF
--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -868,6 +868,15 @@ impl ZeroRttChecker for AllowZeroRtt {
 }
 
 #[derive(Debug)]
+pub struct DisallowZeroRtt {}
+impl ZeroRttChecker for DisallowZeroRtt {
+    fn check(&self, _token: &[u8]) -> ZeroRttCheckResult {
+        qwarn!("DisallowZeroRtt reject 0-RTT");
+        ZeroRttCheckResult::Reject
+    }
+}
+
+#[derive(Debug)]
 struct ZeroRttCheckState {
     fd: *mut ssl::PRFileDesc,
     checker: Pin<Box<dyn ZeroRttChecker>>,

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -36,8 +36,8 @@ mod ssl;
 mod time;
 
 pub use self::agent::{
-    Agent, AllowZeroRtt, Client, HandshakeState, Record, RecordList, ResumptionToken, SecretAgent,
-    SecretAgentInfo, SecretAgentPreInfo, Server, ZeroRttCheckResult, ZeroRttChecker,
+    Agent, AllowZeroRtt, Client, DisallowZeroRtt, HandshakeState, Record, RecordList, ResumptionToken,
+    SecretAgent, SecretAgentInfo, SecretAgentPreInfo, Server, ZeroRttCheckResult, ZeroRttChecker,
 };
 pub use self::auth::AuthenticationStatus;
 pub use self::constants::*;

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -23,7 +23,7 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use neqo_common::{event::Provider, qdebug, qtrace, Datagram};
-use neqo_crypto::{AllowZeroRtt, AuthenticationStatus, ResumptionToken};
+use neqo_crypto::{AllowZeroRtt, AuthenticationStatus, DisallowZeroRtt, ResumptionToken};
 use test_fixture::{self, fixture_init, loopback, now};
 
 // All the tests.
@@ -74,6 +74,22 @@ pub fn default_server() -> Connection {
     .expect("create a default server");
     c.server_enable_0rtt(&test_fixture::anti_replay(), AllowZeroRtt {})
         .expect("enable 0-RTT");
+    c
+}
+
+pub fn disallow_zerortt_server() -> Connection {
+    fixture_init();
+
+    let mut c = Connection::new_server(
+        test_fixture::DEFAULT_KEYS,
+        test_fixture::DEFAULT_ALPN,
+        Rc::new(RefCell::new(FixedConnectionIdManager::new(5))),
+        &CongestionControlAlgorithm::NewReno,
+        QuicVersion::default(),
+    )
+    .expect("create a default server");
+    c.server_enable_0rtt(&test_fixture::anti_replay(), DisallowZeroRtt {})
+        .expect("reject 0-RTT");
     c
 }
 


### PR DESCRIPTION
This patch simply adds `disallow_zerortt_server` to facilitate 0-Rtt reject test.