### PR TITLE
Refactor stream closing events

### DIFF
--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 use crate::connection::Http3State;
-use crate::{Header, HttpRecvStreamEvents, RecvStreamEvents, ResetType, SendStreamEvents};
+use crate::{CloseType, Header, HttpRecvStreamEvents, RecvStreamEvents, SendStreamEvents};
 
 use neqo_common::event::Provider as EventProvider;
 use neqo_crypto::ResumptionToken;
@@ -88,19 +88,17 @@ impl RecvStreamEvents for Http3ClientEvents {
     }
 
     /// Add a new `Reset` event.
-    fn reset(&self, stream_id: u64, error: AppError, reset_type: ResetType) {
-        let local = match reset_type {
-            ResetType::App => return,
-            ResetType::Remote => false,
-            ResetType::Local => true,
+    fn recv_closed(&self, stream_id: u64, close_type: CloseType) {
+        if close_type == CloseType::Done {
+            return;
+        }
+        self.remove_recv_side_events_for_stream_id(stream_id);
+        let (local, error) = match close_type {
+            CloseType::ResetApp(_) | CloseType::Done => return,
+            CloseType::ResetRemote(e) => (false, e),
+            CloseType::LocalError(e) => (true, e),
         };
-        self.remove(|evt| {
-            matches!(evt,
-                Http3ClientEvent::HeaderReady { stream_id: x, .. }
-                | Http3ClientEvent::DataReadable { stream_id: x }
-                | Http3ClientEvent::PushPromise { request_stream_id: x, .. }
-                | Http3ClientEvent::Reset { stream_id: x, .. } if *x == stream_id)
-        });
+
         self.insert(Http3ClientEvent::Reset {
             stream_id,
             error,
@@ -127,19 +125,11 @@ impl SendStreamEvents for Http3ClientEvents {
         self.insert(Http3ClientEvent::DataWritable { stream_id });
     }
 
-    fn remove_send_side_event(&self, stream_id: u64) {
-        self.remove(|evt| {
-            matches!(evt,
-                Http3ClientEvent::DataWritable { stream_id: x }
-                | Http3ClientEvent::StopSending { stream_id: x, .. } if *x == stream_id)
-        });
-    }
-
-    /// Add a new `StopSending` event
-    fn stop_sending(&self, stream_id: u64, error: AppError) {
-        // The stream has received a STOP_SENDING frame, we should remove any DataWritable event.
-        self.remove_send_side_event(stream_id);
-        self.insert(Http3ClientEvent::StopSending { stream_id, error });
+    fn send_closed(&self, stream_id: u64, close_type: CloseType) {
+        self.remove_send_side_events_for_stream_id(stream_id);
+        if let CloseType::ResetRemote(error) = close_type {
+            self.insert(Http3ClientEvent::StopSending { stream_id, error });
+        }
     }
 }
 
@@ -222,14 +212,20 @@ impl Http3ClientEvents {
     }
 
     /// Remove all events for a stream
-    pub(crate) fn remove_events_for_stream_id(&self, stream_id: u64) {
+    fn remove_recv_side_events_for_stream_id(&self, stream_id: u64) {
         self.remove(|evt| {
             matches!(evt,
                 Http3ClientEvent::HeaderReady { stream_id: x, .. }
-                | Http3ClientEvent::DataWritable { stream_id: x }
                 | Http3ClientEvent::DataReadable { stream_id: x }
                 | Http3ClientEvent::PushPromise { request_stream_id: x, .. }
-                | Http3ClientEvent::Reset { stream_id: x, .. }
+                | Http3ClientEvent::Reset { stream_id: x, .. } if *x == stream_id)
+        });
+    }
+
+    fn remove_send_side_events_for_stream_id(&self, stream_id: u64) {
+        self.remove(|evt| {
+            matches!(evt,
+                Http3ClientEvent::DataWritable { stream_id: x }
                 | Http3ClientEvent::StopSending { stream_id: x, .. } if *x == stream_id)
         });
     }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -343,10 +343,10 @@ impl Http3Client {
     /// Both sides, sending and receiving side, will be closed.
     /// # Errors
     /// An error will be return if a stream does not exist.
-    pub fn cancel_http_request(&mut self, stream_id: u64, error: AppError) -> Res<()> {
-        qinfo!([self], "reset_:stream {} error={}.", stream_id, error);
+    pub fn cancel_fetch(&mut self, stream_id: u64, error: AppError) -> Res<()> {
+        qinfo!([self], "reset_stream {} error={}.", stream_id, error);
         self.base_handler
-            .cancel_http_request(stream_id, error, &mut self.conn)
+            .cancel_fetch(stream_id, error, &mut self.conn)
     }
 
     /// This is call when application is done sending a request.
@@ -5754,9 +5754,7 @@ mod tests {
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
         setup_server_side_encoder(&mut client, &mut server);
         // Cancel request.
-        mem::drop(
-            client.cancel_http_request(request_stream_id, Error::HttpRequestCancelled.code()),
-        );
+        mem::drop(client.cancel_fetch(request_stream_id, Error::HttpRequestCancelled.code()));
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
         let out = client.process(None, now());
         mem::drop(server.conn.process(out.dgram(), now()));
@@ -5839,7 +5837,7 @@ mod tests {
 
         // Cancel request.
         client
-            .cancel_http_request(request_stream_id, Error::HttpRequestCancelled.code())
+            .cancel_fetch(request_stream_id, Error::HttpRequestCancelled.code())
             .unwrap();
 
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
@@ -5876,7 +5874,7 @@ mod tests {
 
         // Cancel request.
         client
-            .cancel_http_request(request_stream_id, Error::HttpRequestCancelled.code())
+            .cancel_fetch(request_stream_id, Error::HttpRequestCancelled.code())
             .unwrap();
 
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
@@ -5933,7 +5931,7 @@ mod tests {
 
         // Cancel request.
         client
-            .cancel_http_request(request_stream_id, Error::HttpRequestCancelled.code())
+            .cancel_fetch(request_stream_id, Error::HttpRequestCancelled.code())
             .unwrap();
 
         let out = client.process(None, now());
@@ -5947,7 +5945,7 @@ mod tests {
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
         // Cancel request.
         client
-            .cancel_http_request(request_stream_id, Error::HttpRequestCancelled.code())
+            .cancel_fetch(request_stream_id, Error::HttpRequestCancelled.code())
             .unwrap();
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
         let out = client.process(None, now());
@@ -6532,7 +6530,7 @@ mod tests {
     fn manipulate_conrol_stream(client: &mut Http3Client, stream_id: u64) {
         assert_eq!(
             client
-                .cancel_http_request(stream_id, Error::HttpNoError.code())
+                .cancel_fetch(stream_id, Error::HttpNoError.code())
                 .unwrap_err(),
             Error::InvalidStreamId
         );
@@ -6563,7 +6561,7 @@ mod tests {
         manipulate_conrol_stream(&mut client, server.encoder_stream_id.unwrap());
         manipulate_conrol_stream(&mut client, server.decoder_stream_id.unwrap());
         client
-            .cancel_http_request(request_stream_id, Error::HttpNoError.code())
+            .cancel_fetch(request_stream_id, Error::HttpNoError.code())
             .unwrap();
     }
 

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -52,8 +52,7 @@ impl Http3ServerHandler {
             .http_stream()
             .ok_or(Error::InvalidStreamId)?
             .set_message(headers, Some(data))?;
-        self.base_handler
-            .insert_streams_have_data_to_send(stream_id);
+        self.base_handler.stream_has_pending_data(stream_id);
         Ok(())
     }
 
@@ -61,15 +60,14 @@ impl Http3ServerHandler {
     /// Both sides, sending and receiving side, will be closed.
     /// # Errors
     /// An error will be return if a stream does not exist.
-    pub fn cancel_http_request(
+    pub fn cancel_fetch(
         &mut self,
         stream_id: u64,
         error: AppError,
         conn: &mut Connection,
     ) -> Res<()> {
         qinfo!([self], "reset_:stream {} error={}.", stream_id, error);
-        self.base_handler
-            .cancel_http_request(stream_id, error, conn)
+        self.base_handler.cancel_fetch(stream_id, error, conn)
     }
 
     /// Process HTTTP3 layer.

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -57,17 +57,19 @@ impl Http3ServerHandler {
         Ok(())
     }
 
-    /// Reset a request.
-    pub fn stream_reset(
+    /// An application may reset a stream(request).
+    /// Both sides, sending and receiving side, will be closed.
+    /// # Errors
+    /// An error will be return if a stream does not exist.
+    pub fn cancel_http_request(
         &mut self,
-        conn: &mut Connection,
         stream_id: u64,
-        app_error: AppError,
+        error: AppError,
+        conn: &mut Connection,
     ) -> Res<()> {
-        self.base_handler.stream_reset(conn, stream_id, app_error)?;
-        self.events.remove_events_for_stream_id(stream_id);
-        self.needs_processing = true;
-        Ok(())
+        qinfo!([self], "reset_:stream {} error={}.", stream_id, error);
+        self.base_handler
+            .cancel_http_request(stream_id, error, conn)
     }
 
     /// Process HTTTP3 layer.

--- a/neqo-http3/src/control_stream_remote.rs
+++ b/neqo-http3/src/control_stream_remote.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 
 use crate::hframe::{HFrame, HFrameReader};
-use crate::{AppError, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, ResetType, Stream};
+use crate::{CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream};
 use neqo_common::qdebug;
 use neqo_transport::Connection;
 
@@ -47,7 +47,7 @@ impl Stream for ControlStreamRemote {
 }
 
 impl RecvStream for ControlStreamRemote {
-    fn reset(&mut self, _error: AppError, _reset_type: ResetType) -> Res<()> {
+    fn reset(&mut self, _close_type: CloseType) -> Res<()> {
         Err(Error::HttpClosedCriticalStream)
     }
 

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -319,7 +319,7 @@ pub trait RecvStream: Stream {
     fn receive(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)>;
     /// # Errors
     /// An error may happen while reading a stream, e.g. early close, etc.
-    fn reset(&mut self, error: AppError, reset_type: ResetType) -> Res<()>;
+    fn reset(&mut self, close_type: CloseType) -> Res<()>;
     /// The function allows an app to read directly from the quic stream. The function
     /// returns the number of bytes written into `buf` and true/false if the stream is
     /// completely done and can be forgotten, i.e. removed from all records.
@@ -347,8 +347,7 @@ pub trait HttpRecvStream: RecvStream {
 
 pub trait RecvStreamEvents: Debug {
     fn data_readable(&self, stream_id: u64);
-    fn reset(&self, _stream_id: u64, _error: AppError, _reset_type: ResetType) {}
-    fn done(&self) {}
+    fn recv_closed(&self, _stream_id: u64, _close_type: CloseType) {}
 }
 
 pub(crate) trait HttpRecvStreamEvents: RecvStreamEvents {
@@ -368,7 +367,7 @@ pub trait SendStream: Stream {
     /// # Errors
     /// It may happen that the transport stream is already close. This is unlikely.
     fn close(&mut self, conn: &mut Connection) -> Res<()>;
-    fn stop_sending(&mut self, error: AppError);
+    fn stop_sending(&mut self, close_type: CloseType);
     fn http_stream(&mut self) -> Option<&mut dyn HttpSendStream> {
         None
     }
@@ -381,15 +380,14 @@ pub trait HttpSendStream: SendStream {
 }
 
 pub trait SendStreamEvents: Debug {
-    fn stop_sending(&self, _stream_id: u64, _error: AppError) {}
+    fn send_closed(&self, _stream_id: u64, _close_type: CloseType) {}
     fn data_writable(&self, _stream_id: u64) {}
-    fn remove_send_side_event(&self, _stream_id: u64) {}
-    fn done(&self, _stream_id: u64) {}
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ResetType {
-    App,
-    Remote,
-    Local,
+pub enum CloseType {
+    ResetApp(AppError),
+    ResetRemote(AppError),
+    LocalError(AppError),
+    Done,
 }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -384,6 +384,12 @@ pub trait SendStreamEvents: Debug {
     fn data_writable(&self, _stream_id: u64) {}
 }
 
+/// This enum is used to mark a different type of closing a stream:
+///   `ResetApp` - the application has closed the stream.
+///   `ResetRemote` - the stream was closed by the peer.
+///   `LocalError` - There was a stream error on the stream. The stream errors are errors
+///                  that do not close the complete connection, e.g. unallowed headers.
+///   `Done` - the stream was closed without an error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CloseType {
     ResetApp(AppError),

--- a/neqo-http3/src/qpack_decoder_receiver.rs
+++ b/neqo-http3/src/qpack_decoder_receiver.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{AppError, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, ResetType, Stream};
+use crate::{CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream};
 use neqo_qpack::QPackDecoder;
 use neqo_transport::Connection;
 use std::cell::RefCell;
@@ -29,7 +29,7 @@ impl Stream for DecoderRecvStream {
 }
 
 impl RecvStream for DecoderRecvStream {
-    fn reset(&mut self, _error: AppError, _reset_type: ResetType) -> Res<()> {
+    fn reset(&mut self, _close_type: CloseType) -> Res<()> {
         Err(Error::HttpClosedCriticalStream)
     }
 

--- a/neqo-http3/src/qpack_encoder_receiver.rs
+++ b/neqo-http3/src/qpack_encoder_receiver.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{AppError, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, ResetType, Stream};
+use crate::{CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream};
 use neqo_qpack::QPackEncoder;
 use neqo_transport::Connection;
 use std::cell::RefCell;
@@ -29,7 +29,7 @@ impl Stream for EncoderRecvStream {
 }
 
 impl RecvStream for EncoderRecvStream {
-    fn reset(&mut self, _error: AppError, _reset_type: ResetType) -> Res<()> {
+    fn reset(&mut self, _close_type: CloseType) -> Res<()> {
         Err(Error::HttpClosedCriticalStream)
     }
 

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -6,12 +6,13 @@
 
 use crate::hframe::HFrame;
 use crate::{
-    qlog, Error, Header, Http3StreamType, HttpSendStream, Res, SendStream, SendStreamEvents, Stream,
+    qlog, CloseType, Error, Header, Http3StreamType, HttpSendStream, Res, SendStream,
+    SendStreamEvents, Stream,
 };
 
 use neqo_common::{qdebug, qinfo, qtrace, Encoder};
 use neqo_qpack::encoder::QPackEncoder;
-use neqo_transport::{AppError, Connection};
+use neqo_transport::Connection;
 use std::cell::RefCell;
 use std::cmp::min;
 use std::fmt::Debug;
@@ -290,14 +291,14 @@ impl SendStream for SendMessage {
             }
         }
 
-        self.conn_events.remove_send_side_event(self.stream_id);
+        self.conn_events
+            .send_closed(self.stream_id, CloseType::Done);
         Ok(())
     }
 
-    fn stop_sending(&mut self, app_err: AppError) {
+    fn stop_sending(&mut self, close_type: CloseType) {
         if !self.state.is_sending_closed() {
-            self.conn_events.remove_send_side_event(self.stream_id);
-            self.conn_events.stop_sending(self.stream_id, app_err);
+            self.conn_events.send_closed(self.stream_id, close_type);
         }
     }
 

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -973,7 +973,7 @@ mod tests {
                     assert!(!fin);
                     headers_frames += 1;
                     request
-                        .stream_reset(Error::HttpRequestRejected.code())
+                        .cancel_http_request(Error::HttpRequestRejected.code())
                         .unwrap();
                 }
                 Http3ServerEvent::Data { .. } => {

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -973,7 +973,7 @@ mod tests {
                     assert!(!fin);
                     headers_frames += 1;
                     request
-                        .cancel_http_request(Error::HttpRequestRejected.code())
+                        .cancel_fetch(Error::HttpRequestRejected.code())
                         .unwrap();
                 }
                 Http3ServerEvent::Data { .. } => {

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -77,12 +77,12 @@ impl ClientRequestStream {
     /// Reset a stream/request.
     /// # Errors
     /// It may return `InvalidStreamId` if a stream does not exist anymore
-    pub fn stream_reset(&mut self, app_error: AppError) -> Res<()> {
+    pub fn cancel_http_request(&mut self, app_error: AppError) -> Res<()> {
         qdebug!([self], "reset error:{}.", app_error);
-        self.handler.borrow_mut().stream_reset(
-            &mut self.conn.borrow_mut(),
+        self.handler.borrow_mut().cancel_http_request(
             self.stream_id,
             app_error,
+            &mut self.conn.borrow_mut(),
         )
     }
 }

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -77,9 +77,9 @@ impl ClientRequestStream {
     /// Reset a stream/request.
     /// # Errors
     /// It may return `InvalidStreamId` if a stream does not exist anymore
-    pub fn cancel_http_request(&mut self, app_error: AppError) -> Res<()> {
+    pub fn cancel_fetch(&mut self, app_error: AppError) -> Res<()> {
         qdebug!([self], "reset error:{}.", app_error);
-        self.handler.borrow_mut().cancel_http_request(
+        self.handler.borrow_mut().cancel_fetch(
             self.stream_id,
             app_error,
             &mut self.conn.borrow_mut(),

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 use crate::control_stream_local::HTTP3_UNI_STREAM_TYPE_CONTROL;
-use crate::{AppError, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, ResetType, Stream};
+use crate::{CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream};
 use neqo_common::{qtrace, Decoder, IncrementalDecoderUint, Role};
 use neqo_qpack::decoder::QPACK_UNI_STREAM_TYPE_DECODER;
 use neqo_qpack::encoder::QPACK_UNI_STREAM_TYPE_ENCODER;
@@ -187,7 +187,7 @@ impl Stream for NewStreamHeadReader {
 }
 
 impl RecvStream for NewStreamHeadReader {
-    fn reset(&mut self, _error: AppError, _reset_type: ResetType) -> Res<()> {
+    fn reset(&mut self, _close_type: CloseType) -> Res<()> {
         *self = NewStreamHeadReader::Done;
         Ok(())
     }
@@ -209,7 +209,7 @@ mod tests {
     use test_fixture::{connect, now};
 
     use crate::control_stream_local::HTTP3_UNI_STREAM_TYPE_CONTROL;
-    use crate::{Error, NewStreamType, ReceiveOutput, RecvStream, Res, ResetType};
+    use crate::{CloseType, Error, NewStreamType, ReceiveOutput, RecvStream, Res};
     use neqo_common::{Encoder, Role};
     use neqo_qpack::decoder::QPACK_UNI_STREAM_TYPE_DECODER;
     use neqo_qpack::encoder::QPACK_UNI_STREAM_TYPE_ENCODER;
@@ -377,7 +377,7 @@ mod tests {
     #[test]
     fn reset() {
         let mut t = Test::new(Role::Client);
-        t.decoder.reset(0x100, ResetType::Remote).unwrap();
+        t.decoder.reset(CloseType::ResetRemote(0x100)).unwrap();
         // after a reset NewStreamHeadReader will not read more data.
         t.decode(
             &[QPACK_UNI_STREAM_TYPE_DECODER],

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -184,7 +184,7 @@ fn priority_update_dont_send_for_cancelled_stream() {
 
     let update_priority = Priority::new(6, false);
     client.priority_update(stream_id, update_priority).unwrap();
-    client.cancel_http_request(stream_id, 11).unwrap();
+    client.cancel_fetch(stream_id, 11).unwrap();
     exchange_packets(&mut client, &mut server);
 
     while let Some(event) = server.next_event() {

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -184,7 +184,7 @@ fn priority_update_dont_send_for_cancelled_stream() {
 
     let update_priority = Priority::new(6, false);
     client.priority_update(stream_id, update_priority).unwrap();
-    client.stream_reset(stream_id, 11).unwrap();
+    client.cancel_http_request(stream_id, 11).unwrap();
     exchange_packets(&mut client, &mut server);
 
     while let Some(event) = server.next_event() {

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -294,7 +294,7 @@ impl HttpServer for Http3Server {
 
                     if response.is_none() {
                         request
-                            .cancel_http_request(Error::HttpRequestIncomplete.code())
+                            .cancel_fetch(Error::HttpRequestIncomplete.code())
                             .unwrap();
                         continue;
                     }

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -294,7 +294,7 @@ impl HttpServer for Http3Server {
 
                     if response.is_none() {
                         request
-                            .stream_reset(Error::HttpRequestIncomplete.code())
+                            .cancel_http_request(Error::HttpRequestIncomplete.code())
                             .unwrap();
                         continue;
                     }


### PR DESCRIPTION
The stream closing events, e.g. application close, RESET frame, etc., will be used by WebTransport. This patch tries to cleanup that code so that it would be easier to extend it for WebTransport. ServerPush already uses the events trait, RecvStreamEvents, for the bookkeeping. For example, when a push stream is canceled or finished, the push stream listener that implements RecvStreamEvents, calls appropriate PushController functions to remove the information about the stream, etc. WebTransport will use the events in a similar way.

RecvStream’s function reset() and SendStream’s function stop_sending() now use CloseType. The two functions will be used to inform a stream that it is abruptly closed, either by application(CloseType::AppError), stream error (e.g. unallowed request headers;CloseType::ResetLocal(error)) or the peer reset(CloseType::ResetRemote(error)).

Reset and done functions from RecvStreamEvents are replaced by one function recv_closed that also uses CloseType. Similarly, stop_sending and done functions from SendStreamEvents are replaced by send_closed().
CloseType values are:
Done - stream has finished without error.
AppError(error) - the application closed the stream.
ResetLocal(error) - there was an error on the stream that is not the session error, e.g. unallowed headers.
ResetRemote(error) - the peer has sent RESET/STOP_SENDING frame.

How this all work:
SendStreams will be closed by calling close()(closing without an error) or stop_sending(). These functions will call the events listener function send_closed with appropriate CloseType. If close() is called on a sending stream send_closed will be called immediately, even though not all data is sent (We may need to change this in a separate PR).
RecvSteam will be closed by reset() or by receiving a fin. The fin will be received during execution of functions receive() or read_data(). These functions will call the listener function recv_closed with appropriate CloseType.

Additional changes:
- remove_recv_side_events_for_stream_id and similar functions are not used any more outside Http3ClientEvent and Http3ServerConnEvent. This is a cleaner design.  

- stream_reset API function was used to reset HTTP requests. In the HTTP case it is usual that we want to close both sides, sending and receiving side, of a stream. For WebTransport this will not be the case. This patch renames stream_reset into cancel_http_request and prepares 2 additional functions stream_stop_sending and stream_reset_send. The API for here 2 functions will be added when WebTransport is implemented.