### PR TITLE
Cross-validate min_ack_delay and max_ack_delay

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2185,9 +2185,11 @@ impl Connection {
 
             let max_ad = Duration::from_millis(remote.get_integer(tparams::MAX_ACK_DELAY));
             let min_ad = if remote.has_value(tparams::MIN_ACK_DELAY) {
-                Some(Duration::from_micros(
-                    remote.get_integer(tparams::MIN_ACK_DELAY),
-                ))
+                let min_ad = Duration::from_micros(remote.get_integer(tparams::MIN_ACK_DELAY));
+                if min_ad > max_ad {
+                    return Err(Error::TransportParameterError);
+                }
+                Some(min_ad)
             } else {
                 None
             };

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -14,7 +14,8 @@ use crate::connection::AddressValidation;
 use crate::events::ConnectionEvent;
 use crate::path::PATH_MTU_V6;
 use crate::server::ValidateAddress;
-use crate::tparams::TransportParameter;
+use crate::tparams::{TransportParameter, MIN_ACK_DELAY};
+use crate::tracking::DEFAULT_ACK_DELAY;
 use crate::{
     ConnectionError, ConnectionParameters, EmptyConnectionIdGenerator, Error, QuicVersion,
     StreamType,
@@ -25,6 +26,7 @@ use neqo_crypto::{
     constants::TLS_CHACHA20_POLY1305_SHA256, generate_ech_keys, AuthenticationStatus,
 };
 use std::cell::RefCell;
+use std::convert::TryFrom;
 use std::mem;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::rc::Rc;
@@ -997,4 +999,31 @@ fn ech_retry_fallback_rejected() {
         server.state().error(),
         Some(&ConnectionError::Transport(Error::PeerError(298)))
     ); // A bad_certificate alert.
+}
+
+#[test]
+fn bad_min_ack_delay() {
+    const EXPECTED_ERROR: ConnectionError =
+        ConnectionError::Transport(Error::TransportParameterError);
+    let mut server = default_server();
+    let max_ad = u64::try_from(DEFAULT_ACK_DELAY.as_micros()).unwrap();
+    server
+        .set_local_tparam(MIN_ACK_DELAY, TransportParameter::Integer(max_ad + 1))
+        .unwrap();
+    let mut client = default_client();
+
+    let dgram = client.process_output(now()).dgram();
+    let dgram = server.process(dgram, now()).dgram();
+    client.process_input(dgram.unwrap(), now());
+    client.authenticated(AuthenticationStatus::Ok, now());
+    assert_eq!(client.state().error(), Some(&EXPECTED_ERROR));
+    let dgram = client.process_output(now()).dgram();
+
+    server.process_input(dgram.unwrap(), now());
+    assert_eq!(
+        server.state().error(),
+        Some(&ConnectionError::Transport(Error::PeerError(
+            Error::TransportParameterError.code()
+        )))
+    );
 }


### PR DESCRIPTION
A simple check that I noticed when reviewing the ack-frequency doc.