### PR TITLE
Use url version 2.0, that is what Firefox is already using.

### DIFF
--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -14,7 +14,7 @@ neqo-common = { path="./../neqo-common" }
 neqo-http3 = { path = "./../neqo-http3" }
 neqo-qpack = { path = "./../neqo-qpack" }
 structopt = "0.3.7"
-url = "1.7.2"
+url = "2.0"
 qlog = "0.4.0"
 
 [features]

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -298,7 +298,7 @@ fn get_output_file(
             return None;
         }
 
-        eprintln!("Saving {} to {:?}", url.clone().into_string(), out_path);
+        eprintln!("Saving {} to {:?}", url, out_path);
 
         let f = match OpenOptions::new()
             .write(true)

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -14,7 +14,7 @@ log = {version = "0.4.0", default-features = false}
 smallvec = "1.0.0"
 qlog = "0.4.0"
 sfv = "0.9.1"
-url = "1.7.2"
+url = "2.0"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }


### PR DESCRIPTION
We do not need to have 2 versions of url crate in Firefox. 