### PR TITLE
Implement NEW_CONNECTION_ID::retire_prior_to

### DIFF
--- a/neqo-transport/src/ackrate.rs
+++ b/neqo-transport/src/ackrate.rs
@@ -8,7 +8,7 @@
 #![deny(clippy::pedantic)]
 
 use crate::connection::params::ACK_RATIO_SCALE;
-use crate::frame::{write_varint_frame, FRAME_TYPE_ACK_FREQUENCY};
+use crate::frame::FRAME_TYPE_ACK_FREQUENCY;
 use crate::packet::PacketBuilder;
 use crate::recovery::RecoveryToken;
 use crate::stats::FrameStats;
@@ -45,16 +45,13 @@ impl AckRate {
     }
 
     pub fn write_frame(&self, builder: &mut PacketBuilder, seqno: u64) -> bool {
-        write_varint_frame(
-            builder,
-            &[
-                FRAME_TYPE_ACK_FREQUENCY,
-                seqno,
-                u64::try_from(self.packets + 1).unwrap(),
-                u64::try_from(self.delay.as_micros()).unwrap(),
-                0,
-            ],
-        )
+        builder.write_varint_frame(&[
+            FRAME_TYPE_ACK_FREQUENCY,
+            seqno,
+            u64::try_from(self.packets + 1).unwrap(),
+            u64::try_from(self.delay.as_micros()).unwrap(),
+            0,
+        ])
     }
 
     /// Determine whether to send an update frame.

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1825,8 +1825,10 @@ impl Connection {
             .write_frames(TransmissionPriority::Low, builder, tokens, stats);
 
         #[cfg(test)]
-        if let Some(w) = &mut self.test_frame_writer {
-            w.write_frames(builder);
+        {
+            if let Some(w) = &mut self.test_frame_writer {
+                w.write_frames(builder);
+            }
         }
 
         Ok(())

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2360,7 +2360,7 @@ impl Connection {
                 sequence_number,
                 connection_id,
                 stateless_reset_token,
-                ..
+                retire_prior,
             } => {
                 self.stats.borrow_mut().frame_rx.new_connection_id += 1;
                 self.connection_ids.add_remote(ConnectionIdEntry::new(
@@ -2368,6 +2368,12 @@ impl Connection {
                     ConnectionId::from(connection_id),
                     stateless_reset_token.to_owned(),
                 ))?;
+                self.paths
+                    .retire_cids(retire_prior, &mut self.connection_ids);
+                if self.connection_ids.len() >= LOCAL_ACTIVE_CID_LIMIT {
+                    qinfo!([self], "received too many connection IDs");
+                    return Err(Error::ConnectionIdLimitExceeded);
+                }
             }
             Frame::RetireConnectionId { sequence_number } => {
                 self.stats.borrow_mut().frame_rx.retire_connection_id += 1;

--- a/neqo-transport/src/connection/test_internal.rs
+++ b/neqo-transport/src/connection/test_internal.rs
@@ -1,0 +1,13 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Some access to internal connection stuff for testing purposes.
+
+use crate::packet::PacketBuilder;
+
+pub trait FrameWriter {
+    fn write_frames(&mut self, builder: &mut PacketBuilder);
+}

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -6,10 +6,10 @@
 
 // Directly relating to QUIC frames.
 
-use neqo_common::{qtrace, Decoder, Encoder};
+use neqo_common::{qtrace, Decoder};
 
 use crate::cid::MAX_CONNECTION_ID_LEN;
-use crate::packet::{PacketBuilder, PacketType};
+use crate::packet::PacketType;
 use crate::stream_id::{StreamId, StreamType};
 use crate::{AppError, ConnectionError, Error, Res, TransportError};
 
@@ -93,24 +93,6 @@ impl From<ConnectionError> for CloseError {
 pub struct AckRange {
     pub(crate) gap: u64,
     pub(crate) range: u64,
-}
-
-/// A lot of frames here are just a collection of varints.
-/// This helper functions writes a frame like that safely, returning `true` if
-/// a frame was written.
-pub fn write_varint_frame(builder: &mut PacketBuilder, values: &[u64]) -> bool {
-    let write = builder.remaining()
-        >= values
-            .iter()
-            .map(|&v| Encoder::varint_len(v))
-            .sum::<usize>();
-    if write {
-        for v in values {
-            builder.encode_varint(*v);
-        }
-        debug_assert!(builder.len() <= builder.limit());
-    };
-    write
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -16,7 +16,7 @@ use smallvec::SmallVec;
 
 use crate::events::ConnectionEvents;
 use crate::fc::ReceiverFlowControl;
-use crate::frame::{write_varint_frame, FRAME_TYPE_STOP_SENDING};
+use crate::frame::FRAME_TYPE_STOP_SENDING;
 use crate::packet::PacketBuilder;
 use crate::recovery::RecoveryToken;
 use crate::send_stream::SendStreams;
@@ -596,10 +596,11 @@ impl RecvStream {
             // Maybe send STOP_SENDING
             RecvStreamState::AbortReading { frame_needed, err } => {
                 if *frame_needed
-                    && write_varint_frame(
-                        builder,
-                        &[FRAME_TYPE_STOP_SENDING, self.stream_id.as_u64(), *err],
-                    )
+                    && builder.write_varint_frame(&[
+                        FRAME_TYPE_STOP_SENDING,
+                        self.stream_id.as_u64(),
+                        *err,
+                    ])
                 {
                     tokens.push(RecoveryToken::StopSending {
                         stream_id: self.stream_id,

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -21,7 +21,7 @@ use neqo_common::{qdebug, qerror, qinfo, qtrace, Encoder, Role};
 
 use crate::events::ConnectionEvents;
 use crate::fc::SenderFlowControl;
-use crate::frame::{write_varint_frame, Frame, FRAME_TYPE_RESET_STREAM};
+use crate::frame::{Frame, FRAME_TYPE_RESET_STREAM};
 use crate::packet::PacketBuilder;
 use crate::recovery::RecoveryToken;
 use crate::stats::FrameStats;
@@ -776,15 +776,12 @@ impl SendStream {
             if *priority != Some(p) {
                 return false;
             }
-            if write_varint_frame(
-                builder,
-                &[
-                    FRAME_TYPE_RESET_STREAM,
-                    self.stream_id.as_u64(),
-                    err,
-                    final_size,
-                ],
-            ) {
+            if builder.write_varint_frame(&[
+                FRAME_TYPE_RESET_STREAM,
+                self.stream_id.as_u64(),
+                err,
+                final_size,
+            ]) {
                 tokens.push(RecoveryToken::ResetStream {
                     stream_id: self.stream_id,
                 });


### PR DESCRIPTION
This is the implementation part.  I'm fairly sure that it's good, but I
haven't tested it.  And testing this promises to be tricky as there are
interactions with paths.  And we don't use Retire Prior To for our own
purposes.  It might be possible to do something invasive; I'll see what
I can come up with.