### PR TITLE
Processing saved packet may overflow cubic cc

### DIFF
--- a/neqo-transport/src/cc/cubic.rs
+++ b/neqo-transport/src/cc/cubic.rs
@@ -139,7 +139,13 @@ impl WindowAdjustment for Cubic {
 
         let time_ca = self
             .ca_epoch_start
-            .map_or(min_rtt, |t| now + min_rtt - t)
+            .map_or(min_rtt, |t| {
+                if now + min_rtt < t {
+                    min_rtt
+                } else {
+                    now + min_rtt - t
+                }
+            })
             .as_secs_f64();
         let target_cubic = self.w_cubic(time_ca);
 

--- a/neqo-transport/src/cc/cubic.rs
+++ b/neqo-transport/src/cc/cubic.rs
@@ -141,6 +141,8 @@ impl WindowAdjustment for Cubic {
             .ca_epoch_start
             .map_or(min_rtt, |t| {
                 if now + min_rtt < t {
+                    // This only happens when processing old packets
+                    // that were saved and replayed with old timestamps.
                     min_rtt
                 } else {
                     now + min_rtt - t


### PR DESCRIPTION
Saved packets are process with a timestamp that correspond to time they have been received. This may overflow the calculation of the time spent in ca.