### PR TITLE
Move sending flow control tracking to send streams

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -35,6 +35,7 @@ use crate::cid::{
 use crate::crypto::{Crypto, CryptoDxState, CryptoSpace};
 use crate::dump::*;
 use crate::events::{ConnectionEvent, ConnectionEvents};
+use crate::fc::SenderFlowControl;
 use crate::flow_mgr::FlowMgr;
 use crate::frame::{
     CloseError, Frame, FrameType, FRAME_TYPE_CONNECTION_CLOSE_APPLICATION,
@@ -251,6 +252,7 @@ pub struct Connection {
     pub(crate) indexes: StreamIndexes,
     pub(crate) send_streams: SendStreams,
     pub(crate) recv_streams: RecvStreams,
+    pub(crate) flow_control: Rc<RefCell<SenderFlowControl<()>>>,
     pub(crate) flow_mgr: Rc<RefCell<FlowMgr>>,
     state_signaling: StateSignaling,
     loss_recovery: LossRecovery,
@@ -442,6 +444,7 @@ impl Connection {
             connection_ids: ConnectionIdStore::default(),
             send_streams: SendStreams::default(),
             recv_streams: RecvStreams::default(),
+            flow_control: Rc::new(RefCell::new(SenderFlowControl::new((), 0))),
             flow_mgr: Rc::new(RefCell::new(FlowMgr::default())),
             state_signaling: StateSignaling::Idle,
             loss_recovery: LossRecovery::new(stats.clone()),
@@ -1805,6 +1808,14 @@ impl Connection {
             return Ok(());
         }
 
+        // Send `DATA_BLOCKED` as necessary.
+        self.flow_control
+            .borrow_mut()
+            .write_frames(builder, tokens, stats)?;
+        if builder.remaining() < 2 {
+            return Ok(());
+        }
+
         self.flow_mgr
             .borrow_mut()
             .write_frames(builder, tokens, stats)?;
@@ -2146,9 +2157,9 @@ impl Connection {
             StreamIndex::new(remote.get_integer(tparams::INITIAL_MAX_STREAMS_BIDI));
         self.indexes.remote_max_stream_uni =
             StreamIndex::new(remote.get_integer(tparams::INITIAL_MAX_STREAMS_UNI));
-        self.flow_mgr
+        self.flow_control
             .borrow_mut()
-            .conn_increase_max_credit(remote.get_integer(tparams::INITIAL_MAX_DATA));
+            .update(remote.get_integer(tparams::INITIAL_MAX_DATA));
 
         let peer_timeout = remote.get_integer(tparams::IDLE_TIMEOUT);
         if peer_timeout > 0 {
@@ -2318,11 +2329,8 @@ impl Connection {
     }
 
     fn handle_max_data(&mut self, maximum_data: u64) {
-        let conn_was_blocked = self.flow_mgr.borrow().conn_credit_avail() == 0;
-        let conn_credit_increased = self
-            .flow_mgr
-            .borrow_mut()
-            .conn_increase_max_credit(maximum_data);
+        let conn_was_blocked = self.flow_control.borrow().available() == 0;
+        let conn_credit_increased = self.flow_control.borrow_mut().update(maximum_data);
 
         if conn_was_blocked && conn_credit_increased {
             for (id, ss) in &mut self.send_streams {
@@ -2468,10 +2476,7 @@ impl Connection {
                 // But if it does, open it up all the way
                 self.flow_mgr.borrow_mut().max_data(LOCAL_MAX_DATA);
             }
-            Frame::StreamDataBlocked {
-                stream_id,
-                stream_data_limit,
-            } => {
+            Frame::StreamDataBlocked { stream_id, .. } => {
                 self.stats.borrow_mut().frame_rx.stream_data_blocked += 1;
                 // Terminate connection with STREAM_STATE_ERROR if send-only
                 // stream (-transport 19.13)
@@ -2480,18 +2485,7 @@ impl Connection {
                 }
 
                 if let (_, Some(rs)) = self.obtain_stream(stream_id)? {
-                    if let Some(msd) = rs.max_stream_data() {
-                        qinfo!(
-                            [self],
-                            "Got StreamDataBlocked(id {} MSD {}); curr MSD {}",
-                            stream_id.as_u64(),
-                            stream_data_limit,
-                            msd
-                        );
-                        if stream_data_limit != msd {
-                            self.flow_mgr.borrow_mut().max_stream_data(stream_id, msd)
-                        }
-                    }
+                    rs.send_flowc_update();
                 }
             }
             Frame::StreamsBlocked { stream_type, .. } => {
@@ -2598,7 +2592,6 @@ impl Connection {
                     RecoveryToken::Crypto(ct) => self.crypto.lost(&ct),
                     RecoveryToken::Flow(ft) => self.flow_mgr.borrow_mut().lost(
                         &ft,
-                        &mut self.send_streams,
                         &mut self.recv_streams,
                         &mut self.indexes,
                     ),
@@ -2606,6 +2599,15 @@ impl Connection {
                     RecoveryToken::NewToken(seqno) => self.new_token.lost(*seqno),
                     RecoveryToken::NewConnectionId(ncid) => self.cid_manager.lost(ncid),
                     RecoveryToken::RetireConnectionId(seqno) => self.paths.lost_retire_cid(*seqno),
+                    RecoveryToken::ResetStream { stream_id } => {
+                        self.send_streams.reset_lost(*stream_id)
+                    }
+                    RecoveryToken::DataBlocked(limit) => {
+                        self.flow_control.borrow_mut().lost(*limit)
+                    }
+                    RecoveryToken::StreamDataBlocked { stream_id, limit } => {
+                        self.send_streams.blocked_lost(*stream_id, *limit)
+                    }
                 }
             }
         }
@@ -2650,14 +2652,17 @@ impl Connection {
                     RecoveryToken::Ack(at) => self.acks.acked(at),
                     RecoveryToken::Stream(st) => self.send_streams.acked(st),
                     RecoveryToken::Crypto(ct) => self.crypto.acked(ct),
-                    RecoveryToken::Flow(ft) => {
-                        self.flow_mgr.borrow_mut().acked(ft, &mut self.send_streams)
-                    }
                     RecoveryToken::NewToken(seqno) => self.new_token.acked(*seqno),
                     RecoveryToken::NewConnectionId(entry) => self.cid_manager.acked(entry),
                     RecoveryToken::RetireConnectionId(seqno) => self.paths.acked_retire_cid(*seqno),
-                    // We only worry about when these are lost:
-                    RecoveryToken::HandshakeDone => (),
+                    RecoveryToken::ResetStream { stream_id } => {
+                        self.send_streams.reset_acked(*stream_id)
+                    }
+                    // We only worry when these are lost:
+                    RecoveryToken::Flow(_)
+                    | RecoveryToken::DataBlocked(_)
+                    | RecoveryToken::StreamDataBlocked { .. }
+                    | RecoveryToken::HandshakeDone => (),
                 }
             }
         }
@@ -2884,7 +2889,7 @@ impl Connection {
                             SendStream::new(
                                 next_stream_id,
                                 send_initial_max_stream_data,
-                                self.flow_mgr.clone(),
+                                Rc::clone(&self.flow_control),
                                 self.events.clone(),
                             ),
                         );
@@ -2954,7 +2959,7 @@ impl Connection {
                     SendStream::new(
                         new_id,
                         initial_max_stream_data,
-                        self.flow_mgr.clone(),
+                        Rc::clone(&self.flow_control),
                         self.events.clone(),
                     ),
                 );
@@ -2993,7 +2998,7 @@ impl Connection {
                     SendStream::new(
                         new_id,
                         send_initial_max_stream_data,
-                        self.flow_mgr.clone(),
+                        Rc::clone(&self.flow_control),
                         self.events.clone(),
                     ),
                 );

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -313,6 +313,10 @@ fn fill_cwnd(c: &mut Connection, stream: u64, mut now: Instant) -> (Vec<Datagram
         }
     }
 
+    qtrace!(
+        "fill_cwnd sent {} bytes",
+        total_dgrams.iter().map(|d| d.len()).sum::<usize>()
+    );
     (total_dgrams, now)
 }
 

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::events::ConnectionEvent;
 use crate::recv_stream::RECV_BUFFER_SIZE;
-use crate::send_stream::SEND_BUFFER_SIZE;
+use crate::send_stream::{SendStreamState, SEND_BUFFER_SIZE};
 use crate::tparams::{self, TransportParameter};
 use crate::tracking::MAX_UNACKED_PKTS;
 use crate::{Error, StreamId, StreamType};
@@ -386,28 +386,36 @@ fn stream_data_blocked_generates_max_stream_data() {
 
     let now = now();
 
-    // Send some data and include STREAM_DATA_BLOCKED with any value.
+    // Send some data and consume some flow control.
     let stream_id = server.stream_create(StreamType::UniDi).unwrap();
     let _ = server.stream_send(stream_id, DEFAULT_STREAM_DATA).unwrap();
-    server.flow_mgr.borrow_mut().stream_data_blocked(
-        StreamId::from(stream_id),
-        u64::try_from(DEFAULT_STREAM_DATA.len()).unwrap(),
-    );
-
     let dgram = server.process(None, now).dgram();
     assert!(dgram.is_some());
 
-    let sdb_before = client.stats().frame_rx.stream_data_blocked;
-    client.process_input(dgram.unwrap(), now);
-    assert_eq!(client.stats().frame_rx.stream_data_blocked, sdb_before + 1);
-
     // Consume the data.
+    client.process_input(dgram.unwrap(), now);
     let mut buf = [0; 10];
     let (count, end) = client.stream_recv(stream_id, &mut buf[..]).unwrap();
     assert_eq!(count, DEFAULT_STREAM_DATA.len());
     assert!(!end);
 
-    let dgram = client.process_output(now).dgram();
+    // Now send `STREAM_DATA_BLOCKED`.
+    let internal_stream = server
+        .send_streams
+        .get_mut(StreamId::from(stream_id))
+        .unwrap();
+    if let SendStreamState::Send { fc, .. } = internal_stream.state() {
+        fc.blocked();
+    } else {
+        panic!("unexpected stream state");
+    }
+    let dgram = server.process_output(now).dgram();
+    assert!(dgram.is_some());
+
+    let sdb_before = client.stats().frame_rx.stream_data_blocked;
+    let dgram = client.process(dgram, now).dgram();
+    assert_eq!(client.stats().frame_rx.stream_data_blocked, sdb_before + 1);
+    assert!(dgram.is_some());
 
     // Client should have sent a MAX_STREAM_DATA frame with just a small increase
     // on the default window size.
@@ -415,7 +423,7 @@ fn stream_data_blocked_generates_max_stream_data() {
     server.process_input(dgram.unwrap(), now);
     assert_eq!(server.stats().frame_rx.max_stream_data, msd_before + 1);
 
-    // Test that more space is available, but that it is small.
+    // Test that the entirety of the receive buffer is available now.
     let mut written = 0;
     loop {
         const LARGE_BUFFER: &[u8] = &[0; 1024];
@@ -425,7 +433,7 @@ fn stream_data_blocked_generates_max_stream_data() {
         }
         written += amount;
     }
-    assert_eq!(written, RECV_BUFFER_SIZE - DEFAULT_STREAM_DATA.len());
+    assert_eq!(written, RECV_BUFFER_SIZE);
 }
 
 /// See <https://github.com/mozilla/neqo/issues/871>

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -1,0 +1,236 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tracks possibly-redundant flow control signals from other code and converts
+// into flow control frames needing to be sent to the remote.
+
+use crate::frame::{write_varint_frame, FRAME_TYPE_DATA_BLOCKED, FRAME_TYPE_STREAM_DATA_BLOCKED};
+use crate::packet::PacketBuilder;
+use crate::recovery::RecoveryToken;
+use crate::stats::FrameStats;
+use crate::stream_id::StreamId;
+use crate::Res;
+
+use std::convert::TryFrom;
+use std::fmt::Debug;
+
+#[derive(Debug)]
+pub struct SenderFlowControl<T>
+where
+    T: Debug + Sized,
+{
+    /// The thing that we're counting for.
+    subject: T,
+    /// The limit.
+    limit: u64,
+    /// How much of that limit we've used.
+    used: u64,
+    /// The point at which blocking occurred.
+    /// Note: a value of 0 is reserved to mean no blocking;
+    /// all other values are one higher than the values used in `limit`.
+    blocked_at: u64,
+    /// Whether a blocked frame should be sent.
+    blocked_frame: bool,
+}
+
+impl<T> SenderFlowControl<T>
+where
+    T: Debug + Sized,
+{
+    /// Make a new instance with the initial value and subject.
+    pub fn new(subject: T, initial: u64) -> Self {
+        Self {
+            subject,
+            limit: initial,
+            used: 0,
+            blocked_at: 0,
+            blocked_frame: false,
+        }
+    }
+
+    /// Update the maximum.  Returns `true` if the change was an increase.
+    pub fn update(&mut self, limit: u64) -> bool {
+        debug_assert!(limit < u64::MAX);
+        if limit > self.limit {
+            self.limit = limit;
+            self.blocked_frame = false;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Consume flow control.
+    pub fn consume(&mut self, count: usize) {
+        let amt = u64::try_from(count).unwrap();
+        debug_assert!(self.used + amt <= self.limit);
+        self.used += amt;
+    }
+
+    /// Get available flow control.
+    pub fn available(&self) -> usize {
+        usize::try_from(self.limit - self.used).unwrap_or(usize::MAX)
+    }
+
+    /// How much data has been written.
+    pub fn used(&self) -> u64 {
+        self.used
+    }
+
+    /// Mark flow control as blocked.
+    /// This only does something if the current limit exceeds the last reported blocking limit.
+    pub fn blocked(&mut self) {
+        if self.limit >= self.blocked_at {
+            self.blocked_at = self.limit + 1;
+            self.blocked_frame = true;
+        }
+    }
+
+    /// Return whether a blocking frame needs to be sent.
+    /// This is `Some` with the active limit if `blocked` has been called,
+    /// if a blocking frame has not been sent, and
+    /// if the blocking condition remains.
+    fn blocked_needed(&self) -> Option<u64> {
+        if self.blocked_frame && self.limit < self.blocked_at {
+            Some(self.blocked_at - 1)
+        } else {
+            None
+        }
+    }
+
+    /// Clear the need to send a blocked frame.
+    fn blocked_sent(&mut self) {
+        self.blocked_frame = false;
+    }
+
+    /// Mark a blocked frame as having been lost.
+    /// Only send again if value of `self.blocked_at` hasn't increased since sending.
+    /// That would imply that the limit has since increased.
+    pub fn lost(&mut self, limit: u64) {
+        if self.blocked_at == limit + 1 {
+            self.blocked_frame = true;
+        }
+    }
+}
+
+impl SenderFlowControl<()> {
+    pub fn write_frames(
+        &mut self,
+        builder: &mut PacketBuilder,
+        tokens: &mut Vec<RecoveryToken>,
+        stats: &mut FrameStats,
+    ) -> Res<()> {
+        if let Some(limit) = self.blocked_needed() {
+            if write_varint_frame(builder, &[FRAME_TYPE_DATA_BLOCKED, limit])? {
+                stats.data_blocked += 1;
+                tokens.push(RecoveryToken::DataBlocked(limit));
+                self.blocked_sent();
+            }
+        }
+        Ok(())
+    }
+}
+
+impl SenderFlowControl<StreamId> {
+    pub fn write_frames(
+        &mut self,
+        builder: &mut PacketBuilder,
+        tokens: &mut Vec<RecoveryToken>,
+        stats: &mut FrameStats,
+    ) -> Res<()> {
+        if let Some(limit) = self.blocked_needed() {
+            if write_varint_frame(
+                builder,
+                &[FRAME_TYPE_STREAM_DATA_BLOCKED, self.subject.as_u64(), limit],
+            )? {
+                stats.stream_data_blocked += 1;
+                tokens.push(RecoveryToken::StreamDataBlocked {
+                    stream_id: self.subject,
+                    limit,
+                });
+                self.blocked_sent();
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::SenderFlowControl;
+
+    #[test]
+    fn blocked_at_zero() {
+        let mut fc = SenderFlowControl::new((), 0);
+        fc.blocked();
+        assert_eq!(fc.blocked_needed(), Some(0));
+    }
+
+    #[test]
+    fn blocked() {
+        let mut fc = SenderFlowControl::new((), 10);
+        fc.blocked();
+        assert_eq!(fc.blocked_needed(), Some(10));
+    }
+
+    #[test]
+    fn update_consume() {
+        let mut fc = SenderFlowControl::new((), 10);
+        fc.consume(10);
+        assert_eq!(fc.available(), 0);
+        fc.update(5);
+        assert_eq!(fc.available(), 0); // Small update has no effect.
+        fc.update(15);
+        assert_eq!(fc.available(), 5);
+        fc.consume(3);
+        assert_eq!(fc.available(), 2);
+    }
+
+    #[test]
+    fn update_clears_blocked() {
+        let mut fc = SenderFlowControl::new((), 10);
+        fc.blocked();
+        assert_eq!(fc.blocked_needed(), Some(10));
+        fc.update(5);
+        assert_eq!(fc.blocked_needed(), Some(10));
+        fc.update(11);
+        assert_eq!(fc.blocked_needed(), None);
+    }
+
+    #[test]
+    fn lost_blocked_resent() {
+        let mut fc = SenderFlowControl::new((), 10);
+        fc.blocked();
+        fc.blocked_sent();
+        assert_eq!(fc.blocked_needed(), None);
+        fc.lost(10);
+        assert_eq!(fc.blocked_needed(), Some(10));
+    }
+
+    #[test]
+    fn lost_after_increase() {
+        let mut fc = SenderFlowControl::new((), 10);
+        fc.blocked();
+        fc.blocked_sent();
+        assert_eq!(fc.blocked_needed(), None);
+        fc.update(11);
+        fc.lost(10);
+        assert_eq!(fc.blocked_needed(), None);
+    }
+
+    #[test]
+    fn lost_after_higher_blocked() {
+        let mut fc = SenderFlowControl::new((), 10);
+        fc.blocked();
+        fc.blocked_sent();
+        fc.update(11);
+        fc.blocked();
+        assert_eq!(fc.blocked_needed(), Some(11));
+        fc.blocked_sent();
+        fc.lost(10);
+        assert_eq!(fc.blocked_needed(), None);
+    }
+}

--- a/neqo-transport/src/flow_mgr.rs
+++ b/neqo-transport/src/flow_mgr.rs
@@ -10,17 +10,16 @@
 use std::collections::HashMap;
 use std::mem;
 
-use neqo_common::{qinfo, qwarn, Encoder};
+use neqo_common::qwarn;
 use smallvec::{smallvec, SmallVec};
 
-use crate::frame::Frame;
+use crate::frame::{write_varint_frame, Frame};
 use crate::packet::PacketBuilder;
 use crate::recovery::RecoveryToken;
 use crate::recv_stream::RecvStreams;
-use crate::send_stream::SendStreams;
 use crate::stats::FrameStats;
 use crate::stream_id::{StreamId, StreamIndex, StreamIndexes, StreamType};
-use crate::{AppError, Error, Res};
+use crate::{AppError, Res};
 
 type FlowFrame = Frame<'static>;
 pub type FlowControlRecoveryToken = FlowFrame;
@@ -37,45 +36,10 @@ pub struct FlowMgr {
     // (stream_type, discriminant) as key ensures only 1 of every frame type
     // per stream type will be queued.
     from_stream_types: HashMap<(StreamType, mem::Discriminant<FlowFrame>), FlowFrame>,
-
-    used_data: u64,
-    max_data: u64,
 }
 
 impl FlowMgr {
-    pub fn conn_credit_avail(&self) -> u64 {
-        self.max_data - self.used_data
-    }
-
-    pub fn conn_increase_credit_used(&mut self, amount: u64) {
-        self.used_data += amount;
-        assert!(self.used_data <= self.max_data)
-    }
-
-    // Dummy DataBlocked frame for discriminant use below
-
-    /// Returns whether max credit was actually increased.
-    pub fn conn_increase_max_credit(&mut self, new: u64) -> bool {
-        const DB_FRAME: FlowFrame = Frame::DataBlocked { data_limit: 0 };
-
-        if new > self.max_data {
-            self.max_data = new;
-            self.from_conn.remove(&mem::discriminant(&DB_FRAME));
-
-            true
-        } else {
-            false
-        }
-    }
-
     // -- frames scoped on connection --
-
-    pub fn data_blocked(&mut self) {
-        let frame = Frame::DataBlocked {
-            data_limit: self.max_data,
-        };
-        self.from_conn.insert(mem::discriminant(&frame), frame);
-    }
 
     pub fn max_data(&mut self, maximum_data: u64) {
         let frame = Frame::MaxData { maximum_data };
@@ -83,22 +47,6 @@ impl FlowMgr {
     }
 
     // -- frames scoped on stream --
-
-    /// Indicate to receiving remote the stream is reset
-    pub fn stream_reset(
-        &mut self,
-        stream_id: StreamId,
-        application_error_code: AppError,
-        final_size: u64,
-    ) {
-        let frame = Frame::ResetStream {
-            stream_id,
-            application_error_code,
-            final_size,
-        };
-        self.from_streams
-            .insert((stream_id, mem::discriminant(&frame)), frame);
-    }
 
     /// Indicate to sending remote we are no longer interested in the stream
     pub fn stop_sending(&mut self, stream_id: StreamId, application_error_code: AppError) {
@@ -128,16 +76,6 @@ impl FlowMgr {
         };
         self.from_streams
             .remove(&(stream_id, mem::discriminant(&frame)));
-    }
-
-    /// Indicate to receiving remote we need more credits
-    pub fn stream_data_blocked(&mut self, stream_id: StreamId, stream_data_limit: u64) {
-        let frame = Frame::StreamDataBlocked {
-            stream_id,
-            stream_data_limit,
-        };
-        self.from_streams
-            .insert((stream_id, mem::discriminant(&frame)), frame);
     }
 
     // -- frames scoped on stream type --
@@ -172,56 +110,13 @@ impl FlowMgr {
         }
     }
 
-    pub(crate) fn acked(
-        &mut self,
-        token: &FlowControlRecoveryToken,
-        send_streams: &mut SendStreams,
-    ) {
-        const RESET_STREAM: &Frame = &Frame::ResetStream {
-            stream_id: StreamId::new(0),
-            application_error_code: 0,
-            final_size: 0,
-        };
-
-        if let Frame::ResetStream { stream_id, .. } = token {
-            qinfo!("Reset received stream={}", stream_id.as_u64());
-
-            if self
-                .from_streams
-                .remove(&(*stream_id, mem::discriminant(RESET_STREAM)))
-                .is_some()
-            {
-                qinfo!("Removed RESET_STREAM frame for {}", stream_id.as_u64());
-            }
-
-            send_streams.reset_acked(*stream_id);
-        }
-    }
-
     pub(crate) fn lost(
         &mut self,
         token: &FlowControlRecoveryToken,
-        send_streams: &mut SendStreams,
         recv_streams: &mut RecvStreams,
         indexes: &mut StreamIndexes,
     ) {
         match *token {
-            // Always resend ResetStream if lost
-            Frame::ResetStream {
-                stream_id,
-                application_error_code,
-                final_size,
-            } => {
-                qinfo!(
-                    "Reset lost stream={} err={} final_size={}",
-                    stream_id.as_u64(),
-                    application_error_code,
-                    final_size
-                );
-                if send_streams.get(stream_id).is_ok() {
-                    self.stream_reset(stream_id, application_error_code, final_size);
-                }
-            }
             // Resend MaxStreams if lost (with updated value)
             Frame::MaxStreams { stream_type, .. } => {
                 let local_max = match stream_type {
@@ -232,18 +127,6 @@ impl FlowMgr {
                 self.max_streams(*local_max, stream_type)
             }
             // Only resend "*Blocked" frames if still blocked
-            Frame::DataBlocked { .. } => {
-                if self.conn_credit_avail() == 0 {
-                    self.data_blocked()
-                }
-            }
-            Frame::StreamDataBlocked { stream_id, .. } => {
-                if let Ok(ss) = send_streams.get(stream_id) {
-                    if ss.credit_avail() == 0 {
-                        self.stream_data_blocked(stream_id, ss.max_stream_data())
-                    }
-                }
-            }
             Frame::StreamsBlocked { stream_type, .. } => match stream_type {
                 StreamType::UniDi => {
                     if indexes.remote_next_stream_uni >= indexes.remote_max_stream_uni {
@@ -281,77 +164,36 @@ impl FlowMgr {
         while let Some(frame) = self.peek() {
             // All these frames are bags of varints, so we can just extract the
             // varints and use common code for writing.
-            let values: SmallVec<[_; 3]> = match frame {
-                Frame::ResetStream {
-                    stream_id,
-                    application_error_code,
-                    final_size,
-                } => {
-                    stats.reset_stream += 1;
-                    smallvec![stream_id.as_u64(), *application_error_code, *final_size]
-                }
+            let (mut values, stat): (SmallVec<[_; 3]>, _) = match frame {
                 Frame::StopSending {
                     stream_id,
                     application_error_code,
-                } => {
-                    stats.stop_sending += 1;
-                    smallvec![stream_id.as_u64(), *application_error_code]
-                }
-
+                } => (
+                    smallvec![stream_id.as_u64(), *application_error_code],
+                    &mut stats.stop_sending,
+                ),
                 Frame::MaxStreams {
                     maximum_streams, ..
-                } => {
-                    stats.max_streams += 1;
-                    smallvec![maximum_streams.as_u64()]
-                }
+                } => (smallvec![maximum_streams.as_u64()], &mut stats.max_streams),
                 Frame::StreamsBlocked { stream_limit, .. } => {
-                    stats.streams_blocked += 1;
-                    smallvec![stream_limit.as_u64()]
+                    (smallvec![stream_limit.as_u64()], &mut stats.streams_blocked)
                 }
-
-                Frame::MaxData { maximum_data } => {
-                    stats.max_data += 1;
-                    smallvec![*maximum_data]
-                }
-                Frame::DataBlocked { data_limit } => {
-                    stats.data_blocked += 1;
-                    smallvec![*data_limit]
-                }
-
+                Frame::MaxData { maximum_data } => (smallvec![*maximum_data], &mut stats.max_data),
                 Frame::MaxStreamData {
                     stream_id,
                     maximum_stream_data,
-                } => {
-                    stats.max_stream_data += 1;
-                    smallvec![stream_id.as_u64(), *maximum_stream_data]
-                }
-                Frame::StreamDataBlocked {
-                    stream_id,
-                    stream_data_limit,
-                } => {
-                    stats.stream_data_blocked += 1;
-                    smallvec![stream_id.as_u64(), *stream_data_limit]
-                }
-
+                } => (
+                    smallvec![stream_id.as_u64(), *maximum_stream_data],
+                    &mut stats.max_stream_data,
+                ),
                 _ => unreachable!("{:?}", frame),
             };
+            values.insert(0, frame.get_type());
             debug_assert!(!values.spilled());
 
-            if builder.remaining()
-                >= Encoder::varint_len(frame.get_type())
-                    + values
-                        .iter()
-                        .map(|&v| Encoder::varint_len(v))
-                        .sum::<usize>()
-            {
-                builder.encode_varint(frame.get_type());
-                for v in values {
-                    builder.encode_varint(v);
-                }
-                if builder.len() > builder.limit() {
-                    return Err(Error::InternalError(16));
-                }
+            if write_varint_frame(builder, &values)? {
                 tokens.push(RecoveryToken::Flow(self.next().unwrap()));
+                *stat += 1;
             } else {
                 return Ok(());
             }

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -6,10 +6,10 @@
 
 // Directly relating to QUIC frames.
 
-use neqo_common::{qtrace, Decoder};
+use neqo_common::{qtrace, Decoder, Encoder};
 
 use crate::cid::MAX_CONNECTION_ID_LEN;
-use crate::packet::PacketType;
+use crate::packet::{PacketBuilder, PacketType};
 use crate::stream_id::{StreamId, StreamIndex, StreamType};
 use crate::{AppError, ConnectionError, Error, Res, TransportError};
 
@@ -23,20 +23,20 @@ const FRAME_TYPE_PADDING: FrameType = 0x0;
 pub const FRAME_TYPE_PING: FrameType = 0x1;
 pub const FRAME_TYPE_ACK: FrameType = 0x2;
 const FRAME_TYPE_ACK_ECN: FrameType = 0x3;
-const FRAME_TYPE_RST_STREAM: FrameType = 0x4;
+pub const FRAME_TYPE_RESET_STREAM: FrameType = 0x4;
 const FRAME_TYPE_STOP_SENDING: FrameType = 0x5;
 pub const FRAME_TYPE_CRYPTO: FrameType = 0x6;
 pub const FRAME_TYPE_NEW_TOKEN: FrameType = 0x7;
 const FRAME_TYPE_STREAM: FrameType = 0x8;
 const FRAME_TYPE_STREAM_MAX: FrameType = 0xf;
-const FRAME_TYPE_MAX_DATA: FrameType = 0x10;
-const FRAME_TYPE_MAX_STREAM_DATA: FrameType = 0x11;
-const FRAME_TYPE_MAX_STREAMS_BIDI: FrameType = 0x12;
-const FRAME_TYPE_MAX_STREAMS_UNIDI: FrameType = 0x13;
-const FRAME_TYPE_DATA_BLOCKED: FrameType = 0x14;
-const FRAME_TYPE_STREAM_DATA_BLOCKED: FrameType = 0x15;
-const FRAME_TYPE_STREAMS_BLOCKED_BIDI: FrameType = 0x16;
-const FRAME_TYPE_STREAMS_BLOCKED_UNIDI: FrameType = 0x17;
+pub const FRAME_TYPE_MAX_DATA: FrameType = 0x10;
+pub const FRAME_TYPE_MAX_STREAM_DATA: FrameType = 0x11;
+pub const FRAME_TYPE_MAX_STREAMS_BIDI: FrameType = 0x12;
+pub const FRAME_TYPE_MAX_STREAMS_UNIDI: FrameType = 0x13;
+pub const FRAME_TYPE_DATA_BLOCKED: FrameType = 0x14;
+pub const FRAME_TYPE_STREAM_DATA_BLOCKED: FrameType = 0x15;
+pub const FRAME_TYPE_STREAMS_BLOCKED_BIDI: FrameType = 0x16;
+pub const FRAME_TYPE_STREAMS_BLOCKED_UNIDI: FrameType = 0x17;
 pub const FRAME_TYPE_NEW_CONNECTION_ID: FrameType = 0x18;
 pub const FRAME_TYPE_RETIRE_CONNECTION_ID: FrameType = 0x19;
 pub const FRAME_TYPE_PATH_CHALLENGE: FrameType = 0x1a;
@@ -91,6 +91,26 @@ impl From<ConnectionError> for CloseError {
 pub struct AckRange {
     pub(crate) gap: u64,
     pub(crate) range: u64,
+}
+
+/// A lot of frames here are just a collection of varints.
+/// This helper functions writes a frame like that safely, returning `true` if
+/// a frame was written.
+pub fn write_varint_frame(builder: &mut PacketBuilder, values: &[u64]) -> Res<bool> {
+    let write = builder.remaining()
+        >= values
+            .iter()
+            .map(|&v| Encoder::varint_len(v))
+            .sum::<usize>();
+    if write {
+        for v in values {
+            builder.encode_varint(*v);
+        }
+        if builder.len() > builder.limit() {
+            return Err(Error::InternalError(16));
+        }
+    };
+    Ok(write)
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -194,7 +214,7 @@ impl<'a> Frame<'a> {
             Self::Padding => FRAME_TYPE_PADDING,
             Self::Ping => FRAME_TYPE_PING,
             Self::Ack { .. } => FRAME_TYPE_ACK, // We don't do ACK ECN.
-            Self::ResetStream { .. } => FRAME_TYPE_RST_STREAM,
+            Self::ResetStream { .. } => FRAME_TYPE_RESET_STREAM,
             Self::StopSending { .. } => FRAME_TYPE_STOP_SENDING,
             Self::Crypto { .. } => FRAME_TYPE_CRYPTO,
             Self::NewToken { .. } => FRAME_TYPE_NEW_TOKEN,
@@ -348,7 +368,7 @@ impl<'a> Frame<'a> {
         match t {
             FRAME_TYPE_PADDING => Ok(Self::Padding),
             FRAME_TYPE_PING => Ok(Self::Ping),
-            FRAME_TYPE_RST_STREAM => Ok(Self::ResetStream {
+            FRAME_TYPE_RESET_STREAM => Ok(Self::ResetStream {
                 stream_id: StreamId::from(dv(dec)?),
                 application_error_code: d(dec.decode_varint())?,
                 final_size: match dec.decode_varint() {

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -16,6 +16,7 @@ mod connection;
 mod crypto;
 mod dump;
 mod events;
+mod fc;
 mod flow_mgr;
 mod frame;
 mod pace;

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -28,6 +28,7 @@ use crate::qlog::{self, QlogMetric};
 use crate::rtt::RttEstimate;
 use crate::send_stream::StreamRecoveryToken;
 use crate::stats::{Stats, StatsCell};
+use crate::stream_id::StreamId;
 use crate::tracking::{AckToken, PNSpace, PNSpaceSet, SentPacket};
 
 pub(crate) const PACKET_THRESHOLD: u64 = 3;
@@ -49,6 +50,9 @@ pub enum RecoveryToken {
     NewToken(usize),
     NewConnectionId(ConnectionIdEntry<[u8; 16]>),
     RetireConnectionId(u64),
+    DataBlocked(u64),
+    StreamDataBlocked { stream_id: StreamId, limit: u64 },
+    ResetStream { stream_id: StreamId },
 }
 
 /// `SendProfile` tells a sender how to send packets.

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -671,7 +671,7 @@ impl SendStream {
         (length, false)
     }
 
-    /// Write a `STREAM` frame, return true if it was written.
+    /// Maybe write a `STREAM` frame.
     fn write_stream_frame(
         &mut self,
         priority: TransmissionPriority,
@@ -762,6 +762,7 @@ impl SendStream {
         }
     }
 
+    /// Maybe write a `RESET_STREAM` frame.
     pub fn write_reset_frame(
         &mut self,
         p: TransmissionPriority,
@@ -811,6 +812,7 @@ impl SendStream {
         }
     }
 
+    /// Maybe write a `STREAM_DATA_BLOCKED` frame.
     pub fn write_blocked_frame(
         &mut self,
         priority: TransmissionPriority,


### PR DESCRIPTION
This is the first step of my attempt to eliminate `FlowMgr`.  This creates a new flow control object for sending, which is used for `SendStream` and connection-level flow control.  That object sends `*_BLOCKED` frames more precisely, avoiding unnecessary retransmissions.  Previously, we would send these on multiple occasions especially when `send_atomic` was used; now we just send them when we hit a limit and only retransmit if that frame is lost *and the limit hasn't increased*.

I haven't used this new object for sending `STREAMS_BLOCKED` yet as that requires touching a different piece of code.  That change can come later.  This change is limited to the sending code.

The effect is that `STREAM_DATA_BLOCKED` is sent at the same priority as data on that stream.  

I've moved `RESET_STREAM` sending also.  `RESET_STREAM` is sent at the stream priority too.

There is one tweak that I made to receiving: when we receive `STREAM_DATA_BLOCKED` we will now update the flow control limit immediately, without waiting for the consumed amount to hit half of our limit.  This was to make testing possible.  With the changes, it was no longer possible to send an arbitrary `STREAM_DATA_BLOCKED` frame, which the test was exploiting (in a bad way).

There was also a small bug in `FlowMgr` that I fixed.  We were counting frame stats if there wasn't enough space to send.