### PR TITLE
Fast PTOs

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -393,7 +393,7 @@ impl Connection {
             streams: Streams::new(tphandler, role, events.clone()),
             connection_ids: ConnectionIdStore::default(),
             state_signaling: StateSignaling::Idle,
-            loss_recovery: LossRecovery::new(stats.clone()),
+            loss_recovery: LossRecovery::new(stats.clone(), conn_params.get_fast_pto()),
             events,
             new_token: NewTokenState::new(role),
             stats,

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -253,13 +253,16 @@ impl ConnectionParameters {
         self.fast_pto
     }
 
-    /// Fast PTO scale.  A value of `FAST_PTO_SCALE` follows the spec, a larger value
+    /// Fast PTO scale.  A value of `FAST_PTO_SCALE` follows the spec, a smaller value
     /// does not, but produces more probes with the intent of ensuring lower latency
-    /// in the event of tail loss. A value of `FAST_PTO_SCALE*4` is quite aggressive.
-    /// Larger values are not rejected, but could be very wasteful.
-    /// Values less than `FAST_PTO_SCALE` delay probes and could reduce performance.
-    /// A value of `FAST_PTO_SCALE/8` or less could result in any packet loss being
-    /// interpreted as persistent congestion.
+    /// in the event of tail loss. A value of `FAST_PTO_SCALE/4` is quite aggressive.
+    /// Smaller values than this are not rejected, but could be very wasteful.
+    /// Values greater than `FAST_PTO_SCALE` delay probes and could reduce performance.
+    /// It should not be possible to increase the PTO timer by too much, but a maximum
+    /// value of 255 will result in very poor performance.
+    /// Scaling PTO this way does not affect when persistent congestion is declared,
+    /// but may change how many retransmissions are sent before declaring persistent
+    /// congestion.
     ///
     /// # Panics
     /// A value of 0 is invalid and will cause a panic.

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -253,13 +253,14 @@ impl ConnectionParameters {
         self.fast_pto
     }
 
-    /// Fast PTO scale.  A value of `FAST_PTO_SCALE` follows the spec, a smaller value
-    /// does not, but produces more probes with the intent of ensuring lower latency
-    /// in the event of tail loss. A value of `FAST_PTO_SCALE/4` is quite aggressive.
-    /// Smaller values than this are not rejected, but could be very wasteful.
-    /// Values greater than `FAST_PTO_SCALE` delay probes and could reduce performance.
-    /// It should not be possible to increase the PTO timer by too much, but a maximum
-    /// value of 255 will result in very poor performance.
+    /// Scale the PTO timer.  A value of `FAST_PTO_SCALE` follows the spec, a smaller
+    /// value does not, but produces more probes with the intent of ensuring lower
+    /// latency in the event of tail loss. A value of `FAST_PTO_SCALE/4` is quite
+    /// aggressive. Smaller values (other than zero) are not rejected, but could be
+    /// very wasteful. Values greater than `FAST_PTO_SCALE` delay probes and could
+    /// reduce performance. It should not be possible to increase the PTO timer by
+    /// too much based on the range of valid values, but a maximum value of 255 will
+    /// result in very poor performance.
     /// Scaling PTO this way does not affect when persistent congestion is declared,
     /// but may change how many retransmissions are sent before declaring persistent
     /// congestion.

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -6,10 +6,11 @@
 
 use super::super::{Connection, ConnectionParameters, Output, State};
 use super::{
-    assert_full_cwnd, connect, connect_force_idle, connect_rtt_idle, connect_with_rtt,
+    assert_full_cwnd, connect, connect_force_idle, connect_rtt_idle, connect_with_rtt, cwnd,
     default_client, default_server, fill_cwnd, maybe_authenticate, new_client, send_and_receive,
     send_something, AT_LEAST_PTO, DEFAULT_RTT, DEFAULT_STREAM_DATA, POST_HANDSHAKE_CWND,
 };
+use crate::cc::CWND_MIN;
 use crate::path::PATH_MTU_V6;
 use crate::recovery::{
     FAST_PTO_SCALE, MAX_OUTSTANDING_UNACK, MIN_OUTSTANDING_UNACK, PTO_PACKET_COUNT,
@@ -719,6 +720,17 @@ fn ping_with_ack_min() {
     assert_eq!(receiver.stats().frame_tx.ping, 0);
 }
 
+/// This calculates the PTO timer immediately after connection establishment.
+/// It depends on there only being 2 RTT samples in the handshake.
+fn expected_pto(rtt: Duration) -> Duration {
+    // PTO calculation is rtt + 4rttvar + ack delay.
+    // rttvar should be (rtt + 4 * (rtt / 2) * (3/4)^n + 25ms)/2
+    // where n is the number of round trips
+    // This uses a 25ms ack delay as the ACK delay extension
+    // is negotiated and no ACK_DELAY frame has been received.
+    rtt + rtt * 9 / 8 + Duration::from_millis(25)
+}
+
 #[test]
 fn fast_pto() {
     let mut client = new_client(ConnectionParameters::default().fast_pto(FAST_PTO_SCALE / 2));
@@ -742,16 +754,8 @@ fn fast_pto() {
     assert!(dgram.is_some());
 
     // Nothing to do, should return a callback.
-    let cb = client.process(None, now).callback();
-    // PTO calculation is rtt + 4rttvar + ack delay.
-    // rttvar should be (rtt + 4 * (rtt / 2) * (3/4)^n + 25ms)/2
-    // where n is the number of round trips
-    // This uses a 25ms ack delay as the ACK delay extension
-    // is negotiated and no ACK_DELAY frame has been received.
-    assert_eq!(
-        (DEFAULT_RTT + DEFAULT_RTT * 9 / 8 + Duration::from_millis(25)) / 2,
-        cb
-    );
+    let cb = client.process_output(now).callback();
+    assert_eq!(expected_pto(DEFAULT_RTT) / 2, cb);
 
     // Once the PTO timer expires, a PTO packet should be sent should want to send PTO packet.
     now += cb;
@@ -760,4 +764,46 @@ fn fast_pto() {
     let stream_before = server.stats().frame_rx.stream;
     server.process_input(dgram.unwrap(), now);
     assert_eq!(server.stats().frame_rx.stream, stream_before + 1);
+}
+
+/// Even if the PTO timer is slowed right down, persistent congestion is declared
+/// based on the "true" value of the timer.
+#[test]
+fn fast_pto_persistent_congestion() {
+    let mut client = new_client(ConnectionParameters::default().fast_pto(FAST_PTO_SCALE * 2));
+    let mut server = default_server();
+    let mut now = connect_rtt_idle(&mut client, &mut server, DEFAULT_RTT);
+
+    let res = client.process(None, now);
+    let idle_timeout = ConnectionParameters::default().get_idle_timeout() - (DEFAULT_RTT / 2);
+    assert_eq!(res, Output::Callback(idle_timeout));
+
+    // Send packets spaced by the PTO timer.  And lose them.
+    // Note: This timing is a tiny bit higher than the client will use
+    // to determine persistent congestion. The ACK below adds another RTT
+    // estimate, which will reduce rttvar by 3/4, so persistent congestion
+    // will occur at `rtt + rtt*27/32 + 25ms`.
+    // That is OK as we're still showing that this interval is less than
+    // six times the PTO, which is what would be used if the scaling
+    // applied to the PTO used to determine persistent congestion.
+    let pc_interval = expected_pto(DEFAULT_RTT) * 3;
+    println!("pc_interval {:?}", pc_interval);
+    let _drop1 = send_something(&mut client, now);
+
+    // Check that the PTO matches expectations.
+    let cb = client.process_output(now).callback();
+    assert_eq!(expected_pto(DEFAULT_RTT) * 2, cb);
+
+    now += pc_interval;
+    let _drop2 = send_something(&mut client, now);
+    let _drop3 = send_something(&mut client, now);
+    let _drop4 = send_something(&mut client, now);
+    let dgram = send_something(&mut client, now);
+
+    // Now acknowledge the tail packet and enter persistent congestion.
+    now += DEFAULT_RTT / 2;
+    let ack = server.process(Some(dgram), now).dgram();
+    now += DEFAULT_RTT / 2;
+    client.process_input(ack.unwrap(), now);
+    assert_eq!(cwnd(&client), CWND_MIN);
 }

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -7,11 +7,13 @@
 use super::super::{Connection, ConnectionParameters, Output, State};
 use super::{
     assert_full_cwnd, connect, connect_force_idle, connect_rtt_idle, connect_with_rtt,
-    default_client, default_server, fill_cwnd, maybe_authenticate, send_and_receive,
-    send_something, AT_LEAST_PTO, DEFAULT_RTT, POST_HANDSHAKE_CWND,
+    default_client, default_server, fill_cwnd, maybe_authenticate, new_client, send_and_receive,
+    send_something, AT_LEAST_PTO, DEFAULT_RTT, DEFAULT_STREAM_DATA, POST_HANDSHAKE_CWND,
 };
 use crate::path::PATH_MTU_V6;
-use crate::recovery::{MAX_OUTSTANDING_UNACK, MIN_OUTSTANDING_UNACK, PTO_PACKET_COUNT};
+use crate::recovery::{
+    FAST_PTO_SCALE, MAX_OUTSTANDING_UNACK, MIN_OUTSTANDING_UNACK, PTO_PACKET_COUNT,
+};
 use crate::rtt::GRANULARITY;
 use crate::stats::MAX_PTO_COUNTS;
 use crate::tparams::TransportParameter;
@@ -715,4 +717,47 @@ fn ping_with_ack_min() {
     now += receiver.pto() * 3 + Duration::from_micros(1);
     trickle(&mut sender, &mut receiver, 1, now);
     assert_eq!(receiver.stats().frame_tx.ping, 0);
+}
+
+#[test]
+fn fast_pto() {
+    let mut client = new_client(ConnectionParameters::default().fast_pto(FAST_PTO_SCALE / 2));
+    let mut server = default_server();
+    let mut now = connect_rtt_idle(&mut client, &mut server, DEFAULT_RTT);
+
+    let res = client.process(None, now);
+    let idle_timeout = ConnectionParameters::default().get_idle_timeout() - (DEFAULT_RTT / 2);
+    assert_eq!(res, Output::Callback(idle_timeout));
+
+    // Send data on two streams
+    let stream = client.stream_create(StreamType::UniDi).unwrap();
+    assert_eq!(
+        client.stream_send(stream, DEFAULT_STREAM_DATA).unwrap(),
+        DEFAULT_STREAM_DATA.len()
+    );
+
+    // Send a packet after some time.
+    now += idle_timeout / 2;
+    let dgram = client.process_output(now).dgram();
+    assert!(dgram.is_some());
+
+    // Nothing to do, should return a callback.
+    let cb = client.process(None, now).callback();
+    // PTO calculation is rtt + 4rttvar + ack delay.
+    // rttvar should be (rtt + 4 * (rtt / 2) * (3/4)^n + 25ms)/2
+    // where n is the number of round trips
+    // This uses a 25ms ack delay as the ACK delay extension
+    // is negotiated and no ACK_DELAY frame has been received.
+    assert_eq!(
+        (DEFAULT_RTT + DEFAULT_RTT * 9 / 8 + Duration::from_millis(25)) / 2,
+        cb
+    );
+
+    // Once the PTO timer expires, a PTO packet should be sent should want to send PTO packet.
+    now += cb;
+    let dgram = client.process(None, now).dgram();
+
+    let stream_before = server.stats().frame_rx.stream;
+    server.process_input(dgram.unwrap(), now);
+    assert_eq!(server.stats().frame_rx.stream, stream_before + 1);
 }

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -10,6 +10,7 @@
 
 use std::cmp::{max, min};
 use std::collections::BTreeMap;
+use std::convert::TryFrom;
 use std::mem;
 use std::ops::RangeInclusive;
 use std::time::{Duration, Instant};
@@ -44,6 +45,8 @@ pub const PTO_PACKET_COUNT: usize = 2;
 pub(crate) const MAX_OUTSTANDING_UNACK: usize = 200;
 /// Disable PING until this many packets are outstanding.
 pub(crate) const MIN_OUTSTANDING_UNACK: usize = 16;
+/// The scale we use for the fast PTO feature.
+pub const FAST_PTO_SCALE: u8 = 10;
 
 #[derive(Debug, Clone)]
 #[allow(clippy::module_name_repetitions)]
@@ -562,16 +565,20 @@ pub(crate) struct LossRecovery {
     spaces: LossRecoverySpaces,
     qlog: NeqoQlog,
     stats: StatsCell,
+    /// The factor by which the PTO period is reduced.
+    /// This enables faster probing at a cost in additional lost packets.
+    fast_pto: u8,
 }
 
 impl LossRecovery {
-    pub fn new(stats: StatsCell) -> Self {
+    pub fn new(stats: StatsCell, fast_pto: u8) -> Self {
         Self {
             confirmed_time: None,
             pto_state: None,
             spaces: LossRecoverySpaces::default(),
             qlog: NeqoQlog::default(),
             stats,
+            fast_pto,
         }
     }
 
@@ -818,16 +825,21 @@ impl LossRecovery {
         rtt: &RttEstimate,
         pto_state: Option<&PtoState>,
         pn_space: PacketNumberSpace,
+        fast_pto: u8,
     ) -> Duration {
         rtt.pto(pn_space)
-            .checked_mul(1 << pto_state.map_or(0, |p| p.count))
-            .unwrap_or_else(|| Duration::from_secs(3600))
+            .checked_mul(
+                u32::from(FAST_PTO_SCALE)
+                    .checked_shl(pto_state.map_or(0, |p| u32::try_from(p.count).unwrap_or(0)))
+                    .unwrap_or(u32::MAX),
+            )
+            .map_or(Duration::from_secs(3600), |p| p / u32::from(fast_pto))
     }
 
     /// Get the current PTO period for the given packet number space.
     /// Unlike calling `RttEstimate::pto` directly, this includes exponential backoff.
     fn pto_period(&self, rtt: &RttEstimate, pn_space: PacketNumberSpace) -> Duration {
-        Self::pto_period_inner(rtt, self.pto_state.as_ref(), pn_space)
+        Self::pto_period_inner(rtt, self.pto_state.as_ref(), pn_space, self.fast_pto)
     }
 
     // Calculate PTO time for the given space.
@@ -918,6 +930,7 @@ impl LossRecovery {
                 primary_path.borrow().rtt(),
                 self.pto_state.as_ref(),
                 space.space(),
+                self.fast_pto,
             );
             space.detect_lost_packets(now, loss_delay, pto, &mut lost_packets);
 
@@ -978,7 +991,9 @@ impl ::std::fmt::Display for LossRecovery {
 
 #[cfg(test)]
 mod tests {
-    use super::{LossRecovery, LossRecoverySpace, PacketNumberSpace, SendProfile, SentPacket};
+    use super::{
+        LossRecovery, LossRecoverySpace, PacketNumberSpace, SendProfile, SentPacket, FAST_PTO_SCALE,
+    };
     use crate::cc::CongestionControlAlgorithm;
     use crate::cid::{ConnectionId, ConnectionIdEntry};
     use crate::packet::PacketType;
@@ -1064,7 +1079,7 @@ mod tests {
             );
             path.set_primary(true);
             Self {
-                lr: LossRecovery::new(StatsCell::default()),
+                lr: LossRecovery::new(StatsCell::default(), FAST_PTO_SCALE),
                 path: Rc::new(RefCell::new(path)),
             }
         }


### PR DESCRIPTION
Fastly have an option that enables faster PTOs.  This code adds a tuning parameter that scales PTOs.  It allows for tuning the base scaling of the timer, with a value of 100 being normal; 200 doubles the PTO; 50 halves it.

This deliberately doesn't affect other things that depend on the base PTO timer, like persistent congestion or idle timeouts.  Though those might be affected by a higher or lower rate of "retransmission", changing the timer substantially there might have unforeseen consequences.

The idea here is to allow people to set a value of ~50 to improve latency in cases of tail loss.  The trade-off being that there are more packets sent that might be redundant.