### PR TITLE
Queue multiple outgoing Quic datagrams

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -610,9 +610,9 @@ impl Http3Client {
                 ConnectionEvent::ResumptionToken(token) => {
                     self.create_resumption_token(&token);
                 }
-                ConnectionEvent::QuicDatagram { .. }
-                | ConnectionEvent::OutgoingQuicDatagramOutcome { .. }
-                | ConnectionEvent::IncomingQuicDatagramDropped => {}
+                ConnectionEvent::Datagram { .. }
+                | ConnectionEvent::OutgoingDatagramOutcome { .. }
+                | ConnectionEvent::IncomingDatagramDropped => {}
             }
         }
         Ok(())

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -610,9 +610,9 @@ impl Http3Client {
                 ConnectionEvent::ResumptionToken(token) => {
                     self.create_resumption_token(&token);
                 }
-                ConnectionEvent::Datagram { .. }
-                | ConnectionEvent::DatagramAcked
-                | ConnectionEvent::DatagramLost => {}
+                ConnectionEvent::QuicDatagram { .. }
+                | ConnectionEvent::OutgoingQuicDatagramOutcome { .. }
+                | ConnectionEvent::IncomingQuicDatagramDropped => {}
             }
         }
         Ok(())

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -172,9 +172,9 @@ impl Http3ServerHandler {
                 ConnectionEvent::SendStreamWritable { .. }
                 | ConnectionEvent::SendStreamComplete { .. }
                 | ConnectionEvent::SendStreamCreatable { .. }
-                | ConnectionEvent::QuicDatagram { .. }
-                | ConnectionEvent::OutgoingQuicDatagramOutcome { .. }
-                | ConnectionEvent::IncomingQuicDatagramDropped => {}
+                | ConnectionEvent::Datagram { .. }
+                | ConnectionEvent::OutgoingDatagramOutcome { .. }
+                | ConnectionEvent::IncomingDatagramDropped => {}
             }
         }
         Ok(())

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -171,10 +171,10 @@ impl Http3ServerHandler {
                 | ConnectionEvent::ResumptionToken(..) => return Err(Error::HttpInternal(4)),
                 ConnectionEvent::SendStreamWritable { .. }
                 | ConnectionEvent::SendStreamComplete { .. }
-                | ConnectionEvent::SendStreamCreatable { .. } => {}
-                ConnectionEvent::Datagram { .. }
-                | ConnectionEvent::DatagramAcked
-                | ConnectionEvent::DatagramLost => panic!("Datagrams are not enabled"),
+                | ConnectionEvent::SendStreamCreatable { .. }
+                | ConnectionEvent::QuicDatagram { .. }
+                | ConnectionEvent::OutgoingQuicDatagramOutcome { .. }
+                | ConnectionEvent::IncomingQuicDatagramDropped => {}
             }
         }
         Ok(())

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -36,7 +36,7 @@ use crate::cid::{
 
 use crate::crypto::{Crypto, CryptoDxState, CryptoSpace};
 use crate::dump::*;
-use crate::events::{ConnectionEvent, ConnectionEvents, OutgoingQuicDatagramOutcome};
+use crate::events::{ConnectionEvent, ConnectionEvents, OutgoingDatagramOutcome};
 use crate::frame::{
     CloseError, Frame, FrameType, FRAME_TYPE_CONNECTION_CLOSE_APPLICATION,
     FRAME_TYPE_CONNECTION_CLOSE_TRANSPORT,
@@ -369,9 +369,9 @@ impl Connection {
         let stats = StatsCell::default();
         let events = ConnectionEvents::default();
         let quic_datagrams = QuicDatagrams::new(
-            conn_params.get_quic_datagram_size(),
-            conn_params.get_queued_outgoing_quic_datagrams(),
-            conn_params.get_queued_incoming_quic_datagrams(),
+            conn_params.get_datagram_size(),
+            conn_params.get_outgoing_datagrams_queue(),
+            conn_params.get_incoming_datagrams_queue(),
             events.clone(),
         );
 
@@ -2545,9 +2545,9 @@ impl Connection {
                     RecoveryToken::AckFrequency(rate) => self.paths.lost_ack_frequency(rate),
                     RecoveryToken::KeepAlive => self.idle_timeout.lost_keep_alive(),
                     RecoveryToken::Stream(stream_token) => self.streams.lost(stream_token),
-                    RecoveryToken::QuicDatagram(len) => self
+                    RecoveryToken::Datagram(id) => self
                         .events
-                        .quic_datagram_outcome(*len, OutgoingQuicDatagramOutcome::Lost),
+                        .datagram_outcome(*id, OutgoingDatagramOutcome::Lost),
                 }
             }
         }
@@ -2596,9 +2596,9 @@ impl Connection {
                     RecoveryToken::RetireConnectionId(seqno) => self.paths.acked_retire_cid(*seqno),
                     RecoveryToken::AckFrequency(rate) => self.paths.acked_ack_frequency(rate),
                     RecoveryToken::KeepAlive => self.idle_timeout.ack_keep_alive(),
-                    RecoveryToken::QuicDatagram(len) => self
+                    RecoveryToken::Datagram(id) => self
                         .events
-                        .quic_datagram_outcome(*len, OutgoingQuicDatagramOutcome::Acked),
+                        .datagram_outcome(*id, OutgoingDatagramOutcome::Acked),
                     // We only worry when these are lost
                     RecoveryToken::HandshakeDone => (),
                 }
@@ -2826,7 +2826,7 @@ impl Connection {
         self.streams.keep_alive(stream_id.into(), keep)
     }
 
-    pub fn remote_quic_datagram_size(&self) -> u64 {
+    pub fn remote_datagram_size(&self) -> u64 {
         self.quic_datagrams.remote_datagram_size()
     }
 
@@ -2835,7 +2835,7 @@ impl Connection {
     /// packet number, ack frames, etc.
     /// # Error
     /// The function returns `NotAvailable` if datagrams are not enabled.
-    pub fn max_quic_datagram_size(&self) -> Res<u64> {
+    pub fn max_datagram_size(&self) -> Res<u64> {
         let max_dgram_size = self.quic_datagrams.remote_datagram_size();
         if max_dgram_size == 0 {
             return Err(Error::NotAvailable);
@@ -2881,12 +2881,12 @@ impl Connection {
     /// the allowed remote datagram size. The funcion does not check if the
     /// datagram can fit into a packet (i.e. MTU limit). This is checked during
     /// creation of an actual packet and the datagram will be dropped if it does
-    /// not fit into the packet. The app is encourage to use `max_quic_datagram_size`
+    /// not fit into the packet. The app is encourage to use `max_datagram_size`
     /// to check the estimated max datagram size and to use smaller datagrams.
-    /// `max_quic_datagram_size` is just a current estimate and will change over
+    /// `max_datagram_size` is just a current estimate and will change over
     /// time depending on the encoded size of the packet number, ack frames, etc.
-    pub fn add_quic_datagram(&mut self, buf: &[u8]) -> Res<()> {
-        self.quic_datagrams.add_datagram(buf)
+    pub fn add_datagram(&mut self, buf: &[u8], id: Option<u64>) -> Res<()> {
+        self.quic_datagrams.add_datagram(buf, id)
     }
 }
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2875,7 +2875,7 @@ impl Connection {
         Ok(min(data_len_possible, max_dgram_size))
     }
 
-    /// Returns true if there was an unsent datagram that has been dismissed.
+    /// Queue a datagram for sending.
     /// # Error
     /// The function returns `TooMuchData` if the supply buffer is bigger than
     /// the allowed remote datagram size. The funcion does not check if the

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -68,8 +68,8 @@ pub struct ConnectionParameters {
     idle_timeout: Duration,
     preferred_address: PreferredAddressConfig,
     datagram_size: u64,
-    outgoing_datagrams_queue: usize,
-    incoming_datagrams_queue: usize,
+    outgoing_datagram_queue: usize,
+    incoming_datagram_queue: usize,
 }
 
 impl Default for ConnectionParameters {
@@ -87,8 +87,8 @@ impl Default for ConnectionParameters {
             idle_timeout: DEFAULT_IDLE_TIMEOUT,
             preferred_address: PreferredAddressConfig::Default,
             datagram_size: 0,
-            outgoing_datagrams_queue: MAX_QUEUED_DATAGRAMS_DEFAULT,
-            incoming_datagrams_queue: MAX_QUEUED_DATAGRAMS_DEFAULT,
+            outgoing_datagram_queue: MAX_QUEUED_DATAGRAMS_DEFAULT,
+            incoming_datagram_queue: MAX_QUEUED_DATAGRAMS_DEFAULT,
         }
     }
 }
@@ -226,23 +226,23 @@ impl ConnectionParameters {
         self
     }
 
-    pub fn get_outgoing_datagrams_queue(&self) -> usize {
-        self.outgoing_datagrams_queue
+    pub fn get_outgoing_datagram_queue(&self) -> usize {
+        self.outgoing_datagram_queue
     }
 
-    pub fn outgoing_datagrams_queue(mut self, v: usize) -> Self {
+    pub fn outgoing_datagram_queue(mut self, v: usize) -> Self {
         // The max queue length must be at least 1.
-        self.outgoing_datagrams_queue = max(v, 1);
+        self.outgoing_datagram_queue = max(v, 1);
         self
     }
 
-    pub fn get_incoming_datagrams_queue(&self) -> usize {
-        self.incoming_datagrams_queue
+    pub fn get_incoming_datagram_queue(&self) -> usize {
+        self.incoming_datagram_queue
     }
 
-    pub fn incoming_datagrams_queue(mut self, v: usize) -> Self {
+    pub fn incoming_datagram_queue(mut self, v: usize) -> Self {
         // The max queue length must be at least 1.
-        self.incoming_datagrams_queue = max(v, 1);
+        self.incoming_datagram_queue = max(v, 1);
         self
     }
 

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -66,8 +66,9 @@ pub struct ConnectionParameters {
     /// The duration of the idle timeout for the connection.
     idle_timeout: Duration,
     preferred_address: PreferredAddressConfig,
-    datagram_size: u64,
-    queued_datagrams: usize,
+    quic_datagram_size: u64,
+    queued_outgoing_quic_datagrams: usize,
+    queued_incoming_quic_datagrams: usize,
 }
 
 impl Default for ConnectionParameters {
@@ -84,8 +85,9 @@ impl Default for ConnectionParameters {
             ack_ratio: DEFAULT_ACK_RATIO,
             idle_timeout: DEFAULT_IDLE_TIMEOUT,
             preferred_address: PreferredAddressConfig::Default,
-            datagram_size: 0,
-            queued_datagrams: MAX_QUEUED_DATAGRAMS_DEFAULT,
+            quic_datagram_size: 0,
+            queued_outgoing_quic_datagrams: MAX_QUEUED_DATAGRAMS_DEFAULT,
+            queued_incoming_quic_datagrams: MAX_QUEUED_DATAGRAMS_DEFAULT,
         }
     }
 }
@@ -214,21 +216,30 @@ impl ConnectionParameters {
         self.idle_timeout
     }
 
-    pub fn get_datagram_size(&self) -> u64 {
-        self.datagram_size
+    pub fn get_quic_datagram_size(&self) -> u64 {
+        self.quic_datagram_size
     }
 
-    pub fn datagram_size(mut self, v: u64) -> Self {
-        self.datagram_size = v;
+    pub fn quic_datagram_size(mut self, v: u64) -> Self {
+        self.quic_datagram_size = v;
         self
     }
 
-    pub fn get_queued_datagrams(&self) -> usize {
-        self.queued_datagrams
+    pub fn get_queued_outgoing_quic_datagrams(&self) -> usize {
+        self.queued_outgoing_quic_datagrams
     }
 
-    pub fn queued_datagrams(mut self, v: usize) -> Self {
-        self.queued_datagrams = v;
+    pub fn queued_outgoing_quic_datagrams(mut self, v: usize) -> Self {
+        self.queued_outgoing_quic_datagrams = v;
+        self
+    }
+
+    pub fn get_queued_incoming_quic_datagrams(&self) -> usize {
+        self.queued_incoming_quic_datagrams
+    }
+
+    pub fn queued_incoming_quic_datagrams(mut self, v: usize) -> Self {
+        self.queued_incoming_quic_datagrams = v;
         self
     }
 
@@ -292,7 +303,7 @@ impl ConnectionParameters {
             }
         }
         tps.local
-            .set_integer(tparams::MAX_DATAGRAM_FRAME_SIZE, self.datagram_size);
+            .set_integer(tparams::MAX_DATAGRAM_FRAME_SIZE, self.quic_datagram_size);
         Ok(tps)
     }
 }

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -45,12 +45,12 @@ fn datagram_disabled_both() {
     assert_eq!(client.max_datagram_size(), Err(Error::NotAvailable));
     assert_eq!(server.max_datagram_size(), Err(Error::NotAvailable));
     assert_eq!(
-        client.add_datagram(DATA_SMALLER_THAN_MTU, Some(1)),
+        client.send_datagram(DATA_SMALLER_THAN_MTU, None),
         Err(Error::TooMuchData)
     );
     assert_eq!(server.stats().frame_tx.datagram, 0);
     assert_eq!(
-        server.add_datagram(DATA_SMALLER_THAN_MTU, Some(1)),
+        server.send_datagram(DATA_SMALLER_THAN_MTU, None),
         Err(Error::TooMuchData)
     );
     assert_eq!(server.stats().frame_tx.datagram, 0);
@@ -69,18 +69,19 @@ fn datagram_enabled_on_client() {
         Ok(DATAGRAM_LEN_SMALLER_THAN_MTU)
     );
     assert_eq!(
-        client.add_datagram(DATA_SMALLER_THAN_MTU, Some(1)),
+        client.send_datagram(DATA_SMALLER_THAN_MTU, Some(1)),
         Err(Error::TooMuchData)
     );
     let dgram_sent = server.stats().frame_tx.datagram;
-    assert_eq!(server.add_datagram(DATA_SMALLER_THAN_MTU, Some(1)), Ok(()));
+    assert_eq!(server.send_datagram(DATA_SMALLER_THAN_MTU, Some(1)), Ok(()));
     let out = server.process_output(now()).dgram().unwrap();
     assert_eq!(server.stats().frame_tx.datagram, dgram_sent + 1);
 
     client.process_input(out, now());
-    let datagram =
-        |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU);
-    assert!(client.events().any(datagram));
+    assert!(matches!(
+        client.next_event().unwrap(),
+        ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU
+    ));
 }
 
 #[test]
@@ -96,25 +97,26 @@ fn datagram_enabled_on_server() {
     );
     assert_eq!(server.max_datagram_size(), Err(Error::NotAvailable));
     assert_eq!(
-        server.add_datagram(&DATA_SMALLER_THAN_MTU, Some(1)),
+        server.send_datagram(&DATA_SMALLER_THAN_MTU, Some(1)),
         Err(Error::TooMuchData)
     );
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU, Some(1)), Ok(()));
+    assert_eq!(client.send_datagram(DATA_SMALLER_THAN_MTU, Some(1)), Ok(()));
     let out = client.process_output(now()).dgram().unwrap();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
     server.process_input(out, now());
-    let datagram =
-        |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU);
-    assert!(server.events().any(datagram));
+    assert!(matches!(
+        server.next_event().unwrap(),
+        ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU
+    ));
 }
 
 fn connect_datagram() -> (Connection, Connection) {
     let mut client = new_client(
         ConnectionParameters::default()
             .datagram_size(MAX_QUIC_DATAGRAM)
-            .outgoing_datagrams_queue(OUTGOING_QUEUE),
+            .outgoing_datagram_queue(OUTGOING_QUEUE),
     );
     let mut server = new_server(ConnectionParameters::default().datagram_size(MAX_QUIC_DATAGRAM));
     connect_force_idle(&mut client, &mut server);
@@ -136,23 +138,25 @@ fn limit_data_size() {
     assert!(u64::try_from(DATA_BIGGER_THAN_MTU.len()).unwrap() > DATAGRAM_LEN_MTU);
     // Datagram can be queued because they are smaller than allowed by the peer,
     // but they cannot be sent.
-    assert_eq!(client.add_datagram(DATA_BIGGER_THAN_MTU, Some(1)), Ok(()));
-    assert_eq!(server.add_datagram(DATA_BIGGER_THAN_MTU, Some(1)), Ok(()));
+    assert_eq!(server.send_datagram(DATA_BIGGER_THAN_MTU, Some(1)), Ok(()));
 
     let dgram_sent_s = server.stats().frame_tx.datagram;
     assert!(server.process_output(now()).dgram().is_none());
     assert_eq!(server.stats().frame_tx.datagram, dgram_sent_s);
-    let datagram_dropped = |e| {
-        matches!(
-        e,
-        ConnectionEvent::OutgoingDatagramOutcome { id, outcome } if id == 1 && outcome == OutgoingDatagramOutcome::DroppedTooBig)
-    };
-    assert!(server.events().any(datagram_dropped));
+    assert!(matches!(
+        server.next_event().unwrap(),
+        ConnectionEvent::OutgoingDatagramOutcome { id, outcome } if id == 1 && outcome == OutgoingDatagramOutcome::DroppedTooBig
+    ));
 
+    // The same test for the client side.
+    assert_eq!(client.send_datagram(DATA_BIGGER_THAN_MTU, Some(1)), Ok(()));
     let dgram_sent_c = client.stats().frame_tx.datagram;
     assert!(client.process_output(now()).dgram().is_none());
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent_c);
-    assert!(client.events().any(datagram_dropped));
+    assert!(matches!(
+        client.next_event().unwrap(),
+        ConnectionEvent::OutgoingDatagramOutcome { id, outcome } if id == 1 && outcome == OutgoingDatagramOutcome::DroppedTooBig
+    ));
 }
 
 #[test]
@@ -160,7 +164,7 @@ fn datagram_acked() {
     let (mut client, mut server) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU, Some(1)), Ok(()));
+    assert_eq!(client.send_datagram(DATA_SMALLER_THAN_MTU, Some(1)), Ok(()));
     let out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
@@ -173,17 +177,16 @@ fn datagram_acked() {
     let out = server.process_output(now).dgram();
     assert_eq!(server.stats().frame_tx.ack, ack_sent + 1);
 
-    let datagram =
-        |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU);
-    assert!(server.events().any(datagram));
+    assert!(matches!(
+        server.next_event().unwrap(),
+        ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU
+    ));
 
     client.process_input(out.unwrap(), now);
-    let datagram_acked = |e| {
-        matches!(
-        e,
-        ConnectionEvent::OutgoingDatagramOutcome { id, outcome } if id == 1 && outcome == OutgoingDatagramOutcome::Acked)
-    };
-    assert!(client.events().any(datagram_acked));
+    assert!(matches!(
+        client.next_event().unwrap(),
+        ConnectionEvent::OutgoingDatagramOutcome { id, outcome } if id == 1 && outcome == OutgoingDatagramOutcome::Acked
+    ));
 }
 
 #[test]
@@ -191,7 +194,7 @@ fn datagram_lost() {
     let (mut client, _) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU, Some(1)), Ok(()));
+    assert_eq!(client.send_datagram(DATA_SMALLER_THAN_MTU, Some(1)), Ok(()));
     let _out = client.process_output(now()).dgram(); // This packet will be lost.
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
@@ -205,12 +208,10 @@ fn datagram_lost() {
     assert_eq!(client.stats().frame_tx.ping, pings_sent + 1);
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent);
 
-    let datagram_lost = |e| {
-        matches!(
-        e,
-        ConnectionEvent::OutgoingDatagramOutcome { id, outcome } if id == 1 && outcome == OutgoingDatagramOutcome::Lost)
-    };
-    assert!(client.events().any(datagram_lost));
+    assert!(matches!(
+        client.next_event().unwrap(),
+        ConnectionEvent::OutgoingDatagramOutcome { id, outcome } if id == 1 && outcome == OutgoingDatagramOutcome::Lost
+    ));
 }
 
 #[test]
@@ -218,7 +219,7 @@ fn datagram_sent_once() {
     let (mut client, _) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU, Some(1)), Ok(()));
+    assert_eq!(client.send_datagram(DATA_SMALLER_THAN_MTU, Some(1)), Ok(()));
     let _out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
@@ -270,41 +271,42 @@ fn outgoing_datagram_queue_full() {
     let (mut client, mut server) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU, Some(1)), Ok(()));
+    assert_eq!(client.send_datagram(DATA_SMALLER_THAN_MTU, Some(1)), Ok(()));
     assert_eq!(
-        client.add_datagram(DATA_SMALLER_THAN_MTU_2, Some(2)),
+        client.send_datagram(DATA_SMALLER_THAN_MTU_2, Some(2)),
         Ok(())
     );
     // The outgoing datagram queue limit is 2, therefore the datagram with id 1
     // will be dropped after adding one more datagram.
-    assert_eq!(client.add_datagram(DATA_MTU, Some(3)), Ok(()));
-    let datagram_dropped = |e| {
-        matches!(
-        e,
-        ConnectionEvent::OutgoingDatagramOutcome{ id , outcome } if id == 1 && outcome == OutgoingDatagramOutcome::DroppedQueueFull)
-    };
-    assert!(client.events().any(datagram_dropped));
+    assert_eq!(client.send_datagram(DATA_MTU, Some(3)), Ok(()));
+    assert!(matches!(
+        client.next_event().unwrap(),
+        ConnectionEvent::OutgoingDatagramOutcome { id, outcome } if id == 1 && outcome == OutgoingDatagramOutcome::DroppedQueueFull
+    ));
 
     // Send DATA_SMALLER_THAN_MTU_2 datagram
     let out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
     server.process_input(out.unwrap(), now());
-    let datagram_1 =
-        |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU_2);
-    assert!(server.events().any(datagram_1));
+    assert!(matches!(
+        server.next_event().unwrap(),
+        ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU_2
+    ));
 
     // Send DATA_SMALLER_THAN_MTU_2 datagram
     let dgram_sent = client.stats().frame_tx.datagram;
     let out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
     server.process_input(out.unwrap(), now());
-    let datagram_2 = |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_MTU);
-    assert!(server.events().any(datagram_2));
+    assert!(matches!(
+        server.next_event().unwrap(),
+        ConnectionEvent::Datagram(data) if data == DATA_MTU
+    ));
 }
 
 fn send_datagram(client: &mut Connection, server: &mut Connection, data: &[u8]) {
     let dgram_sent = server.stats().frame_tx.datagram;
-    assert_eq!(server.add_datagram(data, Some(1)), Ok(()));
+    assert_eq!(server.send_datagram(data, Some(1)), Ok(()));
     let out = server.process_output(now()).dgram().unwrap();
     assert_eq!(server.stats().frame_tx.datagram, dgram_sent + 1);
 
@@ -325,7 +327,7 @@ fn multiple_datagram_events() {
     let mut client = new_client(
         ConnectionParameters::default()
             .datagram_size(u64::try_from(DATA_SIZE).unwrap())
-            .incoming_datagrams_queue(MAX_QUEUE),
+            .incoming_datagram_queue(MAX_QUEUE),
     );
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
@@ -371,7 +373,7 @@ fn too_many_datagram_events() {
     let mut client = new_client(
         ConnectionParameters::default()
             .datagram_size(u64::try_from(DATA_SIZE).unwrap())
-            .incoming_datagrams_queue(MAX_QUEUE),
+            .incoming_datagram_queue(MAX_QUEUE),
     );
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
@@ -381,28 +383,27 @@ fn too_many_datagram_events() {
     send_datagram(&mut client, &mut server, THIRD_DATAGRAM);
 
     // Datagram with FIRST_DATAGRAM data will be dropped.
-    let mut datagrams = client.events().filter_map(|evt| {
-        if let ConnectionEvent::Datagram(d) = evt {
-            Some(d)
-        } else {
-            None
-        }
-    });
-    assert_eq!(datagrams.next().unwrap(), SECOND_DATAGRAM);
-    assert_eq!(datagrams.next().unwrap(), THIRD_DATAGRAM);
-    assert!(datagrams.next().is_none());
+    assert!(matches!(
+        client.next_event().unwrap(),
+        ConnectionEvent::Datagram(data) if data == SECOND_DATAGRAM
+    ));
+    assert!(matches!(
+        client.next_event().unwrap(),
+        ConnectionEvent::IncomingDatagramDropped
+    ));
+    assert!(matches!(
+        client.next_event().unwrap(),
+        ConnectionEvent::Datagram(data) if data == THIRD_DATAGRAM
+    ));
+    assert!(client.next_event().is_none());
 
     // New events can be queued.
     send_datagram(&mut client, &mut server, FOURTH_DATAGRAM);
-    let mut datagrams = client.events().filter_map(|evt| {
-        if let ConnectionEvent::Datagram(d) = evt {
-            Some(d)
-        } else {
-            None
-        }
-    });
-    assert_eq!(datagrams.next().unwrap(), FOURTH_DATAGRAM);
-    assert!(datagrams.next().is_none())
+    assert!(matches!(
+        client.next_event().unwrap(),
+        ConnectionEvent::Datagram(data) if data == FOURTH_DATAGRAM
+    ));
+    assert!(client.next_event().is_none());
 }
 
 #[test]
@@ -410,13 +411,13 @@ fn multiple_quic_datagrams_in_one_packet() {
     let (mut client, mut server) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    // Que 2 datagrams that can fit in a single packet.
+    // Enqueue 2 datagrams that can fit in a single packet.
     assert_eq!(
-        client.add_datagram(DATA_SMALLER_THAN_MTU_2, Some(1)),
+        client.send_datagram(DATA_SMALLER_THAN_MTU_2, Some(1)),
         Ok(())
     );
     assert_eq!(
-        client.add_datagram(DATA_SMALLER_THAN_MTU_2, Some(2)),
+        client.send_datagram(DATA_SMALLER_THAN_MTU_2, Some(2)),
         Ok(())
     );
 

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -8,7 +8,7 @@ use super::{
     assert_error, connect_force_idle, default_client, default_server, new_client, new_server,
     AT_LEAST_PTO,
 };
-use crate::events::ConnectionEvent;
+use crate::events::{ConnectionEvent, OutgoingQuicDatagramOutcome};
 use crate::frame::FRAME_TYPE_DATAGRAM;
 use crate::packet::PacketBuilder;
 use crate::quic_datagrams::MAX_QUIC_DATAGRAM;
@@ -22,6 +22,8 @@ const DATA_MTU: &[u8] = &[1; 1310];
 const DATA_BIGGER_THAN_MTU: &[u8] = &[0; 2620];
 const DATAGRAM_LEN_SMALLER_THAN_MTU: u64 = 1200;
 const DATA_SMALLER_THAN_MTU: &[u8] = &[0; 1200];
+const DATA_SMALLER_THAN_MTU_2: &[u8] = &[0; 600];
+const OUTGOING_QUEUE: usize = 2;
 
 struct InsertDatagram<'a> {
     data: &'a [u8],
@@ -40,15 +42,15 @@ fn datagram_disabled_both() {
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
 
-    assert_eq!(client.max_datagram_size(), Err(Error::NotAvailable));
-    assert_eq!(server.max_datagram_size(), Err(Error::NotAvailable));
+    assert_eq!(client.max_quic_datagram_size(), Err(Error::NotAvailable));
+    assert_eq!(server.max_quic_datagram_size(), Err(Error::NotAvailable));
     assert_eq!(
-        client.add_datagram(DATA_SMALLER_THAN_MTU),
+        client.add_quic_datagram(DATA_SMALLER_THAN_MTU),
         Err(Error::TooMuchData)
     );
     assert_eq!(server.stats().frame_tx.datagram, 0);
     assert_eq!(
-        server.add_datagram(DATA_SMALLER_THAN_MTU),
+        server.add_quic_datagram(DATA_SMALLER_THAN_MTU),
         Err(Error::TooMuchData)
     );
     assert_eq!(server.stats().frame_tx.datagram, 0);
@@ -56,61 +58,68 @@ fn datagram_disabled_both() {
 
 #[test]
 fn datagram_enabled_on_client() {
-    let mut client =
-        new_client(ConnectionParameters::default().datagram_size(DATAGRAM_LEN_SMALLER_THAN_MTU));
+    let mut client = new_client(
+        ConnectionParameters::default().quic_datagram_size(DATAGRAM_LEN_SMALLER_THAN_MTU),
+    );
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
 
-    assert_eq!(client.max_datagram_size(), Err(Error::NotAvailable));
+    assert_eq!(client.max_quic_datagram_size(), Err(Error::NotAvailable));
     assert_eq!(
-        server.max_datagram_size(),
+        server.max_quic_datagram_size(),
         Ok(DATAGRAM_LEN_SMALLER_THAN_MTU)
     );
     assert_eq!(
-        client.add_datagram(DATA_SMALLER_THAN_MTU),
+        client.add_quic_datagram(DATA_SMALLER_THAN_MTU),
         Err(Error::TooMuchData)
     );
     let dgram_sent = server.stats().frame_tx.datagram;
-    assert_eq!(server.add_datagram(DATA_SMALLER_THAN_MTU), Ok(false));
+    assert_eq!(server.add_quic_datagram(DATA_SMALLER_THAN_MTU), Ok(()));
     let out = server.process_output(now()).dgram().unwrap();
     assert_eq!(server.stats().frame_tx.datagram, dgram_sent + 1);
 
     client.process_input(out, now());
     let datagram =
-        |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU);
+        |e| matches!(e, ConnectionEvent::QuicDatagram(data) if data == DATA_SMALLER_THAN_MTU);
     assert!(client.events().any(datagram));
 }
 
 #[test]
 fn datagram_enabled_on_server() {
     let mut client = default_client();
-    let mut server =
-        new_server(ConnectionParameters::default().datagram_size(DATAGRAM_LEN_SMALLER_THAN_MTU));
+    let mut server = new_server(
+        ConnectionParameters::default().quic_datagram_size(DATAGRAM_LEN_SMALLER_THAN_MTU),
+    );
     connect_force_idle(&mut client, &mut server);
 
     assert_eq!(
-        client.max_datagram_size(),
+        client.max_quic_datagram_size(),
         Ok(DATAGRAM_LEN_SMALLER_THAN_MTU)
     );
-    assert_eq!(server.max_datagram_size(), Err(Error::NotAvailable));
+    assert_eq!(server.max_quic_datagram_size(), Err(Error::NotAvailable));
     assert_eq!(
-        server.add_datagram(&DATA_SMALLER_THAN_MTU),
+        server.add_quic_datagram(&DATA_SMALLER_THAN_MTU),
         Err(Error::TooMuchData)
     );
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU), Ok(false));
+    assert_eq!(client.add_quic_datagram(DATA_SMALLER_THAN_MTU), Ok(()));
     let out = client.process_output(now()).dgram().unwrap();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
     server.process_input(out, now());
     let datagram =
-        |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU);
+        |e| matches!(e, ConnectionEvent::QuicDatagram(data) if data == DATA_SMALLER_THAN_MTU);
     assert!(server.events().any(datagram));
 }
 
 fn connect_datagram() -> (Connection, Connection) {
-    let mut client = new_client(ConnectionParameters::default().datagram_size(MAX_QUIC_DATAGRAM));
-    let mut server = new_server(ConnectionParameters::default().datagram_size(MAX_QUIC_DATAGRAM));
+    let mut client = new_client(
+        ConnectionParameters::default()
+            .quic_datagram_size(MAX_QUIC_DATAGRAM)
+            .queued_outgoing_quic_datagrams(OUTGOING_QUEUE),
+    );
+    let mut server =
+        new_server(ConnectionParameters::default().quic_datagram_size(MAX_QUIC_DATAGRAM));
     connect_force_idle(&mut client, &mut server);
     (client, server)
 }
@@ -119,8 +128,8 @@ fn connect_datagram() -> (Connection, Connection) {
 fn mtu_limit() {
     let (client, server) = connect_datagram();
 
-    assert_eq!(client.max_datagram_size(), Ok(DATAGRAM_LEN_MTU));
-    assert_eq!(server.max_datagram_size(), Ok(DATAGRAM_LEN_MTU));
+    assert_eq!(client.max_quic_datagram_size(), Ok(DATAGRAM_LEN_MTU));
+    assert_eq!(server.max_quic_datagram_size(), Ok(DATAGRAM_LEN_MTU));
 }
 
 #[test]
@@ -130,16 +139,19 @@ fn limit_data_size() {
     assert!(u64::try_from(DATA_BIGGER_THAN_MTU.len()).unwrap() > DATAGRAM_LEN_MTU);
     // Datagram can be queued because they are smaller than allowed by the peer,
     // but they cannot be sent.
-    assert_eq!(client.add_datagram(DATA_BIGGER_THAN_MTU), Ok(false));
-    assert_eq!(server.add_datagram(DATA_BIGGER_THAN_MTU), Ok(false));
+    assert_eq!(client.add_quic_datagram(DATA_BIGGER_THAN_MTU), Ok(()));
+    assert_eq!(server.add_quic_datagram(DATA_BIGGER_THAN_MTU), Ok(()));
 
     let dgram_sent_s = server.stats().frame_tx.datagram;
     assert!(server.process_output(now()).dgram().is_none());
     assert_eq!(server.stats().frame_tx.datagram, dgram_sent_s);
+    let datagram_dropped = |e| matches!(e, ConnectionEvent::OutgoingQuicDatagramOutcome { outcome, .. } if outcome == OutgoingQuicDatagramOutcome::DroppedTooBig);
+    assert!(server.events().any(datagram_dropped));
 
     let dgram_sent_c = client.stats().frame_tx.datagram;
     assert!(client.process_output(now()).dgram().is_none());
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent_c);
+    assert!(client.events().any(datagram_dropped));
 }
 
 #[test]
@@ -147,7 +159,7 @@ fn datagram_acked() {
     let (mut client, mut server) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU), Ok(false));
+    assert_eq!(client.add_quic_datagram(DATA_SMALLER_THAN_MTU), Ok(()));
     let out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
@@ -161,11 +173,11 @@ fn datagram_acked() {
     assert_eq!(server.stats().frame_tx.ack, ack_sent + 1);
 
     let datagram =
-        |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU);
+        |e| matches!(e, ConnectionEvent::QuicDatagram(data) if data == DATA_SMALLER_THAN_MTU);
     assert!(server.events().any(datagram));
 
     client.process_input(out.unwrap(), now);
-    let datagram_acked = |e| matches!(e, ConnectionEvent::DatagramAcked);
+    let datagram_acked = |e| matches!(e, ConnectionEvent::OutgoingQuicDatagramOutcome { outcome, .. } if outcome == OutgoingQuicDatagramOutcome::Acked);
     assert!(client.events().any(datagram_acked));
 }
 
@@ -174,7 +186,7 @@ fn datagram_lost() {
     let (mut client, _) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU), Ok(false));
+    assert_eq!(client.add_quic_datagram(DATA_SMALLER_THAN_MTU), Ok(()));
     let _out = client.process_output(now()).dgram(); // This packet will be lost.
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
@@ -188,7 +200,7 @@ fn datagram_lost() {
     assert_eq!(client.stats().frame_tx.ping, pings_sent + 1);
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent);
 
-    let datagram_lost = |e| matches!(e, ConnectionEvent::DatagramLost);
+    let datagram_lost = |e| matches!(e, ConnectionEvent::OutgoingQuicDatagramOutcome { outcome, .. } if outcome == OutgoingQuicDatagramOutcome::Lost);
     assert!(client.events().any(datagram_lost));
 }
 
@@ -197,7 +209,7 @@ fn datagram_sent_once() {
     let (mut client, _) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU), Ok(false));
+    assert_eq!(client.add_quic_datagram(DATA_SMALLER_THAN_MTU), Ok(()));
     let _out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
@@ -226,8 +238,9 @@ fn dgram_no_allowed() {
 
 #[test]
 fn dgram_too_big() {
-    let mut client =
-        new_client(ConnectionParameters::default().datagram_size(DATAGRAM_LEN_SMALLER_THAN_MTU));
+    let mut client = new_client(
+        ConnectionParameters::default().quic_datagram_size(DATAGRAM_LEN_SMALLER_THAN_MTU),
+    );
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
 
@@ -245,24 +258,38 @@ fn dgram_too_big() {
 }
 
 #[test]
-fn overwrite_datagram() {
+fn outgoing_datagram_queue_full() {
     let (mut client, mut server) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.add_datagram(DATA_SMALLER_THAN_MTU), Ok(false));
-    // overwrite datagram
-    assert_eq!(client.add_datagram(DATA_MTU), Ok(true));
+    assert_eq!(client.add_quic_datagram(DATA_SMALLER_THAN_MTU), Ok(()));
+    assert_eq!(client.add_quic_datagram(DATA_SMALLER_THAN_MTU_2), Ok(()));
+    // The outgoing datagram queue limit is 2, therefore DATA_SMALLER_THAN_MTU
+    // datagram will be dropped after adding one more datagram.
+    assert_eq!(client.add_quic_datagram(DATA_MTU), Ok(()));
+    let datagram_dropped = |e| matches!(e, ConnectionEvent::OutgoingQuicDatagramOutcome{ len , outcome } if len == DATA_SMALLER_THAN_MTU.len() && outcome == OutgoingQuicDatagramOutcome::DroppedQueueFull);
+    assert!(client.events().any(datagram_dropped));
+
+    // Send DATA_SMALLER_THAN_MTU_2 datagram
     let out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
-
     server.process_input(out.unwrap(), now());
-    let datagram = |e| matches!(e, ConnectionEvent::Datagram(data) if data == DATA_MTU);
-    assert!(server.events().any(datagram));
+    let datagram_1 =
+        |e| matches!(e, ConnectionEvent::QuicDatagram(data) if data == DATA_SMALLER_THAN_MTU_2);
+    assert!(server.events().any(datagram_1));
+
+    // Send DATA_SMALLER_THAN_MTU_2 datagram
+    let dgram_sent = client.stats().frame_tx.datagram;
+    let out = client.process_output(now()).dgram();
+    assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
+    server.process_input(out.unwrap(), now());
+    let datagram_2 = |e| matches!(e, ConnectionEvent::QuicDatagram(data) if data == DATA_MTU);
+    assert!(server.events().any(datagram_2));
 }
 
 fn send_datagram(client: &mut Connection, server: &mut Connection, data: &[u8]) {
     let dgram_sent = server.stats().frame_tx.datagram;
-    assert_eq!(server.add_datagram(data), Ok(false));
+    assert_eq!(server.add_quic_datagram(data), Ok(()));
     let out = server.process_output(now()).dgram().unwrap();
     assert_eq!(server.stats().frame_tx.datagram, dgram_sent + 1);
 
@@ -282,8 +309,8 @@ fn multiple_datagram_events() {
 
     let mut client = new_client(
         ConnectionParameters::default()
-            .datagram_size(u64::try_from(DATA_SIZE).unwrap())
-            .queued_datagrams(MAX_QUEUE),
+            .quic_datagram_size(u64::try_from(DATA_SIZE).unwrap())
+            .queued_incoming_quic_datagrams(MAX_QUEUE),
     );
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
@@ -293,7 +320,7 @@ fn multiple_datagram_events() {
     send_datagram(&mut client, &mut server, THIRD_DATAGRAM);
 
     let mut datagrams = client.events().filter_map(|evt| {
-        if let ConnectionEvent::Datagram(d) = evt {
+        if let ConnectionEvent::QuicDatagram(d) = evt {
             Some(d)
         } else {
             None
@@ -307,7 +334,7 @@ fn multiple_datagram_events() {
     // New events can be queued.
     send_datagram(&mut client, &mut server, FOURTH_DATAGRAM);
     let mut datagrams = client.events().filter_map(|evt| {
-        if let ConnectionEvent::Datagram(d) = evt {
+        if let ConnectionEvent::QuicDatagram(d) = evt {
             Some(d)
         } else {
             None
@@ -328,8 +355,8 @@ fn too_many_datagram_events() {
 
     let mut client = new_client(
         ConnectionParameters::default()
-            .datagram_size(u64::try_from(DATA_SIZE).unwrap())
-            .queued_datagrams(MAX_QUEUE),
+            .quic_datagram_size(u64::try_from(DATA_SIZE).unwrap())
+            .queued_incoming_quic_datagrams(MAX_QUEUE),
     );
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
@@ -340,7 +367,7 @@ fn too_many_datagram_events() {
 
     // Datagram with FIRST_DATAGRAM data will be dropped.
     let mut datagrams = client.events().filter_map(|evt| {
-        if let ConnectionEvent::Datagram(d) = evt {
+        if let ConnectionEvent::QuicDatagram(d) = evt {
             Some(d)
         } else {
             None
@@ -353,7 +380,7 @@ fn too_many_datagram_events() {
     // New events can be queued.
     send_datagram(&mut client, &mut server, FOURTH_DATAGRAM);
     let mut datagrams = client.events().filter_map(|evt| {
-        if let ConnectionEvent::Datagram(d) = evt {
+        if let ConnectionEvent::QuicDatagram(d) = evt {
             Some(d)
         } else {
             None
@@ -361,4 +388,20 @@ fn too_many_datagram_events() {
     });
     assert_eq!(datagrams.next().unwrap(), FOURTH_DATAGRAM);
     assert!(datagrams.next().is_none())
+}
+
+#[test]
+fn multiple_quic_datagrams_in_one_packet() {
+    let (mut client, mut server) = connect_datagram();
+
+    let dgram_sent = client.stats().frame_tx.datagram;
+    // Que 2 datagrams that can fit in a single packet.
+    assert_eq!(client.add_quic_datagram(DATA_SMALLER_THAN_MTU_2), Ok(()));
+    assert_eq!(client.add_quic_datagram(DATA_SMALLER_THAN_MTU_2), Ok(()));
+
+    let out = client.process_output(now()).dgram();
+    assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 2);
+    server.process_input(out.unwrap(), now());
+    let datagram = |e: &_| matches!(e, ConnectionEvent::QuicDatagram(..));
+    assert_eq!(server.events().filter(datagram).count(), 2);
 }

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -11,6 +11,7 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 
 use crate::connection::State;
+use crate::quic_datagrams::DatagramTracking;
 use crate::stream_id::{StreamId, StreamType};
 use crate::AppError;
 use neqo_common::event::Provider as EventProvider;
@@ -200,11 +201,15 @@ impl ConnectionEvents {
             .push_back(ConnectionEvent::Datagram(data.to_vec()));
     }
 
-    pub fn datagram_outcome(&self, id: Option<u64>, outcome: OutgoingDatagramOutcome) {
-        if let Some(d_id) = id {
+    pub fn datagram_outcome(
+        &self,
+        dgram_tracker: &DatagramTracking,
+        outcome: OutgoingDatagramOutcome,
+    ) {
+        if let DatagramTracking::Id(id) = dgram_tracker {
             self.events
                 .borrow_mut()
-                .push_back(ConnectionEvent::OutgoingDatagramOutcome { id: d_id, outcome });
+                .push_back(ConnectionEvent::OutgoingDatagramOutcome { id: *id, outcome });
         }
     }
 

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -89,7 +89,7 @@ pub enum RecoveryToken {
     NewConnectionId(ConnectionIdEntry<[u8; 16]>),
     RetireConnectionId(u64),
     AckFrequency(AckRate),
-    QuicDatagram(usize),
+    Datagram(Option<u64>),
 }
 
 /// `SendProfile` tells a sender how to send packets.

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -24,6 +24,7 @@ use crate::crypto::CryptoRecoveryToken;
 use crate::packet::PacketNumber;
 use crate::path::{Path, PathRef};
 use crate::qlog::{self, QlogMetric};
+use crate::quic_datagrams::DatagramTracking;
 use crate::rtt::RttEstimate;
 use crate::send_stream::SendStreamRecoveryToken;
 use crate::stats::{Stats, StatsCell};
@@ -89,7 +90,7 @@ pub enum RecoveryToken {
     NewConnectionId(ConnectionIdEntry<[u8; 16]>),
     RetireConnectionId(u64),
     AckFrequency(AckRate),
-    Datagram(Option<u64>),
+    Datagram(DatagramTracking),
 }
 
 /// `SendProfile` tells a sender how to send packets.

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -89,7 +89,7 @@ pub enum RecoveryToken {
     NewConnectionId(ConnectionIdEntry<[u8; 16]>),
     RetireConnectionId(u64),
     AckFrequency(AckRate),
-    Datagram,
+    QuicDatagram(usize),
 }
 
 /// `SendProfile` tells a sender how to send packets.


### PR DESCRIPTION
Additional changes:
- The IncomingQuicDatagramDropped event is queued when a queued QuicDatagram event gets dropped due to the number of queued datagrams exceeding the limit. The limit is controlled by a connection parameter.
- The OutgoingQuicDatagramOutcome event is queued when the outcome of the outgoing of a QuicDatagram is known. It can be: lost, asked, dropped because the outgoing queue of datagrams is full(The limit is controlled by a connection parameter) or it can be dropped because it does not fit into a quic packet.
- Change name of some parameters and events from datagram/Datagram to quic_datagram/QuicDatagram for consistency. This does not apply to the QuicDatagram structure because the structure is about QuicDatagrams.
- Fix a bug: multiple Datagrams containing the same data were not queued, just silently dropped because insert() function was used that checks for duplicate events. In this case we want to queue duplicate events.

Fixes #1203 and #1207 