### PR TITLE
fix panic from slice::from_raw_parts

### DIFF
--- a/neqo-crypto/src/cert.rs
+++ b/neqo-crypto/src/cert.rs
@@ -65,10 +65,14 @@ fn signed_cert_timestamp(fd: *mut PRFileDesc) -> Option<Vec<u8>> {
     let sct_nss = unsafe { SSL_PeerSignedCertTimestamps(fd) };
     match NonNull::new(sct_nss as *mut SECItem) {
         Some(sct_ptr) => {
-            let sct_slice = unsafe {
-                slice::from_raw_parts(sct_ptr.as_ref().data, sct_ptr.as_ref().len as usize)
-            };
-            Some(sct_slice.to_owned())
+            if unsafe { sct_ptr.as_ref().len == 0 || sct_ptr.as_ref().data.is_null() } {
+                Some(Vec::new())
+            } else {
+                let sct_slice = unsafe {
+                    slice::from_raw_parts(sct_ptr.as_ref().data, sct_ptr.as_ref().len as usize)
+                };
+                Some(sct_slice.to_owned())
+            }
         }
         None => None,
     }


### PR DESCRIPTION
Sometime  `sct_ptr` is not null, but `sct_ptr.data` is null. In this case, use `slice::from_raw_parts` is UB and violate [safety guarantee](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#safety) (In debug build, this will hit a `debug_assert` failure).
