### PR TITLE
Sketch of priority API

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1770,15 +1770,24 @@ impl Connection {
             return Ok(());
         }
 
-        self.crypto
-            .write_frame(PNSpace::ApplicationData, builder, tokens, stats)?;
+        self.flow_mgr
+            .borrow_mut()
+            .write_frames(builder, tokens, stats)?;
         if builder.remaining() < 2 {
             return Ok(());
         }
 
-        self.flow_mgr
-            .borrow_mut()
-            .write_frames(builder, tokens, stats)?;
+        self.send_streams
+            .write_frames(TransmissionPriority::Important, builder, tokens, stats)?;
+        if builder.remaining() < 2 {
+            return Ok(());
+        }
+
+        self.cid_manager.write_frames(builder, tokens, stats)?;
+        if builder.remaining() < 2 {
+            return Ok(());
+        }
+        self.paths.write_frames(builder, tokens, stats)?;
         if builder.remaining() < 2 {
             return Ok(());
         }
@@ -1789,23 +1798,19 @@ impl Connection {
             return Ok(());
         }
 
-        self.cid_manager.write_frames(builder, tokens, stats)?;
+        self.crypto
+            .write_frame(PNSpace::ApplicationData, builder, tokens, stats)?;
         if builder.remaining() < 2 {
             return Ok(());
         }
 
-        self.paths.write_frames(builder, tokens, stats)?;
+        self.new_token.write_frames(builder, tokens, stats)?;
         if builder.remaining() < 2 {
             return Ok(());
         }
 
         self.send_streams
             .write_frames(TransmissionPriority::Normal, builder, tokens, stats)?;
-        if builder.remaining() < 2 {
-            return Ok(());
-        }
-
-        self.new_token.write_frames(builder, tokens, stats)?;
         if builder.remaining() < 2 {
             return Ok(());
         }

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -33,6 +33,7 @@ mod handshake;
 mod idle;
 mod keys;
 mod migration;
+mod priority;
 mod recovery;
 mod resumption;
 mod stream;

--- a/neqo-transport/src/connection/tests/priority.rs
+++ b/neqo-transport/src/connection/tests/priority.rs
@@ -1,0 +1,212 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use super::super::{Connection, Error, Output};
+use super::{connect, default_client, default_server, fill_cwnd, maybe_authenticate};
+use crate::send_stream::{RetransmissionPriority, TransmissionPriority};
+use crate::{ConnectionEvent, StreamType};
+
+use neqo_common::event::Provider;
+use test_fixture::{self, now};
+
+const BLOCK_SIZE: usize = 4_096;
+
+fn fill_stream(c: &mut Connection, id: u64) {
+    loop {
+        if c.stream_send(id, &[0x42; BLOCK_SIZE]).unwrap() < BLOCK_SIZE {
+            return;
+        }
+    }
+}
+
+/// A receive stream cannot be prioritized (yet).
+#[test]
+fn receive_stream() {
+    const MESSAGE: &[u8] = b"hello";
+    let mut client = default_client();
+    let mut server = default_server();
+    connect(&mut client, &mut server);
+
+    let id = client.stream_create(StreamType::UniDi).unwrap();
+    assert_eq!(MESSAGE.len(), client.stream_send(id, MESSAGE).unwrap());
+    let dgram = client.process_output(now()).dgram();
+
+    server.process_input(dgram.unwrap(), now());
+    assert_eq!(
+        server
+            .stream_priority(
+                id,
+                TransmissionPriority::default(),
+                RetransmissionPriority::default()
+            )
+            .unwrap_err(),
+        Error::InvalidStreamId,
+        "Priority doesn't apply to inbound unidirectional streams"
+    );
+
+    // But the stream does exist and can be read.
+    let mut buf = [0; 10];
+    let (len, end) = server.stream_recv(id, &mut buf).unwrap();
+    assert_eq!(MESSAGE, &buf[..len]);
+    assert!(!end);
+}
+
+/// Higher priority streams get sent ahead of lower ones, even when
+/// the higher priority stream is written to later.
+#[test]
+fn relative() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect(&mut client, &mut server);
+
+    // Normal is created first, but it is lower priority.
+    let normal = client.stream_create(StreamType::UniDi).unwrap();
+    fill_stream(&mut client, normal);
+    let high = client.stream_create(StreamType::UniDi).unwrap();
+    fill_stream(&mut client, high);
+    client
+        .stream_priority(
+            high,
+            TransmissionPriority::High,
+            RetransmissionPriority::default(),
+        )
+        .unwrap();
+
+    let dgram = client.process_output(now()).dgram();
+    server.process_input(dgram.unwrap(), now());
+
+    // The "normal" stream will get a `NewStream` event, but no data.
+    for e in server.events() {
+        if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
+            assert_ne!(stream_id, normal);
+        }
+    }
+}
+
+/// Retransmission can be prioritized differently (usually higher).
+#[test]
+fn repairing_loss() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect(&mut client, &mut server);
+    let mut now = now();
+
+    // Send a few packets at low priority, lose one.
+    let low = client.stream_create(StreamType::UniDi).unwrap();
+    fill_stream(&mut client, low);
+    client
+        .stream_priority(
+            low,
+            TransmissionPriority::Low,
+            RetransmissionPriority::Higher,
+        )
+        .unwrap();
+
+    let _lost = client.process_output(now).dgram();
+    for _ in 0..5 {
+        match client.process_output(now) {
+            Output::Datagram(d) => server.process_input(d, now),
+            Output::Callback(delay) => now += delay,
+            _ => unreachable!(),
+        }
+    }
+
+    // Generate an ACK.  The first packet is now considered lost.
+    let ack = server.process_output(now).dgram();
+    let _ = server.events().count(); // Drain events.
+
+    let normal = client.stream_create(StreamType::UniDi).unwrap();
+    fill_stream(&mut client, normal);
+
+    let dgram = client.process(ack, now).dgram();
+    assert_eq!(client.stats().lost, 1); // Client should have noticed the loss.
+    server.process_input(dgram.unwrap(), now);
+
+    // Only the "normal" stream has data as the retransmission of the data from
+    // the lost packet is more important than the high priority stream.
+    for e in server.events() {
+        println!("Event: {:?}", e);
+        if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
+            assert_eq!(stream_id, low);
+        }
+    }
+
+    // However, only the retransmission is prioritized.
+    // Though this might contain some retransmitted data, as other frames might push
+    // the retransmitted data into a second packet, it will also contain data from the
+    // normal priority stream.
+    let dgram = client.process_output(now).dgram();
+    server.process_input(dgram.unwrap(), now);
+    assert!(server.events().any(
+        |e| matches!(e, ConnectionEvent::RecvStreamReadable { stream_id } if stream_id == normal),
+    ));
+}
+
+#[test]
+fn critical() {
+    let mut client = default_client();
+    let mut server = default_server();
+    let now = now();
+
+    // Rather than connect, send stream data in 0.5-RTT.
+    // That allows this to test that critical streams pre-empt most frame types.
+    let dgram = client.process_output(now).dgram();
+    let dgram = server.process(dgram, now).dgram();
+
+    let id = server.stream_create(StreamType::UniDi).unwrap();
+    server
+        .stream_priority(
+            id,
+            TransmissionPriority::Critical,
+            RetransmissionPriority::default(),
+        )
+        .unwrap();
+    // Can't use fill_cwnd here because the server is blocked on the amplification
+    // limit, so it can't fill the congestion window.
+    fill_stream(&mut server, id);
+    let stats_before = server.stats();
+    let mut packets = Vec::new();
+    // Get some packets.
+    while let Output::Datagram(dgram) = server.process_output(now) {
+        packets.push(dgram);
+    }
+    let stats_after = server.stats();
+    assert_eq!(stats_after.frame_tx.crypto, stats_before.frame_tx.crypto);
+    assert_eq!(stats_after.frame_tx.stream_data_blocked, 0);
+    assert_eq!(stats_after.frame_tx.new_connection_id, 0);
+    assert_eq!(stats_after.frame_tx.new_token, 0);
+    assert_eq!(stats_after.frame_tx.handshake_done, 0);
+
+    // Complete the handshake.  Read the bytes.
+    client.process_input(dgram.unwrap(), now);
+    maybe_authenticate(&mut client);
+    for p in packets {
+        client.process_input(p, now);
+    }
+
+    // Drain the stream so we can go again.
+    loop {
+        let mut buf = [0; BLOCK_SIZE];
+        let (count, end) = client.stream_recv(id, &mut buf).unwrap();
+        assert!(!end);
+        if count == 0 {
+            break;
+        }
+    }
+    // Finish the handshake and send an ACK for all those packets.
+    let dgram = client.process_output(now).dgram();
+    server.process_input(dgram.unwrap(), now);
+
+    // Critical beats everything but HANDSHAKE_DONE.
+    let stats_before = server.stats();
+    let _ = fill_cwnd(&mut server, id, now);
+    let stats_after = server.stats();
+    assert_eq!(stats_after.frame_tx.crypto, stats_before.frame_tx.crypto);
+    assert_eq!(stats_after.frame_tx.stream_data_blocked, 0);
+    assert_eq!(stats_after.frame_tx.new_connection_id, 0);
+    assert_eq!(stats_after.frame_tx.new_token, 0);
+    assert_eq!(stats_after.frame_tx.handshake_done, 1);
+}

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -77,11 +77,11 @@ fn pto_works_full_cwnd() {
     assert_eq!(dgrams.len(), 2);
     assert_eq!(dgrams[0].len(), PATH_MTU_V6);
 
-    // Both datagrams contain a STREAM frame.
+    // Both datagrams contain one or more STREAM frames.
     for d in dgrams {
         let stream_before = server.stats().frame_rx.stream;
         server.process_input(d, now);
-        assert_eq!(server.stats().frame_rx.stream, stream_before + 1);
+        assert!(server.stats().frame_rx.stream > stream_before);
     }
 }
 


### PR DESCRIPTION
This adds the ability to prioritize streams.

The most important aspect of this is that the default behaviour here
prioritizes retransmission over transmission.

This comes at a small cost: we iterate through all the active streams 5
times rather than just once.  I've tried to mitigate that by adding an
early exit: if we fill up the packet, we stop looking to add frames.

This isn't complete as it doesn't include any tests that verify that
prioritization works as expected.  And the HTTP fetch API needs priority
hooks too.