### PR TITLE
PushStream does not need to hold a PriorityHandler

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -12,7 +12,9 @@ use crate::push_stream::PushStream;
 use crate::recv_message::{MessageType, RecvMessage};
 use crate::send_message::{SendMessage, SendMessageEvents};
 use crate::settings::HSettings;
-use crate::{Header, NewStreamType, Priority, ReceiveOutput, RecvMessageEvents, ResetType};
+use crate::{
+    Header, NewStreamType, Priority, PriorityHandler, ReceiveOutput, RecvMessageEvents, ResetType,
+};
 use neqo_common::{
     event::Provider as EventProvider, hex, hex_with_len, qdebug, qinfo, qlog::NeqoQlog, qtrace,
     Datagram, Decoder, Encoder, Role,
@@ -315,7 +317,7 @@ impl Http3Client {
                 Rc::clone(&self.base_handler.qpack_decoder),
                 Box::new(self.events.clone()),
                 Some(Rc::clone(&self.push_handler)),
-                priority,
+                PriorityHandler::new(false, priority),
             )),
         );
 

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -9,7 +9,7 @@ use crate::hframe::HFrame;
 use crate::recv_message::{MessageType, RecvMessage};
 use crate::send_message::SendMessage;
 use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents};
-use crate::{Error, Header, Priority, ReceiveOutput, Res};
+use crate::{Error, Header, Priority, PriorityHandler, ReceiveOutput, Res};
 use neqo_common::{event::Provider, qdebug, qinfo, qtrace, Role};
 use neqo_qpack::QpackSettings;
 use neqo_transport::{AppError, Connection, ConnectionEvent, StreamId, StreamType};
@@ -132,7 +132,7 @@ impl Http3ServerHandler {
                             Rc::clone(&self.base_handler.qpack_decoder),
                             Box::new(self.events.clone()),
                             None,
-                            Priority::default(),
+                            PriorityHandler::new(false, Priority::default()),
                         )),
                     ),
                     StreamType::UniDi => self

--- a/neqo-http3/src/push_stream.rs
+++ b/neqo-http3/src/push_stream.rs
@@ -39,7 +39,6 @@ pub(crate) struct PushStream {
     push_id: u64,
     response: RecvMessage,
     push_handler: Rc<RefCell<PushController>>,
-    priority_handler: PriorityHandler,
 }
 
 impl PushStream {
@@ -57,12 +56,11 @@ impl PushStream {
                 qpack_decoder,
                 Box::new(RecvPushEvents::new(push_id, push_handler.clone())),
                 None,
-                Priority::default(),
+                PriorityHandler::new(true, priority),
             ),
             stream_id,
             push_id,
             push_handler,
-            priority_handler: PriorityHandler::new(true, priority),
         }
     }
 }
@@ -129,6 +127,6 @@ impl HttpRecvStream for PushStream {
     }
 
     fn priority_handler_mut(&mut self) -> &mut PriorityHandler {
-        &mut self.priority_handler
+        self.response.priority_handler_mut()
     }
 }

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -6,10 +6,9 @@
 
 use crate::hframe::{HFrame, HFrameReader};
 use crate::push_controller::PushController;
-use crate::{qlog, Priority};
 use crate::{
-    Error, Header, Http3StreamType, HttpRecvStream, ReceiveOutput, RecvMessageEvents, RecvStream,
-    Res, ResetType,
+    qlog, Error, Header, Http3StreamType, HttpRecvStream, ReceiveOutput, RecvMessageEvents,
+    RecvStream, Res, ResetType,
 };
 
 use crate::priority::PriorityHandler;
@@ -94,7 +93,7 @@ impl RecvMessage {
         qpack_decoder: Rc<RefCell<QPackDecoder>>,
         conn_events: Box<dyn RecvMessageEvents>,
         push_handler: Option<Rc<RefCell<PushController>>>,
-        priority: Priority,
+        priority_handler: PriorityHandler,
     ) -> Self {
         Self {
             state: RecvMessageState::WaitingForResponseHeaders {
@@ -105,7 +104,7 @@ impl RecvMessage {
             conn_events,
             push_handler,
             stream_id,
-            priority_handler: PriorityHandler::new(false, priority),
+            priority_handler,
             blocked_push_promise: VecDeque::new(),
         }
     }


### PR DESCRIPTION
PR #1202 made PushStream a simpler wrapper around RecvMessage and that made possible to remove PropertyHandler rom PushStream