### PR TITLE
Rust 1.48 clippy changes

### DIFF
--- a/neqo-crypto/src/prio.rs
+++ b/neqo-crypto/src/prio.rs
@@ -5,7 +5,11 @@
 // except according to those terms.
 
 #![allow(dead_code, non_upper_case_globals, non_snake_case)]
-#![allow(clippy::cognitive_complexity, clippy::empty_enum, clippy::too_many_lines)]
+#![allow(
+    clippy::cognitive_complexity,
+    clippy::empty_enum,
+    clippy::too_many_lines
+)]
 
 include!(concat!(env!("OUT_DIR"), "/nspr_io.rs"));
 

--- a/neqo-crypto/src/time.rs
+++ b/neqo-crypto/src/time.rs
@@ -104,11 +104,9 @@ impl TryFrom<PRTime> for Time {
         let base = get_base();
         if let Some(delta) = prtime.checked_sub(base.prtime) {
             let d = Duration::from_micros(delta.try_into()?);
-            if let Some(t) = base.instant.checked_add(d) {
-                Ok(Self { t })
-            } else {
-                Err(Error::TimeTravelError)
-            }
+            base.instant
+                .checked_add(d)
+                .map_or(Err(Error::TimeTravelError), |t| Ok(Self { t }))
         } else {
             Err(Error::TimeTravelError)
         }
@@ -122,11 +120,8 @@ impl TryInto<PRTime> for Time {
         // TODO(mt) use checked_duration_since when that is available.
         let delta = self.t.duration_since(base.instant);
         if let Ok(d) = PRTime::try_from(delta.as_micros()) {
-            if let Some(v) = d.checked_add(base.prtime) {
-                Ok(v)
-            } else {
-                Err(Error::TimeTravelError)
-            }
+            d.checked_add(base.prtime)
+                .map_or(Err(Error::TimeTravelError), Ok)
         } else {
             Err(Error::TimeTravelError)
         }

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -488,16 +488,18 @@ impl Http3Connection {
             }
             QPACK_UNI_STREAM_TYPE_ENCODER => {
                 qinfo!([self], "A new remote qpack encoder stream {}", stream_id);
-                self.qpack_decoder
-                    .add_recv_stream(stream_id)
-                    .map_err(|_| Error::HttpStreamCreation)?;
+                Error::map_error(
+                    self.qpack_decoder.add_recv_stream(stream_id),
+                    Error::HttpStreamCreation,
+                )?;
                 Ok(false)
             }
             QPACK_UNI_STREAM_TYPE_DECODER => {
                 qinfo!([self], "A new remote qpack decoder stream {}", stream_id);
-                self.qpack_encoder
-                    .add_recv_stream(stream_id)
-                    .map_err(|_| Error::HttpStreamCreation)?;
+                Error::map_error(
+                    self.qpack_encoder.add_recv_stream(stream_id),
+                    Error::HttpStreamCreation,
+                )?;
                 Ok(false)
             }
             _ => {

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -218,11 +218,11 @@ impl Http3Connection {
         if fin {
             self.new_streams.remove(&stream_id);
             Ok(false)
-        } else if let Some(t) = stream_type {
-            self.new_streams.remove(&stream_id);
-            self.decode_new_stream(conn, t, stream_id)
         } else {
-            Ok(false)
+            stream_type.map_or(Ok(false), |t| {
+                self.new_streams.remove(&stream_id);
+                self.decode_new_stream(conn, t, stream_id)
+            })
         }
     }
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -190,9 +190,10 @@ impl Http3Client {
         qtrace!([self], "  settings {}", hex_with_len(&settings_slice));
         let mut dec_settings = Decoder::from(settings_slice);
         let mut settings = HSettings::default();
-        settings
-            .decode_frame_contents(&mut dec_settings)
-            .map_err(|_| Error::InvalidResumptionToken)?;
+        Error::map_error(
+            settings.decode_frame_contents(&mut dec_settings),
+            Error::InvalidResumptionToken,
+        )?;
         let tok = dec.decode_remainder();
         qtrace!([self], "  Transport token {}", hex(&tok));
         self.conn.enable_resumption(now, tok)?;
@@ -421,11 +422,9 @@ impl Http3Client {
         buf: &mut [u8],
     ) -> Res<(usize, bool)> {
         let stream_id = self.push_handler.borrow_mut().get_active_stream_id(push_id);
-        if let Some(id) = stream_id {
+        stream_id.map_or(Err(Error::InvalidStreamId), |id| {
             self.read_response_data(now, id, buf)
-        } else {
-            Err(Error::InvalidStreamId)
-        }
+        })
     }
 
     pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -4790,7 +4790,7 @@ mod tests {
         // Connect and send a request
         let (mut client, _, _) = connect_and_send_request(true);
 
-        assert_eq!(client.cancel_push(6), Err(Error::InvalidStreamId));
+        assert_eq!(client.cancel_push(6), Err(Error::HttpId));
         assert_eq!(client.state(), Http3State::Connected);
     }
 

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -336,8 +336,7 @@ impl PushController {
     ) -> Res<()> {
         qtrace!("Cancel push_id={}", push_id);
 
-        self.check_push_id(push_id)
-            .map_err(|_| Error::InvalidStreamId)?;
+        self.check_push_id(push_id)?;
 
         match self.push_streams.get(push_id) {
             None => {

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -332,6 +332,7 @@ impl RecvMessage {
             MessageType::Response => {
                 let status = headers.iter().find(|(name, _value)| name == ":status");
                 if let Some((_name, value)) = status {
+                    #[allow(clippy::map_err_ignore, clippy::unknown_clippy_lints)]
                     let status_code = value.parse::<i32>().map_err(|_| Error::InvalidHeader)?;
                     Ok(status_code >= 100 && status_code < 200)
                 } else {

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -102,33 +102,32 @@ impl QPackDecoder {
         }
     }
 
-    #[allow(clippy::map_err_ignore)] // We don't care about qpack specifics here.
     fn execute_instruction(&mut self, instruction: DecodedEncoderInstruction) -> Res<()> {
         match instruction {
             DecodedEncoderInstruction::Capacity { value } => self.set_capacity(value)?,
             DecodedEncoderInstruction::InsertWithNameRefStatic { index, value } => {
-                self.table
-                    .insert_with_name_ref(true, index, &value)
-                    .map_err(|_| Error::EncoderStream)?;
+                Error::map_error(
+                    self.table.insert_with_name_ref(true, index, &value),
+                    Error::EncoderStream,
+                )?;
                 self.stats.dynamic_table_inserts += 1;
             }
             DecodedEncoderInstruction::InsertWithNameRefDynamic { index, value } => {
-                self.table
-                    .insert_with_name_ref(false, index, &value)
-                    .map_err(|_| Error::EncoderStream)?;
+                Error::map_error(
+                    self.table.insert_with_name_ref(false, index, &value),
+                    Error::EncoderStream,
+                )?;
                 self.stats.dynamic_table_inserts += 1;
             }
             DecodedEncoderInstruction::InsertWithNameLiteral { name, value } => {
-                self.table
-                    .insert(&name, &value)
-                    .map(|_| ())
-                    .map_err(|_| Error::EncoderStream)?;
+                Error::map_error(
+                    self.table.insert(&name, &value).map(|_| ()),
+                    Error::EncoderStream,
+                )?;
                 self.stats.dynamic_table_inserts += 1;
             }
             DecodedEncoderInstruction::Duplicate { index } => {
-                self.table
-                    .duplicate(index)
-                    .map_err(|_| Error::EncoderStream)?;
+                Error::map_error(self.table.duplicate(index), Error::EncoderStream)?;
                 self.stats.dynamic_table_inserts += 1;
             }
             DecodedEncoderInstruction::NoInstruction => {
@@ -162,7 +161,7 @@ impl QPackDecoder {
 
     /// # Errors
     ///     May return an error in case of any transport error. TODO: define transport errors.
-    #[allow(clippy::map_err_ignore)]
+    #[allow(clippy::map_err_ignore, clippy::unknown_clippy_lints)]
     pub fn send(&mut self, conn: &mut Connection) -> Res<()> {
         // Encode increment instruction if needed.
         let increment = self.table.base() - self.acked_inserts;

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -102,6 +102,7 @@ impl QPackDecoder {
         }
     }
 
+    #[allow(clippy::map_err_ignore)] // We don't care about qpack specifics here.
     fn execute_instruction(&mut self, instruction: DecodedEncoderInstruction) -> Res<()> {
         match instruction {
             DecodedEncoderInstruction::Capacity { value } => self.set_capacity(value)?,
@@ -161,6 +162,7 @@ impl QPackDecoder {
 
     /// # Errors
     ///     May return an error in case of any transport error. TODO: define transport errors.
+    #[allow(clippy::map_err_ignore)]
     pub fn send(&mut self, conn: &mut Connection) -> Res<()> {
         // Encode increment instruction if needed.
         let increment = self.table.base() - self.acked_inserts;

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -155,7 +155,7 @@ impl QPackEncoder {
         }
     }
 
-    #[allow(clippy::map_err_ignore)]
+    #[allow(clippy::map_err_ignore, clippy::unknown_clippy_lints)]
     fn insert_count_instruction(&mut self, increment: u64) -> Res<()> {
         self.table
             .increment_acked(increment)

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -155,6 +155,7 @@ impl QPackEncoder {
         }
     }
 
+    #[allow(clippy::map_err_ignore)]
     fn insert_count_instruction(&mut self, increment: u64) -> Res<()> {
         self.table
             .increment_acked(increment)

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -79,6 +79,18 @@ impl Error {
             _ => 3,
         }
     }
+
+    /// # Errors
+    ///   Any error is mapped to the indicated type.
+    fn map_error<R>(r: Result<R, Self>, err: Self) -> Result<R, Self> {
+        Ok(r.map_err(|e| {
+            if matches!(e, Self::ClosedCriticalStream) {
+                e
+            } else {
+                err
+            }
+        })?)
+    }
 }
 
 impl ::std::error::Error for Error {

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -395,7 +395,6 @@ mod tests {
     use crate::packet::{PacketNumber, PacketType};
     use crate::tracking::SentPacket;
     use std::convert::TryFrom;
-    use std::rc::Rc;
     use std::time::{Duration, Instant};
     use test_fixture::now;
 
@@ -430,27 +429,27 @@ mod tests {
         let sent_packets = vec![
             SentPacket::new(
                 PacketType::Short,
-                1,             // pn
-                time_before,   // time sent
-                true,          // ack eliciting
-                Rc::default(), // tokens
-                103,           // size
+                1,           // pn
+                time_before, // time sent
+                true,        // ack eliciting
+                Vec::new(),  // tokens
+                103,         // size
             ),
             SentPacket::new(
                 PacketType::Short,
-                2,             // pn
-                time_before,   // time sent
-                true,          // ack eliciting
-                Rc::default(), // tokens
-                105,           // size
+                2,           // pn
+                time_before, // time sent
+                true,        // ack eliciting
+                Vec::new(),  // tokens
+                105,         // size
             ),
             SentPacket::new(
                 PacketType::Short,
-                3,             // pn
-                time_after,    // time sent
-                true,          // ack eliciting
-                Rc::default(), // tokens
-                107,           // size
+                3,          // pn
+                time_after, // time sent
+                true,       // ack eliciting
+                Vec::new(), // tokens
+                107,        // size
             ),
         ];
 
@@ -499,7 +498,7 @@ mod tests {
             pn,
             now() + t,
             ack_eliciting,
-            Rc::default(),
+            Vec::new(),
             100,
         )
     }
@@ -670,7 +669,7 @@ mod tests {
                     u64::try_from(i).unwrap(),
                     by_pto(t),
                     true,
-                    Rc::default(),
+                    Vec::new(),
                     1000,
                 )
             })
@@ -731,7 +730,7 @@ mod tests {
             lost[0].pn,
             lost[0].time_sent,
             false,
-            Rc::default(),
+            Vec::new(),
             lost[0].size,
         );
         assert!(!persistent_congestion_by_pto(0, 0, &lost));

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1698,7 +1698,7 @@ impl Connection {
                 pn,
                 now,
                 ack_eliciting,
-                Rc::new(tokens),
+                tokens,
                 encoder.len() - header_start,
             );
             if padded {
@@ -2220,7 +2220,7 @@ impl Connection {
     /// to retransmit the frame as needed.
     fn handle_lost_packets(&mut self, lost_packets: &[SentPacket]) {
         for lost in lost_packets {
-            for token in lost.tokens.as_ref() {
+            for token in &lost.tokens {
                 qdebug!([self], "Lost: {:?}", token);
                 match token {
                     RecoveryToken::Ack(_) => {}
@@ -2278,7 +2278,7 @@ impl Connection {
             now,
         );
         for acked in acked_packets {
-            for token in acked.tokens.as_ref() {
+            for token in &acked.tokens {
                 match token {
                     RecoveryToken::Ack(at) => self.acks.acked(at),
                     RecoveryToken::Stream(st) => self.send_streams.acked(st),
@@ -2708,7 +2708,7 @@ impl Connection {
         let stream = self
             .recv_streams
             .get_mut(&stream_id.into())
-            .ok_or_else(|| Error::InvalidStreamId)?;
+            .ok_or(Error::InvalidStreamId)?;
 
         let rb = stream.read(data)?;
         Ok((rb.0 as usize, rb.1))
@@ -2719,7 +2719,7 @@ impl Connection {
         let stream = self
             .recv_streams
             .get_mut(&stream_id.into())
-            .ok_or_else(|| Error::InvalidStreamId)?;
+            .ok_or(Error::InvalidStreamId)?;
 
         stream.stop_sending(err);
         Ok(())

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -393,7 +393,7 @@ impl LossRecoverySpace {
     /// We try to keep these around until a probe is sent for them, so it is
     /// important that `cd` is set to at least the current PTO time; otherwise we
     /// might remove all in-flight packets and stop sending probes.
-    #[allow(clippy::option_if_let_else)] // Hard enough to read as-is.
+    #[allow(clippy::option_if_let_else, clippy::unknown_clippy_lints)] // Hard enough to read as-is.
     fn remove_old_lost(&mut self, now: Instant, cd: Duration) {
         let mut it = self.sent_packets.iter();
         // If the first item is not expired, do nothing.
@@ -991,7 +991,7 @@ impl LossRecovery {
 
     /// Check how packets should be sent, based on whether there is a PTO,
     /// what the current congestion window is, and what the pacer says.
-    #[allow(clippy::option_if_let_else)]
+    #[allow(clippy::option_if_let_else, clippy::unknown_clippy_lints)]
     pub fn send_profile(&mut self, now: Instant, mtu: usize) -> SendProfile {
         qdebug!([self], "get send profile {:?}", now);
         if let Some(pto) = self.pto_state.as_mut() {

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -822,11 +822,11 @@ pub(crate) struct SendStreams(IndexMap<StreamId, SendStream>);
 
 impl SendStreams {
     pub fn get(&self, id: StreamId) -> Res<&SendStream> {
-        self.0.get(&id).ok_or_else(|| Error::InvalidStreamId)
+        self.0.get(&id).ok_or(Error::InvalidStreamId)
     }
 
     pub fn get_mut(&mut self, id: StreamId) -> Res<&mut SendStream> {
-        self.0.get_mut(&id).ok_or_else(|| Error::InvalidStreamId)
+        self.0.get_mut(&id).ok_or(Error::InvalidStreamId)
     }
 
     pub fn exists(&self, id: StreamId) -> bool {

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -12,7 +12,6 @@ use std::cmp::min;
 use std::collections::VecDeque;
 use std::convert::TryFrom;
 use std::ops::{Index, IndexMut};
-use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use neqo_common::{qdebug, qinfo, qtrace, qwarn};
@@ -137,7 +136,7 @@ pub struct SentPacket {
     pub pn: PacketNumber,
     ack_eliciting: bool,
     pub time_sent: Instant,
-    pub tokens: Rc<Vec<RecoveryToken>>,
+    pub tokens: Vec<RecoveryToken>,
 
     time_declared_lost: Option<Instant>,
     /// After a PTO, this is true when the packet has been released.
@@ -152,7 +151,7 @@ impl SentPacket {
         pn: PacketNumber,
         time_sent: Instant,
         ack_eliciting: bool,
-        tokens: Rc<Vec<RecoveryToken>>,
+        tokens: Vec<RecoveryToken>,
         size: usize,
     ) -> Self {
         Self {
@@ -200,11 +199,8 @@ impl SentPacket {
     /// Ask whether this tracked packet has been declared lost for long enough
     /// that it can be expired and no longer tracked.
     pub fn expired(&self, now: Instant, expiration_period: Duration) -> bool {
-        if let Some(loss_time) = self.time_declared_lost {
-            (loss_time + expiration_period) <= now
-        } else {
-            false
-        }
+        self.time_declared_lost
+            .map_or(false, |loss_time| (loss_time + expiration_period) <= now)
     }
 
     /// Whether the packet contents were cleared out after a PTO.


### PR DESCRIPTION
There was one here that was genuinely useful, but some of the others were just annoying.  The insistence on using `Option::map_or` made some of the code worse, so I suppressed it.  Also, qpack usage deliberately overwrites specific error codes with `Result::map_err`, which now generates warnings that - rather than suppressing directly - I created a wrapper function for.