### PR TITLE
Update 0-RTT flow control limits

### DIFF
--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -587,15 +587,14 @@ mod tests {
 
     fn connect_generic(huffman: bool, max_data: Option<u64>) -> TestEncoder {
         let mut conn = default_client();
-        let mut peer_conn = if let Some(max) = max_data {
+        let mut peer_conn = max_data.map_or_else(default_server, |max| {
             configure_server(
                 ConnectionParameters::default()
-                    .max_stream_data(StreamType::UniDi, max)
-                    .max_stream_data(StreamType::BiDi, max),
+                    .max_stream_data(StreamType::UniDi, true, max)
+                    .max_stream_data(StreamType::BiDi, true, max)
+                    .max_stream_data(StreamType::BiDi, false, max),
             )
-        } else {
-            default_server()
-        };
+        });
         handshake(&mut conn, &mut peer_conn);
 
         // create a stream

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2135,6 +2135,12 @@ impl Connection {
             self.idle_timeout
                 .set_peer_timeout(Duration::from_millis(peer_timeout));
         }
+        // As a client, there are two sets of initial limits for sending stream data.
+        // If the second limit is higher and streams have been created, then
+        // ensure that streams are not blocked on the lower limit.
+        if self.role == Role::Client {
+            self.send_streams.update_initial_limit(&remote);
+        }
     }
 
     /// Process the final set of transport parameters.

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -43,7 +43,7 @@ pub struct ConnectionParameters {
     max_stream_data_uni: u64,
     /// Initial limit on bidirectional streams that the peer creates.
     max_streams_bidi: StreamIndex,
-    /// Initial limit on bidirectional streams that this endpoint creates.
+    /// Initial limit on unidirectional streams that this endpoint creates.
     max_streams_uni: StreamIndex,
     preferred_address: PreferredAddressConfig,
 }


### PR DESCRIPTION
After accepting 0-RTT, the server might increase flow control limits on
streams.  We need to ensure that these limits are applied to open
streams.

As part of this, I had to change the API for setting initial flow
control limits as we only had controls for bidirectional streams in the
wrong direction for the test (a server could only limit the streams it
created).  The API is more complex as a result, but it now works.  Note
that the qpack encoder test is now more general as a result, though I
think that the bidirectional limits aren't really relevant to that test.

Closes #1119.