### PR TITLE
Fix missing link in documentation causing `cargo doc` to fail

### DIFF
--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -496,6 +496,8 @@ impl SecretAgent {
     /// This should always panic rather than return an error.
     /// # Panics
     /// If any of the provided `protocols` are more than 255 bytes long.
+    ///
+    /// [RFC7301]: https://datatracker.ietf.org/doc/html/rfc7301
     pub fn set_alpn(&mut self, protocols: &[impl AsRef<str>]) -> Res<()> {
         // Validate and set length.
         let mut encoded_len = protocols.len();


### PR DESCRIPTION
Cargo doc previously failed with:

```rust
    Checking neqo-transport v0.4.29 (/home/user/dev/neqo/neqo-transport)
error: unresolved link to `RFC7301`
   --> neqo-crypto/src/agent.rs:489:22
    |
489 |     /// Though ALPN [RFC7301] permits octet sequences, this only allows for UTF-8-encoded
    |                      ^^^^^^^ no item named `RFC7301` in scope
    |
note: the lint level is defined here
   --> neqo-crypto/src/lib.rs:7:45
    |
7   | #![cfg_attr(feature = "deny-warnings", deny(warnings))]
    |                                             ^^^^^^^^
    = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(warnings)]`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

error: aborting due to previous error

error: could not document `neqo-crypto`
```