### PR TITLE
Resetting a wrong stream

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -12,7 +12,7 @@ use crate::push_stream::PushStream;
 use crate::recv_message::{MessageType, RecvMessage};
 use crate::send_message::{SendMessage, SendMessageEvents};
 use crate::settings::HSettings;
-use crate::{Header, ReceiveOutput, RecvMessageEvents, ResetType};
+use crate::{Header, Http3StreamType, ReceiveOutput, RecvMessageEvents, ResetType};
 use neqo_common::{
     event::Provider as EventProvider, hex, hex_with_len, qdebug, qinfo, qlog::NeqoQlog, qtrace,
     Datagram, Decoder, Encoder, Role,
@@ -549,7 +549,18 @@ impl Http3Client {
                 }
                 ConnectionEvent::RecvStreamReadable { stream_id } => {
                     if let Err(e) = self.handle_stream_readable(stream_id) {
-                        if e.stream_reset_error() {
+                        let is_critical =
+                            if let Some(r) = self.base_handler.recv_streams.get(&stream_id) {
+                                matches!(
+                                    r.stream_type(),
+                                    Http3StreamType::Control
+                                        | Http3StreamType::Encoder
+                                        | Http3StreamType::Decoder
+                                )
+                            } else {
+                                false
+                            };
+                        if !is_critical && e.stream_reset_error() {
                             self.reset_stream_on_error(stream_id, e.code());
                         } else {
                             return Err(e);
@@ -6520,5 +6531,50 @@ mod tests {
         let out = server.conn.process(None, now());
         client.process(out.dgram(), now());
         assert_closed(&client, &Error::HttpGeneralProtocol);
+    }
+
+    #[test]
+    fn error_request_stream() {
+        let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
+
+        setup_server_side_encoder(&mut client, &mut server);
+
+        let headers = vec![
+            Header::new(":status", "200"),
+            Header::new(":method", "GET"),
+            Header::new("my-header", "my-header"),
+            Header::new("content-length", "3"),
+        ];
+        let encoded_headers = server
+            .encoder
+            .borrow_mut()
+            .encode_header_block(&mut server.conn, &headers, request_stream_id)
+            .unwrap();
+        let hframe = HFrame::Headers {
+            header_block: encoded_headers.to_vec(),
+        };
+
+        // Send the encoder instructions, but delay them so that the stream is blocked on decoding headers.
+        let encoder_inst_pkt = server.conn.process(None, now());
+
+        // Send response
+        let mut d = Encoder::default();
+        hframe.encode(&mut d);
+        let d_frame = HFrame::Data { len: 3 };
+        d_frame.encode(&mut d);
+        d.encode(&[0x61, 0x62, 0x63]);
+        server_send_response_and_exchange_packet(
+            &mut client,
+            &mut server,
+            request_stream_id,
+            &d,
+            true,
+        );
+
+        // Let client receive the encoder instructions.
+        client.process_input(encoder_inst_pkt.dgram().unwrap(), now());
+
+        let reset_event = |e| matches!(e, Http3ClientEvent::Reset { stream_id, .. } if stream_id == request_stream_id);
+        assert!(client.events().any(reset_event));
     }
 }


### PR DESCRIPTION
If we get data on the decoder that unblocks some header decoding and one of the stream headers is malformed, neqo will reset a wrong stream(the decoder stream)