### PR TITLE
More linting for rust 1.52

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -424,7 +424,9 @@ impl<'a> Handler<'a> {
                     "Successfully created stream id {} for {}",
                     client_stream_id, url
                 );
-                let _ = client.stream_close_send(client_stream_id);
+                client
+                    .stream_close_send(client_stream_id)
+                    .expect("failed to close send stream");
 
                 let out_file = get_output_file(&url, &self.args.output_dir, &mut self.all_paths);
 
@@ -843,10 +845,10 @@ mod old {
                 Ok(client_stream_id) => {
                     println!("Created stream {} for {}", client_stream_id, url);
                     let req = format!("GET {}\r\n", url.path());
-                    client
+                    let _ = client
                         .stream_send(client_stream_id, req.as_bytes())
                         .unwrap();
-                    let _ = client.stream_close_send(client_stream_id);
+                    client.stream_close_send(client_stream_id).unwrap();
                     let out_file =
                         get_output_file(&url, &self.args.output_dir, &mut self.all_paths);
                     self.streams.insert(client_stream_id, out_file);

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -322,7 +322,7 @@ fn setup_standalone() -> Vec<String> {
 fn setup_for_gecko() -> Vec<String> {
     let mut flags: Vec<String> = Vec::new();
 
-    let fold_libs = env::var("MOZ_FOLD_LIBS").unwrap_or("".to_string()) == "1";
+    let fold_libs = env::var("MOZ_FOLD_LIBS").unwrap_or_default() == "1";
     let libs = if fold_libs {
         vec!["nss3"]
     } else {

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -61,8 +61,9 @@ macro_rules! scoped_ptr {
         }
 
         impl Drop for $scoped {
+            #[allow(unused_must_use)]
             fn drop(&mut self) {
-                let _ = unsafe { $dtor(self.ptr) };
+                unsafe { $dtor(self.ptr) };
             }
         }
     };

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -545,10 +545,10 @@ impl Http3Connection {
             found = true;
         }
 
-        // Stream maybe already be closed and we may get an error here, but we do not care.
-        let _ = conn.stream_reset_send(stream_id, error);
-        // Stream maybe already be closed and we may get an error here, but we do not care.
-        let _ = conn.stream_stop_sending(stream_id, error);
+        // Stream may be already be closed and we may get an error here, but we do not care.
+        mem::drop(conn.stream_reset_send(stream_id, error));
+        // Stream may be already be closed and we may get an error here, but we do not care.
+        mem::drop(conn.stream_stop_sending(stream_id, error));
         if found {
             Ok(())
         } else {
@@ -564,9 +564,9 @@ impl Http3Connection {
             .send_streams
             .get_mut(&stream_id)
             .ok_or(Error::InvalidStreamId)?;
-        // The following funcion may return InvalidStreamId from the transport layer if the stream has been cloesd
+        // The following function may return InvalidStreamId from the transport layer if the stream has been cloesd
         // already. It is ok to ignore it here.
-        let _ = send_stream.close(conn);
+        mem::drop(send_stream.close(conn));
         if send_stream.done() {
             self.send_streams.remove(&stream_id);
         }

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -305,11 +305,11 @@ impl PushController {
                 }
                 PushState::OnlyPushStream { stream_id, .. }
                 | PushState::Active { stream_id, .. } => {
-                    let _ = base_handler.stream_reset(
+                    mem::drop(base_handler.stream_reset(
                         conn,
                         stream_id,
                         Error::HttpRequestCancelled.code(),
-                    );
+                    ));
                     self.conn_events.remove_events_for_push_id(push_id);
                     self.conn_events.push_canceled(push_id);
                     Ok(())
@@ -359,8 +359,11 @@ impl PushController {
             Some(PushState::Active { stream_id, .. }) => {
                 self.conn_events.remove_events_for_push_id(push_id);
                 // Cancel the stream. the transport steam may already be done, so ignore an error.
-                let _ =
-                    base_handler.stream_reset(conn, *stream_id, Error::HttpRequestCancelled.code());
+                mem::drop(base_handler.stream_reset(
+                    conn,
+                    *stream_id,
+                    Error::HttpRequestCancelled.code(),
+                ));
                 self.push_streams.close(push_id);
                 Ok(())
             }

--- a/neqo-http3/src/push_stream.rs
+++ b/neqo-http3/src/push_stream.rs
@@ -13,6 +13,7 @@ use neqo_qpack::decoder::QPackDecoder;
 use neqo_transport::{AppError, Connection};
 use std::cell::RefCell;
 use std::fmt::Display;
+use std::mem;
 use std::rc::Rc;
 
 #[derive(Debug)]
@@ -111,10 +112,10 @@ impl RecvStream for PushStream {
                                 ),
                             };
                         } else {
-                            let _ = conn.stream_stop_sending(
+                            mem::drop(conn.stream_stop_sending(
                                 self.stream_id,
                                 Error::HttpRequestCancelled.code(),
-                            );
+                            ));
                             self.state = PushStreamState::Closed;
                             return Ok(());
                         }

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -297,7 +297,9 @@ impl HttpServer for Http3Server {
                             });
 
                     if response.is_none() {
-                        let _ = request.stream_reset(Error::HttpRequestIncomplete.code());
+                        request
+                            .stream_reset(Error::HttpRequestIncomplete.code())
+                            .unwrap();
                         continue;
                     }
 

--- a/neqo-server/src/old_https.rs
+++ b/neqo-server/src/old_https.rs
@@ -153,7 +153,7 @@ impl Http09Server {
                 if args.qns_test.is_some() {
                     qns_read_response(path)
                 } else {
-                    let count = usize::from_str_radix(path, 10).unwrap();
+                    let count = path.parse().unwrap();
                     Some(vec![b'a'; count])
                 }
             }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1462,7 +1462,7 @@ impl Connection {
                 self.setup_handshake_path(&path, now);
             } else {
                 // Otherwise try to get a usable connection ID.
-                let _ = self.ensure_permanent(&path);
+                mem::drop(self.ensure_permanent(&path));
             }
         }
     }

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -16,6 +16,7 @@ use crate::tracking::PacketNumberSpace;
 use crate::StreamType;
 
 use neqo_common::Encoder;
+use std::mem;
 use std::time::Duration;
 use test_fixture::{self, now, split_datagram};
 
@@ -31,10 +32,10 @@ fn idle_timeout() {
     assert_eq!(res, Output::Callback(LOCAL_IDLE_TIMEOUT));
 
     // Still connected after 29 seconds. Idle timer not reset
-    let _ = client.process(None, now + LOCAL_IDLE_TIMEOUT - Duration::from_secs(1));
+    mem::drop(client.process(None, now + LOCAL_IDLE_TIMEOUT - Duration::from_secs(1)));
     assert!(matches!(client.state(), State::Confirmed));
 
-    let _ = client.process(None, now + LOCAL_IDLE_TIMEOUT);
+    mem::drop(client.process(None, now + LOCAL_IDLE_TIMEOUT));
 
     // Not connected after LOCAL_IDLE_TIMEOUT seconds.
     assert!(matches!(client.state(), State::Closed(_)));
@@ -172,10 +173,10 @@ fn idle_send_packet2() {
 
     // First transmission at t=GAP.
     now += GAP;
-    let _ = send_something(&mut client, now);
+    mem::drop(send_something(&mut client, now));
 
     // Second transmission at t=2*GAP.
-    let _ = send_something(&mut client, now + GAP);
+    mem::drop(send_something(&mut client, now + GAP));
     assert!((GAP * 2 + DELTA) < LOCAL_IDLE_TIMEOUT);
 
     // Still connected just before GAP + LOCAL_IDLE_TIMEOUT.
@@ -213,16 +214,16 @@ fn idle_recv_packet() {
     let out = server.process_output(now + Duration::from_secs(10));
     assert_ne!(out.as_dgram_ref(), None);
 
-    let _ = client.process(out.dgram(), now + Duration::from_secs(20));
+    mem::drop(client.process(out.dgram(), now + Duration::from_secs(20)));
     assert!(matches!(client.state(), State::Confirmed));
 
     // Still connected after 49 seconds because idle timer reset by received
     // packet
-    let _ = client.process(None, now + LOCAL_IDLE_TIMEOUT + Duration::from_secs(19));
+    mem::drop(client.process(None, now + LOCAL_IDLE_TIMEOUT + Duration::from_secs(19)));
     assert!(matches!(client.state(), State::Confirmed));
 
     // Not connected after 50 seconds.
-    let _ = client.process(None, now + LOCAL_IDLE_TIMEOUT + Duration::from_secs(20));
+    mem::drop(client.process(None, now + LOCAL_IDLE_TIMEOUT + Duration::from_secs(20)));
 
     assert!(matches!(client.state(), State::Closed(_)));
 }
@@ -247,11 +248,11 @@ fn idle_caching() {
     // Perform an exchange and keep the connection alive.
     // Only allow a packet containing a PING to pass.
     let middle = start + AT_LEAST_PTO;
-    let _ = client.process_output(middle);
+    mem::drop(client.process_output(middle));
     let dgram = client.process_output(middle).dgram();
 
     // Get the server to send its first probe and throw that away.
-    let _ = server.process_output(middle).dgram();
+    mem::drop(server.process_output(middle).dgram());
     // Now let the server process the client PING.  This causes the server
     // to send CRYPTO frames again, so manually extract and discard those.
     let ping_before_s = server.stats().frame_rx.ping;
@@ -297,7 +298,7 @@ fn idle_caching() {
     let dgram = server.process_output(end).dgram();
     let (initial, _) = split_datagram(&dgram.unwrap());
     neqo_common::qwarn!("client ingests initial, finally");
-    let _ = client.process(Some(initial), end);
+    mem::drop(client.process(Some(initial), end));
     maybe_authenticate(&mut client);
     let dgram = client.process_output(end).dgram();
     let dgram = server.process(dgram, end).dgram();

--- a/neqo-transport/src/connection/tests/keys.rs
+++ b/neqo-transport/src/connection/tests/keys.rs
@@ -15,11 +15,12 @@ use crate::packet::PacketNumber;
 use crate::path::PATH_MTU_V6;
 
 use neqo_common::{qdebug, Datagram};
+use std::mem;
 use test_fixture::{self, now};
 
 fn check_discarded(peer: &mut Connection, pkt: Datagram, dropped: usize, dups: usize) {
     // Make sure to flush any saved datagrams before doing this.
-    let _ = peer.process_output(now());
+    mem::drop(peer.process_output(now()));
 
     let before = peer.stats();
     let out = peer.process(Some(pkt), now());
@@ -134,7 +135,7 @@ fn key_update_client() {
     let dgram = client.process(None, now).dgram();
     assert!(dgram.is_some()); // Drop this packet.
     assert_eq!(client.get_epochs(), (Some(4), Some(3)));
-    let _ = server.process(None, now);
+    mem::drop(server.process(None, now));
     assert_eq!(server.get_epochs(), (Some(4), Some(4)));
 
     // Even though the server has updated, it hasn't received an ACK yet.
@@ -159,7 +160,7 @@ fn key_update_client() {
     assert_update_blocked(&mut server);
 
     now += AT_LEAST_PTO;
-    let _ = client.process(None, now);
+    mem::drop(client.process(None, now));
     assert_eq!(client.get_epochs(), (Some(4), Some(4)));
 }
 
@@ -175,7 +176,7 @@ fn key_update_consecutive() {
 
     // Server sends something.
     // Send twice and drop the first to induce an ACK from the client.
-    let _ = send_something(&mut server, now); // Drop this.
+    mem::drop(send_something(&mut server, now)); // Drop this.
 
     // Another packet from the server will cause the client to ACK and update keys.
     let dgram = send_and_receive(&mut server, &mut client, now);
@@ -187,7 +188,7 @@ fn key_update_consecutive() {
         assert_eq!(server.get_epochs(), (Some(4), Some(3)));
         // Now move the server temporarily into the future so that it
         // rotates the keys.  The client stays in the present.
-        let _ = server.process(None, now + AT_LEAST_PTO);
+        mem::drop(server.process(None, now + AT_LEAST_PTO));
         assert_eq!(server.get_epochs(), (Some(4), Some(4)));
     } else {
         panic!("server should have a timer set");
@@ -293,7 +294,7 @@ fn automatic_update_write_keys() {
     connect_force_idle(&mut client, &mut server);
 
     overwrite_invocations(UPDATE_WRITE_KEYS_AT);
-    let _ = send_something(&mut client, now());
+    mem::drop(send_something(&mut client, now()));
     assert_eq!(client.get_epochs(), (Some(4), Some(3)));
 }
 
@@ -305,10 +306,10 @@ fn automatic_update_write_keys_later() {
 
     overwrite_invocations(UPDATE_WRITE_KEYS_AT + 2);
     // No update after the first.
-    let _ = send_something(&mut client, now());
+    mem::drop(send_something(&mut client, now()));
     assert_eq!(client.get_epochs(), (Some(3), Some(3)));
     // The second will update though.
-    let _ = send_something(&mut client, now());
+    mem::drop(send_something(&mut client, now()));
     assert_eq!(client.get_epochs(), (Some(4), Some(3)));
 }
 

--- a/neqo-transport/src/connection/tests/priority.rs
+++ b/neqo-transport/src/connection/tests/priority.rs
@@ -384,7 +384,7 @@ fn low() {
     // The resulting CRYPTO frame beats out the stream data.
     let stats_before = server.stats().frame_tx;
     server.send_ticket(now, &[0; 2048]).unwrap();
-    let _ = server.process_output(now);
+    mem::drop(server.process_output(now));
     let stats_after = server.stats().frame_tx;
     assert_eq!(stats_after.crypto, stats_before.crypto + 1);
     assert_eq!(stats_after.stream, stats_before.stream);
@@ -393,7 +393,7 @@ fn low() {
     // it is very hard to ensure that the STREAM frame won't also fit.
     // However, we can ensure that the next packet doesn't consist of just STREAM.
     let stats_before = server.stats().frame_tx;
-    let _ = server.process_output(now);
+    mem::drop(server.process_output(now));
     let stats_after = server.stats().frame_tx;
     assert_eq!(stats_after.crypto, stats_before.crypto + 1);
     assert_eq!(stats_after.new_token, 1);

--- a/neqo-transport/src/connection/tests/resumption.rs
+++ b/neqo-transport/src/connection/tests/resumption.rs
@@ -11,6 +11,7 @@ use super::{
 use crate::addr_valid::{AddressValidation, ValidateAddress};
 
 use std::cell::RefCell;
+use std::mem;
 use std::rc::Rc;
 use std::time::Duration;
 use test_fixture::{self, assertions, now};
@@ -127,19 +128,19 @@ fn two_tickets_on_timer() {
     // We need to wait for release_resumption_token_timer to expire. The timer will be
     // set to 3 * PTO
     let mut now = now() + 3 * client.pto();
-    let _ = client.process(None, now);
+    mem::drop(client.process(None, now));
     let mut recv_tokens = get_tokens(&mut client);
     assert_eq!(recv_tokens.len(), 1);
     let token1 = recv_tokens.pop().unwrap();
     // Wai for anottheer 3 * PTO to get the nex okeen.
     now += 3 * client.pto();
-    let _ = client.process(None, now);
+    mem::drop(client.process(None, now));
     let mut recv_tokens = get_tokens(&mut client);
     assert_eq!(recv_tokens.len(), 1);
     let token2 = recv_tokens.pop().unwrap();
     // Wait for 3 * PTO, but now there are no more tokens.
     now += 3 * client.pto();
-    let _ = client.process(None, now);
+    mem::drop(client.process(None, now));
     assert_eq!(get_tokens(&mut client).len(), 0);
     assert_ne!(token1.as_ref(), token2.as_ref());
 

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -20,6 +20,7 @@ use crate::{Error, StreamId, StreamType};
 use neqo_common::{event::Provider, qdebug};
 use std::cmp::max;
 use std::convert::TryFrom;
+use std::mem;
 use test_fixture::now;
 
 #[test]
@@ -31,7 +32,7 @@ fn stream_create() {
     let out = server.process(out.dgram(), now());
 
     let out = client.process(out.dgram(), now());
-    let _ = server.process(out.dgram(), now());
+    mem::drop(server.process(out.dgram(), now()));
     assert!(maybe_authenticate(&mut client));
     let out = client.process(None, now());
 
@@ -41,7 +42,7 @@ fn stream_create() {
     assert_eq!(client.stream_create(StreamType::BiDi).unwrap(), 0);
     assert_eq!(client.stream_create(StreamType::BiDi).unwrap(), 4);
 
-    let _ = server.process(out.dgram(), now());
+    mem::drop(server.process(out.dgram(), now()));
     // server now in State::Connected
     assert_eq!(server.stream_create(StreamType::UniDi).unwrap(), 3);
     assert_eq!(server.stream_create(StreamType::UniDi).unwrap(), 7);
@@ -127,11 +128,11 @@ fn report_fin_when_stream_closed_wo_data() {
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
     let out = client.process(None, now());
-    let _ = server.process(out.dgram(), now());
+    mem::drop(server.process(out.dgram(), now()));
 
     server.stream_close_send(stream_id).unwrap();
     let out = server.process(None, now());
-    let _ = client.process(out.dgram(), now());
+    mem::drop(client.process(out.dgram(), now()));
     let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
     assert!(client.events().any(stream_readable));
 }
@@ -224,7 +225,7 @@ fn do_not_accept_data_after_stop_sending() {
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
     let out = client.process(None, now());
-    let _ = server.process(out.dgram(), now());
+    mem::drop(server.process(out.dgram(), now()));
 
     let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
     assert!(server.events().any(stream_readable));
@@ -244,7 +245,7 @@ fn do_not_accept_data_after_stop_sending() {
     let out = server.process(out_second_data_frame.dgram(), now());
     assert!(!server.events().any(stream_readable));
 
-    let _ = client.process(out.dgram(), now());
+    mem::drop(client.process(out.dgram(), now()));
     assert_eq!(
         Err(Error::FinalSizeError),
         client.stream_send(stream_id, &[0x00])
@@ -344,7 +345,7 @@ fn after_fin_is_read_conn_events_for_stream_should_be_removed() {
     let out = server.process(None, now()).dgram();
     assert!(out.is_some());
 
-    let _ = client.process(out, now());
+    mem::drop(client.process(out, now()));
 
     // read from the stream before checking connection events.
     let mut buf = vec![0; 4000];
@@ -369,7 +370,7 @@ fn after_stream_stop_sending_is_called_conn_events_for_stream_should_be_removed(
     let out = server.process(None, now()).dgram();
     assert!(out.is_some());
 
-    let _ = client.process(out, now());
+    mem::drop(client.process(out, now()));
 
     // send stop seending.
     client
@@ -506,7 +507,7 @@ fn no_dupdata_readable_events() {
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
     let out = client.process(None, now());
-    let _ = server.process(out.dgram(), now());
+    mem::drop(server.process(out.dgram(), now()));
 
     // We have a data_readable event.
     let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
@@ -516,7 +517,7 @@ fn no_dupdata_readable_events() {
     // therefore there should not be a new DataReadable event.
     client.stream_send(stream_id, &[0x00]).unwrap();
     let out_second_data_frame = client.process(None, now());
-    let _ = server.process(out_second_data_frame.dgram(), now());
+    mem::drop(server.process(out_second_data_frame.dgram(), now()));
     assert!(!server.events().any(stream_readable));
 
     // One more frame with a fin will not produce a new DataReadable event, because the
@@ -524,7 +525,7 @@ fn no_dupdata_readable_events() {
     client.stream_send(stream_id, &[0x00]).unwrap();
     client.stream_close_send(stream_id).unwrap();
     let out_third_data_frame = client.process(None, now());
-    let _ = server.process(out_third_data_frame.dgram(), now());
+    mem::drop(server.process(out_third_data_frame.dgram(), now()));
     assert!(!server.events().any(stream_readable));
 }
 
@@ -538,7 +539,7 @@ fn no_dupdata_readable_events_empty_last_frame() {
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
     let out = client.process(None, now());
-    let _ = server.process(out.dgram(), now());
+    mem::drop(server.process(out.dgram(), now()));
 
     // We have a data_readable event.
     let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
@@ -548,7 +549,7 @@ fn no_dupdata_readable_events_empty_last_frame() {
     // the previous stream data has not been read yet.
     client.stream_close_send(stream_id).unwrap();
     let out_second_data_frame = client.process(None, now());
-    let _ = server.process(out_second_data_frame.dgram(), now());
+    mem::drop(server.process(out_second_data_frame.dgram(), now()));
     assert!(!server.events().any(stream_readable));
 }
 
@@ -570,7 +571,7 @@ fn change_flow_control(stream_type: StreamType, new_fc: u64) {
 
     // Send the stream to the client.
     let out = server.process(None, now());
-    let _ = client.process(out.dgram(), now());
+    mem::drop(client.process(out.dgram(), now()));
 
     // change max_stream_data for stream_id.
     client.set_stream_max_data(stream_id, new_fc).unwrap();
@@ -592,7 +593,7 @@ fn change_flow_control(stream_type: StreamType, new_fc: u64) {
     // Exchange packets so that client gets all data.
     let out4 = client.process(out3.dgram(), now());
     let out5 = server.process(out4.dgram(), now());
-    let _ = client.process(out5.dgram(), now());
+    mem::drop(client.process(out5.dgram(), now()));
 
     // read all data by client
     let mut buf = [0x0; 10000];
@@ -600,7 +601,7 @@ fn change_flow_control(stream_type: StreamType, new_fc: u64) {
     assert_eq!(u64::try_from(read).unwrap(), max(RECV_BUFFER_START, new_fc));
 
     let out4 = client.process(None, now());
-    let _ = server.process(out4.dgram(), now());
+    mem::drop(server.process(out4.dgram(), now()));
 
     let written3 = server.stream_send(stream_id, &[0x0; 10000]).unwrap();
     assert_eq!(u64::try_from(written3).unwrap(), new_fc);

--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -10,6 +10,7 @@ use crate::packet::PACKET_BIT_LONG;
 use crate::{Error, QuicVersion};
 
 use neqo_common::{Datagram, Decoder, Encoder};
+use std::mem;
 use std::time::Duration;
 use test_fixture::{self, addr, now};
 
@@ -20,14 +21,14 @@ const INITIAL_PTO: Duration = Duration::from_millis(300);
 fn unknown_version() {
     let mut client = default_client();
     // Start the handshake.
-    let _ = client.process(None, now()).dgram();
+    mem::drop(client.process(None, now()).dgram());
 
     let mut unknown_version_packet = vec![0x80, 0x1a, 0x1a, 0x1a, 0x1a];
     unknown_version_packet.resize(1200, 0x0);
-    let _ = client.process(
+    mem::drop(client.process(
         Some(Datagram::new(addr(), addr(), unknown_version_packet)),
         now(),
-    );
+    ));
     assert_eq!(1, client.stats().dropped_rx);
 }
 

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -34,18 +34,10 @@ pub fn connection_tparams_set(qlog: &mut NeqoQlog, tph: &TransportParametersHand
             None,
             None,
             None,
-            if let Some(ocid) = remote.get_bytes(tparams::ORIGINAL_DESTINATION_CONNECTION_ID) {
-                // Cannot use packet::ConnectionId's Display trait implementation
-                // because it does not include the 0x prefix.
-                Some(hex(ocid))
-            } else {
-                None
-            },
-            if let Some(srt) = remote.get_bytes(tparams::STATELESS_RESET_TOKEN) {
-                Some(hex(srt))
-            } else {
-                None
-            },
+            remote
+                .get_bytes(tparams::ORIGINAL_DESTINATION_CONNECTION_ID)
+                .map(hex),
+            remote.get_bytes(tparams::STATELESS_RESET_TOKEN).map(hex),
             if remote.get_empty(tparams::DISABLE_MIGRATION) {
                 Some(true)
             } else {

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -312,11 +312,7 @@ impl Server {
     }
 
     fn connection(&self, cid: &ConnectionIdRef) -> Option<StateRef> {
-        if let Some(c) = self.connections.borrow().get(&cid[..]) {
-            Some(Rc::clone(&c))
-        } else {
-            None
-        }
+        self.connections.borrow().get(&cid[..]).map(Rc::clone)
     }
 
     fn handle_initial(

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -570,6 +570,7 @@ where
 #[allow(unused_variables)]
 mod tests {
     use super::*;
+    use std::mem;
 
     #[test]
     fn basic_tps() {
@@ -756,7 +757,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn preferred_address_neither() {
-        let _ = PreferredAddress::new(None, None);
+        mem::drop(PreferredAddress::new(None, None));
     }
 
     #[test]

--- a/neqo-transport/tests/common/mod.rs
+++ b/neqo-transport/tests/common/mod.rs
@@ -22,6 +22,7 @@ use test_fixture::{self, default_client, now, CountingConnectionIdGenerator};
 
 use std::cell::RefCell;
 use std::convert::TryFrom;
+use std::mem;
 use std::ops::Range;
 use std::rc::Rc;
 
@@ -207,7 +208,7 @@ pub fn get_ticket(server: &mut Server) -> ResumptionToken {
     // Have the client close the connection and then let the server clean up.
     client.close(now(), 0, "got a ticket");
     let dgram = client.process_output(now()).dgram();
-    let _ = server.process(dgram, now());
+    mem::drop(server.process(dgram, now()));
     // Calling active_connections clears the set of active connections.
     assert_eq!(server.active_connections().len(), 1);
     ticket

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -18,6 +18,7 @@ use neqo_common::{hex_with_len, qdebug, qtrace, Datagram, Encoder};
 use neqo_crypto::AuthenticationStatus;
 use neqo_transport::{server::ValidateAddress, ConnectionError, Error, State, StreamType};
 use std::convert::TryFrom;
+use std::mem;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 use test_fixture::{self, addr, assertions, default_client, now, split_datagram};
@@ -39,7 +40,7 @@ fn retry_basic() {
     assert!(dgram.is_some());
     let dgram = server.process(dgram, now()).dgram(); // Initial, HS
     assert!(dgram.is_some());
-    let _ = client.process(dgram, now()).dgram(); // Ingest, drop any ACK.
+    mem::drop(client.process(dgram, now()).dgram()); // Ingest, drop any ACK.
     client.authenticated(AuthenticationStatus::Ok, now());
     let dgram = client.process(None, now()).dgram(); // Send Finished
     assert!(dgram.is_some());


### PR DESCRIPTION
There are a lot of changes here, mostly where we were ignoring the
return values of functions using `let _ = f()`.  The new linter doesn't
like that.

This highlighted a few bugs in a few places, so I've gone through and
validated a bunch of these statements.  These now either:

1. Use `mem::drop` because the return value needed to be explicitly
dropped.

2. Use `let _ = ` because the return value is `Copy` rather than `Drop`.

3. Use `.unwrap()` because the return value was `Result` and we weren't
checking it.

This last one only really applies in test code; there are cases where we
explicitly ignored the return value in regular code.  For instance, if
we are going to reset a stream due to an error, we were in a few cases
ignoring the result in case the stream was already closed.  But for test
code, we really want the extra assertion that `.unwrap()` causes.

There are a couple of small tweaks hidden in here for other lints.

* I had to suppress a warning in a macro for the same reason and because
the macro was used for functions that return `Result` and for functions
that do not; so making this consistent would have been hard.

* An initializer is reordered to match the declaration.

* A few instances of `Option::map` and an `unwrap_or_default()` replace
less clean versions of the same.

* Use `<str>::parse` instead of `usize::from_str_radix` at the linter's
behest.