### PR TITLE
Send a PING with ACK occasionally

### DIFF
--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -655,7 +655,7 @@ fn ping_with_ack(fast: bool) {
 
     if !fast {
         // Wait at least one PTO, from the reciever's perspective.
-        // After this it should send a PING to force the sender to acknowledge.
+        // A receiver that hasn't received MAX_OUTSTANDING_UNACK won't send PING.
         now += receiver.pto() + Duration::from_micros(1);
         trickle(&mut sender, &mut receiver, 1, now);
         assert_eq!(receiver.stats().frame_tx.ping, 0);

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -4,14 +4,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::super::{Output, State, LOCAL_IDLE_TIMEOUT};
+use super::super::{Connection, Output, State, LOCAL_IDLE_TIMEOUT};
 use super::{
     assert_full_cwnd, connect, connect_force_idle, connect_rtt_idle, connect_with_rtt,
     default_client, default_server, fill_cwnd, maybe_authenticate, send_and_receive,
     send_something, AT_LEAST_PTO, DEFAULT_RTT, POST_HANDSHAKE_CWND,
 };
 use crate::path::PATH_MTU_V6;
-use crate::recovery::PTO_PACKET_COUNT;
+use crate::recovery::{MAX_OUTSTANDING_UNACK, MIN_OUTSTANDING_UNACK, PTO_PACKET_COUNT};
 use crate::stats::MAX_PTO_COUNTS;
 use crate::tparams::TransportParameter;
 use crate::tracking::ACK_DELAY;
@@ -19,7 +19,7 @@ use crate::StreamType;
 
 use neqo_common::qdebug;
 use neqo_crypto::AuthenticationStatus;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use test_fixture::{self, now, split_datagram};
 
 #[test]
@@ -613,4 +613,92 @@ fn loss_time_past_largest_acked() {
     let delay = client.process(None, now).callback();
     assert_ne!(delay, Duration::from_secs(0));
     assert!(delay > lr_time);
+}
+
+/// `sender` sends a little, `receiver` acknowledges it.
+/// Repeat until `count` acknowledgements are sent.
+/// Returns the last packet containing acknowledgements, if any.
+fn trickle(sender: &mut Connection, receiver: &mut Connection, mut count: usize, now: Instant) {
+    let id = sender.stream_create(StreamType::UniDi).unwrap();
+    let mut maybe_ack = None;
+    while count > 0 {
+        qdebug!("trickle: remaining={}", count);
+        assert_eq!(sender.stream_send(id, &[9]).unwrap(), 1);
+        let dgram = sender.process(maybe_ack, now).dgram();
+
+        maybe_ack = receiver.process(dgram, now).dgram();
+        count -= usize::from(maybe_ack.is_some());
+    }
+    sender.process_input(maybe_ack.unwrap(), now);
+}
+
+/// Ensure that a PING frame is sent with ACK sometimes.
+/// `fast` allows testing of when `MAX_OUTSTANDING_UNACK` packets are
+/// outstanding (`fast` is `true`) within 1 PTO and when only
+/// `MIN_OUTSTANDING_UNACK` packets arrive after 2 PTOs (`fast` is `false`).
+fn ping_with_ack(fast: bool) {
+    let mut sender = default_client();
+    let mut receiver = default_server();
+    let mut now = now();
+    connect_force_idle(&mut sender, &mut receiver);
+    let sender_acks_before = sender.stats().frame_tx.ack;
+    let receiver_acks_before = receiver.stats().frame_tx.ack;
+    let count = if fast {
+        MAX_OUTSTANDING_UNACK
+    } else {
+        MIN_OUTSTANDING_UNACK
+    };
+    trickle(&mut sender, &mut receiver, count, now);
+    assert_eq!(sender.stats().frame_tx.ack, sender_acks_before);
+    assert_eq!(receiver.stats().frame_tx.ack, receiver_acks_before + count);
+    assert_eq!(receiver.stats().frame_tx.ping, 0);
+
+    if !fast {
+        // Wait at least one PTO, from the reciever's perspective.
+        // After this it should send a PING to force the sender to acknowledge.
+        now += receiver.pto() + Duration::from_micros(1);
+        trickle(&mut sender, &mut receiver, 1, now);
+        assert_eq!(receiver.stats().frame_tx.ping, 0);
+    }
+
+    // After a second PTO (or the first if fast), new acknowledgements come
+    // with a PING frame and cause an ACK to be sent by the sender.
+    now += receiver.pto() + Duration::from_micros(1);
+    trickle(&mut sender, &mut receiver, 1, now);
+    assert_eq!(receiver.stats().frame_tx.ping, 1);
+    if let Output::Callback(t) = sender.process_output(now) {
+        assert_eq!(t, ACK_DELAY);
+        assert!(sender.process_output(now + t).dgram().is_some());
+    }
+    assert_eq!(sender.stats().frame_tx.ack, sender_acks_before + 1);
+}
+
+#[test]
+fn ping_with_ack_fast() {
+    ping_with_ack(true);
+}
+
+#[test]
+fn ping_with_ack_slow() {
+    ping_with_ack(false);
+}
+
+#[test]
+fn ping_with_ack_min() {
+    const COUNT: usize = MIN_OUTSTANDING_UNACK - 2;
+    let mut sender = default_client();
+    let mut receiver = default_server();
+    let mut now = now();
+    connect_force_idle(&mut sender, &mut receiver);
+    let sender_acks_before = sender.stats().frame_tx.ack;
+    let receiver_acks_before = receiver.stats().frame_tx.ack;
+    trickle(&mut sender, &mut receiver, COUNT, now);
+    assert_eq!(sender.stats().frame_tx.ack, sender_acks_before);
+    assert_eq!(receiver.stats().frame_tx.ack, receiver_acks_before + COUNT);
+    assert_eq!(receiver.stats().frame_tx.ping, 0);
+
+    // After 3 PTO, no PING because there are too few outstanding packets.
+    now += receiver.pto() * 3 + Duration::from_micros(1);
+    trickle(&mut sender, &mut receiver, 1, now);
+    assert_eq!(receiver.stats().frame_tx.ping, 0);
 }

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -38,6 +38,12 @@ pub(crate) const ACK_ONLY_SIZE_LIMIT: usize = 256;
 /// The number of packets we send on a PTO.
 /// And the number to declare lost when the PTO timer is hit.
 pub const PTO_PACKET_COUNT: usize = 2;
+/// The preferred limit on the number of packets that are tracked.
+/// If we exceed this number, we start sending `PING` frames sooner to
+/// force the peer to acknowledge some of them.
+pub(crate) const MAX_OUTSTANDING_UNACK: usize = 200;
+/// Disable PING until this many packets are outstanding.
+pub(crate) const MIN_OUTSTANDING_UNACK: usize = 16;
 
 #[derive(Debug, Clone)]
 #[allow(clippy::module_name_repetitions)]
@@ -134,11 +140,11 @@ pub(crate) struct LossRecoverySpace {
     /// The time used to calculate the PTO timer for this space.
     /// This is the time that the last ACK-eliciting packet in this space
     /// was sent.  This might be the time that a probe was sent.
-    pto_base_time: Option<Instant>,
+    last_ack_eliciting: Option<Instant>,
     /// The number of outstanding packets in this space that are in flight.
     /// This might be less than the number of ACK-eliciting packets,
     /// because PTO packets don't count.
-    in_flight_outstanding: u64,
+    in_flight_outstanding: usize,
     sent_packets: BTreeMap<u64, SentPacket>,
     /// The time that the first out-of-order packet was sent.
     /// This is `None` if there were no out-of-order packets detected.
@@ -152,7 +158,7 @@ impl LossRecoverySpace {
             space,
             largest_acked: None,
             largest_acked_sent_time: None,
-            pto_base_time: None,
+            last_ack_eliciting: None,
             in_flight_outstanding: 0,
             sent_packets: BTreeMap::default(),
             first_ooo_time: None,
@@ -192,8 +198,8 @@ impl LossRecoverySpace {
 
     pub fn pto_base_time(&self) -> Option<Instant> {
         if self.in_flight_outstanding() {
-            debug_assert!(self.pto_base_time.is_some());
-            self.pto_base_time
+            debug_assert!(self.last_ack_eliciting.is_some());
+            self.last_ack_eliciting
         } else if self.space == PNSpace::ApplicationData {
             None
         } else {
@@ -202,25 +208,43 @@ impl LossRecoverySpace {
             // of the handshake.  Technically, this has to stop once we receive
             // an ACK of Handshake or 1-RTT, or when we receive HANDSHAKE_DONE,
             // but a few extra probes won't hurt.
+            // It only means that we fail anti-amplification tests.
             // A server shouldn't arm its PTO timer this way. The server sends
             // ack-eliciting, in-flight packets immediately so this only
             // happens when the server has nothing outstanding.  If we had
             // client authentication, this might cause some extra probes,
             // but they would be harmless anyway.
-            self.pto_base_time
+            self.last_ack_eliciting
         }
     }
 
     pub fn on_packet_sent(&mut self, sent_packet: SentPacket) {
         if sent_packet.ack_eliciting() {
-            self.pto_base_time = Some(sent_packet.time_sent);
+            self.last_ack_eliciting = Some(sent_packet.time_sent);
             self.in_flight_outstanding += 1;
-        } else if self.space != PNSpace::ApplicationData && self.pto_base_time.is_none() {
+        } else if self.space != PNSpace::ApplicationData && self.last_ack_eliciting.is_none() {
             // For Initial and Handshake spaces, make sure that we have a PTO baseline
             // always. See `LossRecoverySpace::pto_base_time()` for details.
-            self.pto_base_time = Some(sent_packet.time_sent);
+            self.last_ack_eliciting = Some(sent_packet.time_sent);
         }
         self.sent_packets.insert(sent_packet.pn, sent_packet);
+    }
+
+    /// If we are only sending ACK frames, send a PING frame after 2 PTOs so that
+    /// the peer sends an ACK frame.  If we have received lots of packets and no ACK,
+    /// send a PING frame after 1 PTO.  Note that this can't be within a PTO, or
+    /// we would risk setting up a feedback loop; having this many packets
+    /// outstanding can be normal and we don't want to PING too often.
+    pub fn should_probe(&self, pto: Duration, now: Instant) -> bool {
+        let n_pto = if self.sent_packets.len() >= MAX_OUTSTANDING_UNACK {
+            1
+        } else if self.sent_packets.len() >= MIN_OUTSTANDING_UNACK {
+            2
+        } else {
+            return false;
+        };
+        self.last_ack_eliciting
+            .map_or(false, |t| now > t + (pto * n_pto))
     }
 
     fn remove_packet(&mut self, p: &SentPacket) {
@@ -229,12 +253,6 @@ impl LossRecoverySpace {
             self.in_flight_outstanding -= 1;
             if self.in_flight_outstanding == 0 {
                 qtrace!("remove_packet outstanding == 0 for space {}", self.space);
-
-                // See above comments; keep PTO armed for Initial/Handshake even
-                // if no outstanding packets.
-                if self.space == PNSpace::ApplicationData {
-                    self.pto_base_time = None;
-                }
             }
         }
     }
@@ -569,6 +587,13 @@ impl LossRecovery {
                 sent_packet.pn
             );
         }
+    }
+
+    pub fn should_probe(&self, pto: Duration, now: Instant) -> bool {
+        self.spaces
+            .get(PNSpace::ApplicationData)
+            .unwrap()
+            .should_probe(pto, now)
     }
 
     /// Record an RTT sample.


### PR DESCRIPTION
I decided to make this marginally more complex, sending slightly earlier
if we have lots of outstanding packets.  The logic is now that we send a
PING after 1 PTO if there are either 200 packets outstanding or after 2
PTOs with at least 16 packets outstanding, otherwise no PING.

These numbers are arbitrary, except for the minimum of 1 PTO.  The goal
is to make the larger high enough to encourage good ACK sending from
even the fastest peers; and to make the smaller enough that bad ACK
sending from a very slow sender doesn't lead to us asking for ACK when
we don't really need it.  Either threshold could be much larger or
smaller as you like, though the smaller probably shouldn't be lower than
a reasonable ACK threshold.

Closes #830.