### PR TITLE
Assert if encode_vec_with overflows

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -313,6 +313,7 @@ impl Encoder {
         self.buf.resize(self.buf.len() + n, 0);
         f(self);
         let len = self.buf.len() - start - n;
+        assert!(len < (1 << (n * 8)));
         for i in 0..n {
             self.buf[start + i] = ((len >> (8 * (n - i - 1))) & 0xff) as u8
         }
@@ -730,6 +731,15 @@ mod tests {
             enc_inner.encode(&Encoder::from_hex("02"));
         });
         assert_eq!(enc, Encoder::from_hex("000102"));
+    }
+
+    #[test]
+    #[should_panic]
+    fn encode_vec_with_overflow() {
+        let mut enc = Encoder::default();
+        enc.encode_vec_with(1, |enc_inner| {
+            enc_inner.encode(&[0xb0; 256]);
+        });
     }
 
     #[test]

--- a/neqo-crypto/src/prio.rs
+++ b/neqo-crypto/src/prio.rs
@@ -5,7 +5,11 @@
 // except according to those terms.
 
 #![allow(dead_code, non_upper_case_globals, non_snake_case)]
-#![allow(clippy::cognitive_complexity, clippy::empty_enum, clippy::too_many_lines)]
+#![allow(
+    clippy::cognitive_complexity,
+    clippy::empty_enum,
+    clippy::too_many_lines
+)]
 
 include!(concat!(env!("OUT_DIR"), "/nspr_io.rs"));
 


### PR DESCRIPTION
I don't why I saw this, but we should be more rigorous with stuff that might be used in multiple places.  We already assert in encode_vvec_with.