### PR TITLE
Use winapi for high resolution timer when using gecko

### DIFF
--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -12,7 +12,13 @@ env_logger = {version = "0.8", default-features = false}
 lazy_static = "1.3.0"
 qlog = "0.4.0"
 chrono = "0.4.10"
+winapi = { version = "0.3", optional = true }
 
 [features]
 default = ["deny-warnings"]
 deny-warnings = []
+gecko = ["winapi"]
+
+[target."cfg(windows)".dependencies.winapi]
+version = "0.3"
+features = ["timeapi"]

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -12,12 +12,10 @@ env_logger = {version = "0.8", default-features = false}
 lazy_static = "1.3.0"
 qlog = "0.4.0"
 chrono = "0.4.10"
-winapi = { version = "0.3", optional = true }
 
 [features]
 default = ["deny-warnings"]
 deny-warnings = []
-gecko = ["winapi"]
 
 [target."cfg(windows)".dependencies.winapi]
 version = "0.3"


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1698438#c6.
The linker failed to link `timeBeginPeriod` and `timeEndPeriod` in win32 platforms. Switching to use `winapi` seems to fix this issue.