### PR TITLE
Wt streams

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -511,7 +511,7 @@ impl<'a> Handler<'a> {
                         Some(out_file) => loop {
                             let mut data = vec![0; 4096];
                             let (sz, fin) = client
-                                .read_response_data(Instant::now(), stream_id, &mut data)
+                                .read_data(Instant::now(), stream_id, &mut data)
                                 .expect("Read should succeed");
 
                             if let Some(out_file) = out_file {

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -44,15 +44,22 @@ impl ExtendedConnectType {
     }
 
     #[must_use]
-    #[allow(clippy::unused_self)] // This will change when we have more features using ExtendedConnectType.
+    #[allow(clippy::unused_self)] // this will change when there is more types of the extended CONNECT.
     pub fn setting_type(self) -> HSettingType {
         HSettingType::EnableWebTransport
     }
 
-    #[allow(clippy::unused_self)] // this will change when there is more types of the extended CONNECT.
+    #[allow(clippy::unused_self)] // This will change when we have more features using ExtendedConnectType.
     #[must_use]
-    pub fn get_stream_type(&self, session_id: StreamId) -> Http3StreamType {
+    pub fn get_stream_type(self, session_id: StreamId) -> Http3StreamType {
         Http3StreamType::WebTransport(session_id)
+    }
+}
+
+impl From<ExtendedConnectType> for HSettingType {
+    fn from(_type: ExtendedConnectType) -> Self {
+        // This will change when we have more features using ExtendedConnectType.
+        HSettingType::EnableWebTransport
     }
 }
 
@@ -67,7 +74,7 @@ impl ExtendedConnectFeature {
     #[must_use]
     pub fn new(connect_type: ExtendedConnectType, enable: bool) -> Self {
         Self {
-            feature_negotiation: NegotiationState::new(enable, connect_type.setting_type()),
+            feature_negotiation: NegotiationState::new(enable, HSettingType::from(connect_type)),
             connect_type,
             sessions: HashMap::new(),
         }

--- a/neqo-http3/src/features/extended_connect/webtransport.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport.rs
@@ -1,0 +1,202 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use super::ExtendedConnectSession;
+use crate::{
+    CloseType, Http3StreamInfo, Http3StreamType, ReceiveOutput, RecvStream, RecvStreamEvents, Res,
+    SendStream, SendStreamEvents, Stream,
+};
+use neqo_common::Encoder;
+use neqo_transport::{Connection, StreamId};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub const WEBTRANSPORT_UNI_STREAM: u64 = 0x54;
+pub const WEBTRANSPORT_STREAM: u64 = 0x41;
+
+#[derive(Debug)]
+pub struct WebTransportRecvStream {
+    stream_id: StreamId,
+    events: Box<dyn RecvStreamEvents>,
+    session: Rc<RefCell<ExtendedConnectSession>>,
+    session_id: StreamId,
+    fin: bool,
+}
+
+impl WebTransportRecvStream {
+    pub fn new(
+        stream_id: StreamId,
+        session_id: StreamId,
+        events: Box<dyn RecvStreamEvents>,
+        session: Rc<RefCell<ExtendedConnectSession>>,
+    ) -> Self {
+        Self {
+            stream_id,
+            events,
+            session_id,
+            session,
+            fin: false,
+        }
+    }
+
+    fn get_info(&self) -> Http3StreamInfo {
+        Http3StreamInfo::new(self.stream_id, self.stream_type())
+    }
+}
+
+impl Stream for WebTransportRecvStream {
+    fn stream_type(&self) -> Http3StreamType {
+        Http3StreamType::WebTransport(self.session_id)
+    }
+}
+
+impl RecvStream for WebTransportRecvStream {
+    fn receive(&mut self, _conn: &mut Connection) -> Res<(ReceiveOutput, bool)> {
+        self.events.data_readable(self.get_info());
+        Ok((ReceiveOutput::NoOutput, false))
+    }
+
+    fn reset(&mut self, close_type: CloseType) -> Res<()> {
+        if !matches!(close_type, CloseType::ResetApp(_)) {
+            self.events.recv_closed(self.get_info(), close_type);
+        }
+        self.session.borrow_mut().remove_recv_stream(self.stream_id);
+        Ok(())
+    }
+
+    fn read_data(&mut self, conn: &mut Connection, buf: &mut [u8]) -> Res<(usize, bool)> {
+        let (amount, fin) = conn.stream_recv(self.stream_id, buf)?;
+        self.fin = fin;
+        if fin {
+            self.session.borrow_mut().remove_recv_stream(self.stream_id);
+        }
+        Ok((amount, fin))
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum WebTransportSenderStreamState {
+    SendingInit { buf: Vec<u8>, fin: bool },
+    SendingData,
+    Done,
+}
+
+#[derive(Debug)]
+pub struct WebTransportSendStream {
+    stream_id: StreamId,
+    state: WebTransportSenderStreamState,
+    events: Box<dyn SendStreamEvents>,
+    session: Rc<RefCell<ExtendedConnectSession>>,
+    session_id: StreamId,
+}
+
+impl WebTransportSendStream {
+    pub fn new(
+        stream_id: StreamId,
+        session_id: StreamId,
+        events: Box<dyn SendStreamEvents>,
+        session: Rc<RefCell<ExtendedConnectSession>>,
+        local: bool,
+    ) -> Self {
+        Self {
+            stream_id,
+            state: if local {
+                let mut d = Encoder::default();
+                if stream_id.is_uni() {
+                    d.encode_varint(WEBTRANSPORT_UNI_STREAM);
+                } else {
+                    d.encode_varint(WEBTRANSPORT_STREAM);
+                }
+                d.encode_varint(session_id.as_u64());
+                WebTransportSenderStreamState::SendingInit {
+                    buf: d.into(),
+                    fin: false,
+                }
+            } else {
+                WebTransportSenderStreamState::SendingData
+            },
+            events,
+            session_id,
+            session,
+        }
+    }
+
+    fn set_done(&mut self, close_type: CloseType) {
+        self.state = WebTransportSenderStreamState::Done;
+        self.events.send_closed(self.get_info(), close_type);
+        self.session.borrow_mut().remove_send_stream(self.stream_id);
+    }
+
+    fn get_info(&self) -> Http3StreamInfo {
+        Http3StreamInfo::new(self.stream_id, self.stream_type())
+    }
+}
+
+impl Stream for WebTransportSendStream {
+    fn stream_type(&self) -> Http3StreamType {
+        Http3StreamType::WebTransport(self.session_id)
+    }
+}
+
+impl SendStream for WebTransportSendStream {
+    fn send(&mut self, conn: &mut Connection) -> Res<()> {
+        if let WebTransportSenderStreamState::SendingInit { ref mut buf, fin } = self.state {
+            let sent = conn.stream_send(self.stream_id, &buf[..])?;
+            if sent == buf.len() {
+                if fin {
+                    conn.stream_close_send(self.stream_id)?;
+                    self.set_done(CloseType::Done);
+                } else {
+                    self.state = WebTransportSenderStreamState::SendingData;
+                }
+            } else {
+                let b = buf.split_off(sent);
+                *buf = b;
+            }
+        }
+        Ok(())
+    }
+
+    fn has_data_to_send(&self) -> bool {
+        matches!(
+            self.state,
+            WebTransportSenderStreamState::SendingInit { .. }
+        )
+    }
+
+    fn stream_writable(&self) {
+        self.events.data_writable(self.get_info());
+    }
+
+    fn done(&self) -> bool {
+        self.state == WebTransportSenderStreamState::Done
+    }
+
+    fn send_data(&mut self, conn: &mut Connection, buf: &[u8]) -> Res<usize> {
+        self.send(conn)?;
+        if self.state == WebTransportSenderStreamState::SendingData {
+            let sent = conn.stream_send(self.stream_id, buf)?;
+            Ok(sent)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn handle_stop_sending(&mut self, close_type: CloseType) {
+        self.set_done(close_type);
+    }
+
+    fn close(&mut self, conn: &mut Connection) -> Res<()> {
+        if let WebTransportSenderStreamState::SendingInit { ref mut fin, .. } = self.state {
+            *fin = true;
+        } else {
+            self.state = WebTransportSenderStreamState::Done;
+            conn.stream_close_send(self.stream_id)?;
+            self.set_done(CloseType::Done);
+        }
+        Ok(())
+    }
+}

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -118,7 +118,7 @@ fn priority_update() {
 
     match header_event {
         Http3ServerEvent::Headers {
-            request: _,
+            stream: _,
             headers,
             fin,
         } => {

--- a/neqo-http3/tests/webtransport/mod.rs
+++ b/neqo-http3/tests/webtransport/mod.rs
@@ -6,14 +6,15 @@
 
 mod negotiation;
 mod sessions;
+mod streams;
 
 use neqo_common::event::Provider;
 use neqo_crypto::AuthenticationStatus;
 use neqo_http3::{
-    Error, Http3Client, Http3ClientEvent, Http3Parameters, Http3Server, Http3ServerEvent,
-    Http3State, WebTransportEvent, WebTransportRequest, WebTransportServerEvent,
+    Error, Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3Parameters, Http3Server,
+    Http3ServerEvent, Http3State, WebTransportEvent, WebTransportRequest, WebTransportServerEvent,
 };
-use neqo_transport::{AppError, ConnectionParameters, StreamId};
+use neqo_transport::{AppError, ConnectionParameters, StreamId, StreamType};
 use std::cell::RefCell;
 use std::rc::Rc;
 use test_fixture::{
@@ -116,12 +117,10 @@ impl WtTest {
         let mut wt_server_session = None;
         while let Some(event) = self.server.next_event() {
             match event {
-                Http3ServerEvent::WebTransport(
-                    WebTransportServerEvent::WebTransportNewSession {
-                        mut session,
-                        headers,
-                    },
-                ) => {
+                Http3ServerEvent::WebTransport(WebTransportServerEvent::NewSession {
+                    mut session,
+                    headers,
+                }) => {
                     assert!(
                         headers
                             .iter()
@@ -219,9 +218,10 @@ impl WtTest {
         id: StreamId,
         expected_error: &Option<AppError>,
     ) -> bool {
-        if let Http3ServerEvent::WebTransport(
-            WebTransportServerEvent::WebTransportSessionClosed { session, error },
-        ) = e
+        if let Http3ServerEvent::WebTransport(WebTransportServerEvent::SessionClosed {
+            session,
+            error,
+        }) = e
         {
             session.stream_id() == id && error == expected_error
         } else {
@@ -240,5 +240,181 @@ impl WtTest {
             wt_session.stream_id(),
             &expected_error
         ));
+    }
+
+    fn create_wt_stream_client(
+        &mut self,
+        wt_session_id: StreamId,
+        stream_type: StreamType,
+    ) -> StreamId {
+        let wt_stream_id = self
+            .client
+            .webtransport_create_stream(wt_session_id, stream_type)
+            .unwrap();
+        // TODO investigate why this is needed.
+        self.exchange_packets();
+        wt_stream_id
+    }
+
+    fn send_data_client(&mut self, wt_stream_id: StreamId, data: &[u8]) {
+        assert_eq!(
+            self.client.send_data(wt_stream_id, data).unwrap(),
+            data.len()
+        );
+        self.exchange_packets();
+    }
+
+    fn receive_data_client(
+        &mut self,
+        expected_stream_id: StreamId,
+        new_stream: bool,
+        expected_data: &[u8],
+        expected_fin: bool,
+    ) {
+        let mut new_stream_received = false;
+        let mut data_received = false;
+        while let Some(event) = self.client.next_event() {
+            match event {
+                Http3ClientEvent::WebTransport(WebTransportEvent::NewStream {
+                    stream_id, ..
+                }) => {
+                    assert_eq!(stream_id, expected_stream_id);
+                    new_stream_received = true;
+                }
+                Http3ClientEvent::DataReadable { stream_id } => {
+                    assert_eq!(stream_id, expected_stream_id);
+                    let mut buf = [0; 100];
+                    let (amount, fin) = self.client.read_data(now(), stream_id, &mut buf).unwrap();
+                    assert_eq!(fin, expected_fin);
+                    assert_eq!(amount, expected_data.len());
+                    assert_eq!(&buf[..amount], expected_data);
+                    data_received = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(data_received);
+        assert_eq!(new_stream, new_stream_received);
+    }
+
+    fn close_stream_sending_client(&mut self, wt_stream_id: StreamId) {
+        self.client.stream_close_send(wt_stream_id).unwrap();
+        self.exchange_packets();
+    }
+
+    fn reset_stream_client(&mut self, wt_stream_id: StreamId) {
+        self.client
+            .stream_reset_send(wt_stream_id, Error::HttpNoError.code())
+            .unwrap();
+        self.exchange_packets();
+    }
+
+    fn receive_reset_client(&mut self, expected_stream_id: StreamId) {
+        let wt_reset_event = |e| {
+            matches!(
+                e,
+                Http3ClientEvent::Reset {
+                    stream_id,
+                    error,
+                    local
+                } if stream_id == expected_stream_id && error == Error::HttpNoError.code() && !local
+            )
+        };
+        assert!(self.client.events().any(wt_reset_event));
+    }
+
+    fn stream_stop_sending_client(&mut self, stream_id: StreamId) {
+        self.client
+            .stream_stop_sending(stream_id, Error::HttpNoError.code())
+            .unwrap();
+        self.exchange_packets();
+    }
+
+    fn receive_stop_sending_client(&mut self, expected_stream_id: StreamId) {
+        let wt_stop_sending_event = |e| matches!(e,  Http3ClientEvent::StopSending { stream_id, error } if stream_id == expected_stream_id && error == Error::HttpNoError.code());
+        assert!(self.client.events().any(wt_stop_sending_event));
+    }
+
+    fn create_wt_stream_server(
+        &mut self,
+        wt_server_session: &mut WebTransportRequest,
+        stream_type: StreamType,
+    ) -> Http3OrWebTransportStream {
+        wt_server_session.create_stream(stream_type).unwrap()
+    }
+
+    fn send_data_server(&mut self, wt_stream: &mut Http3OrWebTransportStream, data: &[u8]) {
+        assert_eq!(wt_stream.send_data(data).unwrap(), data.len());
+        self.exchange_packets();
+    }
+
+    fn receive_data_server(
+        &mut self,
+        stream_id: StreamId,
+        new_stream: bool,
+        expected_data: &[u8],
+        expected_fin: bool,
+    ) -> Http3OrWebTransportStream {
+        self.exchange_packets();
+        let mut new_stream_received = false;
+        let mut data_received = false;
+        let mut wt_stream = None;
+        let mut stream_closed = false;
+        let mut recv_data = Vec::new();
+        while let Some(event) = self.server.next_event() {
+            match event {
+                Http3ServerEvent::WebTransport(WebTransportServerEvent::NewStream(request)) => {
+                    assert_eq!(stream_id, request.stream_id());
+                    new_stream_received = true;
+                }
+                Http3ServerEvent::Data {
+                    mut data,
+                    fin,
+                    stream,
+                } => {
+                    recv_data.append(&mut data);
+                    stream_closed = fin;
+                    data_received = true;
+                    wt_stream = Some(stream);
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(&recv_data[..], expected_data);
+        assert!(data_received);
+        assert_eq!(new_stream, new_stream_received);
+        assert_eq!(stream_closed, expected_fin);
+        wt_stream.unwrap()
+    }
+
+    fn close_stream_sending_server(&mut self, wt_stream: &mut Http3OrWebTransportStream) {
+        wt_stream.stream_close_send().unwrap();
+        self.exchange_packets();
+    }
+
+    fn reset_stream_server(&mut self, wt_stream: &mut Http3OrWebTransportStream) {
+        wt_stream
+            .stream_reset_send(Error::HttpNoError.code())
+            .unwrap();
+        self.exchange_packets();
+    }
+
+    fn stream_stop_sending_server(&mut self, wt_stream: &mut Http3OrWebTransportStream) {
+        wt_stream
+            .stream_stop_sending(Error::HttpNoError.code())
+            .unwrap();
+        self.exchange_packets();
+    }
+
+    fn receive_reset_server(&mut self, expected_stream_id: StreamId) {
+        assert!(
+            matches!(self.server.next_event().unwrap(), Http3ServerEvent::StreamReset { stream, error } if stream.stream_id() == expected_stream_id && error == Error::HttpNoError.code())
+        );
+    }
+
+    fn receive_stop_sending_server(&mut self, expected_stream_id: StreamId) {
+        assert!(
+            matches!(self.server.next_event().unwrap(), Http3ServerEvent::StreamStopSending { stream, error } if stream.stream_id() == expected_stream_id && error == Error::HttpNoError.code())
+        );
     }
 }

--- a/neqo-http3/tests/webtransport/mod.rs
+++ b/neqo-http3/tests/webtransport/mod.rs
@@ -247,13 +247,9 @@ impl WtTest {
         wt_session_id: StreamId,
         stream_type: StreamType,
     ) -> StreamId {
-        let wt_stream_id = self
-            .client
+        self.client
             .webtransport_create_stream(wt_session_id, stream_type)
-            .unwrap();
-        // TODO investigate why this is needed.
-        self.exchange_packets();
-        wt_stream_id
+            .unwrap()
     }
 
     fn send_data_client(&mut self, wt_stream_id: StreamId, data: &[u8]) {
@@ -331,7 +327,15 @@ impl WtTest {
     }
 
     fn receive_stop_sending_client(&mut self, expected_stream_id: StreamId) {
-        let wt_stop_sending_event = |e| matches!(e,  Http3ClientEvent::StopSending { stream_id, error } if stream_id == expected_stream_id && error == Error::HttpNoError.code());
+        let wt_stop_sending_event = |e| {
+            matches!(
+                e,
+                Http3ClientEvent::StopSending {
+                    stream_id,
+                    error
+                } if stream_id == expected_stream_id && error == Error::HttpNoError.code()
+            )
+        };
         assert!(self.client.events().any(wt_stop_sending_event));
     }
 
@@ -407,14 +411,22 @@ impl WtTest {
     }
 
     fn receive_reset_server(&mut self, expected_stream_id: StreamId) {
-        assert!(
-            matches!(self.server.next_event().unwrap(), Http3ServerEvent::StreamReset { stream, error } if stream.stream_id() == expected_stream_id && error == Error::HttpNoError.code())
-        );
+        assert!(matches!(
+            self.server.next_event().unwrap(),
+            Http3ServerEvent::StreamReset {
+                stream,
+                error
+            } if stream.stream_id() == expected_stream_id && error == Error::HttpNoError.code()
+        ));
     }
 
     fn receive_stop_sending_server(&mut self, expected_stream_id: StreamId) {
-        assert!(
-            matches!(self.server.next_event().unwrap(), Http3ServerEvent::StreamStopSending { stream, error } if stream.stream_id() == expected_stream_id && error == Error::HttpNoError.code())
-        );
+        assert!(matches!(
+            self.server.next_event().unwrap(),
+            Http3ServerEvent::StreamStopSending {
+                stream,
+                error
+            } if stream.stream_id() == expected_stream_id && error == Error::HttpNoError.code()
+        ));
     }
 }

--- a/neqo-http3/tests/webtransport/streams.rs
+++ b/neqo-http3/tests/webtransport/streams.rs
@@ -1,0 +1,320 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::webtransport::WtTest;
+use neqo_http3::Error;
+use neqo_transport::StreamType;
+use std::mem;
+
+#[test]
+fn wt_client_stream_uni() {
+    const BUF_CLIENT: &[u8] = &[0; 10];
+
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let wt_stream = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::UniDi);
+    wt.send_data_client(wt_stream, BUF_CLIENT);
+    wt.receive_data_server(wt_stream, true, BUF_CLIENT, false);
+}
+
+#[test]
+fn wt_client_stream_bidi() {
+    const BUF_CLIENT: &[u8] = &[0; 10];
+    const BUF_SERVER: &[u8] = &[1; 20];
+
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let wt_client_stream = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::BiDi);
+    wt.send_data_client(wt_client_stream, BUF_CLIENT);
+    let mut wt_server_stream = wt.receive_data_server(wt_client_stream, true, BUF_CLIENT, false);
+    wt.send_data_server(&mut wt_server_stream, BUF_SERVER);
+    wt.receive_data_client(wt_client_stream, false, BUF_SERVER, false);
+}
+
+#[test]
+fn wt_server_stream_uni() {
+    const BUF_SERVER: &[u8] = &[2; 30];
+
+    let mut wt = WtTest::new();
+    let mut wt_session = wt.create_wt_session();
+    let mut wt_server_stream = wt.create_wt_stream_server(&mut wt_session, StreamType::UniDi);
+    wt.send_data_server(&mut wt_server_stream, BUF_SERVER);
+    wt.receive_data_client(wt_server_stream.stream_id(), true, BUF_SERVER, false);
+}
+
+#[test]
+fn wt_server_stream_bidi() {
+    const BUF_CLIENT: &[u8] = &[0; 10];
+    const BUF_SERVER: &[u8] = &[1; 20];
+
+    let mut wt = WtTest::new();
+    let mut wt_session = wt.create_wt_session();
+    let mut wt_server_stream = wt.create_wt_stream_server(&mut wt_session, StreamType::BiDi);
+    wt.send_data_server(&mut wt_server_stream, BUF_SERVER);
+    wt.receive_data_client(wt_server_stream.stream_id(), true, BUF_SERVER, false);
+    wt.send_data_client(wt_server_stream.stream_id(), BUF_CLIENT);
+    mem::drop(wt.receive_data_server(wt_server_stream.stream_id(), false, BUF_CLIENT, false));
+}
+
+#[test]
+fn wt_client_stream_uni_close() {
+    const BUF_CLIENT: &[u8] = &[0; 10];
+
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let wt_stream = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::UniDi);
+    wt.send_data_client(wt_stream, BUF_CLIENT);
+    wt.close_stream_sending_client(wt_stream);
+    wt.receive_data_server(wt_stream, true, BUF_CLIENT, true);
+}
+
+#[test]
+fn wt_client_stream_bidi_close() {
+    const BUF_CLIENT: &[u8] = &[0; 10];
+    const BUF_SERVER: &[u8] = &[1; 20];
+
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let wt_client_stream = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::BiDi);
+
+    wt.send_data_client(wt_client_stream, BUF_CLIENT);
+    wt.close_stream_sending_client(wt_client_stream);
+
+    let mut wt_server_stream = wt.receive_data_server(wt_client_stream, true, BUF_CLIENT, true);
+
+    wt.send_data_server(&mut wt_server_stream, BUF_SERVER);
+    wt.close_stream_sending_server(&mut wt_server_stream);
+    wt.receive_data_client(wt_client_stream, false, BUF_SERVER, true);
+}
+
+#[test]
+fn wt_server_stream_uni_closed() {
+    const BUF_SERVER: &[u8] = &[2; 30];
+
+    let mut wt = WtTest::new();
+    let mut wt_session = wt.create_wt_session();
+    let mut wt_server_stream = wt.create_wt_stream_server(&mut wt_session, StreamType::UniDi);
+    wt.send_data_server(&mut wt_server_stream, BUF_SERVER);
+    wt.close_stream_sending_server(&mut wt_server_stream);
+    wt.receive_data_client(wt_server_stream.stream_id(), true, BUF_SERVER, true);
+}
+
+#[test]
+fn wt_server_stream_bidi_close() {
+    const BUF_CLIENT: &[u8] = &[0; 10];
+    const BUF_SERVER: &[u8] = &[1; 20];
+
+    let mut wt = WtTest::new();
+    let mut wt_session = wt.create_wt_session();
+    let mut wt_server_stream = wt.create_wt_stream_server(&mut wt_session, StreamType::BiDi);
+    wt.send_data_server(&mut wt_server_stream, BUF_SERVER);
+    wt.close_stream_sending_server(&mut wt_server_stream);
+    wt.receive_data_client(wt_server_stream.stream_id(), true, BUF_SERVER, true);
+    wt.send_data_client(wt_server_stream.stream_id(), BUF_CLIENT);
+    wt.close_stream_sending_client(wt_server_stream.stream_id());
+    mem::drop(wt.receive_data_server(wt_server_stream.stream_id(), false, BUF_CLIENT, true));
+}
+
+#[test]
+fn wt_client_stream_uni_reset() {
+    const BUF_CLIENT: &[u8] = &[0; 10];
+
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let wt_stream = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::UniDi);
+    wt.send_data_client(wt_stream, BUF_CLIENT);
+    mem::drop(wt.receive_data_server(wt_stream, true, BUF_CLIENT, false));
+    wt.reset_stream_client(wt_stream);
+    wt.receive_reset_server(wt_stream);
+}
+
+#[test]
+fn wt_server_stream_uni_reset() {
+    const BUF_SERVER: &[u8] = &[2; 30];
+
+    let mut wt = WtTest::new();
+    let mut wt_session = wt.create_wt_session();
+    let mut wt_server_stream = wt.create_wt_stream_server(&mut wt_session, StreamType::UniDi);
+    wt.send_data_server(&mut wt_server_stream, BUF_SERVER);
+    wt.receive_data_client(wt_server_stream.stream_id(), true, BUF_SERVER, false);
+    wt.reset_stream_server(&mut wt_server_stream);
+    wt.receive_reset_client(wt_server_stream.stream_id());
+}
+
+#[test]
+fn wt_client_stream_bidi_reset() {
+    const BUF_CLIENT: &[u8] = &[0; 10];
+
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let wt_client_stream = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::BiDi);
+
+    wt.send_data_client(wt_client_stream, BUF_CLIENT);
+    let mut wt_server_stream = wt.receive_data_server(wt_client_stream, true, BUF_CLIENT, false);
+
+    wt.reset_stream_client(wt_client_stream);
+    wt.receive_reset_server(wt_server_stream.stream_id());
+
+    wt.reset_stream_server(&mut wt_server_stream);
+    wt.receive_reset_client(wt_client_stream);
+}
+
+#[test]
+fn wt_server_stream_bidi_reset() {
+    const BUF_SERVER: &[u8] = &[1; 20];
+
+    let mut wt = WtTest::new();
+    let mut wt_session = wt.create_wt_session();
+    let mut wt_server_stream = wt.create_wt_stream_server(&mut wt_session, StreamType::BiDi);
+    wt.send_data_server(&mut wt_server_stream, BUF_SERVER);
+    wt.receive_data_client(wt_server_stream.stream_id(), true, BUF_SERVER, false);
+
+    wt.reset_stream_client(wt_server_stream.stream_id());
+    wt.receive_reset_server(wt_server_stream.stream_id());
+
+    wt.reset_stream_server(&mut wt_server_stream);
+    wt.receive_reset_client(wt_server_stream.stream_id());
+}
+
+#[test]
+fn wt_client_stream_uni_stop_sending() {
+    const BUF_CLIENT: &[u8] = &[0; 10];
+
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let wt_stream = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::UniDi);
+    wt.send_data_client(wt_stream, BUF_CLIENT);
+    let mut wt_server_stream = wt.receive_data_server(wt_stream, true, BUF_CLIENT, false);
+    wt.stream_stop_sending_server(&mut wt_server_stream);
+    wt.receive_stop_sending_client(wt_stream);
+}
+
+#[test]
+fn wt_server_stream_uni_stop_sending() {
+    const BUF_SERVER: &[u8] = &[2; 30];
+
+    let mut wt = WtTest::new();
+    let mut wt_session = wt.create_wt_session();
+    let mut wt_server_stream = wt.create_wt_stream_server(&mut wt_session, StreamType::UniDi);
+    wt.send_data_server(&mut wt_server_stream, BUF_SERVER);
+    wt.receive_data_client(wt_server_stream.stream_id(), true, BUF_SERVER, false);
+    wt.stream_stop_sending_client(wt_server_stream.stream_id());
+    wt.receive_stop_sending_server(wt_server_stream.stream_id());
+}
+
+#[test]
+fn wt_client_stream_bidi_stop_sending() {
+    const BUF_CLIENT: &[u8] = &[0; 10];
+
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+
+    let wt_client_stream = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::BiDi);
+
+    wt.send_data_client(wt_client_stream, BUF_CLIENT);
+
+    let mut wt_server_stream = wt.receive_data_server(wt_client_stream, true, BUF_CLIENT, false);
+
+    wt.stream_stop_sending_client(wt_client_stream);
+
+    wt.receive_stop_sending_server(wt_server_stream.stream_id());
+    wt.stream_stop_sending_server(&mut wt_server_stream);
+    wt.receive_stop_sending_client(wt_server_stream.stream_id());
+}
+
+#[test]
+fn wt_server_stream_bidi_stop_sending() {
+    const BUF_SERVER: &[u8] = &[1; 20];
+
+    let mut wt = WtTest::new();
+    let mut wt_session = wt.create_wt_session();
+    let mut wt_server_stream = wt.create_wt_stream_server(&mut wt_session, StreamType::BiDi);
+
+    wt.send_data_server(&mut wt_server_stream, BUF_SERVER);
+    wt.receive_data_client(wt_server_stream.stream_id(), true, BUF_SERVER, false);
+    wt.stream_stop_sending_client(wt_server_stream.stream_id());
+    wt.receive_stop_sending_server(wt_server_stream.stream_id());
+    wt.stream_stop_sending_server(&mut wt_server_stream);
+    wt.receive_stop_sending_client(wt_server_stream.stream_id());
+}
+
+#[test]
+fn wt_client_session_close() {
+    const BUF: &[u8] = &[0; 10];
+
+    let mut wt = WtTest::new();
+    let mut wt_session = wt.create_wt_session();
+
+    let wt_c_bidi = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::BiDi);
+    wt.send_data_client(wt_c_bidi, BUF);
+    let _wt_s_bidi_from_c = wt.receive_data_server(wt_c_bidi, true, BUF, false);
+
+    let wt_c_unidi = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::UniDi);
+    wt.send_data_client(wt_c_unidi, BUF);
+    let _wt_s_uni_from_c = wt.receive_data_server(wt_c_unidi, true, BUF, false);
+
+    let mut wt_s_bidi = wt.create_wt_stream_server(&mut wt_session, StreamType::BiDi);
+    wt.send_data_server(&mut wt_s_bidi, BUF);
+    wt.receive_data_client(wt_s_bidi.stream_id(), true, BUF, false);
+
+    let mut wt_s_unidi = wt.create_wt_stream_server(&mut wt_session, StreamType::UniDi);
+    wt.send_data_server(&mut wt_s_unidi, BUF);
+    wt.receive_data_client(wt_s_unidi.stream_id(), true, BUF, false);
+
+    wt.cancel_session_client(wt_session.stream_id());
+
+    wt.check_session_closed_event_server(&mut wt_session, Some(Error::HttpNoError.code()));
+
+    //TODO cancel associated streams.
+    //wt.receive_reset_server(wt_s_bidi_from_c.stream_id());
+    //wt.receive_stop_sending_server(wt_s_uni_from_c.stream_id());
+    //wt.receive_reset_server(wt_s_bidi_from_c.stream_id());
+
+    //wt.receive_stop_sending_server(wt_s_bidi.stream_id());
+    //wt.receive_reset_server(wt_s_bidi.stream_id());
+    //wt.receive_stop_sending_server(wt_s_unidi.stream_id());
+
+    //assert!(wt.client.next_event().is_none());
+}
+
+#[test]
+fn wt_client_session_server_close() {
+    const BUF: &[u8] = &[0; 10];
+
+    let mut wt = WtTest::new();
+    let mut wt_session = wt.create_wt_session();
+
+    let wt_c_bidi = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::BiDi);
+    wt.send_data_client(wt_c_bidi, BUF);
+    let _wt_s_bidi_from_c = wt.receive_data_server(wt_c_bidi, true, BUF, false);
+
+    let wt_c_unidi = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::UniDi);
+    wt.send_data_client(wt_c_unidi, BUF);
+    let _wt_s_uni_from_c = wt.receive_data_server(wt_c_unidi, true, BUF, false);
+
+    let mut wt_s_bidi = wt.create_wt_stream_server(&mut wt_session, StreamType::BiDi);
+    wt.send_data_server(&mut wt_s_bidi, BUF);
+    wt.receive_data_client(wt_s_bidi.stream_id(), true, BUF, false);
+
+    let mut wt_s_unidi = wt.create_wt_stream_server(&mut wt_session, StreamType::UniDi);
+    wt.send_data_server(&mut wt_s_unidi, BUF);
+    wt.receive_data_client(wt_s_unidi.stream_id(), true, BUF, false);
+
+    wt.cancel_session_server(&mut wt_session);
+
+    wt.check_session_closed_event_client(wt_session.stream_id(), Some(Error::HttpNoError.code()));
+
+    //TODO cancel associated stream
+    //wt.receive_reset_client(wt_s_bidi_from_c.stream_id());
+    //wt.receive_stop_sending_client(wt_s_uni_from_c.stream_id());
+    //wt.receive_reset_client(wt_s_bidi_from_c.stream_id());
+
+    //wt.receive_stop_sending_client(wt_s_bidi.stream_id());
+    //wt.receive_reset_client(wt_s_bidi.stream_id());
+    //wt.receive_stop_sending_client(wt_s_unidi.stream_id());
+
+    //assert!(wt.server.next_event().is_none());
+}

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -340,7 +340,7 @@ impl H3Handler {
 
                     let (_sz, fin) = self
                         .h3
-                        .read_response_data(Instant::now(), stream_id, &mut data)
+                        .read_data(Instant::now(), stream_id, &mut data)
                         .expect("Read should succeed");
                     if let Ok(txt) = String::from_utf8(data.clone()) {
                         eprintln!("READ[{}]: {}", stream_id, txt);

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -272,11 +272,11 @@ impl HttpServer for Http3Server {
         while let Some(event) = self.next_event() {
             match event {
                 Http3ServerEvent::Headers {
-                    mut request,
+                    mut stream,
                     headers,
                     fin,
                 } => {
-                    println!("Headers (request={} fin={}): {:?}", request, fin, headers);
+                    println!("Headers (request={} fin={}): {:?}", stream, fin, headers);
 
                     let default_ret = b"Hello World".to_vec();
 
@@ -292,7 +292,7 @@ impl HttpServer for Http3Server {
                     });
 
                     if response.is_none() {
-                        request
+                        stream
                             .cancel_fetch(Error::HttpRequestIncomplete.code())
                             .unwrap();
                         continue;
@@ -300,17 +300,17 @@ impl HttpServer for Http3Server {
 
                     let response = response.unwrap();
 
-                    request
+                    stream
                         .send_headers(&[
                             Header::new(":status", "200"),
                             Header::new("content-length", response.len()),
                         ])
                         .unwrap();
-                    request.send_data(&response).unwrap();
-                    request.stream_close_send().unwrap();
+                    stream.send_data(&response).unwrap();
+                    stream.stream_close_send().unwrap();
                 }
-                Http3ServerEvent::Data { request, data, fin } => {
-                    println!("Data (request={} fin={}): {:?}", request, fin, data);
+                Http3ServerEvent::Data { stream, data, fin } => {
+                    println!("Data (request={} fin={}): {:?}", stream, fin, data);
                 }
                 _ => {}
             }


### PR DESCRIPTION
This implements WebTransport streams. A stream is a very thin layer that is responsible for posting RecvStreamEvents and SendStreamEvents and removing itself from the ExtendedConnectSession.
    
The WebTransport streams reuse a lot of API that was used for HTTP requests, e.g. reading data, stream_close_send, stream_reset. Also all events are reused. The only difference between a HTTP request and WebTransport is that WebTransport starts with a new event “NewStream”(if they are peer initiated) and the HTTP request starts with HeadersReady. The events now use Http3StreamInfo that contains the type and the stream number.
    
Parts that are not so nice is that Http3Connection cannot create streams directly because it need Box<dyn Send/RecvStreamEvents>, so the WebTransport streams are partially handle by Http3Connection, i.e. the are rejected if a session does not exist, and then they are actually created by Http3Client. (This is a TODO to improve)
    
On the server side stream handles are renamed from ClientRequestStream to Http3OrWebTransportStream, because they are used for HTTP3 request and WebTransport streams.
    
Additional changes:
- Rename read_response_data/read_request_data/send_request_data into read_data/send_data. This is now a more general function used for HTTP requests and WebTransport streams.
- Http3Connection now knows its Role.
- Set self.needs_processing to true in the Http3ServerHandler. This flag is  used to make sure that a particular server is processed(function process() is called) after some API activities. Some of this API may trigger the process in a different way, but it is better to be sure. This is server side only, we may consider improving the server side at some point in the future (it is not a priority at the moment).
- Clippy also ask for changing Http3Server::process_http3() because it is too long.