### PR TITLE
Move connection parameters a little

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -56,6 +56,7 @@ use crate::ConnectionParameters;
 use crate::{AppError, ConnectionError, Error, Res};
 
 mod idle;
+pub mod params;
 mod saved;
 mod state;
 

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -57,9 +57,7 @@ impl ConnectionParameters {
     }
 
     pub fn max_streams(mut self, stream_type: StreamType, v: u64) -> Self {
-        if v > (1 << 60) {
-            panic!("max_streams's parameter too big");
-        }
+        assert!(v <= (1 << 60), "max_streams's parameter too big");
         match stream_type {
             StreamType::BiDi => {
                 self.max_streams_bidi = v;

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -13,7 +13,6 @@ mod addr_valid;
 mod cc;
 mod cid;
 mod connection;
-mod connection_parameters;
 mod crypto;
 mod dump;
 mod events;
@@ -36,13 +35,11 @@ mod tracking;
 pub use self::cc::CongestionControlAlgorithm;
 pub use self::cid::{ConnectionId, ConnectionIdManager};
 pub use self::connection::{
-    Connection, FixedConnectionIdManager, Output, State, ZeroRttState, LOCAL_STREAM_LIMIT_BIDI,
-    LOCAL_STREAM_LIMIT_UNI,
+    params::ConnectionParameters, Connection, FixedConnectionIdManager, Output, State,
+    ZeroRttState, LOCAL_STREAM_LIMIT_BIDI, LOCAL_STREAM_LIMIT_UNI,
 };
-pub use self::connection_parameters::ConnectionParameters;
 pub use self::events::{ConnectionEvent, ConnectionEvents};
-pub use self::frame::CloseError;
-pub use self::frame::StreamType;
+pub use self::frame::{CloseError, StreamType};
 pub use self::packet::QuicVersion;
 pub use self::sender::PacketSender;
 pub use self::stats::Stats;
@@ -51,7 +48,7 @@ pub use self::stream_id::StreamId;
 pub use self::recv_stream::RECV_BUFFER_SIZE;
 pub use self::send_stream::SEND_BUFFER_SIZE;
 
-type TransportError = u64;
+pub type TransportError = u64;
 const ERROR_APPLICATION_CLOSE: TransportError = 12;
 const ERROR_AEAD_LIMIT_REACHED: TransportError = 15;
 


### PR DESCRIPTION
I think that when you have connection_params and connection, that indicates that what you really want is connection::params.  This does that.  I also noticed that our type alias for TransportError isn't public, so I made it so.