### PR TITLE
Updated MAX_SAVED_DATAGRAMS from 32 to 4 #1152

### DIFF
--- a/neqo-transport/src/connection/saved.rs
+++ b/neqo-transport/src/connection/saved.rs
@@ -12,11 +12,7 @@ use neqo_common::{qdebug, qinfo, Datagram};
 
 /// The number of datagrams that are saved during the handshake when
 /// keys to decrypt them are not yet available.
-///
-/// This value exceeds what should be possible to send during the handshake.
-/// Neither endpoint should have enough congestion window to send this
-/// much before the handshake completes.
-const MAX_SAVED_DATAGRAMS: usize = 32;
+const MAX_SAVED_DATAGRAMS: usize = 4;
 
 pub struct SavedDatagram {
     /// The datagram.

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -531,7 +531,7 @@ fn reorder_handshake() {
 #[test]
 fn reorder_1rtt() {
     const RTT: Duration = Duration::from_millis(100);
-    const PACKETS: usize = 6; // Many, but not enough to overflow cwnd.
+    const PACKETS: usize = 4; // Many, but not enough to overflow cwnd.
     let mut client = default_client();
     let mut server = default_server();
     let mut now = now();


### PR DESCRIPTION
Issue #1152

As per the issue I reduced the saved datagrams to 4. Also updated the reorder_1rrt() test accordingly.