### PR TITLE
Move decoding of PushId into NewStreamTypeReader

### DIFF
--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -13,9 +13,9 @@ use crate::qpack_decoder_receiver::DecoderRecvStream;
 use crate::qpack_encoder_receiver::EncoderRecvStream;
 use crate::send_message::SendMessage;
 use crate::settings::{HSetting, HSettingType, HSettings, HttpZeroRttChecker};
-use crate::stream_type_reader::NewStreamTypeReader;
+use crate::stream_type_reader::NewStreamHeadReader;
 use crate::{Http3StreamType, NewStreamType, Priority, ReceiveOutput, RecvStream, ResetType};
-use neqo_common::{qdebug, qerror, qinfo, qtrace, qwarn};
+use neqo_common::{qdebug, qerror, qinfo, qtrace, qwarn, Role};
 use neqo_qpack::decoder::QPackDecoder;
 use neqo_qpack::encoder::QPackEncoder;
 use neqo_qpack::QpackSettings;
@@ -203,11 +203,11 @@ impl Http3Connection {
         }
     }
 
-    pub fn handle_new_unidi_stream(&mut self, stream_id: u64, push_stream_allowed: bool) {
+    pub fn handle_new_unidi_stream(&mut self, stream_id: u64, role: Role) {
         qtrace!([self], "A new stream: {}.", stream_id);
         self.recv_streams.insert(
             stream_id,
-            Box::new(NewStreamTypeReader::new(stream_id, push_stream_allowed)),
+            Box::new(NewStreamHeadReader::new(stream_id, role)),
         );
     }
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -555,7 +555,7 @@ impl Http3Client {
                     StreamType::BiDi => return Err(Error::HttpStreamCreation),
                     StreamType::UniDi => self
                         .base_handler
-                        .handle_new_unidi_stream(stream_id.as_u64(), true),
+                        .handle_new_unidi_stream(stream_id.as_u64(), Role::Client),
                 },
                 ConnectionEvent::SendStreamWritable { stream_id } => {
                     if let Some(s) = self.base_handler.send_streams.get_mut(&stream_id.as_u64()) {
@@ -655,7 +655,7 @@ impl Http3Client {
             return Err(Error::HttpId);
         }
 
-        // Add a new pish stream to `PushController`. `add_new_push_stream` may return an error
+        // Add a new push stream to `PushController`. `add_new_push_stream` may return an error
         // (this will be a connection error) or a bool.
         // If false is returned that means that the stream should be reset because the push has
         // been already canceled (CANCEL_PUSH frame or canceling push from the application).

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -680,6 +680,7 @@ impl Http3Client {
                 push_id,
                 Rc::clone(&self.push_handler),
                 Rc::clone(&self.base_handler.qpack_decoder),
+                Priority::default(),
             )),
         );
         let res = self

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -10,7 +10,7 @@ use crate::recv_message::{MessageType, RecvMessage};
 use crate::send_message::SendMessage;
 use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents};
 use crate::{Error, Header, Priority, ReceiveOutput, Res};
-use neqo_common::{event::Provider, qdebug, qinfo, qtrace};
+use neqo_common::{event::Provider, qdebug, qinfo, qtrace, Role};
 use neqo_qpack::QpackSettings;
 use neqo_transport::{AppError, Connection, ConnectionEvent, StreamId, StreamType};
 use std::rc::Rc;
@@ -137,7 +137,7 @@ impl Http3ServerHandler {
                     ),
                     StreamType::UniDi => self
                         .base_handler
-                        .handle_new_unidi_stream(stream_id.as_u64(), false),
+                        .handle_new_unidi_stream(stream_id.as_u64(), Role::Server),
                 },
                 ConnectionEvent::RecvStreamReadable { stream_id } => {
                     self.handle_stream_readable(conn, stream_id)?

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -137,7 +137,7 @@ impl Http3ServerHandler {
                     ),
                     StreamType::UniDi => self
                         .base_handler
-                        .handle_new_unidi_stream(stream_id.as_u64()),
+                        .handle_new_unidi_stream(stream_id.as_u64(), false),
                 },
                 ConnectionEvent::RecvStreamReadable { stream_id } => {
                     self.handle_stream_readable(conn, stream_id)?

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -5,11 +5,13 @@
 // except according to those terms.
 
 use crate::hframe::HFrame;
-use crate::{Http3StreamType, RecvStream, Res, HTTP3_UNI_STREAM_TYPE_CONTROL};
+use crate::{RecvStream, Res};
 use neqo_common::{qtrace, Encoder};
 use neqo_transport::{Connection, StreamType};
 use std::collections::{HashMap, VecDeque};
 use std::convert::TryFrom;
+
+pub const HTTP3_UNI_STREAM_TYPE_CONTROL: u64 = 0x0;
 
 // The local control stream, responsible for encoding frames and sending them
 #[derive(Debug)]

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 
 use crate::hframe::HFrame;
-use crate::{RecvStream, Res};
+use crate::{Http3StreamType, RecvStream, Res};
 use neqo_common::{qtrace, Encoder};
 use neqo_transport::{Connection, StreamType};
 use std::collections::{HashMap, VecDeque};

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -29,9 +29,6 @@ mod server_events;
 mod settings;
 mod stream_type_reader;
 
-use crate::control_stream_local::HTTP3_UNI_STREAM_TYPE_CONTROL;
-use neqo_qpack::decoder::QPACK_UNI_STREAM_TYPE_DECODER;
-use neqo_qpack::encoder::QPACK_UNI_STREAM_TYPE_ENCODER;
 use neqo_qpack::Error as QpackError;
 pub use neqo_transport::Output;
 use neqo_transport::{AppError, Connection, Error as TransportError};
@@ -48,6 +45,7 @@ pub use priority::Priority;
 pub use server::Http3Server;
 pub use server_events::{ClientRequestStream, Http3ServerEvent};
 pub use settings::HttpZeroRttChecker;
+pub use stream_type_reader::NewStreamType;
 
 type Res<T> = Result<T, Error>;
 
@@ -280,8 +278,6 @@ impl ::std::fmt::Display for Error {
     }
 }
 
-pub const HTTP3_UNI_STREAM_TYPE_PUSH: u64 = 0x1;
-
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Http3StreamType {
     Control,
@@ -291,32 +287,6 @@ pub enum Http3StreamType {
     Http,
     Push,
     Unknown,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum NewStreamType {
-    Control,
-    Decoder,
-    Encoder,
-    Http,
-    Push(u64),
-    Unknown,
-}
-
-impl NewStreamType {
-    fn decode_stream_type(
-        stream_type: u64,
-        push_stream_allowed: bool,
-    ) -> Res<Option<NewStreamType>> {
-        match (stream_type, push_stream_allowed) {
-            (HTTP3_UNI_STREAM_TYPE_CONTROL, _) => Ok(Some(NewStreamType::Control)),
-            (QPACK_UNI_STREAM_TYPE_ENCODER, _) => Ok(Some(NewStreamType::Decoder)),
-            (QPACK_UNI_STREAM_TYPE_DECODER, _) => Ok(Some(NewStreamType::Encoder)),
-            (HTTP3_UNI_STREAM_TYPE_PUSH, true) => Ok(None),
-            (HTTP3_UNI_STREAM_TYPE_PUSH, false) => Err(Error::HttpStreamCreation),
-            _ => Ok(Some(NewStreamType::Unknown)),
-        }
-    }
 }
 
 #[derive(PartialEq, Debug)]

--- a/neqo-http3/src/push_stream.rs
+++ b/neqo-http3/src/push_stream.rs
@@ -4,55 +4,31 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::client_events::Http3ClientEvents;
+
+
 use crate::priority::PriorityHandler;
 use crate::push_controller::{PushController, RecvPushEvents};
 use crate::recv_message::{MessageType, RecvMessage};
-use crate::{
-    Error, Http3StreamType, HttpRecvStream, Priority, ReceiveOutput, RecvStream, Res, ResetType,
-};
-use neqo_common::{Decoder, IncrementalDecoderUint};
+use crate::{Http3StreamType, HttpRecvStream, Priority, ReceiveOutput, RecvStream, Res, ResetType};
 use neqo_qpack::decoder::QPackDecoder;
 use neqo_transport::{AppError, Connection};
 use std::cell::RefCell;
 use std::fmt::Display;
-use std::mem;
 use std::rc::Rc;
-
-#[derive(Debug)]
-enum PushStreamState {
-    ReadPushId(IncrementalDecoderUint),
-    ReadResponse { push_id: u64, response: RecvMessage },
-    Closed,
-}
-
-impl PushStreamState {
-    pub fn push_id(&self) -> Option<u64> {
-        match self {
-            Self::ReadResponse { push_id, .. } => Some(*push_id),
-            _ => None,
-        }
-    }
-}
 
 // The `PushController` keeps information about all push streams. Each push stream is responsible for contacting the
 // `PushController` to consult it about the push state and to inform it when the push stream is done (this are signal
 // from the peer: stream has been closed or reset). `PushController` handles CANCEL_PUSH frames and canceling
 // push from applications and PUSH_PROMISE frames.
 //
-// `PushStream` is responsible for reading from a push stream. It is used for reading push_id as well.
+// `PushStream` is responsible for reading from a push stream.
 // It is created when a new push stream is received.
-//
-// After push_id has been read, The `PushController` is informed about the stream and its push_id. This is done by
-// calling `add_new_push_stream`. `add_new_push_stream` may return an error (this will be a connection error)
-// or a bool. true means that the streams should continue and false means that the stream should be reset(the stream
-// will be canceled if the push has been canceled already (CANCEL_PUSH frame or canceling push from the application)
 //
 // `PushStreams` are kept in Http3Connection::recv_streams the same as a normal request/response stream.
 // Http3Connection and read_data is responsible for reading the push data.
 //
 // PushHeaderReady and PushDataReadable are posted through the `PushController` that may decide to postpone them if
-// a push_promise has not been received for the stream.
+// a push_promise has not been yet received for the stream.
 //
 // `PushStream` is responsible for removing itself from the `PushController`.
 //
@@ -61,120 +37,72 @@ impl PushStreamState {
 
 #[derive(Debug)]
 pub(crate) struct PushStream {
-    state: PushStreamState,
     stream_id: u64,
+    push_id: u64,
+    response: RecvMessage,
     push_handler: Rc<RefCell<PushController>>,
-    qpack_decoder: Rc<RefCell<QPackDecoder>>,
-    events: Http3ClientEvents,
     priority_handler: PriorityHandler,
 }
 
 impl PushStream {
     pub fn new(
         stream_id: u64,
+        push_id: u64,
         push_handler: Rc<RefCell<PushController>>,
         qpack_decoder: Rc<RefCell<QPackDecoder>>,
-        events: Http3ClientEvents,
         priority: Priority,
     ) -> Self {
         Self {
-            state: PushStreamState::ReadPushId(IncrementalDecoderUint::default()),
+            response: RecvMessage::new(
+                MessageType::Response,
+                stream_id,
+                qpack_decoder,
+                Box::new(RecvPushEvents::new(push_id, push_handler.clone())),
+                None,
+            ),
             stream_id,
+            push_id,
             push_handler,
-            qpack_decoder,
-            events,
             priority_handler: PriorityHandler::new(true, priority),
         }
-    }
-
-    fn push_id_decoded(&mut self, push_id: u64, conn: &mut Connection) -> Res<()> {
-        if self
-            .push_handler
-            .borrow_mut()
-            .add_new_push_stream(push_id, self.stream_id)?
-        {
-            self.state = PushStreamState::ReadResponse {
-                push_id,
-                response: RecvMessage::new(
-                    MessageType::Response,
-                    self.stream_id,
-                    Rc::clone(&self.qpack_decoder),
-                    Box::new(RecvPushEvents::new(push_id, Rc::clone(&self.push_handler))),
-                    None,
-                    Priority::default(),
-                ),
-            };
-        } else {
-            mem::drop(conn.stream_stop_sending(self.stream_id, Error::HttpRequestCancelled.code()));
-            self.state = PushStreamState::Closed;
-        }
-        Ok(())
     }
 }
 
 impl Display for PushStream {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Push stream {:?}", self.stream_id)
+        write!(
+            f,
+            "Push stream {:?} push_id={}",
+            self.stream_id, self.push_id
+        )
     }
 }
 
 impl RecvStream for PushStream {
     fn receive(&mut self, conn: &mut Connection) -> Res<ReceiveOutput> {
         loop {
-            match &mut self.state {
-                PushStreamState::ReadPushId(id_reader) => {
-                    let to_read = id_reader.min_remaining();
-                    let mut buf = vec![0; to_read];
-                    match conn.stream_recv(self.stream_id, &mut buf[..])? {
-                        (_, true) => {
-                            self.state = PushStreamState::Closed;
-                            return Err(Error::HttpGeneralProtocol);
-                        }
-                        (0, false) => return Ok(ReceiveOutput::NoOutput),
-                        (amount, false) => {
-                            if let Some(p) = id_reader.consume(&mut Decoder::from(&buf[..amount])) {
-                                self.push_id_decoded(p, conn)?;
-                                if self.done() {
-                                    return Ok(ReceiveOutput::NoOutput);
-                                }
-                            }
-                        }
-                    }
-                }
-                PushStreamState::ReadResponse { response, push_id } => {
-                    response.receive(conn)?;
-                    if response.done() {
-                        self.push_handler.borrow_mut().close(*push_id);
-                        self.state = PushStreamState::Closed;
-                    }
-                    return Ok(ReceiveOutput::NoOutput);
-                }
-                PushStreamState::Closed => return Ok(ReceiveOutput::NoOutput),
+            self.response.receive(conn)?;
+            if self.response.done() {
+                self.push_handler.borrow_mut().close(self.push_id);
             }
+            return Ok(ReceiveOutput::NoOutput);
         }
     }
 
     fn done(&self) -> bool {
-        matches!(self.state, PushStreamState::Closed)
+        self.response.done()
     }
 
     fn stream_reset(&mut self, app_error: AppError, reset_type: ResetType) -> Res<()> {
-        if !self.done() {
-            self.qpack_decoder
-                .borrow_mut()
-                .cancel_stream(self.stream_id);
-        }
         match reset_type {
             ResetType::App => {}
             t => {
-                if let Some(push_id) = self.state.push_id() {
-                    self.push_handler
-                        .borrow_mut()
-                        .push_stream_reset(push_id, app_error, t);
-                }
+                self.push_handler
+                    .borrow_mut()
+                    .push_stream_reset(self.push_id, app_error, t);
             }
         }
-        self.state = PushStreamState::Closed;
+        self.response.stream_reset(app_error, reset_type)?;
         Ok(())
     }
 
@@ -194,15 +122,11 @@ impl HttpRecvStream for PushStream {
     }
 
     fn read_data(&mut self, conn: &mut Connection, buf: &mut [u8]) -> Res<(usize, bool)> {
-        if let PushStreamState::ReadResponse { response, push_id } = &mut self.state {
-            let res = response.read_data(conn, buf);
-            if response.done() {
-                self.push_handler.borrow_mut().close(*push_id);
-            }
-            res
-        } else {
-            Err(Error::InvalidStreamId)
+        let res = self.response.read_data(conn, buf);
+        if self.response.done() {
+            self.push_handler.borrow_mut().close(self.push_id);
         }
+        res
     }
 
     fn priority_handler_mut(&mut self) -> &mut PriorityHandler {

--- a/neqo-http3/src/push_stream.rs
+++ b/neqo-http3/src/push_stream.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-
 use crate::priority::PriorityHandler;
 use crate::push_controller::{PushController, RecvPushEvents};
 use crate::recv_message::{MessageType, RecvMessage};
@@ -59,6 +57,7 @@ impl PushStream {
                 qpack_decoder,
                 Box::new(RecvPushEvents::new(push_id, push_handler.clone())),
                 None,
+                Priority::default(),
             ),
             stream_id,
             push_id,


### PR DESCRIPTION
This is extracted from my work on WebTransport and simplifies PushStream implementation. PushStream is not any more responsible for reading PushId and therefore it is transformed into a very simple wrapper around RecvMessage.

This PR also changes the behavior regarding closing a stream too early, e.g. if a stream is closed before the stream id is read it will return HttpStreamCreation.