### PR TITLE
Use session flow control

### DIFF
--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -798,14 +798,14 @@ fn session_flow_control_stop_sending_state_size_known() {
     client.stream_close_send(stream_id).unwrap();
     let out2 = client.process(None, now()).dgram();
 
-    mem::drop(server.process(out2, now()).dgram());
+    server.process_input(out2.unwrap(), now());
 
     server
         .stream_stop_sending(stream_id, Error::NoError.code())
         .unwrap();
 
     // In this case the final size is known when stream_stop_sending is called
-    // and tthe server release flow control imediatley and send STOP_SENDING and
+    // and the server releases flow control immediately and sends STOP_SENDING and
     // MAX_DATA in the same packet.
     let out = server.process(out1, now()).dgram();
     client.process_input(out.unwrap(), now());

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -203,11 +203,11 @@ where
     max_active: u64,
     /// Last max allowed sent.
     max_allowed: u64,
-    /// Item received not consumed.
+    /// Item received, but not retired yet.
     /// This will be used for byte flow control: each stream will remember is largest byte
-    /// offset received and session flow control will remember the sum of all bytes reserved
+    /// offset received and session flow control will remember the sum of all bytes consumed
     /// by all streams.
-    reserved: u64,
+    consumed: u64,
     /// Retired items.
     retired: u64,
     frame_pending: bool,
@@ -223,7 +223,7 @@ where
             subject,
             max_active: max,
             max_allowed: max,
-            reserved: 0,
+            consumed: 0,
             retired: 0,
             frame_pending: false,
         }
@@ -288,12 +288,12 @@ where
         self.retired
     }
 
-    pub fn reserved(&self) -> u64 {
-        self.reserved
+    pub fn consumed(&self) -> u64 {
+        self.consumed
     }
 
-    pub fn add_reserved(&mut self, count: u64) {
-        self.reserved += count;
+    pub fn consume(&mut self, count: u64) {
+        self.consumed += count;
     }
 }
 
@@ -351,10 +351,10 @@ impl ReceiverFlowControl<StreamId> {
         }
     }
 
-    pub fn reserve(&mut self, reserved: u64) -> u64 {
-        let new_reserved = reserved - self.reserved;
-        self.reserved = reserved;
-        new_reserved
+    pub fn set_consumed(&mut self, consumed: u64) -> u64 {
+        let new_consumed = consumed - self.consumed;
+        self.consumed = consumed;
+        new_consumed
     }
 }
 

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -192,7 +192,7 @@ impl SenderFlowControl<StreamType> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ReceiverFlowControl<T>
 where
     T: Debug + Sized,
@@ -349,6 +349,12 @@ impl ReceiverFlowControl<StreamId> {
         if self.retired + self.max_active / 2 > self.max_allowed {
             self.frame_pending = true;
         }
+    }
+
+    pub fn reserve(&mut self, reserved: u64) -> u64 {
+        let new_reserved = reserved - self.reserved;
+        self.reserved = reserved;
+        new_reserved
     }
 }
 

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -365,17 +365,17 @@ impl ReceiverFlowControl<StreamId> {
     }
 
     pub fn set_consumed(&mut self, consumed: u64) -> Res<u64> {
-        if consumed > self.consumed {
-            if consumed > self.max_allowed {
-                qtrace!("Stream RX window exceeded: {}", consumed);
-                return Err(Error::FlowControlError);
-            }
-            let new_consumed = consumed - self.consumed;
-            self.consumed = consumed;
-            Ok(new_consumed)
-        } else {
-            Ok(0)
+        if consumed <= self.consumed {
+            return Ok(0);
         }
+
+        if consumed > self.max_allowed {
+            qtrace!("Stream RX window exceeded: {}", consumed);
+            return Err(Error::FlowControlError);
+        }
+        let new_consumed = consumed - self.consumed;
+        self.consumed = consumed;
+        Ok(new_consumed)
     }
 }
 

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -203,6 +203,11 @@ where
     max_active: u64,
     /// Last max allowed sent.
     max_allowed: u64,
+    /// Item received not consumed.
+    /// This will be used for byte flow control: each stream will remember is largest byte
+    /// offset received and session flow control will remember the sum of all bytes reserved
+    /// by all streams.
+    reserved: u64,
     /// Retired items.
     retired: u64,
     frame_pending: bool,
@@ -218,6 +223,7 @@ where
             subject,
             max_active: max,
             max_allowed: max,
+            reserved: 0,
             retired: 0,
             frame_pending: false,
         }
@@ -280,6 +286,14 @@ where
 
     pub fn current_retired(&self) -> u64 {
         self.retired
+    }
+
+    pub fn reserved(&self) -> u64 {
+        self.reserved
+    }
+
+    pub fn add_reserved(&mut self, count: u64) {
+        self.reserved += count;
     }
 }
 

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -277,6 +277,10 @@ where
         self.frame_pending |= self.max_active < max;
         self.max_active = max;
     }
+
+    pub fn current_retired(&self) -> u64 {
+        self.retired
+    }
 }
 
 impl ReceiverFlowControl<()> {
@@ -292,6 +296,13 @@ impl ReceiverFlowControl<()> {
                 tokens.push(RecoveryToken::MaxData(max_allowed));
                 self.frame_sent(max_allowed);
             }
+        }
+    }
+
+    pub fn add_retired(&mut self, count: u64) {
+        self.retired += count;
+        if self.retired + self.max_active / 2 > self.max_allowed {
+            self.frame_pending = true;
         }
     }
 }

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -1402,7 +1402,7 @@ mod tests {
         assert_eq!(fc.retired(), retired);
     }
 
-    // Test consuming the flow control in RecvStreamState::Recv
+    /// Test consuming the flow control in RecvStreamState::Recv
     #[test]
     fn fc_state_recv_1() {
         const SW: u64 = 1024;
@@ -1419,8 +1419,8 @@ mod tests {
         check_fc(s.fc().unwrap(), SW / 4, 0);
     }
 
-    // Test consuming the flow control in RecvStreamState::Recv
-    // with multiple streams
+    /// Test consuming the flow control in RecvStreamState::Recv
+    /// with multiple streams
     #[test]
     fn fc_state_recv_2() {
         const SW: u64 = 1024;
@@ -1446,8 +1446,8 @@ mod tests {
         check_fc(s2.fc().unwrap(), SW / 4, 0);
     }
 
-    // Test retiring the flow control in RecvStreamState::Recv
-    // with multiple streams
+    /// Test retiring the flow control in RecvStreamState::Recv
+    /// with multiple streams
     #[test]
     fn fc_state_recv_3() {
         const SW: u64 = 1024;
@@ -1498,7 +1498,7 @@ mod tests {
         check_fc(s2.fc().unwrap(), SW / 4, SW / 4);
     }
 
-    // Test consuming the flow control in RecvStreamState::Recv - duplicate data
+    /// Test consuming the flow control in RecvStreamState::Recv - duplicate data
     #[test]
     fn fc_state_recv_4() {
         const SW: u64 = 1024;
@@ -1521,8 +1521,8 @@ mod tests {
         check_fc(s.fc().unwrap(), SW / 4, 0);
     }
 
-    // Test consuming the flow control in RecvStreamState::Recv - filling a gap in the
-    // data stream.
+    /// Test consuming the flow control in RecvStreamState::Recv - filling a gap in the
+    /// data stream.
     #[test]
     fn fc_state_recv_5() {
         const SW: u64 = 1024;
@@ -1542,8 +1542,8 @@ mod tests {
         check_fc(s.fc().unwrap(), SW / 4, 0);
     }
 
-    // Test consuming the flow control in RecvStreamState::Recv - receiving frame past
-    // the flow control will cause an error.
+    /// Test consuming the flow control in RecvStreamState::Recv - receiving frame past
+    /// the flow control will cause an error.
     #[test]
     fn fc_state_recv_6() {
         const SW: u64 = 1024;
@@ -1558,7 +1558,7 @@ mod tests {
         );
     }
 
-    // Test that the flow controls will send updates.
+    /// Test that the flow controls will send updates.
     #[test]
     fn fc_state_recv_7() {
         const SW: u64 = 1024;
@@ -1603,10 +1603,14 @@ mod tests {
         assert!(fc.borrow().frame_needed().is_none());
         assert!(s.fc().unwrap().frame_needed().is_some());
 
-        // Write the fc updatte frame
+        // Write the fc update frame
         let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
         let mut token = Vec::new();
-        s.write_frame(&mut builder, &mut token, &mut FrameStats::default());
+        let mut stats = FrameStats::default();
+        fc.borrow_mut().write_frames(&mut builder, &mut token, &mut stats);
+        assert_eq!(stats.max_data, 0);
+        s.write_frame(&mut builder, &mut token, &mut stats);
+        assert_eq!(stats.max_stream_data, 1);
 
         // Receive 1 byte that will case a session fc update after it is read.
         s.inbound_stream_frame(false, SW / 2, &[0]).unwrap();
@@ -1615,9 +1619,13 @@ mod tests {
         check_fc(s.fc().unwrap(), SW / 2 + 1, SW / 2 + 1);
         assert!(fc.borrow().frame_needed().is_some());
         assert!(s.fc().unwrap().frame_needed().is_none());
+        fc.borrow_mut().write_frames(&mut builder, &mut token, &mut stats);
+        assert_eq!(stats.max_data, 1);
+        s.write_frame(&mut builder, &mut token, &mut stats);
+        assert_eq!(stats.max_stream_data, 1);
     }
 
-    // Test flow control in RecvStreamState::SizeKnown
+    /// Test flow control in RecvStreamState::SizeKnown
     #[test]
     fn fc_state_size_known() {
         const SW: u64 = 1024;
@@ -1674,7 +1682,7 @@ mod tests {
         assert!(s.fc().is_none());
     }
 
-    // Test flow control in RecvStreamState::DataRecvd
+    /// Test flow control in RecvStreamState::DataRecvd
     #[test]
     fn fc_state_data_recv() {
         const SW: u64 = 1024;
@@ -1719,7 +1727,7 @@ mod tests {
         assert!(s.fc().is_none());
     }
 
-    // Test flow control in RecvStreamState::DataRead
+    /// Test flow control in RecvStreamState::DataRead
     #[test]
     fn fc_state_data_read() {
         const SW: u64 = 1024;
@@ -1757,7 +1765,7 @@ mod tests {
         assert!(s.fc().is_none());
     }
 
-    // Test flow control in RecvStreamState::AbortReading and final size is known
+    /// Test flow control in RecvStreamState::AbortReading and final size is known
     #[test]
     fn fc_state_abort_reading_1() {
         const SW: u64 = 1024;
@@ -1799,7 +1807,7 @@ mod tests {
         check_fc(s.fc().unwrap(), SW / 2, SW / 2);
     }
 
-    // Test flow control in RecvStreamState::AbortReading and final size is unknown
+    /// Test flow control in RecvStreamState::AbortReading and final size is unknown
     #[test]
     fn fc_state_abort_reading_2() {
         const SW: u64 = 1024;
@@ -1857,7 +1865,7 @@ mod tests {
         check_fc(s.fc().unwrap(), SW / 2 + 20, SW / 2 + 20);
     }
 
-    // Test flow control in RecvStreamState::WaitForReset
+    /// Test flow control in RecvStreamState::WaitForReset
     #[test]
     fn fc_state_wait_for_reset() {
         const SW: u64 = 1024;

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -436,6 +436,35 @@ impl RecvStream {
         self.state = new_state;
     }
 
+    fn check_flow_control_limits(
+        new_end: u64,
+        fc: &mut ReceiverFlowControl<StreamId>,
+        session_fc: &mut Rc<RefCell<ReceiverFlowControl<()>>>,
+    ) -> Res<()> {
+        // If we have new data that exceeds the current largest offset, check that
+        // the flow control limitts are not exceeded.
+        // We are checking new_end - 1, this is the offset of the last byte of the data.
+        if new_end != 0 && (new_end - 1 > fc.reserved()) {
+            let last_offset = new_end - 1;
+            if !fc.check_allowed(last_offset) {
+                qtrace!("Stream RX window exceeded: {}", new_end);
+                return Err(Error::FlowControlError);
+            }
+            let new_bytes_received = last_offset - fc.reserved();
+            fc.add_reserved(new_bytes_received);
+            let session_reserved = session_fc.borrow_mut().reserved();
+            if !session_fc
+                .borrow_mut()
+                .check_allowed(session_reserved + new_bytes_received)
+            {
+                qtrace!("Session RX window exceeded: {}", new_end);
+                return Err(Error::FlowControlError);
+            }
+            session_fc.borrow_mut().add_reserved(new_bytes_received);
+        }
+        Ok(())
+    }
+
     pub fn inbound_stream_frame(&mut self, fin: bool, offset: u64, data: &[u8]) -> Res<()> {
         // We should post a DataReadable event only once when we change from no-data-ready to
         // data-ready. Therefore remember the state before processing a new frame.
@@ -450,12 +479,12 @@ impl RecvStream {
         }
 
         match &mut self.state {
-            RecvStreamState::Recv { recv_buf, fc, .. } => {
-                // We are checking new_end - 1, this is the offset of the last byte of the data.
-                if new_end != 0 && !fc.check_allowed(new_end - 1) {
-                    qtrace!("Stream RX window exceeded: {}", new_end);
-                    return Err(Error::FlowControlError);
-                }
+            RecvStreamState::Recv {
+                recv_buf,
+                fc,
+                session_fc,
+            } => {
+                RecvStream::check_flow_control_limits(new_end, fc, session_fc)?;
 
                 if fin {
                     let final_size = offset + data.len() as u64;

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -457,17 +457,16 @@ impl RecvStream {
         session_fc: &mut Rc<RefCell<ReceiverFlowControl<()>>>,
     ) -> Res<()> {
         // If we have new data that exceeds the current largest offset, check that
-        // the flow control limitts are not exceeded.
+        // the flow control limits are not exceeded.
         // We are checking new_end - 1, this is the offset of the last byte of the data.
-        if new_end != 0 && (new_end - 1 > fc.reserved()) {
+        if new_end > fc.reserved() + 1 {
             let last_offset = new_end - 1;
             if !fc.check_allowed(last_offset) {
                 qtrace!("Stream RX window exceeded: {}", new_end);
                 return Err(Error::FlowControlError);
             }
-            let new_bytes_received = last_offset - fc.reserved();
-            fc.add_reserved(new_bytes_received);
-            let session_reserved = session_fc.borrow_mut().reserved();
+            let new_bytes_received = fc.reserve(last_offset);
+            let session_reserved = session_fc.borrow().reserved();
             if !session_fc
                 .borrow_mut()
                 .check_allowed(session_reserved + new_bytes_received)
@@ -509,11 +508,8 @@ impl RecvStream {
                     recv_buf.inbound_frame(offset, data);
 
                     let buf = mem::replace(recv_buf, RxStreamOrderer::new());
-                    let fc_copy = mem::replace(fc, ReceiverFlowControl::new(StreamId::new(0), 0));
-                    let session_fc_copy = mem::replace(
-                        session_fc,
-                        Rc::new(RefCell::new(ReceiverFlowControl::new((), 0))),
-                    );
+                    let fc_copy = mem::take(fc);
+                    let session_fc_copy = mem::take(session_fc);
                     if final_size == buf.retired() + buf.bytes_ready() as u64 {
                         self.set_state(RecvStreamState::DataRecvd {
                             fc: fc_copy,
@@ -541,11 +537,8 @@ impl RecvStream {
                 recv_buf.inbound_frame(offset, data);
                 if *final_size == recv_buf.retired() + recv_buf.bytes_ready() as u64 {
                     let buf = mem::replace(recv_buf, RxStreamOrderer::new());
-                    let fc_copy = mem::replace(fc, ReceiverFlowControl::new(StreamId::new(0), 0));
-                    let session_fc_copy = mem::replace(
-                        session_fc,
-                        Rc::new(RefCell::new(ReceiverFlowControl::new((), 0))),
-                    );
+                    let fc_copy = mem::take(fc);
+                    let session_fc_copy = mem::take(session_fc);
                     self.set_state(RecvStreamState::DataRecvd {
                         fc: fc_copy,
                         session_fc: session_fc_copy,
@@ -694,11 +687,8 @@ impl RecvStream {
         match &mut self.state {
             RecvStreamState::Recv { fc, session_fc, .. }
             | RecvStreamState::SizeKnown { fc, session_fc, .. } => {
-                let fc_copy = mem::replace(fc, ReceiverFlowControl::new(StreamId::new(0), 0));
-                let session_fc_copy = mem::replace(
-                    session_fc,
-                    Rc::new(RefCell::new(ReceiverFlowControl::new((), 0))),
-                );
+                let fc_copy = mem::take(fc);
+                let session_fc_copy = mem::take(session_fc);
                 self.set_state(RecvStreamState::AbortReading {
                     fc: fc_copy,
                     session_fc: session_fc_copy,
@@ -777,13 +767,12 @@ impl RecvStream {
         } = &mut self.state
         {
             if *final_size_known {
+                // We already know the final_size of the stream therefore we
+                // do not need to wait for RESET.
                 self.set_state(RecvStreamState::ResetRecvd);
             } else {
-                let fc_copy = mem::replace(fc, ReceiverFlowControl::new(StreamId::new(0), 0));
-                let session_fc_copy = mem::replace(
-                    session_fc,
-                    Rc::new(RefCell::new(ReceiverFlowControl::new((), 0))),
-                );
+                let fc_copy = mem::take(fc);
+                let session_fc_copy = mem::take(session_fc);
                 self.set_state(RecvStreamState::WaitForReset {
                     fc: fc_copy,
                     session_fc: session_fc_copy,
@@ -1229,24 +1218,12 @@ mod tests {
 
     #[test]
     fn stream_flowc_update() {
-        let conn_events = ConnectionEvents::default();
-
-        let frame1 = vec![0; RECV_BUFFER_SIZE];
-
-        let mut s = RecvStream::new(
-            StreamId::from(4),
-            RX_STREAM_DATA_WINDOW,
-            Rc::new(RefCell::new(ReceiverFlowControl::new(
-                (),
-                1024 * RX_STREAM_DATA_WINDOW,
-            ))),
-            conn_events,
-        );
-
+        let mut s = create_stream(1024 * RX_STREAM_DATA_WINDOW);
         let mut buf = vec![0u8; RECV_BUFFER_SIZE + 100]; // Make it overlarge
 
         assert!(!s.has_frames_to_write());
-        s.inbound_stream_frame(false, 0, &frame1).unwrap();
+        s.inbound_stream_frame(false, 0, &[0; RECV_BUFFER_SIZE])
+            .unwrap();
         assert!(!s.has_frames_to_write());
         assert_eq!(s.read(&mut buf).unwrap(), (RECV_BUFFER_SIZE, false));
         assert!(!s.data_ready());
@@ -1263,23 +1240,22 @@ mod tests {
         assert!(!s.has_frames_to_write());
     }
 
-    #[test]
-    fn stream_max_stream_data() {
+    fn create_stream(fc: u64) -> RecvStream {
         let conn_events = ConnectionEvents::default();
-
-        let frame1 = vec![0; RECV_BUFFER_SIZE];
-        let mut s = RecvStream::new(
+        RecvStream::new(
             StreamId::from(67),
             RX_STREAM_DATA_WINDOW,
-            Rc::new(RefCell::new(ReceiverFlowControl::new(
-                (),
-                1024 * RX_STREAM_DATA_WINDOW,
-            ))),
+            Rc::new(RefCell::new(ReceiverFlowControl::new((), fc))),
             conn_events,
-        );
+        )
+    }
 
+    #[test]
+    fn stream_max_stream_data() {
+        let mut s = create_stream(1024 * RX_STREAM_DATA_WINDOW);
         assert!(!s.has_frames_to_write());
-        s.inbound_stream_frame(false, 0, &frame1).unwrap();
+        s.inbound_stream_frame(false, 0, &[0; RECV_BUFFER_SIZE])
+            .unwrap();
         s.inbound_stream_frame(false, RX_STREAM_DATA_WINDOW, &[1; 1])
             .unwrap_err();
     }
@@ -1321,21 +1297,9 @@ mod tests {
 
     #[test]
     fn no_stream_flowc_event_after_exiting_recv() {
-        let conn_events = ConnectionEvents::default();
-
-        let frame1 = vec![0; RECV_BUFFER_SIZE];
-        let stream_id = StreamId::from(67);
-        let mut s = RecvStream::new(
-            stream_id,
-            RX_STREAM_DATA_WINDOW,
-            Rc::new(RefCell::new(ReceiverFlowControl::new(
-                (),
-                1024 * RX_STREAM_DATA_WINDOW,
-            ))),
-            conn_events,
-        );
-
-        s.inbound_stream_frame(false, 0, &frame1).unwrap();
+        let mut s = create_stream(1024 * RX_STREAM_DATA_WINDOW);
+        s.inbound_stream_frame(false, 0, &[0; RECV_BUFFER_SIZE])
+            .unwrap();
         let mut buf = [0; RECV_BUFFER_SIZE];
         s.read(&mut buf).unwrap();
         assert!(s.has_frames_to_write());
@@ -1347,6 +1311,7 @@ mod tests {
     #[test]
     fn session_flow_control() {
         const SESSION_WINDOW: usize = 1024;
+        assert!(RX_STREAM_DATA_WINDOW > u64::try_from(SESSION_WINDOW).unwrap());
         let session_fc = Rc::new(RefCell::new(ReceiverFlowControl::new(
             (),
             u64::try_from(SESSION_WINDOW).unwrap(),
@@ -1358,10 +1323,12 @@ mod tests {
             ConnectionEvents::default(),
         );
 
-        let frame1 = vec![0; SESSION_WINDOW];
-        s.inbound_stream_frame(false, 0, &frame1).unwrap();
+        s.inbound_stream_frame(false, 0, &[0; SESSION_WINDOW])
+            .unwrap();
         assert!(!session_fc.borrow().frame_needed().is_some());
-        let mut buf = [0; RECV_BUFFER_SIZE];
+        // The buffer is big enough to hold SESSION_WINDOW, this will make sure that we always
+        // read everything from he stream.
+        let mut buf = [0; 2 * SESSION_WINDOW];
         s.read(&mut buf).unwrap();
         assert!(session_fc.borrow().frame_needed().is_some());
         // consume it
@@ -1404,7 +1371,8 @@ mod tests {
             ConnectionEvents::default(),
         );
 
-        s.inbound_stream_frame(true, 0, &frame1).unwrap();
+        s.inbound_stream_frame(true, 0, &[0; SESSION_WINDOW])
+            .unwrap();
         assert!(!session_fc.borrow().frame_needed().is_some());
         s.read(&mut buf).unwrap();
         assert!(session_fc.borrow().frame_needed().is_some());
@@ -1413,6 +1381,7 @@ mod tests {
     #[test]
     fn session_flow_control_reset() {
         const SESSION_WINDOW: usize = 1024;
+        assert!(RX_STREAM_DATA_WINDOW > u64::try_from(SESSION_WINDOW).unwrap());
         let session_fc = Rc::new(RefCell::new(ReceiverFlowControl::new(
             (),
             u64::try_from(SESSION_WINDOW).unwrap(),
@@ -1424,8 +1393,8 @@ mod tests {
             ConnectionEvents::default(),
         );
 
-        let frame1 = vec![0; SESSION_WINDOW / 2];
-        s.inbound_stream_frame(false, 0, &frame1).unwrap();
+        s.inbound_stream_frame(false, 0, &[0; SESSION_WINDOW / 2])
+            .unwrap();
         assert!(!session_fc.borrow().frame_needed().is_some());
 
         s.reset(

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -415,22 +415,15 @@ impl RecvStreamState {
         };
 
         // Check final size:
-        match (fin, final_size_reached) {
-            (true, true) => {
-                if consumed != fc.consumed() {
-                    return Err(Error::FinalSizeError);
-                }
-            }
-            (false, true) => {
-                if consumed > fc.consumed() {
-                    return Err(Error::FinalSizeError);
-                }
-            }
-            (_, false) => {
-                if fin && consumed < fc.consumed() {
-                    return Err(Error::FinalSizeError);
-                }
-            }
+        let final_size_ok = match (fin, final_size_reached) {
+            (true, true) => consumed == fc.consumed(),
+            (false, true) => consumed <= fc.consumed(),
+            (true, false) => consumed >= fc.consumed(),
+            (false, false) => true,
+        };
+
+        if !final_size_ok {
+            return Err(Error::FinalSizeError);
         }
 
         let new_bytes_consumed = fc.set_consumed(consumed)?;
@@ -1607,7 +1600,8 @@ mod tests {
         let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
         let mut token = Vec::new();
         let mut stats = FrameStats::default();
-        fc.borrow_mut().write_frames(&mut builder, &mut token, &mut stats);
+        fc.borrow_mut()
+            .write_frames(&mut builder, &mut token, &mut stats);
         assert_eq!(stats.max_data, 0);
         s.write_frame(&mut builder, &mut token, &mut stats);
         assert_eq!(stats.max_stream_data, 1);
@@ -1619,7 +1613,8 @@ mod tests {
         check_fc(s.fc().unwrap(), SW / 2 + 1, SW / 2 + 1);
         assert!(fc.borrow().frame_needed().is_some());
         assert!(s.fc().unwrap().frame_needed().is_none());
-        fc.borrow_mut().write_frames(&mut builder, &mut token, &mut stats);
+        fc.borrow_mut()
+            .write_frames(&mut builder, &mut token, &mut stats);
         assert_eq!(stats.max_data, 1);
         s.write_frame(&mut builder, &mut token, &mut stats);
         assert_eq!(stats.max_stream_data, 1);

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -343,6 +343,7 @@ enum RecvStreamState {
     AbortReading {
         fc: ReceiverFlowControl<StreamId>,
         session_fc: Rc<RefCell<ReceiverFlowControl<()>>>,
+        final_size_reached: bool,
         frame_needed: bool,
         err: AppError,
     },
@@ -392,23 +393,53 @@ impl RecvStreamState {
     }
 
     fn flow_control_consume_data(&mut self, consumed: u64, fin: bool) -> Res<()> {
-        match self {
-            Self::Recv { fc, session_fc, .. }
-            | Self::SizeKnown { fc, session_fc, .. }
-            | Self::DataRecvd { fc, session_fc, .. } => {
-                let new_bytes_consumed = fc.set_consumed(consumed, fin)?;
-                session_fc.borrow_mut().consume(new_bytes_consumed)
+        let (fc, session_fc, final_size_reached, retire_data) = match self {
+            Self::Recv { fc, session_fc, .. } => (fc, session_fc, false, false),
+            Self::WaitForReset { fc, session_fc, .. } => (fc, session_fc, false, true),
+            Self::SizeKnown { fc, session_fc, .. } | Self::DataRecvd { fc, session_fc, .. } => {
+                (fc, session_fc, true, false)
             }
-            Self::AbortReading { fc, session_fc, .. }
-            | Self::WaitForReset { fc, session_fc, .. } => {
-                let new_bytes_consumed = fc.set_consumed(consumed, fin)?;
-                session_fc.borrow_mut().consume(new_bytes_consumed)?;
-                // Let's also retire this data since the stream has been aborted
-                RecvStream::flow_control_retire_data(fc.consumed() - fc.retired(), fc, session_fc);
-                Ok(())
+            Self::AbortReading {
+                fc,
+                session_fc,
+                final_size_reached,
+                ..
+            } => {
+                let old_final_size_reached = *final_size_reached;
+                *final_size_reached |= fin;
+                (fc, session_fc, old_final_size_reached, true)
             }
-            _ => Ok(()),
+            Self::DataRead | Self::ResetRecvd => {
+                return Ok(());
+            }
+        };
+
+        // Check final size:
+        match (fin, final_size_reached) {
+            (true, true) => {
+                if consumed != fc.consumed() {
+                    return Err(Error::FinalSizeError);
+                }
+            }
+            (false, true) => {
+                if consumed > fc.consumed() {
+                    return Err(Error::FinalSizeError);
+                }
+            }
+            (_, false) => {
+                if fin && consumed < fc.consumed() {
+                    return Err(Error::FinalSizeError);
+                }
+            }
         }
+
+        let new_bytes_consumed = fc.set_consumed(consumed)?;
+        session_fc.borrow_mut().consume(new_bytes_consumed)?;
+        if retire_data {
+            // Let's also retire this data since the stream has been aborted
+            RecvStream::flow_control_retire_data(fc.consumed() - fc.retired(), fc, session_fc);
+        }
+        Ok(())
     }
 }
 
@@ -469,8 +500,8 @@ impl RecvStream {
             } => {
                 recv_buf.inbound_frame(offset, data);
                 if fin {
-                    let all_recv = fc.final_size().unwrap()
-                        == recv_buf.retired() + recv_buf.bytes_ready() as u64;
+                    let all_recv =
+                        fc.consumed() == recv_buf.retired() + recv_buf.bytes_ready() as u64;
                     let buf = mem::replace(recv_buf, RxStreamOrderer::new());
                     let fc_copy = mem::take(fc);
                     let session_fc_copy = mem::take(session_fc);
@@ -495,7 +526,7 @@ impl RecvStream {
                 session_fc,
             } => {
                 recv_buf.inbound_frame(offset, data);
-                if fc.final_size().unwrap() == recv_buf.retired() + recv_buf.bytes_ready() as u64 {
+                if fc.consumed() == recv_buf.retired() + recv_buf.bytes_ready() as u64 {
                     let buf = mem::replace(recv_buf, RxStreamOrderer::new());
                     let fc_copy = mem::take(fc);
                     let session_fc_copy = mem::take(session_fc);
@@ -641,6 +672,7 @@ impl RecvStream {
                 self.set_state(RecvStreamState::AbortReading {
                     fc: fc_copy,
                     session_fc: session_fc_copy,
+                    final_size_reached: matches!(self.state, RecvStreamState::SizeKnown { .. }),
                     frame_needed: true,
                     err,
                 })
@@ -703,8 +735,14 @@ impl RecvStream {
     }
 
     pub fn stop_sending_acked(&mut self) {
-        if let RecvStreamState::AbortReading { fc, session_fc, .. } = &mut self.state {
-            if fc.final_size().is_some() {
+        if let RecvStreamState::AbortReading {
+            fc,
+            session_fc,
+            final_size_reached,
+            ..
+        } = &mut self.state
+        {
+            if *final_size_reached {
                 // We already know the final_size of the stream therefore we
                 // do not need to wait for RESET.
                 self.set_state(RecvStreamState::ResetRecvd);
@@ -1192,12 +1230,12 @@ mod tests {
         assert!(!s.has_frames_to_write());
     }
 
-    fn create_stream(fc: u64) -> RecvStream {
+    fn create_stream(session_fc: u64) -> RecvStream {
         let conn_events = ConnectionEvents::default();
         RecvStream::new(
             StreamId::from(67),
             RX_STREAM_DATA_WINDOW,
-            Rc::new(RefCell::new(ReceiverFlowControl::new((), fc))),
+            Rc::new(RefCell::new(ReceiverFlowControl::new((), session_fc))),
             conn_events,
         )
     }
@@ -1359,149 +1397,163 @@ mod tests {
         assert!(session_fc.borrow().frame_needed().is_some());
     }
 
-    fn check_fc_values(
-        session_fc: &Rc<RefCell<ReceiverFlowControl<()>>>,
-        s1: &RecvStream,
-        session_c: u64,
-        session_r: u64,
-        s1_c: u64,
-        s1_r: u64,
-    ) {
-        assert_eq!(session_fc.borrow().consumed(), session_c);
-        assert_eq!(s1.fc().unwrap().consumed(), s1_c);
-        assert_eq!(session_fc.borrow().retired(), session_r);
-        assert_eq!(s1.fc().unwrap().retired(), s1_r);
+    fn check_fc<T: std::fmt::Debug>(fc: &ReceiverFlowControl<T>, consumed: u64, retired: u64) {
+        assert_eq!(fc.consumed(), consumed);
+        assert_eq!(fc.retired(), retired);
     }
 
-    fn check_fc_values_2(
-        session_fc: &Rc<RefCell<ReceiverFlowControl<()>>>,
-        s1: &RecvStream,
-        s2: &RecvStream,
-        session_v: (u64, u64),
-        s1_v: (u64, u64),
-        s2_v: (u64, u64),
-    ) {
-        assert_eq!(session_fc.borrow().consumed(), session_v.0);
-        assert_eq!(s1.fc().unwrap().consumed(), s1_v.0);
-        assert_eq!(s2.fc().unwrap().consumed(), s2_v.0);
-        assert_eq!(session_fc.borrow().retired(), session_v.1);
-        assert_eq!(s1.fc().unwrap().retired(), s1_v.1);
-        assert_eq!(s2.fc().unwrap().retired(), s2_v.1);
-    }
-
-    // Test flow control in RecvStreamState::Recv
+    // Test consuming the flow control in RecvStreamState::Recv
     #[test]
-    fn fc_state_recv() {
+    fn fc_state_recv_1() {
+        const SW: u64 = 1024;
+        const SW_US: usize = 1024;
+        let fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), SW)));
+        let mut s = create_stream_with_fc(Rc::clone(&fc), SW * 3 / 4);
+
+        check_fc(&fc.borrow(), 0, 0);
+        check_fc(s.fc().unwrap(), 0, 0);
+
+        s.inbound_stream_frame(false, 0, &[0; SW_US / 4]).unwrap();
+
+        check_fc(&fc.borrow(), SW / 4, 0);
+        check_fc(s.fc().unwrap(), SW / 4, 0);
+    }
+
+    // Test consuming the flow control in RecvStreamState::Recv
+    // with multiple streams
+    #[test]
+    fn fc_state_recv_2() {
         const SW: u64 = 1024;
         const SW_US: usize = 1024;
         let fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), SW)));
         let mut s1 = create_stream_with_fc(Rc::clone(&fc), SW * 3 / 4);
         let mut s2 = create_stream_with_fc(Rc::clone(&fc), SW * 3 / 4);
 
-        check_fc_values_2(&fc, &s1, &s2, (0, 0), (0, 0), (0, 0));
+        check_fc(&fc.borrow(), 0, 0);
+        check_fc(s1.fc().unwrap(), 0, 0);
+        check_fc(s2.fc().unwrap(), 0, 0);
 
         s1.inbound_stream_frame(false, 0, &[0; SW_US / 4]).unwrap();
 
-        check_fc_values_2(&fc, &s1, &s2, (SW / 4, 0), (SW / 4, 0), (0, 0));
+        check_fc(&fc.borrow(), SW / 4, 0);
+        check_fc(s1.fc().unwrap(), SW / 4, 0);
+        check_fc(s2.fc().unwrap(), 0, 0);
 
         s2.inbound_stream_frame(false, 0, &[0; SW_US / 4]).unwrap();
 
-        check_fc_values_2(&fc, &s1, &s2, (SW / 2, 0), (SW / 4, 0), (SW / 4, 0));
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s1.fc().unwrap(), SW / 4, 0);
+        check_fc(s2.fc().unwrap(), SW / 4, 0);
+    }
 
-        // Receiving duplicate frames (already consumed data) will not cause an error or
-        // change fc.
-        s2.inbound_stream_frame(false, 0, &[0; SW_US / 8]).unwrap();
-        check_fc_values_2(&fc, &s1, &s2, (SW / 2, 0), (SW / 4, 0), (SW / 4, 0));
-        s2.inbound_stream_frame(false, SW / 8, &[0; SW_US / 8])
-            .unwrap();
-        check_fc_values_2(&fc, &s1, &s2, (SW / 2, 0), (SW / 4, 0), (SW / 4, 0));
+    // Test retiring the flow control in RecvStreamState::Recv
+    // with multiple streams
+    #[test]
+    fn fc_state_recv_3() {
+        const SW: u64 = 1024;
+        const SW_US: usize = 1024;
+        let fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), SW)));
+        let mut s1 = create_stream_with_fc(Rc::clone(&fc), SW * 3 / 4);
+        let mut s2 = create_stream_with_fc(Rc::clone(&fc), SW * 3 / 4);
+
+        check_fc(&fc.borrow(), 0, 0);
+        check_fc(s1.fc().unwrap(), 0, 0);
+        check_fc(s2.fc().unwrap(), 0, 0);
+
+        s1.inbound_stream_frame(false, 0, &[0; SW_US / 4]).unwrap();
+        s2.inbound_stream_frame(false, 0, &[0; SW_US / 4]).unwrap();
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s1.fc().unwrap(), SW / 4, 0);
+        check_fc(s2.fc().unwrap(), SW / 4, 0);
 
         // Read data
         let mut buf = [1; SW_US];
         assert_eq!(s1.read(&mut buf).unwrap(), (SW_US / 4, false));
-        check_fc_values_2(
-            &fc,
-            &s1,
-            &s2,
-            (SW / 2, SW / 4),
-            (SW / 4, SW / 4),
-            (SW / 4, 0),
-        );
+        check_fc(&fc.borrow(), SW / 2, SW / 4);
+        check_fc(s1.fc().unwrap(), SW / 4, SW / 4);
+        check_fc(s2.fc().unwrap(), SW / 4, 0);
 
         assert_eq!(s2.read(&mut buf).unwrap(), (SW_US / 4, false));
-        check_fc_values_2(
-            &fc,
-            &s1,
-            &s2,
-            (SW / 2, SW / 2),
-            (SW / 4, SW / 4),
-            (SW / 4, SW / 4),
-        );
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        check_fc(s1.fc().unwrap(), SW / 4, SW / 4);
+        check_fc(s2.fc().unwrap(), SW / 4, SW / 4);
 
         // Read when there is no more date to be read will not change fc.
         assert_eq!(s1.read(&mut buf).unwrap(), (0, false));
-        check_fc_values_2(
-            &fc,
-            &s1,
-            &s2,
-            (SW / 2, SW / 2),
-            (SW / 4, SW / 4),
-            (SW / 4, SW / 4),
-        );
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        check_fc(s1.fc().unwrap(), SW / 4, SW / 4);
+        check_fc(s2.fc().unwrap(), SW / 4, SW / 4);
 
-        // Receive more data for s1
+        // Receiving more data on a stream.
         s1.inbound_stream_frame(false, SW / 4, &[0; SW_US / 4])
             .unwrap();
-        check_fc_values_2(
-            &fc,
-            &s1,
-            &s2,
-            (SW * 3 / 4, SW / 2),
-            (SW / 2, SW / 4),
-            (SW / 4, SW / 4),
-        );
+        check_fc(&fc.borrow(), SW * 3 / 4, SW / 2);
+        check_fc(s1.fc().unwrap(), SW / 2, SW / 4);
+        check_fc(s2.fc().unwrap(), SW / 4, SW / 4);
 
         // Read data
         assert_eq!(s1.read(&mut buf).unwrap(), (SW_US / 4, false));
-        check_fc_values_2(
-            &fc,
-            &s1,
-            &s2,
-            (SW * 3 / 4, SW * 3 / 4),
-            (SW / 2, SW / 2),
-            (SW / 4, SW / 4),
-        );
+        check_fc(&fc.borrow(), SW * 3 / 4, SW * 3 / 4);
+        check_fc(s1.fc().unwrap(), SW / 2, SW / 2);
+        check_fc(s2.fc().unwrap(), SW / 4, SW / 4);
+    }
 
-        // Receive data out of order
-        s2.inbound_stream_frame(false, SW * 3 / 8, &[0; SW_US / 8])
+    // Test consuming the flow control in RecvStreamState::Recv - duplicate data
+    #[test]
+    fn fc_state_recv_4() {
+        const SW: u64 = 1024;
+        const SW_US: usize = 1024;
+        let fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), SW)));
+        let mut s = create_stream_with_fc(Rc::clone(&fc), SW * 3 / 4);
+
+        check_fc(&fc.borrow(), 0, 0);
+        check_fc(s.fc().unwrap(), 0, 0);
+
+        s.inbound_stream_frame(false, 0, &[0; SW_US / 4]).unwrap();
+
+        check_fc(&fc.borrow(), SW / 4, 0);
+        check_fc(s.fc().unwrap(), SW / 4, 0);
+
+        // Receiving duplicate frames (already consumed data) will not cause an error or
+        // change fc.
+        s.inbound_stream_frame(false, 0, &[0; SW_US / 8]).unwrap();
+        check_fc(&fc.borrow(), SW / 4, 0);
+        check_fc(s.fc().unwrap(), SW / 4, 0);
+    }
+
+    // Test consuming the flow control in RecvStreamState::Recv - filling a gap in the
+    // data stream.
+    #[test]
+    fn fc_state_recv_5() {
+        const SW: u64 = 1024;
+        const SW_US: usize = 1024;
+        let fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), SW)));
+        let mut s = create_stream_with_fc(Rc::clone(&fc), SW * 3 / 4);
+
+        // Receive out of order data.
+        s.inbound_stream_frame(false, SW / 8, &[0; SW_US / 8])
             .unwrap();
-        check_fc_values_2(
-            &fc,
-            &s1,
-            &s2,
-            (SW, SW * 3 / 4),
-            (SW / 2, SW / 2),
-            (SW / 2, SW / 4),
-        );
+        check_fc(&fc.borrow(), SW / 4, 0);
+        check_fc(s.fc().unwrap(), SW / 4, 0);
 
         // Filling in the gap will not change fc.
-        s2.inbound_stream_frame(false, SW / 4, &[0; SW_US / 8])
-            .unwrap();
-        check_fc_values_2(
-            &fc,
-            &s1,
-            &s2,
-            (SW, SW * 3 / 4),
-            (SW / 2, SW / 2),
-            (SW / 2, SW / 4),
-        );
+        s.inbound_stream_frame(false, 0, &[0; SW_US / 8]).unwrap();
+        check_fc(&fc.borrow(), SW / 4, 0);
+        check_fc(s.fc().unwrap(), SW / 4, 0);
+    }
 
-        assert_eq!(s2.read(&mut buf).unwrap(), (SW_US / 4, false));
-        check_fc_values_2(&fc, &s1, &s2, (SW, SW), (SW / 2, SW / 2), (SW / 2, SW / 2));
+    // Test consuming the flow control in RecvStreamState::Recv - receiving frame past
+    // the flow control will cause an error.
+    #[test]
+    fn fc_state_recv_6() {
+        const SW: u64 = 1024;
+        const SW_US: usize = 1024;
+        let fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), SW)));
+        let mut s = create_stream_with_fc(Rc::clone(&fc), SW * 3 / 4);
 
-        // Receiving frame pass the flow control will cause an error.
+        // Receiving frame past the flow control will cause an error.
         assert_eq!(
-            s2.inbound_stream_frame(false, 0, &[0; SW_US * 3 / 4 + 1]),
+            s.inbound_stream_frame(false, 0, &[0; SW_US * 3 / 4 + 1]),
             Err(Error::FlowControlError)
         );
     }
@@ -1515,45 +1567,52 @@ mod tests {
 
         let mut s = create_stream_with_fc(Rc::clone(&fc), SW);
 
-        check_fc_values(&fc, &s, 0, 0, 0, 0);
+        check_fc(&fc.borrow(), 0, 0);
+        check_fc(s.fc().unwrap(), 0, 0);
 
         s.inbound_stream_frame(true, SW / 4, &[0; SW_US / 4])
             .unwrap();
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
         // Receiving duplicate frames (already consumed data) will not cause an error or
         // change fc.
         s.inbound_stream_frame(true, SW / 4, &[0; SW_US / 4])
             .unwrap();
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
         // The stream can still receive duplicate data without a fin bit.
         s.inbound_stream_frame(false, SW / 4, &[0; SW_US / 4])
             .unwrap();
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
-        // Receiving frame pass the final size of a stream will return an error.
+        // Receiving frame past the final size of a stream will return an error.
         assert_eq!(
             s.inbound_stream_frame(true, SW / 4, &[0; SW_US / 4 + 1]),
             Err(Error::FinalSizeError)
         );
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
         // Add new data to the gap will not change fc.
         s.inbound_stream_frame(false, SW / 8, &[0; SW_US / 8])
             .unwrap();
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
         // Fill the gap
         s.inbound_stream_frame(false, 0, &[0; SW_US / 8]).unwrap();
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
         // Read all data
         let mut buf = [1; SW_US];
         assert_eq!(s.read(&mut buf).unwrap(), (SW_US / 2, true));
         // the stream does not have fc any more. We can only check the session fc.
-        assert_eq!(fc.borrow().consumed(), SW / 2);
-        assert_eq!(fc.borrow().retired(), SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        assert!(s.fc().is_none());
     }
 
     // Test flow control in RecvStreamState::DataRecvd
@@ -1565,35 +1624,40 @@ mod tests {
 
         let mut s = create_stream_with_fc(Rc::clone(&fc), SW);
 
-        check_fc_values(&fc, &s, 0, 0, 0, 0);
+        check_fc(&fc.borrow(), 0, 0);
+        check_fc(s.fc().unwrap(), 0, 0);
 
         s.inbound_stream_frame(true, 0, &[0; SW_US / 2]).unwrap();
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
         // Receiving duplicate frames (already consumed data) will not cause an error or
         // change fc.
         s.inbound_stream_frame(true, SW / 4, &[0; SW_US / 4])
             .unwrap();
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
         // The stream can still receive duplicate data without a fin bit.
         s.inbound_stream_frame(false, SW / 4, &[0; SW_US / 4])
             .unwrap();
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
-        // Receiving frame pass the final size of a stream will return an error.
+        // Receiving frame past the final size of a stream will return an error.
         assert_eq!(
             s.inbound_stream_frame(true, SW / 4, &[0; SW_US / 4 + 1]),
             Err(Error::FinalSizeError)
         );
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
         // Read all data
         let mut buf = [1; SW_US];
         assert_eq!(s.read(&mut buf).unwrap(), (SW_US / 2, true));
         // the stream does not have fc any more. We can only check the session fc.
-        assert_eq!(fc.borrow().consumed(), SW / 2);
-        assert_eq!(fc.borrow().retired(), SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        assert!(s.fc().is_none());
     }
 
     // Test flow control in RecvStreamState::DataRead
@@ -1604,31 +1668,34 @@ mod tests {
         let fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), SW)));
 
         let mut s = create_stream_with_fc(Rc::clone(&fc), SW * 3 / 4);
-        check_fc_values(&fc, &s, 0, 0, 0, 0);
+        check_fc(&fc.borrow(), 0, 0);
+        check_fc(s.fc().unwrap(), 0, 0);
 
         s.inbound_stream_frame(true, 0, &[0; SW_US / 2]).unwrap();
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
         let mut buf = [1; SW_US];
         assert_eq!(s.read(&mut buf).unwrap(), (SW_US / 2, true));
         // the stream does not have fc any more. We can only check the session fc.
-        assert_eq!(fc.borrow().consumed(), SW / 2);
-        assert_eq!(fc.borrow().retired(), SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        assert!(s.fc().is_none());
 
         // Receiving duplicate frames (already consumed data) will not cause an error or
         // change fc.
         s.inbound_stream_frame(true, 0, &[0; SW_US / 2]).unwrap();
         // the stream does not have fc any more. We can only check the session fc.
-        assert_eq!(fc.borrow().consumed(), SW / 2);
-        assert_eq!(fc.borrow().retired(), SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        assert!(s.fc().is_none());
 
-        // Receiving frame pass the final size of a stream will NOT return an error.
+        // Receiving frame past the final size of a stream or the stream's fc limit
+        // will NOT return an error.
         s.inbound_stream_frame(true, 0, &[0; SW_US / 2 + 1])
             .unwrap();
-
-        // Receiving frame pass the stream's fc limit will not return an error.
         s.inbound_stream_frame(true, 0, &[0; SW_US * 3 / 4 + 1])
             .unwrap();
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        assert!(s.fc().is_none());
     }
 
     // Test flow control in RecvStreamState::AbortReading and final size is known
@@ -1639,32 +1706,38 @@ mod tests {
         let fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), SW)));
 
         let mut s = create_stream_with_fc(Rc::clone(&fc), SW * 3 / 4);
-        check_fc_values(&fc, &s, 0, 0, 0, 0);
+        check_fc(&fc.borrow(), 0, 0);
+        check_fc(s.fc().unwrap(), 0, 0);
 
         s.inbound_stream_frame(true, SW / 4, &[0; SW_US / 4])
             .unwrap();
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
         s.stop_sending(Error::NoError.code());
         // All data will de retired
-        check_fc_values(&fc, &s, SW / 2, SW / 2, SW / 2, SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        check_fc(s.fc().unwrap(), SW / 2, SW / 2);
 
         // Receiving duplicate frames (already consumed data) will not cause an error or
         // change fc.
         s.inbound_stream_frame(true, 0, &[0; SW_US / 2]).unwrap();
-        check_fc_values(&fc, &s, SW / 2, SW / 2, SW / 2, SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        check_fc(s.fc().unwrap(), SW / 2, SW / 2);
 
         // The stream can still receive duplicate data without a fin bit.
         s.inbound_stream_frame(false, SW / 4, &[0; SW_US / 4])
             .unwrap();
-        check_fc_values(&fc, &s, SW / 2, SW / 2, SW / 2, SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        check_fc(s.fc().unwrap(), SW / 2, SW / 2);
 
-        // Receiving frame pass the final size of a stream will return an error.
+        // Receiving frame past the final size of a stream will return an error.
         assert_eq!(
             s.inbound_stream_frame(true, SW / 4, &[0; SW_US / 4 + 1]),
             Err(Error::FinalSizeError)
         );
-        check_fc_values(&fc, &s, SW / 2, SW / 2, SW / 2, SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        check_fc(s.fc().unwrap(), SW / 2, SW / 2);
     }
 
     // Test flow control in RecvStreamState::AbortReading and final size is unknown
@@ -1675,21 +1748,25 @@ mod tests {
         let fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), SW)));
 
         let mut s = create_stream_with_fc(Rc::clone(&fc), SW * 3 / 4);
-        check_fc_values(&fc, &s, 0, 0, 0, 0);
+        check_fc(&fc.borrow(), 0, 0);
+        check_fc(s.fc().unwrap(), 0, 0);
 
         s.inbound_stream_frame(false, 0, &[0; SW_US / 2]).unwrap();
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
         s.stop_sending(Error::NoError.code());
         // All data will de retired
-        check_fc_values(&fc, &s, SW / 2, SW / 2, SW / 2, SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        check_fc(s.fc().unwrap(), SW / 2, SW / 2);
 
         // Receiving duplicate frames (already consumed data) will not cause an error or
         // change fc.
         s.inbound_stream_frame(false, 0, &[0; SW_US / 2]).unwrap();
-        check_fc_values(&fc, &s, SW / 2, SW / 2, SW / 2, SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        check_fc(s.fc().unwrap(), SW / 2, SW / 2);
 
-        // Receiving data pass the flow control limit will cause an error.
+        // Receiving data past the flow control limit will cause an error.
         assert_eq!(
             s.inbound_stream_frame(false, 0, &[0; SW_US * 3 / 4 + 1]),
             Err(Error::FlowControlError)
@@ -1698,23 +1775,27 @@ mod tests {
         // The stream can still receive duplicate data without a fin bit.
         s.inbound_stream_frame(false, SW / 4, &[0; SW_US / 4])
             .unwrap();
-        check_fc_values(&fc, &s, SW / 2, SW / 2, SW / 2, SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        check_fc(s.fc().unwrap(), SW / 2, SW / 2);
 
         // Receiving more data will case the data to be retired.
         // The stream can still receive duplicate data without a fin bit.
         s.inbound_stream_frame(false, SW / 2, &[0; 10]).unwrap();
-        check_fc_values(&fc, &s, SW / 2 + 10, SW / 2 + 10, SW / 2 + 10, SW / 2 + 10);
+        check_fc(&fc.borrow(), SW / 2 + 10, SW / 2 + 10);
+        check_fc(s.fc().unwrap(), SW / 2 + 10, SW / 2 + 10);
 
         // We can still receive the final size.
         s.inbound_stream_frame(true, SW / 2, &[0; 20]).unwrap();
-        check_fc_values(&fc, &s, SW / 2 + 20, SW / 2 + 20, SW / 2 + 20, SW / 2 + 20);
+        check_fc(&fc.borrow(), SW / 2 + 20, SW / 2 + 20);
+        check_fc(s.fc().unwrap(), SW / 2 + 20, SW / 2 + 20);
 
-        // Receiving frame pass the final size of a stream will return an error.
+        // Receiving frame past the final size of a stream will return an error.
         assert_eq!(
             s.inbound_stream_frame(true, SW / 2, &[0; 21]),
             Err(Error::FinalSizeError)
         );
-        check_fc_values(&fc, &s, SW / 2 + 20, SW / 2 + 20, SW / 2 + 20, SW / 2 + 20);
+        check_fc(&fc.borrow(), SW / 2 + 20, SW / 2 + 20);
+        check_fc(s.fc().unwrap(), SW / 2 + 20, SW / 2 + 20);
     }
 
     // Test flow control in RecvStreamState::WaitForReset
@@ -1725,22 +1806,28 @@ mod tests {
         let fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), SW)));
 
         let mut s = create_stream_with_fc(Rc::clone(&fc), SW * 3 / 4);
-        check_fc_values(&fc, &s, 0, 0, 0, 0);
+        check_fc(&fc.borrow(), 0, 0);
+        check_fc(s.fc().unwrap(), 0, 0);
 
         s.inbound_stream_frame(false, 0, &[0; SW_US / 2]).unwrap();
-        check_fc_values(&fc, &s, SW / 2, 0, SW / 2, 0);
+        check_fc(&fc.borrow(), SW / 2, 0);
+        check_fc(s.fc().unwrap(), SW / 2, 0);
 
         s.stop_sending(Error::NoError.code());
-        check_fc_values(&fc, &s, SW / 2, SW / 2, SW / 2, SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        check_fc(s.fc().unwrap(), SW / 2, SW / 2);
+
         s.stop_sending_acked();
-        check_fc_values(&fc, &s, SW / 2, SW / 2, SW / 2, SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        check_fc(s.fc().unwrap(), SW / 2, SW / 2);
 
         // Receiving duplicate frames (already consumed data) will not cause an error or
         // change fc.
         s.inbound_stream_frame(false, 0, &[0; SW_US / 2]).unwrap();
-        check_fc_values(&fc, &s, SW / 2, SW / 2, SW / 2, SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        check_fc(s.fc().unwrap(), SW / 2, SW / 2);
 
-        // Receiving data pass the flow control limit will cause an error.
+        // Receiving data past the flow control limit will cause an error.
         assert_eq!(
             s.inbound_stream_frame(false, 0, &[0; SW_US * 3 / 4 + 1]),
             Err(Error::FlowControlError)
@@ -1749,11 +1836,13 @@ mod tests {
         // The stream can still receive duplicate data without a fin bit.
         s.inbound_stream_frame(false, SW / 4, &[0; SW_US / 4])
             .unwrap();
-        check_fc_values(&fc, &s, SW / 2, SW / 2, SW / 2, SW / 2);
+        check_fc(&fc.borrow(), SW / 2, SW / 2);
+        check_fc(s.fc().unwrap(), SW / 2, SW / 2);
 
         // Receiving more data will case the data to be retired.
         // The stream can still receive duplicate data without a fin bit.
         s.inbound_stream_frame(false, SW / 2, &[0; 10]).unwrap();
-        check_fc_values(&fc, &s, SW / 2 + 10, SW / 2 + 10, SW / 2 + 10, SW / 2 + 10);
+        check_fc(&fc.borrow(), SW / 2 + 10, SW / 2 + 10);
+        check_fc(s.fc().unwrap(), SW / 2 + 10, SW / 2 + 10);
     }
 }

--- a/neqo-transport/src/stream_id.rs
+++ b/neqo-transport/src/stream_id.rs
@@ -16,7 +16,7 @@ pub enum StreamType {
     UniDi,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd, Hash, Default)]
 pub struct StreamId(u64);
 
 impl StreamId {

--- a/neqo-transport/src/stream_id.rs
+++ b/neqo-transport/src/stream_id.rs
@@ -16,7 +16,7 @@ pub enum StreamType {
     UniDi,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd, Hash, Default)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd, Hash)]
 pub struct StreamId(u64);
 
 impl StreamId {

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -329,6 +329,7 @@ impl Streams {
                 RecvStream::new(
                     next_stream_id,
                     recv_initial_max_stream_data,
+                    Rc::clone(&self.receiver_fc),
                     self.events.clone(),
                 ),
             );
@@ -402,7 +403,12 @@ impl Streams {
 
                     self.recv.insert(
                         new_id,
-                        RecvStream::new(new_id, recv_initial_max_stream_data, self.events.clone()),
+                        RecvStream::new(
+                            new_id,
+                            recv_initial_max_stream_data,
+                            Rc::clone(&self.receiver_fc),
+                            self.events.clone(),
+                        ),
                     );
                 }
                 Ok(new_id.as_u64())

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -86,11 +86,11 @@ impl Streams {
             Frame::ResetStream {
                 stream_id,
                 application_error_code,
-                ..
+                final_size,
             } => {
                 stats.reset_stream += 1;
                 if let (_, Some(rs)) = self.obtain_stream(stream_id)? {
-                    rs.reset(application_error_code);
+                    rs.reset(application_error_code, final_size)?;
                 }
             }
             Frame::StopSending {
@@ -279,7 +279,8 @@ impl Streams {
             | RecoveryToken::StreamDataBlocked { .. }
             | RecoveryToken::MaxStreamData { .. }
             | RecoveryToken::StreamsBlocked { .. }
-            | RecoveryToken::MaxStreams { .. } => (),
+            | RecoveryToken::MaxStreams { .. }
+            | RecoveryToken::MaxData(_) => (),
             _ => unreachable!("This is not a stream RecoveryToken"),
         }
     }


### PR DESCRIPTION
We set the flow control limit to the max possible and therefore we have not implemented actually calculating retired data.
This is fine with the limit set to max possible, but this is needed if we set it to something smaller.

This changes adds calculation of retired bytes.
Ensuring that the other side does not exceed the limit will be added in the follow up commit.