### PR TITLE
Clippy 1.50

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -764,9 +764,8 @@ mod tests {
         enc.encode_vvec_with(|enc_inner| {
             enc_inner.encode(&[0xa5; 65]);
         });
-        let mut v: Vec<u8> = enc.into();
-        let _ = v.split_off(3);
-        assert_eq!(v, vec![0x40, 0x41, 0xa5]);
+        let v: Vec<u8> = enc.into();
+        assert_eq!(&v[..3], &[0x40, 0x41, 0xa5]);
     }
 
     // Test that Deref to &[u8] works for Encoder.

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -54,7 +54,10 @@ pub enum Http3State {
 impl Http3State {
     #[must_use]
     pub fn active(&self) -> bool {
-        matches!(self, Http3State::Connected | Http3State::GoingAway(_) | Http3State::ZeroRtt)
+        matches!(
+            self,
+            Http3State::Connected | Http3State::GoingAway(_) | Http3State::ZeroRtt
+        )
     }
 }
 
@@ -398,7 +401,7 @@ impl Http3Connection {
                 Ok(true)
             }
             State::Closing { error, .. } | State::Draining { error, .. } => {
-                if matches!(self.state, Http3State::Closing(_)| Http3State::Closed(_)) {
+                if matches!(self.state, Http3State::Closing(_) | Http3State::Closed(_)) {
                     Ok(false)
                 } else {
                     self.state = Http3State::Closing(error.clone());
@@ -569,7 +572,10 @@ impl Http3Connection {
     fn handle_control_frame(&mut self, f: HFrame) -> Res<Option<HFrame>> {
         qinfo!([self], "Handle a control frame {:?}", f);
         if !matches!(f, HFrame::Settings { .. })
-            && !matches!(self.settings_state, Http3RemoteSettingsState::Received{..})
+            && !matches!(
+                self.settings_state,
+                Http3RemoteSettingsState::Received { .. }
+            )
         {
             return Err(Error::HttpMissingSettings);
         }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -226,7 +226,10 @@ impl Http3Client {
         S: AsRef<str> + Display,
     {
         qinfo!([self], "Close the connection error={} msg={}.", error, msg);
-        if !matches!(self.base_handler.state, Http3State::Closing(_)| Http3State::Closed(_)) {
+        if !matches!(
+            self.base_handler.state,
+            Http3State::Closing(_) | Http3State::Closed(_)
+        ) {
             self.push_handler.borrow_mut().clear();
             self.conn.close(now, error, msg);
             self.base_handler.close(error);
@@ -4468,28 +4471,21 @@ mod tests {
         let any_push_event = |e| {
             matches!(
                 e,
-                Http3ClientEvent::PushPromise{..}
-                | Http3ClientEvent::PushHeaderReady{..}
-                | Http3ClientEvent::PushDataReadable{..})
+                Http3ClientEvent::PushPromise { .. }
+                    | Http3ClientEvent::PushHeaderReady { .. }
+                    | Http3ClientEvent::PushDataReadable { .. }
+            )
         };
         client.events().any(any_push_event)
     }
 
     fn check_data_readable(client: &mut Http3Client) -> bool {
-        let any_data_event = |e| {
-            matches!(
-                e,
-                Http3ClientEvent::DataReadable{..})
-        };
+        let any_data_event = |e| matches!(e, Http3ClientEvent::DataReadable { .. });
         client.events().any(any_data_event)
     }
 
     fn check_header_ready(client: &mut Http3Client) -> bool {
-        let any_event = |e| {
-            matches!(
-                e,
-                Http3ClientEvent::HeaderReady{..})
-        };
+        let any_event = |e| matches!(e, Http3ClientEvent::HeaderReady { .. });
         client.events().any(any_event)
     }
 
@@ -4497,8 +4493,8 @@ mod tests {
         let any_event = |e| {
             matches!(
                 e,
-                Http3ClientEvent::HeaderReady{..}
-                | Http3ClientEvent::PushPromise{..})
+                Http3ClientEvent::HeaderReady { .. } | Http3ClientEvent::PushPromise { .. }
+            )
         };
         client.events().any(any_event)
     }
@@ -4744,7 +4740,7 @@ mod tests {
         send_push_promise_and_exchange_packets(&mut client, &mut server, request_stream_id_2, 5);
 
         // Check that we do not have a Http3ClientEvent::PushPromise.
-        let push_event = |e| matches!(e, Http3ClientEvent::PushPromise{ .. });
+        let push_event = |e| matches!(e, Http3ClientEvent::PushPromise { .. });
         assert!(!client.events().any(push_event));
     }
 

--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -214,9 +214,8 @@ impl HFrameReader {
             if fin {
                 if self.decoding_in_progress() {
                     break Err(Error::HttpFrame);
-                } else {
-                    break Ok((None, fin));
                 }
+                break Ok((None, fin));
             }
 
             if !read {
@@ -266,12 +265,11 @@ impl HFrameReader {
                         | H3_FRAME_TYPE_HEADERS => {
                             if len == 0 {
                                 return Ok(Some(self.get_frame()?));
-                            } else {
-                                HFrameReaderState::GetData {
-                                    decoder: IncrementalDecoderBuffer::new(
-                                        usize::try_from(len).or(Err(Error::HttpFrame))?,
-                                    ),
-                                }
+                            }
+                            HFrameReaderState::GetData {
+                                decoder: IncrementalDecoderBuffer::new(
+                                    usize::try_from(len).or(Err(Error::HttpFrame))?,
+                                ),
                             }
                         }
                         _ => {

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -322,7 +322,7 @@ impl PushController {
     pub fn close(&mut self, push_id: u64) {
         qtrace!("Push stream has been closed.");
         if let Some(push_state) = self.push_streams.close(push_id) {
-            debug_assert!(matches!(push_state, PushState::Active{..}));
+            debug_assert!(matches!(push_state, PushState::Active { .. }));
         } else {
             debug_assert!(false, "Closing non existing push stream!");
         }

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -268,7 +268,9 @@ impl RecvMessage {
                             if matches!(self.state, RecvMessageState::Closed) {
                                 break Ok(());
                             }
-                            if fin && !matches!(self.state, RecvMessageState::DecodingHeaders{..}) {
+                            if fin
+                                && !matches!(self.state, RecvMessageState::DecodingHeaders { .. })
+                            {
                                 break self.set_state_to_close_pending(post_readable_event);
                             }
                         }

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -106,9 +106,8 @@ impl RecvMessage {
             RecvMessageState::WaitingForResponseHeaders {..} => {
                 if header_block.is_empty() {
                     return Err(Error::HttpGeneralProtocolStream);
-                } else {
-                    self.state = RecvMessageState::DecodingHeaders { header_block, fin };
                 }
+                    self.state = RecvMessageState::DecodingHeaders { header_block, fin };
              }
             RecvMessageState::WaitingForData { ..} => {
                 // TODO implement trailers, for now just ignore them.

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -271,7 +271,10 @@ impl SendMessage {
     // This method returns if they're still being sent. Request body (if any) is sent by
     // http client afterwards using `send_request_body` after receiving DataWritable event.
     pub fn has_data_to_send(&self) -> bool {
-        matches!(self.state, SendMessageState::Initialized {..} | SendMessageState::SendingInitialMessage { .. } )
+        matches!(
+            self.state,
+            SendMessageState::Initialized { .. } | SendMessageState::SendingInitialMessage { .. }
+        )
     }
 
     pub fn close(&mut self, conn: &mut Connection) -> Res<()> {

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -283,15 +283,27 @@ mod tests {
     }
 
     fn assert_connected(hconn: &mut Http3Server) {
-        let connected =
-            |e| matches!(e, Http3ServerEvent::StateChange{ state: Http3State::Connected, ..} );
+        let connected = |e| {
+            matches!(
+                e,
+                Http3ServerEvent::StateChange {
+                    state: Http3State::Connected,
+                    ..
+                }
+            )
+        };
         assert!(hconn.events().any(connected));
     }
 
     fn assert_not_closed(hconn: &mut Http3Server) {
         let closed = |e| {
-            matches!(e,
-            Http3ServerEvent::StateChange{ state: Http3State::Closing(..), .. })
+            matches!(
+                e,
+                Http3ServerEvent::StateChange {
+                    state: Http3State::Closing(..),
+                    ..
+                }
+            )
         };
         assert!(!hconn.events().any(closed));
     }

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -674,7 +674,7 @@ impl Handler for VnHandler {
     }
 }
 
-fn test_vn(nctx: &NetworkCtx, peer: &Peer) -> Result<Connection, String> {
+fn test_vn(nctx: &NetworkCtx, peer: &Peer) -> Connection {
     let mut client = Connection::new_client(
         peer.host,
         &["hq-28"],
@@ -688,8 +688,7 @@ fn test_vn(nctx: &NetworkCtx, peer: &Peer) -> Result<Connection, String> {
     // Temporary here to help out the type inference engine
     let mut h = VnHandler {};
     let _res = process_loop(nctx, &mut client, &mut h);
-
-    Ok(client)
+    client
 }
 
 fn run_test<'t>(peer: &Peer, test: &'t Test) -> (&'t Test, String) {
@@ -706,15 +705,12 @@ fn run_test<'t>(peer: &Peer, test: &'t Test) -> (&'t Test, String) {
     };
 
     if let Test::VN = test {
-        let res = test_vn(&nctx, peer);
-        return match res {
-            Err(e) => (test, format!("ERROR: {}", e)),
-            Ok(client) => match client.state() {
-                State::Closed(ConnectionError::Transport(Error::VersionNegotiation)) => {
-                    (test, String::from("OK"))
-                }
-                _ => (test, format!("ERROR: Wrong state {:?}", client.state())),
-            },
+        let client = test_vn(&nctx, peer);
+        return match client.state() {
+            State::Closed(ConnectionError::Transport(Error::VersionNegotiation)) => {
+                (test, String::from("OK"))
+            }
+            _ => (test, format!("ERROR: Wrong state {:?}", client.state())),
         };
     }
 

--- a/neqo-qpack/src/header_block.rs
+++ b/neqo-qpack/src/header_block.rs
@@ -316,9 +316,8 @@ impl<'a> HeaderDecoder<'a> {
             if req_insert_cnt > max_value {
                 if req_insert_cnt < full_range {
                     return Err(Error::DecompressionFailed);
-                } else {
-                    req_insert_cnt -= full_range;
                 }
+                req_insert_cnt -= full_range;
             }
             Ok(req_insert_cnt)
         }

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -290,12 +290,10 @@ impl LiteralReader {
                         self.state = LiteralReaderState::Done;
                         if self.use_huffman {
                             break Ok(decode_huffman(&self.literal)?);
-                        } else {
-                            break Ok(mem::replace(&mut self.literal, Vec::new()));
                         }
-                    } else {
-                        break Err(Error::NeedMoreData);
+                        break Ok(mem::replace(&mut self.literal, Vec::new()));
                     }
+                    break Err(Error::NeedMoreData);
                 }
                 LiteralReaderState::Done => {
                     panic!("Should not call read() in this state.");

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1160,7 +1160,10 @@ impl Connection {
                         if versions.is_empty()
                             || versions.contains(&self.version().as_u32())
                             || packet.dcid() != self.odcid().unwrap()
-                            || matches!(self.address_validation, AddressValidationInfo::Retry { .. })
+                            || matches!(
+                                self.address_validation,
+                                AddressValidationInfo::Retry { .. }
+                            )
                         {
                             // Ignore VersionNegotiation packets that contain the current version.
                             // Or don't have the right connection ID.
@@ -2750,7 +2753,10 @@ impl Connection {
         } else if mem::discriminant(&state) != mem::discriminant(&self.state) {
             // Only tolerate a regression in state if the new state is closing
             // and the connection is already closed.
-            debug_assert!(matches!(state, State::Closing { .. } | State::Draining { .. }));
+            debug_assert!(matches!(
+                state,
+                State::Closing { .. } | State::Draining { .. }
+            ));
             debug_assert!(self.state.closed());
         }
     }

--- a/neqo-transport/src/connection/state.rs
+++ b/neqo-transport/src/connection/state.rs
@@ -46,7 +46,10 @@ impl State {
 
     #[must_use]
     pub fn closed(&self) -> bool {
-        matches!(self, Self::Closing { .. } | Self::Draining { .. } | Self::Closed(_))
+        matches!(
+            self,
+            Self::Closing { .. } | Self::Draining { .. } | Self::Closed(_)
+        )
     }
 }
 

--- a/neqo-transport/src/connection/tests/cc.rs
+++ b/neqo-transport/src/connection/tests/cc.rs
@@ -19,6 +19,7 @@ use crate::tracking::MAX_UNACKED_PKTS;
 
 use neqo_common::{qdebug, qinfo, qtrace, Datagram};
 use std::convert::TryFrom;
+use std::mem;
 use std::time::{Duration, Instant};
 
 // Get the current congestion window for the connection.
@@ -361,7 +362,7 @@ fn cc_slow_start_to_persistent_congestion_no_acks() {
 
     // Server: Receive and generate ack
     now += DEFAULT_RTT / 2;
-    let _ = ack_bytes(&mut server, 0, c_tx_dgrams, now);
+    mem::drop(ack_bytes(&mut server, 0, c_tx_dgrams, now));
 
     // ACK lost.
     induce_persistent_congestion(&mut client, &mut server, now);
@@ -414,7 +415,7 @@ fn cc_persistent_congestion_to_slow_start() {
 
     // Server: Receive and generate ack
     now += Duration::from_millis(10);
-    let _ = ack_bytes(&mut server, 0, c_tx_dgrams, now);
+    mem::drop(ack_bytes(&mut server, 0, c_tx_dgrams, now));
 
     // ACK lost.
 

--- a/neqo-transport/src/connection/tests/keys.rs
+++ b/neqo-transport/src/connection/tests/keys.rs
@@ -277,9 +277,13 @@ fn exhaust_read_keys() {
     ));
 
     client.process_input(dgram.unwrap(), now());
-    assert!(matches!(client.state(), State::Draining {
-        error: ConnectionError::Transport(Error::PeerError(ERROR_AEAD_LIMIT_REACHED)), ..
-    }));
+    assert!(matches!(
+        client.state(),
+        State::Draining {
+            error: ConnectionError::Transport(Error::PeerError(ERROR_AEAD_LIMIT_REACHED)),
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -146,7 +146,12 @@ fn handshake(
     let mut now = now;
 
     let mut input = None;
-    let is_done = |c: &mut Connection| matches!(c.state(), State::Confirmed | State::Closing { .. } | State::Closed(..));
+    let is_done = |c: &mut Connection| {
+        matches!(
+            c.state(),
+            State::Confirmed | State::Closing { .. } | State::Closed(..)
+        )
+    };
 
     while !is_done(a) {
         let _ = maybe_authenticate(a);

--- a/neqo-transport/src/connection/tests/priority.rs
+++ b/neqo-transport/src/connection/tests/priority.rs
@@ -12,6 +12,7 @@ use crate::{ConnectionEvent, StreamType};
 
 use neqo_common::event::Provider;
 use std::cell::RefCell;
+use std::mem;
 use std::rc::Rc;
 use test_fixture::{self, now};
 
@@ -239,7 +240,7 @@ fn critical() {
 
     // Critical beats everything but HANDSHAKE_DONE.
     let stats_before = server.stats().frame_tx;
-    let _ = fill_cwnd(&mut server, id, now);
+    mem::drop(fill_cwnd(&mut server, id, now));
     let stats_after = server.stats().frame_tx;
     assert_eq!(stats_after.crypto, stats_before.crypto);
     assert_eq!(stats_after.streams_blocked, 0);
@@ -291,7 +292,7 @@ fn important() {
 
     // Important beats everything but flow control.
     let stats_before = server.stats().frame_tx;
-    let _ = fill_cwnd(&mut server, id, now);
+    mem::drop(fill_cwnd(&mut server, id, now));
     let stats_after = server.stats().frame_tx;
     assert_eq!(stats_after.crypto, stats_before.crypto);
     assert_eq!(stats_after.streams_blocked, 1);
@@ -346,7 +347,7 @@ fn high_normal() {
     // but they beat CRYPTO/NEW_TOKEN.
     let stats_before = server.stats().frame_tx;
     server.send_ticket(now, &[]).unwrap();
-    let _ = fill_cwnd(&mut server, id, now);
+    mem::drop(fill_cwnd(&mut server, id, now));
     let stats_after = server.stats().frame_tx;
     assert_eq!(stats_after.crypto, stats_before.crypto);
     assert_eq!(stats_after.streams_blocked, 1);

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -130,7 +130,7 @@ fn report_fin_when_stream_closed_wo_data() {
     server.stream_close_send(stream_id).unwrap();
     let out = server.process(None, now());
     let _ = client.process(out.dgram(), now());
-    let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable {..});
+    let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
     assert!(client.events().any(stream_readable));
 }
 
@@ -203,7 +203,10 @@ fn max_data() {
 
     let evts = client.events().collect::<Vec<_>>();
     assert_eq!(evts.len(), 1);
-    assert!(matches!(evts[0], ConnectionEvent::SendStreamWritable{..}));
+    assert!(matches!(
+        evts[0],
+        ConnectionEvent::SendStreamWritable { .. }
+    ));
 }
 
 #[test]
@@ -221,7 +224,7 @@ fn do_not_accept_data_after_stop_sending() {
     let out = client.process(None, now());
     let _ = server.process(out.dgram(), now());
 
-    let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable {..});
+    let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
     assert!(server.events().any(stream_readable));
 
     // Send one more packet from client. The packet should arrive after the server
@@ -504,7 +507,7 @@ fn no_dupdata_readable_events() {
     let _ = server.process(out.dgram(), now());
 
     // We have a data_readable event.
-    let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable {..});
+    let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
     assert!(server.events().any(stream_readable));
 
     // Send one more data frame from client. The previous stream data has not been read yet,
@@ -536,7 +539,7 @@ fn no_dupdata_readable_events_empty_last_frame() {
     let _ = server.process(out.dgram(), now());
 
     // We have a data_readable event.
-    let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable {..});
+    let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
     assert!(server.events().any(stream_readable));
 
     // An empty frame with a fin will not produce a new DataReadable event, because

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -1182,7 +1182,7 @@ impl CryptoStreams {
                     *self = Self::ApplicationData {
                         application: mem::take(application),
                     };
-                } else if matches!(self, Self::Initial {..}) {
+                } else if matches!(self, Self::Initial { .. }) {
                     panic!("Discarding handshake before initial discarded");
                 }
             }

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -259,17 +259,22 @@ impl<'a> Frame<'a> {
     /// If the frame causes a recipient to generate an ACK within its
     /// advertised maximum acknowledgement delay.
     pub fn ack_eliciting(&self) -> bool {
-        !matches!(self, Self::Ack { .. } | Self::Padding | Self::ConnectionClose { .. })
+        !matches!(
+            self,
+            Self::Ack { .. } | Self::Padding | Self::ConnectionClose { .. }
+        )
     }
 
     /// If the frame can be sent in a path probe
     /// without initiating migration to that path.
     pub fn path_probing(&self) -> bool {
-        matches!(self,
+        matches!(
+            self,
             Self::Padding
-            | Self::NewConnectionId { .. }
-            | Self::PathChallenge { .. }
-            | Self::PathResponse { .. })
+                | Self::NewConnectionId { .. }
+                | Self::PathChallenge { .. }
+                | Self::PathResponse { .. }
+        )
     }
 
     /// Converts AckRanges as encoded in a ACK frame (see -transport

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -1087,7 +1087,10 @@ mod tests {
 
         s.inbound_stream_frame(false, 0, &frame1).unwrap();
         flow_mgr.borrow_mut().max_stream_data(stream_id, 100);
-        assert!(matches!(s.flow_mgr.borrow().peek().unwrap(), Frame::MaxStreamData{..}));
+        assert!(matches!(
+            s.flow_mgr.borrow().peek().unwrap(),
+            Frame::MaxStreamData { .. }
+        ));
         s.inbound_stream_frame(true, RX_STREAM_DATA_WINDOW, &[])
             .unwrap();
         assert!(matches!(s.flow_mgr.borrow().peek(), None));
@@ -1122,6 +1125,9 @@ mod tests {
         assert!(matches!(s.flow_mgr.borrow().peek(), None));
         // But if lost, another frame is generated
         flow_mgr.borrow_mut().max_stream_data(stream_id, 100);
-        assert!(matches!(s.flow_mgr.borrow_mut().next().unwrap(), Frame::MaxStreamData{..}));
+        assert!(matches!(
+            s.flow_mgr.borrow_mut().next().unwrap(),
+            Frame::MaxStreamData { .. }
+        ));
     }
 }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -933,7 +933,10 @@ impl SendStream {
     }
 
     pub fn is_terminal(&self) -> bool {
-        matches!(self.state, SendStreamState::DataRecvd { .. } | SendStreamState::ResetRecvd)
+        matches!(
+            self.state,
+            SendStreamState::DataRecvd { .. } | SendStreamState::ResetRecvd
+        )
     }
 
     pub fn send(&mut self, buf: &[u8]) -> Res<usize> {
@@ -974,7 +977,7 @@ impl SendStream {
             });
         }
 
-        if !matches!(self.state, SendStreamState::Send{..}) {
+        if !matches!(self.state, SendStreamState::Send { .. }) {
             return Err(Error::FinalSizeError);
         }
 
@@ -1502,7 +1505,10 @@ mod tests {
         s.set_max_stream_data(2);
         let evts = conn_events.events().collect::<Vec<_>>();
         assert_eq!(evts.len(), 1);
-        assert!(matches!(evts[0], ConnectionEvent::SendStreamWritable{..}));
+        assert!(matches!(
+            evts[0],
+            ConnectionEvent::SendStreamWritable { .. }
+        ));
         assert_eq!(s.send(b"hello").unwrap(), 2);
 
         // increasing to (conn:2, stream:4) will not generate an event or allow
@@ -1558,7 +1564,10 @@ mod tests {
         // an event.
         let evts = conn_events.events().collect::<Vec<_>>();
         assert_eq!(evts.len(), 1);
-        assert!(matches!(evts[0], ConnectionEvent::SendStreamWritable{..}));
+        assert!(matches!(
+            evts[0],
+            ConnectionEvent::SendStreamWritable { .. }
+        ));
     }
 
     #[test]

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -98,7 +98,12 @@ fn complete_connection(
     server: &mut Server,
     mut datagram: Option<Datagram>,
 ) -> ActiveConnectionRef {
-    let is_done = |c: &Connection| matches!(c.state(), State::Confirmed | State::Closing { .. } | State::Closed(..));
+    let is_done = |c: &Connection| {
+        matches!(
+            c.state(),
+            State::Confirmed | State::Closing { .. } | State::Closed(..)
+        )
+    };
     while !is_done(client) {
         let _ = test_fixture::maybe_authenticate(client);
         let out = client.process(datagram, now());
@@ -881,7 +886,7 @@ fn mitm_retry() {
     assert!(dgram.is_some()); // Client sending CLOSE_CONNECTIONs
     assert!(matches!(
         *client.state(),
-        State::Closing{
+        State::Closing {
             error: ConnectionError::Transport(Error::ProtocolViolation),
             ..
         }

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -170,7 +170,12 @@ pub fn handshake(client: &mut Connection, server: &mut Connection) {
     let mut a = client;
     let mut b = server;
     let mut datagram = None;
-    let is_done = |c: &Connection| matches!(c.state(), State::Confirmed | State::Closing { .. } | State::Closed(..));
+    let is_done = |c: &Connection| {
+        matches!(
+            c.state(),
+            State::Confirmed | State::Closing { .. } | State::Closed(..)
+        )
+    };
     while !is_done(a) {
         let _ = maybe_authenticate(a);
         let d = a.process(datagram, now());


### PR DESCRIPTION
These are one of three things:

1. Unnecessary else (after return/break on the main arm)
2. Unnecessary Result (when all returned values are Ok(T)
3. Non-binding assignment when the value implements Drop

None of these were tricky, just keeping new versions of Rust usable.

Note: built on #1104.