### PR TITLE
Split internal errors for debugging purposes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,13 @@ jobs:
             cargo run --bin neqo-client -- 'https://127.0.0.1:4433/'
 
       - run:
+          name: Internal Errors Check
+          command: |
+            all_internal_errors=($(find . -name '*.rs' -print | xargs -I {} sed '/Error::\(InternalError\|HttpInternal(\)/s/.*\(Error::[a-zA-Z]*([0-9]*)\)/\1/')); \
+            unique_internal_errors=($(for e in "${all_internal_errors[@]}"; do echo "$e"; done | sort | uniq)); \
+            [[ "${#all_internal_errors[@]}" -eq "${#unique_internal_errors[@]}" ]]
+
+      - run:
           name: "Prepare for Caching"
           command: "git gc --auto"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,9 +82,7 @@ jobs:
       - run:
           name: Internal Errors Check
           command: |
-            all_internal_errors=($(find . -name '*.rs' -print | xargs -I {} sed '/Error::\(InternalError\|HttpInternal(\)/s/.*\(Error::[a-zA-Z]*([0-9]*)\)/\1/')); \
-            unique_internal_errors=($(for e in "${all_internal_errors[@]}"; do echo "$e"; done | sort | uniq)); \
-            [[ "${#all_internal_errors[@]}" -eq "${#unique_internal_errors[@]}" ]]
+            ./check_internal_errors
 
       - run:
           name: "Prepare for Caching"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,7 @@ jobs:
 
       - run:
           name: Internal Errors Check
-          command: |
-            ./check_internal_errors
+          command: ./check_internal_errors
 
       - run:
           name: "Prepare for Caching"

--- a/check_internal_errors
+++ b/check_internal_errors
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [[ "$1" == "-v" ]]; then
+    verbose=1
+    shift
+else
+    verbose=
+fi
+
+if [[ "$#" -ge 1 ]]; then
+    files=("$@")
+else
+    files=($(find . -name '*.rs' -print | sed -e 's~^\./~~;/^target\//d'))
+fi
+
+dirs=($(for f in "${files[@]}"; do echo "${f%%/*}"; done | uniq))
+
+find_internal_errors() {
+    d="$1"
+    shift
+    for f in "$@"; do
+        if [[ "${f#$d/}" != "$f" ]]; then
+            sed -e '/Error::\(InternalError\|HttpInternal(\)/{s/.*[^a-zA-Z]\([a-zA-Z]*Error::[a-zA-Z]*([0-9]*)\).*/\1/;t;};d' "$f"
+        fi
+    done
+}
+
+err=0
+for d in "${dirs[@]}"; do
+    all=($(find_internal_errors "$d" "${files[@]}"))
+    print_all() { for e in "${all[@]}"; do echo "$e"; done; }
+    if [[ -n "$verbose" ]]; then
+        echo "$d:"
+        print_all | paste /dev/null /dev/stdin
+    fi
+    unique=($(print_all | sort | uniq))
+    if [[ "${#all[@]}" -ne "${#unique[@]}" ]]; then
+        echo "Found ${#all[@]} internal errors, but only ${#unique[@]} unique values." 1>&2
+        err=1
+    fi
+done
+exit $err

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -34,3 +34,6 @@ if ! errors=($(cargo fmt -- --check -l)); then
     done
     exit 1
 fi
+
+# Check internal errors
+./check_internal_errors

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -17,7 +17,7 @@ use neqo_common::{qdebug, qerror, qinfo, qtrace, qwarn};
 use neqo_qpack::decoder::{QPackDecoder, QPACK_UNI_STREAM_TYPE_DECODER};
 use neqo_qpack::encoder::{QPackEncoder, QPACK_UNI_STREAM_TYPE_ENCODER};
 use neqo_qpack::QpackSettings;
-use neqo_transport::{AppError, CloseError, Connection, State, StreamType};
+use neqo_transport::{AppError, Connection, ConnectionError, State, StreamType};
 use std::collections::{BTreeSet, HashMap};
 use std::fmt::Debug;
 use std::mem;
@@ -47,8 +47,8 @@ pub enum Http3State {
     ZeroRtt,
     Connected,
     GoingAway(u64),
-    Closing(CloseError),
-    Closed(CloseError),
+    Closing(ConnectionError),
+    Closed(ConnectionError),
 }
 
 impl Http3State {
@@ -401,7 +401,7 @@ impl Http3Connection {
                 if matches!(self.state, Http3State::Closing(_)| Http3State::Closed(_)) {
                     Ok(false)
                 } else {
-                    self.state = Http3State::Closing(error.clone().into());
+                    self.state = Http3State::Closing(error.clone());
                     Ok(true)
                 }
             }
@@ -409,7 +409,7 @@ impl Http3Connection {
                 if matches!(self.state, Http3State::Closed(_)) {
                     Ok(false)
                 } else {
-                    self.state = Http3State::Closed(error.clone().into());
+                    self.state = Http3State::Closed(error.clone());
                     Ok(true)
                 }
             }
@@ -512,7 +512,7 @@ impl Http3Connection {
     /// This is called when an application closes the connection.
     pub fn close(&mut self, error: AppError) {
         qinfo!([self], "Close connection error {:?}.", error);
-        self.state = Http3State::Closing(CloseError::Application(error));
+        self.state = Http3State::Closing(ConnectionError::Application(error));
         if (!self.send_streams.is_empty() || !self.recv_streams.is_empty()) && (error == 0) {
             qwarn!("close(0) called when streams still active");
         }

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -434,7 +434,7 @@ impl Http3Connection {
             Ok(())
         } else {
             debug_assert!(false, "Zero rtt rejected in the wrong state.");
-            Err(Error::HttpInternal)
+            Err(Error::HttpInternal(3))
         }
     }
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -743,7 +743,7 @@ mod tests {
     use neqo_qpack::encoder::QPackEncoder;
     use neqo_transport::tparams::{self, TransportParameter};
     use neqo_transport::{
-        CloseError, ConnectionEvent, ConnectionParameters, Output, State, RECV_BUFFER_SIZE,
+        ConnectionError, ConnectionEvent, ConnectionParameters, Output, State, RECV_BUFFER_SIZE,
         SEND_BUFFER_SIZE,
     };
     use std::convert::TryFrom;
@@ -756,7 +756,7 @@ mod tests {
     fn assert_closed(client: &Http3Client, expected: &Error) {
         match client.state() {
             Http3State::Closing(err) | Http3State::Closed(err) => {
-                assert_eq!(err, CloseError::Application(expected.code()))
+                assert_eq!(err, ConnectionError::Application(expected.code()))
             }
             _ => panic!("Wrong state {:?}", client.state()),
         };
@@ -3705,7 +3705,7 @@ mod tests {
                 HSetting::new(HSettingType::BlockedStreams, 100),
                 HSetting::new(HSettingType::MaxHeaderListSize, 10000),
             ],
-            &Http3State::Closing(CloseError::Application(265)),
+            &Http3State::Closing(ConnectionError::Application(265)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }
@@ -3723,7 +3723,7 @@ mod tests {
                 HSetting::new(HSettingType::MaxTableCapacity, 100),
                 HSetting::new(HSettingType::MaxHeaderListSize, 10000),
             ],
-            &Http3State::Closing(CloseError::Application(265)),
+            &Http3State::Closing(ConnectionError::Application(265)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }
@@ -3760,7 +3760,7 @@ mod tests {
                 HSetting::new(HSettingType::BlockedStreams, 100),
                 HSetting::new(HSettingType::MaxHeaderListSize, 10000),
             ],
-            &Http3State::Closing(CloseError::Application(514)),
+            &Http3State::Closing(ConnectionError::Application(514)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }
@@ -3779,7 +3779,7 @@ mod tests {
                 HSetting::new(HSettingType::BlockedStreams, 100),
                 HSetting::new(HSettingType::MaxHeaderListSize, 10000),
             ],
-            &Http3State::Closing(CloseError::Application(265)),
+            &Http3State::Closing(ConnectionError::Application(265)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }
@@ -3817,7 +3817,7 @@ mod tests {
                 HSetting::new(HSettingType::BlockedStreams, 50),
                 HSetting::new(HSettingType::MaxHeaderListSize, 10000),
             ],
-            &Http3State::Closing(CloseError::Application(265)),
+            &Http3State::Closing(ConnectionError::Application(265)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }
@@ -3855,7 +3855,7 @@ mod tests {
                 HSetting::new(HSettingType::BlockedStreams, 100),
                 HSetting::new(HSettingType::MaxHeaderListSize, 5000),
             ],
-            &Http3State::Closing(CloseError::Application(265)),
+            &Http3State::Closing(ConnectionError::Application(265)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }
@@ -3912,7 +3912,7 @@ mod tests {
                 HSetting::new(HSettingType::BlockedStreams, 100),
                 HSetting::new(HSettingType::MaxHeaderListSize, 10000),
             ],
-            &Http3State::Closing(CloseError::Application(265)),
+            &Http3State::Closing(ConnectionError::Application(265)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -169,7 +169,7 @@ impl Http3ServerHandler {
                 }
                 ConnectionEvent::AuthenticationNeeded
                 | ConnectionEvent::ZeroRttRejected
-                | ConnectionEvent::ResumptionToken(..) => return Err(Error::HttpInternal),
+                | ConnectionEvent::ResumptionToken(..) => return Err(Error::HttpInternal(4)),
                 ConnectionEvent::SendStreamWritable { .. }
                 | ConnectionEvent::SendStreamComplete { .. }
                 | ConnectionEvent::SendStreamCreatable { .. } => {}

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -95,7 +95,7 @@ impl Error {
             Self::HttpGeneralProtocol | Self::HttpGeneralProtocolStream | Self::InvalidHeader => {
                 0x101
             }
-            Self::HttpInternal( .. ) => 0x102,
+            Self::HttpInternal(..) => 0x102,
             Self::HttpStreamCreation => 0x103,
             Self::HttpClosedCriticalStream => 0x104,
             Self::HttpFrameUnexpected => 0x105,
@@ -120,7 +120,7 @@ impl Error {
         matches!(
             self,
             Self::HttpGeneralProtocol
-                | Self::HttpInternal( .. )
+                | Self::HttpInternal(..)
                 | Self::HttpStreamCreation
                 | Self::HttpClosedCriticalStream
                 | Self::HttpFrameUnexpected
@@ -194,8 +194,8 @@ impl Error {
     ///   Any error is mapped to the indicated type.
     fn map_error<R>(r: Result<R, impl Into<Self>>, err: Self) -> Result<R, Self> {
         Ok(r.map_err(|e| {
-            debug_assert!(!matches!(e.into(), Self::HttpInternal( .. )));
-            debug_assert!(!matches!(err, Self::HttpInternal( .. )));
+            debug_assert!(!matches!(e.into(), Self::HttpInternal(..)));
+            debug_assert!(!matches!(err, Self::HttpInternal(..)));
             err
         })?)
     }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -48,9 +48,9 @@ pub enum Error {
     HttpNoError,
     HttpGeneralProtocol,
     HttpGeneralProtocolStream, //this is the same as the above but it should only close a stream not a connection.
-    HttpInternal,
-    HttpInternal1,
-    HttpInternal2,
+    // Each time tihe error is return a different parameter is supply.
+    // This will be use to distinguish each occurance of this error.
+    HttpInternal(u16),
     HttpStreamCreation,
     HttpClosedCriticalStream,
     HttpFrameUnexpected,
@@ -95,7 +95,7 @@ impl Error {
             Self::HttpGeneralProtocol | Self::HttpGeneralProtocolStream | Self::InvalidHeader => {
                 0x101
             }
-            Self::HttpInternal | Self::HttpInternal1 | Self::HttpInternal2 => 0x102,
+            Self::HttpInternal( .. ) => 0x102,
             Self::HttpStreamCreation => 0x103,
             Self::HttpClosedCriticalStream => 0x104,
             Self::HttpFrameUnexpected => 0x105,
@@ -120,9 +120,7 @@ impl Error {
         matches!(
             self,
             Self::HttpGeneralProtocol
-                | Self::HttpInternal
-                | Self::HttpInternal1
-                | Self::HttpInternal2
+                | Self::HttpInternal( .. )
                 | Self::HttpStreamCreation
                 | Self::HttpClosedCriticalStream
                 | Self::HttpFrameUnexpected
@@ -196,14 +194,8 @@ impl Error {
     ///   Any error is mapped to the indicated type.
     fn map_error<R>(r: Result<R, impl Into<Self>>, err: Self) -> Result<R, Self> {
         Ok(r.map_err(|e| {
-            debug_assert!(!matches!(
-                e.into(),
-                Self::HttpInternal | Self::HttpInternal1 | Self::HttpInternal2
-            ));
-            debug_assert!(!matches!(
-                err,
-                Self::HttpInternal | Self::HttpInternal1 | Self::HttpInternal2
-            ));
+            debug_assert!(!matches!(e.into(), Self::HttpInternal( .. )));
+            debug_assert!(!matches!(err, Self::HttpInternal( .. )));
             err
         })?)
     }
@@ -219,8 +211,7 @@ impl From<QpackError> for Error {
     fn from(err: QpackError) -> Self {
         match err {
             QpackError::ClosedCriticalStream => Error::HttpClosedCriticalStream,
-            QpackError::InternalError1 => Error::HttpInternal1,
-            QpackError::InternalError2 => Error::HttpInternal2,
+            QpackError::InternalError(i) => Error::HttpInternal(10 + i),
             e => Self::QpackError(e),
         }
     }
@@ -247,7 +238,7 @@ impl From<AppError> for Error {
             0x200 => Self::QpackError(QpackError::DecompressionFailed),
             0x201 => Self::QpackError(QpackError::EncoderStream),
             0x202 => Self::QpackError(QpackError::DecoderStream),
-            _ => Self::HttpInternal,
+            _ => Self::HttpInternal(0),
         }
     }
 }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -48,8 +48,8 @@ pub enum Error {
     HttpNoError,
     HttpGeneralProtocol,
     HttpGeneralProtocolStream, //this is the same as the above but it should only close a stream not a connection.
-    // Each time tihe error is return a different parameter is supply.
-    // This will be use to distinguish each occurance of this error.
+    // When using this error, you need to provide a value that is unique, which
+    // will allow the specific error to be identified.  This will be validated in CI.
     HttpInternal(u16),
     HttpStreamCreation,
     HttpClosedCriticalStream,
@@ -211,7 +211,6 @@ impl From<QpackError> for Error {
     fn from(err: QpackError) -> Self {
         match err {
             QpackError::ClosedCriticalStream => Error::HttpClosedCriticalStream,
-            QpackError::InternalError(i) => Error::HttpInternal(10 + i),
             e => Self::QpackError(e),
         }
     }

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -239,14 +239,14 @@ impl SendMessage {
 
         if let SendMessageState::SendingInitialMessage { ref mut buf, fin } = self.state {
             let sent =
-                Error::map_error(conn.stream_send(self.stream_id, &buf), Error::HttpInternal)?;
+                Error::map_error(conn.stream_send(self.stream_id, &buf), Error::HttpInternal(5))?;
             qlog::h3_data_moved_down(&mut conn.qlog_mut(), self.stream_id, sent);
 
             qtrace!([label], "{} bytes sent", sent);
 
             if sent == buf.len() {
                 if fin {
-                    Error::map_error(conn.stream_close_send(self.stream_id), Error::HttpInternal)?;
+                    Error::map_error(conn.stream_close_send(self.stream_id), Error::HttpInternal(6))?;
                     self.state = SendMessageState::Closed;
                     qtrace!([label], "done sending request");
                 } else {

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -238,15 +238,20 @@ impl SendMessage {
         };
 
         if let SendMessageState::SendingInitialMessage { ref mut buf, fin } = self.state {
-            let sent =
-                Error::map_error(conn.stream_send(self.stream_id, &buf), Error::HttpInternal(5))?;
+            let sent = Error::map_error(
+                conn.stream_send(self.stream_id, &buf),
+                Error::HttpInternal(5)
+            )?;
             qlog::h3_data_moved_down(&mut conn.qlog_mut(), self.stream_id, sent);
 
             qtrace!([label], "{} bytes sent", sent);
 
             if sent == buf.len() {
                 if fin {
-                    Error::map_error(conn.stream_close_send(self.stream_id), Error::HttpInternal(6))?;
+                    Error::map_error(
+                        conn.stream_close_send(self.stream_id),
+                        Error::HttpInternal(6)
+                    )?;
                     self.state = SendMessageState::Closed;
                     qtrace!([label], "done sending request");
                 } else {

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -240,7 +240,7 @@ impl SendMessage {
         if let SendMessageState::SendingInitialMessage { ref mut buf, fin } = self.state {
             let sent = Error::map_error(
                 conn.stream_send(self.stream_id, &buf),
-                Error::HttpInternal(5)
+                Error::HttpInternal(5),
             )?;
             qlog::h3_data_moved_down(&mut conn.qlog_mut(), self.stream_id, sent);
 
@@ -250,7 +250,7 @@ impl SendMessage {
                 if fin {
                     Error::map_error(
                         conn.stream_close_send(self.stream_id),
-                        Error::HttpInternal(6)
+                        Error::HttpInternal(6),
                     )?;
                     self.state = SendMessageState::Closed;
                     qtrace!([label], "done sending request");

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -238,7 +238,7 @@ mod tests {
     use neqo_qpack::encoder::QPackEncoder;
     use neqo_qpack::QpackSettings;
     use neqo_transport::{
-        CloseError, Connection, ConnectionEvent, State, StreamType, ZeroRttState,
+        Connection, ConnectionError, ConnectionEvent, State, StreamType, ZeroRttState,
     };
     use std::ops::{Deref, DerefMut};
     use test_fixture::{
@@ -271,7 +271,7 @@ mod tests {
     }
 
     fn assert_closed(hconn: &mut Http3Server, expected: &Error) {
-        let err = CloseError::Application(expected.code());
+        let err = ConnectionError::Application(expected.code());
         let closed = |e| {
             matches!(e,
             Http3ServerEvent::StateChange{ state: Http3State::Closing(e), .. }

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -305,7 +305,7 @@ impl QPackEncoder {
                     false,
                     "can_evict_to should have checked and make sure this operation is possible"
                 );
-                return Err(Error::InternalError1);
+                return Err(Error::InternalError(1));
             }
             self.max_entries = cap / 32;
             self.next_capacity = None;
@@ -520,7 +520,7 @@ fn map_stream_send_atomic_error(err: &TransportError) -> Error {
         }
         _ => {
             debug_assert!(false, "Unexpected error");
-            Error::InternalError2
+            Error::InternalError(2)
         }
     }
 }

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -305,7 +305,7 @@ impl QPackEncoder {
                     false,
                     "can_evict_to should have checked and make sure this operation is possible"
                 );
-                return Err(Error::InternalError);
+                return Err(Error::InternalError1);
             }
             self.max_entries = cap / 32;
             self.next_capacity = None;
@@ -520,7 +520,7 @@ fn map_stream_send_atomic_error(err: &TransportError) -> Error {
         }
         _ => {
             debug_assert!(false, "Unexpected error");
-            Error::InternalError
+            Error::InternalError2
         }
     }
 }

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -47,7 +47,8 @@ pub enum Error {
     EncoderStream,
     DecoderStream,
     ClosedCriticalStream,
-    InternalError,
+    InternalError1,
+    InternalError2,
 
     // These are internal errors, they will be transformed into one of the above.
     NeedMoreData, // Return when an input stream does not have more data that a decoder needs.(It does not mean that a stream is closed.)

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -47,8 +47,7 @@ pub enum Error {
     EncoderStream,
     DecoderStream,
     ClosedCriticalStream,
-    InternalError1,
-    InternalError2,
+    InternalError(u16),
 
     // These are internal errors, they will be transformed into one of the above.
     NeedMoreData, // Return when an input stream does not have more data that a decoder needs.(It does not mean that a stream is closed.)

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -148,7 +148,7 @@ impl Crypto {
                 self.tls.read_secret(TLS_EPOCH_ZERO_RTT),
             ),
         };
-        let secret = secret.ok_or(Error::InternalError)?;
+        let secret = secret.ok_or(Error::InternalError1)?;
         self.states.set_0rtt_keys(dir, &secret, cipher.unwrap());
         Ok(true)
     }
@@ -177,12 +177,12 @@ impl Crypto {
         let read_secret = self
             .tls
             .read_secret(TLS_EPOCH_HANDSHAKE)
-            .ok_or(Error::InternalError)?;
+            .ok_or(Error::InternalError2)?;
         let cipher = match self.tls.info() {
             None => self.tls.preinfo()?.cipher_suite(),
             Some(info) => Some(info.cipher_suite()),
         }
-        .ok_or(Error::InternalError)?;
+        .ok_or(Error::InternalError3)?;
         self.states
             .set_handshake_keys(&write_secret, &read_secret, cipher);
         qdebug!([self], "Handshake keys installed");
@@ -206,7 +206,7 @@ impl Crypto {
         let read_secret = self
             .tls
             .read_secret(TLS_EPOCH_APPLICATION_DATA)
-            .ok_or(Error::InternalError)?;
+            .ok_or(Error::InternalError4)?;
         self.states
             .set_application_read_key(read_secret, expire_0rtt)?;
         qdebug!([self], "application read keys installed");

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -148,7 +148,7 @@ impl Crypto {
                 self.tls.read_secret(TLS_EPOCH_ZERO_RTT),
             ),
         };
-        let secret = secret.ok_or(Error::InternalError1)?;
+        let secret = secret.ok_or(Error::InternalError(1))?;
         self.states.set_0rtt_keys(dir, &secret, cipher.unwrap());
         Ok(true)
     }
@@ -177,12 +177,12 @@ impl Crypto {
         let read_secret = self
             .tls
             .read_secret(TLS_EPOCH_HANDSHAKE)
-            .ok_or(Error::InternalError2)?;
+            .ok_or(Error::InternalError(2))?;
         let cipher = match self.tls.info() {
             None => self.tls.preinfo()?.cipher_suite(),
             Some(info) => Some(info.cipher_suite()),
         }
-        .ok_or(Error::InternalError3)?;
+        .ok_or(Error::InternalError(3))?;
         self.states
             .set_handshake_keys(&write_secret, &read_secret, cipher);
         qdebug!([self], "Handshake keys installed");
@@ -206,7 +206,7 @@ impl Crypto {
         let read_secret = self
             .tls
             .read_secret(TLS_EPOCH_APPLICATION_DATA)
-            .ok_or(Error::InternalError4)?;
+            .ok_or(Error::InternalError(4))?;
         self.states
             .set_application_read_key(read_secret, expire_0rtt)?;
         qdebug!([self], "application read keys installed");

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -56,7 +56,12 @@ const ERROR_AEAD_LIMIT_REACHED: TransportError = 15;
 #[allow(clippy::pub_enum_variant_names)]
 pub enum Error {
     NoError,
-    InternalError,
+    InternalError1,
+    InternalError2,
+    InternalError3,
+    InternalError4,
+    InternalError5,
+    InternalError6,
     ConnectionRefused,
     FlowControlError,
     StreamLimitError,

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -56,12 +56,9 @@ const ERROR_AEAD_LIMIT_REACHED: TransportError = 15;
 #[allow(clippy::pub_enum_variant_names)]
 pub enum Error {
     NoError,
-    InternalError1,
-    InternalError2,
-    InternalError3,
-    InternalError4,
-    InternalError5,
-    InternalError6,
+    // Each time tihe error is return a different parameter is supply.
+    // This will be use to distinguish each occurance of this error.
+    InternalError(u16),
     ConnectionRefused,
     FlowControlError,
     StreamLimitError,

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -307,7 +307,7 @@ impl PacketBuilder {
         if self.len() > self.limit {
             qwarn!("Packet contents are more than the limit");
             debug_assert!(false);
-            return Err(Error::InternalError);
+            return Err(Error::InternalError(5));
         }
 
         self.pad_for_crypto(crypto);

--- a/neqo-transport/src/packet/retry.rs
+++ b/neqo-transport/src/packet/retry.rs
@@ -49,7 +49,7 @@ where
     .try_with(|aead| f(&aead.borrow()))
     .map_err(|e| {
         qerror!("Unable to access Retry AEAD: {:?}", e);
-        Error::InternalError6
+        Error::InternalError(6)
     })?
 }
 

--- a/neqo-transport/src/packet/retry.rs
+++ b/neqo-transport/src/packet/retry.rs
@@ -49,7 +49,7 @@ where
     .try_with(|aead| f(&aead.borrow()))
     .map_err(|e| {
         qerror!("Unable to access Retry AEAD: {:?}", e);
-        Error::InternalError
+        Error::InternalError6
     })?
 }
 


### PR DESCRIPTION
neqo-http3 events should use ConnectionError not Close error. This will give us more information in necko.