### PR TITLE
Lots of clippy changes this time.

### DIFF
--- a/neqo-common/src/incrdecoder.rs
+++ b/neqo-common/src/incrdecoder.rs
@@ -21,6 +21,9 @@ impl IncrementalDecoderUint {
         self.remaining.unwrap_or(1)
     }
 
+    /// Consume some data.
+    #[allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
+    #[allow(clippy::missing_panics_doc)] // See https://github.com/rust-lang/rust-clippy/issues/6699
     pub fn consume(&mut self, dv: &mut Decoder) -> Option<u64> {
         if let Some(r) = &mut self.remaining {
             let amount = min(*r, dv.remaining());
@@ -84,6 +87,9 @@ impl IncrementalDecoderBuffer {
         self.remaining
     }
 
+    /// Consume some bytes from the decoder.
+    /// # Panics
+    /// Never; but rust doesn't know that.
     pub fn consume(&mut self, dv: &mut Decoder) -> Option<Vec<u8>> {
         let amount = min(self.remaining, dv.remaining());
         let b = dv.decode(amount).unwrap();

--- a/neqo-common/src/timer.rs
+++ b/neqo-common/src/timer.rs
@@ -34,6 +34,8 @@ pub struct Timer<T> {
 
 impl<T> Timer<T> {
     /// Construct a new wheel at the given granularity, starting at the given time.
+    /// # Panics
+    /// When `capacity` is too large to fit in `u32` or `granularity` is zero.
     pub fn new(now: Instant, granularity: Duration, capacity: usize) -> Self {
         assert!(u32::try_from(capacity).is_ok());
         assert!(granularity.as_nanos() > 0);
@@ -89,7 +91,7 @@ impl<T> Timer<T> {
     }
 
     /// Slide forward in time by `n * self.granularity`.
-    #[allow(clippy::unknown_clippy_lints)] // Until we require rust 1.45.
+    #[allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.45.
     #[allow(clippy::cast_possible_truncation, clippy::reversed_empty_ranges)]
     // cast_possible_truncation is ok because we have an assertion guard.
     // reversed_empty_ranges is to avoid different types on the if/else.
@@ -108,6 +110,8 @@ impl<T> Timer<T> {
     }
 
     /// Asserts if the time given is in the past or too far in the future.
+    /// # Panics
+    /// When `time` is in the past relative to previous calls.
     pub fn add(&mut self, time: Instant, item: T) {
         assert!(time >= self.now);
         // Skip forward quickly if there is too large a gap.
@@ -115,7 +119,7 @@ impl<T> Timer<T> {
         if time >= (self.now + self.span() + short_span) {
             // Assert that there aren't any items.
             for i in &self.items {
-                assert!(i.is_empty());
+                debug_assert!(i.is_empty());
             }
             self.now = time - short_span;
             self.cursor = 0;

--- a/neqo-crypto/src/aead.rs
+++ b/neqo-crypto/src/aead.rs
@@ -81,7 +81,7 @@ impl Aead {
             version,
             cipher,
             secret,
-            p.as_ptr().cast::<c_char>(),
+            p.as_ptr().cast(),
             c_uint::try_from(p.len())?,
             &mut ctx,
         )?;

--- a/neqo-crypto/src/aead.rs
+++ b/neqo-crypto/src/aead.rs
@@ -81,7 +81,7 @@ impl Aead {
             version,
             cipher,
             secret,
-            p.as_ptr() as *const c_char,
+            p.as_ptr().cast::<c_char>(),
             c_uint::try_from(p.len())?,
             &mut ctx,
         )?;

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -268,7 +268,7 @@ impl SecretAgent {
         }
         let fd = unsafe {
             (*base_fd).secret = as_c_void(io).cast();
-            ssl::SSL_ImportFD(null_mut(), base_fd.cast::<ssl::PRFileDesc>())
+            ssl::SSL_ImportFD(null_mut(), base_fd.cast())
         };
         if fd.is_null() {
             unsafe { prio::PR_Close(base_fd) };
@@ -298,8 +298,7 @@ impl SecretAgent {
         let alert = alert.as_ref().unwrap();
         if alert.level == 2 {
             // Fatal alerts demand attention.
-            let p = arg.cast::<Option<Alert>>();
-            let st = p.as_mut().unwrap();
+            let st = arg.cast::<Option<Alert>>().as_mut().unwrap();
             if st.is_none() {
                 *st = Some(alert.description);
             } else {
@@ -655,11 +654,11 @@ impl SecretAgent {
         if let Some(true) = self.raw {
             // Need to hold the record list in scope until the close is done.
             let _records = self.setup_raw().expect("Can only close");
-            unsafe { prio::PR_Close(self.fd.cast::<prio::PRFileDesc>()) };
+            unsafe { prio::PR_Close(self.fd.cast()) };
         } else {
             // Need to hold the IO wrapper in scope until the close is done.
             let _io = self.io.wrap(&[]);
-            unsafe { prio::PR_Close(self.fd.cast::<prio::PRFileDesc>()) };
+            unsafe { prio::PR_Close(self.fd.cast()) };
         };
         let _output = self.io.take_output();
         self.fd = null_mut();
@@ -772,8 +771,7 @@ impl Client {
             // Ignore the token.
             return ssl::SECSuccess;
         }
-        let resumption_ptr = arg.cast::<Vec<ResumptionToken>>();
-        let resumption = resumption_ptr.as_mut().unwrap();
+        let resumption = arg.cast::<Vec<ResumptionToken>>().as_mut().unwrap();
         let len = usize::try_from(len).unwrap();
         let mut v = Vec::with_capacity(len);
         v.extend_from_slice(std::slice::from_raw_parts(token, len));

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -128,6 +128,9 @@ impl SecretAgentPreInfo {
     pub fn early_data(&self) -> bool {
         self.info.canSendEarlyData != 0
     }
+
+    /// # Panics
+    /// If `usize` is less than 32 bits and the value is too large.
     #[must_use]
     pub fn max_early_data(&self) -> usize {
         usize::try_from(self.info.maxEarlyDataSize).unwrap()
@@ -264,8 +267,8 @@ impl SecretAgent {
             return Err(Error::CreateSslSocket);
         }
         let fd = unsafe {
-            (*base_fd).secret = as_c_void(io) as *mut _;
-            ssl::SSL_ImportFD(null_mut(), base_fd as *mut ssl::PRFileDesc)
+            (*base_fd).secret = as_c_void(io).cast();
+            ssl::SSL_ImportFD(null_mut(), base_fd.cast::<ssl::PRFileDesc>())
         };
         if fd.is_null() {
             unsafe { prio::PR_Close(base_fd) };
@@ -280,7 +283,7 @@ impl SecretAgent {
         _check_sig: ssl::PRBool,
         _is_server: ssl::PRBool,
     ) -> ssl::SECStatus {
-        let auth_required_ptr = arg as *mut bool;
+        let auth_required_ptr = arg.cast::<bool>();
         *auth_required_ptr = true;
         // NSS insists on getting SECWouldBlock here rather than accepting
         // the usual combination of PR_WOULD_BLOCK_ERROR and SECFailure.
@@ -295,7 +298,7 @@ impl SecretAgent {
         let alert = alert.as_ref().unwrap();
         if alert.level == 2 {
             // Fatal alerts demand attention.
-            let p = arg as *mut Option<Alert>;
+            let p = arg.cast::<Option<Alert>>();
             let st = p.as_mut().unwrap();
             if st.is_none() {
                 *st = Some(alert.description);
@@ -430,11 +433,14 @@ impl SecretAgent {
     ///
     /// # Errors
     /// This should always panic rather than return an error.
+    /// # Panics
+    /// If any of the provided `protocols` are more than 255 bytes long.
     pub fn set_alpn(&mut self, protocols: &[impl AsRef<str>]) -> Res<()> {
         // Validate and set length.
         let mut encoded_len = protocols.len();
         for v in protocols {
             assert!(v.as_ref().len() < 256);
+            assert!(!v.as_ref().is_empty());
             encoded_len += v.as_ref().len();
         }
 
@@ -538,6 +544,8 @@ impl SecretAgent {
     /// Call this function to mark the peer as authenticated.
     /// Only call this function if `handshake/handshake_raw` returns
     /// `HandshakeState::AuthenticationPending`, or it will panic.
+    /// # Panics
+    /// If the handshake doesn't need to be authenticated.
     pub fn authenticated(&mut self, status: AuthenticationStatus) {
         assert_eq!(self.state, HandshakeState::AuthenticationPending);
         *self.auth_required = false;
@@ -647,11 +655,11 @@ impl SecretAgent {
         if let Some(true) = self.raw {
             // Need to hold the record list in scope until the close is done.
             let _records = self.setup_raw().expect("Can only close");
-            unsafe { prio::PR_Close(self.fd as *mut prio::PRFileDesc) };
+            unsafe { prio::PR_Close(self.fd.cast::<prio::PRFileDesc>()) };
         } else {
             // Need to hold the IO wrapper in scope until the close is done.
             let _io = self.io.wrap(&[]);
-            unsafe { prio::PR_Close(self.fd as *mut prio::PRFileDesc) };
+            unsafe { prio::PR_Close(self.fd.cast::<prio::PRFileDesc>()) };
         };
         let _output = self.io.take_output();
         self.fd = null_mut();
@@ -764,7 +772,7 @@ impl Client {
             // Ignore the token.
             return ssl::SECSuccess;
         }
-        let resumption_ptr = arg as *mut Vec<ResumptionToken>;
+        let resumption_ptr = arg.cast::<Vec<ResumptionToken>>();
         let resumption = resumption_ptr.as_mut().unwrap();
         let len = usize::try_from(len).unwrap();
         let mut v = Vec::with_capacity(len);
@@ -937,8 +945,7 @@ impl Server {
             return ssl::SSLHelloRetryRequestAction::ssl_hello_retry_accept;
         }
 
-        let p = arg as *mut ZeroRttCheckState;
-        let check_state = p.as_mut().unwrap();
+        let check_state = arg.cast::<ZeroRttCheckState>().as_mut().unwrap();
         let token = if client_token.is_null() {
             &[]
         } else {

--- a/neqo-crypto/src/agentio.rs
+++ b/neqo-crypto/src/agentio.rs
@@ -28,7 +28,7 @@ const PR_FAILURE: PrStatus = prio::PRStatus::PR_FAILURE;
 
 /// Convert a pinned, boxed object into a void pointer.
 pub fn as_c_void<T: Unpin>(pin: &mut Pin<Box<T>>) -> *mut c_void {
-    Pin::into_inner(pin.as_mut()) as *mut T as *mut c_void
+    (Pin::into_inner(pin.as_mut()) as *mut T).cast::<c_void>()
 }
 
 // This holds the length of the slice, not the slice itself.
@@ -103,8 +103,7 @@ impl RecordList {
         len: c_uint,
         arg: *mut c_void,
     ) -> ssl::SECStatus {
-        let a = arg as *mut Self;
-        let records = a.as_mut().unwrap();
+        let records = arg.cast::<Self>().as_mut().unwrap();
 
         let slice = std::slice::from_raw_parts(data, len as usize);
         records.append(epoch, ContentType::try_from(ct).unwrap(), slice);
@@ -226,8 +225,7 @@ impl AgentIo {
 
     unsafe fn borrow(fd: &mut PrFd) -> &mut Self {
         #[allow(clippy::cast_ptr_alignment)]
-        let io = (**fd).secret as *mut Self;
-        io.as_mut().unwrap()
+        (**fd).secret.cast::<Self>().as_mut().unwrap()
     }
 
     pub fn wrap<'a: 'c, 'b: 'c, 'c>(&'a mut self, input: &'b [u8]) -> AgentIoInputContext<'c> {
@@ -265,7 +263,7 @@ unsafe extern "C" fn agent_close(fd: PrFd) -> PrStatus {
 unsafe extern "C" fn agent_read(mut fd: PrFd, buf: *mut c_void, amount: prio::PRInt32) -> PrStatus {
     let io = AgentIo::borrow(&mut fd);
     if let Ok(a) = usize::try_from(amount) {
-        match io.input.read_input(buf as *mut u8, a) {
+        match io.input.read_input(buf.cast::<u8>(), a) {
             Ok(_) => PR_SUCCESS,
             Err(_) => PR_FAILURE,
         }
@@ -286,7 +284,7 @@ unsafe extern "C" fn agent_recv(
         return PR_FAILURE;
     }
     if let Ok(a) = usize::try_from(amount) {
-        match io.input.read_input(buf as *mut u8, a) {
+        match io.input.read_input(buf.cast::<u8>(), a) {
             Ok(v) => prio::PRInt32::try_from(v).unwrap_or(PR_FAILURE),
             Err(_) => PR_FAILURE,
         }
@@ -302,7 +300,7 @@ unsafe extern "C" fn agent_write(
 ) -> PrStatus {
     let io = AgentIo::borrow(&mut fd);
     if let Ok(a) = usize::try_from(amount) {
-        io.save_output(buf as *const u8, a);
+        io.save_output(buf.cast::<u8>(), a);
         amount
     } else {
         PR_FAILURE
@@ -322,7 +320,7 @@ unsafe extern "C" fn agent_send(
         return PR_FAILURE;
     }
     if let Ok(a) = usize::try_from(amount) {
-        io.save_output(buf as *const u8, a);
+        io.save_output(buf.cast::<u8>(), a);
         amount
     } else {
         PR_FAILURE

--- a/neqo-crypto/src/auth.rs
+++ b/neqo-crypto/src/auth.rs
@@ -33,34 +33,42 @@ pub enum AuthenticationStatus {
     Unknown,
 }
 
-impl Into<PRErrorCode> for AuthenticationStatus {
+impl From<AuthenticationStatus> for PRErrorCode {
     #[must_use]
-    fn into(self) -> PRErrorCode {
-        match self {
-            Self::Ok => 0,
-            Self::CaInvalid => sec::SEC_ERROR_CA_CERT_INVALID,
-            Self::CaNotV3 => mozpkix::MOZILLA_PKIX_ERROR_V1_CERT_USED_AS_CA,
-            Self::CertAlgorithmDisabled => sec::SEC_ERROR_CERT_SIGNATURE_ALGORITHM_DISABLED,
-            Self::CertExpired => sec::SEC_ERROR_EXPIRED_CERTIFICATE,
-            Self::CertInvalidTime => sec::SEC_ERROR_INVALID_TIME,
-            Self::CertIsCa => mozpkix::MOZILLA_PKIX_ERROR_CA_CERT_USED_AS_END_ENTITY,
-            Self::CertKeyUsage => sec::SEC_ERROR_INADEQUATE_KEY_USAGE,
-            Self::CertMitm => mozpkix::MOZILLA_PKIX_ERROR_MITM_DETECTED,
-            Self::CertNotYetValid => mozpkix::MOZILLA_PKIX_ERROR_NOT_YET_VALID_CERTIFICATE,
-            Self::CertRevoked => sec::SEC_ERROR_REVOKED_CERTIFICATE,
-            Self::CertSelfSigned => mozpkix::MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT,
-            Self::CertSubjectInvalid => ssl::SSL_ERROR_BAD_CERT_DOMAIN,
-            Self::CertUntrusted => sec::SEC_ERROR_UNTRUSTED_CERT,
-            Self::CertWeakKey => mozpkix::MOZILLA_PKIX_ERROR_INADEQUATE_KEY_SIZE,
-            Self::IssuerEmptyName => mozpkix::MOZILLA_PKIX_ERROR_EMPTY_ISSUER_NAME,
-            Self::IssuerExpired => sec::SEC_ERROR_EXPIRED_ISSUER_CERTIFICATE,
-            Self::IssuerNotYetValid => mozpkix::MOZILLA_PKIX_ERROR_NOT_YET_VALID_ISSUER_CERTIFICATE,
-            Self::IssuerUnknown => sec::SEC_ERROR_UNKNOWN_ISSUER,
-            Self::IssuerUntrusted => sec::SEC_ERROR_UNTRUSTED_ISSUER,
-            Self::PolicyRejection => {
+    fn from(v: AuthenticationStatus) -> Self {
+        match v {
+            AuthenticationStatus::Ok => 0,
+            AuthenticationStatus::CaInvalid => sec::SEC_ERROR_CA_CERT_INVALID,
+            AuthenticationStatus::CaNotV3 => mozpkix::MOZILLA_PKIX_ERROR_V1_CERT_USED_AS_CA,
+            AuthenticationStatus::CertAlgorithmDisabled => {
+                sec::SEC_ERROR_CERT_SIGNATURE_ALGORITHM_DISABLED
+            }
+            AuthenticationStatus::CertExpired => sec::SEC_ERROR_EXPIRED_CERTIFICATE,
+            AuthenticationStatus::CertInvalidTime => sec::SEC_ERROR_INVALID_TIME,
+            AuthenticationStatus::CertIsCa => {
+                mozpkix::MOZILLA_PKIX_ERROR_CA_CERT_USED_AS_END_ENTITY
+            }
+            AuthenticationStatus::CertKeyUsage => sec::SEC_ERROR_INADEQUATE_KEY_USAGE,
+            AuthenticationStatus::CertMitm => mozpkix::MOZILLA_PKIX_ERROR_MITM_DETECTED,
+            AuthenticationStatus::CertNotYetValid => {
+                mozpkix::MOZILLA_PKIX_ERROR_NOT_YET_VALID_CERTIFICATE
+            }
+            AuthenticationStatus::CertRevoked => sec::SEC_ERROR_REVOKED_CERTIFICATE,
+            AuthenticationStatus::CertSelfSigned => mozpkix::MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT,
+            AuthenticationStatus::CertSubjectInvalid => ssl::SSL_ERROR_BAD_CERT_DOMAIN,
+            AuthenticationStatus::CertUntrusted => sec::SEC_ERROR_UNTRUSTED_CERT,
+            AuthenticationStatus::CertWeakKey => mozpkix::MOZILLA_PKIX_ERROR_INADEQUATE_KEY_SIZE,
+            AuthenticationStatus::IssuerEmptyName => mozpkix::MOZILLA_PKIX_ERROR_EMPTY_ISSUER_NAME,
+            AuthenticationStatus::IssuerExpired => sec::SEC_ERROR_EXPIRED_ISSUER_CERTIFICATE,
+            AuthenticationStatus::IssuerNotYetValid => {
+                mozpkix::MOZILLA_PKIX_ERROR_NOT_YET_VALID_ISSUER_CERTIFICATE
+            }
+            AuthenticationStatus::IssuerUnknown => sec::SEC_ERROR_UNKNOWN_ISSUER,
+            AuthenticationStatus::IssuerUntrusted => sec::SEC_ERROR_UNTRUSTED_ISSUER,
+            AuthenticationStatus::PolicyRejection => {
                 mozpkix::MOZILLA_PKIX_ERROR_ADDITIONAL_POLICY_CONSTRAINT_FAILED
             }
-            Self::Unknown => sec::SEC_ERROR_LIBRARY_FAILURE,
+            AuthenticationStatus::Unknown => sec::SEC_ERROR_LIBRARY_FAILURE,
         }
     }
 }

--- a/neqo-crypto/src/cert.rs
+++ b/neqo-crypto/src/cert.rs
@@ -54,7 +54,7 @@ fn stapled_ocsp_responses(fd: *mut PRFileDesc) -> Option<Vec<Vec<u8>>> {
                 return None;
             };
             for idx in 0..len {
-                let itemp = unsafe { ocsp_ptr.as_ref().items.offset(idx).cast::<SECItem>() };
+                let itemp: *const SECItem = unsafe { ocsp_ptr.as_ref().items.offset(idx).cast() };
                 let item = unsafe { slice::from_raw_parts((*itemp).data, (*itemp).len as usize) };
                 ocsp_helper.push(item.to_owned());
             }
@@ -92,17 +92,14 @@ impl CertificateInfo {
 
     fn head(certs: &CertList) -> *const CERTCertListNode {
         // Three stars: one for the reference, one for the wrapper, one to deference the pointer.
-        unsafe { (&(***certs).list as *const PRCList).cast::<CERTCertListNode>() }
+        unsafe { (&(***certs).list as *const PRCList).cast() }
     }
 }
 
 impl<'a> Iterator for &'a mut CertificateInfo {
     type Item = &'a [u8];
     fn next(&mut self) -> Option<&'a [u8]> {
-        self.cursor = unsafe { *self.cursor }
-            .links
-            .next
-            .cast::<CERTCertListNode>();
+        self.cursor = unsafe { *self.cursor }.links.next.cast();
         if self.cursor == CertificateInfo::head(&self.certs) {
             return None;
         }

--- a/neqo-crypto/src/cert.rs
+++ b/neqo-crypto/src/cert.rs
@@ -32,7 +32,7 @@ pub struct CertificateInfo {
 
 fn peer_certificate_chain(fd: *mut PRFileDesc) -> Option<(CertList, *const CERTCertListNode)> {
     let chain = unsafe { SSL_PeerCertificateChain(fd) };
-    let certs = match NonNull::new(chain as *mut CERTCertList) {
+    let certs = match NonNull::new(chain.cast::<CERTCertList>()) {
         Some(certs_ptr) => CertList::new(certs_ptr),
         None => return None,
     };
@@ -54,7 +54,7 @@ fn stapled_ocsp_responses(fd: *mut PRFileDesc) -> Option<Vec<Vec<u8>>> {
                 return None;
             };
             for idx in 0..len {
-                let itemp = unsafe { ocsp_ptr.as_ref().items.offset(idx) as *const SECItem };
+                let itemp = unsafe { ocsp_ptr.as_ref().items.offset(idx).cast::<SECItem>() };
                 let item = unsafe { slice::from_raw_parts((*itemp).data, (*itemp).len as usize) };
                 ocsp_helper.push(item.to_owned());
             }
@@ -92,14 +92,17 @@ impl CertificateInfo {
 
     fn head(certs: &CertList) -> *const CERTCertListNode {
         // Three stars: one for the reference, one for the wrapper, one to deference the pointer.
-        unsafe { &(***certs).list as *const PRCList as *const CERTCertListNode }
+        unsafe { (&(***certs).list as *const PRCList).cast::<CERTCertListNode>() }
     }
 }
 
 impl<'a> Iterator for &'a mut CertificateInfo {
     type Item = &'a [u8];
     fn next(&mut self) -> Option<&'a [u8]> {
-        self.cursor = unsafe { *self.cursor }.links.next as *const CERTCertListNode;
+        self.cursor = unsafe { *self.cursor }
+            .links
+            .next
+            .cast::<CERTCertListNode>();
         if self.cursor == CertificateInfo::head(&self.certs) {
             return None;
         }

--- a/neqo-crypto/src/err.rs
+++ b/neqo-crypto/src/err.rs
@@ -4,7 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(dead_code)]
+#![allow(dead_code, clippy::upper_case_acronyms)]
+#![allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
 
 use std::os::raw::c_char;
 

--- a/neqo-crypto/src/ext.rs
+++ b/neqo-crypto/src/ext.rs
@@ -69,8 +69,7 @@ impl ExtensionTracker {
     where
         F: FnOnce(&mut dyn ExtensionHandler) -> T,
     {
-        let handler_ptr = arg as *mut BoxedExtensionHandler;
-        let rc = handler_ptr.as_mut().unwrap();
+        let rc = arg.cast::<BoxedExtensionHandler>().as_mut().unwrap();
         f(&mut *rc.borrow_mut())
     }
 

--- a/neqo-crypto/src/hkdf.rs
+++ b/neqo-crypto/src/hkdf.rs
@@ -140,7 +140,7 @@ pub fn expand_label(
             **prk,
             handshake_hash.as_ptr(),
             c_uint::try_from(handshake_hash.len())?,
-            l.as_ptr().cast::<c_char>(),
+            l.as_ptr().cast(),
             c_uint::try_from(l.len())?,
             &mut secret,
         )

--- a/neqo-crypto/src/hkdf.rs
+++ b/neqo-crypto/src/hkdf.rs
@@ -140,7 +140,7 @@ pub fn expand_label(
             **prk,
             handshake_hash.as_ptr(),
             c_uint::try_from(handshake_hash.len())?,
-            l.as_ptr() as *const c_char,
+            l.as_ptr().cast::<c_char>(),
             c_uint::try_from(l.len())?,
             &mut secret,
         )

--- a/neqo-crypto/src/hp.rs
+++ b/neqo-crypto/src/hp.rs
@@ -67,7 +67,7 @@ impl HpKey {
                 **prk,
                 null(),
                 0,
-                l.as_ptr().cast::<c_char>(),
+                l.as_ptr().cast(),
                 c_uint::try_from(l.len())?,
                 mech,
                 key_size,

--- a/neqo-crypto/src/hp.rs
+++ b/neqo-crypto/src/hp.rs
@@ -45,6 +45,8 @@ impl HpKey {
     ///
     /// # Errors
     /// Errors if HKDF fails or if the label is too long to fit in a `c_uint`.
+    /// # Panics
+    /// When `cipher` is not known to this code.
     pub fn extract(version: Version, cipher: Cipher, prk: &SymKey, label: &str) -> Res<Self> {
         let l = label.as_bytes();
         let mut secret: *mut PK11SymKey = null_mut();
@@ -65,7 +67,7 @@ impl HpKey {
                 **prk,
                 null(),
                 0,
-                l.as_ptr() as *const c_char,
+                l.as_ptr().cast::<c_char>(),
                 c_uint::try_from(l.len())?,
                 mech,
                 key_size,
@@ -93,6 +95,8 @@ impl HpKey {
     /// # Errors
     /// An error is returned if the NSS functions fail; a sample of the
     /// wrong size is the obvious cause.
+    /// # Panics
+    /// When the mechanism for our key is not supported.
     pub fn mask(&self, sample: &[u8]) -> Res<Vec<u8>> {
         let k: *mut PK11SymKey = *self.0;
         let mech = unsafe { PK11_GetMechanism(k) };
@@ -123,7 +127,7 @@ impl HpKey {
                 output_slice.as_mut_ptr(),
                 &mut output_len,
                 c_uint::try_from(output.len())?,
-                inbuf.as_ptr() as *const u8,
+                inbuf.as_ptr().cast(),
                 c_uint::try_from(inbuf.len())?,
             )
         })?;

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -51,12 +51,16 @@ pub use self::ssl::Opt;
 use self::once::OnceResult;
 
 use std::ffi::CString;
-use std::os::raw::c_char;
 use std::path::{Path, PathBuf};
 use std::ptr::null;
 
 mod nss {
-    #![allow(clippy::redundant_static_lifetimes, non_upper_case_globals)]
+    #![allow(
+        non_upper_case_globals,
+        clippy::redundant_static_lifetimes,
+        clippy::upper_case_acronyms
+    )]
+    #![allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
     include!(concat!(env!("OUT_DIR"), "/nss_init.rs"));
 }
 
@@ -118,6 +122,9 @@ fn enable_ssl_trace() {
         .expect("SSL_OptionGetDefault failed");
 }
 
+/// Initialize with a database.
+/// # Panics
+/// If NSS cannot be initialized.
 pub fn init_db<P: Into<PathBuf>>(dir: P) {
     time::init();
     unsafe {
@@ -135,7 +142,7 @@ pub fn init_db<P: Into<PathBuf>>(dir: P) {
                 dircstr.as_ptr(),
                 empty.as_ptr(),
                 empty.as_ptr(),
-                nss::SECMOD_DB.as_ptr() as *const c_char,
+                nss::SECMOD_DB.as_ptr().cast(),
                 nss::NSS_INIT_READONLY,
             ))
             .expect("NSS_Initialize failed");
@@ -157,7 +164,8 @@ pub fn init_db<P: Into<PathBuf>>(dir: P) {
     }
 }
 
-/// Panic if NSS isn't initialized.
+/// # Panics
+/// If NSS isn't initialized.
 pub fn assert_initialized() {
     unsafe {
         INITIALIZED.call_once(|| {

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -17,7 +17,8 @@ use std::convert::TryInto;
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
-#[allow(clippy::unreadable_literal)]
+#[allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
+#[allow(clippy::unreadable_literal, clippy::upper_case_acronyms)]
 mod nss_p11 {
     include!(concat!(env!("OUT_DIR"), "/nss_p11.rs"));
 }
@@ -102,6 +103,8 @@ impl std::fmt::Debug for SymKey {
 }
 
 /// Generate a randomized buffer.
+/// # Panics
+/// When `size` is too large or NSS fails.
 #[must_use]
 pub fn random(size: usize) -> Vec<u8> {
     let mut buf = vec![0; size];

--- a/neqo-crypto/src/prio.rs
+++ b/neqo-crypto/src/prio.rs
@@ -4,12 +4,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(dead_code, non_upper_case_globals, non_snake_case)]
 #![allow(
+    dead_code,
+    non_upper_case_globals,
+    non_snake_case,
     clippy::cognitive_complexity,
     clippy::empty_enum,
-    clippy::too_many_lines
+    clippy::too_many_lines,
+    clippy::upper_case_acronyms
 )]
+#![allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
 
 include!(concat!(env!("OUT_DIR"), "/nspr_io.rs"));
 

--- a/neqo-crypto/src/replay.rs
+++ b/neqo-crypto/src/replay.rs
@@ -15,7 +15,8 @@ use std::ptr::{null_mut, NonNull};
 use std::time::{Duration, Instant};
 
 // This is an opaque struct in NSS.
-#[allow(clippy::empty_enum)]
+#[allow(clippy::empty_enum, clippy::upper_case_acronyms)]
+#[allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
 pub enum SSLAntiReplayContext {}
 
 experimental_api!(SSL_CreateAntiReplayContext(

--- a/neqo-crypto/src/secrets.rs
+++ b/neqo-crypto/src/secrets.rs
@@ -77,8 +77,7 @@ impl Secrets {
         secret: *mut PK11SymKey,
         arg: *mut c_void,
     ) {
-        let secrets_ptr = arg as *mut Self;
-        let secrets = secrets_ptr.as_mut().unwrap();
+        let secrets = arg.cast::<Self>().as_mut().unwrap();
         secrets.put_raw(epoch, dir, secret);
     }
 

--- a/neqo-crypto/src/ssl.rs
+++ b/neqo-crypto/src/ssl.rs
@@ -4,8 +4,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(dead_code, non_upper_case_globals, non_snake_case)]
-#![allow(clippy::cognitive_complexity, clippy::too_many_lines)]
+#![allow(
+    dead_code,
+    non_upper_case_globals,
+    non_snake_case,
+    clippy::cognitive_complexity,
+    clippy::too_many_lines,
+    clippy::upper_case_acronyms
+)]
+#![allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
 
 use crate::constants::Epoch;
 use crate::err::{secstatus_to_res, Res};

--- a/neqo-crypto/src/time.rs
+++ b/neqo-crypto/src/time.rs
@@ -4,6 +4,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(clippy::upper_case_acronyms)]
+#![allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
+
 use crate::agentio::as_c_void;
 use crate::err::{Error, Res};
 use crate::once::OnceResult;
@@ -127,9 +130,10 @@ impl TryInto<PRTime> for Time {
     }
 }
 
-impl Into<Instant> for Time {
-    fn into(self) -> Instant {
-        self.t
+impl From<Time> for Instant {
+    #[must_use]
+    fn from(t: Time) -> Self {
+        t.t
     }
 }
 
@@ -176,7 +180,7 @@ pub struct TimeHolder {
 
 impl TimeHolder {
     unsafe extern "C" fn time_func(arg: *mut c_void) -> PRTime {
-        let p = arg as *mut PRTime as *const PRTime;
+        let p = arg as *const PRTime;
         *p.as_ref().unwrap()
     }
 

--- a/neqo-crypto/tests/init.rs
+++ b/neqo-crypto/tests/init.rs
@@ -12,8 +12,14 @@ use neqo_crypto::{assert_initialized, init_db};
 
 // Pull in the NSS internals so that we can ask NSS if it thinks that
 // it is properly initialized.
-#[allow(dead_code, non_upper_case_globals)]
-#[allow(clippy::redundant_static_lifetimes, clippy::unseparated_literal_suffix)]
+#[allow(
+    dead_code,
+    non_upper_case_globals,
+    clippy::redundant_static_lifetimes,
+    clippy::unseparated_literal_suffix,
+    clippy::upper_case_acronyms
+)]
+#[allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
 mod nss {
     include!(concat!(env!("OUT_DIR"), "/nss_init.rs"));
 }

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -247,6 +247,12 @@ impl Http3Connection {
         }
     }
 
+    #[allow(
+        clippy::vec_init_then_push,
+        unknown_lints,
+        renamed_and_removed_lints,
+        clippy::unknown_clippy_lints
+    )]
     fn recv_control(&mut self, conn: &mut Connection, stream_id: u64) -> Res<HandleReadableOutput> {
         assert!(self.control_stream_remote.is_recv_stream(stream_id));
         let mut control_frames = Vec::new();

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -179,6 +179,8 @@ impl Http3Client {
     /// This may be call if an application has a resumption token. This must be called before connection starts.
     /// # Errors
     /// An error is return if token cannot be decoded or a connection is is a wrong state.
+    /// # Panics
+    /// On closing if the base handler can't handle it (debug only).
     pub fn enable_resumption(&mut self, now: Instant, token: impl AsRef<[u8]>) -> Res<()> {
         if self.base_handler.state != Http3State::Initializing {
             return Err(Error::InvalidState);
@@ -200,12 +202,10 @@ impl Http3Client {
         self.conn.enable_resumption(now, tok)?;
         if self.conn.state().closed() {
             let state = self.conn.state().clone();
-            debug_assert!(
-                Ok(true)
-                    == self
-                        .base_handler
-                        .handle_state_change(&mut self.conn, &state)
-            );
+            let res = self
+                .base_handler
+                .handle_state_change(&mut self.conn, &state);
+            debug_assert_eq!(Ok(true), res);
             return Err(Error::FatalError);
         }
         if *self.conn.zero_rtt_state() == ZeroRttState::Sending {
@@ -285,11 +285,12 @@ impl Http3Client {
             .map_err(|e| Error::map_stream_create_errors(&e))?;
 
         // Transform pseudo-header fields
-        let mut final_headers = Vec::new();
-        final_headers.push((":method".into(), method.to_owned()));
-        final_headers.push((":scheme".into(), scheme.to_owned()));
-        final_headers.push((":authority".into(), host.to_owned()));
-        final_headers.push((":path".into(), path.to_owned()));
+        let mut final_headers = vec![
+            (":method".into(), method.to_owned()),
+            (":scheme".into(), scheme.to_owned()),
+            (":authority".into(), host.to_owned()),
+            (":path".into(), path.to_owned()),
+        ];
         final_headers.extend_from_slice(headers);
 
         self.base_handler.add_streams(

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -139,6 +139,8 @@ impl Error {
         matches!(self, Self::HttpGeneralProtocolStream | Self::InvalidHeader)
     }
 
+    /// # Panics
+    /// On unexpected errors, in debug mode.
     #[must_use]
     pub fn map_stream_send_errors(err: &TransportError) -> Self {
         match err {
@@ -153,6 +155,8 @@ impl Error {
         }
     }
 
+    /// # Panics
+    /// On unexpected errors, in debug mode.
     #[must_use]
     pub fn map_stream_create_errors(err: &TransportError) -> Self {
         match err {
@@ -165,6 +169,8 @@ impl Error {
         }
     }
 
+    /// # Panics
+    /// On unexpected errors, in debug mode.
     #[must_use]
     pub fn map_stream_recv_errors(err: &TransportError) -> Self {
         match err {
@@ -192,12 +198,14 @@ impl Error {
 
     /// # Errors
     ///   Any error is mapped to the indicated type.
+    /// # Panics
+    /// On internal errors, in debug mode.
     fn map_error<R>(r: Result<R, impl Into<Self>>, err: Self) -> Result<R, Self> {
-        Ok(r.map_err(|e| {
+        r.map_err(|e| {
             debug_assert!(!matches!(e.into(), Self::HttpInternal(..)));
             debug_assert!(!matches!(err, Self::HttpInternal(..)));
             err
-        })?)
+        })
     }
 }
 

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -333,7 +333,8 @@ impl RecvMessage {
             MessageType::Response => {
                 let status = headers.iter().find(|(name, _value)| name == ":status");
                 if let Some((_name, value)) = status {
-                    #[allow(clippy::map_err_ignore, clippy::unknown_clippy_lints)]
+                    #[allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)]
+                    #[allow(clippy::map_err_ignore)]
                     let status_code = value.parse::<i32>().map_err(|_| Error::InvalidHeader)?;
                     Ok((100..200).contains(&status_code))
                 } else {

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -402,6 +402,8 @@ impl ToSocketAddrs for Peer {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
+#[allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
 #[derive(Debug, PartialEq)]
 enum Test {
     Connect,

--- a/neqo-qpack/src/decoder_instructions.rs
+++ b/neqo-qpack/src/decoder_instructions.rs
@@ -7,7 +7,7 @@
 use crate::prefix::{
     DECODER_HEADER_ACK, DECODER_INSERT_COUNT_INCREMENT, DECODER_STREAM_CANCELLATION,
 };
-use crate::qpack_send_buf::QPData;
+use crate::qpack_send_buf::QpackData;
 use crate::reader::{IntReader, ReadByte};
 use crate::Res;
 use neqo_common::{qdebug, qtrace};
@@ -34,7 +34,7 @@ impl DecoderInstruction {
         }
     }
 
-    pub(crate) fn marshal(&self, enc: &mut QPData) {
+    pub(crate) fn marshal(&self, enc: &mut QpackData) {
         match self {
             Self::InsertCountIncrement { increment } => {
                 enc.encode_prefixed_encoded_int(DECODER_INSERT_COUNT_INCREMENT, *increment);
@@ -123,12 +123,12 @@ impl DecoderInstructionReader {
 #[cfg(test)]
 mod test {
 
-    use super::{DecoderInstruction, DecoderInstructionReader, QPData};
+    use super::{DecoderInstruction, DecoderInstructionReader, QpackData};
     use crate::reader::test_receiver::TestReceiver;
     use crate::Error;
 
     fn test_encoding_decoding(instruction: DecoderInstruction) {
-        let mut buf = QPData::default();
+        let mut buf = QpackData::default();
         instruction.marshal(&mut buf);
         let mut test_receiver: TestReceiver = TestReceiver::default();
         test_receiver.write(&buf);
@@ -152,7 +152,7 @@ mod test {
     }
 
     fn test_encoding_decoding_slow_reader(instruction: DecoderInstruction) {
-        let mut buf = QPData::default();
+        let mut buf = QpackData::default();
         instruction.marshal(&mut buf);
         let mut test_receiver: TestReceiver = TestReceiver::default();
         let mut decoder = DecoderInstructionReader::new();

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -8,7 +8,7 @@ use crate::decoder_instructions::{DecoderInstruction, DecoderInstructionReader};
 use crate::encoder_instructions::EncoderInstruction;
 use crate::header_block::HeaderEncoder;
 use crate::qlog;
-use crate::qpack_send_buf::QPData;
+use crate::qpack_send_buf::QpackData;
 use crate::reader::ReceiverConnWrapper;
 use crate::stats::Stats;
 use crate::table::{HeaderTable, LookupResult, ADDITIONAL_TABLE_ENTRY_SIZE};
@@ -155,7 +155,12 @@ impl QPackEncoder {
         }
     }
 
-    #[allow(clippy::map_err_ignore, clippy::unknown_clippy_lints)]
+    #[allow(
+        clippy::map_err_ignore,
+        unknown_lints,
+        renamed_and_removed_lints,
+        clippy::unknown_clippy_lints
+    )]
     fn insert_count_instruction(&mut self, increment: u64) -> Res<()> {
         self.table
             .increment_acked(increment)
@@ -241,6 +246,8 @@ impl QPackEncoder {
     /// `EncoderStreamBlocked` if the encoder stream is blocked by the flow control.
     /// `DynamicTableFull` if the dynamic table does not have enough space for the entry.
     /// The function can return transport errors: `InvalidStreamId`, `InvalidInput` and `FinalSizeError`.
+    /// # Panics
+    /// When the insertion fails (it should not).
     pub fn send_and_insert(
         &mut self,
         conn: &mut Connection,
@@ -255,7 +262,7 @@ impl QPackEncoder {
             return Err(Error::DynamicTableFull);
         }
 
-        let mut buf = QPData::default();
+        let mut buf = QpackData::default();
         EncoderInstruction::InsertWithNameLiteral {
             name: &name,
             value: &value,
@@ -297,7 +304,7 @@ impl QPackEncoder {
             if cap < self.table.capacity() && !self.table.can_evict_to(cap) {
                 return Err(Error::DynamicTableFull);
             }
-            let mut buf = QPData::default();
+            let mut buf = QpackData::default();
             EncoderInstruction::Capacity { value: cap }.marshal(&mut buf, self.use_huffman);
             if !conn.stream_send_atomic(stream_id.as_u64(), &buf)? {
                 return Err(Error::EncoderStreamBlocked);
@@ -325,7 +332,7 @@ impl QPackEncoder {
                 Ok(())
             }
             LocalStreamState::Uninitialized(stream_id) => {
-                let mut buf = QPData::default();
+                let mut buf = QpackData::default();
                 buf.encode_varint(QPACK_UNI_STREAM_TYPE_ENCODER);
                 if !conn.stream_send_atomic(stream_id.as_u64(), &buf[..])? {
                     return Err(Error::EncoderStreamBlocked);
@@ -355,6 +362,8 @@ impl QPackEncoder {
     /// # Errors
     /// `ClosedCriticalStream` if the encoder stream is closed.
     /// `InternalError` if an unexpected error occurred.
+    /// # Panics
+    /// If there is a programming error.
     pub fn encode_header_block(
         &mut self,
         conn: &mut Connection,
@@ -460,6 +469,8 @@ impl QPackEncoder {
     }
 
     /// Encoder stream has been created. Add the stream id.
+    /// # Panics
+    /// If a stream has already been added.
     pub fn add_send_stream(&mut self, stream_id: u64) {
         if self.local_stream == LocalStreamState::NoStream {
             self.local_stream = LocalStreamState::Uninitialized(StreamId::new(stream_id));

--- a/neqo-qpack/src/encoder_instructions.rs
+++ b/neqo-qpack/src/encoder_instructions.rs
@@ -8,7 +8,7 @@ use crate::prefix::{
     ENCODER_CAPACITY, ENCODER_DUPLICATE, ENCODER_INSERT_WITH_NAME_LITERAL,
     ENCODER_INSERT_WITH_NAME_REF_DYNAMIC, ENCODER_INSERT_WITH_NAME_REF_STATIC, NO_PREFIX,
 };
-use crate::qpack_send_buf::QPData;
+use crate::qpack_send_buf::QpackData;
 use crate::reader::{IntReader, LiteralReader, ReadByte, Reader};
 use crate::Res;
 use neqo_common::{qdebug, qtrace};
@@ -29,7 +29,7 @@ pub enum EncoderInstruction<'a> {
 }
 
 impl<'a> EncoderInstruction<'a> {
-    pub(crate) fn marshal(&self, enc: &mut QPData, use_huffman: bool) {
+    pub(crate) fn marshal(&self, enc: &mut QpackData, use_huffman: bool) {
         match self {
             Self::Capacity { value } => {
                 enc.encode_prefixed_encoded_int(ENCODER_CAPACITY, *value);
@@ -264,12 +264,12 @@ impl EncoderInstructionReader {
 #[cfg(test)]
 mod test {
 
-    use super::{EncoderInstruction, EncoderInstructionReader, QPData};
+    use super::{EncoderInstruction, EncoderInstructionReader, QpackData};
     use crate::reader::test_receiver::TestReceiver;
     use crate::Error;
 
     fn test_encoding_decoding(instruction: &EncoderInstruction, use_huffman: bool) {
-        let mut buf = QPData::default();
+        let mut buf = QpackData::default();
         instruction.marshal(&mut buf, use_huffman);
         let mut test_receiver: TestReceiver = TestReceiver::default();
         test_receiver.write(&buf);
@@ -363,7 +363,7 @@ mod test {
     }
 
     fn test_encoding_decoding_slow_reader(instruction: &EncoderInstruction, use_huffman: bool) {
-        let mut buf = QPData::default();
+        let mut buf = QpackData::default();
         instruction.marshal(&mut buf, use_huffman);
         let mut test_receiver: TestReceiver = TestReceiver::default();
         let mut decoder = EncoderInstructionReader::new();

--- a/neqo-qpack/src/header_block.rs
+++ b/neqo-qpack/src/header_block.rs
@@ -10,7 +10,7 @@ use crate::prefix::{
     HEADER_FIELD_LITERAL_NAME_REF_DYNAMIC, HEADER_FIELD_LITERAL_NAME_REF_DYNAMIC_POST,
     HEADER_FIELD_LITERAL_NAME_REF_STATIC, NO_PREFIX,
 };
-use crate::qpack_send_buf::QPData;
+use crate::qpack_send_buf::QpackData;
 use crate::reader::{to_string, ReceiverBufferWrapper};
 use crate::table::HeaderTable;
 use crate::Header;
@@ -21,7 +21,7 @@ use std::ops::{Deref, Div};
 
 #[derive(Default, Debug, PartialEq)]
 pub struct HeaderEncoder {
-    buf: QPData,
+    buf: QpackData,
     base: u64,
     use_huffman: bool,
     max_entries: u64,
@@ -37,7 +37,7 @@ impl ::std::fmt::Display for HeaderEncoder {
 impl HeaderEncoder {
     pub fn new(base: u64, use_huffman: bool, max_entries: u64) -> Self {
         Self {
-            buf: QPData::default(),
+            buf: QpackData::default(),
             base,
             use_huffman,
             max_entries,

--- a/neqo-qpack/src/huffman.rs
+++ b/neqo-qpack/src/huffman.rs
@@ -65,8 +65,10 @@ impl<'a> BitReader<'a> {
 }
 
 /// Decodes huffman encoded input.
-/// ### Errors
+/// # Errors
 /// This function may return `HuffmanDecompressionFailed` if `input` is not a correct huffman-encoded array of bits.
+/// # Panics
+/// Never, but rust can't know that.
 pub fn decode_huffman(input: &[u8]) -> Res<Vec<u8>> {
     let mut reader = BitReader::new(input);
     let mut output = Vec::new();
@@ -106,6 +108,8 @@ fn decode_character(reader: &mut BitReader) -> Res<Option<u16>> {
     Ok(node.value)
 }
 
+/// # Panics
+/// Never, but rust doesn't know that.
 #[must_use]
 pub fn encode_huffman(input: &[u8]) -> Vec<u8> {
     let mut output: Vec<u8> = Vec::new();

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -83,13 +83,13 @@ impl Error {
     /// # Errors
     ///   Any error is mapped to the indicated type.
     fn map_error<R>(r: Result<R, Self>, err: Self) -> Result<R, Self> {
-        Ok(r.map_err(|e| {
+        r.map_err(|e| {
             if matches!(e, Self::ClosedCriticalStream) {
                 e
             } else {
                 err
             }
-        })?)
+        })
     }
 }
 

--- a/neqo-qpack/src/qpack_send_buf.rs
+++ b/neqo-qpack/src/qpack_send_buf.rs
@@ -11,11 +11,11 @@ use std::convert::TryFrom;
 use std::ops::Deref;
 
 #[derive(Default, Debug, PartialEq)]
-pub(crate) struct QPData {
+pub(crate) struct QpackData {
     buf: Vec<u8>,
 }
 
-impl QPData {
+impl QpackData {
     pub fn len(&self) -> usize {
         self.buf.len()
     }
@@ -96,7 +96,7 @@ impl QPData {
     }
 }
 
-impl Deref for QPData {
+impl Deref for QpackData {
     type Target = [u8];
     fn deref(&self) -> &Self::Target {
         &*self.buf
@@ -105,25 +105,25 @@ impl Deref for QPData {
 
 #[cfg(test)]
 mod tests {
-    use super::{Prefix, QPData};
+    use super::{Prefix, QpackData};
 
     #[test]
     fn test_encode_prefixed_encoded_int_1() {
-        let mut d = QPData::default();
+        let mut d = QpackData::default();
         d.encode_prefixed_encoded_int(Prefix::new(0xC0, 2), 5);
         assert_eq!(d[..], [0xc5]);
     }
 
     #[test]
     fn test_encode_prefixed_encoded_int_2() {
-        let mut d = QPData::default();
+        let mut d = QpackData::default();
         d.encode_prefixed_encoded_int(Prefix::new(0xC0, 2), 65);
         assert_eq!(d[..], [0xff, 0x02]);
     }
 
     #[test]
     fn test_encode_prefixed_encoded_int_3() {
-        let mut d = QPData::default();
+        let mut d = QpackData::default();
         d.encode_prefixed_encoded_int(Prefix::new(0xC0, 2), 100_000);
         assert_eq!(d[..], [0xff, 0xe1, 0x8c, 0x06]);
     }
@@ -137,14 +137,14 @@ mod tests {
 
     #[test]
     fn test_encode_literal() {
-        let mut d = QPData::default();
+        let mut d = QpackData::default();
         d.encode_literal(false, Prefix::new(0xC0, 2), VALUE);
         assert_eq!(&&d[..], &LITERAL);
     }
 
     #[test]
     fn test_encode_literal_huffman() {
-        let mut d = QPData::default();
+        let mut d = QpackData::default();
         d.encode_literal(true, Prefix::new(0xC0, 2), VALUE);
         assert_eq!(&&d[..], &LITERAL_HUFFMAN);
     }

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -158,6 +158,8 @@ pub struct IntReader {
 impl IntReader {
     /// `IntReader` is created by suppling the first byte anf prefix length.
     /// A varint may take only one byte, In that case already the first by has set state to done.
+    /// # Panics
+    /// When `prefix_len` is 8 or larger.
     #[must_use]
     pub fn new(first_byte: u8, prefix_len: u8) -> Self {
         debug_assert!(prefix_len < 8, "prefix cannot larger than 7.");
@@ -175,6 +177,8 @@ impl IntReader {
         }
     }
 
+    /// # Panics
+    /// Never, but rust doesn't know that.
     #[must_use]
     pub fn make(first_byte: u8, prefixes: &[Prefix]) -> Self {
         for prefix in prefixes {
@@ -245,6 +249,8 @@ impl LiteralReader {
     /// Creates `LiteralReader` with the first byte. This constructor is always used
     /// when a litreral has a prefix.
     /// For literals without a prefix please use the default constructor.
+    /// # Panics
+    /// If `prefix_len` is 8 or more.
     #[must_use]
     pub fn new_with_first_byte(first_byte: u8, prefix_len: u8) -> Self {
         assert!(prefix_len < 8);
@@ -265,6 +271,8 @@ impl LiteralReader {
     ///  2) `IntegerOverflow`
     ///  3) Any `ReadByte`'s error
     /// It returns value if reading the literal is done or None if it needs more data.
+    /// # Panics
+    /// When this object is complete.
     pub fn read<T: ReadByte + Reader>(&mut self, s: &mut T) -> Res<Vec<u8>> {
         loop {
             qdebug!("state = {:?}", self.state);

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::packet::PacketBuilder;
 use crate::stats::FrameStats;
 use crate::tparams::{self, TransportParameter};
-use crate::tracking::PNSpace;
+use crate::tracking::PacketNumberSpace;
 use crate::StreamType;
 
 use neqo_common::Encoder;
@@ -256,7 +256,7 @@ fn idle_caching() {
         .crypto
         .streams
         .write_frame(
-            PNSpace::Initial,
+            PacketNumberSpace::Initial,
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
@@ -268,7 +268,7 @@ fn idle_caching() {
         .crypto
         .streams
         .write_frame(
-            PNSpace::Initial,
+            PacketNumberSpace::Initial,
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -27,7 +27,7 @@ use crate::recv_stream::RxStreamOrderer;
 use crate::send_stream::TxBuffer;
 use crate::stats::FrameStats;
 use crate::tparams::{TpZeroRttChecker, TransportParameters, TransportParametersHandler};
-use crate::tracking::PNSpace;
+use crate::tracking::PacketNumberSpace;
 use crate::{Error, Res};
 
 const MAX_AUTH_TAG: usize = 32;
@@ -111,16 +111,16 @@ impl Crypto {
     pub fn handshake(
         &mut self,
         now: Instant,
-        space: PNSpace,
+        space: PacketNumberSpace,
         data: Option<&[u8]>,
     ) -> Res<&HandshakeState> {
         let input = data.map(|d| {
             qtrace!("Handshake record received {:0x?} ", d);
             let epoch = match space {
-                PNSpace::Initial => TLS_EPOCH_INITIAL,
-                PNSpace::Handshake => TLS_EPOCH_HANDSHAKE,
+                PacketNumberSpace::Initial => TLS_EPOCH_INITIAL,
+                PacketNumberSpace::Handshake => TLS_EPOCH_HANDSHAKE,
                 // Our epoch progresses forward, but the TLS epoch is fixed to 3.
-                PNSpace::ApplicationData => TLS_EPOCH_APPLICATION_DATA,
+                PacketNumberSpace::ApplicationData => TLS_EPOCH_APPLICATION_DATA,
             };
             Record {
                 ct: TLS_CT_HANDSHAKE,
@@ -235,14 +235,14 @@ impl Crypto {
                 return Err(Error::ProtocolViolation);
             }
             qtrace!([self], "Adding CRYPTO data {:?}", r);
-            self.streams.send(PNSpace::from(r.epoch), &r.data);
+            self.streams.send(PacketNumberSpace::from(r.epoch), &r.data);
         }
         Ok(())
     }
 
     pub fn write_frame(
         &mut self,
-        space: PNSpace,
+        space: PacketNumberSpace,
         builder: &mut PacketBuilder,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
@@ -272,13 +272,13 @@ impl Crypto {
 
     /// Mark any outstanding frames in the indicated space as "lost" so
     /// that they can be sent again.
-    pub fn resend_unacked(&mut self, space: PNSpace) {
+    pub fn resend_unacked(&mut self, space: PacketNumberSpace) {
         self.streams.resend_unacked(space);
     }
 
     /// Discard state for a packet number space and return true
     /// if something was discarded.
-    pub fn discard(&mut self, space: PNSpace) -> bool {
+    pub fn discard(&mut self, space: PacketNumberSpace) -> bool {
         self.streams.discard(space);
         self.states.discard(space)
     }
@@ -352,7 +352,7 @@ pub struct CryptoDxState {
 }
 
 impl CryptoDxState {
-    #[allow(clippy::unknown_clippy_lints)] // Until we require rust 1.45.
+    #[allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.45.
     #[allow(clippy::reversed_empty_ranges)] // To initialize an empty range.
     pub fn new(
         direction: CryptoDxDirection,
@@ -735,18 +735,21 @@ pub struct CryptoStates {
 }
 
 impl CryptoStates {
-    /// Select a `CryptoDxState` and `CryptoSpace` for the given `PNSpace`.
-    /// This selects 0-RTT keys for `PNSpace::ApplicationData` if 1-RTT keys are
+    /// Select a `CryptoDxState` and `CryptoSpace` for the given `PacketNumberSpace`.
+    /// This selects 0-RTT keys for `PacketNumberSpace::ApplicationData` if 1-RTT keys are
     /// not yet available.
-    pub fn select_tx(&mut self, space: PNSpace) -> Option<(CryptoSpace, &mut CryptoDxState)> {
+    pub fn select_tx(
+        &mut self,
+        space: PacketNumberSpace,
+    ) -> Option<(CryptoSpace, &mut CryptoDxState)> {
         match space {
-            PNSpace::Initial => self
+            PacketNumberSpace::Initial => self
                 .tx(CryptoSpace::Initial)
                 .map(|dx| (CryptoSpace::Initial, dx)),
-            PNSpace::Handshake => self
+            PacketNumberSpace::Handshake => self
                 .tx(CryptoSpace::Handshake)
                 .map(|dx| (CryptoSpace::Handshake, dx)),
-            PNSpace::ApplicationData => {
+            PacketNumberSpace::ApplicationData => {
                 if let Some(app) = self.app_write.as_mut() {
                     Some((CryptoSpace::ApplicationData, &mut app.dx))
                 } else {
@@ -856,11 +859,11 @@ impl CryptoStates {
     }
 
     /// Discard keys and return true if that happened.
-    pub fn discard(&mut self, space: PNSpace) -> bool {
+    pub fn discard(&mut self, space: PacketNumberSpace) -> bool {
         match space {
-            PNSpace::Initial => self.initial.take().is_some(),
-            PNSpace::Handshake => self.handshake.take().is_some(),
-            PNSpace::ApplicationData => panic!("Can't drop application data keys"),
+            PacketNumberSpace::Initial => self.initial.take().is_some(),
+            PacketNumberSpace::Handshake => self.handshake.take().is_some(),
+            PacketNumberSpace::ApplicationData => panic!("Can't drop application data keys"),
         }
     }
 
@@ -1162,9 +1165,9 @@ pub enum CryptoStreams {
 }
 
 impl CryptoStreams {
-    pub fn discard(&mut self, space: PNSpace) {
+    pub fn discard(&mut self, space: PacketNumberSpace) {
         match space {
-            PNSpace::Initial => {
+            PacketNumberSpace::Initial => {
                 if let Self::Initial {
                     handshake,
                     application,
@@ -1177,7 +1180,7 @@ impl CryptoStreams {
                     };
                 }
             }
-            PNSpace::Handshake => {
+            PacketNumberSpace::Handshake => {
                 if let Self::Handshake { application, .. } = self {
                     *self = Self::ApplicationData {
                         application: mem::take(application),
@@ -1186,23 +1189,25 @@ impl CryptoStreams {
                     panic!("Discarding handshake before initial discarded");
                 }
             }
-            PNSpace::ApplicationData => panic!("Discarding application data crypto streams"),
+            PacketNumberSpace::ApplicationData => {
+                panic!("Discarding application data crypto streams")
+            }
         }
     }
 
-    pub fn send(&mut self, space: PNSpace, data: &[u8]) {
+    pub fn send(&mut self, space: PacketNumberSpace, data: &[u8]) {
         self.get_mut(space).unwrap().tx.send(data);
     }
 
-    pub fn inbound_frame(&mut self, space: PNSpace, offset: u64, data: &[u8]) {
+    pub fn inbound_frame(&mut self, space: PacketNumberSpace, offset: u64, data: &[u8]) {
         self.get_mut(space).unwrap().rx.inbound_frame(offset, data);
     }
 
-    pub fn data_ready(&self, space: PNSpace) -> bool {
+    pub fn data_ready(&self, space: PacketNumberSpace) -> bool {
         self.get(space).map_or(false, |cs| cs.rx.data_ready())
     }
 
-    pub fn read_to_end(&mut self, space: PNSpace, buf: &mut Vec<u8>) -> usize {
+    pub fn read_to_end(&mut self, space: PacketNumberSpace, buf: &mut Vec<u8>) -> usize {
         self.get_mut(space).unwrap().rx.read_to_end(buf)
     }
 
@@ -1222,15 +1227,15 @@ impl CryptoStreams {
 
     /// Resend any Initial or Handshake CRYPTO frames that might be outstanding.
     /// This can help speed up handshake times.
-    pub fn resend_unacked(&mut self, space: PNSpace) {
-        if space != PNSpace::ApplicationData {
+    pub fn resend_unacked(&mut self, space: PacketNumberSpace) {
+        if space != PacketNumberSpace::ApplicationData {
             if let Some(cs) = self.get_mut(space) {
                 cs.tx.unmark_sent();
             }
         }
     }
 
-    fn get(&self, space: PNSpace) -> Option<&CryptoStream> {
+    fn get(&self, space: PacketNumberSpace) -> Option<&CryptoStream> {
         let (initial, hs, app) = match self {
             Self::Initial {
                 initial,
@@ -1244,13 +1249,13 @@ impl CryptoStreams {
             Self::ApplicationData { application } => (None, None, Some(application)),
         };
         match space {
-            PNSpace::Initial => initial,
-            PNSpace::Handshake => hs,
-            PNSpace::ApplicationData => app,
+            PacketNumberSpace::Initial => initial,
+            PacketNumberSpace::Handshake => hs,
+            PacketNumberSpace::ApplicationData => app,
         }
     }
 
-    fn get_mut(&mut self, space: PNSpace) -> Option<&mut CryptoStream> {
+    fn get_mut(&mut self, space: PacketNumberSpace) -> Option<&mut CryptoStream> {
         let (initial, hs, app) = match self {
             Self::Initial {
                 initial,
@@ -1264,15 +1269,15 @@ impl CryptoStreams {
             Self::ApplicationData { application } => (None, None, Some(application)),
         };
         match space {
-            PNSpace::Initial => initial,
-            PNSpace::Handshake => hs,
-            PNSpace::ApplicationData => app,
+            PacketNumberSpace::Initial => initial,
+            PacketNumberSpace::Handshake => hs,
+            PacketNumberSpace::ApplicationData => app,
         }
     }
 
     pub fn write_frame(
         &mut self,
-        space: PNSpace,
+        space: PacketNumberSpace,
         builder: &mut PacketBuilder,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
@@ -1326,7 +1331,7 @@ impl Default for CryptoStreams {
 
 #[derive(Debug, Clone)]
 pub struct CryptoRecoveryToken {
-    space: PNSpace,
+    space: PacketNumberSpace,
     offset: u64,
     length: usize,
 }

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -66,13 +66,13 @@ impl PacketType {
     }
 }
 
-impl Into<CryptoSpace> for PacketType {
-    fn into(self) -> CryptoSpace {
-        match self {
-            Self::Initial => CryptoSpace::Initial,
-            Self::ZeroRtt => CryptoSpace::ZeroRtt,
-            Self::Handshake => CryptoSpace::Handshake,
-            Self::Short => CryptoSpace::ApplicationData,
+impl From<PacketType> for CryptoSpace {
+    fn from(v: PacketType) -> Self {
+        match v {
+            PacketType::Initial => Self::Initial,
+            PacketType::ZeroRtt => Self::ZeroRtt,
+            PacketType::Handshake => Self::Handshake,
+            PacketType::Short => Self::ApplicationData,
             _ => panic!("shouldn't be here"),
         }
     }
@@ -183,7 +183,7 @@ impl PacketBuilder {
     ///
     /// If, after calling this method, `remaining()` returns 0, then call `abort()` to get
     /// the encoder back.
-    #[allow(clippy::unknown_clippy_lints)] // Until we require rust 1.45.
+    #[allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.45.
     #[allow(clippy::reversed_empty_ranges)]
     pub fn short(mut encoder: Encoder, key_phase: bool, dcid: impl AsRef<[u8]>) -> Self {
         let mut limit = Self::infer_limit(&encoder);
@@ -216,7 +216,8 @@ impl PacketBuilder {
     /// even if the token is empty.
     ///
     /// See `short()` for more on how to handle this in cases where there is no space.
-    #[allow(clippy::unknown_clippy_lints)] // Until we require rust 1.45.
+    #[allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)]
+    // Until we require rust 1.45.
     #[allow(clippy::reversed_empty_ranges)] // For initializing an empty range.
     pub fn long(
         mut encoder: Encoder,
@@ -492,9 +493,9 @@ impl DerefMut for PacketBuilder {
     }
 }
 
-impl Into<Encoder> for PacketBuilder {
-    fn into(self) -> Encoder {
-        self.encoder
+impl From<PacketBuilder> for Encoder {
+    fn from(v: PacketBuilder) -> Self {
+        v.encoder
     }
 }
 

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -25,7 +25,7 @@ use crate::recovery::RecoveryToken;
 use crate::rtt::RttEstimate;
 use crate::sender::PacketSender;
 use crate::stats::FrameStats;
-use crate::tracking::{PNSpace, SentPacket};
+use crate::tracking::{PacketNumberSpace, SentPacket};
 use crate::{Error, Res};
 
 use neqo_common::{hex, qdebug, qinfo, qlog::NeqoQlog, qtrace, Datagram, Encoder};
@@ -840,7 +840,7 @@ impl Path {
     pub fn on_packets_lost(
         &mut self,
         prev_largest_acked_sent: Option<Instant>,
-        space: PNSpace,
+        space: PacketNumberSpace,
         lost_packets: &[SentPacket],
     ) {
         debug_assert!(self.is_primary());

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -28,7 +28,7 @@ use crate::rtt::RttEstimate;
 use crate::send_stream::StreamRecoveryToken;
 use crate::stats::{Stats, StatsCell};
 use crate::stream_id::{StreamId, StreamType};
-use crate::tracking::{AckToken, PNSpace, PNSpaceSet, SentPacket};
+use crate::tracking::{AckToken, PacketNumberSpace, PacketNumberSpaceSet, SentPacket};
 
 pub(crate) const PACKET_THRESHOLD: u64 = 3;
 /// `ACK_ONLY_SIZE_LIMIT` is the minimum size of the congestion window.
@@ -86,9 +86,9 @@ pub struct SendProfile {
     /// The limit on the size of the packet.
     limit: usize,
     /// Whether this is a PTO, and what space the PTO is for.
-    pto: Option<PNSpace>,
+    pto: Option<PacketNumberSpace>,
     /// What spaces should be probed.
-    probe: PNSpaceSet,
+    probe: PacketNumberSpaceSet,
     /// Whether pacing is active.
     paced: bool,
 }
@@ -101,7 +101,7 @@ impl SendProfile {
         Self {
             limit: max(ACK_ONLY_SIZE_LIMIT - 1, limit),
             pto: None,
-            probe: PNSpaceSet::default(),
+            probe: PacketNumberSpaceSet::default(),
             paced: false,
         }
     }
@@ -111,12 +111,12 @@ impl SendProfile {
         Self {
             limit: ACK_ONLY_SIZE_LIMIT - 1,
             pto: None,
-            probe: PNSpaceSet::default(),
+            probe: PacketNumberSpaceSet::default(),
             paced: true,
         }
     }
 
-    pub fn new_pto(pn_space: PNSpace, mtu: usize, probe: PNSpaceSet) -> Self {
+    pub fn new_pto(pn_space: PacketNumberSpace, mtu: usize, probe: PacketNumberSpaceSet) -> Self {
         debug_assert!(mtu > ACK_ONLY_SIZE_LIMIT);
         debug_assert!(probe[pn_space]);
         Self {
@@ -130,7 +130,7 @@ impl SendProfile {
     /// Whether probing this space is helpful.  This isn't necessarily the space
     /// that caused the timer to pop, but it is helpful to send a PING in a space
     /// that has the PTO timer armed.
-    pub fn should_probe(&self, space: PNSpace) -> bool {
+    pub fn should_probe(&self, space: PacketNumberSpace) -> bool {
         self.probe[space]
     }
 
@@ -138,7 +138,7 @@ impl SendProfile {
     /// number space.
     /// Send only ACKs either: when the space available is too small, or when a PTO
     /// exists for a later packet number space (which should get the most space).
-    pub fn ack_only(&self, space: PNSpace) -> bool {
+    pub fn ack_only(&self, space: PacketNumberSpace) -> bool {
         self.limit < ACK_ONLY_SIZE_LIMIT || self.pto.map_or(false, |sp| space < sp)
     }
 
@@ -153,7 +153,7 @@ impl SendProfile {
 
 #[derive(Debug)]
 pub(crate) struct LossRecoverySpace {
-    space: PNSpace,
+    space: PacketNumberSpace,
     largest_acked: Option<PacketNumber>,
     largest_acked_sent_time: Option<Instant>,
     /// The time used to calculate the PTO timer for this space.
@@ -172,7 +172,7 @@ pub(crate) struct LossRecoverySpace {
 }
 
 impl LossRecoverySpace {
-    pub fn new(space: PNSpace) -> Self {
+    pub fn new(space: PacketNumberSpace) -> Self {
         Self {
             space,
             largest_acked: None,
@@ -185,7 +185,7 @@ impl LossRecoverySpace {
     }
 
     #[must_use]
-    pub fn space(&self) -> PNSpace {
+    pub fn space(&self) -> PacketNumberSpace {
         self.space
     }
 
@@ -219,7 +219,7 @@ impl LossRecoverySpace {
         if self.in_flight_outstanding() {
             debug_assert!(self.last_ack_eliciting.is_some());
             self.last_ack_eliciting
-        } else if self.space == PNSpace::ApplicationData {
+        } else if self.space == PacketNumberSpace::ApplicationData {
             None
         } else {
             // Nasty special case to prevent handshake deadlocks.
@@ -241,7 +241,9 @@ impl LossRecoverySpace {
         if sent_packet.ack_eliciting() {
             self.last_ack_eliciting = Some(sent_packet.time_sent);
             self.in_flight_outstanding += 1;
-        } else if self.space != PNSpace::ApplicationData && self.last_ack_eliciting.is_none() {
+        } else if self.space != PacketNumberSpace::ApplicationData
+            && self.last_ack_eliciting.is_none()
+        {
             // For Initial and Handshake spaces, make sure that we have a PTO baseline
             // always. See `LossRecoverySpace::pto_base_time()` for details.
             self.last_ack_eliciting = Some(sent_packet.time_sent);
@@ -340,7 +342,12 @@ impl LossRecoverySpace {
     /// We try to keep these around until a probe is sent for them, so it is
     /// important that `cd` is set to at least the current PTO time; otherwise we
     /// might remove all in-flight packets and stop sending probes.
-    #[allow(clippy::option_if_let_else, clippy::unknown_clippy_lints)] // Hard enough to read as-is.
+    #[allow(
+        clippy::option_if_let_else,
+        unknown_lints,
+        renamed_and_removed_lints,
+        clippy::unknown_clippy_lints
+    )] // Hard enough to read as-is.
     fn remove_old_lost(&mut self, now: Instant, cd: Duration) {
         let mut it = self.sent_packets.iter();
         // If the first item is not expired, do nothing.
@@ -434,11 +441,11 @@ pub(crate) struct LossRecoverySpaces {
 }
 
 impl LossRecoverySpaces {
-    fn idx(space: PNSpace) -> usize {
+    fn idx(space: PacketNumberSpace) -> usize {
         match space {
-            PNSpace::ApplicationData => 0,
-            PNSpace::Handshake => 1,
-            PNSpace::Initial => 2,
+            PacketNumberSpace::ApplicationData => 0,
+            PacketNumberSpace::Handshake => 1,
+            PacketNumberSpace::Initial => 2,
         }
     }
 
@@ -446,26 +453,26 @@ impl LossRecoverySpaces {
     /// outstanding, so that those can be marked as lost.
     /// # Panics
     /// If the space has already been removed.
-    pub fn drop_space(&mut self, space: PNSpace) -> impl IntoIterator<Item = SentPacket> {
+    pub fn drop_space(&mut self, space: PacketNumberSpace) -> impl IntoIterator<Item = SentPacket> {
         let sp = match space {
-            PNSpace::Initial => self.spaces.pop(),
-            PNSpace::Handshake => {
+            PacketNumberSpace::Initial => self.spaces.pop(),
+            PacketNumberSpace::Handshake => {
                 let sp = self.spaces.pop();
                 self.spaces.shrink_to_fit();
                 sp
             }
-            PNSpace::ApplicationData => panic!("discarding application space"),
+            PacketNumberSpace::ApplicationData => panic!("discarding application space"),
         };
         let mut sp = sp.unwrap();
         assert_eq!(sp.space(), space, "dropping spaces out of order");
         sp.remove_ignored()
     }
 
-    pub fn get(&self, space: PNSpace) -> Option<&LossRecoverySpace> {
+    pub fn get(&self, space: PacketNumberSpace) -> Option<&LossRecoverySpace> {
         self.spaces.get(Self::idx(space))
     }
 
-    pub fn get_mut(&mut self, space: PNSpace) -> Option<&mut LossRecoverySpace> {
+    pub fn get_mut(&mut self, space: PacketNumberSpace) -> Option<&mut LossRecoverySpace> {
         self.spaces.get_mut(Self::idx(space))
     }
 
@@ -482,9 +489,9 @@ impl Default for LossRecoverySpaces {
     fn default() -> Self {
         Self {
             spaces: smallvec![
-                LossRecoverySpace::new(PNSpace::ApplicationData),
-                LossRecoverySpace::new(PNSpace::Handshake),
-                LossRecoverySpace::new(PNSpace::Initial),
+                LossRecoverySpace::new(PacketNumberSpace::ApplicationData),
+                LossRecoverySpace::new(PacketNumberSpace::Handshake),
+                LossRecoverySpace::new(PacketNumberSpace::Initial),
             ],
         }
     }
@@ -493,16 +500,16 @@ impl Default for LossRecoverySpaces {
 #[derive(Debug)]
 struct PtoState {
     /// The packet number space that caused the PTO to fire.
-    space: PNSpace,
+    space: PacketNumberSpace,
     /// The number of probes that we have sent.
     count: usize,
     packets: usize,
     /// The complete set of packet number spaces that can have probes sent.
-    probe: PNSpaceSet,
+    probe: PacketNumberSpaceSet,
 }
 
 impl PtoState {
-    pub fn new(space: PNSpace, probe: PNSpaceSet) -> Self {
+    pub fn new(space: PacketNumberSpace, probe: PacketNumberSpaceSet) -> Self {
         debug_assert!(probe[space]);
         Self {
             space,
@@ -512,7 +519,7 @@ impl PtoState {
         }
     }
 
-    pub fn pto(&mut self, space: PNSpace, probe: PNSpaceSet) {
+    pub fn pto(&mut self, space: PacketNumberSpace, probe: PacketNumberSpaceSet) {
         debug_assert!(probe[space]);
         self.space = space;
         self.count += 1;
@@ -562,7 +569,7 @@ impl LossRecovery {
         }
     }
 
-    pub fn largest_acknowledged_pn(&self, pn_space: PNSpace) -> Option<PacketNumber> {
+    pub fn largest_acknowledged_pn(&self, pn_space: PacketNumberSpace) -> Option<PacketNumber> {
         self.spaces.get(pn_space).and_then(|sp| sp.largest_acked)
     }
 
@@ -575,13 +582,13 @@ impl LossRecovery {
         // The client should not have received any ACK frames when it drops 0-RTT.
         assert!(self
             .spaces
-            .get(PNSpace::ApplicationData)
+            .get(PacketNumberSpace::ApplicationData)
             .unwrap()
             .largest_acked
             .is_none());
         let mut dropped = self
             .spaces
-            .get_mut(PNSpace::ApplicationData)
+            .get_mut(PacketNumberSpace::ApplicationData)
             .unwrap()
             .remove_ignored()
             .collect::<Vec<_>>();
@@ -593,7 +600,7 @@ impl LossRecovery {
     }
 
     pub fn on_packet_sent(&mut self, path: &PathRef, mut sent_packet: SentPacket) {
-        let pn_space = PNSpace::from(sent_packet.pt);
+        let pn_space = PacketNumberSpace::from(sent_packet.pt);
         qdebug!([self], "packet {}-{} sent", pn_space, sent_packet.pn);
         if let Some(space) = self.spaces.get_mut(pn_space) {
             path.borrow_mut().packet_sent(&mut sent_packet);
@@ -610,7 +617,7 @@ impl LossRecovery {
 
     pub fn should_probe(&self, pto: Duration, now: Instant) -> bool {
         self.spaces
-            .get(PNSpace::ApplicationData)
+            .get(PacketNumberSpace::ApplicationData)
             .unwrap()
             .should_probe(pto, now)
     }
@@ -632,7 +639,7 @@ impl LossRecovery {
     pub fn on_ack_received<R>(
         &mut self,
         primary_path: &PathRef,
-        pn_space: PNSpace,
+        pn_space: PacketNumberSpace,
         largest_acked: u64,
         acked_ranges: R,
         ack_delay: Duration,
@@ -735,10 +742,10 @@ impl LossRecovery {
         self.confirmed_time = Some(now);
         // Up until now, the ApplicationData space has been ignored for PTO.
         // So maybe fire a PTO.
-        if let Some(pto) = self.pto_time(rtt, PNSpace::ApplicationData) {
+        if let Some(pto) = self.pto_time(rtt, PacketNumberSpace::ApplicationData) {
             if pto < now {
-                let probes = PNSpaceSet::from(&[PNSpace::ApplicationData]);
-                self.fire_pto(PNSpace::ApplicationData, probes);
+                let probes = PacketNumberSpaceSet::from(&[PacketNumberSpace::ApplicationData]);
+                self.fire_pto(PacketNumberSpace::ApplicationData, probes);
             }
         }
     }
@@ -754,7 +761,7 @@ impl LossRecovery {
     }
 
     /// Discard state for a given packet number space.
-    pub fn discard(&mut self, primary_path: &PathRef, space: PNSpace, now: Instant) {
+    pub fn discard(&mut self, primary_path: &PathRef, space: PacketNumberSpace, now: Instant) {
         qdebug!([self], "Reset loss recovery state for {}", space);
         let mut path = primary_path.borrow_mut();
         for p in self.spaces.drop_space(space) {
@@ -766,7 +773,7 @@ impl LossRecovery {
         // the server has completed address validation, but ignore that.
         self.pto_state = None;
 
-        if space == PNSpace::Handshake {
+        if space == PacketNumberSpace::Handshake {
             self.confirmed(path.rtt(), now);
         }
     }
@@ -803,7 +810,7 @@ impl LossRecovery {
     fn pto_period_inner(
         rtt: &RttEstimate,
         pto_state: Option<&PtoState>,
-        pn_space: PNSpace,
+        pn_space: PacketNumberSpace,
     ) -> Duration {
         rtt.pto(pn_space)
             .checked_mul(1 << pto_state.map_or(0, |p| p.count))
@@ -812,13 +819,13 @@ impl LossRecovery {
 
     /// Get the current PTO period for the given packet number space.
     /// Unlike calling `RttEstimate::pto` directly, this includes exponential backoff.
-    fn pto_period(&self, rtt: &RttEstimate, pn_space: PNSpace) -> Duration {
+    fn pto_period(&self, rtt: &RttEstimate, pn_space: PacketNumberSpace) -> Duration {
         Self::pto_period_inner(rtt, self.pto_state.as_ref(), pn_space)
     }
 
     // Calculate PTO time for the given space.
-    fn pto_time(&self, rtt: &RttEstimate, pn_space: PNSpace) -> Option<Instant> {
-        if self.confirmed_time.is_none() && pn_space == PNSpace::ApplicationData {
+    fn pto_time(&self, rtt: &RttEstimate, pn_space: PacketNumberSpace) -> Option<Instant> {
+        if self.confirmed_time.is_none() && pn_space == PacketNumberSpace::ApplicationData {
             None
         } else {
             self.spaces.get(pn_space).and_then(|space| {
@@ -833,17 +840,17 @@ impl LossRecovery {
     /// Ignore Application if either Initial or Handshake have an active PTO.
     fn earliest_pto(&self, rtt: &RttEstimate) -> Option<Instant> {
         if self.confirmed_time.is_some() {
-            self.pto_time(rtt, PNSpace::ApplicationData)
+            self.pto_time(rtt, PacketNumberSpace::ApplicationData)
         } else {
-            self.pto_time(rtt, PNSpace::Initial)
+            self.pto_time(rtt, PacketNumberSpace::Initial)
                 .iter()
-                .chain(self.pto_time(rtt, PNSpace::Handshake).iter())
+                .chain(self.pto_time(rtt, PacketNumberSpace::Handshake).iter())
                 .min()
                 .cloned()
         }
     }
 
-    fn fire_pto(&mut self, pn_space: PNSpace, allow_probes: PNSpaceSet) {
+    fn fire_pto(&mut self, pn_space: PacketNumberSpace, allow_probes: PacketNumberSpaceSet) {
         if let Some(st) = &mut self.pto_state {
             st.pto(pn_space, allow_probes);
         } else {
@@ -870,8 +877,8 @@ impl LossRecovery {
     fn maybe_fire_pto(&mut self, rtt: &RttEstimate, now: Instant, lost: &mut Vec<SentPacket>) {
         let mut pto_space = None;
         // The spaces in which we will allow probing.
-        let mut allow_probes = PNSpaceSet::default();
-        for pn_space in PNSpace::iter() {
+        let mut allow_probes = PacketNumberSpaceSet::default();
+        for pn_space in PacketNumberSpace::iter() {
             if let Some(t) = self.pto_time(rtt, *pn_space) {
                 allow_probes[*pn_space] = true;
                 if t <= now {
@@ -921,7 +928,12 @@ impl LossRecovery {
 
     /// Check how packets should be sent, based on whether there is a PTO,
     /// what the current congestion window is, and what the pacer says.
-    #[allow(clippy::option_if_let_else, clippy::unknown_clippy_lints)]
+    #[allow(
+        clippy::option_if_let_else,
+        unknown_lints,
+        renamed_and_removed_lints,
+        clippy::unknown_clippy_lints
+    )]
     pub fn send_profile(&mut self, path: &Path, now: Instant) -> SendProfile {
         qdebug!([self], "get send profile {:?}", now);
         let sender = path.sender();
@@ -948,7 +960,7 @@ impl LossRecovery {
                 // After entering recovery, allow a packet to be sent immediately.
                 // This uses the PTO machinery, probing in all spaces. This will
                 // result in a PING being sent in every active space.
-                SendProfile::new_pto(PNSpace::Initial, mtu, PNSpaceSet::all())
+                SendProfile::new_pto(PacketNumberSpace::Initial, mtu, PacketNumberSpaceSet::all())
             } else {
                 SendProfile::new_limited(limit)
             }
@@ -964,7 +976,7 @@ impl ::std::fmt::Display for LossRecovery {
 
 #[cfg(test)]
 mod tests {
-    use super::{LossRecovery, LossRecoverySpace, PNSpace, SendProfile, SentPacket};
+    use super::{LossRecovery, LossRecoverySpace, PacketNumberSpace, SendProfile, SentPacket};
     use crate::cc::CongestionControlAlgorithm;
     use crate::cid::{ConnectionId, ConnectionIdEntry};
     use crate::packet::PacketType;
@@ -999,7 +1011,7 @@ mod tests {
     impl Fixture {
         pub fn on_ack_received(
             &mut self,
-            pn_space: PNSpace,
+            pn_space: PacketNumberSpace,
             largest_acked: u64,
             acked_ranges: Vec<RangeInclusive<u64>>,
             ack_delay: Duration,
@@ -1027,11 +1039,11 @@ mod tests {
             self.lr.next_timeout(self.path.borrow().rtt())
         }
 
-        pub fn discard(&mut self, space: PNSpace, now: Instant) {
+        pub fn discard(&mut self, space: PacketNumberSpace, now: Instant) {
             self.lr.discard(&self.path, space, now)
         }
 
-        pub fn pto_time(&self, space: PNSpace) -> Option<Instant> {
+        pub fn pto_time(&self, space: PacketNumberSpace) -> Option<Instant> {
             self.lr.pto_time(self.path.borrow().rtt(), space)
         }
 
@@ -1107,18 +1119,22 @@ mod tests {
         };
         println!(
             "loss times: {:?} {:?} {:?}",
-            est(PNSpace::Initial),
-            est(PNSpace::Handshake),
-            est(PNSpace::ApplicationData),
+            est(PacketNumberSpace::Initial),
+            est(PacketNumberSpace::Handshake),
+            est(PacketNumberSpace::ApplicationData),
         );
-        assert_eq!(est(PNSpace::Initial), initial, "Initial earliest sent time");
         assert_eq!(
-            est(PNSpace::Handshake),
+            est(PacketNumberSpace::Initial),
+            initial,
+            "Initial earliest sent time"
+        );
+        assert_eq!(
+            est(PacketNumberSpace::Handshake),
             handshake,
             "Handshake earliest sent time"
         );
         assert_eq!(
-            est(PNSpace::ApplicationData),
+            est(PacketNumberSpace::ApplicationData),
             app_data,
             "AppData earliest sent time"
         );
@@ -1151,7 +1167,7 @@ mod tests {
     /// Acknowledge PN with the identified delay.
     fn ack(lr: &mut Fixture, pn: u64, delay: Duration) {
         lr.on_ack_received(
-            PNSpace::ApplicationData,
+            PacketNumberSpace::ApplicationData,
             pn,
             vec![pn..=pn],
             ACK_DELAY,
@@ -1178,7 +1194,7 @@ mod tests {
 
     #[test]
     fn remove_acked() {
-        let mut lrs = LossRecoverySpace::new(PNSpace::ApplicationData);
+        let mut lrs = LossRecoverySpace::new(PacketNumberSpace::ApplicationData);
         let mut stats = Stats::default();
         add_sent(&mut lrs, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         let (acked, _) = lrs.remove_acked(vec![], &mut stats);
@@ -1298,7 +1314,7 @@ mod tests {
             ON_SENT_SIZE,
         ));
         let (_, lost) = lr.on_ack_received(
-            PNSpace::ApplicationData,
+            PacketNumberSpace::ApplicationData,
             1,
             vec![1..=1],
             ACK_DELAY,
@@ -1321,7 +1337,7 @@ mod tests {
         assert!(pn1_loss_time > pn2_ack_time);
 
         let (_, lost) = lr.on_ack_received(
-            PNSpace::ApplicationData,
+            PacketNumberSpace::ApplicationData,
             2,
             vec![2..=2],
             ACK_DELAY,
@@ -1350,7 +1366,7 @@ mod tests {
         // Acknowledge just 2-4, which will cause pn 1 to be marked as lost.
         assert_eq!(super::PACKET_THRESHOLD, 3);
         let (_, lost) = lr.on_ack_received(
-            PNSpace::ApplicationData,
+            PacketNumberSpace::ApplicationData,
             4,
             vec![2..=4],
             ACK_DELAY,
@@ -1363,23 +1379,23 @@ mod tests {
     #[should_panic(expected = "discarding application space")]
     fn drop_app() {
         let mut lr = Fixture::default();
-        lr.discard(PNSpace::ApplicationData, now());
+        lr.discard(PacketNumberSpace::ApplicationData, now());
     }
 
     #[test]
     #[should_panic(expected = "dropping spaces out of order")]
     fn drop_out_of_order() {
         let mut lr = Fixture::default();
-        lr.discard(PNSpace::Handshake, now());
+        lr.discard(PacketNumberSpace::Handshake, now());
     }
 
     #[test]
     #[should_panic(expected = "ACK on discarded space")]
     fn ack_after_drop() {
         let mut lr = Fixture::default();
-        lr.discard(PNSpace::Initial, now());
+        lr.discard(PacketNumberSpace::Initial, now());
         lr.on_ack_received(
-            PNSpace::Initial,
+            PacketNumberSpace::Initial,
             0,
             vec![],
             Duration::from_millis(0),
@@ -1422,7 +1438,7 @@ mod tests {
             PacketType::Short,
         ] {
             let sent_pkt = SentPacket::new(*sp, 1, pn_time(3), true, Vec::new(), ON_SENT_SIZE);
-            let pn_space = PNSpace::from(sent_pkt.pt);
+            let pn_space = PacketNumberSpace::from(sent_pkt.pt);
             lr.on_packet_sent(sent_pkt);
             lr.on_ack_received(pn_space, 1, vec![1..=1], Duration::from_secs(0), pn_time(3));
             let mut lost = Vec::new();
@@ -1435,10 +1451,10 @@ mod tests {
             assert!(lost.is_empty());
         }
 
-        lr.discard(PNSpace::Initial, pn_time(3));
+        lr.discard(PacketNumberSpace::Initial, pn_time(3));
         assert_sent_times(&lr, None, Some(pn_time(1)), Some(pn_time(2)));
 
-        lr.discard(PNSpace::Handshake, pn_time(3));
+        lr.discard(PacketNumberSpace::Handshake, pn_time(3));
         assert_sent_times(&lr, None, None, Some(pn_time(2)));
 
         // There are cases where we send a packet that is not subsequently tracked.
@@ -1474,20 +1490,20 @@ mod tests {
             ON_SENT_SIZE,
         ));
 
-        assert_eq!(lr.pto_time(PNSpace::ApplicationData), None);
-        lr.discard(PNSpace::Initial, pn_time(1));
-        assert_eq!(lr.pto_time(PNSpace::ApplicationData), None);
+        assert_eq!(lr.pto_time(PacketNumberSpace::ApplicationData), None);
+        lr.discard(PacketNumberSpace::Initial, pn_time(1));
+        assert_eq!(lr.pto_time(PacketNumberSpace::ApplicationData), None);
 
         // Expiring state after the PTO on the ApplicationData space has
         // expired should result in setting a PTO state.
-        let default_pto = RttEstimate::default().pto(PNSpace::ApplicationData);
+        let default_pto = RttEstimate::default().pto(PacketNumberSpace::ApplicationData);
         let expected_pto = pn_time(2) + default_pto;
-        lr.discard(PNSpace::Handshake, expected_pto);
+        lr.discard(PacketNumberSpace::Handshake, expected_pto);
         let profile = lr.send_profile(now());
         assert!(profile.pto.is_some());
-        assert!(!profile.should_probe(PNSpace::Initial));
-        assert!(!profile.should_probe(PNSpace::Handshake));
-        assert!(profile.should_probe(PNSpace::ApplicationData));
+        assert!(!profile.should_probe(PacketNumberSpace::Initial));
+        assert!(!profile.should_probe(PacketNumberSpace::Handshake));
+        assert!(profile.should_probe(PacketNumberSpace::ApplicationData));
     }
 
     #[test]
@@ -1511,14 +1527,14 @@ mod tests {
             ON_SENT_SIZE,
         ));
 
-        let handshake_pto = RttEstimate::default().pto(PNSpace::Handshake);
+        let handshake_pto = RttEstimate::default().pto(PacketNumberSpace::Handshake);
         let expected_pto = now() + handshake_pto;
-        assert_eq!(lr.pto_time(PNSpace::Initial), Some(expected_pto));
+        assert_eq!(lr.pto_time(PacketNumberSpace::Initial), Some(expected_pto));
         let profile = lr.send_profile(now());
-        assert!(profile.ack_only(PNSpace::Initial));
+        assert!(profile.ack_only(PacketNumberSpace::Initial));
         assert!(profile.pto.is_none());
-        assert!(!profile.should_probe(PNSpace::Initial));
-        assert!(!profile.should_probe(PNSpace::Handshake));
-        assert!(!profile.should_probe(PNSpace::ApplicationData));
+        assert!(!profile.should_probe(PacketNumberSpace::Initial));
+        assert!(!profile.should_probe(PacketNumberSpace::Handshake));
+        assert!(!profile.should_probe(PacketNumberSpace::ApplicationData));
     }
 }

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use neqo_common::{qlog::NeqoQlog, qtrace};
 
 use crate::qlog::{self, QlogMetric};
-use crate::tracking::PNSpace;
+use crate::tracking::PacketNumberSpace;
 
 /// The smallest time that the system timer (via `sleep()`, `nanosleep()`,
 /// `select()`, or similar) can reliably deliver; see `neqo_common::hrtime`.
@@ -116,10 +116,10 @@ impl RttEstimate {
         self.smoothed_rtt
     }
 
-    pub fn pto(&self, pn_space: PNSpace) -> Duration {
+    pub fn pto(&self, pn_space: PacketNumberSpace) -> Duration {
         self.estimate()
             + max(4 * self.rttvar, GRANULARITY)
-            + if pn_space == PNSpace::ApplicationData {
+            + if pn_space == PacketNumberSpace::ApplicationData {
                 self.max_ack_delay
             } else {
                 Duration::from_millis(0)

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -140,6 +140,8 @@ impl Stats {
         )
     }
 
+    /// # Panics
+    /// When preconditions are violated.
     pub fn add_pto_count(&mut self, count: usize) {
         debug_assert!(count > 0);
         if count >= MAX_PTO_COUNTS {

--- a/test-fixture/src/assertions.rs
+++ b/test-fixture/src/assertions.rs
@@ -20,7 +20,9 @@ fn assert_default_version(dec: &mut Decoder) {
     assert_eq!(version, QuicVersion::default());
 }
 
-// Do a simple decode of the datagram to verify that it is coalesced.
+/// Do a simple decode of the datagram to verify that it is coalesced.
+/// # Panics
+/// If the tests fail.
 pub fn assert_coalesced_0rtt(payload: &[u8]) {
     assert!(payload.len() >= 1200);
     let mut dec = Decoder::from(payload);
@@ -36,10 +38,14 @@ pub fn assert_coalesced_0rtt(payload: &[u8]) {
     assert_eq!(zrtt_type & PACKET_TYPE_MASK, 0b1001_0000);
 }
 
+/// # Panics
+/// If the tests fail.
 pub fn assert_retry(payload: &[u8]) {
     assert_eq!(payload[0] & PACKET_TYPE_MASK, 0b1011_0000);
 }
 
+/// # Panics
+/// If the tests fail.
 pub fn assert_initial(payload: &[u8], expect_token: bool) {
     assert_eq!(payload[0] & PACKET_TYPE_MASK, 0b1000_0000);
 
@@ -52,6 +58,8 @@ pub fn assert_initial(payload: &[u8], expect_token: bool) {
     assert_eq!(expect_token, !token.is_empty());
 }
 
+/// # Panics
+/// If the tests fail.
 pub fn assert_no_1rtt(payload: &[u8]) {
     let mut dec = Decoder::from(payload);
     while let Some(b1) = dec.decode_byte() {

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -53,12 +53,16 @@ fn earlier() -> Instant {
 
 /// The current time for the test.  Which is in the future,
 /// because 0-RTT tests need to run at least `ANTI_REPLAY_WINDOW` in the past.
+/// # Panics
+/// When the setup fails.
 #[must_use]
 pub fn now() -> Instant {
     earlier().checked_add(ANTI_REPLAY_WINDOW).unwrap()
 }
 
 // Create a default anti-replay context.
+/// # Panics
+/// When the setup fails.
 #[must_use]
 pub fn anti_replay() -> AntiReplay {
     AntiReplay::new(earlier(), ANTI_REPLAY_WINDOW, 1, 3).expect("setup anti-replay")
@@ -201,6 +205,8 @@ pub fn handshake(client: &mut Connection, server: &mut Connection) {
     }
 }
 
+/// # Panics
+/// When the connection fails.
 #[must_use]
 pub fn connect() -> (Connection, Connection) {
     let mut client = default_client();
@@ -212,6 +218,8 @@ pub fn connect() -> (Connection, Connection) {
 }
 
 /// Create a http3 client with default configuration.
+/// # Panics
+/// When the client can't be created.
 #[must_use]
 pub fn default_http3_client() -> Http3Client {
     fixture_init();
@@ -235,6 +243,8 @@ pub fn default_http3_client() -> Http3Client {
 }
 
 /// Create a http3 server with default configuration.
+/// # Panics
+/// When the server can't be created.
 #[must_use]
 pub fn default_http3_server() -> Http3Server {
     fixture_init();


### PR DESCRIPTION
The main offenders here are the insistence that we document panics.

There is also a rename of QPData and PNSpace to comply with updating
naming conventions.

And there was a warning about initializing vectors followed by a push.

And all Into implementations are inverted and replaced with From implementations.

And all `as` casting for pointers is changed to pointer::cast(), with turbofish as needed.

I had to suppress some warnings, which was annoying.  Particularly since
suppressing the unknown lint warning requires three warning suppressions
now: the new way of suppressing, the old way of suppressing, and a new
lint that warns about the old way of suppressing still being there.