### PR TITLE
Cleanup ACK token stuff properly

### DIFF
--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -520,15 +520,16 @@ impl RecvdPackets {
         &mut self,
         now: Instant,
         builder: &mut PacketBuilder,
+        tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
-    ) -> Option<RecoveryToken> {
+    ) {
         // The worst possible ACK frame, assuming only one range.
         // Note that this assumes one byte for the type and count of extra ranges.
         const LONGEST_ACK_HEADER: usize = 1 + 8 + 8 + 1 + 8;
 
         // Check that we aren't delaying ACKs.
         if !self.ack_now(now) {
-            return None;
+            return;
         }
 
         // Drop extra ACK ranges to fit the available space.  Do this based on
@@ -541,7 +542,7 @@ impl RecvdPackets {
             // Apply a hard maximum to keep plenty of space for other stuff.
             min(1 + (avail / 16), MAX_ACKS_PER_FRAME)
         } else {
-            return None;
+            return;
         };
 
         let ranges = self
@@ -556,7 +557,7 @@ impl RecvdPackets {
         let mut iter = ranges.iter();
         let first = match iter.next() {
             Some(v) => v,
-            None => return None, // Nothing to send.
+            None => return, // Nothing to send.
         };
         builder.encode_varint(first.largest);
         stats.largest_acknowledged = first.largest;
@@ -583,10 +584,10 @@ impl RecvdPackets {
         self.ack_time = None;
         self.pkts_since_last_ack = 0;
 
-        Some(RecoveryToken::Ack(AckToken {
+        tokens.push(RecoveryToken::Ack(AckToken {
             space: self.space,
             ranges,
-        }))
+        }));
     }
 }
 
@@ -654,16 +655,16 @@ impl AckTracker {
         pn_space: PNSpace,
         now: Instant,
         builder: &mut PacketBuilder,
+        tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
-    ) -> Res<Option<RecoveryToken>> {
-        let res = self
-            .get_mut(pn_space)
-            .and_then(|space| space.write_frame(now, builder, stats));
-
-        if builder.len() > builder.limit() {
-            return Err(Error::InternalError(24));
+    ) -> Res<()> {
+        if let Some(space) = self.get_mut(pn_space) {
+            space.write_frame(now, builder, tokens, stats);
+            if builder.len() > builder.limit() {
+                return Err(Error::InternalError(24));
+            }
         }
-        Ok(res)
+        Ok(())
     }
 }
 
@@ -873,15 +874,19 @@ mod tests {
             .set_received(*NOW, 0, true);
         // The reference time for `ack_time` has to be in the past or we filter out the timer.
         assert!(tracker.ack_time(*NOW - Duration::from_millis(1)).is_some());
-        let token = tracker
+
+        let mut tokens = Vec::new();
+        let mut stats = FrameStats::default();
+        tracker
             .write_frame(
                 PNSpace::Initial,
                 *NOW,
                 &mut builder,
-                &mut FrameStats::default(),
+                &mut tokens,
+                &mut stats,
             )
             .unwrap();
-        assert!(token.is_some());
+        assert_eq!(stats.ack, 1);
 
         // Mark another packet as received so we have cause to send another ACK in that space.
         tracker
@@ -895,17 +900,18 @@ mod tests {
 
         assert!(tracker.get_mut(PNSpace::Initial).is_none());
         assert!(tracker.ack_time(*NOW - Duration::from_millis(1)).is_none());
-        assert!(tracker
+        tracker
             .write_frame(
                 PNSpace::Initial,
                 *NOW,
                 &mut builder,
-                &mut FrameStats::default()
+                &mut tokens,
+                &mut stats,
             )
-            .unwrap()
-            .is_none());
-        if let RecoveryToken::Ack(tok) = token.unwrap() {
-            tracker.acked(&tok); // Should be a noop.
+            .unwrap();
+        assert_eq!(stats.ack, 1);
+        if let RecoveryToken::Ack(tok) = &tokens[0] {
+            tracker.acked(tok); // Should be a noop.
         } else {
             panic!("not an ACK token");
         }
@@ -923,15 +929,17 @@ mod tests {
         let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
         builder.set_limit(10);
 
-        let token = tracker
+        let mut stats = FrameStats::default();
+        tracker
             .write_frame(
                 PNSpace::Initial,
                 *NOW,
                 &mut builder,
-                &mut FrameStats::default(),
+                &mut Vec::new(),
+                &mut stats,
             )
             .unwrap();
-        assert!(token.is_none());
+        assert_eq!(stats.ack, 0);
         assert_eq!(builder.len(), 1); // Only the short packet header has been added.
     }
 
@@ -951,15 +959,17 @@ mod tests {
         let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
         builder.set_limit(32);
 
-        let token = tracker
+        let mut stats = FrameStats::default();
+        tracker
             .write_frame(
                 PNSpace::Initial,
                 *NOW,
                 &mut builder,
-                &mut FrameStats::default(),
+                &mut Vec::new(),
+                &mut stats,
             )
             .unwrap();
-        assert!(token.is_some());
+        assert_eq!(stats.ack, 1);
 
         let mut dec = builder.as_decoder();
         let _ = dec.decode_byte().unwrap(); // Skip the short header.


### PR DESCRIPTION
After cleaning up the way we track whether an ACK has been sent, now we
don't need to save the token that the ACK writer generates.  That
simplifies things quite a bit.