### PR TITLE
More clippy treadmill

### DIFF
--- a/neqo-common/src/incrdecoder.rs
+++ b/neqo-common/src/incrdecoder.rs
@@ -96,7 +96,7 @@ impl IncrementalDecoderBuffer {
         self.v.extend_from_slice(b);
         self.remaining -= amount;
         if self.remaining == 0 {
-            Some(mem::replace(&mut self.v, Vec::new()))
+            Some(mem::take(&mut self.v))
         } else {
             None
         }
@@ -251,7 +251,7 @@ mod tests {
             assert!(dec.min_remaining() < tail);
 
             if tail > 1 {
-                assert_eq!(res, false);
+                assert!(!res);
                 assert!(dec.min_remaining() > 0);
                 let mut dv = Decoder::from(&db[split..]);
                 eprintln!("  split remainder {}: {:?}", split, dv);
@@ -260,7 +260,7 @@ mod tests {
             }
 
             assert_eq!(dec.min_remaining(), 0);
-            assert_eq!(res, true);
+            assert!(res);
         }
     }
 }

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -71,6 +71,12 @@ impl HandshakeState {
     }
 }
 
+#[allow(
+    unknown_lints,
+    renamed_and_removed_lints,
+    clippy::unknown_clippy_lints,
+    clippy::unnested_or_patterns
+)] // Until we require rust 1.53 we can't use or_patterns.
 fn get_alpn(fd: *mut ssl::PRFileDesc, pre: bool) -> Res<Option<String>> {
     let mut alpn_state = ssl::SSLNextProtoState::SSL_NEXT_PROTO_NO_SUPPORT;
     let mut chosen = vec![0_u8; 255];

--- a/neqo-crypto/src/agentio.rs
+++ b/neqo-crypto/src/agentio.rs
@@ -242,7 +242,7 @@ impl AgentIo {
 
     pub fn take_output(&mut self) -> Vec<u8> {
         qtrace!([self], "take output");
-        mem::replace(&mut self.output, Vec::new())
+        mem::take(&mut self.output)
     }
 }
 

--- a/neqo-crypto/src/err.rs
+++ b/neqo-crypto/src/err.rs
@@ -4,8 +4,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(dead_code, clippy::upper_case_acronyms)]
-#![allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
+#![allow(dead_code)]
+#![allow(
+    unknown_lints,
+    renamed_and_removed_lints,
+    clippy::unknown_clippy_lints,
+    clippy::upper_case_acronyms
+)] // Until we require rust 1.51.
 
 use std::os::raw::c_char;
 use std::str::Utf8Error;

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -73,13 +73,14 @@ use std::ffi::CString;
 use std::path::{Path, PathBuf};
 use std::ptr::null;
 
+#[allow(non_upper_case_globals, clippy::redundant_static_lifetimes)]
+#[allow(
+    unknown_lints,
+    renamed_and_removed_lints,
+    clippy::unknown_clippy_lints,
+    clippy::upper_case_acronyms
+)] // Until we require rust 1.51.
 mod nss {
-    #![allow(
-        non_upper_case_globals,
-        clippy::redundant_static_lifetimes,
-        clippy::upper_case_acronyms
-    )]
-    #![allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
     include!(concat!(env!("OUT_DIR"), "/nss_init.rs"));
 }
 
@@ -96,11 +97,8 @@ enum NssLoaded {
 
 impl Drop for NssLoaded {
     fn drop(&mut self) {
-        match self {
-            Self::NoDb | Self::Db(_) => unsafe {
-                secstatus_to_res(nss::NSS_Shutdown()).expect("NSS Shutdown failed")
-            },
-            _ => {}
+        if !matches!(self, Self::External) {
+            unsafe { secstatus_to_res(nss::NSS_Shutdown()).expect("NSS Shutdown failed") }
         }
     }
 }

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -18,8 +18,14 @@ use std::ops::{Deref, DerefMut};
 use std::os::raw::{c_int, c_uint};
 use std::ptr::null_mut;
 
-#[allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
-#[allow(clippy::unreadable_literal, clippy::upper_case_acronyms)]
+#[allow(
+    unknown_lints,
+    renamed_and_removed_lints,
+    clippy::unknown_clippy_lints,
+    clippy::upper_case_acronyms
+)] // Until we require rust 1.51.
+#[allow(unknown_lints, deref_nullptr)] // Until we require rust 1.53 or bindgen#1651 is fixed.
+#[allow(clippy::unreadable_literal)]
 mod nss_p11 {
     include!(concat!(env!("OUT_DIR"), "/nss_p11.rs"));
 }

--- a/neqo-crypto/src/prio.rs
+++ b/neqo-crypto/src/prio.rs
@@ -5,15 +5,20 @@
 // except according to those terms.
 
 #![allow(
+    unknown_lints,
+    renamed_and_removed_lints,
+    clippy::unknown_clippy_lints,
+    clippy::upper_case_acronyms
+)] // Until we require rust 1.51.
+#![allow(unknown_lints, deref_nullptr)] // Until we require rust 1.53 or bindgen#1651 is fixed.
+#![allow(
     dead_code,
     non_upper_case_globals,
     non_snake_case,
     clippy::cognitive_complexity,
     clippy::empty_enum,
-    clippy::too_many_lines,
-    clippy::upper_case_acronyms
+    clippy::too_many_lines
 )]
-#![allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
 
 include!(concat!(env!("OUT_DIR"), "/nspr_io.rs"));
 

--- a/neqo-crypto/src/replay.rs
+++ b/neqo-crypto/src/replay.rs
@@ -15,8 +15,13 @@ use std::ptr::null_mut;
 use std::time::{Duration, Instant};
 
 // This is an opaque struct in NSS.
-#[allow(clippy::empty_enum, clippy::upper_case_acronyms)]
-#[allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
+#[allow(
+    unknown_lints,
+    renamed_and_removed_lints,
+    clippy::unknown_clippy_lints,
+    clippy::upper_case_acronyms
+)] // Until we require rust 1.51.
+#[allow(clippy::empty_enum)]
 pub enum SSLAntiReplayContext {}
 
 experimental_api!(SSL_CreateAntiReplayContext(

--- a/neqo-crypto/src/ssl.rs
+++ b/neqo-crypto/src/ssl.rs
@@ -5,14 +5,19 @@
 // except according to those terms.
 
 #![allow(
+    unknown_lints,
+    renamed_and_removed_lints,
+    clippy::unknown_clippy_lints,
+    clippy::upper_case_acronyms
+)] // Until we require rust 1.51.
+#![allow(
     dead_code,
     non_upper_case_globals,
     non_snake_case,
     clippy::cognitive_complexity,
-    clippy::too_many_lines,
-    clippy::upper_case_acronyms
+    clippy::too_many_lines
 )]
-#![allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
+#![allow(unknown_lints, deref_nullptr)] // Until we require rust 1.53 or bindgen#1651 is fixed.
 
 use crate::constants::Epoch;
 use crate::err::{secstatus_to_res, Res};

--- a/neqo-crypto/src/time.rs
+++ b/neqo-crypto/src/time.rs
@@ -4,8 +4,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(clippy::upper_case_acronyms)]
-#![allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
+#![allow(
+    unknown_lints,
+    renamed_and_removed_lints,
+    clippy::unknown_clippy_lints,
+    clippy::upper_case_acronyms
+)] // Until we require rust 1.51.
 
 use crate::agentio::as_c_void;
 use crate::err::{Error, Res};

--- a/neqo-crypto/tests/agent.rs
+++ b/neqo-crypto/tests/agent.rs
@@ -74,7 +74,7 @@ fn basic() {
 fn check_client_preinfo(client_preinfo: &SecretAgentPreInfo) {
     assert_eq!(client_preinfo.version(), None);
     assert_eq!(client_preinfo.cipher_suite(), None);
-    assert_eq!(client_preinfo.early_data(), false);
+    assert!(!client_preinfo.early_data());
     assert_eq!(client_preinfo.early_data_cipher(), None);
     assert_eq!(client_preinfo.max_early_data(), 0);
     assert_eq!(client_preinfo.alpn(), None);
@@ -83,7 +83,7 @@ fn check_client_preinfo(client_preinfo: &SecretAgentPreInfo) {
 fn check_server_preinfo(server_preinfo: &SecretAgentPreInfo) {
     assert_eq!(server_preinfo.version(), Some(TLS_VERSION_1_3));
     assert_eq!(server_preinfo.cipher_suite(), Some(TLS_AES_128_GCM_SHA256));
-    assert_eq!(server_preinfo.early_data(), false);
+    assert!(!server_preinfo.early_data());
     assert_eq!(server_preinfo.early_data_cipher(), None);
     assert_eq!(server_preinfo.max_early_data(), 0);
     assert_eq!(server_preinfo.alpn(), None);

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -156,11 +156,17 @@ impl Http3Connection {
     }
 
     /// Call `send` for all streams that need to send data.
+    #[allow(
+        unknown_lints,
+        renamed_and_removed_lints,
+        clippy::unknown_clippy_lints,
+        clippy::unnested_or_patterns
+    )] // Until we require rust 1.53 we can't use or_patterns.
     pub fn process_sending(&mut self, conn: &mut Connection) -> Res<()> {
         // check if control stream has data to send.
         self.control_stream_local.send(conn)?;
 
-        let to_send = mem::replace(&mut self.streams_have_data_to_send, BTreeSet::new());
+        let to_send = mem::take(&mut self.streams_have_data_to_send);
         for stream_id in to_send {
             let mut remove = false;
             if let Some(s) = &mut self.send_streams.get_mut(&stream_id) {
@@ -627,7 +633,7 @@ impl Http3Connection {
                             qpack_changed = true;
                         }
                         HSettingType::BlockedStreams => qpack_changed = true,
-                        _ => (),
+                        HSettingType::MaxHeaderListSize => (),
                     }
                 }
                 if qpack_changed {

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -1495,14 +1495,14 @@ mod tests {
                     assert!(push_streams.contains(&push_id));
                     check_push_response_header(&headers);
                     num_push_stream_headers += 1;
-                    assert_eq!(fin, false);
-                    assert_eq!(interim, false);
+                    assert!(!fin);
+                    assert!(!interim);
                 }
                 Http3ClientEvent::PushDataReadable { push_id } => {
                     assert!(push_streams.contains(&push_id));
                     let mut buf = [0_u8; 100];
                     let (amount, fin) = client.push_read_data(now(), push_id, &mut buf).unwrap();
-                    assert_eq!(fin, true);
+                    assert!(fin);
                     assert_eq!(amount, EXPECTED_PUSH_RESPONSE_DATA_FRAME.len());
                     assert_eq!(&buf[..amount], EXPECTED_PUSH_RESPONSE_DATA_FRAME);
                     num_push_stream_data += 1;
@@ -1515,8 +1515,8 @@ mod tests {
                 } => {
                     assert_eq!(stream_id, response_stream_id);
                     check_response_header_2(&headers);
-                    assert_eq!(fin, false);
-                    assert_eq!(interim, false);
+                    assert!(!fin);
+                    assert!(!interim);
                 }
                 Http3ClientEvent::DataReadable { stream_id } => {
                     assert_eq!(stream_id, response_stream_id);
@@ -1940,8 +1940,8 @@ mod tests {
                 } => {
                     assert_eq!(stream_id, request_stream_id);
                     check_response_header_1(&headers);
-                    assert_eq!(fin, false);
-                    assert_eq!(interim, false);
+                    assert!(!fin);
+                    assert!(!interim);
                 }
                 Http3ClientEvent::DataReadable { stream_id } => {
                     assert_eq!(stream_id, request_stream_id);
@@ -1949,7 +1949,7 @@ mod tests {
                     let (amount, fin) = client
                         .read_response_data(now(), stream_id, &mut buf)
                         .unwrap();
-                    assert_eq!(fin, true);
+                    assert!(fin);
                     assert_eq!(amount, EXPECTED_RESPONSE_DATA_1.len());
                     assert_eq!(&buf[..amount], EXPECTED_RESPONSE_DATA_1);
                 }
@@ -1981,8 +1981,8 @@ mod tests {
                 } => {
                     assert_eq!(stream_id, request_stream_id);
                     check_response_header_2(&headers);
-                    assert_eq!(fin, false);
-                    assert_eq!(interim, false);
+                    assert!(!fin);
+                    assert!(!interim);
                 }
                 Http3ClientEvent::DataReadable { stream_id } => {
                     assert_eq!(stream_id, request_stream_id);
@@ -1990,7 +1990,7 @@ mod tests {
                     let (amount, fin) = client
                         .read_response_data(now(), stream_id, &mut buf)
                         .unwrap();
-                    assert_eq!(fin, true);
+                    assert!(fin);
                     assert_eq!(amount, EXPECTED_RESPONSE_DATA_2_FRAME_1.len());
                     assert_eq!(&buf[..amount], EXPECTED_RESPONSE_DATA_2_FRAME_1);
                 }
@@ -2044,7 +2044,7 @@ mod tests {
                     // Read request body.
                     let mut buf = [0_u8; 100];
                     let (amount, fin) = server.conn.stream_recv(stream_id, &mut buf).unwrap();
-                    assert_eq!(fin, true);
+                    assert!(fin);
                     assert_eq!(amount, EXPECTED_REQUEST_BODY_FRAME.len());
                     assert_eq!(&buf[..amount], EXPECTED_REQUEST_BODY_FRAME);
 
@@ -2089,7 +2089,7 @@ mod tests {
                     // Read the DATA frame.
                     let mut buf = vec![1_u8; RECV_BUFFER_SIZE];
                     let (amount, fin) = server.conn.stream_recv(stream_id, &mut buf).unwrap();
-                    assert_eq!(fin, true);
+                    assert!(fin);
                     assert_eq!(
                         amount,
                         request_body.len() + expected_data_frame_header.len()
@@ -2181,7 +2181,7 @@ mod tests {
                     // Read DATA frames.
                     let mut buf = vec![1_u8; RECV_BUFFER_SIZE];
                     let (amount, fin) = server.conn.stream_recv(stream_id, &mut buf).unwrap();
-                    assert_eq!(fin, true);
+                    assert!(fin);
                     assert_eq!(
                         amount,
                         expected_first_data_frame_header.len()
@@ -2333,8 +2333,8 @@ mod tests {
                 } => {
                     assert_eq!(stream_id, request_stream_id);
                     check_response_header_2(&headers);
-                    assert_eq!(fin, false);
-                    assert_eq!(interim, false);
+                    assert!(!fin);
+                    assert!(!interim);
                     response_headers = true;
                 }
                 Http3ClientEvent::DataReadable { stream_id } => {
@@ -2343,7 +2343,7 @@ mod tests {
                     let (amount, fin) = client
                         .read_response_data(now(), stream_id, &mut buf)
                         .unwrap();
-                    assert_eq!(fin, true);
+                    assert!(fin);
                     assert_eq!(amount, EXPECTED_RESPONSE_DATA_2_FRAME_1.len());
                     assert_eq!(&buf[..amount], EXPECTED_RESPONSE_DATA_2_FRAME_1);
                     response_body = true;
@@ -2405,7 +2405,7 @@ mod tests {
                 } => {
                     assert_eq!(stream_id, request_stream_id);
                     assert_eq!(error, Error::HttpRequestRejected.code());
-                    assert_eq!(local, false);
+                    assert!(!local);
                     reset = true;
                 }
                 Http3ClientEvent::HeaderReady { .. } | Http3ClientEvent::DataReadable { .. } => {
@@ -2524,7 +2524,7 @@ mod tests {
                 } => {
                     assert_eq!(stream_id, request_stream_id);
                     assert_eq!(error, Error::HttpRequestCancelled.code());
-                    assert_eq!(local, false);
+                    assert!(!local);
                     reset = true;
                 }
                 Http3ClientEvent::HeaderReady { .. } | Http3ClientEvent::DataReadable { .. } => {
@@ -2604,7 +2604,7 @@ mod tests {
         let (amount, fin) = client
             .read_response_data(now(), request_stream_id, &mut buf)
             .unwrap();
-        assert_eq!(fin, false);
+        assert!(!fin);
         assert_eq!(amount, EXPECTED_RESPONSE_DATA_2_FRAME_1.len());
         assert_eq!(&buf[..amount], EXPECTED_RESPONSE_DATA_2_FRAME_1);
 
@@ -2642,7 +2642,7 @@ mod tests {
                 } => {
                     assert_eq!(stream_id, request_stream_id);
                     assert_eq!(error, Error::HttpRequestCancelled.code());
-                    assert_eq!(local, false);
+                    assert!(!local);
                     reset = true;
                 }
                 Http3ClientEvent::HeaderReady { .. } | Http3ClientEvent::DataReadable { .. } => {
@@ -2745,7 +2745,7 @@ mod tests {
             match e {
                 Http3ClientEvent::HeaderReady { headers, fin, .. } => {
                     check_response_header_1(&headers);
-                    assert_eq!(fin, false);
+                    assert!(!fin);
                 }
                 Http3ClientEvent::DataReadable { stream_id } => {
                     assert!(
@@ -2766,7 +2766,7 @@ mod tests {
                 } => {
                     assert_eq!(stream_id, request_stream_id_3);
                     assert_eq!(error, Error::HttpRequestRejected.code());
-                    assert_eq!(local, false);
+                    assert!(!local);
                     stream_reset = true;
                 }
                 _ => {}
@@ -2818,7 +2818,7 @@ mod tests {
             {
                 assert_eq!(stream_id, request_stream_id_3);
                 assert_eq!(error, Error::HttpRequestRejected.code());
-                assert_eq!(local, false);
+                assert!(!local);
                 stream_reset_1 += 1;
             }
         }
@@ -2846,7 +2846,7 @@ mod tests {
             match e {
                 Http3ClientEvent::HeaderReady { headers, fin, .. } => {
                     check_response_header_1(&headers);
-                    assert_eq!(fin, false);
+                    assert!(!fin);
                 }
                 Http3ClientEvent::DataReadable { stream_id } => {
                     assert!(stream_id == request_stream_id_1);
@@ -2865,7 +2865,7 @@ mod tests {
                 } => {
                     assert_eq!(stream_id, request_stream_id_2);
                     assert_eq!(error, Error::HttpRequestRejected.code());
-                    assert_eq!(local, false);
+                    assert!(!local);
                     stream_reset_2 += 1;
                 }
                 _ => {}
@@ -2977,8 +2977,8 @@ mod tests {
         {
             assert_eq!(stream_id, request_stream_id);
             check_response_header_2(&headers);
-            assert_eq!(fin, true);
-            assert_eq!(interim, false);
+            assert!(fin);
+            assert!(!interim);
         } else {
             panic!("wrong event type");
         }
@@ -3016,8 +3016,8 @@ mod tests {
                 } => {
                     assert_eq!(stream_id, request_stream_id);
                     check_response_header_2(&headers);
-                    assert_eq!(fin, false);
-                    assert_eq!(interim, false);
+                    assert!(!fin);
+                    assert!(!interim);
                 }
                 Http3ClientEvent::DataReadable { .. } => {
                     panic!("We should not receive a DataGeadable event!");
@@ -3044,7 +3044,7 @@ mod tests {
                     let res = client.read_response_data(now(), stream_id, &mut buf);
                     let (len, fin) = res.expect("should read");
                     assert_eq!(0, len);
-                    assert_eq!(fin, true);
+                    assert!(fin);
                 }
                 _ => {}
             };
@@ -3090,8 +3090,8 @@ mod tests {
                 } => {
                     assert_eq!(stream_id, request_stream_id);
                     check_response_header_2(&headers);
-                    assert_eq!(fin, false);
-                    assert_eq!(interim, false);
+                    assert!(!fin);
+                    assert!(!interim);
                 }
                 Http3ClientEvent::DataReadable { stream_id } => {
                     assert_eq!(stream_id, request_stream_id);
@@ -3144,8 +3144,8 @@ mod tests {
                 } => {
                     assert_eq!(stream_id, request_stream_id);
                     check_response_header_2(&headers);
-                    assert_eq!(fin, false);
-                    assert_eq!(interim, false);
+                    assert!(!fin);
+                    assert!(!interim);
                 }
                 Http3ClientEvent::DataReadable { .. } => {
                     panic!("We should not receive a DataGeadable event!");
@@ -3172,7 +3172,7 @@ mod tests {
                     let res = client.read_response_data(now(), stream_id, &mut buf);
                     let (len, fin) = res.expect("should read");
                     assert_eq!(0, len);
-                    assert_eq!(fin, true);
+                    assert!(fin);
                 }
                 _ => {}
             };
@@ -3209,8 +3209,8 @@ mod tests {
                 } => {
                     assert_eq!(stream_id, request_stream_id);
                     check_response_header_2(&headers);
-                    assert_eq!(fin, false);
-                    assert_eq!(interim, false);
+                    assert!(!fin);
+                    assert!(!interim);
                 }
                 Http3ClientEvent::DataReadable { stream_id } => {
                     assert_eq!(stream_id, request_stream_id);
@@ -3219,7 +3219,7 @@ mod tests {
                     let (len, fin) = res.expect("should have data");
                     assert_eq!(len, EXPECTED_RESPONSE_DATA_2_FRAME_1.len());
                     assert_eq!(&buf[..len], EXPECTED_RESPONSE_DATA_2_FRAME_1);
-                    assert_eq!(fin, false);
+                    assert!(!fin);
                 }
                 _ => {}
             };
@@ -3238,7 +3238,7 @@ mod tests {
             let res = client.read_response_data(now(), stream_id, &mut buf);
             let (len, fin) = res.expect("should read");
             assert_eq!(0, len);
-            assert_eq!(fin, true);
+            assert!(fin);
         } else {
             panic!("wrong event type");
         }
@@ -3323,7 +3323,7 @@ mod tests {
                     .unwrap();
                 assert_eq!(len, EXPECTED_RESPONSE_DATA_2_FRAME_1.len());
                 assert_eq!(&buf[..len], EXPECTED_RESPONSE_DATA_2_FRAME_1);
-                assert_eq!(fin, true);
+                assert!(fin);
             }
             x => {
                 eprintln!("event {:?}", x);
@@ -3457,8 +3457,8 @@ mod tests {
             {
                 assert_eq!(stream_id, request_stream_id);
                 assert_eq!(headers, sent_headers);
-                assert_eq!(fin, true);
-                assert_eq!(interim, false);
+                assert!(fin);
+                assert!(!interim);
                 recv_header = true;
             } else {
                 panic!("event {:?}", e);
@@ -3990,8 +3990,8 @@ mod tests {
             {
                 assert_eq!(stream_id, request_stream_id);
                 check_response_header_0(&headers);
-                assert_eq!(fin, false);
-                assert_eq!(interim, false);
+                assert!(!fin);
+                assert!(!interim);
                 response_headers = true;
             }
         }
@@ -4022,7 +4022,7 @@ mod tests {
             .read_response_data(now(), request_stream_id, &mut buf)
             .unwrap();
         assert_eq!(0, len);
-        assert_eq!(fin, true)
+        assert!(fin);
     }
 
     #[test]
@@ -4051,8 +4051,8 @@ mod tests {
             {
                 assert_eq!(stream_id, request_stream_id);
                 check_response_header_0(&headers);
-                assert_eq!(fin, false);
-                assert_eq!(interim, false);
+                assert!(!fin);
+                assert!(!interim);
                 response_headers = true;
             }
         }
@@ -4092,7 +4092,7 @@ mod tests {
             .read_response_data(now(), request_stream_id, &mut buf)
             .unwrap();
         assert_eq!(0, len);
-        assert_eq!(fin, true);
+        assert!(fin);
     }
 
     #[test]
@@ -4121,8 +4121,8 @@ mod tests {
             {
                 assert_eq!(stream_id, request_stream_id);
                 check_response_header_0(&headers);
-                assert_eq!(fin, false);
-                assert_eq!(interim, false);
+                assert!(!fin);
+                assert!(!interim);
                 response_headers = true;
             }
         }
@@ -4880,7 +4880,7 @@ mod tests {
         assert!(server.conn.events().any(control_stream_readable));
         let mut buf = [0_u8; 100];
         let (amount, fin) = server.conn.stream_recv(2, &mut buf).unwrap();
-        assert_eq!(fin, false);
+        assert!(!fin);
 
         assert_eq!(amount, MAX_PUSH_ID_FRAME.len());
         assert_eq!(&buf[..3], MAX_PUSH_ID_FRAME);
@@ -5408,7 +5408,7 @@ mod tests {
             .conn
             .stream_recv(CLIENT_SIDE_DECODER_STREAM_ID, &mut inst)
             .unwrap();
-        assert_eq!(fin, false);
+        assert!(!fin);
         assert_eq!(amount, STREAM_CANCELED_ID_0.len());
         assert_eq!(&inst[..amount], STREAM_CANCELED_ID_0);
     }

--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -311,7 +311,7 @@ impl HFrameReader {
     /// # Errors
     /// May return `HttpFrame` if a frame cannot be decoded.
     fn get_frame(&mut self) -> Res<HFrame> {
-        let payload = mem::replace(&mut self.payload, Vec::new());
+        let payload = mem::take(&mut self.payload);
         let mut dec = Decoder::from(&payload[..]);
         let f = match self.hframe_type {
             H3_FRAME_TYPE_DATA => HFrame::Data {
@@ -392,7 +392,7 @@ mod tests {
         mem::drop(conn_c.process(out.dgram(), now()));
 
         let (frame, fin) = fr.receive(&mut conn_c, stream_id).unwrap();
-        assert_eq!(fin, false);
+        assert!(!fin);
         assert!(frame.is_some());
         assert_eq!(*f, frame.unwrap());
 
@@ -494,7 +494,7 @@ mod tests {
             let out = self.conn_s.process(None, now());
             mem::drop(self.conn_c.process(out.dgram(), now()));
             let (frame, fin) = self.fr.receive(&mut self.conn_c, self.stream_id).unwrap();
-            assert_eq!(fin, false);
+            assert!(!fin);
             frame
         }
     }
@@ -650,17 +650,17 @@ mod tests {
             }
             FrameReadingTestExpect::FrameComplete => {
                 let (f, fin) = rv.unwrap();
-                assert_eq!(fin, false);
+                assert!(!fin);
                 assert!(f.is_some());
             }
             FrameReadingTestExpect::FrameAndStreamComplete => {
                 let (f, fin) = rv.unwrap();
-                assert_eq!(fin, true);
+                assert!(fin);
                 assert!(f.is_some());
             }
             FrameReadingTestExpect::StreamDoneWithoutFrame => {
                 let (f, fin) = rv.unwrap();
-                assert_eq!(fin, true);
+                assert!(fin);
                 assert!(f.is_none());
             }
         };

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -117,6 +117,12 @@ impl Error {
     }
 
     #[must_use]
+    #[allow(
+        unknown_lints,
+        renamed_and_removed_lints,
+        clippy::unknown_clippy_lints,
+        clippy::unnested_or_patterns
+    )] // Until we require rust 1.53 we can't use or_patterns.
     pub fn connection_error(&self) -> bool {
         matches!(
             self,

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -254,7 +254,7 @@ impl PushController {
                     Ok(true)
                 }
                 PushState::PushPromise { headers } => {
-                    let tmp = mem::replace(headers, Vec::new());
+                    let tmp = mem::take(headers);
                     *push_state = PushState::Active {
                         stream_id,
                         headers: tmp,

--- a/neqo-http3/src/push_stream.rs
+++ b/neqo-http3/src/push_stream.rs
@@ -129,7 +129,7 @@ impl RecvStream for PushStream {
                     }
                     return Ok(());
                 }
-                _ => return Ok(()),
+                PushStreamState::Closed => return Ok(()),
             }
         }
     }

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -32,7 +32,7 @@ fn process_server_events(server: &mut Http3Server) {
                     (String::from(":path"), String::from("/"))
                 ]
             );
-            assert_eq!(fin, true);
+            assert!(fin);
             request
                 .set_response(
                     &[
@@ -45,7 +45,7 @@ fn process_server_events(server: &mut Http3Server) {
             request_found = true;
         }
     }
-    assert_eq!(request_found, true);
+    assert!(request_found);
 }
 
 fn process_client_events(conn: &mut Http3Client) {
@@ -61,13 +61,13 @@ fn process_client_events(conn: &mut Http3Client) {
                         (String::from("content-length"), String::from("3")),
                     ]
                 );
-                assert_eq!(fin, false);
+                assert!(!fin);
                 response_header_found = true;
             }
             Http3ClientEvent::DataReadable { stream_id } => {
                 let mut buf = [0u8; 100];
                 let (amount, fin) = conn.read_response_data(now(), stream_id, &mut buf).unwrap();
-                assert_eq!(fin, true);
+                assert!(fin);
                 assert_eq!(amount, RESPONSE_DATA.len());
                 assert_eq!(&buf[..RESPONSE_DATA.len()], RESPONSE_DATA);
                 response_data_found = true;
@@ -75,8 +75,8 @@ fn process_client_events(conn: &mut Http3Client) {
             _ => {}
         }
     }
-    assert_eq!(response_header_found, true);
-    assert_eq!(response_data_found, true)
+    assert!(response_header_found);
+    assert!(response_data_found);
 }
 
 fn connect() -> (Http3Client, Http3Server, Option<Datagram>) {
@@ -96,9 +96,9 @@ fn connect() -> (Http3Client, Http3Server, Option<Datagram>) {
     let out = hconn_s.process(out.dgram(), now()); // Handshake
     let out = hconn_c.process(out.dgram(), now());
     let out = hconn_s.process(out.dgram(), now());
-    // assert_eq!(hconn_s.settings_received, true);
+    // assert!(hconn_s.settings_received);
     let out = hconn_c.process(out.dgram(), now());
-    // assert_eq!(hconn_c.settings_received, true);
+    // assert!(hconn_c.settings_received);
 
     (hconn_c, hconn_s, out.dgram())
 }

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -403,8 +403,12 @@ impl ToSocketAddrs for Peer {
     }
 }
 
-#[allow(clippy::upper_case_acronyms)]
-#[allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)] // Until we require rust 1.51.
+#[allow(
+    unknown_lints,
+    renamed_and_removed_lints,
+    clippy::unknown_clippy_lints,
+    clippy::upper_case_acronyms
+)] // Until we require rust 1.51.
 #[derive(Debug, PartialEq)]
 enum Test {
     Connect,

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -359,7 +359,7 @@ mod tests {
             .peer_conn
             .stream_recv(decoder.send_stream_id, &mut buf)
             .unwrap();
-        assert_eq!(fin, false);
+        assert!(!fin);
         assert_eq!(&buf[..amount], decoder_instruction);
     }
 

--- a/neqo-qpack/src/decoder_instructions.rs
+++ b/neqo-qpack/src/decoder_instructions.rs
@@ -112,7 +112,9 @@ impl DecoderInstructionReader {
                                 DecoderInstruction::NoInstruction,
                             ));
                         }
-                        _ => unreachable!("This instruction cannot be in this state."),
+                        DecoderInstruction::NoInstruction => {
+                            unreachable!("This instruction cannot be in this state.")
+                        }
                     }
                 }
             }

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -235,7 +235,7 @@ impl QPackEncoder {
                 self.stream_cancellation(stream_id);
                 Ok(())
             }
-            _ => Ok(()),
+            DecoderInstruction::NoInstruction => Ok(()),
         }
     }
 
@@ -364,6 +364,12 @@ impl QPackEncoder {
     /// `InternalError` if an unexpected error occurred.
     /// # Panics
     /// If there is a programming error.
+    #[allow(
+        unknown_lints,
+        renamed_and_removed_lints,
+        clippy::unknown_clippy_lints,
+        clippy::unnested_or_patterns
+    )] // Until we require rust 1.53 we can't use or_patterns.
     pub fn encode_header_block(
         &mut self,
         conn: &mut Connection,
@@ -592,7 +598,7 @@ mod tests {
                 .peer_conn
                 .stream_recv(self.send_stream_id, &mut buf)
                 .unwrap();
-            assert_eq!(fin, false);
+            assert!(!fin);
             assert_eq!(buf[..amount], encoder_instruction[..]);
         }
     }

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -299,7 +299,7 @@ impl LiteralReader {
                         if self.use_huffman {
                             break Ok(decode_huffman(&self.literal)?);
                         }
-                        break Ok(mem::replace(&mut self.literal, Vec::new()));
+                        break Ok(mem::take(&mut self.literal));
                     }
                     break Err(Error::NeedMoreData);
                 }

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -817,14 +817,17 @@ fn retire_all() {
     let ncid = send_something(&mut server, now());
     server.test_frame_writer = None;
 
-    let ncid_before = client.stats().frame_rx.new_connection_id;
-    let rcid_before = client.stats().frame_tx.retire_connection_id;
+    let new_cid_before = client.stats().frame_rx.new_connection_id;
+    let retire_cid_before = client.stats().frame_tx.retire_connection_id;
     client.process_input(ncid, now());
     let retire = send_something(&mut client, now());
-    assert_eq!(client.stats().frame_rx.new_connection_id, ncid_before + 1);
+    assert_eq!(
+        client.stats().frame_rx.new_connection_id,
+        new_cid_before + 1
+    );
     assert_eq!(
         client.stats().frame_tx.retire_connection_id,
-        rcid_before + LOCAL_ACTIVE_CID_LIMIT
+        retire_cid_before + LOCAL_ACTIVE_CID_LIMIT
     );
 
     assert_ne!(get_cid(&retire), original_cid);

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -103,16 +103,16 @@ fn transfer() {
     assert!(stream_ids.next().is_none());
     let (received1, fin1) = server.stream_recv(first_stream.as_u64(), &mut buf).unwrap();
     assert_eq!(received1, 4000);
-    assert_eq!(fin1, false);
+    assert!(!fin1);
     let (received2, fin2) = server.stream_recv(first_stream.as_u64(), &mut buf).unwrap();
     assert_eq!(received2, 140);
-    assert_eq!(fin2, false);
+    assert!(!fin2);
 
     let (received3, fin3) = server
         .stream_recv(second_stream.as_u64(), &mut buf)
         .unwrap();
     assert_eq!(received3, 60);
-    assert_eq!(fin3, true);
+    assert!(fin3);
 }
 
 #[test]
@@ -350,7 +350,7 @@ fn after_fin_is_read_conn_events_for_stream_should_be_removed() {
     // read from the stream before checking connection events.
     let mut buf = vec![0; 4000];
     let (_, fin) = client.stream_recv(id, &mut buf).unwrap();
-    assert_eq!(fin, true);
+    assert!(fin);
 
     // Make sure we do not have RecvStreamReadable events for the stream when fin has been read.
     let readable_stream_evt =

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -865,7 +865,7 @@ impl LossRecovery {
                 .iter()
                 .chain(self.pto_time(rtt, PacketNumberSpace::Handshake).iter())
                 .min()
-                .cloned()
+                .copied()
         }
     }
 

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -894,7 +894,7 @@ mod tests {
 
         // test receiving a contig frame and reading it works
         s.inbound_stream_frame(false, 0, &[1; 10]).unwrap();
-        assert_eq!(s.data_ready(), true);
+        assert!(s.data_ready());
         let mut buf = vec![0u8; 100];
         assert_eq!(s.read(&mut buf).unwrap(), (10, false));
         assert_eq!(s.state.recv_buf().unwrap().retired(), 10);
@@ -902,27 +902,27 @@ mod tests {
 
         // test receiving a noncontig frame
         s.inbound_stream_frame(false, 12, &[2; 12]).unwrap();
-        assert_eq!(s.data_ready(), false);
+        assert!(!s.data_ready());
         assert_eq!(s.read(&mut buf).unwrap(), (0, false));
         assert_eq!(s.state.recv_buf().unwrap().retired(), 10);
         assert_eq!(s.state.recv_buf().unwrap().buffered(), 12);
 
         // another frame that overlaps the first
         s.inbound_stream_frame(false, 14, &[3; 8]).unwrap();
-        assert_eq!(s.data_ready(), false);
+        assert!(!s.data_ready());
         assert_eq!(s.state.recv_buf().unwrap().retired(), 10);
         assert_eq!(s.state.recv_buf().unwrap().buffered(), 12);
 
         // fill in the gap, but with a FIN
         s.inbound_stream_frame(true, 10, &[4; 6]).unwrap_err();
-        assert_eq!(s.data_ready(), false);
+        assert!(!s.data_ready());
         assert_eq!(s.read(&mut buf).unwrap(), (0, false));
         assert_eq!(s.state.recv_buf().unwrap().retired(), 10);
         assert_eq!(s.state.recv_buf().unwrap().buffered(), 12);
 
         // fill in the gap
         s.inbound_stream_frame(false, 10, &[5; 10]).unwrap();
-        assert_eq!(s.data_ready(), true);
+        assert!(s.data_ready());
         assert_eq!(s.state.recv_buf().unwrap().retired(), 10);
         assert_eq!(s.state.recv_buf().unwrap().buffered(), 14);
 
@@ -930,7 +930,7 @@ mod tests {
         s.inbound_stream_frame(true, 24, &[6; 18]).unwrap();
         assert_eq!(s.state.recv_buf().unwrap().retired(), 10);
         assert_eq!(s.state.recv_buf().unwrap().buffered(), 32);
-        assert_eq!(s.data_ready(), true);
+        assert!(s.data_ready());
         assert_eq!(s.read(&mut buf).unwrap(), (32, true));
 
         // Stream now no longer readable (is in DataRead state)
@@ -1079,7 +1079,7 @@ mod tests {
         s.maybe_send_flowc_update();
         assert!(!s.has_frames_to_write());
         assert_eq!(s.read(&mut buf).unwrap(), (RECV_BUFFER_SIZE, false));
-        assert_eq!(s.data_ready(), false);
+        assert!(!s.data_ready());
         s.maybe_send_flowc_update();
 
         // flow msg generated!

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1522,7 +1522,7 @@ mod tests {
         // Increasing conn max (conn:4, stream:4) will unblock but not emit
         // event b/c that happens in Connection::emit_frame() (tested in
         // connection.rs)
-        assert_eq!(conn_fc.borrow_mut().update(4), true);
+        assert!(conn_fc.borrow_mut().update(4));
         let evts = conn_events.events().collect::<Vec<_>>();
         assert_eq!(evts.len(), 0);
         assert_eq!(s.avail(), 2);

--- a/neqo-transport/src/stream_id.rs
+++ b/neqo-transport/src/stream_id.rs
@@ -127,38 +127,38 @@ mod test {
     #[test]
     fn bidi_stream_properties() {
         let id1 = StreamId::from(16);
-        assert_eq!(id1.is_bidi(), true);
-        assert_eq!(id1.is_uni(), false);
-        assert_eq!(id1.is_client_initiated(), true);
-        assert_eq!(id1.is_server_initiated(), false);
+        assert!(id1.is_bidi());
+        assert!(!id1.is_uni());
+        assert!(id1.is_client_initiated());
+        assert!(!id1.is_server_initiated());
         assert_eq!(id1.role(), Role::Client);
-        assert_eq!(id1.is_self_initiated(Role::Client), true);
-        assert_eq!(id1.is_self_initiated(Role::Server), false);
-        assert_eq!(id1.is_remote_initiated(Role::Client), false);
-        assert_eq!(id1.is_remote_initiated(Role::Server), true);
-        assert_eq!(id1.is_send_only(Role::Server), false);
-        assert_eq!(id1.is_send_only(Role::Client), false);
-        assert_eq!(id1.is_recv_only(Role::Server), false);
-        assert_eq!(id1.is_recv_only(Role::Client), false);
+        assert!(id1.is_self_initiated(Role::Client));
+        assert!(!id1.is_self_initiated(Role::Server));
+        assert!(!id1.is_remote_initiated(Role::Client));
+        assert!(id1.is_remote_initiated(Role::Server));
+        assert!(!id1.is_send_only(Role::Server));
+        assert!(!id1.is_send_only(Role::Client));
+        assert!(!id1.is_recv_only(Role::Server));
+        assert!(!id1.is_recv_only(Role::Client));
         assert_eq!(id1.as_u64(), 16);
     }
 
     #[test]
     fn uni_stream_properties() {
         let id2 = StreamId::from(35);
-        assert_eq!(id2.is_bidi(), false);
-        assert_eq!(id2.is_uni(), true);
-        assert_eq!(id2.is_client_initiated(), false);
-        assert_eq!(id2.is_server_initiated(), true);
+        assert!(!id2.is_bidi());
+        assert!(id2.is_uni());
+        assert!(!id2.is_client_initiated());
+        assert!(id2.is_server_initiated());
         assert_eq!(id2.role(), Role::Server);
-        assert_eq!(id2.is_self_initiated(Role::Client), false);
-        assert_eq!(id2.is_self_initiated(Role::Server), true);
-        assert_eq!(id2.is_remote_initiated(Role::Client), true);
-        assert_eq!(id2.is_remote_initiated(Role::Server), false);
-        assert_eq!(id2.is_send_only(Role::Server), true);
-        assert_eq!(id2.is_send_only(Role::Client), false);
-        assert_eq!(id2.is_recv_only(Role::Server), false);
-        assert_eq!(id2.is_recv_only(Role::Client), true);
+        assert!(!id2.is_self_initiated(Role::Client));
+        assert!(id2.is_self_initiated(Role::Server));
+        assert!(id2.is_remote_initiated(Role::Client));
+        assert!(!id2.is_remote_initiated(Role::Server));
+        assert!(id2.is_send_only(Role::Server));
+        assert!(!id2.is_send_only(Role::Client));
+        assert!(!id2.is_recv_only(Role::Server));
+        assert!(id2.is_recv_only(Role::Client));
         assert_eq!(id2.as_u64(), 35);
     }
 }

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -598,10 +598,10 @@ mod tests {
         assert_eq!(tps2.get_bytes(ORIGINAL_DESTINATION_CONNECTION_ID), None);
         assert_eq!(tps2.get_bytes(INITIAL_SOURCE_CONNECTION_ID), None);
         assert_eq!(tps2.get_bytes(RETRY_SOURCE_CONNECTION_ID), None);
-        assert_eq!(tps2.has_value(ORIGINAL_DESTINATION_CONNECTION_ID), false);
-        assert_eq!(tps2.has_value(INITIAL_SOURCE_CONNECTION_ID), false);
-        assert_eq!(tps2.has_value(RETRY_SOURCE_CONNECTION_ID), false);
-        assert_eq!(tps2.has_value(STATELESS_RESET_TOKEN), true);
+        assert!(!tps2.has_value(ORIGINAL_DESTINATION_CONNECTION_ID));
+        assert!(!tps2.has_value(INITIAL_SOURCE_CONNECTION_ID));
+        assert!(!tps2.has_value(RETRY_SOURCE_CONNECTION_ID));
+        assert!(tps2.has_value(STATELESS_RESET_TOKEN));
 
         let mut enc = Encoder::default();
         tps.encode(&mut enc);


### PR DESCRIPTION
Mostly this is just `assert_eq!(x, true|false)` being fixed.

There was a new lint about `mem::replace(x, <default>)` being replaced
with `mem::take(x)`.

I had to suppress a new lint (unnested_or_patterns) because that was
introduced in this version.  There is a way to configure clippy with a
minimum supported rust version, which works nicely, but that doesn't
work with the version in 1.43.0, so we can't use it.

In suppressing the lint, I decided to make sure that all of the lints
that are version based follow the same pattern:

```rust
  unknown_lints, // Needed in recent rust versions.
  renamed_and_removed_lints, // Needed so that new versions don't
                             // complain about the next one.
  clippy::unknown_clippy_lints, // Needed for older rust versions.
  <the lint we care about>
)] // A comment about the version this can go away in.
```

It's a bit of a mess, and probably better fixed with a macro, but I'm
not up to that today.

Finally, bindgen relies on UB, so we have to suppress a warning for
that.  I guess that I could instead stop it from generating tests, but
that seems less good.