### PR TITLE
WebTransport session

### DIFF
--- a/neqo-common/src/headers.rs
+++ b/neqo-common/src/headers.rs
@@ -13,6 +13,7 @@ const PSEUDO_HEADER_METHOD: u8 = 0x2;
 const PSEUDO_HEADER_SCHEME: u8 = 0x4;
 const PSEUDO_HEADER_AUTHORITY: u8 = 0x8;
 const PSEUDO_HEADER_PATH: u8 = 0x10;
+const PSEUDO_HEADER_PROTOCOL: u8 = 0x20;
 const REGULAR_HEADER: u8 = 0x80;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -62,6 +63,7 @@ impl Headers {
                 (MessageType::Request, ":scheme") => PSEUDO_HEADER_SCHEME,
                 (MessageType::Request, ":authority") => PSEUDO_HEADER_AUTHORITY,
                 (MessageType::Request, ":path") => PSEUDO_HEADER_PATH,
+                (MessageType::Request, ":protocol") => PSEUDO_HEADER_PROTOCOL,
                 (_, _) => return Err(Error::InvalidHeader),
             };
             (true, bit)
@@ -111,6 +113,14 @@ impl Headers {
                 }
             }
         };
+
+        if (MessageType::Request == message_type)
+            && ((pseudo_state & PSEUDO_HEADER_PROTOCOL) > 0)
+            && method_value != Some(&"CONNECT".to_string())
+        {
+            return Err(Error::InvalidHeader);
+        }
+
         if pseudo_state & pseudo_header_mask != pseudo_header_mask {
             return Err(Error::InvalidHeader);
         }

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -160,9 +160,9 @@ impl SendStreamEvents for Http3ClientEvents {
 impl ExtendedConnectEvents for Http3ClientEvents {
     fn session_start(&self, connect_type: ExtendedConnectType, stream_id: StreamId) {
         if connect_type == ExtendedConnectType::WebTransport {
-            self.insert(Http3ClientEvent::WebTransport(
-                WebTransportEvent::Session(stream_id),
-            ));
+            self.insert(Http3ClientEvent::WebTransport(WebTransportEvent::Session(
+                stream_id,
+            )));
         }
     }
 

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -22,9 +22,9 @@ use std::rc::Rc;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum WebTransportEvent {
-    WebTransportNegotiated(bool),
-    WebTransportSession(StreamId),
-    WebTransportSessionClosed {
+    Negotiated(bool),
+    Session(StreamId),
+    SessionClosed {
         stream_id: StreamId,
         error: Option<AppError>,
     },
@@ -161,7 +161,7 @@ impl ExtendedConnectEvents for Http3ClientEvents {
     fn session_start(&self, connect_type: ExtendedConnectType, stream_id: StreamId) {
         if connect_type == ExtendedConnectType::WebTransport {
             self.insert(Http3ClientEvent::WebTransport(
-                WebTransportEvent::WebTransportSession(stream_id),
+                WebTransportEvent::Session(stream_id),
             ));
         }
     }
@@ -174,7 +174,7 @@ impl ExtendedConnectEvents for Http3ClientEvents {
     ) {
         if connect_type == ExtendedConnectType::WebTransport {
             self.insert(Http3ClientEvent::WebTransport(
-                WebTransportEvent::WebTransportSessionClosed { stream_id, error },
+                WebTransportEvent::SessionClosed { stream_id, error },
             ));
         } else {
             unreachable!("There are no other types.");
@@ -301,7 +301,7 @@ impl Http3ClientEvents {
     pub fn negotiation_done(&self, feature_type: HSettingType, negotiated: bool) {
         if feature_type == HSettingType::EnableWebTransport {
             self.insert(Http3ClientEvent::WebTransport(
-                WebTransportEvent::WebTransportNegotiated(negotiated),
+                WebTransportEvent::Negotiated(negotiated),
             ));
         }
     }

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -158,19 +158,15 @@ impl SendStreamEvents for Http3ClientEvents {
 }
 
 impl ExtendedConnectEvents for Http3ClientEvents {
-    fn extended_connect_session_established(
-        &self,
-        connect_type: ExtendedConnectType,
-        stream_id: StreamId,
-    ) {
+    fn session_start(&self, connect_type: ExtendedConnectType, stream_id: StreamId) {
         if connect_type == ExtendedConnectType::WebTransport {
             self.insert(Http3ClientEvent::WebTransport(
                 WebTransportEvent::WebTransportSession(stream_id),
-            ))
+            ));
         }
     }
 
-    fn extended_connect_session_closed(
+    fn session_end(
         &self,
         connect_type: ExtendedConnectType,
         stream_id: StreamId,
@@ -180,6 +176,8 @@ impl ExtendedConnectEvents for Http3ClientEvents {
             self.insert(Http3ClientEvent::WebTransport(
                 WebTransportEvent::WebTransportSessionClosed { stream_id, error },
             ));
+        } else {
+            unreachable!("There are no other types.");
         }
     }
 }

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(clippy::module_name_repetitions)]
+
 pub mod session;
 
 use crate::client_events::Http3ClientEvents;
@@ -17,12 +19,8 @@ use std::fmt::Debug;
 use std::rc::Rc;
 
 pub trait ExtendedConnectEvents: Debug {
-    fn extended_connect_session_established(
-        &self,
-        connect_type: ExtendedConnectType,
-        stream_id: StreamId,
-    );
-    fn extended_connect_session_closed(
+    fn session_start(&self, connect_type: ExtendedConnectType, stream_id: StreamId);
+    fn session_end(
         &self,
         connect_type: ExtendedConnectType,
         stream_id: StreamId,
@@ -36,10 +34,14 @@ pub enum ExtendedConnectType {
 }
 
 impl ExtendedConnectType {
+    #[must_use]
+    #[allow(clippy::unused_self)] // This will change when we have more features using ExtendedConnectType.
     pub fn string(&self) -> &str {
         "webtransport"
     }
 
+    #[must_use]
+    #[allow(clippy::unused_self)] // This will change when we have more features using ExtendedConnectType.
     pub fn setting_type(&self) -> HSettingType {
         HSettingType::EnableWebTransport
     }
@@ -53,6 +55,7 @@ pub struct ExtendedConnectFeature {
 }
 
 impl ExtendedConnectFeature {
+    #[must_use]
     pub fn new(connect_type: ExtendedConnectType, enable: bool) -> Self {
         Self {
             feature_negotiation: NegotiationState::new(enable, connect_type.setting_type()),
@@ -73,6 +76,7 @@ impl ExtendedConnectFeature {
         self.feature_negotiation.handle_settings(settings);
     }
 
+    #[must_use]
     pub fn enabled(&self) -> bool {
         self.feature_negotiation.enabled()
     }

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -1,0 +1,79 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub mod session;
+
+use crate::client_events::Http3ClientEvents;
+use crate::features::NegotiationState;
+use crate::settings::{HSettingType, HSettings};
+use neqo_transport::{AppError, StreamId};
+pub use session::ExtendedConnectSession;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::rc::Rc;
+
+pub trait ExtendedConnectEvents: Debug {
+    fn extended_connect_session_established(
+        &self,
+        connect_type: ExtendedConnectType,
+        stream_id: StreamId,
+    );
+    fn extended_connect_session_closed(
+        &self,
+        connect_type: ExtendedConnectType,
+        stream_id: StreamId,
+        error: Option<AppError>,
+    );
+}
+
+#[derive(Debug, PartialEq, Copy, Clone, Eq)]
+pub enum ExtendedConnectType {
+    WebTransport,
+}
+
+impl ExtendedConnectType {
+    pub fn string(&self) -> &str {
+        "webtransport"
+    }
+
+    pub fn setting_type(&self) -> HSettingType {
+        HSettingType::EnableWebTransport
+    }
+}
+
+#[derive(Debug)]
+pub struct ExtendedConnectFeature {
+    connect_type: ExtendedConnectType,
+    feature_negotiation: NegotiationState,
+    sessions: HashMap<StreamId, Rc<RefCell<ExtendedConnectSession>>>,
+}
+
+impl ExtendedConnectFeature {
+    pub fn new(connect_type: ExtendedConnectType, enable: bool) -> Self {
+        Self {
+            feature_negotiation: NegotiationState::new(enable, connect_type.setting_type()),
+            connect_type,
+            sessions: HashMap::new(),
+        }
+    }
+
+    pub fn set_listener(&mut self, new_listener: Http3ClientEvents) {
+        self.feature_negotiation.set_listener(new_listener);
+    }
+
+    pub fn insert(&mut self, stream_id: StreamId, session: Rc<RefCell<ExtendedConnectSession>>) {
+        self.sessions.insert(stream_id, session);
+    }
+
+    pub fn handle_settings(&mut self, settings: &HSettings) {
+        self.feature_negotiation.handle_settings(settings);
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.feature_negotiation.enabled()
+    }
+}

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -42,7 +42,7 @@ impl ExtendedConnectType {
 
     #[must_use]
     #[allow(clippy::unused_self)] // This will change when we have more features using ExtendedConnectType.
-    pub fn setting_type(&self) -> HSettingType {
+    pub fn setting_type(self) -> HSettingType {
         HSettingType::EnableWebTransport
     }
 }

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -1,0 +1,112 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use super::{ExtendedConnectEvents, ExtendedConnectType};
+use crate::{CloseType, Error, HttpRecvStreamEvents, RecvStreamEvents, SendStreamEvents};
+use neqo_common::{qtrace, Headers};
+use neqo_transport::{AppError, StreamId};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Debug, PartialEq)]
+enum SessionState {
+    Negotiating,
+    Active,
+    Done,
+}
+
+#[derive(Debug)]
+pub struct ExtendedConnectSession {
+    connect_type: ExtendedConnectType,
+    state: SessionState,
+    events: Box<dyn ExtendedConnectEvents>,
+}
+
+impl ::std::fmt::Display for ExtendedConnectSession {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(
+            f,
+            "ExtendedConnectSesssion for {}",
+            self.connect_type.string(),
+        )
+    }
+}
+
+impl ExtendedConnectSession {
+    pub fn new(connect_type: ExtendedConnectType, events: Box<dyn ExtendedConnectEvents>) -> Self {
+        Self {
+            connect_type,
+            state: SessionState::Negotiating,
+            events,
+        }
+    }
+
+    fn close(&mut self, stream_id: StreamId, error: Option<AppError>) {
+        if self.state == SessionState::Done {
+            return;
+        }
+        qtrace!("ExtendedConnect close the session");
+        self.state = SessionState::Done;
+        self.events
+            .extended_connect_session_closed(self.connect_type, stream_id, error);
+    }
+
+    fn negotiation_done(&mut self, stream_id: StreamId, succeeded: bool) {
+        if self.state == SessionState::Done {
+            return;
+        }
+        self.state = if succeeded {
+            self.events
+                .extended_connect_session_established(self.connect_type, stream_id);
+            SessionState::Active
+        } else {
+            self.events
+                .extended_connect_session_closed(self.connect_type, stream_id, None);
+            SessionState::Done
+        };
+    }
+}
+
+impl RecvStreamEvents for Rc<RefCell<ExtendedConnectSession>> {
+    fn data_readable(&self, stream_id: StreamId) {
+        // A session request is not expected to receive any data. This may change in
+        // the future.
+        self.borrow_mut()
+            .close(stream_id, Some(Error::HttpGeneralProtocolStream.code()));
+    }
+
+    fn recv_closed(&self, stream_id: StreamId, close_type: CloseType) {
+        self.borrow_mut().close(stream_id, close_type.error());
+    }
+}
+
+impl HttpRecvStreamEvents for Rc<RefCell<ExtendedConnectSession>> {
+    fn header_ready(&self, stream_id: StreamId, headers: Headers, _interim: bool, _fin: bool) {
+        qtrace!("ExtendedConnect response headers {:?}", headers);
+        self.borrow_mut().negotiation_done(
+            stream_id,
+            headers
+                .iter()
+                .find_map(|h| {
+                    if h.name() == ":status" && h.value() == "200" {
+                        Some(())
+                    } else {
+                        None
+                    }
+                })
+                .is_some(),
+        );
+    }
+}
+
+impl SendStreamEvents for Rc<RefCell<ExtendedConnectSession>> {
+    fn data_writable(&self, _stream_id: StreamId) {}
+
+    /// Add a new `StopSending` event
+    fn send_closed(&self, stream_id: StreamId, close_type: CloseType) {
+        self.borrow_mut().close(stream_id, close_type.error());
+    }
+}

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(clippy::module_name_repetitions)]
+
 use super::{ExtendedConnectEvents, ExtendedConnectType};
 use crate::{CloseType, Error, HttpRecvStreamEvents, RecvStreamEvents, SendStreamEvents};
 use neqo_common::{qtrace, Headers};
@@ -36,6 +38,7 @@ impl ::std::fmt::Display for ExtendedConnectSession {
 }
 
 impl ExtendedConnectSession {
+    #[must_use]
     pub fn new(connect_type: ExtendedConnectType, events: Box<dyn ExtendedConnectEvents>) -> Self {
         Self {
             connect_type,
@@ -50,8 +53,7 @@ impl ExtendedConnectSession {
         }
         qtrace!("ExtendedConnect close the session");
         self.state = SessionState::Done;
-        self.events
-            .extended_connect_session_closed(self.connect_type, stream_id, error);
+        self.events.session_end(self.connect_type, stream_id, error);
     }
 
     fn negotiation_done(&mut self, stream_id: StreamId, succeeded: bool) {
@@ -59,12 +61,10 @@ impl ExtendedConnectSession {
             return;
         }
         self.state = if succeeded {
-            self.events
-                .extended_connect_session_established(self.connect_type, stream_id);
+            self.events.session_start(self.connect_type, stream_id);
             SessionState::Active
         } else {
-            self.events
-                .extended_connect_session_closed(self.connect_type, stream_id, None);
+            self.events.session_end(self.connect_type, stream_id, None);
             SessionState::Done
         };
     }

--- a/neqo-http3/src/features/mod.rs
+++ b/neqo-http3/src/features/mod.rs
@@ -12,6 +12,8 @@ use neqo_common::qtrace;
 use std::fmt::Debug;
 use std::mem;
 
+pub mod extended_connect;
+
 /// States:
 /// - `Disable` - it is not turned on for this connection.
 /// - `Negotiating` - the feature is enabled locally, but settings from the peer

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -424,6 +424,7 @@ pub enum CloseType {
 }
 
 impl CloseType {
+    #[must_use]
     pub fn error(&self) -> Option<AppError> {
         match self {
             Self::ResetApp(error) | Self::ResetRemote(error) | Self::LocalError(error) => {

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -296,6 +296,10 @@ impl HttpSendStream for SendMessage {
         self.stream.buffer(&buf);
         Ok(())
     }
+
+    fn set_new_listener(&mut self, conn_events: Box<dyn SendStreamEvents>) {
+        self.conn_events = conn_events;
+    }
 }
 
 impl ::std::fmt::Display for SendMessage {

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -199,7 +199,7 @@ impl Http3Server {
                             self.events.webtransport_new_session(
                                 WebTransportRequest::new(conn.clone(), handler.clone(), stream_id),
                                 headers,
-                            )
+                            );
                         }
                         Http3ServerConnEvent::ExtendedConnectClosed {
                             stream_id, error, ..

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -82,14 +82,9 @@ impl HttpRecvStreamEvents for Http3ServerConnEvents {
 }
 
 impl ExtendedConnectEvents for Http3ServerConnEvents {
-    fn extended_connect_session_established(
-        &self,
-        _connect_type: ExtendedConnectType,
-        _stream_id: StreamId,
-    ) {
-    }
+    fn session_start(&self, _connect_type: ExtendedConnectType, _stream_id: StreamId) {}
 
-    fn extended_connect_session_closed(
+    fn session_end(
         &self,
         connect_type: ExtendedConnectType,
         stream_id: StreamId,

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -15,6 +15,7 @@ use neqo_transport::{AppError, Connection, StreamId};
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
+use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 
 #[derive(Debug, Clone)]
@@ -172,19 +173,19 @@ impl ClientRequestStream {
         qinfo!([self], "Set new response.");
         self.stream_handler.stream_close_send()
     }
+}
 
-    /// Request a peer to stop sending a request.
-    /// # Errors
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn stream_stop_sending(&mut self, app_error: AppError) -> Res<()> {
-        self.stream_handler.stream_stop_sending(app_error)
+impl Deref for ClientRequestStream {
+    type Target = StreamHandler;
+    #[must_use]
+    fn deref(&self) -> &Self::Target {
+        &self.stream_handler
     }
+}
 
-    /// Reset a stream/request.
-    /// # Errors
-    /// It may return `InvalidStreamId` if a stream does not exist anymore
-    pub fn cancel_fetch(&mut self, app_error: AppError) -> Res<()> {
-        self.stream_handler.cancel_fetch(app_error)
+impl DerefMut for ClientRequestStream {
+    fn deref_mut(&mut self) -> &mut StreamHandler {
+        &mut self.stream_handler
     }
 }
 
@@ -229,15 +230,15 @@ impl WebTransportRequest {
         }
     }
 
-    /// Respond to a webTransport session request.
+    /// Respond to a `WebTransport` session request.
     /// # Errors
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn response(&mut self, accept: bool) -> Res<()> {
-        qinfo!([self], "Set a respons for a WebTransport session.");
+        qinfo!([self], "Set a response for a WebTransport session.");
         self.stream_handler
             .handler
             .borrow_mut()
-            .webtransport_session_response(
+            .webtransport_session_accept(
                 &mut self.stream_handler.conn.borrow_mut(),
                 self.stream_handler.stream_id,
                 accept,

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -245,6 +245,7 @@ impl WebTransportRequest {
             )
     }
 
+    #[must_use]
     pub fn stream_id(&self) -> StreamId {
         self.stream_handler.stream_id
     }

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -8,8 +8,8 @@
 
 use crate::connection::Http3State;
 use crate::connection_server::Http3ServerHandler;
-use crate::{Header, Headers, Priority, Res};
-use neqo_common::{qdebug, qinfo};
+use crate::{Headers, Priority, Res};
+use neqo_common::{qdebug, qinfo, Header};
 use neqo_transport::server::ActiveConnectionRef;
 use neqo_transport::{AppError, Connection, StreamId};
 
@@ -18,36 +18,36 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 
 #[derive(Debug, Clone)]
-pub struct ClientRequestStream {
+pub struct StreamHandler {
     conn: ActiveConnectionRef,
     handler: Rc<RefCell<Http3ServerHandler>>,
     stream_id: StreamId,
 }
 
-impl ::std::fmt::Display for ClientRequestStream {
+impl ::std::fmt::Display for StreamHandler {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         let conn: &Connection = &self.conn.borrow();
-        write!(
-            f,
-            "Http3 server conn={:?} stream_id={}",
-            conn, self.stream_id
-        )
+        write!(f, "conn={} stream_id={}", conn, self.stream_id)
     }
 }
 
-impl ClientRequestStream {
-    pub(crate) fn new(
-        conn: ActiveConnectionRef,
-        handler: Rc<RefCell<Http3ServerHandler>>,
-        stream_id: StreamId,
-    ) -> Self {
-        Self {
-            conn,
-            handler,
-            stream_id,
-        }
+impl std::hash::Hash for StreamHandler {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.conn.hash(state);
+        state.write_u64(self.stream_id.as_u64());
+        state.finish();
     }
+}
 
+impl PartialEq for StreamHandler {
+    fn eq(&self, other: &Self) -> bool {
+        self.conn == other.conn && self.stream_id == other.stream_id
+    }
+}
+
+impl Eq for StreamHandler {}
+
+impl StreamHandler {
     /// Supply a response header to a request.
     /// # Errors
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
@@ -67,16 +67,17 @@ impl ClientRequestStream {
             .send_data(self.stream_id, data, &mut self.conn.borrow_mut())
     }
 
-    /// Close senidng side of the stream.
+    /// Close sending side.
     /// # Errors
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn close_send(&mut self) -> Res<()> {
+    pub fn stream_close_send(&mut self) -> Res<()> {
+        qinfo!([self], "Set new response.");
         self.handler
             .borrow_mut()
             .stream_close_send(self.stream_id, &mut self.conn.borrow_mut())
     }
 
-    /// Request a peer to stop sending a request.
+    /// Request a peer to stop sending a stream.
     /// # Errors
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn stream_stop_sending(&mut self, app_error: AppError) -> Res<()> {
@@ -86,10 +87,28 @@ impl ClientRequestStream {
             self.stream_id,
             app_error
         );
-        self.conn
-            .borrow_mut()
-            .stream_stop_sending(self.stream_id, app_error)?;
-        Ok(())
+        self.handler.borrow_mut().stream_stop_sending(
+            self.stream_id,
+            app_error,
+            &mut self.conn.borrow_mut(),
+        )
+    }
+
+    /// Reset sending side of a stream.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn stream_reset_send(&mut self, app_error: AppError) -> Res<()> {
+        qdebug!(
+            [self],
+            "reset send stream_id:{} error:{}.",
+            self.stream_id,
+            app_error
+        );
+        self.handler.borrow_mut().stream_reset_send(
+            self.stream_id,
+            app_error,
+            &mut self.conn.borrow_mut(),
+        )
     }
 
     /// Reset a stream/request.
@@ -105,21 +124,185 @@ impl ClientRequestStream {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct ClientRequestStream {
+    stream_handler: StreamHandler,
+}
+
+impl ::std::fmt::Display for ClientRequestStream {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "Http3 server {:?}", self.stream_handler)
+    }
+}
+
+impl ClientRequestStream {
+    pub(crate) fn new(
+        conn: ActiveConnectionRef,
+        handler: Rc<RefCell<Http3ServerHandler>>,
+        stream_id: StreamId,
+    ) -> Self {
+        Self {
+            stream_handler: StreamHandler {
+                conn,
+                handler,
+                stream_id,
+            },
+        }
+    }
+
+    /// Supply a response header to a request.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn send_headers(&mut self, headers: &[Header]) -> Res<()> {
+        self.stream_handler.send_headers(headers)
+    }
+
+    /// Supply response data to a request.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn send_data(&mut self, data: &[u8]) -> Res<()> {
+        qinfo!([self], "Set new response.");
+        self.stream_handler.send_data(data)
+    }
+
+    /// Close sending side.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn stream_close_send(&mut self) -> Res<()> {
+        qinfo!([self], "Set new response.");
+        self.stream_handler.stream_close_send()
+    }
+
+    /// Request a peer to stop sending a request.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn stream_stop_sending(&mut self, app_error: AppError) -> Res<()> {
+        self.stream_handler.stream_stop_sending(app_error)
+    }
+
+    /// Reset a stream/request.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore
+    pub fn cancel_fetch(&mut self, app_error: AppError) -> Res<()> {
+        self.stream_handler.cancel_fetch(app_error)
+    }
+}
+
 impl std::hash::Hash for ClientRequestStream {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.conn.hash(state);
-        state.write_u64(self.stream_id.as_u64());
+        self.stream_handler.hash(state);
         state.finish();
     }
 }
 
 impl PartialEq for ClientRequestStream {
     fn eq(&self, other: &Self) -> bool {
-        self.conn == other.conn && self.stream_id == other.stream_id
+        self.stream_handler == other.stream_handler
     }
 }
 
 impl Eq for ClientRequestStream {}
+
+#[derive(Debug, Clone)]
+pub struct WebTransportRequest {
+    stream_handler: StreamHandler,
+}
+
+impl ::std::fmt::Display for WebTransportRequest {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "WebTransport session {}", self.stream_handler)
+    }
+}
+
+impl WebTransportRequest {
+    pub(crate) fn new(
+        conn: ActiveConnectionRef,
+        handler: Rc<RefCell<Http3ServerHandler>>,
+        stream_id: StreamId,
+    ) -> Self {
+        Self {
+            stream_handler: StreamHandler {
+                conn,
+                handler,
+                stream_id,
+            },
+        }
+    }
+
+    /// Respond to a webTransport session request.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn response(&mut self, accept: bool) -> Res<()> {
+        qinfo!([self], "Set a respons for a WebTransport session.");
+        self.stream_handler
+            .handler
+            .borrow_mut()
+            .webtransport_session_response(
+                &mut self.stream_handler.conn.borrow_mut(),
+                self.stream_handler.stream_id,
+                accept,
+            )
+    }
+
+    pub fn stream_id(&self) -> StreamId {
+        self.stream_handler.stream_id
+    }
+
+    /// Close sending side.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn stream_close_send(&mut self) -> Res<()> {
+        self.stream_handler.stream_close_send()
+    }
+
+    /// Request a peer to stop sending a request.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn stream_stop_sending(&mut self, app_error: AppError) -> Res<()> {
+        self.stream_handler.stream_stop_sending(app_error)
+    }
+
+    /// Reset sending side of a stream.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn stream_reset_send(&mut self, app_error: AppError) -> Res<()> {
+        self.stream_handler.stream_reset_send(app_error)
+    }
+
+    /// Reset a stream/request.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore
+    pub fn cancel_fetch(&mut self, app_error: AppError) -> Res<()> {
+        self.stream_handler.cancel_fetch(app_error)
+    }
+}
+
+impl std::hash::Hash for WebTransportRequest {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.stream_handler.hash(state);
+        state.finish();
+    }
+}
+
+impl PartialEq for WebTransportRequest {
+    fn eq(&self, other: &Self) -> bool {
+        self.stream_handler == other.stream_handler
+    }
+}
+
+impl Eq for WebTransportRequest {}
+
+#[derive(Debug, Clone)]
+pub enum WebTransportServerEvent {
+    WebTransportNewSession {
+        session: WebTransportRequest,
+        headers: Headers,
+    },
+    WebTransportSessionClosed {
+        session: WebTransportRequest,
+        error: Option<AppError>,
+    },
+}
 
 #[derive(Debug, Clone)]
 pub enum Http3ServerEvent {
@@ -144,6 +327,7 @@ pub enum Http3ServerEvent {
         stream_id: StreamId,
         priority: Priority,
     },
+    WebTransport(WebTransportServerEvent),
 }
 
 #[derive(Debug, Default, Clone)]
@@ -195,5 +379,21 @@ impl Http3ServerEvents {
             stream_id,
             priority,
         });
+    }
+
+    pub(crate) fn webtransport_new_session(&self, session: WebTransportRequest, headers: Headers) {
+        self.insert(Http3ServerEvent::WebTransport(
+            WebTransportServerEvent::WebTransportNewSession { session, headers },
+        ));
+    }
+
+    pub(crate) fn webtransport_session_closed(
+        &self,
+        session: WebTransportRequest,
+        error: Option<AppError>,
+    ) {
+        self.insert(Http3ServerEvent::WebTransport(
+            WebTransportServerEvent::WebTransportSessionClosed { session, error },
+        ));
     }
 }

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -49,7 +49,7 @@ fn set_response(request: &mut ClientRequestStream) {
         ])
         .unwrap();
     request.send_data(RESPONSE_DATA).unwrap();
-    request.close_send().unwrap();
+    request.stream_close_send().unwrap();
 }
 
 fn process_server_events(server: &mut Http3Server) {

--- a/neqo-http3/tests/mod.rs
+++ b/neqo-http3/tests/mod.rs
@@ -1,0 +1,7 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod webtransport;

--- a/neqo-http3/tests/send_message.rs
+++ b/neqo-http3/tests/send_message.rs
@@ -168,7 +168,7 @@ fn response_trailers1() {
     send_headers(&mut request).unwrap();
     request.send_data(RESPONSE_DATA).unwrap();
     send_trailers(&mut request).unwrap();
-    request.close_send().unwrap();
+    request.stream_close_send().unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
     process_client_events(&mut hconn_c);
 }
@@ -180,7 +180,7 @@ fn response_trailers2() {
     request.send_data(RESPONSE_DATA).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
     send_trailers(&mut request).unwrap();
-    request.close_send().unwrap();
+    request.stream_close_send().unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
     process_client_events(&mut hconn_c);
 }
@@ -193,7 +193,7 @@ fn response_trailers3() {
     exchange_packets(&mut hconn_c, &mut hconn_s);
     send_trailers(&mut request).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
-    request.close_send().unwrap();
+    request.stream_close_send().unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
     process_client_events(&mut hconn_c);
 }
@@ -205,7 +205,7 @@ fn response_trailers_no_data() {
     exchange_packets(&mut hconn_c, &mut hconn_s);
     send_trailers(&mut request).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
-    request.close_send().unwrap();
+    request.stream_close_send().unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
     process_client_events_no_data(&mut hconn_c);
 }
@@ -221,7 +221,7 @@ fn multiple_response_trailers() {
 
     assert_eq!(send_trailers(&mut request), Err(Error::InvalidInput));
 
-    request.close_send().unwrap();
+    request.stream_close_send().unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
     process_client_events(&mut hconn_c);
 }
@@ -237,7 +237,7 @@ fn data_after_trailer() {
 
     assert_eq!(request.send_data(RESPONSE_DATA), Err(Error::InvalidInput));
 
-    request.close_send().unwrap();
+    request.stream_close_send().unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
     process_client_events(&mut hconn_c);
 }
@@ -247,7 +247,7 @@ fn trailers_after_close() {
     let (mut hconn_c, mut hconn_s, mut request) = connect_send_and_receive_request();
     send_headers(&mut request).unwrap();
     request.send_data(RESPONSE_DATA).unwrap();
-    request.close_send().unwrap();
+    request.stream_close_send().unwrap();
 
     assert_eq!(send_trailers(&mut request), Err(Error::InvalidStreamId));
 
@@ -265,7 +265,7 @@ fn multiple_response_headers() {
         Err(Error::InvalidHeader)
     );
 
-    request.close_send().unwrap();
+    request.stream_close_send().unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
     process_client_events_no_data(&mut hconn_c);
 }
@@ -280,7 +280,7 @@ fn informational_after_response_headers() {
         Err(Error::InvalidHeader)
     );
 
-    request.close_send().unwrap();
+    request.stream_close_send().unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
     process_client_events_no_data(&mut hconn_c);
 }
@@ -294,7 +294,7 @@ fn data_after_informational() {
 
     send_headers(&mut request).unwrap();
     request.send_data(RESPONSE_DATA).unwrap();
-    request.close_send().unwrap();
+    request.stream_close_send().unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
     process_client_events(&mut hconn_c);
 }
@@ -311,7 +311,7 @@ fn non_trailers_headers_after_data() {
         Err(Error::InvalidHeader)
     );
 
-    request.close_send().unwrap();
+    request.stream_close_send().unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
     process_client_events(&mut hconn_c);
 }
@@ -323,7 +323,7 @@ fn data_before_headers() {
 
     send_headers(&mut request).unwrap();
     request.send_data(RESPONSE_DATA).unwrap();
-    request.close_send().unwrap();
+    request.stream_close_send().unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
     process_client_events(&mut hconn_c);
 }

--- a/neqo-http3/tests/webtransport/mod.rs
+++ b/neqo-http3/tests/webtransport/mod.rs
@@ -182,12 +182,12 @@ impl WtTest {
         id: StreamId,
         expected_error: &Option<AppError>,
     ) -> bool {
-        if let Http3ClientEvent::WebTransport(e) = e {
-            if let WebTransportEvent::WebTransportSessionClosed { stream_id, error } = e {
-                *stream_id == id && error == expected_error
-            } else {
-                false
-            }
+        if let Http3ClientEvent::WebTransport(WebTransportEvent::WebTransportSessionClosed {
+            stream_id,
+            error,
+        }) = e
+        {
+            *stream_id == id && error == expected_error
         } else {
             false
         }
@@ -219,12 +219,11 @@ impl WtTest {
         id: StreamId,
         expected_error: &Option<AppError>,
     ) -> bool {
-        if let Http3ServerEvent::WebTransport(e) = e {
-            if let WebTransportServerEvent::WebTransportSessionClosed { session, error } = e {
-                session.stream_id() == id && error == expected_error
-            } else {
-                false
-            }
+        if let Http3ServerEvent::WebTransport(
+            WebTransportServerEvent::WebTransportSessionClosed { session, error },
+        ) = e
+        {
+            session.stream_id() == id && error == expected_error
         } else {
             false
         }

--- a/neqo-http3/tests/webtransport/mod.rs
+++ b/neqo-http3/tests/webtransport/mod.rs
@@ -149,7 +149,7 @@ impl WtTest {
         let wt_session_negotiated_event = |e| {
             matches!(
                 e,
-                Http3ClientEvent::WebTransport(WebTransportEvent::WebTransportSession(stream_id)) if stream_id == wt_session_id
+                Http3ClientEvent::WebTransport(WebTransportEvent::Session(stream_id)) if stream_id == wt_session_id
             )
         };
         assert!(self.client.events().any(wt_session_negotiated_event));
@@ -182,7 +182,7 @@ impl WtTest {
         id: StreamId,
         expected_error: &Option<AppError>,
     ) -> bool {
-        if let Http3ClientEvent::WebTransport(WebTransportEvent::WebTransportSessionClosed {
+        if let Http3ClientEvent::WebTransport(WebTransportEvent::SessionClosed {
             stream_id,
             error,
         }) = e

--- a/neqo-http3/tests/webtransport/mod.rs
+++ b/neqo-http3/tests/webtransport/mod.rs
@@ -1,0 +1,205 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use neqo_common::event::Provider;
+use neqo_crypto::AuthenticationStatus;
+use neqo_http3::{
+    Error, Http3Client, Http3ClientEvent, Http3Parameters, Http3Server, Http3ServerEvent,
+    Http3State, WebTransportEvent, WebTransportRequest, WebTransportServerEvent,
+};
+use neqo_transport::{AppError, ConnectionParameters, StreamId};
+use std::cell::RefCell;
+use std::rc::Rc;
+use test_fixture::{
+    addr, anti_replay, fixture_init, now, CountingConnectionIdGenerator, DEFAULT_ALPN_H3,
+    DEFAULT_KEYS, DEFAULT_SERVER_NAME,
+};
+
+pub fn default_http3_client(webtransport: bool) -> Http3Client {
+    fixture_init();
+    Http3Client::new(
+        DEFAULT_SERVER_NAME,
+        Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
+        addr(),
+        addr(),
+        ConnectionParameters::default(),
+        Http3Parameters::default().webtransport(webtransport),
+        now(),
+    )
+    .expect("create a default client")
+}
+
+pub fn default_http3_server(webtransport: bool) -> Http3Server {
+    Http3Server::new(
+        now(),
+        DEFAULT_KEYS,
+        DEFAULT_ALPN_H3,
+        anti_replay(),
+        Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
+        Http3Parameters::default().webtransport(webtransport),
+        None,
+    )
+    .expect("create a server")
+}
+
+fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
+    let mut out = None;
+    loop {
+        out = client.process(out, now()).dgram();
+        out = server.process(out, now()).dgram();
+        if out.is_none() {
+            break;
+        }
+    }
+}
+
+// Perform only Quic transport handshake.
+fn connect_with(client: &mut Http3Client, server: &mut Http3Server) {
+    assert_eq!(client.state(), Http3State::Initializing);
+    let out = client.process(None, now());
+    assert_eq!(client.state(), Http3State::Initializing);
+
+    let out = server.process(out.dgram(), now());
+    let out = client.process(out.dgram(), now());
+    let out = server.process(out.dgram(), now());
+    assert!(out.as_dgram_ref().is_none());
+
+    let authentication_needed = |e| matches!(e, Http3ClientEvent::AuthenticationNeeded);
+    assert!(client.events().any(authentication_needed));
+    client.authenticated(AuthenticationStatus::Ok, now());
+
+    let out = client.process(out.dgram(), now());
+    let connected = |e| matches!(e, Http3ClientEvent::StateChange(Http3State::Connected));
+    assert!(client.events().any(connected));
+
+    assert_eq!(client.state(), Http3State::Connected);
+
+    // Exchange H3 setttings
+    let out = server.process(out.dgram(), now());
+    let out = client.process(out.dgram(), now());
+    let out = server.process(out.dgram(), now());
+    let out = client.process(out.dgram(), now());
+    let _ = server.process(out.dgram(), now());
+}
+
+fn connect(wt_enable_client: bool, wt_enable_server: bool) -> (Http3Client, Http3Server) {
+    let mut client = default_http3_client(wt_enable_client);
+    let mut server = default_http3_server(wt_enable_server);
+    connect_with(&mut client, &mut server);
+    (client, server)
+}
+
+struct WtTest {
+    client: Http3Client,
+    server: Http3Server,
+}
+
+impl WtTest {
+    pub fn new() -> Self {
+        let (client, server) = connect(true, true);
+        Self { client, server }
+    }
+
+    fn negotiate_wt_session(&mut self, accept: bool) -> (StreamId, Option<WebTransportRequest>) {
+        let wt_session_id = self
+            .client
+            .webtransport_create_session(now(), &("https", "something.com", "/"))
+            .unwrap();
+        self.exchange_packets();
+
+        let mut wt_server_session = None;
+        while let Some(event) = self.server.next_event() {
+            match event {
+                Http3ServerEvent::WebTransport(
+                    WebTransportServerEvent::WebTransportNewSession {
+                        mut session,
+                        headers,
+                    },
+                ) => {
+                    assert!(
+                        headers
+                            .iter()
+                            .any(|h| h.name() == ":method" && h.value() == "CONNECT")
+                            && headers
+                                .iter()
+                                .any(|h| h.name() == ":protocol" && h.value() == "webtransport")
+                    );
+                    session.response(accept).unwrap();
+                    wt_server_session = Some(session);
+                }
+                Http3ServerEvent::Data { .. } => {
+                    panic!("There should not be ane data events!");
+                }
+                _ => {}
+            }
+        }
+
+        self.exchange_packets();
+        (wt_session_id, wt_server_session)
+    }
+
+    fn create_wt_session(&mut self) -> (StreamId, WebTransportRequest) {
+        let (wt_session_id, wt_server_session) = self.negotiate_wt_session(true);
+        let wt_session_negotiated_event = |e| {
+            matches!(
+                e,
+                Http3ClientEvent::WebTransport(WebTransportEvent::WebTransportSession(stream_id)) if stream_id == wt_session_id
+            )
+        };
+        assert!(self.client.events().any(wt_session_negotiated_event));
+
+        (wt_session_id, wt_server_session.unwrap())
+    }
+
+    fn exchange_packets(&mut self) {
+        let mut out = None;
+        loop {
+            out = self.client.process(out, now()).dgram();
+            out = self.server.process(out, now()).dgram();
+            if out.is_none() {
+                break;
+            }
+        }
+    }
+
+    pub fn cancel_session_client(&mut self, wt_stream_id: StreamId) {
+        self.client
+            .cancel_fetch(wt_stream_id, Error::HttpNoError.code())
+            .unwrap();
+        self.exchange_packets();
+    }
+
+    pub fn check_session_closed_event_client(
+        &mut self,
+        wt_session_id: StreamId,
+        expected_error: Option<AppError>,
+    ) {
+        let wt_session_closed = |e| {
+            matches!(
+                e,
+                Http3ClientEvent::WebTransport(WebTransportEvent::WebTransportSessionClosed{stream_id, error}) if stream_id == wt_session_id && error == expected_error
+            )
+        };
+        assert!(self.client.events().any(wt_session_closed));
+    }
+
+    pub fn cancel_session_server(&mut self, wt_session: &mut WebTransportRequest) {
+        wt_session.cancel_fetch(Error::HttpNoError.code()).unwrap();
+        self.exchange_packets();
+    }
+
+    pub fn check_session_closed_event_server(
+        &mut self,
+        wt_session: &mut WebTransportRequest,
+        expected_error: Option<AppError>,
+    ) {
+        let wt_session_closed = |e| matches!(e, Http3ServerEvent::WebTransport(WebTransportServerEvent::WebTransportSessionClosed{session, error}) if session.stream_id() == wt_session.stream_id() && error == expected_error);
+        assert!(self.server.events().any(wt_session_closed));
+    }
+}
+
+mod negotiation;
+mod sessions;

--- a/neqo-http3/tests/webtransport/negotiation.rs
+++ b/neqo-http3/tests/webtransport/negotiation.rs
@@ -12,7 +12,7 @@ use test_fixture::*;
 
 fn check_wt_event(client: &mut Http3Client, wt_enable_client: bool, wt_enable_server: bool) {
     let wt_event = client.events().find_map(|e| {
-        if let Http3ClientEvent::WebTransport(WebTransportEvent::WebTransportNegotiated(neg)) = e {
+        if let Http3ClientEvent::WebTransport(WebTransportEvent::Negotiated(neg)) = e {
             Some(neg)
         } else {
             None

--- a/neqo-http3/tests/webtransport/negotiation.rs
+++ b/neqo-http3/tests/webtransport/negotiation.rs
@@ -4,74 +4,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use super::{connect, default_http3_client, default_http3_server, exchange_packets};
 use neqo_common::event::Provider;
-
-use neqo_crypto::AuthenticationStatus;
-use neqo_http3::{Http3Client, Http3ClientEvent, Http3Parameters, Http3Server, Http3State};
-use neqo_transport::ConnectionParameters;
-use std::cell::RefCell;
-use std::rc::Rc;
+use neqo_http3::{Http3Client, Http3ClientEvent, Http3State, WebTransportEvent};
 use std::time::Duration;
 use test_fixture::*;
 
-pub fn default_http3_client(webtransport: bool) -> Http3Client {
-    fixture_init();
-    Http3Client::new(
-        DEFAULT_SERVER_NAME,
-        Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
-        addr(),
-        addr(),
-        ConnectionParameters::default(),
-        Http3Parameters::default().webtransport(webtransport),
-        now(),
-    )
-    .expect("create a default client")
-}
-
-pub fn default_http3_server(webtransport: bool) -> Http3Server {
-    Http3Server::new(
-        now(),
-        DEFAULT_KEYS,
-        DEFAULT_ALPN_H3,
-        anti_replay(),
-        Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
-        Http3Parameters::default().webtransport(webtransport),
-        None,
-    )
-    .expect("create a server")
-}
-
-// Perform only Quic transport handshake.
-fn connect_with(client: &mut Http3Client, server: &mut Http3Server) {
-    assert_eq!(client.state(), Http3State::Initializing);
-    let out = client.process(None, now());
-    assert_eq!(client.state(), Http3State::Initializing);
-
-    let out = server.process(out.dgram(), now());
-    let out = client.process(out.dgram(), now());
-    let out = server.process(out.dgram(), now());
-    assert!(out.as_dgram_ref().is_none());
-
-    let authentication_needed = |e| matches!(e, Http3ClientEvent::AuthenticationNeeded);
-    assert!(client.events().any(authentication_needed));
-    client.authenticated(AuthenticationStatus::Ok, now());
-
-    let out = client.process(out.dgram(), now());
-    let connected = |e| matches!(e, Http3ClientEvent::StateChange(Http3State::Connected));
-    assert!(client.events().any(connected));
-
-    assert_eq!(client.state(), Http3State::Connected);
-    let out = server.process(out.dgram(), now());
-
-    // Exchange H3 setttings
-    let out = client.process(out.dgram(), now());
-    let out = server.process(out.dgram(), now());
-    let _ = client.process(out.dgram(), now());
-}
-
 fn check_wt_event(client: &mut Http3Client, wt_enable_client: bool, wt_enable_server: bool) {
     let wt_event = client.events().find_map(|e| {
-        if let Http3ClientEvent::WebTransportNegotiated(neg) = e {
+        if let Http3ClientEvent::WebTransport(WebTransportEvent::WebTransportNegotiated(neg)) = e {
             Some(neg)
         } else {
             None
@@ -82,13 +23,6 @@ fn check_wt_event(client: &mut Http3Client, wt_enable_client: bool, wt_enable_se
     if let Some(wt) = wt_event {
         assert_eq!(wt, wt_enable_client && wt_enable_server);
     }
-}
-
-fn connect(wt_enable_client: bool, wt_enable_server: bool) -> (Http3Client, Http3Server) {
-    let mut client = default_http3_client(wt_enable_client);
-    let mut server = default_http3_server(wt_enable_server);
-    connect_with(&mut client, &mut server);
-    (client, server)
 }
 
 #[test]
@@ -136,16 +70,8 @@ fn zero_rtt(client_org: bool, server_org: bool, client_resumed: bool, server_res
         .enable_resumption(now(), &token)
         .expect("Set resumption token.");
     assert_eq!(client.state(), Http3State::ZeroRtt);
-    let out = client.process(None, now());
 
-    assert_eq!(client.state(), Http3State::ZeroRtt);
-    let out = server.process(out.dgram(), now());
-    let out = client.process(out.dgram(), now());
-    let out = server.process(out.dgram(), now());
-    let out = client.process(out.dgram(), now());
-    let out = server.process(out.dgram(), now());
-    let out = client.process(out.dgram(), now());
-    let _ = server.process(out.dgram(), now());
+    exchange_packets(&mut client, &mut server);
 
     assert_eq!(&client.state(), &Http3State::Connected);
     assert_eq!(

--- a/neqo-http3/tests/webtransport/sessions.rs
+++ b/neqo-http3/tests/webtransport/sessions.rs
@@ -25,30 +25,30 @@ fn wt_session_reject() {
 #[test]
 fn wt_session_close_client() {
     let mut wt = WtTest::new();
-    let (wt_session_id, mut wt_session) = wt.create_wt_session();
+    let mut wt_session = wt.create_wt_session();
 
-    wt.cancel_session_client(wt_session_id);
+    wt.cancel_session_client(wt_session.stream_id());
     wt.check_session_closed_event_server(&mut wt_session, Some(Error::HttpNoError.code()));
 }
 
 #[test]
 fn wt_session_close_server() {
     let mut wt = WtTest::new();
-    let (wt_session_id, mut wt_session) = wt.create_wt_session();
+    let mut wt_session = wt.create_wt_session();
 
     wt.cancel_session_server(&mut wt_session);
-    wt.check_session_closed_event_client(wt_session_id, Some(Error::HttpNoError.code()));
+    wt.check_session_closed_event_client(wt_session.stream_id(), Some(Error::HttpNoError.code()));
 }
 
 #[test]
 fn wt_session_close_server_close_send() {
     let mut wt = WtTest::new();
-    let (wt_session_id, mut wt_session) = wt.create_wt_session();
+    let mut wt_session = wt.create_wt_session();
 
     wt_session.stream_close_send().unwrap();
     wt.exchange_packets();
     wt.check_session_closed_event_client(
-        wt_session_id,
+        wt_session.stream_id(),
         Some(Error::HttpGeneralProtocolStream.code()),
     );
 }
@@ -56,23 +56,23 @@ fn wt_session_close_server_close_send() {
 #[test]
 fn wt_session_close_server_stop_sending() {
     let mut wt = WtTest::new();
-    let (wt_session_id, mut wt_session) = wt.create_wt_session();
+    let mut wt_session = wt.create_wt_session();
 
     wt_session
         .stream_stop_sending(Error::HttpNoError.code())
         .unwrap();
     wt.exchange_packets();
-    wt.check_session_closed_event_client(wt_session_id, Some(Error::HttpNoError.code()));
+    wt.check_session_closed_event_client(wt_session.stream_id(), Some(Error::HttpNoError.code()));
 }
 
 #[test]
 fn wt_session_close_server_reset() {
     let mut wt = WtTest::new();
-    let (wt_session_id, mut wt_session) = wt.create_wt_session();
+    let mut wt_session = wt.create_wt_session();
 
     wt_session
         .stream_reset_send(Error::HttpNoError.code())
         .unwrap();
     wt.exchange_packets();
-    wt.check_session_closed_event_client(wt_session_id, Some(Error::HttpNoError.code()));
+    wt.check_session_closed_event_client(wt_session.stream_id(), Some(Error::HttpNoError.code()));
 }

--- a/neqo-http3/tests/webtransport/sessions.rs
+++ b/neqo-http3/tests/webtransport/sessions.rs
@@ -1,0 +1,78 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::webtransport::WtTest;
+use neqo_http3::Error;
+use std::mem;
+
+#[test]
+fn wt_session() {
+    let mut wt = WtTest::new();
+    mem::drop(wt.create_wt_session());
+}
+
+#[test]
+fn wt_session_reject() {
+    let mut wt = WtTest::new();
+    let (wt_session_id, _wt_session) = wt.negotiate_wt_session(false);
+
+    wt.check_session_closed_event_client(wt_session_id, Some(Error::HttpRequestRejected.code()));
+}
+
+#[test]
+fn wt_session_close_client() {
+    let mut wt = WtTest::new();
+    let (wt_session_id, mut wt_session) = wt.create_wt_session();
+
+    wt.cancel_session_client(wt_session_id);
+    wt.check_session_closed_event_server(&mut wt_session, Some(Error::HttpNoError.code()));
+}
+
+#[test]
+fn wt_session_close_server() {
+    let mut wt = WtTest::new();
+    let (wt_session_id, mut wt_session) = wt.create_wt_session();
+
+    wt.cancel_session_server(&mut wt_session);
+    wt.check_session_closed_event_client(wt_session_id, Some(Error::HttpNoError.code()));
+}
+
+#[test]
+fn wt_session_close_server_close_send() {
+    let mut wt = WtTest::new();
+    let (wt_session_id, mut wt_session) = wt.create_wt_session();
+
+    wt_session.stream_close_send().unwrap();
+    wt.exchange_packets();
+    wt.check_session_closed_event_client(
+        wt_session_id,
+        Some(Error::HttpGeneralProtocolStream.code()),
+    );
+}
+
+#[test]
+fn wt_session_close_server_stop_sending() {
+    let mut wt = WtTest::new();
+    let (wt_session_id, mut wt_session) = wt.create_wt_session();
+
+    wt_session
+        .stream_stop_sending(Error::HttpNoError.code())
+        .unwrap();
+    wt.exchange_packets();
+    wt.check_session_closed_event_client(wt_session_id, Some(Error::HttpNoError.code()));
+}
+
+#[test]
+fn wt_session_close_server_reset() {
+    let mut wt = WtTest::new();
+    let (wt_session_id, mut wt_session) = wt.create_wt_session();
+
+    wt_session
+        .stream_reset_send(Error::HttpNoError.code())
+        .unwrap();
+    wt.exchange_packets();
+    wt.check_session_closed_event_client(wt_session_id, Some(Error::HttpNoError.code()));
+}

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -307,7 +307,7 @@ impl HttpServer for Http3Server {
                         ])
                         .unwrap();
                     request.send_data(&response).unwrap();
-                    request.close_send().unwrap();
+                    request.stream_close_send().unwrap();
                 }
                 Http3ServerEvent::Data { request, data, fin } => {
                     println!("Data (request={} fin={}): {:?}", request, fin, data);


### PR DESCRIPTION
This PR creates a generic ExtendedConnectFeature structure that is responsible for a feature negotiation and keeps a HashMap of the extended connect requests. The HashMap will be used for finding active sessions.

An extended connect request will be created as a regular fetch request only the listener for the events will be different.  A generic ExtendedConnectSession structure is created for each extended connect request and is responsible for listening to request events and following the state of the request/session, e.g. the session is being negotiated, a stream is closed, etc..This structure will be responsible for bookkeeping, i.e. it will hold information about active streams open on a session and it will make sure to close all streams if the session request is closed.
Currently ExtendedConnectSession cannot read data from the request stream, this will be fixed in a separate PR.
On the server side, upon receiving headers a regular http request will be transformed into an extended connect request and a new ExtendedConnectSession will be set to be the listener for the request.

Regular http request functions will be used for closing an extended connect request, e.g. steam_stop_sending, cancel_fetch, etc. 

Additional changes:
Now it is not easily possible to distinguish between Http stream and Push stream, therefore  RecvMessage holds the type of the stream.
WebTransport’s extended connect request will be created as a normal fetch request. The listener for the events on this request will be different

All WebTransport events are put into a separate enum structure.
