### PR TITLE
Rework frames that fill packets

### DIFF
--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -14,7 +14,9 @@ use crate::packet::PacketBuilder;
 use crate::quic_datagrams::MAX_QUIC_DATAGRAM;
 use crate::{Connection, ConnectionError, ConnectionParameters, Error};
 use neqo_common::event::Provider;
+use std::cell::RefCell;
 use std::convert::TryFrom;
+use std::rc::Rc;
 use test_fixture::now;
 
 const DATAGRAM_LEN_MTU: u64 = 1310;
@@ -345,15 +347,15 @@ fn outgoing_datagram_queue_full() {
     ));
 }
 
-fn send_datagram(client: &mut Connection, server: &mut Connection, data: &[u8]) {
-    let dgram_sent = server.stats().frame_tx.datagram;
-    assert_eq!(server.send_datagram(data, Some(1)), Ok(()));
-    let out = server.process_output(now()).dgram().unwrap();
-    assert_eq!(server.stats().frame_tx.datagram, dgram_sent + 1);
+fn send_datagram(sender: &mut Connection, receiver: &mut Connection, data: &[u8]) {
+    let dgram_sent = sender.stats().frame_tx.datagram;
+    assert_eq!(sender.send_datagram(data, Some(1)), Ok(()));
+    let out = sender.process_output(now()).dgram().unwrap();
+    assert_eq!(sender.stats().frame_tx.datagram, dgram_sent + 1);
 
-    let dgram_received = client.stats().frame_rx.datagram;
-    client.process_input(out, now());
-    assert_eq!(client.stats().frame_rx.datagram, dgram_received + 1);
+    let dgram_received = receiver.stats().frame_rx.datagram;
+    receiver.process_input(out, now());
+    assert_eq!(receiver.stats().frame_rx.datagram, dgram_received + 1);
 }
 
 #[test]
@@ -373,9 +375,9 @@ fn multiple_datagram_events() {
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
 
-    send_datagram(&mut client, &mut server, FIRST_DATAGRAM);
-    send_datagram(&mut client, &mut server, SECOND_DATAGRAM);
-    send_datagram(&mut client, &mut server, THIRD_DATAGRAM);
+    send_datagram(&mut server, &mut client, FIRST_DATAGRAM);
+    send_datagram(&mut server, &mut client, SECOND_DATAGRAM);
+    send_datagram(&mut server, &mut client, THIRD_DATAGRAM);
 
     let mut datagrams = client.events().filter_map(|evt| {
         if let ConnectionEvent::Datagram(d) = evt {
@@ -390,7 +392,7 @@ fn multiple_datagram_events() {
     assert!(datagrams.next().is_none());
 
     // New events can be queued.
-    send_datagram(&mut client, &mut server, FOURTH_DATAGRAM);
+    send_datagram(&mut server, &mut client, FOURTH_DATAGRAM);
     let mut datagrams = client.events().filter_map(|evt| {
         if let ConnectionEvent::Datagram(d) = evt {
             Some(d)
@@ -419,9 +421,9 @@ fn too_many_datagram_events() {
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
 
-    send_datagram(&mut client, &mut server, FIRST_DATAGRAM);
-    send_datagram(&mut client, &mut server, SECOND_DATAGRAM);
-    send_datagram(&mut client, &mut server, THIRD_DATAGRAM);
+    send_datagram(&mut server, &mut client, FIRST_DATAGRAM);
+    send_datagram(&mut server, &mut client, SECOND_DATAGRAM);
+    send_datagram(&mut server, &mut client, THIRD_DATAGRAM);
 
     // Datagram with FIRST_DATAGRAM data will be dropped.
     assert!(matches!(
@@ -440,7 +442,7 @@ fn too_many_datagram_events() {
     assert_eq!(client.stats().incoming_datagram_dropped, 1);
 
     // New events can be queued.
-    send_datagram(&mut client, &mut server, FOURTH_DATAGRAM);
+    send_datagram(&mut server, &mut client, FOURTH_DATAGRAM);
     assert!(matches!(
         client.next_event().unwrap(),
         ConnectionEvent::Datagram(data) if data == FOURTH_DATAGRAM
@@ -469,4 +471,64 @@ fn multiple_quic_datagrams_in_one_packet() {
     server.process_input(out.unwrap(), now());
     let datagram = |e: &_| matches!(e, ConnectionEvent::Datagram(..));
     assert_eq!(server.events().filter(datagram).count(), 2);
+}
+
+/// Datagrams that are close to the capacity of the packet need special
+/// handling.  They need to use the packet-filling frame type and
+/// they cannot allow other frames to follow.
+#[test]
+fn datagram_fill() {
+    struct PanickingFrameWriter {}
+    impl crate::connection::test_internal::FrameWriter for PanickingFrameWriter {
+        fn write_frames(&mut self, builder: &mut PacketBuilder) {
+            panic!(
+                "builder invoked with {} bytes remaining",
+                builder.remaining()
+            );
+        }
+    }
+    struct TrackingFrameWriter {
+        called: Rc<RefCell<bool>>,
+    }
+    impl crate::connection::test_internal::FrameWriter for TrackingFrameWriter {
+        fn write_frames(&mut self, builder: &mut PacketBuilder) {
+            assert_eq!(builder.remaining(), 2);
+            *self.called.borrow_mut() = true;
+        }
+    }
+
+    let (mut client, mut server) = connect_datagram();
+
+    // Work out how much space we have for a datagram.
+    let space = {
+        let p = client.paths.primary();
+        let path = p.borrow();
+        // Minimum overhead is connection ID length, 1 byte short header, 1 byte packet number,
+        // 1 byte for the DATAGRAM frame type, and 16 bytes for the AEAD.
+        path.mtu() - path.remote_cid().len() - 19
+    };
+    assert!(space >= 64); // Unlikely, but this test depends on the datagram being this large.
+
+    // This should not be called.
+    client.test_frame_writer = Some(Box::new(PanickingFrameWriter {}));
+
+    let buf = vec![9; space];
+    // This will completely fill available space.
+    send_datagram(&mut client, &mut server, &buf);
+    // This will leave 1 byte free, but more frames won't be added in this space.
+    send_datagram(&mut client, &mut server, &buf[..buf.len() - 1]);
+    // This will leave 2 bytes free, which is enough space for a length field,
+    // but not enough space for another frame after that.
+    send_datagram(&mut client, &mut server, &buf[..buf.len() - 2]);
+    // Three bytes free will be space enough for a length frame, but not enough
+    // space left over for another frame (we need 2 bytes).
+    send_datagram(&mut client, &mut server, &buf[..buf.len() - 3]);
+
+    // Four bytes free is enough space for another frame.
+    let called = Rc::new(RefCell::new(false));
+    client.test_frame_writer = Some(Box::new(TrackingFrameWriter {
+        called: Rc::clone(&called),
+    }));
+    send_datagram(&mut client, &mut server, &buf[..buf.len() - 4]);
+    assert!(*called.borrow());
 }

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -158,6 +158,9 @@ pub struct PacketBuilder {
 }
 
 impl PacketBuilder {
+    /// The minimum useful frame size.  If space is less than this, we will claim to be full.
+    pub const MINIMUM_FRAME_SIZE: usize = 2;
+
     fn infer_limit(encoder: &Encoder) -> usize {
         if encoder.capacity() > 64 {
             encoder.capacity()
@@ -258,6 +261,8 @@ impl PacketBuilder {
         self.limit = limit;
     }
 
+    /// Get the current limit.
+    #[must_use]
     pub fn limit(&mut self) -> usize {
         self.limit
     }
@@ -272,7 +277,12 @@ impl PacketBuilder {
     #[must_use]
     pub fn is_full(&self) -> bool {
         // No useful frame is smaller than 2 bytes long.
-        self.limit < self.encoder.len() + 2
+        self.limit < self.encoder.len() + Self::MINIMUM_FRAME_SIZE
+    }
+
+    /// Adjust the limit to ensure that no more data is added.
+    pub fn mark_full(&mut self) {
+        self.limit = self.encoder.len()
     }
 
     /// Mark the packet as needing padding (or not).

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -649,7 +649,7 @@ impl SendStream {
     /// the remainder of the space can be filled (or if a length field is needed).
     fn length_and_fill(data_len: usize, space: usize) -> (usize, bool) {
         if data_len >= space {
-            // Either more data than space allows, or an exact fit.
+            // More data than space allows, or an exact fit => fast path.
             qtrace!("SendStream::length_and_fill fill {}", space);
             return (space, true);
         }
@@ -658,18 +658,13 @@ impl SendStream {
         // less 1, which is the worst case.
         let length = min(space.saturating_sub(1), data_len);
         let length_len = Encoder::varint_len(u64::try_from(length).unwrap());
-        if length_len > space {
-            qtrace!(
-                "SendStream::length_and_fill no room for length of {} in {}",
-                length,
-                space
-            );
-            return (0, false);
-        }
+        debug_assert!(length_len <= space); // We don't depend on this being true, but it is true.
 
-        let length = min(data_len, space - length_len);
-        qtrace!("SendStream::length_and_fill {} in {}", length, space);
-        (length, false)
+        // From here we can always fit `data_len`, but we might as well fill
+        // if there is no space for the length field plus another frame.
+        let fill = data_len + length_len + PacketBuilder::MINIMUM_FRAME_SIZE > space;
+        qtrace!("SendStream::length_and_fill {} fill {}", data_len, fill);
+        (data_len, fill)
     }
 
     /// Maybe write a `STREAM` frame.
@@ -718,6 +713,7 @@ impl SendStream {
             }
             if fill {
                 builder.encode(&data[..length]);
+                builder.mark_full();
             } else {
                 builder.encode_vvec(&data[..length]);
             }
@@ -1943,6 +1939,16 @@ mod tests {
 
     fn frame_sent_sid(stream: u64, offset: usize, len: usize, fin: bool, space: usize) -> bool {
         const BUF: &[u8] = &[0x42; 128];
+
+        qtrace!(
+            "frame_sent stream={} offset={} len={} fin={}, space={}",
+            stream,
+            offset,
+            len,
+            fin,
+            space
+        );
+
         let mut s = stream_with_sent(stream, offset);
 
         // Now write out the proscribed data and maybe close.
@@ -2044,100 +2050,68 @@ mod tests {
         assert!(frame_sent_sid(BIG, BIGSZ, 1, true, 100));
     }
 
-    #[test]
-    fn stream_frame_16384() {
-        const DATA16384: &[u8] = &[0x43; 16384];
+    fn stream_frame_at_boundary(data: &[u8]) {
+        fn send_with_extra_capacity(data: &[u8], extra: usize, expect_full: bool) -> Vec<u8> {
+            qtrace!("send_with_extra_capacity {} + {}", data.len(), extra);
+            let mut s = stream_with_sent(0, 0);
+            s.send(data).unwrap();
+            s.close();
 
-        // 16383/16384 is an odd boundary in STREAM frame construction.
-        // That is the boundary where a length goes from 2 bytes to 4 bytes.
-        // If the data fits in the available space, then it is simple:
-        let mut s = stream_with_sent(0, 0);
-        s.send(DATA16384).unwrap();
-        s.close();
+            let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
+            let header_len = builder.len();
+            // Add 2 for the frame type and stream ID, then add the extra.
+            builder.set_limit(header_len + data.len() + 2 + extra);
+            let mut tokens = Vec::new();
+            let mut stats = FrameStats::default();
+            s.write_stream_frame(
+                TransmissionPriority::default(),
+                &mut builder,
+                &mut tokens,
+                &mut stats,
+            );
+            assert_eq!(stats.stream, 1);
+            assert_eq!(builder.is_full(), expect_full);
+            Vec::from(Encoder::from(builder)).split_off(header_len)
+        }
 
-        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
-        let header_len = builder.len();
-        builder.set_limit(header_len + DATA16384.len() + 2);
-        let mut tokens = Vec::new();
-        let mut stats = FrameStats::default();
-        s.write_stream_frame(
-            TransmissionPriority::default(),
-            &mut builder,
-            &mut tokens,
-            &mut stats,
-        );
-        assert_eq!(stats.stream, 1);
-        // Expect STREAM + FIN only.
-        assert_eq!(&builder[header_len..header_len + 2], &[0b1001, 0]);
-        assert_eq!(&builder[header_len + 2..], DATA16384);
+        // The minimum amount of extra space for getting another frame in.
+        let mut enc = Encoder::new();
+        enc.encode_varint(u64::try_from(data.len()).unwrap());
+        let len_buf = Vec::from(enc);
+        let minimum_extra = len_buf.len() + PacketBuilder::MINIMUM_FRAME_SIZE;
 
-        s.mark_as_lost(0, DATA16384.len(), true);
+        // For anything short of the minimum extra, the frame should fill the packet.
+        for i in 0..minimum_extra {
+            let frame = send_with_extra_capacity(data, i, true);
+            let (header, body) = frame.split_at(2);
+            assert_eq!(header, &[0b1001, 0]);
+            assert_eq!(body, data);
+        }
 
-        // However, if there is one extra byte of space, we will try to add a length.
-        // That length will then make the frame to be too large and the data will be
-        // truncated.  The frame could carry one more byte of data, but it's a corner
-        // case we don't want to address as it should be rare (if not impossible).
-        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
-        let header_len = builder.len();
-        builder.set_limit(header_len + DATA16384.len() + 3);
-        s.write_stream_frame(
-            TransmissionPriority::default(),
-            &mut builder,
-            &mut tokens,
-            &mut stats,
-        );
-        assert_eq!(stats.stream, 2);
-        // Expect STREAM + LEN + FIN.
-        assert_eq!(
-            &builder[header_len..header_len + 4],
-            &[0b1010, 0, 0x7f, 0xfd]
-        );
-        assert_eq!(
-            &builder[header_len + 4..],
-            &DATA16384[..DATA16384.len() - 3]
-        );
+        // Once there is space for another packet AND a length field,
+        // then a length will be added.
+        let frame = send_with_extra_capacity(data, minimum_extra, false);
+        let (header, rest) = frame.split_at(2);
+        assert_eq!(header, &[0b1011, 0]);
+        let (len, body) = rest.split_at(len_buf.len());
+        assert_eq!(len, &len_buf);
+        assert_eq!(body, data);
     }
 
+    /// 16383/16384 is an odd boundary in STREAM frame construction.
+    /// That is the boundary where a length goes from 2 bytes to 4 bytes.
+    /// Test that we correctly add a length field to the frame; and test
+    /// that if we don't, then we don't allow other frames to be added.
+    #[test]
+    fn stream_frame_16384() {
+        stream_frame_at_boundary(&[4; 16383]);
+        stream_frame_at_boundary(&[4; 16384]);
+    }
+
+    /// 63/64 is the other odd boundary.
     #[test]
     fn stream_frame_64() {
-        const DATA64: &[u8] = &[0x43; 64];
-
-        // Unlike 16383/16384, the boundary at 63/64 is easy because the difference
-        // is just one byte.  We lose just the last byte when there is more space.
-        let mut s = stream_with_sent(0, 0);
-        s.send(DATA64).unwrap();
-        s.close();
-
-        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
-        let header_len = builder.len();
-        builder.set_limit(header_len + 66);
-        let mut tokens = Vec::new();
-        let mut stats = FrameStats::default();
-        s.write_stream_frame(
-            TransmissionPriority::default(),
-            &mut builder,
-            &mut tokens,
-            &mut stats,
-        );
-        assert_eq!(stats.stream, 1);
-        // Expect STREAM + FIN only.
-        assert_eq!(&builder[header_len..header_len + 2], &[0b1001, 0]);
-        assert_eq!(&builder[header_len + 2..], DATA64);
-
-        s.mark_as_lost(0, DATA64.len(), true);
-
-        let mut builder = PacketBuilder::short(Encoder::new(), false, &[]);
-        let header_len = builder.len();
-        builder.set_limit(header_len + 67);
-        s.write_stream_frame(
-            TransmissionPriority::default(),
-            &mut builder,
-            &mut tokens,
-            &mut stats,
-        );
-        assert_eq!(stats.stream, 2);
-        // Expect STREAM + LEN, not FIN.
-        assert_eq!(&builder[header_len..header_len + 3], &[0b1010, 0, 63]);
-        assert_eq!(&builder[header_len + 3..], &DATA64[..63]);
+        stream_frame_at_boundary(&[2; 63]);
+        stream_frame_at_boundary(&[2; 64]);
     }
 }


### PR DESCRIPTION
I started out just looking at the DATAGRAM frame, for which we need to
be careful in two ways: we need to ensure that the entire payload is
sent in one piece, and we need to ensure that when we using the packet
filling frame type, we don't follow the frame with other frames.

Then I looked at the STREAM frame and what we are doing was wasteful.
We were adding a length field just to fill the packet, even when we
could have used the packet filling option.  That was wasteful, because
the extra length field meant that we sent a larger packet than was
necessary.

This logic turns out to be a whole lot simpler.  And we save a byte or
two here and there.

The negative side of this is that those byte savings might make our
packets ever-so-slightly more vulnerable to traffic analysis.  And the
way that packets are marked as "full" will make padding them more
challenging later.  I'm not overly concerned about this as the change is
tiny and we will need special logic for padding of packet-filling frames
anyway.

Closes #1229.