### PR TITLE
Define and use RequestTarget for fetch

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -415,9 +415,7 @@ impl<'a> Handler<'a> {
         match client.fetch(
             Instant::now(),
             &self.args.method,
-            url.scheme(),
-            url.host_str().unwrap(),
-            url.path(),
+            &url,
             &to_headers(&self.args.header),
             Priority::default(),
         ) {

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -14,6 +14,7 @@ log = {version = "0.4.0", default-features = false}
 smallvec = "1.0.0"
 qlog = "0.4.0"
 sfv = "0.9.1"
+url = "1.7.2"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -21,6 +21,7 @@ mod qlog;
 mod qpack_decoder_receiver;
 mod qpack_encoder_receiver;
 mod recv_message;
+pub mod request_target;
 mod send_message;
 pub mod server;
 mod server_connection_events;
@@ -80,21 +81,22 @@ pub enum Error {
     AlreadyClosed,
     AlreadyInitialized,
     DecodingFrame,
+    FatalError,
     HttpGoaway,
     Internal,
+    InvalidHeader,
+    InvalidInput,
+    InvalidRequestTarget,
     InvalidResumptionToken,
-    InvalidStreamId,
     InvalidState,
+    InvalidStreamId,
     NoMoreData,
     NotEnoughData,
+    StreamLimitError,
     TransportError(TransportError),
+    TransportStreamDoesNotExist,
     Unavailable,
     Unexpected,
-    StreamLimitError,
-    TransportStreamDoesNotExist,
-    InvalidInput,
-    FatalError,
-    InvalidHeader,
 }
 
 impl Error {

--- a/neqo-http3/src/request_target.rs
+++ b/neqo-http3/src/request_target.rs
@@ -1,0 +1,127 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(clippy::module_name_repetitions)]
+
+use std::fmt::{Debug, Formatter};
+use url::{ParseError, Url};
+
+pub trait RequestTarget: Debug {
+    fn scheme(&self) -> &str;
+    fn authority(&self) -> &str;
+    fn path(&self) -> &str;
+}
+
+pub struct RefRequestTarget<'s, 'a, 'p> {
+    scheme: &'s str,
+    authority: &'a str,
+    path: &'p str,
+}
+
+impl RequestTarget for RefRequestTarget<'_, '_, '_> {
+    fn scheme(&self) -> &str {
+        self.scheme
+    }
+
+    fn authority(&self) -> &str {
+        self.authority
+    }
+
+    fn path(&self) -> &str {
+        self.path
+    }
+}
+
+impl<'s, 'a, 'p> RefRequestTarget<'s, 'a, 'p> {
+    #[must_use]
+    pub fn new(scheme: &'s str, authority: &'a str, path: &'p str) -> Self {
+        Self {
+            scheme,
+            authority,
+            path,
+        }
+    }
+}
+
+impl Debug for RefRequestTarget<'_, '_, '_> {
+    fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
+        write!(f, "{}://{}{}", self.scheme, self.authority, self.path)
+    }
+}
+
+/// `AsRequestTarget` is a trait that produces a `RequestTarget` that
+/// refers to the identified object.
+pub trait AsRequestTarget<'x> {
+    type Target: RequestTarget;
+    type Error;
+    /// Produce a `RequestTarget` that refers to `self.
+    /// # Errors
+    /// This method can generate an error of type `Self::Error`
+    /// if the conversion is unsuccessful.
+    fn as_request_target(&'x self) -> Result<Self::Target, Self::Error>;
+}
+
+impl<'x, S, A, P> AsRequestTarget<'x> for (S, A, P)
+where
+    S: AsRef<str> + 'x,
+    A: AsRef<str> + 'x,
+    P: AsRef<str> + 'x,
+{
+    type Target = RefRequestTarget<'x, 'x, 'x>;
+    type Error = ();
+    fn as_request_target(&'x self) -> Result<Self::Target, Self::Error> {
+        Ok(RefRequestTarget::new(
+            self.0.as_ref(),
+            self.1.as_ref(),
+            self.2.as_ref(),
+        ))
+    }
+}
+
+impl<'x> AsRequestTarget<'x> for Url {
+    type Target = RefRequestTarget<'x, 'x, 'x>;
+    type Error = ();
+    fn as_request_target(&'x self) -> Result<Self::Target, Self::Error> {
+        Ok(RefRequestTarget::new(
+            self.scheme(),
+            self.host_str().unwrap_or(""),
+            self.path(),
+        ))
+    }
+}
+
+pub struct UrlRequestTarget {
+    url: Url,
+}
+
+impl RequestTarget for UrlRequestTarget {
+    fn scheme(&self) -> &str {
+        self.url.scheme()
+    }
+
+    fn authority(&self) -> &str {
+        self.url.host_str().unwrap_or("")
+    }
+
+    fn path(&self) -> &str {
+        self.url.path()
+    }
+}
+
+impl Debug for UrlRequestTarget {
+    fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
+        self.url.fmt(f)
+    }
+}
+
+impl<'x> AsRequestTarget<'x> for str {
+    type Target = UrlRequestTarget;
+    type Error = ParseError;
+    fn as_request_target(&'x self) -> Result<Self::Target, Self::Error> {
+        let url = Url::parse(self)?;
+        Ok(UrlRequestTarget { url })
+    }
+}

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -119,9 +119,7 @@ fn test_fetch() {
         .fetch(
             now(),
             "GET",
-            "https",
-            "something.com",
-            "/",
+            &("https", "something.com", "/"),
             &[],
             Priority::default(),
         )

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -111,9 +111,7 @@ fn priority_update() {
         .fetch(
             Instant::now(),
             "GET",
-            "https",
-            "something.com",
-            "/",
+            &("https", "something.com", "/"),
             &[],
             Priority::new(4, true),
         )
@@ -177,9 +175,7 @@ fn priority_update_dont_send_for_cancelled_stream() {
         .fetch(
             Instant::now(),
             "GET",
-            "https",
-            "something.com",
-            "/",
+            &("https", "something.com", "/"),
             &[],
             Priority::new(5, false),
         )

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -542,9 +542,7 @@ fn test_h3(nctx: &NetworkCtx, peer: &Peer, client: Connection, test: &Test) -> R
         .fetch(
             Instant::now(),
             "GET",
-            "https",
-            &hc.host,
-            &hc.path,
+            &("https", &hc.host, &hc.path),
             &[],
             Priority::default(),
         )
@@ -563,9 +561,7 @@ fn test_h3(nctx: &NetworkCtx, peer: &Peer, client: Connection, test: &Test) -> R
             .fetch(
                 Instant::now(),
                 "GET",
-                "https",
-                &hc.host,
-                &hc.path,
+                &("https", &hc.host, &hc.path),
                 &[Header::new("something1", "something2")],
                 Priority::default(),
             )
@@ -602,9 +598,7 @@ fn test_h3_rz(
         .fetch(
             Instant::now(),
             "GET",
-            "https",
-            &hc.host,
-            &hc.path,
+            &("https", &hc.host, &hc.path),
             &[],
             Priority::default(),
         )
@@ -661,9 +655,7 @@ fn test_h3_rz(
             .fetch(
                 Instant::now(),
                 "GET",
-                "https",
-                &hc.host,
-                &hc.path,
+                &("https", &hc.host, &hc.path),
                 &[],
                 Priority::default(),
             )


### PR DESCRIPTION
This does a little generic magic in order to allow for three basic forms
of request target natively:

* A simple string (this is the most costly, because we have to parse the
URL)
* A Url (in case one exists, as is the case with neqo-client)
* A three-tuple of things that turn into `str`

More of these can be implemented if that turns out to be convenient for
the caller.  Monomorphism ensures that only those forms that are used
are paid for.

This was a little fiddly to implement.  I would have liked to make the
string form more generic, ideally `AsRef<str>` but because we take
`&Url` and because `Url` implements `AsRef<str>` that causes rust to get
confused.  I tried fixing it, but you end up needing extra type
parameters on every invocation, which is less friendly than just having
people call `as_ref()` themselves.

Closes #1226.