### PR TITLE
Datagrams

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -99,7 +99,6 @@ impl Http3Client {
         http3_parameters: &Http3Parameters,
         now: Instant,
     ) -> Res<Self> {
-        assert!(conn_params.get_max_datagram_frame_size() == 0);
         Ok(Self::new_with_conn(
             Connection::new_client(
                 server_name,
@@ -613,7 +612,7 @@ impl Http3Client {
                 }
                 ConnectionEvent::Datagram { .. }
                 | ConnectionEvent::DatagramAcked
-                | ConnectionEvent::DatagramLost => panic!("Datagrams are not enabled"),
+                | ConnectionEvent::DatagramLost => {}
             }
         }
         Ok(())

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -99,6 +99,7 @@ impl Http3Client {
         http3_parameters: &Http3Parameters,
         now: Instant,
     ) -> Res<Self> {
+        assert!(conn_params.get_max_datagram_frame_size() == 0);
         Ok(Self::new_with_conn(
             Connection::new_client(
                 server_name,
@@ -610,6 +611,9 @@ impl Http3Client {
                 ConnectionEvent::ResumptionToken(token) => {
                     self.create_resumption_token(&token);
                 }
+                ConnectionEvent::Datagram { .. }
+                | ConnectionEvent::DatagramAcked
+                | ConnectionEvent::DatagramLost => panic!("Datagrams are not enabled"),
             }
         }
         Ok(())

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -172,6 +172,9 @@ impl Http3ServerHandler {
                 ConnectionEvent::SendStreamWritable { .. }
                 | ConnectionEvent::SendStreamComplete { .. }
                 | ConnectionEvent::SendStreamCreatable { .. } => {}
+                ConnectionEvent::Datagram { .. }
+                | ConnectionEvent::DatagramAcked
+                | ConnectionEvent::DatagramLost => panic!("Datagrams are not enabled"),
             }
         }
         Ok(())

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -65,6 +65,7 @@ pub struct ConnectionParameters {
     /// The duration of the idle timeout for the connection.
     idle_timeout: Duration,
     preferred_address: PreferredAddressConfig,
+    max_datagram_frame_size: u64,
 }
 
 impl Default for ConnectionParameters {
@@ -81,6 +82,7 @@ impl Default for ConnectionParameters {
             ack_ratio: DEFAULT_ACK_RATIO,
             idle_timeout: DEFAULT_IDLE_TIMEOUT,
             preferred_address: PreferredAddressConfig::Default,
+            max_datagram_frame_size: 0,
         }
     }
 }
@@ -209,6 +211,15 @@ impl ConnectionParameters {
         self.idle_timeout
     }
 
+    pub fn get_max_datagram_frame_size(&self) -> u64 {
+        self.max_datagram_frame_size
+    }
+
+    pub fn max_datagram_frame_size(mut self, v: u64) -> Self {
+        self.max_datagram_frame_size = v;
+        self
+    }
+
     pub fn create_transport_parameter(
         &self,
         role: Role,
@@ -268,6 +279,10 @@ impl ConnectionParameters {
                 );
             }
         }
+        tps.local.set_integer(
+            tparams::MAX_DATAGRAM_FRAME_SIZE,
+            self.max_datagram_frame_size,
+        );
         Ok(tps)
     }
 }

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -24,6 +24,7 @@ pub const ACK_RATIO_SCALE: u8 = 10;
 const DEFAULT_ACK_RATIO: u8 = 4 * ACK_RATIO_SCALE;
 /// The local value for the idle timeout period.
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_QUEUED_DATAGRAMS_DEFAULT: usize = 10;
 
 /// What to do with preferred addresses.
 #[derive(Debug, Clone)]
@@ -65,7 +66,8 @@ pub struct ConnectionParameters {
     /// The duration of the idle timeout for the connection.
     idle_timeout: Duration,
     preferred_address: PreferredAddressConfig,
-    max_datagram_frame_size: u64,
+    datagram_size: u64,
+    queued_datagrams: usize,
 }
 
 impl Default for ConnectionParameters {
@@ -82,7 +84,8 @@ impl Default for ConnectionParameters {
             ack_ratio: DEFAULT_ACK_RATIO,
             idle_timeout: DEFAULT_IDLE_TIMEOUT,
             preferred_address: PreferredAddressConfig::Default,
-            max_datagram_frame_size: 0,
+            datagram_size: 0,
+            queued_datagrams: MAX_QUEUED_DATAGRAMS_DEFAULT,
         }
     }
 }
@@ -211,12 +214,21 @@ impl ConnectionParameters {
         self.idle_timeout
     }
 
-    pub fn get_max_datagram_frame_size(&self) -> u64 {
-        self.max_datagram_frame_size
+    pub fn get_datagram_size(&self) -> u64 {
+        self.datagram_size
     }
 
-    pub fn max_datagram_frame_size(mut self, v: u64) -> Self {
-        self.max_datagram_frame_size = v;
+    pub fn datagram_size(mut self, v: u64) -> Self {
+        self.datagram_size = v;
+        self
+    }
+
+    pub fn get_queued_datagrams(&self) -> usize {
+        self.queued_datagrams
+    }
+
+    pub fn queued_datagrams(mut self, v: usize) -> Self {
+        self.queued_datagrams = v;
         self
     }
 
@@ -279,10 +291,8 @@ impl ConnectionParameters {
                 );
             }
         }
-        tps.local.set_integer(
-            tparams::MAX_DATAGRAM_FRAME_SIZE,
-            self.max_datagram_frame_size,
-        );
+        tps.local
+            .set_integer(tparams::MAX_DATAGRAM_FRAME_SIZE, self.datagram_size);
         Ok(tps)
     }
 }

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -1,0 +1,243 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use super::{
+    assert_error, connect_force_idle, default_client, default_server, new_client, new_server,
+    AT_LEAST_PTO,
+};
+use crate::events::ConnectionEvent;
+use crate::{Connection, ConnectionError, ConnectionParameters, Error};
+use neqo_common::event::Provider;
+use std::convert::TryFrom;
+use std::time::Duration;
+use test_fixture::now;
+
+const DATAGRAM_LEN_MAX: u64 = 65535;
+const DATAGRAM_LEN_MTU: u64 = 1310;
+const DATA_MTU: &[u8] = &[1; 1310];
+const DATA_BIGGER_THAN_MTU: &[u8] = &[0; 2620];
+const DATAGRAM_LEN_SMALLER_THAN_MTU: u64 = 1200;
+const DATA_SMALLER_THAN_MTU: &[u8] = &[0; 1200];
+
+#[test]
+fn datagram_disabled_both() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+
+    assert_eq!(client.max_dgram_size(), Err(Error::NotAvailable));
+    assert_eq!(server.max_dgram_size(), Err(Error::NotAvailable));
+    assert_eq!(
+        client.send_dgram(DATA_SMALLER_THAN_MTU),
+        Err(Error::NotAvailable)
+    );
+    assert_eq!(server.stats().frame_tx.datagram, 0);
+    assert_eq!(
+        server.send_dgram(DATA_SMALLER_THAN_MTU),
+        Err(Error::NotAvailable)
+    );
+    assert_eq!(server.stats().frame_tx.datagram, 0);
+}
+
+#[test]
+fn datagram_enabled_on_client() {
+    let mut client = new_client(
+        ConnectionParameters::default().max_datagram_frame_size(DATAGRAM_LEN_SMALLER_THAN_MTU),
+    );
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+
+    assert_eq!(client.max_dgram_size(), Err(Error::NotAvailable));
+    assert_eq!(server.max_dgram_size(), Ok(DATAGRAM_LEN_SMALLER_THAN_MTU));
+    assert_eq!(
+        client.send_dgram(DATA_SMALLER_THAN_MTU),
+        Err(Error::NotAvailable)
+    );
+    let dgram_sent = server.stats().frame_tx.datagram;
+    assert_eq!(server.send_dgram(DATA_SMALLER_THAN_MTU), Ok(false));
+    let out = server.process_output(now()).dgram().unwrap();
+    assert_eq!(server.stats().frame_tx.datagram, dgram_sent + 1);
+
+    client.process_input(out, now());
+    let datagram =
+        |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU);
+    assert!(client.events().any(datagram));
+}
+
+#[test]
+fn datagram_enabled_on_server() {
+    let mut client = default_client();
+    let mut server = new_server(
+        ConnectionParameters::default().max_datagram_frame_size(DATAGRAM_LEN_SMALLER_THAN_MTU),
+    );
+    connect_force_idle(&mut client, &mut server);
+
+    assert_eq!(client.max_dgram_size(), Ok(DATAGRAM_LEN_SMALLER_THAN_MTU));
+    assert_eq!(server.max_dgram_size(), Err(Error::NotAvailable));
+    assert_eq!(
+        server.send_dgram(&DATA_SMALLER_THAN_MTU),
+        Err(Error::NotAvailable)
+    );
+    let dgram_sent = client.stats().frame_tx.datagram;
+    assert_eq!(client.send_dgram(DATA_SMALLER_THAN_MTU), Ok(false));
+    let out = client.process_output(now()).dgram().unwrap();
+    assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
+
+    server.process_input(out, now());
+    let datagram =
+        |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU);
+    assert!(server.events().any(datagram));
+}
+
+fn create_and_connect_with_dgrams() -> (Connection, Connection) {
+    let mut client =
+        new_client(ConnectionParameters::default().max_datagram_frame_size(DATAGRAM_LEN_MAX));
+    let mut server =
+        new_server(ConnectionParameters::default().max_datagram_frame_size(DATAGRAM_LEN_MAX));
+    connect_force_idle(&mut client, &mut server);
+    (client, server)
+}
+
+#[test]
+fn mtu_limit() {
+    let (client, server) = create_and_connect_with_dgrams();
+
+    assert_eq!(client.max_dgram_size(), Ok(DATAGRAM_LEN_MTU));
+    assert_eq!(server.max_dgram_size(), Ok(DATAGRAM_LEN_MTU));
+}
+
+#[test]
+fn limit_data_size() {
+    let (mut client, mut server) = create_and_connect_with_dgrams();
+
+    assert!(u64::try_from(DATA_BIGGER_THAN_MTU.len()).unwrap() > DATAGRAM_LEN_MTU);
+    assert_eq!(
+        client.send_dgram(DATA_BIGGER_THAN_MTU),
+        Err(Error::TooMuchData)
+    );
+    assert_eq!(
+        server.send_dgram(DATA_BIGGER_THAN_MTU),
+        Err(Error::TooMuchData)
+    );
+}
+
+#[test]
+fn datagram_acked() {
+    let (mut client, mut server) = create_and_connect_with_dgrams();
+
+    let dgram_sent = client.stats().frame_tx.datagram;
+    assert_eq!(client.send_dgram(DATA_SMALLER_THAN_MTU), Ok(false));
+    let out = client.process_output(now()).dgram();
+    assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
+
+    let dgram_received = server.stats().frame_rx.datagram;
+    server.process_input(out.unwrap(), now());
+    assert_eq!(server.stats().frame_rx.datagram, dgram_received + 1);
+    let now = now() + Duration::from_millis(1);
+    // Ack should be sent
+    let ack_sent = server.stats().frame_tx.ack;
+    let out = server.process_output(now).dgram();
+    assert_eq!(server.stats().frame_tx.ack, ack_sent + 1);
+
+    let datagram =
+        |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU);
+    assert!(server.events().any(datagram));
+
+    client.process_input(out.unwrap(), now);
+    let datagram_acked = |e| matches!(e, ConnectionEvent::DatagramAcked);
+    assert!(client.events().any(datagram_acked));
+}
+
+#[test]
+fn datagram_lost() {
+    let (mut client, _) = create_and_connect_with_dgrams();
+
+    let dgram_sent = client.stats().frame_tx.datagram;
+    assert_eq!(client.send_dgram(DATA_SMALLER_THAN_MTU), Ok(false));
+    let _out = client.process_output(now()).dgram(); // This packet will be lost.
+    assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
+
+    // Wait for PTO
+    let now = now() + AT_LEAST_PTO;
+    let dgram_sent = client.stats().frame_tx.datagram;
+    let out = client.process_output(now).dgram();
+    assert!(out.is_some()); //PING probing
+                            // Datagram is not sent again.
+    assert_eq!(client.stats().frame_tx.datagram, dgram_sent);
+
+    let datagram_lost = |e| matches!(e, ConnectionEvent::DatagramLost);
+    assert!(client.events().any(datagram_lost));
+}
+
+#[test]
+fn datagram_sent_once() {
+    let (mut client, _) = create_and_connect_with_dgrams();
+
+    let dgram_sent = client.stats().frame_tx.datagram;
+    assert_eq!(client.send_dgram(DATA_SMALLER_THAN_MTU), Ok(false));
+    let _out = client.process_output(now()).dgram();
+    assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
+
+    // Call process_output again should not send any new Datagram.
+    let dgram_sent = client.stats().frame_tx.datagram;
+    assert!(client.process_output(now()).dgram().is_none());
+    assert_eq!(client.stats().frame_tx.datagram, dgram_sent);
+}
+
+#[test]
+fn dgram_no_allowed() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+    server.set_max_dgram_size(DATAGRAM_LEN_MTU);
+    assert_eq!(server.max_dgram_size(), Ok(DATAGRAM_LEN_MTU));
+    assert_eq!(server.send_dgram(DATA_MTU), Ok(false));
+
+    let out = server.process_output(now()).dgram().unwrap();
+    client.process_input(out, now());
+
+    assert_error(
+        &client,
+        &ConnectionError::Transport(Error::ProtocolViolation),
+    );
+}
+
+#[test]
+fn dgram_too_big() {
+    let mut client = new_client(
+        ConnectionParameters::default().max_datagram_frame_size(DATAGRAM_LEN_SMALLER_THAN_MTU),
+    );
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+    server.set_max_dgram_size(DATAGRAM_LEN_MTU);
+    assert!(DATAGRAM_LEN_MTU > DATAGRAM_LEN_SMALLER_THAN_MTU);
+    assert_eq!(server.max_dgram_size(), Ok(DATAGRAM_LEN_MTU));
+    assert_eq!(server.send_dgram(DATA_MTU), Ok(false));
+
+    let out = server.process_output(now()).dgram().unwrap();
+    client.process_input(out, now());
+
+    assert_error(
+        &client,
+        &ConnectionError::Transport(Error::ProtocolViolation),
+    );
+}
+
+#[test]
+fn overwrite_datagram() {
+    let (mut client, mut server) = create_and_connect_with_dgrams();
+
+    let dgram_sent = client.stats().frame_tx.datagram;
+    assert_eq!(client.send_dgram(DATA_SMALLER_THAN_MTU), Ok(false));
+    // overwrite datagram
+    assert_eq!(client.send_dgram(DATA_MTU), Ok(true));
+    let out = client.process_output(now()).dgram();
+    assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
+
+    server.process_input(out.unwrap(), now());
+    let datagram = |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_MTU);
+    assert!(server.events().any(datagram));
+}

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -304,7 +304,7 @@ fn multiple_datagram_events() {
     assert_eq!(datagrams.next().unwrap(), THIRD_DATAGRAM);
     assert!(datagrams.next().is_none());
 
-    // New evens can be queued.
+    // New events can be queued.
     send_datagram(&mut client, &mut server, FOURTH_DATAGRAM);
     let mut datagrams = client.events().filter_map(|evt| {
         if let ConnectionEvent::Datagram(d) = evt {
@@ -350,7 +350,7 @@ fn too_many_datagram_events() {
     assert_eq!(datagrams.next().unwrap(), THIRD_DATAGRAM);
     assert!(datagrams.next().is_none());
 
-    // New evens can be queued.
+    // New events can be queued.
     send_datagram(&mut client, &mut server, FOURTH_DATAGRAM);
     let mut datagrams = client.events().filter_map(|evt| {
         if let ConnectionEvent::Datagram(d) = evt {

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -15,7 +15,6 @@ use crate::quic_datagrams::MAX_QUIC_DATAGRAM;
 use crate::{Connection, ConnectionError, ConnectionParameters, Error};
 use neqo_common::event::Provider;
 use std::convert::TryFrom;
-use std::time::Duration;
 use test_fixture::now;
 
 const DATAGRAM_LEN_MTU: u64 = 1310;
@@ -155,7 +154,7 @@ fn datagram_acked() {
     let dgram_received = server.stats().frame_rx.datagram;
     server.process_input(out.unwrap(), now());
     assert_eq!(server.stats().frame_rx.datagram, dgram_received + 1);
-    let now = now() + Duration::from_millis(1);
+    let now = now() + AT_LEAST_PTO;
     // Ack should be sent
     let ack_sent = server.stats().frame_tx.ack;
     let out = server.process_output(now).dgram();

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -9,18 +9,31 @@ use super::{
     AT_LEAST_PTO,
 };
 use crate::events::ConnectionEvent;
+use crate::frame::FRAME_TYPE_DATAGRAM;
+use crate::packet::PacketBuilder;
+use crate::quic_datagrams::MAX_QUIC_DATAGRAM;
 use crate::{Connection, ConnectionError, ConnectionParameters, Error};
 use neqo_common::event::Provider;
 use std::convert::TryFrom;
 use std::time::Duration;
 use test_fixture::now;
 
-const DATAGRAM_LEN_MAX: u64 = 65535;
 const DATAGRAM_LEN_MTU: u64 = 1310;
 const DATA_MTU: &[u8] = &[1; 1310];
 const DATA_BIGGER_THAN_MTU: &[u8] = &[0; 2620];
 const DATAGRAM_LEN_SMALLER_THAN_MTU: u64 = 1200;
 const DATA_SMALLER_THAN_MTU: &[u8] = &[0; 1200];
+
+struct InsertDatagram<'a> {
+    data: &'a [u8],
+}
+
+impl crate::connection::test_internal::FrameWriter for InsertDatagram<'_> {
+    fn write_frames(&mut self, builder: &mut PacketBuilder) {
+        builder.encode_varint(FRAME_TYPE_DATAGRAM);
+        builder.encode(self.data);
+    }
+}
 
 #[test]
 fn datagram_disabled_both() {
@@ -28,36 +41,38 @@ fn datagram_disabled_both() {
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
 
-    assert_eq!(client.max_dgram_size(), Err(Error::NotAvailable));
-    assert_eq!(server.max_dgram_size(), Err(Error::NotAvailable));
+    assert_eq!(client.max_datagram_size(), Err(Error::NotAvailable));
+    assert_eq!(server.max_datagram_size(), Err(Error::NotAvailable));
     assert_eq!(
-        client.send_dgram(DATA_SMALLER_THAN_MTU),
-        Err(Error::NotAvailable)
+        client.add_datagram(DATA_SMALLER_THAN_MTU),
+        Err(Error::TooMuchData)
     );
     assert_eq!(server.stats().frame_tx.datagram, 0);
     assert_eq!(
-        server.send_dgram(DATA_SMALLER_THAN_MTU),
-        Err(Error::NotAvailable)
+        server.add_datagram(DATA_SMALLER_THAN_MTU),
+        Err(Error::TooMuchData)
     );
     assert_eq!(server.stats().frame_tx.datagram, 0);
 }
 
 #[test]
 fn datagram_enabled_on_client() {
-    let mut client = new_client(
-        ConnectionParameters::default().max_datagram_frame_size(DATAGRAM_LEN_SMALLER_THAN_MTU),
-    );
+    let mut client =
+        new_client(ConnectionParameters::default().datagram_size(DATAGRAM_LEN_SMALLER_THAN_MTU));
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
 
-    assert_eq!(client.max_dgram_size(), Err(Error::NotAvailable));
-    assert_eq!(server.max_dgram_size(), Ok(DATAGRAM_LEN_SMALLER_THAN_MTU));
+    assert_eq!(client.max_datagram_size(), Err(Error::NotAvailable));
     assert_eq!(
-        client.send_dgram(DATA_SMALLER_THAN_MTU),
-        Err(Error::NotAvailable)
+        server.max_datagram_size(),
+        Ok(DATAGRAM_LEN_SMALLER_THAN_MTU)
+    );
+    assert_eq!(
+        client.add_datagram(DATA_SMALLER_THAN_MTU),
+        Err(Error::TooMuchData)
     );
     let dgram_sent = server.stats().frame_tx.datagram;
-    assert_eq!(server.send_dgram(DATA_SMALLER_THAN_MTU), Ok(false));
+    assert_eq!(server.add_datagram(DATA_SMALLER_THAN_MTU), Ok(false));
     let out = server.process_output(now()).dgram().unwrap();
     assert_eq!(server.stats().frame_tx.datagram, dgram_sent + 1);
 
@@ -70,19 +85,21 @@ fn datagram_enabled_on_client() {
 #[test]
 fn datagram_enabled_on_server() {
     let mut client = default_client();
-    let mut server = new_server(
-        ConnectionParameters::default().max_datagram_frame_size(DATAGRAM_LEN_SMALLER_THAN_MTU),
-    );
+    let mut server =
+        new_server(ConnectionParameters::default().datagram_size(DATAGRAM_LEN_SMALLER_THAN_MTU));
     connect_force_idle(&mut client, &mut server);
 
-    assert_eq!(client.max_dgram_size(), Ok(DATAGRAM_LEN_SMALLER_THAN_MTU));
-    assert_eq!(server.max_dgram_size(), Err(Error::NotAvailable));
     assert_eq!(
-        server.send_dgram(&DATA_SMALLER_THAN_MTU),
-        Err(Error::NotAvailable)
+        client.max_datagram_size(),
+        Ok(DATAGRAM_LEN_SMALLER_THAN_MTU)
+    );
+    assert_eq!(server.max_datagram_size(), Err(Error::NotAvailable));
+    assert_eq!(
+        server.add_datagram(&DATA_SMALLER_THAN_MTU),
+        Err(Error::TooMuchData)
     );
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.send_dgram(DATA_SMALLER_THAN_MTU), Ok(false));
+    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU), Ok(false));
     let out = client.process_output(now()).dgram().unwrap();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
@@ -92,44 +109,46 @@ fn datagram_enabled_on_server() {
     assert!(server.events().any(datagram));
 }
 
-fn create_and_connect_with_dgrams() -> (Connection, Connection) {
-    let mut client =
-        new_client(ConnectionParameters::default().max_datagram_frame_size(DATAGRAM_LEN_MAX));
-    let mut server =
-        new_server(ConnectionParameters::default().max_datagram_frame_size(DATAGRAM_LEN_MAX));
+fn connect_datagram() -> (Connection, Connection) {
+    let mut client = new_client(ConnectionParameters::default().datagram_size(MAX_QUIC_DATAGRAM));
+    let mut server = new_server(ConnectionParameters::default().datagram_size(MAX_QUIC_DATAGRAM));
     connect_force_idle(&mut client, &mut server);
     (client, server)
 }
 
 #[test]
 fn mtu_limit() {
-    let (client, server) = create_and_connect_with_dgrams();
+    let (client, server) = connect_datagram();
 
-    assert_eq!(client.max_dgram_size(), Ok(DATAGRAM_LEN_MTU));
-    assert_eq!(server.max_dgram_size(), Ok(DATAGRAM_LEN_MTU));
+    assert_eq!(client.max_datagram_size(), Ok(DATAGRAM_LEN_MTU));
+    assert_eq!(server.max_datagram_size(), Ok(DATAGRAM_LEN_MTU));
 }
 
 #[test]
 fn limit_data_size() {
-    let (mut client, mut server) = create_and_connect_with_dgrams();
+    let (mut client, mut server) = connect_datagram();
 
     assert!(u64::try_from(DATA_BIGGER_THAN_MTU.len()).unwrap() > DATAGRAM_LEN_MTU);
-    assert_eq!(
-        client.send_dgram(DATA_BIGGER_THAN_MTU),
-        Err(Error::TooMuchData)
-    );
-    assert_eq!(
-        server.send_dgram(DATA_BIGGER_THAN_MTU),
-        Err(Error::TooMuchData)
-    );
+    // Datagram can be queued because they are smaller than allowed by the peer,
+    // but they cannot be sent.
+    assert_eq!(client.add_datagram(DATA_BIGGER_THAN_MTU), Ok(false));
+    assert_eq!(server.add_datagram(DATA_BIGGER_THAN_MTU), Ok(false));
+
+    let dgram_sent_s = server.stats().frame_tx.datagram;
+    assert!(server.process_output(now()).dgram().is_none());
+    assert_eq!(server.stats().frame_tx.datagram, dgram_sent_s);
+
+    let dgram_sent_c = client.stats().frame_tx.datagram;
+    assert!(client.process_output(now()).dgram().is_none());
+    assert_eq!(client.stats().frame_tx.datagram, dgram_sent_c);
 }
 
 #[test]
 fn datagram_acked() {
-    let (mut client, mut server) = create_and_connect_with_dgrams();
+    let (mut client, mut server) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.send_dgram(DATA_SMALLER_THAN_MTU), Ok(false));
+    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU), Ok(false));
     let out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
@@ -153,19 +172,21 @@ fn datagram_acked() {
 
 #[test]
 fn datagram_lost() {
-    let (mut client, _) = create_and_connect_with_dgrams();
+    let (mut client, _) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.send_dgram(DATA_SMALLER_THAN_MTU), Ok(false));
+    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU), Ok(false));
     let _out = client.process_output(now()).dgram(); // This packet will be lost.
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
     // Wait for PTO
     let now = now() + AT_LEAST_PTO;
     let dgram_sent = client.stats().frame_tx.datagram;
+    let pings_sent = client.stats().frame_tx.ping;
     let out = client.process_output(now).dgram();
     assert!(out.is_some()); //PING probing
                             // Datagram is not sent again.
+    assert_eq!(client.stats().frame_tx.ping, pings_sent + 1);
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent);
 
     let datagram_lost = |e| matches!(e, ConnectionEvent::DatagramLost);
@@ -174,10 +195,10 @@ fn datagram_lost() {
 
 #[test]
 fn datagram_sent_once() {
-    let (mut client, _) = create_and_connect_with_dgrams();
+    let (mut client, _) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.send_dgram(DATA_SMALLER_THAN_MTU), Ok(false));
+    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU), Ok(false));
     let _out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
@@ -192,11 +213,10 @@ fn dgram_no_allowed() {
     let mut client = default_client();
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
-    server.set_max_dgram_size(DATAGRAM_LEN_MTU);
-    assert_eq!(server.max_dgram_size(), Ok(DATAGRAM_LEN_MTU));
-    assert_eq!(server.send_dgram(DATA_MTU), Ok(false));
-
+    server.test_frame_writer = Some(Box::new(InsertDatagram { data: DATA_MTU }));
     let out = server.process_output(now()).dgram().unwrap();
+    server.test_frame_writer = None;
+
     client.process_input(out, now());
 
     assert_error(
@@ -207,17 +227,16 @@ fn dgram_no_allowed() {
 
 #[test]
 fn dgram_too_big() {
-    let mut client = new_client(
-        ConnectionParameters::default().max_datagram_frame_size(DATAGRAM_LEN_SMALLER_THAN_MTU),
-    );
+    let mut client =
+        new_client(ConnectionParameters::default().datagram_size(DATAGRAM_LEN_SMALLER_THAN_MTU));
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
-    server.set_max_dgram_size(DATAGRAM_LEN_MTU);
-    assert!(DATAGRAM_LEN_MTU > DATAGRAM_LEN_SMALLER_THAN_MTU);
-    assert_eq!(server.max_dgram_size(), Ok(DATAGRAM_LEN_MTU));
-    assert_eq!(server.send_dgram(DATA_MTU), Ok(false));
 
+    assert!(DATAGRAM_LEN_MTU > DATAGRAM_LEN_SMALLER_THAN_MTU);
+    server.test_frame_writer = Some(Box::new(InsertDatagram { data: DATA_MTU }));
     let out = server.process_output(now()).dgram().unwrap();
+    server.test_frame_writer = None;
+
     client.process_input(out, now());
 
     assert_error(
@@ -228,16 +247,119 @@ fn dgram_too_big() {
 
 #[test]
 fn overwrite_datagram() {
-    let (mut client, mut server) = create_and_connect_with_dgrams();
+    let (mut client, mut server) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.send_dgram(DATA_SMALLER_THAN_MTU), Ok(false));
+    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU), Ok(false));
     // overwrite datagram
-    assert_eq!(client.send_dgram(DATA_MTU), Ok(true));
+    assert_eq!(client.add_datagram(DATA_MTU), Ok(true));
     let out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
     server.process_input(out.unwrap(), now());
     let datagram = |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_MTU);
     assert!(server.events().any(datagram));
+}
+
+fn send_datagram(client: &mut Connection, server: &mut Connection, data: &[u8]) {
+    let dgram_sent = server.stats().frame_tx.datagram;
+    assert_eq!(server.add_datagram(data), Ok(false));
+    let out = server.process_output(now()).dgram().unwrap();
+    assert_eq!(server.stats().frame_tx.datagram, dgram_sent + 1);
+
+    let dgram_received = client.stats().frame_rx.datagram;
+    client.process_input(out, now());
+    assert_eq!(client.stats().frame_rx.datagram, dgram_received + 1);
+}
+
+#[test]
+fn multiple_datagram_events() {
+    const DATA_SIZE: usize = 1200;
+    const MAX_QUEUE: usize = 3;
+    const FIRST_DATAGRAM: &[u8] = &[0; DATA_SIZE];
+    const SECOND_DATAGRAM: &[u8] = &[1; DATA_SIZE];
+    const THIRD_DATAGRAM: &[u8] = &[2; DATA_SIZE];
+    const FOURTH_DATAGRAM: &[u8] = &[3; DATA_SIZE];
+
+    let mut client = new_client(
+        ConnectionParameters::default()
+            .datagram_size(u64::try_from(DATA_SIZE).unwrap())
+            .queued_datagrams(MAX_QUEUE),
+    );
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+
+    send_datagram(&mut client, &mut server, FIRST_DATAGRAM);
+    send_datagram(&mut client, &mut server, SECOND_DATAGRAM);
+    send_datagram(&mut client, &mut server, THIRD_DATAGRAM);
+
+    let mut datagrams = client.events().filter_map(|evt| {
+        if let ConnectionEvent::Datagram(d) = evt {
+            Some(d)
+        } else {
+            None
+        }
+    });
+    assert_eq!(datagrams.next().unwrap(), FIRST_DATAGRAM);
+    assert_eq!(datagrams.next().unwrap(), SECOND_DATAGRAM);
+    assert_eq!(datagrams.next().unwrap(), THIRD_DATAGRAM);
+    assert!(datagrams.next().is_none());
+
+    // New evens can be queued.
+    send_datagram(&mut client, &mut server, FOURTH_DATAGRAM);
+    let mut datagrams = client.events().filter_map(|evt| {
+        if let ConnectionEvent::Datagram(d) = evt {
+            Some(d)
+        } else {
+            None
+        }
+    });
+    assert_eq!(datagrams.next().unwrap(), FOURTH_DATAGRAM);
+    assert!(datagrams.next().is_none())
+}
+
+#[test]
+fn too_many_datagram_events() {
+    const DATA_SIZE: usize = 1200;
+    const MAX_QUEUE: usize = 2;
+    const FIRST_DATAGRAM: &[u8] = &[0; DATA_SIZE];
+    const SECOND_DATAGRAM: &[u8] = &[1; DATA_SIZE];
+    const THIRD_DATAGRAM: &[u8] = &[2; DATA_SIZE];
+    const FOURTH_DATAGRAM: &[u8] = &[3; DATA_SIZE];
+
+    let mut client = new_client(
+        ConnectionParameters::default()
+            .datagram_size(u64::try_from(DATA_SIZE).unwrap())
+            .queued_datagrams(MAX_QUEUE),
+    );
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+
+    send_datagram(&mut client, &mut server, FIRST_DATAGRAM);
+    send_datagram(&mut client, &mut server, SECOND_DATAGRAM);
+    send_datagram(&mut client, &mut server, THIRD_DATAGRAM);
+
+    // Datagram with FIRST_DATAGRAM data will be dropped.
+    let mut datagrams = client.events().filter_map(|evt| {
+        if let ConnectionEvent::Datagram(d) = evt {
+            Some(d)
+        } else {
+            None
+        }
+    });
+    assert_eq!(datagrams.next().unwrap(), SECOND_DATAGRAM);
+    assert_eq!(datagrams.next().unwrap(), THIRD_DATAGRAM);
+    assert!(datagrams.next().is_none());
+
+    // New evens can be queued.
+    send_datagram(&mut client, &mut server, FOURTH_DATAGRAM);
+    let mut datagrams = client.events().filter_map(|evt| {
+        if let ConnectionEvent::Datagram(d) = evt {
+            Some(d)
+        } else {
+            None
+        }
+    });
+    assert_eq!(datagrams.next().unwrap(), FOURTH_DATAGRAM);
+    assert!(datagrams.next().is_none())
 }

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -31,6 +31,7 @@ use test_fixture::{self, addr, fixture_init, now};
 mod ackrate;
 mod cc;
 mod close;
+mod datagram;
 mod fuzzing;
 mod handshake;
 mod idle;

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -64,7 +64,7 @@ pub enum ConnectionEvent {
     ResumptionToken(ResumptionToken),
     Datagram(Vec<u8>),
     // TODO: datagrams probably need some identifiers. The packet number they
-    // are sent in would be enough. In that case we need an even DaagramSent
+    // are sent in would be enough. In that case we need an event DatagramSent
     // as well.
     DatagramLost,
     DatagramAcked,
@@ -158,6 +158,8 @@ impl ConnectionEvents {
         self.remove(|evt| matches!(evt, ConnectionEvent::RecvStreamReadable { stream_id: x } if *x == stream_id.as_u64()));
     }
 
+    // The number of datagrams in the events queue is limited to max_queued_datagrams.
+    // This function ensure this and deletes the oldest datagrams if needed.
     fn check_datagram_queued(&self, max_queued_datagrams: usize) {
         let mut q = self.events.borrow_mut();
         let mut remove = None;
@@ -183,7 +185,7 @@ impl ConnectionEvents {
         }
     }
 
-    pub fn datagram(&self, max_queued_datagrams: usize, data: &[u8]) {
+    pub fn add_datagram(&self, max_queued_datagrams: usize, data: &[u8]) {
         self.check_datagram_queued(max_queued_datagrams);
         self.insert(ConnectionEvent::Datagram(data.to_vec()));
     }

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -62,6 +62,12 @@ pub enum ConnectionEvent {
     /// Any data written to streams needs to be written again.
     ZeroRttRejected,
     ResumptionToken(ResumptionToken),
+    Datagram(Vec<u8>),
+    // TODO: datagrams probably need some identifiers. The packet number they
+    // are sent in would be enough. In that case we need an even DaagramSent
+    // as well.
+    DatagramLost,
+    DatagramAcked,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -150,6 +156,18 @@ impl ConnectionEvents {
     pub fn recv_stream_complete(&self, stream_id: StreamId) {
         // If stopped, no longer readable.
         self.remove(|evt| matches!(evt, ConnectionEvent::RecvStreamReadable { stream_id: x } if *x == stream_id.as_u64()));
+    }
+
+    pub fn datagram(&self, data: &[u8]) {
+        self.insert(ConnectionEvent::Datagram(data.to_vec()));
+    }
+
+    pub fn datagram_lost(&self) {
+        self.insert(ConnectionEvent::DatagramLost);
+    }
+
+    pub fn datagram_acked(&self) {
+        self.insert(ConnectionEvent::DatagramAcked);
     }
 
     fn insert(&self, event: ConnectionEvent) {

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -117,6 +117,7 @@ pub enum Error {
     UnknownFrameType,
     VersionNegotiation,
     WrongRole,
+    NotAvailable,
 }
 
 impl Error {

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -24,6 +24,7 @@ mod pace;
 mod packet;
 mod path;
 mod qlog;
+mod quic_datagrams;
 mod recovery;
 mod recv_stream;
 mod rtt;

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -421,6 +421,7 @@ fn frame_to_qlogframe(frame: &Frame) -> QuicFrame {
         ),
         Frame::HandshakeDone => QuicFrame::handshake_done(),
         Frame::AckFrequency { .. } => QuicFrame::unknown(frame.get_type()),
+        Frame::Datagram { .. } => QuicFrame::unknown(frame.get_type()),
     }
 }
 

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -1,0 +1,113 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// https://datatracker.ietf.org/doc/html/draft-ietf-quic-datagram
+
+use crate::frame::{FRAME_TYPE_DATAGRAM, FRAME_TYPE_DATAGRAM_WITH_LEN};
+use crate::packet::PacketBuilder;
+use crate::recovery::RecoveryToken;
+use crate::stats::FrameStats;
+use crate::{ConnectionEvents, Error, Res};
+use neqo_common::Encoder;
+use std::cmp::min;
+use std::convert::TryFrom;
+
+pub const MAX_QUIC_DATAGRAM: u64 = 65535;
+
+pub struct QuicDatagrams {
+    /// The max size of a datagram that would be acceptable.
+    local_datagram_size: u64,
+    /// The max size of a datagram that would be acceptable by the peer.
+    remote_datagram_size: u64,
+    /// The max number of datagrams that will be queued in connection events.
+    /// If the number is exceeded, the oldest datagram will be dropped.
+    max_queued_datagrams: usize,
+    /// Datagram queued for sending.
+    datagram: Option<Vec<u8>>,
+    conn_events: ConnectionEvents,
+}
+
+impl QuicDatagrams {
+    pub fn new(
+        local_datagram_size: u64,
+        max_queued_datagrams: usize,
+        conn_events: ConnectionEvents,
+    ) -> Self {
+        Self {
+            local_datagram_size,
+            remote_datagram_size: 0,
+            max_queued_datagrams,
+            datagram: None,
+            conn_events,
+        }
+    }
+
+    pub fn remote_datagram_size(&self) -> u64 {
+        self.remote_datagram_size
+    }
+
+    pub fn set_remote_datagram_size(&mut self, v: u64) {
+        self.remote_datagram_size = min(v, MAX_QUIC_DATAGRAM);
+    }
+
+    /// This function tries to write a datagram frame into a packet.
+    /// If the frame does not fit into the packet, the datagram will
+    /// be dropped and a DatagramLost event will be posted.
+    pub fn write_frames(
+        &mut self,
+        builder: &mut PacketBuilder,
+        tokens: &mut Vec<RecoveryToken>,
+        stats: &mut FrameStats,
+    ) {
+        if let Some(data) = &self.datagram.take() {
+            let len = data.len();
+            if builder.remaining() >= len + 1 {
+                // + 1 for Frame type
+                let length_len = Encoder::varint_len(u64::try_from(len).unwrap());
+                if builder.remaining() > 1 + length_len + len {
+                    builder.encode_varint(FRAME_TYPE_DATAGRAM_WITH_LEN);
+                    builder.encode_vvec(&data);
+                } else {
+                    builder.encode_varint(FRAME_TYPE_DATAGRAM);
+                    builder.encode(&data);
+                }
+                debug_assert!(builder.len() <= builder.limit());
+                self.datagram = None;
+                stats.datagram += 1;
+                tokens.push(RecoveryToken::Datagram);
+            } else {
+                // TODO try writing in a completely empty packet,
+                // before dropping a datagram.
+                self.conn_events.datagram_lost();
+            }
+        }
+    }
+
+    /// Returns true if there was an unsent datagram that has been dismissed.
+    /// # Error
+    /// The function returns `TooMuchData` if the supply buffer is bigger than
+    /// the allowed remote datagram size. The funcion does not check if the
+    /// datagram can fit into a packet (i.e. MTU limit). This is checked during
+    /// creation of an actual packet and the datagram will be dropped if it does
+    /// not fit into the packet.
+    pub fn add_datagram(&mut self, buf: &[u8]) -> Res<bool> {
+        if u64::try_from(buf.len()).unwrap() > self.remote_datagram_size {
+            return Err(Error::TooMuchData);
+        }
+        //        let dismissed = self.datagram.is_some();
+        //        self.datagram = Some(buf.to_vec());
+        //        dismissed
+        Ok(self.datagram.replace(buf.to_vec()).is_some())
+    }
+
+    pub fn handle_datagram(&self, data: &[u8]) -> Res<()> {
+        if self.local_datagram_size < u64::try_from(data.len()).unwrap() {
+            return Err(Error::ProtocolViolation);
+        }
+        self.conn_events.datagram(self.max_queued_datagrams, data);
+        Ok(())
+    }
+}

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -97,9 +97,6 @@ impl QuicDatagrams {
         if u64::try_from(buf.len()).unwrap() > self.remote_datagram_size {
             return Err(Error::TooMuchData);
         }
-        //        let dismissed = self.datagram.is_some();
-        //        self.datagram = Some(buf.to_vec());
-        //        dismissed
         Ok(self.datagram.replace(buf.to_vec()).is_some())
     }
 
@@ -107,7 +104,8 @@ impl QuicDatagrams {
         if self.local_datagram_size < u64::try_from(data.len()).unwrap() {
             return Err(Error::ProtocolViolation);
         }
-        self.conn_events.datagram(self.max_queued_datagrams, data);
+        self.conn_events
+            .add_datagram(self.max_queued_datagrams, data);
         Ok(())
     }
 }

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -89,6 +89,7 @@ pub enum RecoveryToken {
     NewConnectionId(ConnectionIdEntry<[u8; 16]>),
     RetireConnectionId(u64),
     AckFrequency(AckRate),
+    Datagram,
 }
 
 /// `SendProfile` tells a sender how to send packets.

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -49,6 +49,7 @@ pub struct FrameStats {
     pub new_token: usize,
 
     pub ack_frequency: usize,
+    pub datagram: usize,
 }
 
 impl Debug for FrameStats {

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -48,6 +48,7 @@ tpids! {
     RETRY_SOURCE_CONNECTION_ID = 0x10,
     GREASE_QUIC_BIT = 0x2ab2,
     MIN_ACK_DELAY = 0xff02_de1a,
+    MAX_DATAGRAM_FRAME_SIZE = 0x0020,
 }
 
 #[derive(Clone, Debug)]
@@ -218,7 +219,8 @@ impl TransportParameter {
             | INITIAL_MAX_STREAM_DATA_BIDI_LOCAL
             | INITIAL_MAX_STREAM_DATA_BIDI_REMOTE
             | INITIAL_MAX_STREAM_DATA_UNI
-            | MAX_ACK_DELAY => match d.decode_varint() {
+            | MAX_ACK_DELAY
+            | MAX_DATAGRAM_FRAME_SIZE => match d.decode_varint() {
                 Some(v) => Self::Integer(v),
                 None => return Err(Error::TransportParameterError),
             },
@@ -311,12 +313,13 @@ impl TransportParameters {
             | INITIAL_MAX_STREAM_DATA_BIDI_REMOTE
             | INITIAL_MAX_STREAM_DATA_UNI
             | INITIAL_MAX_STREAMS_BIDI
-            | INITIAL_MAX_STREAMS_UNI => 0,
+            | INITIAL_MAX_STREAMS_UNI
+            | MIN_ACK_DELAY
+            | MAX_DATAGRAM_FRAME_SIZE => 0,
             MAX_UDP_PAYLOAD_SIZE => 65527,
             ACK_DELAY_EXPONENT => 3,
             MAX_ACK_DELAY => 25,
             ACTIVE_CONNECTION_ID_LIMIT => 2,
-            MIN_ACK_DELAY => 0,
             _ => panic!("Transport parameter not known or not an Integer"),
         };
         match self.params.get(&tp) {
@@ -340,7 +343,8 @@ impl TransportParameters {
             | ACK_DELAY_EXPONENT
             | MAX_ACK_DELAY
             | ACTIVE_CONNECTION_ID_LIMIT
-            | MIN_ACK_DELAY => {
+            | MIN_ACK_DELAY
+            | MAX_DATAGRAM_FRAME_SIZE => {
                 self.set(tp, TransportParameter::Integer(value));
             }
             _ => panic!("Transport parameter not known"),
@@ -855,6 +859,7 @@ mod tests {
             INITIAL_MAX_STREAMS_UNI,
             MAX_UDP_PAYLOAD_SIZE,
             MIN_ACK_DELAY,
+            MAX_DATAGRAM_FRAME_SIZE,
         ];
         for i in INTEGER_KEYS {
             tps_a.set(*i, TransportParameter::Integer(12));


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/draft-ietf-quic-datagram

API:
- Event Datagram(Vec<u8>) - gives a new datagram to the application (TODO: we should limit number of datagrams that are queued in the Events)
- Events DatagramLost/DatagramAcked - this event is set when a datagram was acked or marked lost. It is not clear how much use the application will have from this signal. (TODO the datagrams need identifiers, otherwise these events have a limited use;)
- max_dgram_size() - returns the current max size of a datagram. This is calculated from the peer’s supplied limit and MTU and the exact current QUIC packet header size
- send_dgram() - stores a datagram into neqo-transport::Connection. The datagrams will be sent as soon as possible depending on the congestion control and pacing. If send_dgram() before the previous datagram has been sent, the previous datagram will be dismissed. (TODO: currently only one datagram is stored even if it is not filling a QUIC packet. We should store multiple datagrams if all can fit into a QUIC packet)

Other changes:
select_tx() returns a mutable reference to CryptoDxState. His function is renamed into select_tx_mut() and select_tx() returns an immutable reference to CryptoDxState. The new function is used to calculate QUIC packet header size.