### PR TITLE
Fixed Build NSS command on Linux build document

### DIFF
--- a/docs/linux_build.md
+++ b/docs/linux_build.md
@@ -113,7 +113,7 @@ export LD_LIBRARY_PATH=$NSS_DIR/../dist/Debug/lib
 5. Clone **NSS** and **NSPR**
 
 ```shell
-hg clone -u c7a1c91cd9be https://hg.mozilla.org/projects/nss "$NSS_DIR"
+hg clone https://hg.mozilla.org/projects/nss "$NSS_DIR"
 hg clone -u NSPR_4_25_RTM https://hg.mozilla.org/projects/nspr "$NSPR_DIR"
 ```
 


### PR DESCRIPTION
When I followed Linux build document, I faced same problem as #1156.
The cause of this problem was `-u c7a1c91cd9be` which means to use `NSS_3_53_BETA1`.