### PR TITLE
Clamp cwnd values to 1<<53

### DIFF
--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -209,6 +209,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
                 min_rtt,
                 now,
             );
+            debug_assert!(bytes_for_increase > 0);
             // If enough credit has been accumulated already, apply them gradually.
             // If we have sudden increase in allowed rate we actually increase cwnd gently.
             if self.acked_bytes >= bytes_for_increase {

--- a/neqo-transport/src/cc/cubic.rs
+++ b/neqo-transport/src/cc/cubic.rs
@@ -35,9 +35,11 @@ pub const CUBIC_FAST_CONVERGENCE: f64 = 0.85; // (1.0 + CUBIC_BETA) / 2.0;
 /// A value of 1.0 would mean a return to the rate used in slow start.
 const EXPONENTIAL_GROWTH_REDUCTION: f64 = 2.0;
 
+/// Convert an integer congestion window value into a floating point value.
+/// This has the effect of reducing larger values to `1<<53`.
+/// If you have a congestion window that large, something is probably wrong.
 fn convert_to_f64(v: usize) -> f64 {
-    assert!(v < (1 << 53));
-    let mut f_64 = f64::try_from(u32::try_from(v >> 21).unwrap()).unwrap();
+    let mut f_64 = f64::try_from(u32::try_from(v >> 21).unwrap_or(u32::MAX)).unwrap();
     f_64 *= 2_097_152.0; // f_64 <<= 21
     f_64 += f64::try_from(u32::try_from(v & 0x1f_ffff).unwrap()).unwrap();
     f_64


### PR DESCRIPTION
Now, this is papering over what might be a real issue in the code, but
it should at least stop the crashing.

Why anyone would have a congestion window that large is hard to imagine.
That is 8Pb of memory to just hold the outstanding data.

That points to a genuine bug somewhere in our calculations.  I took a
look and I haven't seen any case that is obvious.  Cubic will increase
the congestion window by up to 1300 times the base rate, but at most
2700 bytes of increase per new acknowledgment.  To reach 8Pb, we would
need to send trillions of bytes and receive trillions of fresh
acknowledgments.