### PR TITLE
Lots of lints

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -334,7 +334,7 @@ fn process_loop(
         loop {
             match client.process_output(Instant::now()) {
                 Output::Datagram(dgram) => {
-                    if let Err(e) = emit_datagram(&socket, dgram) {
+                    if let Err(e) = emit_datagram(socket, dgram) {
                         eprintln!("UDP write error: {}", e);
                         client.close(Instant::now(), 0, e.to_string());
                         exiting = true;
@@ -415,9 +415,9 @@ impl<'a> Handler<'a> {
         match client.fetch(
             Instant::now(),
             &self.args.method,
-            &url.scheme(),
-            &url.host_str().unwrap(),
-            &url.path(),
+            url.scheme(),
+            url.host_str().unwrap(),
+            url.path(),
             &to_headers(&self.args.header),
             Priority::default(),
         ) {
@@ -620,7 +620,7 @@ fn client(
         streams: HashMap::new(),
         url_queue: VecDeque::from(urls.to_vec()),
         all_paths: Vec::new(),
-        args: &args,
+        args,
         key_update,
     };
 
@@ -1017,7 +1017,7 @@ mod old {
             loop {
                 match client.process_output(Instant::now()) {
                     Output::Datagram(dgram) => {
-                        if let Err(e) = emit_datagram(&socket, dgram) {
+                        if let Err(e) = emit_datagram(socket, dgram) {
                             eprintln!("UDP write error: {}", e);
                             client.close(Instant::now(), 0, e.to_string());
                             exiting = true;
@@ -1099,19 +1099,19 @@ mod old {
             client.set_ciphers(&ciphers)?;
         }
 
-        client.set_qlog(qlog_new(args, origin, &client.odcid().unwrap())?);
+        client.set_qlog(qlog_new(args, origin, client.odcid().unwrap())?);
 
         let key_update = KeyUpdateState(args.key_update);
         let mut h = HandlerOld {
             streams: HashMap::new(),
             url_queue: VecDeque::from(urls.to_vec()),
             all_paths: Vec::new(),
-            args: &args,
+            args,
             token: None,
             key_update,
         };
 
-        process_loop_old(&local_addr, &socket, &mut client, &mut h)?;
+        process_loop_old(&local_addr, socket, &mut client, &mut h)?;
 
         let token = if args.resume {
             // If we haven't received an event, take a token if there is one.

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -253,7 +253,7 @@ impl Encoder {
     /// Note: for a view of a slice, use `Decoder::new(&enc[s..e])`
     #[must_use]
     pub fn as_decoder(&self) -> Decoder {
-        Decoder::new(&self)
+        Decoder::new(self)
     }
 
     /// Don't use this except in testing.
@@ -335,7 +335,7 @@ impl Encoder {
         let len = self.buf.len() - start - n;
         assert!(len < (1 << (n * 8)));
         for i in 0..n {
-            self.buf[start + i] = ((len >> (8 * (n - i - 1))) & 0xff) as u8
+            self.buf[start + i] = ((len >> (8 * (n - i - 1))) & 0xff) as u8;
         }
         self
     }
@@ -671,7 +671,7 @@ mod tests {
     fn builder_from_slice() {
         let slice = &[1, 2, 3];
         let enc = Encoder::from(&slice[..]);
-        assert_eq!(enc, Encoder::from_hex("010203"))
+        assert_eq!(enc, Encoder::from_hex("010203"));
     }
 
     #[test]

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -95,7 +95,7 @@ impl fmt::Debug for NeqoQlogShared {
 impl Drop for NeqoQlogShared {
     fn drop(&mut self) {
         if let Err(e) = self.streamer.finish_log() {
-            crate::do_log!(::log::Level::Error, "Error dropping NeqoQlog: {}", e)
+            crate::do_log!(::log::Level::Error, "Error dropping NeqoQlog: {}", e);
         }
     }
 }

--- a/neqo-common/src/timer.rs
+++ b/neqo-common/src/timer.rs
@@ -304,8 +304,7 @@ mod test {
         let v = 9;
         t.add(future, v);
         assert_eq!(future, t.next_time().expect("should return a value"));
-        let values: Vec<_> = t.take_until(future).collect();
-        assert!(values.contains(&v));
+        assert!(t.take_until(future).any(|x| x == v));
     }
 
     #[test]
@@ -315,8 +314,7 @@ mod test {
         let v = 9;
         t.add(far_future, v);
         assert_eq!(far_future, t.next_time().expect("should return a value"));
-        let values: Vec<_> = t.take_until(far_future).collect();
-        assert!(values.contains(&v));
+        assert!(t.take_until(far_future).any(|x| x == v));
     }
 
     const TIMES: &[Duration] = &[
@@ -341,6 +339,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::needless_collect)] // false positive
     fn multiple_values() {
         let mut t = with_times();
         let values: Vec<_> = t.take_until(*NOW + *TIMES.iter().max().unwrap()).collect();
@@ -350,6 +349,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::needless_collect)] // false positive
     fn take_far_future() {
         let mut t = with_times();
         let values: Vec<_> = t.take_until(*NOW + Duration::from_secs(100)).collect();

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -71,12 +71,7 @@ impl HandshakeState {
     }
 }
 
-#[allow(
-    unknown_lints,
-    renamed_and_removed_lints,
-    clippy::unknown_clippy_lints,
-    clippy::unnested_or_patterns
-)] // Until we require rust 1.53 we can't use or_patterns.
+#[allow(clippy::unnested_or_patterns)] // Until we require rust 1.53 we can't use or_patterns.
 fn get_alpn(fd: *mut ssl::PRFileDesc, pre: bool) -> Res<Option<String>> {
     let mut alpn_state = ssl::SSLNextProtoState::SSL_NEXT_PROTO_NO_SUPPORT;
     let mut chosen = vec![0_u8; 255];

--- a/neqo-crypto/src/agentio.rs
+++ b/neqo-crypto/src/agentio.rs
@@ -177,14 +177,16 @@ impl AgentIoInput {
     fn read_input(&mut self, buf: *mut u8, count: usize) -> Res<usize> {
         let amount = min(self.available, count);
         if amount == 0 {
-            unsafe { PR_SetError(nspr::PR_WOULD_BLOCK_ERROR, 0) };
+            unsafe {
+                PR_SetError(nspr::PR_WOULD_BLOCK_ERROR, 0);
+            }
             return Err(Error::NoDataAvailable);
         }
 
         let src = unsafe { std::slice::from_raw_parts(self.input, amount) };
         qtrace!([self], "read {}", hex(src));
         let dst = unsafe { std::slice::from_raw_parts_mut(buf, amount) };
-        dst.copy_from_slice(&src);
+        dst.copy_from_slice(src);
         self.input = self.input.wrapping_add(amount);
         self.available -= amount;
         Ok(amount)

--- a/neqo-crypto/src/ech.rs
+++ b/neqo-crypto/src/ech.rs
@@ -183,7 +183,7 @@ pub fn encode_config(config: u8, public_name: &str, pk: &PublicKey) -> Res<Vec<u
             encoded.as_mut_ptr(),
             &mut encoded_len,
             c_uint::try_from(encoded.len())?,
-        )?
-    };
+        )?;
+    }
     Ok(Vec::from(&encoded[..usize::try_from(encoded_len)?]))
 }

--- a/neqo-crypto/src/err.rs
+++ b/neqo-crypto/src/err.rs
@@ -150,7 +150,9 @@ mod tests {
     fn set_error_code(code: PRErrorCode) {
         // This code doesn't work without initializing NSS first.
         fixture_init();
-        unsafe { PR_SetError(code, 0) };
+        unsafe {
+            PR_SetError(code, 0);
+        }
     }
 
     #[test]

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -100,7 +100,9 @@ enum NssLoaded {
 impl Drop for NssLoaded {
     fn drop(&mut self) {
         if !matches!(self, Self::External) {
-            unsafe { secstatus_to_res(nss::NSS_Shutdown()).expect("NSS Shutdown failed") }
+            unsafe {
+                secstatus_to_res(nss::NSS_Shutdown()).expect("NSS Shutdown failed");
+            }
         }
     }
 }

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -148,7 +148,9 @@ impl PrivateKey {
         // The data that `key_item` refers to needs to be freed, but we can't
         // use the scoped `Item` implementation.  This is OK as long as nothing
         // panics between `PK11_ReadRawAttribute` succeeding and here.
-        unsafe { SECITEM_FreeItem(&mut key_item, PRBool::from(false)) };
+        unsafe {
+            SECITEM_FreeItem(&mut key_item, PRBool::from(false));
+        }
         Ok(key)
     }
 }

--- a/neqo-crypto/tests/agent.rs
+++ b/neqo-crypto/tests/agent.rs
@@ -128,8 +128,7 @@ fn raw() {
 
     // The client should have one certificate for the server.
     let mut certs = client.peer_certificate().unwrap();
-    let cert_vec: Vec<&[u8]> = certs.collect();
-    assert_eq!(1, cert_vec.len());
+    assert_eq!(1, certs.count());
 
     // The server shouldn't have a client certificate.
     assert!(server.peer_certificate().is_none());

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -198,7 +198,7 @@ impl Http3ClientEvents {
     where
         F: Fn(&Http3ClientEvent) -> bool,
     {
-        self.events.borrow_mut().retain(|evt| !f(evt))
+        self.events.borrow_mut().retain(|evt| !f(evt));
     }
 
     /// Add a new `StateChange` event.

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -150,12 +150,7 @@ impl Http3Connection {
     }
 
     /// Call `send` for all streams that need to send data.
-    #[allow(
-        unknown_lints,
-        renamed_and_removed_lints,
-        clippy::unknown_clippy_lints,
-        clippy::unnested_or_patterns
-    )] // Until we require rust 1.53 we can't use or_patterns.
+    #[allow(clippy::unnested_or_patterns)] // Until we require rust 1.53 we can't use or_patterns.
     pub fn process_sending(&mut self, conn: &mut Connection) -> Res<()> {
         // check if control stream has data to send.
         self.control_stream_local
@@ -274,6 +269,7 @@ impl Http3Connection {
             output = self.handle_new_stream(conn, stream_type, stream_id)?;
         }
 
+        #[allow(clippy::match_same_arms)] // clippy is being stupid here
         match output {
             ReceiveOutput::UnblockedStreams(unblocked_streams) => {
                 self.handle_unblocked_streams(unblocked_streams, conn)?;
@@ -457,7 +453,7 @@ impl Http3Connection {
                     )),
                 );
             }
-            _ => {
+            NewStreamType::Unknown => {
                 conn.stream_stop_sending(stream_id, Error::HttpStreamCreation.code())?;
             }
         };
@@ -467,7 +463,7 @@ impl Http3Connection {
                 self.stream_receive(conn, stream_id)
             }
             NewStreamType::Push(_) => Ok(ReceiveOutput::NewStream(stream_type)),
-            _ => Ok(ReceiveOutput::NoOutput),
+            NewStreamType::Unknown => Ok(ReceiveOutput::NoOutput),
         }
     }
 
@@ -566,7 +562,7 @@ impl Http3Connection {
             qinfo!([self], " {:?} = {:?}", s.setting_type, s.value);
             match s.setting_type {
                 HSettingType::MaxTableCapacity => {
-                    self.qpack_encoder.borrow_mut().set_max_capacity(s.value)?
+                    self.qpack_encoder.borrow_mut().set_max_capacity(s.value)?;
                 }
                 HSettingType::BlockedStreams => self
                     .qpack_encoder

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -263,7 +263,7 @@ impl Http3Client {
     /// is created. A response body may be added by calling `send_request_body`.
     /// # Errors
     /// If a new stream cannot be created an error will be return.
-    #[allow(clippy::too_many_arguments)] //
+    #[allow(clippy::too_many_arguments)] // https://github.com/mozilla/neqo/issues/1226
     pub fn fetch(
         &mut self,
         now: Instant,

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -140,7 +140,7 @@ impl Http3ServerHandler {
                         .handle_new_unidi_stream(stream_id.as_u64(), Role::Server),
                 },
                 ConnectionEvent::RecvStreamReadable { stream_id } => {
-                    self.handle_stream_readable(conn, stream_id)?
+                    self.handle_stream_readable(conn, stream_id)?;
                 }
                 ConnectionEvent::RecvStreamReset {
                     stream_id,

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -67,7 +67,7 @@ impl ControlStreamLocal {
             }
             // only send priority updates if all buffer data has been sent
             if self.buf.is_empty() {
-                self.send_priority_update(stream_id, conn, recv_conn)?
+                self.send_priority_update(stream_id, conn, recv_conn)?;
             }
         }
         Ok(())

--- a/neqo-http3/src/control_stream_remote.rs
+++ b/neqo-http3/src/control_stream_remote.rs
@@ -47,6 +47,7 @@ impl RecvStream for ControlStreamRemote {
         Err(Error::HttpClosedCriticalStream)
     }
 
+    #[allow(clippy::vec_init_then_push)] // Clippy fail.
     fn receive(&mut self, conn: &mut Connection) -> Res<ReceiveOutput> {
         let mut control_frames = Vec::new();
 

--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -722,7 +722,7 @@ mod tests {
     ) {
         let mut fr = HFrameReaderTest::new();
 
-        fr.conn_s.stream_send(fr.stream_id, &buf).unwrap();
+        fr.conn_s.stream_send(fr.stream_id, buf).unwrap();
         if let FrameReadingTestSend::DataWithFin = test_to_send {
             fr.conn_s.stream_close_send(fr.stream_id).unwrap();
         }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -6,7 +6,6 @@
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::pedantic)]
-#![allow(clippy::pub_enum_variant_names)]
 
 mod client_events;
 mod connection;
@@ -50,6 +49,11 @@ pub use stream_type_reader::NewStreamType;
 type Res<T> = Result<T, Error>;
 
 #[derive(Clone, Debug, PartialEq)]
+#[allow(
+    renamed_and_removed_lints,
+    clippy::pub_enum_variant_names,
+    clippy::enum_variant_names
+)]
 pub enum Error {
     HttpNoError,
     HttpGeneralProtocol,
@@ -122,12 +126,7 @@ impl Error {
     }
 
     #[must_use]
-    #[allow(
-        unknown_lints,
-        renamed_and_removed_lints,
-        clippy::unknown_clippy_lints,
-        clippy::unnested_or_patterns
-    )] // Until we require rust 1.53 we can't use or_patterns.
+    #[allow(clippy::unnested_or_patterns)] // Until we require rust 1.53 we can't use or_patterns.
     pub fn connection_error(&self) -> bool {
         matches!(
             self,

--- a/neqo-http3/src/push_stream.rs
+++ b/neqo-http3/src/push_stream.rs
@@ -77,13 +77,11 @@ impl Display for PushStream {
 
 impl RecvStream for PushStream {
     fn receive(&mut self, conn: &mut Connection) -> Res<ReceiveOutput> {
-        loop {
-            self.response.receive(conn)?;
-            if self.response.done() {
-                self.push_handler.borrow_mut().close(self.push_id);
-            }
-            return Ok(ReceiveOutput::NoOutput);
+        self.response.receive(conn)?;
+        if self.response.done() {
+            self.push_handler.borrow_mut().close(self.push_id);
         }
+        Ok(ReceiveOutput::NoOutput)
     }
 
     fn done(&self) -> bool {

--- a/neqo-http3/src/qlog.rs
+++ b/neqo-http3/src/qlog.rs
@@ -20,7 +20,7 @@ pub fn h3_data_moved_up(qlog: &mut NeqoQlog, stream_id: u64, amount: usize) {
             Some(H3DataRecipient::Application),
             None,
         ))
-    })
+    });
 }
 
 pub fn h3_data_moved_down(qlog: &mut NeqoQlog, stream_id: u64, amount: usize) {
@@ -33,5 +33,5 @@ pub fn h3_data_moved_down(qlog: &mut NeqoQlog, stream_id: u64, amount: usize) {
             Some(H3DataRecipient::Transport),
             None,
         ))
-    })
+    });
 }

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -192,7 +192,7 @@ impl RecvMessage {
             RecvMessageState::WaitingForData { .. }
             | RecvMessageState::WaitingForFinAfterTrailers { .. } => {
                 if post_readable_event {
-                    self.conn_events.data_readable(self.stream_id)
+                    self.conn_events.data_readable(self.stream_id);
                 }
             }
             _ => unreachable!("Closing an already closed transaction."),
@@ -222,7 +222,7 @@ impl RecvMessage {
                 .as_ref()
                 .ok_or(Error::HttpFrameUnexpected)?
                 .borrow_mut()
-                .new_push_promise(push_id, self.stream_id, headers)?
+                .new_push_promise(push_id, self.stream_id, headers)?;
         } else {
             self.blocked_push_promise.push_back(PushInfo {
                 push_id,
@@ -256,7 +256,7 @@ impl RecvMessage {
                             );
                             match frame {
                                 HFrame::Headers { header_block } => {
-                                    self.handle_headers_frame(header_block, fin)?
+                                    self.handle_headers_frame(header_block, fin)?;
                                 }
                                 HFrame::Data { len } => self.handle_data_frame(len, fin)?,
                                 HFrame::PushPromise {
@@ -389,7 +389,7 @@ impl RecvMessage {
         let mut pseudo_state = 0;
         for header in headers {
             let is_pseudo =
-                Self::track_pseudo(&header.name(), &mut pseudo_state, &self.message_type)?;
+                Self::track_pseudo(header.name(), &mut pseudo_state, &self.message_type)?;
 
             let mut bytes = header.name().bytes();
             if is_pseudo {

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -198,7 +198,7 @@ impl SendMessage {
     fn ensure_encoded(&mut self, conn: &mut Connection, encoder: &mut QPackEncoder) -> Res<()> {
         if let SendMessageState::Initialized { headers, data, fin } = &self.state {
             qdebug!([self], "Encoding headers");
-            let header_block = encoder.encode_header_block(conn, &headers, self.stream_id)?;
+            let header_block = encoder.encode_header_block(conn, headers, self.stream_id)?;
             let hframe = HFrame::Headers {
                 header_block: header_block.to_vec(),
             };
@@ -210,7 +210,7 @@ impl SendMessage {
                     len: buf.len() as u64,
                 };
                 d_frame.encode(&mut d);
-                d.encode(&buf);
+                d.encode(buf);
             }
 
             self.state = SendMessageState::SendingInitialMessage {
@@ -239,7 +239,7 @@ impl SendMessage {
 
         if let SendMessageState::SendingInitialMessage { ref mut buf, fin } = self.state {
             let sent = Error::map_error(
-                conn.stream_send(self.stream_id, &buf),
+                conn.stream_send(self.stream_id, buf),
                 Error::HttpInternal(5),
             )?;
             qlog::h3_data_moved_down(&mut conn.qlog_mut(), self.stream_id, sent);

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -74,7 +74,7 @@ impl Http3Server {
     }
 
     pub fn set_qlog_dir(&mut self, dir: Option<PathBuf>) {
-        self.server.set_qlog_dir(dir)
+        self.server.set_qlog_dir(dir);
     }
 
     pub fn set_validation(&mut self, v: ValidateAddress) {
@@ -133,7 +133,7 @@ impl Http3Server {
             .http3_handlers
             .iter()
             .filter_map(|(conn, handler)| {
-                if handler.borrow_mut().should_be_processed() && !active_conns.contains(&conn) {
+                if handler.borrow_mut().should_be_processed() && !active_conns.contains(conn) {
                     Some(conn)
                 } else {
                     None
@@ -177,7 +177,7 @@ impl Http3Server {
                                 stream_id,
                                 &mut handler_borrowed,
                                 &mut conn,
-                                &handler,
+                                handler,
                                 now,
                                 &mut self.events,
                             );
@@ -302,12 +302,7 @@ mod tests {
         create_server(DEFAULT_SETTINGS)
     }
 
-    #[allow(
-        unknown_lints,
-        renamed_and_removed_lints,
-        clippy::unknown_clippy_lints,
-        clippy::unnested_or_patterns
-    )] // Until we require rust 1.53 we can't use or_patterns.
+    #[allow(clippy::unnested_or_patterns)] // Until we require rust 1.53 we can't use or_patterns.
     fn assert_closed(hconn: &mut Http3Server, expected: &Error) {
         let err = ConnectionError::Application(expected.code());
         let closed = |e| {
@@ -876,8 +871,7 @@ mod tests {
                         .unwrap();
                     data_received += 1;
                 }
-                Http3ServerEvent::StateChange { .. } => {}
-                Http3ServerEvent::PriorityUpdate { .. } => {}
+                Http3ServerEvent::StateChange { .. } | Http3ServerEvent::PriorityUpdate { .. } => {}
             }
         }
         assert_eq!(headers_frames, 1);
@@ -925,8 +919,7 @@ mod tests {
                 Http3ServerEvent::Data { .. } => {
                     panic!("We should not have a Data event");
                 }
-                Http3ServerEvent::StateChange { .. } => {}
-                Http3ServerEvent::PriorityUpdate { .. } => {}
+                Http3ServerEvent::StateChange { .. } | Http3ServerEvent::PriorityUpdate { .. } => {}
             }
         }
         let out = hconn.process(None, now());
@@ -948,8 +941,7 @@ mod tests {
                 Http3ServerEvent::Data { .. } => {
                     panic!("We should not have a Data event");
                 }
-                Http3ServerEvent::StateChange { .. } => {}
-                Http3ServerEvent::PriorityUpdate { .. } => {}
+                Http3ServerEvent::StateChange { .. } | Http3ServerEvent::PriorityUpdate { .. } => {}
             }
         }
         assert_eq!(headers_frames, 1);
@@ -988,8 +980,7 @@ mod tests {
                 Http3ServerEvent::Data { .. } => {
                     panic!("We should not have a Data event");
                 }
-                Http3ServerEvent::StateChange { .. } => {}
-                Http3ServerEvent::PriorityUpdate { .. } => {}
+                Http3ServerEvent::StateChange { .. } | Http3ServerEvent::PriorityUpdate { .. } => {}
             }
         }
         let out = hconn.process(None, now());
@@ -1191,13 +1182,13 @@ mod tests {
         let request_stream_id_1 = peer_conn.stream_create(StreamType::BiDi).unwrap();
         // Send only request headers for now.
         peer_conn
-            .stream_send(request_stream_id_1, &REQUEST_WITH_BODY)
+            .stream_send(request_stream_id_1, REQUEST_WITH_BODY)
             .unwrap();
 
         let request_stream_id_2 = peer_conn.stream_create(StreamType::BiDi).unwrap();
         // Send only request headers for now.
         peer_conn
-            .stream_send(request_stream_id_2, &REQUEST_WITH_BODY)
+            .stream_send(request_stream_id_2, REQUEST_WITH_BODY)
             .unwrap();
 
         let out = peer_conn.process(None, now());
@@ -1213,8 +1204,7 @@ mod tests {
                 Http3ServerEvent::Data { request, .. } => {
                     assert!(requests.get(&request).is_some());
                 }
-                Http3ServerEvent::StateChange { .. } => {}
-                Http3ServerEvent::PriorityUpdate { .. } => {}
+                Http3ServerEvent::StateChange { .. } | Http3ServerEvent::PriorityUpdate { .. } => {}
             }
         }
         assert_eq!(requests.len(), 2);

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -80,7 +80,7 @@ impl Http3ServerConnEvents {
     where
         F: Fn(&Http3ServerConnEvent) -> bool,
     {
-        self.events.borrow_mut().retain(|evt| !f(evt))
+        self.events.borrow_mut().retain(|evt| !f(evt));
     }
 
     pub fn has_events(&self) -> bool {
@@ -99,7 +99,7 @@ impl Http3ServerConnEvents {
         self.insert(Http3ServerConnEvent::PriorityUpdate {
             stream_id,
             priority,
-        })
+        });
     }
 
     pub fn remove_events_for_stream_id(&self, stream_id: u64) {

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -176,6 +176,6 @@ impl Http3ServerEvents {
         self.insert(Http3ServerEvent::PriorityUpdate {
             stream_id,
             priority,
-        })
+        });
     }
 }

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -33,7 +33,7 @@ impl NewStreamType {
     /// # Error
     /// Push streams received by the server are not allowed and this function will return
     /// `HttpStreamCreation` error.
-    fn final_stream_type(stream_type: u64, role: &Role) -> Res<Option<NewStreamType>> {
+    fn final_stream_type(stream_type: u64, role: Role) -> Res<Option<NewStreamType>> {
         match (stream_type, role) {
             (HTTP3_UNI_STREAM_TYPE_CONTROL, _) => Ok(Some(NewStreamType::Control)),
             (QPACK_UNI_STREAM_TYPE_ENCODER, _) => Ok(Some(NewStreamType::Decoder)),
@@ -50,8 +50,8 @@ impl NewStreamType {
 ///  - streams identified by the single type (varint encoded). Most streams belong to
 ///    this category. The `NewStreamHeadReader` will switch from `ReadType`to `Done` state.
 ///  - streams identified by the type and the ID (both varint encoded). For example, a
-///    push stream is identified by the type and PushId. After reading the type in
-///    the `ReadType` state, `NewStreamHeadReader` changes to ReadId state and from there
+///    push stream is identified by the type and `PushId`. After reading the type in
+///    the `ReadType` state, `NewStreamHeadReader` changes to `ReadId` state and from there
 ///    to `Done` state
 #[derive(Debug)]
 pub enum NewStreamHeadReader {
@@ -125,7 +125,7 @@ impl NewStreamHeadReader {
                     //  - None - if a stream is not identified by the type only, but it needs
                     //    additional data from the header to produce the final type, e.g.
                     //    a push stream needs pushId as well.
-                    let final_type = NewStreamType::final_stream_type(output, role);
+                    let final_type = NewStreamType::final_stream_type(output, *role);
                     match (&final_type, fin) {
                         (Err(_), _) => {
                             *self = NewStreamHeadReader::Done;
@@ -133,7 +133,7 @@ impl NewStreamHeadReader {
                         }
                         (Ok(t), true) => {
                             *self = NewStreamHeadReader::Done;
-                            return self.map_stream_fin(*t);
+                            return Self::map_stream_fin(*t);
                         }
                         (Ok(Some(t)), false) => {
                             qtrace!("Decoded stream type {:?}", *t);
@@ -158,13 +158,14 @@ impl NewStreamHeadReader {
                     return Ok(Some(NewStreamType::Push(output)));
                 }
                 NewStreamHeadReader::Done => {
-                    unreachable!("Cannot be in state NewStreamHeadReader::Done")
+                    unreachable!("Cannot be in state NewStreamHeadReader::Done");
                 }
             }
         }
     }
 
-    fn map_stream_fin(&self, decoded: Option<NewStreamType>) -> Res<Option<NewStreamType>> {
+    #[allow(clippy::unnested_or_patterns)] // Until we require rust 1.53 we can't use or_patterns.
+    fn map_stream_fin(decoded: Option<NewStreamType>) -> Res<Option<NewStreamType>> {
         match decoded {
             Some(NewStreamType::Control)
             | Some(NewStreamType::Encoder)
@@ -187,7 +188,7 @@ impl RecvStream for NewStreamHeadReader {
     fn receive(&mut self, conn: &mut Connection) -> Res<ReceiveOutput> {
         Ok(self
             .get_type(conn)?
-            .map_or(ReceiveOutput::NoOutput, |t| ReceiveOutput::NewStream(t)))
+            .map_or(ReceiveOutput::NoOutput, ReceiveOutput::NewStream))
     }
 
     fn done(&self) -> bool {
@@ -243,7 +244,7 @@ mod tests {
             &mut self,
             enc: &[u8],
             fin: bool,
-            outcome: Res<ReceiveOutput>,
+            outcome: &Res<ReceiveOutput>,
             done: bool,
         ) {
             let len = enc.len() - 1;
@@ -267,7 +268,7 @@ mod tests {
             }
             let out = self.conn_s.process(None, now());
             mem::drop(self.conn_c.process(out.dgram(), now()));
-            assert_eq!(self.decoder.receive(&mut self.conn_c), outcome);
+            assert_eq!(&self.decoder.receive(&mut self.conn_c), outcome);
             assert_eq!(self.decoder.done(), done);
         }
 
@@ -275,7 +276,7 @@ mod tests {
             &mut self,
             to_encode: &[u64],
             fin: bool,
-            outcome: Res<ReceiveOutput>,
+            outcome: &Res<ReceiveOutput>,
             done: bool,
         ) {
             let mut enc = Encoder::default();
@@ -292,7 +293,7 @@ mod tests {
         t.decode(
             &[QPACK_UNI_STREAM_TYPE_DECODER],
             false,
-            Ok(ReceiveOutput::NewStream(NewStreamType::Encoder)),
+            &Ok(ReceiveOutput::NewStream(NewStreamType::Encoder)),
             true,
         );
     }
@@ -303,7 +304,7 @@ mod tests {
         t.decode(
             &[QPACK_UNI_STREAM_TYPE_ENCODER],
             false,
-            Ok(ReceiveOutput::NewStream(NewStreamType::Decoder)),
+            &Ok(ReceiveOutput::NewStream(NewStreamType::Decoder)),
             true,
         );
     }
@@ -314,7 +315,7 @@ mod tests {
         t.decode(
             &[HTTP3_UNI_STREAM_TYPE_CONTROL],
             false,
-            Ok(ReceiveOutput::NewStream(NewStreamType::Control)),
+            &Ok(ReceiveOutput::NewStream(NewStreamType::Control)),
             true,
         );
     }
@@ -325,7 +326,7 @@ mod tests {
         t.decode(
             &[HTTP3_UNI_STREAM_TYPE_PUSH, 0xaaaa_aaaa],
             false,
-            Ok(ReceiveOutput::NewStream(NewStreamType::Push(0xaaaa_aaaa))),
+            &Ok(ReceiveOutput::NewStream(NewStreamType::Push(0xaaaa_aaaa))),
             true,
         );
 
@@ -333,7 +334,7 @@ mod tests {
         t.decode(
             &[HTTP3_UNI_STREAM_TYPE_PUSH],
             false,
-            Err(Error::HttpStreamCreation),
+            &Err(Error::HttpStreamCreation),
             true,
         );
     }
@@ -344,7 +345,7 @@ mod tests {
         t.decode(
             &[0x3fff_ffff_ffff_ffff],
             false,
-            Ok(ReceiveOutput::NewStream(NewStreamType::Unknown)),
+            &Ok(ReceiveOutput::NewStream(NewStreamType::Unknown)),
             true,
         );
     }
@@ -355,14 +356,14 @@ mod tests {
         t.decode(
             &[0x3fff],
             false,
-            Ok(ReceiveOutput::NewStream(NewStreamType::Unknown)),
+            &Ok(ReceiveOutput::NewStream(NewStreamType::Unknown)),
             true,
         );
         // NewStreamHeadReader is done, it will not continue reading from the stream.
         t.decode(
             &[QPACK_UNI_STREAM_TYPE_DECODER],
             false,
-            Ok(ReceiveOutput::NoOutput),
+            &Ok(ReceiveOutput::NoOutput),
             true,
         );
     }
@@ -370,7 +371,7 @@ mod tests {
     #[test]
     fn decoding_truncate() {
         let mut t = Test::new(Role::Client);
-        t.decode_buffer(&[0xff], false, Ok(ReceiveOutput::NoOutput), false);
+        t.decode_buffer(&[0xff], false, &Ok(ReceiveOutput::NoOutput), false);
     }
 
     #[test]
@@ -381,7 +382,7 @@ mod tests {
         t.decode(
             &[QPACK_UNI_STREAM_TYPE_DECODER],
             false,
-            Ok(ReceiveOutput::NoOutput),
+            &Ok(ReceiveOutput::NoOutput),
             true,
         );
     }
@@ -392,7 +393,7 @@ mod tests {
         t.decode(
             &[QPACK_UNI_STREAM_TYPE_DECODER],
             true,
-            Err(Error::HttpClosedCriticalStream),
+            &Err(Error::HttpClosedCriticalStream),
             true,
         );
     }
@@ -403,7 +404,7 @@ mod tests {
         t.decode(
             &[QPACK_UNI_STREAM_TYPE_ENCODER],
             true,
-            Err(Error::HttpClosedCriticalStream),
+            &Err(Error::HttpClosedCriticalStream),
             true,
         );
     }
@@ -414,7 +415,7 @@ mod tests {
         t.decode(
             &[HTTP3_UNI_STREAM_TYPE_CONTROL],
             true,
-            Err(Error::HttpClosedCriticalStream),
+            &Err(Error::HttpClosedCriticalStream),
             true,
         );
     }
@@ -425,7 +426,7 @@ mod tests {
         t.decode(
             &[HTTP3_UNI_STREAM_TYPE_PUSH, 0xaaaa_aaaa],
             true,
-            Err(Error::HttpGeneralProtocol),
+            &Err(Error::HttpGeneralProtocol),
             true,
         );
 
@@ -433,7 +434,7 @@ mod tests {
         t.decode(
             &[HTTP3_UNI_STREAM_TYPE_PUSH],
             true,
-            Err(Error::HttpStreamCreation),
+            &Err(Error::HttpStreamCreation),
             true,
         );
     }
@@ -444,7 +445,7 @@ mod tests {
         t.decode(
             &[0x3fff_ffff_ffff_ffff],
             true,
-            Ok(ReceiveOutput::NewStream(NewStreamType::Unknown)),
+            &Ok(ReceiveOutput::NewStream(NewStreamType::Unknown)),
             true,
         );
 
@@ -452,6 +453,6 @@ mod tests {
         // A stream ID of 0x3fff_ffff_ffff_ffff is encoded into [0xff; 8].
         // For this test the stream type is truncated.
         // This should cause an error.
-        t.decode_buffer(&[0xff; 7], true, Err(Error::HttpStreamCreation), true);
+        t.decode_buffer(&[0xff; 7], true, &Err(Error::HttpStreamCreation), true);
     }
 }

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -142,7 +142,7 @@ fn priority_update() {
                 Header::new("priority", "u=4,i"),
             ];
             assert_eq!(headers, expected_headers);
-            assert_eq!(fin, false);
+            assert!(!fin);
         }
         other => panic!("unexpected server event: {:?}", other),
     }

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -777,7 +777,7 @@ fn run_peer(args: &Args, peer: &'static Peer) -> Vec<(&'static Test, String)> {
     let mut children = Vec::new();
 
     for test in &TESTS {
-        if !peer.test_enabled(&test) {
+        if !peer.test_enabled(test) {
             continue;
         }
 
@@ -926,7 +926,7 @@ fn main() {
         }
 
         let at = args.clone();
-        let child = thread::spawn(move || run_peer(&at, &peer));
+        let child = thread::spawn(move || run_peer(&at, peer));
         children.push((peer, child));
     }
 

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -133,7 +133,7 @@ impl QPackDecoder {
                 self.stats.dynamic_table_inserts += 1;
             }
             DecodedEncoderInstruction::NoInstruction => {
-                unreachable!("This can be call only with an instruction.")
+                unreachable!("This can be call only with an instruction.");
             }
         }
         Ok(())

--- a/neqo-qpack/src/decoder_instructions.rs
+++ b/neqo-qpack/src/decoder_instructions.rs
@@ -113,7 +113,7 @@ impl DecoderInstructionReader {
                             ));
                         }
                         DecoderInstruction::NoInstruction => {
-                            unreachable!("This instruction cannot be in this state.")
+                            unreachable!("This instruction cannot be in this state.");
                         }
                     }
                 }

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -250,11 +250,8 @@ impl QPackEncoder {
         }
 
         let mut buf = QpackData::default();
-        EncoderInstruction::InsertWithNameLiteral {
-            name: &name,
-            value: &value,
-        }
-        .marshal(&mut buf, self.use_huffman);
+        EncoderInstruction::InsertWithNameLiteral { name, value }
+            .marshal(&mut buf, self.use_huffman);
 
         let stream_id = self.local_stream.stream_id().ok_or(Error::Internal)?;
 
@@ -351,12 +348,7 @@ impl QPackEncoder {
     /// `InternalError` if an unexpected error occurred.
     /// # Panics
     /// If there is a programming error.
-    #[allow(
-        unknown_lints,
-        renamed_and_removed_lints,
-        clippy::unknown_clippy_lints,
-        clippy::unnested_or_patterns
-    )] // Until we require rust 1.53 we can't use or_patterns.
+    #[allow(clippy::unnested_or_patterns)] // Until we require rust 1.53 we can't use or_patterns.
     pub fn encode_header_block(
         &mut self,
         conn: &mut Connection,
@@ -427,7 +419,7 @@ impl QPackEncoder {
                     Err(Error::EncoderStreamBlocked) | Err(Error::DynamicTableFull) => {
                         // As soon as one of the instructions cannot be written or the table is full, do not try again.
                         encoder_blocked = true;
-                        encoded_h.encode_literal_with_name_literal(&name, &value)
+                        encoded_h.encode_literal_with_name_literal(&name, &value);
                     }
                     Err(e) => {
                         // `InternalError`, `ClosedCriticalStream`

--- a/neqo-qpack/src/encoder_instructions.rs
+++ b/neqo-qpack/src/encoder_instructions.rs
@@ -177,7 +177,7 @@ impl EncoderInstructionReader {
                 }
             }
             DecodedEncoderInstruction::NoInstruction => {
-                unreachable!("We must have instruction at this point.")
+                unreachable!("We must have instruction at this point.");
             }
         }
         Ok(())
@@ -195,7 +195,7 @@ impl EncoderInstructionReader {
         loop {
             match &mut self.state {
                 EncoderInstructionReaderState::ReadInstruction => {
-                    self.decode_instruction_type(recv)?
+                    self.decode_instruction_type(recv)?;
                 }
                 EncoderInstructionReaderState::ReadFirstInt { reader } => {
                     let val = reader.read(recv)?;

--- a/neqo-qpack/src/huffman.rs
+++ b/neqo-qpack/src/huffman.rs
@@ -96,7 +96,7 @@ fn decode_character(reader: &mut BitReader) -> Res<Option<u16>> {
             Ok(b) => {
                 i += 1;
                 if let Some(next) = &node.next[usize::from(b)] {
-                    node = &next;
+                    node = next;
                 } else {
                     reader.verify_ending(i)?;
                     return Ok(None);

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -8,8 +8,6 @@
 #![warn(clippy::pedantic)]
 // This is because of Encoder and Decoder structs. TODO: think about a better namings for crate and structs.
 #![allow(clippy::module_name_repetitions)]
-// We need this because of TransportError.
-#![allow(clippy::pub_enum_variant_names)]
 
 pub mod decoder;
 mod decoder_instructions;
@@ -41,6 +39,11 @@ pub struct QpackSettings {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+#[allow(
+    renamed_and_removed_lints,
+    clippy::pub_enum_variant_names,
+    clippy::enum_variant_names
+)]
 pub enum Error {
     DecompressionFailed,
     EncoderStream,

--- a/neqo-qpack/src/qpack_send_buf.rs
+++ b/neqo-qpack/src/qpack_send_buf.rs
@@ -79,7 +79,7 @@ impl QpackData {
             self.write_bytes(&encoded);
         } else {
             self.encode_prefixed_encoded_int(real_prefix, u64::try_from(value.len()).unwrap());
-            self.write_bytes(&value);
+            self.write_bytes(value);
         }
     }
 

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -283,7 +283,7 @@ impl HttpServer for Http3Server {
 
                     let response = headers.iter().find(|&h| h.name() == ":path").and_then(|h| {
                         if args.qns_test.is_some() {
-                            qns_read_response(&h.value())
+                            qns_read_response(h.value())
                         } else {
                             match h.value().trim_matches(|p| p == '/').parse::<usize>() {
                                 Ok(v) => Some(vec![b'a'; v]),
@@ -404,7 +404,7 @@ impl ServersRunner {
         }
 
         for (i, host) in self.hosts.iter().enumerate() {
-            let socket = match UdpSocket::bind(&host) {
+            let socket = match UdpSocket::bind(host) {
                 Err(err) => {
                     eprintln!("Unable to bind UDP socket: {}", err);
                     return Err(err);

--- a/neqo-server/src/old_https.rs
+++ b/neqo-server/src/old_https.rs
@@ -141,7 +141,7 @@ impl Http09Server {
         } else {
             Regex::new(r"GET +/(\d+)(?:\r)?\n").unwrap()
         };
-        let m = re.captures(&msg);
+        let m = re.captures(msg);
         let resp = match m.and_then(|m| m.get(1)) {
             None => {
                 self.save_partial(stream_id, buf, conn);

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -147,7 +147,7 @@ impl<'a> std::ops::Deref for ConnectionIdRef<'a> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
-        &self.cid
+        self.cid
     }
 }
 

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -488,7 +488,7 @@ fn reorder_handshake() {
     // It can only send another Initial packet.
     now += RTT / 2;
     let dgram = client.process(s_hs, now).dgram();
-    assertions::assert_initial(&dgram.as_ref().unwrap(), false);
+    assertions::assert_initial(dgram.as_ref().unwrap(), false);
     assert_eq!(client.stats().saved_datagrams, 1);
     assert_eq!(client.stats().packets_rx, 1);
 
@@ -665,7 +665,7 @@ fn extra_initial_hs() {
     // another Initial packet.
     for _ in 0..=super::super::EXTRA_INITIALS {
         let c_init = client.process(undecryptable.clone(), now).dgram();
-        assertions::assert_initial(&c_init.as_ref().unwrap(), false);
+        assertions::assert_initial(c_init.as_ref().unwrap(), false);
         now += DEFAULT_RTT / 10;
     }
 

--- a/neqo-transport/src/connection/tests/keys.rs
+++ b/neqo-transport/src/connection/tests/keys.rs
@@ -34,7 +34,7 @@ fn assert_update_blocked(c: &mut Connection) {
     assert_eq!(
         c.initiate_key_update().unwrap_err(),
         Error::KeyUpdateBlocked
-    )
+    );
 }
 
 fn overwrite_invocations(n: PacketNumber) {

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -734,7 +734,7 @@ fn migration_invalid_address() {
         assert_eq!(
             client.migrate(local, remote, true, now()).unwrap_err(),
             Error::InvalidMigration
-        )
+        );
     };
 
     // Providing neither address is pointless and therefore an error.

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -362,7 +362,7 @@ fn pto_handshake_frames() {
     now += Duration::from_millis(10);
     let crypto_before = server.stats().frame_rx.crypto;
     server.process_input(pkt2.unwrap(), now);
-    assert_eq!(server.stats().frame_rx.crypto, crypto_before + 1)
+    assert_eq!(server.stats().frame_rx.crypto, crypto_before + 1);
 }
 
 /// In the case that the Handshake takes too many packets, the server might

--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -105,7 +105,7 @@ fn version_negotiation_only_reserved() {
     assert_eq!(client.process(Some(dgram), now()), Output::None);
     match client.state() {
         State::Closed(err) => {
-            assert_eq!(*err, ConnectionError::Transport(Error::VersionNegotiation))
+            assert_eq!(*err, ConnectionError::Transport(Error::VersionNegotiation));
         }
         _ => panic!("Invalid client state"),
     }
@@ -167,7 +167,7 @@ fn version_negotiation_not_supported() {
     );
     match client.state() {
         State::Closed(err) => {
-            assert_eq!(*err, ConnectionError::Transport(Error::VersionNegotiation))
+            assert_eq!(*err, ConnectionError::Transport(Error::VersionNegotiation));
         }
         _ => panic!("Invalid client state"),
     }

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -533,13 +533,13 @@ impl<'a> Frame<'a> {
             FRAME_TYPE_PATH_CHALLENGE => {
                 let data = d(dec.decode(8))?;
                 let mut datav: [u8; 8] = [0; 8];
-                datav.copy_from_slice(&data);
+                datav.copy_from_slice(data);
                 Ok(Self::PathChallenge { data: datav })
             }
             FRAME_TYPE_PATH_RESPONSE => {
                 let data = d(dec.decode(8))?;
                 let mut datav: [u8; 8] = [0; 8];
-                datav.copy_from_slice(&data);
+                datav.copy_from_slice(data);
                 Ok(Self::PathResponse { data: datav })
             }
             FRAME_TYPE_CONNECTION_CLOSE_TRANSPORT | FRAME_TYPE_CONNECTION_CLOSE_APPLICATION => {

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -59,7 +59,7 @@ const ERROR_APPLICATION_CLOSE: TransportError = 12;
 const ERROR_AEAD_LIMIT_REACHED: TransportError = 15;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
-#[allow(clippy::pub_enum_variant_names)]
+// #[allow(clippy::pub_enum_variant_names)]
 pub enum Error {
     NoError,
     // Each time tihe error is return a different parameter is supply.

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -59,7 +59,6 @@ const ERROR_APPLICATION_CLOSE: TransportError = 12;
 const ERROR_AEAD_LIMIT_REACHED: TransportError = 15;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
-// #[allow(clippy::pub_enum_variant_names)]
 pub enum Error {
     NoError,
     // Each time tihe error is return a different parameter is supply.

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -935,7 +935,7 @@ mod tests {
         );
         builder.initial_token(&[]);
         builder.pn(1, 2);
-        builder.encode(&SAMPLE_INITIAL_PAYLOAD);
+        builder.encode(SAMPLE_INITIAL_PAYLOAD);
         let packet = builder.build(&mut prot).expect("build");
         assert_eq!(&packet[..], SAMPLE_INITIAL);
     }

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -94,7 +94,7 @@ impl Paths {
             .unwrap_or_else(|| {
                 let mut p = Path::temporary(local, remote, cc, self.qlog.clone(), now);
                 if let Some(primary) = self.primary.as_ref() {
-                    p.prime_rtt(primary.borrow().rtt())
+                    p.prime_rtt(primary.borrow().rtt());
                 }
                 Rc::new(RefCell::new(p))
             })
@@ -176,7 +176,7 @@ impl Paths {
         local_cid: Option<ConnectionId>,
         remote_cid: RemoteConnectionIdEntry,
     ) {
-        debug_assert!(self.is_temporary(&path));
+        debug_assert!(self.is_temporary(path));
 
         // Make sure not to track too many paths.
         // This protects index 0, which contains the primary path.
@@ -200,9 +200,9 @@ impl Paths {
 
         qdebug!([path.borrow()], "Make permanent");
         path.borrow_mut().make_permanent(local_cid, remote_cid);
-        self.paths.push(Rc::clone(&path));
+        self.paths.push(Rc::clone(path));
         if self.primary.is_none() {
-            assert!(self.select_primary(&path).is_none());
+            assert!(self.select_primary(path).is_none());
         }
     }
 

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -416,7 +416,7 @@ fn frame_to_qlogframe(frame: &Frame) -> QuicFrame {
             },
             error_code.code(),
             0,
-            String::from_utf8_lossy(&reason_phrase).to_string(),
+            String::from_utf8_lossy(reason_phrase).to_string(),
             Some(frame_type.to_string()),
         ),
         Frame::HandshakeDone => QuicFrame::handshake_done(),

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -33,11 +33,11 @@ impl From<Option<u64>> for DatagramTracking {
     }
 }
 
-impl Into<Option<u64>> for DatagramTracking {
-    fn into(self) -> Option<u64> {
-        match self {
-            Self::Id(id) => Some(id),
-            Self::None => None,
+impl From<DatagramTracking> for Option<u64> {
+    fn from(v: DatagramTracking) -> Self {
+        match v {
+            DatagramTracking::Id(id) => Some(id),
+            DatagramTracking::None => None,
         }
     }
 }
@@ -111,7 +111,7 @@ impl QuicDatagrams {
     ) {
         while let Some(dgram) = self.datagrams.pop_front() {
             let len = dgram.len();
-            if builder.remaining() >= len + 1 {
+            if builder.remaining() > len {
                 // + 1 for Frame type
                 let length_len = Encoder::varint_len(u64::try_from(len).unwrap());
                 if builder.remaining() > 1 + length_len + len {
@@ -124,19 +124,17 @@ impl QuicDatagrams {
                 debug_assert!(builder.len() <= builder.limit());
                 stats.frame_tx.datagram += 1;
                 tokens.push(RecoveryToken::Datagram(*dgram.tracking()));
+            } else if tokens.is_empty() {
+                // If the packet is empty, except packet headers, and the
+                // datagram cannot fit, drop it.
+                // Also continue trying to write the next QuicDatagram.
+                self.conn_events
+                    .datagram_outcome(dgram.tracking(), OutgoingDatagramOutcome::DroppedTooBig);
+                stats.datagram_tx.dropped_too_big += 1;
             } else {
-                if tokens.is_empty() {
-                    // If the packet is empty, except packet headers, and the
-                    // datagram cannot fit, drop it.
-                    // Also continue trying to write the next QuicDatagram.
-                    self.conn_events
-                        .datagram_outcome(dgram.tracking(), OutgoingDatagramOutcome::DroppedTooBig);
-                    stats.datagram_tx.dropped_too_big += 1;
-                } else {
-                    self.datagrams.push_front(dgram);
-                    // Try later on an empty packet.
-                    return;
-                }
+                self.datagrams.push_front(dgram);
+                // Try later on an empty packet.
+                return;
             }
         }
     }

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -112,7 +112,7 @@ impl QuicDatagrams {
         while let Some(dgram) = self.datagrams.pop_front() {
             let len = dgram.len();
             if builder.remaining() > len {
-                // + 1 for Frame type
+                // we need 1 more than `len` for the Frame type
                 let length_len = Encoder::varint_len(u64::try_from(len).unwrap());
                 if builder.remaining() > 1 + length_len + len {
                     builder.encode_varint(FRAME_TYPE_DATAGRAM_WITH_LEN);

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -1040,7 +1040,7 @@ mod tests {
         }
 
         pub fn on_packet_sent(&mut self, sent_packet: SentPacket) {
-            self.lr.on_packet_sent(&self.path, sent_packet)
+            self.lr.on_packet_sent(&self.path, sent_packet);
         }
 
         pub fn timeout(&mut self, now: Instant) -> Vec<SentPacket> {
@@ -1052,7 +1052,7 @@ mod tests {
         }
 
         pub fn discard(&mut self, space: PacketNumberSpace, now: Instant) {
-            self.lr.discard(&self.path, space, now)
+            self.lr.discard(&self.path, space, now);
         }
 
         pub fn pto_time(&self, space: PacketNumberSpace) -> Option<Instant> {
@@ -1288,8 +1288,8 @@ mod tests {
     fn no_new_acks() {
         let mut lr = setup_lr(1);
         let check = |lr: &Fixture| {
-            assert_rtts(&lr, TEST_RTT, TEST_RTT, TEST_RTTVAR, TEST_RTT);
-            assert_no_sent_times(&lr);
+            assert_rtts(lr, TEST_RTT, TEST_RTT, TEST_RTTVAR, TEST_RTT);
+            assert_no_sent_times(lr);
         };
         check(&lr);
 

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -102,7 +102,7 @@ impl RecvStreams {
         let mut removed_bidi = 0;
         let mut removed_uni = 0;
         for id in &recv_to_remove {
-            self.streams.remove(&id);
+            self.streams.remove(id);
             if id.is_remote_initiated(role) {
                 if id.is_bidi() {
                     removed_bidi += 1;

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -51,7 +51,7 @@ impl RttEstimate {
         qtrace!("initial RTT={:?}", rtt);
         if rtt >= GRANULARITY {
             // Ignore if the value is too small.
-            self.init(rtt)
+            self.init(rtt);
         }
     }
 
@@ -131,7 +131,7 @@ impl RttEstimate {
     pub fn pto(&self, pn_space: PacketNumberSpace) -> Duration {
         let mut t = self.estimate() + max(4 * self.rttvar, GRANULARITY);
         if pn_space == PacketNumberSpace::ApplicationData {
-            t += self.ack_delay.max()
+            t += self.ack_delay.max();
         }
         t
     }

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -91,8 +91,9 @@ impl Debug for FrameStats {
     }
 }
 
-///Datagram stats
+/// Datagram stats
 #[derive(Default, Clone)]
+#[allow(clippy::module_name_repetitions)]
 pub struct DatagramStats {
     /// The number of datagrams declared lost.
     pub lost: usize,
@@ -159,7 +160,7 @@ impl Stats {
             "Dropped received packet: {}; Total: {}",
             reason.as_ref(),
             self.dropped_rx
-        )
+        );
     }
 
     /// # Panics

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -234,7 +234,7 @@ impl Streams {
 
     pub fn lost(&mut self, token: &StreamRecoveryToken) {
         match token {
-            StreamRecoveryToken::Stream(st) => self.send.lost(&st),
+            StreamRecoveryToken::Stream(st) => self.send.lost(st),
             StreamRecoveryToken::ResetStream { stream_id } => self.send.reset_lost(*stream_id),
             StreamRecoveryToken::StreamDataBlocked { stream_id, limit } => {
                 self.send.blocked_lost(*stream_id, *limit)

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -362,7 +362,7 @@ impl TransportParameters {
 
         match self.params.get(&tp) {
             None => None,
-            Some(TransportParameter::Bytes(x)) => Some(&x),
+            Some(TransportParameter::Bytes(x)) => Some(x),
             _ => panic!("Internal error"),
         }
     }

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -537,7 +537,7 @@ impl RecvdPackets {
                     None => return,
                 };
             }
-            cur.acknowledged(&ack);
+            cur.acknowledged(ack);
         }
     }
 

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -34,7 +34,7 @@ fn retry_basic() {
     let dgram = server.process(dgram, now()).dgram(); // Retry
     assert!(dgram.is_some());
 
-    assertions::assert_retry(&dgram.as_ref().unwrap());
+    assertions::assert_retry(dgram.as_ref().unwrap());
 
     let dgram = client.process(dgram, now()).dgram(); // Initial w/token
     assert!(dgram.is_some());
@@ -62,7 +62,7 @@ fn retry_expired() {
     let dgram = server.process(dgram, now).dgram(); // Retry
     assert!(dgram.is_some());
 
-    assertions::assert_retry(&dgram.as_ref().unwrap());
+    assertions::assert_retry(dgram.as_ref().unwrap());
 
     let dgram = client.process(dgram, now).dgram(); // Initial w/token
     assert!(dgram.is_some());
@@ -121,7 +121,7 @@ fn retry_different_ip() {
     let dgram = server.process(dgram, now()).dgram(); // Retry
     assert!(dgram.is_some());
 
-    assertions::assert_retry(&dgram.as_ref().unwrap());
+    assertions::assert_retry(dgram.as_ref().unwrap());
 
     let dgram = client.process(dgram, now()).dgram(); // Initial w/token
     assert!(dgram.is_some());
@@ -202,7 +202,7 @@ fn retry_after_initial() {
 
     let retry = retry_server.process(cinit, now()).dgram(); // Retry!
     assert!(retry.is_some());
-    assertions::assert_retry(&retry.as_ref().unwrap());
+    assertions::assert_retry(retry.as_ref().unwrap());
 
     // The client should ignore the retry.
     let junk = client.process(retry, now()).dgram();
@@ -288,7 +288,7 @@ fn retry_after_pto() {
     assert_ne!(cb, Duration::new(0, 0));
 
     let retry = server.process(ci, now).dgram();
-    assertions::assert_retry(&retry.as_ref().unwrap());
+    assertions::assert_retry(retry.as_ref().unwrap());
 
     let ci2 = client.process(retry, now).dgram();
     assert!(ci2.unwrap().len() >= 1200);
@@ -305,7 +305,7 @@ fn vn_after_retry() {
     let dgram = server.process(dgram, now()).dgram(); // Retry
     assert!(dgram.is_some());
 
-    assertions::assert_retry(&dgram.as_ref().unwrap());
+    assertions::assert_retry(dgram.as_ref().unwrap());
 
     let dgram = client.process(dgram, now()).dgram(); // Initial w/token
     assert!(dgram.is_some());
@@ -356,7 +356,7 @@ fn mitm_retry() {
     let (protected_header, d_cid, s_cid, payload) = decode_initial_header(&client_initial2);
 
     // Now we have enough information to make keys.
-    let (aead, hp) = client_initial_aead_and_hp(&d_cid);
+    let (aead, hp) = client_initial_aead_and_hp(d_cid);
     let (header, pn) = remove_header_protection(&hp, protected_header, payload);
     let pn_len = header.len() - protected_header.len();
 

--- a/neqo-transport/tests/sim/connection.rs
+++ b/neqo-transport/tests/sim/connection.rs
@@ -113,7 +113,7 @@ impl Node for ConnectionNode {
                     self.c.authenticated(AuthenticationStatus::Ok, now);
                 }
 
-                active |= self.process_goals(|goal, c| goal.handle_event(c, &e, now))
+                active |= self.process_goals(|goal, c| goal.handle_event(c, &e, now));
             }
             // Exit at this point if the connection produced a datagram.
             // We also exit if none of the goals were active, as there is


### PR DESCRIPTION
It seems like a lot of code landed without any of these checks being
run.  Hopefully we can be stricter about this in future.  There were
some minor (but relevant) problems in there.

(Lots of missing semicolons, which I blame rustfmt for; and lots of
extra `&`, which I might have to own up to.)