### PR TITLE
Split stream-related recovery tokens out

### DIFF
--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -19,7 +19,7 @@ use crate::events::ConnectionEvents;
 use crate::fc::ReceiverFlowControl;
 use crate::frame::FRAME_TYPE_STOP_SENDING;
 use crate::packet::PacketBuilder;
-use crate::recovery::RecoveryToken;
+use crate::recovery::{RecoveryToken, StreamRecoveryToken};
 use crate::send_stream::SendStreams;
 use crate::stats::FrameStats;
 use crate::stream_id::StreamId;
@@ -737,9 +737,9 @@ impl RecvStream {
                         *err,
                     ])
                 {
-                    tokens.push(RecoveryToken::StopSending {
+                    tokens.push(RecoveryToken::Stream(StreamRecoveryToken::StopSending {
                         stream_id: self.stream_id,
-                    });
+                    }));
                     stats.stop_sending += 1;
                     *frame_needed = false;
                 }

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -9,7 +9,7 @@
 use crate::fc::{LocalStreamLimits, ReceiverFlowControl, RemoteStreamLimits, SenderFlowControl};
 use crate::frame::Frame;
 use crate::packet::PacketBuilder;
-use crate::recovery::RecoveryToken;
+use crate::recovery::{RecoveryToken, StreamRecoveryToken};
 use crate::recv_stream::{RecvStream, RecvStreams};
 use crate::send_stream::{SendStream, SendStreams, TransmissionPriority};
 use crate::stats::FrameStats;
@@ -228,14 +228,14 @@ impl Streams {
         self.send.write_frames(priority, builder, tokens, stats);
     }
 
-    pub fn lost(&mut self, token: &RecoveryToken) {
+    pub fn lost(&mut self, token: &StreamRecoveryToken) {
         match token {
-            RecoveryToken::Stream(st) => self.send.lost(&st),
-            RecoveryToken::ResetStream { stream_id } => self.send.reset_lost(*stream_id),
-            RecoveryToken::StreamDataBlocked { stream_id, limit } => {
+            StreamRecoveryToken::Stream(st) => self.send.lost(&st),
+            StreamRecoveryToken::ResetStream { stream_id } => self.send.reset_lost(*stream_id),
+            StreamRecoveryToken::StreamDataBlocked { stream_id, limit } => {
                 self.send.blocked_lost(*stream_id, *limit)
             }
-            RecoveryToken::MaxStreamData {
+            StreamRecoveryToken::MaxStreamData {
                 stream_id,
                 max_data,
             } => {
@@ -243,45 +243,45 @@ impl Streams {
                     rs.max_stream_data_lost(*max_data);
                 }
             }
-            RecoveryToken::StopSending { stream_id } => {
+            StreamRecoveryToken::StopSending { stream_id } => {
                 if let Ok((_, Some(rs))) = self.obtain_stream(*stream_id) {
                     rs.stop_sending_lost();
                 }
             }
-            RecoveryToken::StreamsBlocked { stream_type, limit } => {
+            StreamRecoveryToken::StreamsBlocked { stream_type, limit } => {
                 self.local_stream_limits[*stream_type].frame_lost(*limit);
             }
-            RecoveryToken::MaxStreams {
+            StreamRecoveryToken::MaxStreams {
                 stream_type,
                 max_streams,
             } => {
                 self.remote_stream_limits[*stream_type].frame_lost(*max_streams);
             }
-            RecoveryToken::DataBlocked(limit) => self.sender_fc.borrow_mut().frame_lost(*limit),
-            RecoveryToken::MaxData(maximum_data) => {
+            StreamRecoveryToken::DataBlocked(limit) => {
+                self.sender_fc.borrow_mut().frame_lost(*limit)
+            }
+            StreamRecoveryToken::MaxData(maximum_data) => {
                 self.receiver_fc.borrow_mut().frame_lost(*maximum_data)
             }
-            _ => unreachable!("This is not a stream RecoveryToken"),
         }
     }
 
-    pub fn acked(&mut self, token: &RecoveryToken) {
+    pub fn acked(&mut self, token: &StreamRecoveryToken) {
         match token {
-            RecoveryToken::Stream(st) => self.send.acked(st),
-            RecoveryToken::ResetStream { stream_id } => self.send.reset_acked(*stream_id),
-            RecoveryToken::StopSending { stream_id } => {
+            StreamRecoveryToken::Stream(st) => self.send.acked(st),
+            StreamRecoveryToken::ResetStream { stream_id } => self.send.reset_acked(*stream_id),
+            StreamRecoveryToken::StopSending { stream_id } => {
                 if let Ok((_, Some(rs))) = self.obtain_stream(*stream_id) {
                     rs.stop_sending_acked();
                 }
             }
             // We only worry when these are lost
-            RecoveryToken::DataBlocked(_)
-            | RecoveryToken::StreamDataBlocked { .. }
-            | RecoveryToken::MaxStreamData { .. }
-            | RecoveryToken::StreamsBlocked { .. }
-            | RecoveryToken::MaxStreams { .. }
-            | RecoveryToken::MaxData(_) => (),
-            _ => unreachable!("This is not a stream RecoveryToken"),
+            StreamRecoveryToken::DataBlocked(_)
+            | StreamRecoveryToken::StreamDataBlocked { .. }
+            | StreamRecoveryToken::MaxStreamData { .. }
+            | StreamRecoveryToken::StreamsBlocked { .. }
+            | StreamRecoveryToken::MaxStreams { .. }
+            | StreamRecoveryToken::MaxData(_) => (),
         }
     }
 


### PR DESCRIPTION
In part, the reason we had issues with the keep-alive patch was that we
had `_ => panic!()` clauses in our `match` statements.  This patch moves
the stream-related pieces of the enum into a new structure.  This might
add an extra discriminator to the layout, but the overall effect is
otherwise minimal.  And we no longer have catch-all clauses in our match
statements.