### PR TITLE
Convert API to use StreamId

### DIFF
--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -710,6 +710,7 @@ impl SecretAgent {
         Ok(*Pin::into_inner(records))
     }
 
+    #[allow(unknown_lints, clippy::branches_sharing_code)]
     pub fn close(&mut self) {
         // It should be safe to close multiple times.
         if self.fd.is_null() {

--- a/neqo-http3/src/buffered_send_stream.rs
+++ b/neqo-http3/src/buffered_send_stream.rs
@@ -22,7 +22,7 @@ impl Default for BufferedStream {
 
 impl ::std::fmt::Display for BufferedStream {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "BufferedStream {:?}", Option::<u64>::from(self))
+        write!(f, "BufferedStream {:?}", Option::<StreamId>::from(self))
     }
 }
 
@@ -63,7 +63,7 @@ impl BufferedStream {
         if let Self::Initialized { stream_id, buf } = self {
             if !buf.is_empty() {
                 qtrace!([label], "sending data.");
-                sent = conn.stream_send(stream_id.as_u64(), &buf[..])?;
+                sent = conn.stream_send(*stream_id, &buf[..])?;
                 if sent == buf.len() {
                     buf.clear();
                 } else {
@@ -82,7 +82,7 @@ impl BufferedStream {
         self.send_buffer(conn)?;
         if let Self::Initialized { stream_id, buf } = self {
             if buf.is_empty() {
-                let res = conn.stream_send_atomic(stream_id.as_u64(), to_send)?;
+                let res = conn.stream_send_atomic(*stream_id, to_send)?;
                 Ok(res)
             } else {
                 Ok(false)
@@ -93,10 +93,10 @@ impl BufferedStream {
     }
 }
 
-impl From<&BufferedStream> for Option<u64> {
-    fn from(stream: &BufferedStream) -> Option<u64> {
+impl From<&BufferedStream> for Option<StreamId> {
+    fn from(stream: &BufferedStream) -> Option<StreamId> {
         if let BufferedStream::Initialized { stream_id, .. } = stream {
-            Some(stream_id.as_u64())
+            Some(*stream_id)
         } else {
             None
         }

--- a/neqo-http3/src/control_stream_remote.rs
+++ b/neqo-http3/src/control_stream_remote.rs
@@ -7,12 +7,12 @@
 use crate::hframe::{HFrame, HFrameReader};
 use crate::{CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream};
 use neqo_common::qdebug;
-use neqo_transport::Connection;
+use neqo_transport::{Connection, StreamId};
 
 /// The remote control stream is responsible only for reading frames. The frames are handled by `Http3Connection`.
 #[derive(Debug)]
 pub(crate) struct ControlStreamRemote {
-    stream_id: u64,
+    stream_id: StreamId,
     frame_reader: HFrameReader,
 }
 
@@ -23,7 +23,7 @@ impl ::std::fmt::Display for ControlStreamRemote {
 }
 
 impl ControlStreamRemote {
-    pub fn new(stream_id: u64) -> Self {
+    pub fn new(stream_id: StreamId) -> Self {
         Self {
             stream_id,
             frame_reader: HFrameReader::new(),

--- a/neqo-http3/src/hframe.rs
+++ b/neqo-http3/src/hframe.rs
@@ -10,7 +10,7 @@ use neqo_common::{
     IncrementalDecoderUint,
 };
 use neqo_crypto::random;
-use neqo_transport::Connection;
+use neqo_transport::{Connection, StreamId};
 use std::convert::TryFrom;
 use std::io::Write;
 use std::mem;
@@ -52,7 +52,7 @@ pub enum HFrame {
         header_block: Vec<u8>,
     },
     Goaway {
-        stream_id: u64,
+        stream_id: StreamId,
     },
     MaxPushId {
         push_id: u64,
@@ -116,7 +116,7 @@ impl HFrame {
             }
             Self::Goaway { stream_id } => {
                 enc.encode_vvec_with(|enc_inner| {
-                    enc_inner.encode_varint(*stream_id);
+                    enc_inner.encode_varint(stream_id.as_u64());
                 });
             }
             Self::MaxPushId { push_id } => {
@@ -229,7 +229,7 @@ impl HFrameReader {
     pub fn receive(
         &mut self,
         conn: &mut Connection,
-        stream_id: u64,
+        stream_id: StreamId,
     ) -> Res<(Option<HFrame>, bool)> {
         loop {
             let to_read = std::cmp::min(self.min_remaining(), MAX_READ_SIZE);
@@ -384,7 +384,7 @@ impl HFrameReader {
                 header_block: dec.decode_remainder().to_vec(),
             },
             H3_FRAME_TYPE_GOAWAY => HFrame::Goaway {
-                stream_id: dec.decode_varint().ok_or(Error::HttpFrame)?,
+                stream_id: StreamId::new(dec.decode_varint().ok_or(Error::HttpFrame)?),
             },
             H3_FRAME_TYPE_MAX_PUSH_ID => HFrame::MaxPushId {
                 push_id: dec.decode_varint().ok_or(Error::HttpFrame)?,
@@ -418,7 +418,7 @@ mod tests {
     use crate::settings::{HSetting, HSettingType};
     use crate::Priority;
     use neqo_crypto::AuthenticationStatus;
-    use neqo_transport::{Connection, StreamType};
+    use neqo_transport::{Connection, StreamId, StreamType};
     use std::mem;
     use test_fixture::{connect, default_client, default_server, fixture_init, now};
 
@@ -503,7 +503,9 @@ mod tests {
 
     #[test]
     fn test_goaway_frame4() {
-        let f = HFrame::Goaway { stream_id: 5 };
+        let f = HFrame::Goaway {
+            stream_id: StreamId::new(5),
+        };
         enc_dec(&f, "070105", 0);
     }
 
@@ -581,7 +583,7 @@ mod tests {
         pub fr: HFrameReader,
         pub conn_c: Connection,
         pub conn_s: Connection,
-        pub stream_id: u64,
+        pub stream_id: StreamId,
     }
 
     impl HFrameReaderTest {
@@ -946,7 +948,9 @@ mod tests {
         test_complete_and_incomplete_frame(&buf, buf.len());
 
         // H3_FRAME_TYPE_GOAWAY
-        let f = HFrame::Goaway { stream_id: 5 };
+        let f = HFrame::Goaway {
+            stream_id: StreamId::new(5),
+        };
         let mut enc = Encoder::default();
         f.encode(&mut enc);
         let buf: Vec<_> = enc.into();

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -32,8 +32,8 @@ mod settings;
 mod stream_type_reader;
 
 use neqo_qpack::Error as QpackError;
-pub use neqo_transport::Output;
 use neqo_transport::{AppError, Connection, Error as TransportError};
+pub use neqo_transport::{Output, StreamId};
 use std::fmt::Debug;
 
 use crate::priority::PriorityHandler;
@@ -298,7 +298,7 @@ pub enum ReceiveOutput {
     NoOutput,
     PushStream,
     ControlFrames(Vec<HFrame>),
-    UnblockedStreams(Vec<u64>),
+    UnblockedStreams(Vec<StreamId>),
     NewStream(NewStreamType),
 }
 
@@ -348,12 +348,12 @@ pub trait HttpRecvStream: RecvStream {
 }
 
 pub trait RecvStreamEvents: Debug {
-    fn data_readable(&self, stream_id: u64);
-    fn recv_closed(&self, _stream_id: u64, _close_type: CloseType) {}
+    fn data_readable(&self, stream_id: StreamId);
+    fn recv_closed(&self, _stream_id: StreamId, _close_type: CloseType) {}
 }
 
 pub(crate) trait HttpRecvStreamEvents: RecvStreamEvents {
-    fn header_ready(&self, stream_id: u64, headers: Vec<Header>, interim: bool, fin: bool);
+    fn header_ready(&self, stream_id: StreamId, headers: Vec<Header>, interim: bool, fin: bool);
 }
 
 pub trait SendStream: Stream {
@@ -382,8 +382,8 @@ pub trait HttpSendStream: SendStream {
 }
 
 pub trait SendStreamEvents: Debug {
-    fn send_closed(&self, _stream_id: u64, _close_type: CloseType) {}
-    fn data_writable(&self, _stream_id: u64) {}
+    fn send_closed(&self, _stream_id: StreamId, _close_type: CloseType) {}
+    fn data_writable(&self, _stream_id: StreamId) {}
 }
 
 /// This enum is used to mark a different type of closing a stream:

--- a/neqo-http3/src/qlog.rs
+++ b/neqo-http3/src/qlog.rs
@@ -9,8 +9,9 @@ use std::convert::TryFrom;
 use qlog::{self, event::Event, H3DataRecipient};
 
 use neqo_common::qlog::NeqoQlog;
+use neqo_transport::StreamId;
 
-pub fn h3_data_moved_up(qlog: &mut NeqoQlog, stream_id: u64, amount: usize) {
+pub fn h3_data_moved_up(qlog: &mut NeqoQlog, stream_id: StreamId, amount: usize) {
     qlog.add_event(|| {
         Some(Event::h3_data_moved(
             stream_id.to_string(),
@@ -23,7 +24,7 @@ pub fn h3_data_moved_up(qlog: &mut NeqoQlog, stream_id: u64, amount: usize) {
     });
 }
 
-pub fn h3_data_moved_down(qlog: &mut NeqoQlog, stream_id: u64, amount: usize) {
+pub fn h3_data_moved_down(qlog: &mut NeqoQlog, stream_id: StreamId, amount: usize) {
     qlog.add_event(|| {
         Some(Event::h3_data_moved(
             stream_id.to_string(),

--- a/neqo-http3/src/qpack_decoder_receiver.rs
+++ b/neqo-http3/src/qpack_decoder_receiver.rs
@@ -6,18 +6,18 @@
 
 use crate::{CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream};
 use neqo_qpack::QPackDecoder;
-use neqo_transport::Connection;
+use neqo_transport::{Connection, StreamId};
 use std::cell::RefCell;
 use std::rc::Rc;
 
 #[derive(Debug)]
 pub struct DecoderRecvStream {
-    stream_id: u64,
+    stream_id: StreamId,
     decoder: Rc<RefCell<QPackDecoder>>,
 }
 
 impl DecoderRecvStream {
-    pub fn new(stream_id: u64, decoder: Rc<RefCell<QPackDecoder>>) -> Self {
+    pub fn new(stream_id: StreamId, decoder: Rc<RefCell<QPackDecoder>>) -> Self {
         Self { stream_id, decoder }
     }
 }

--- a/neqo-http3/src/qpack_encoder_receiver.rs
+++ b/neqo-http3/src/qpack_encoder_receiver.rs
@@ -6,18 +6,18 @@
 
 use crate::{CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream};
 use neqo_qpack::QPackEncoder;
-use neqo_transport::Connection;
+use neqo_transport::{Connection, StreamId};
 use std::cell::RefCell;
 use std::rc::Rc;
 
 #[derive(Debug)]
 pub struct EncoderRecvStream {
-    stream_id: u64,
+    stream_id: StreamId,
     encoder: Rc<RefCell<QPackEncoder>>,
 }
 
 impl EncoderRecvStream {
-    pub fn new(stream_id: u64, encoder: Rc<RefCell<QPackEncoder>>) -> Self {
+    pub fn new(stream_id: StreamId, encoder: Rc<RefCell<QPackEncoder>>) -> Self {
         Self { stream_id, encoder }
     }
 }

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -14,7 +14,7 @@ use crate::{
 use crate::priority::PriorityHandler;
 use neqo_common::{qdebug, qinfo, qtrace};
 use neqo_qpack::decoder::QPackDecoder;
-use neqo_transport::Connection;
+use neqo_transport::{Connection, StreamId};
 use std::cell::RefCell;
 use std::cmp::min;
 use std::collections::VecDeque;
@@ -75,7 +75,7 @@ pub(crate) struct RecvMessage {
     qpack_decoder: Rc<RefCell<QPackDecoder>>,
     conn_events: Box<dyn HttpRecvStreamEvents>,
     push_handler: Option<Rc<RefCell<PushController>>>,
-    stream_id: u64,
+    stream_id: StreamId,
     priority_handler: PriorityHandler,
     blocked_push_promise: VecDeque<PushInfo>,
 }
@@ -89,7 +89,7 @@ impl ::std::fmt::Display for RecvMessage {
 impl RecvMessage {
     pub fn new(
         message_type: MessageType,
-        stream_id: u64,
+        stream_id: StreamId,
         qpack_decoder: Rc<RefCell<QPackDecoder>>,
         conn_events: Box<dyn HttpRecvStreamEvents>,
         push_handler: Option<Rc<RefCell<PushController>>>,

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use neqo_common::{qdebug, qinfo, qtrace, Encoder};
 use neqo_qpack::encoder::QPackEncoder;
-use neqo_transport::Connection;
+use neqo_transport::{Connection, StreamId};
 use std::cell::RefCell;
 use std::cmp::min;
 use std::fmt::Debug;
@@ -76,14 +76,14 @@ impl SendMessageState {
 #[derive(Debug)]
 pub(crate) struct SendMessage {
     state: SendMessageState,
-    stream_id: u64,
+    stream_id: StreamId,
     encoder: Rc<RefCell<QPackEncoder>>,
     conn_events: Box<dyn SendStreamEvents>,
 }
 
 impl SendMessage {
     pub fn new(
-        stream_id: u64,
+        stream_id: StreamId,
         encoder: Rc<RefCell<QPackEncoder>>,
         conn_events: Box<dyn SendStreamEvents>,
     ) -> Self {
@@ -97,7 +97,7 @@ impl SendMessage {
     }
 
     pub fn new_with_headers(
-        stream_id: u64,
+        stream_id: StreamId,
         headers: Vec<Header>,
         encoder: Rc<RefCell<QPackEncoder>>,
         conn_events: Box<dyn SendStreamEvents>,

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -79,18 +79,18 @@ pub enum NewStreamHeadReader {
     ReadType {
         role: Role,
         reader: IncrementalDecoderUint,
-        stream_id: u64,
+        stream_id: StreamId,
     },
     ReadId {
         stream_type: u64,
         reader: IncrementalDecoderUint,
-        stream_id: u64,
+        stream_id: StreamId,
     },
     Done,
 }
 
 impl NewStreamHeadReader {
-    pub fn new(stream_id: u64, role: Role) -> Self {
+    pub fn new(stream_id: StreamId, role: Role) -> Self {
         NewStreamHeadReader::ReadType {
             role,
             reader: IncrementalDecoderUint::default(),
@@ -149,11 +149,8 @@ impl NewStreamHeadReader {
                     //  - None - if a stream is not identified by the type only, but it needs
                     //    additional data from the header to produce the final type, e.g.
                     //    a push stream needs pushId as well.
-                    let final_type = NewStreamType::final_stream_type(
-                        output,
-                        StreamId::new(*stream_id).stream_type(),
-                        *role,
-                    );
+                    let final_type =
+                        NewStreamType::final_stream_type(output, stream_id.stream_type(), *role);
                     match (&final_type, fin) {
                         (Err(_), _) => {
                             *self = NewStreamHeadReader::Done;
@@ -244,7 +241,7 @@ mod tests {
         NewStreamHeadReader, HTTP3_UNI_STREAM_TYPE_PUSH, WEBTRANSPORT_STREAM,
         WEBTRANSPORT_UNI_STREAM,
     };
-    use neqo_transport::{Connection, StreamType};
+    use neqo_transport::{Connection, StreamId, StreamType};
     use std::mem;
     use test_fixture::{connect, now};
 
@@ -258,7 +255,7 @@ mod tests {
     struct Test {
         conn_c: Connection,
         conn_s: Connection,
-        stream_id: u64,
+        stream_id: StreamId,
         decoder: NewStreamHeadReader,
     }
 

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -12,7 +12,7 @@ use neqo_crypto::{init, AuthenticationStatus, ResumptionToken};
 use neqo_http3::{Header, Http3Client, Http3ClientEvent, Http3Parameters, Http3State, Priority};
 use neqo_transport::{
     Connection, ConnectionError, ConnectionEvent, ConnectionParameters, EmptyConnectionIdGenerator,
-    Error, Output, State, StreamType,
+    Error, Output, State, StreamId, StreamType,
 };
 
 use std::cell::RefCell;
@@ -168,7 +168,7 @@ impl Handler for PreConnectHandler {
 struct H9Handler {
     rbytes: usize,
     rsfin: bool,
-    streams: HashSet<u64>,
+    streams: HashSet<StreamId>,
 }
 
 // This is a bit fancier than actually needed.
@@ -246,7 +246,7 @@ impl FromStr for Headers {
 }
 
 struct H3Handler {
-    streams: HashSet<u64>,
+    streams: HashSet<StreamId>,
     h3: Http3Client,
     host: String,
     path: String,

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -13,7 +13,7 @@ use crate::stats::Stats;
 use crate::table::HeaderTable;
 use crate::{Error, QpackSettings, Res};
 use neqo_common::{qdebug, Header};
-use neqo_transport::Connection;
+use neqo_transport::{Connection, StreamId};
 use std::convert::TryFrom;
 
 pub const QPACK_UNI_STREAM_TYPE_DECODER: u64 = 0x3;
@@ -25,10 +25,10 @@ pub struct QPackDecoder {
     acked_inserts: u64,
     max_entries: u64,
     send_buf: QpackData,
-    local_stream_id: Option<u64>,
+    local_stream_id: Option<StreamId>,
     max_table_size: u64,
     max_blocked_streams: usize,
-    blocked_streams: Vec<(u64, u64)>, //stream_id and requested inserts count.
+    blocked_streams: Vec<(StreamId, u64)>, //stream_id and requested inserts count.
     stats: Stats,
 }
 
@@ -75,7 +75,7 @@ impl QPackDecoder {
     /// # Errors
     /// May return: `ClosedCriticalStream` if stream has been closed or `EncoderStream`
     /// in case of any other transport error.
-    pub fn receive(&mut self, conn: &mut Connection, stream_id: u64) -> Res<Vec<u64>> {
+    pub fn receive(&mut self, conn: &mut Connection, stream_id: StreamId) -> Res<Vec<StreamId>> {
         let base_old = self.table.base();
         self.read_instructions(conn, stream_id)
             .map_err(|e| map_error(&e))?;
@@ -93,7 +93,7 @@ impl QPackDecoder {
         Ok(r)
     }
 
-    fn read_instructions(&mut self, conn: &mut Connection, stream_id: u64) -> Res<()> {
+    fn read_instructions(&mut self, conn: &mut Connection, stream_id: StreamId) -> Res<()> {
         let mut recv = ReceiverConnWrapper::new(conn, stream_id);
         loop {
             match self.instruction_reader.read_instructions(&mut recv) {
@@ -147,14 +147,14 @@ impl QPackDecoder {
         self.table.set_capacity(cap)
     }
 
-    fn header_ack(&mut self, stream_id: u64, required_inserts: u64) {
+    fn header_ack(&mut self, stream_id: StreamId, required_inserts: u64) {
         DecoderInstruction::HeaderAck { stream_id }.marshal(&mut self.send_buf);
         if required_inserts > self.acked_inserts {
             self.acked_inserts = required_inserts;
         }
     }
 
-    pub fn cancel_stream(&mut self, stream_id: u64) {
+    pub fn cancel_stream(&mut self, stream_id: StreamId) {
         if self.table.capacity() > 0 {
             self.blocked_streams.retain(|(id, _)| *id != stream_id);
             DecoderInstruction::StreamCancellation { stream_id }.marshal(&mut self.send_buf);
@@ -195,7 +195,11 @@ impl QPackDecoder {
     /// May return `DecompressionFailed` if header block is incorrect or incomplete.
     /// # Panics
     /// When there is a programming error.
-    pub fn decode_header_block(&mut self, buf: &[u8], stream_id: u64) -> Res<Option<Vec<Header>>> {
+    pub fn decode_header_block(
+        &mut self,
+        buf: &[u8],
+        stream_id: StreamId,
+    ) -> Res<Option<Vec<Header>>> {
         qdebug!([self], "decode header block.");
         let mut decoder = HeaderDecoder::new(buf);
 
@@ -231,7 +235,7 @@ impl QPackDecoder {
 
     /// # Panics
     /// When a stream has already been added.
-    pub fn add_send_stream(&mut self, stream_id: u64) {
+    pub fn add_send_stream(&mut self, stream_id: StreamId) {
         if self.local_stream_id.is_some() {
             panic!("Adding multiple local streams");
         }
@@ -239,7 +243,7 @@ impl QPackDecoder {
     }
 
     #[must_use]
-    pub fn local_stream_id(&self) -> Option<u64> {
+    pub fn local_stream_id(&self) -> Option<StreamId> {
         self.local_stream_id
     }
 
@@ -267,15 +271,17 @@ fn map_error(err: &Error) -> Error {
 mod tests {
     use super::{Connection, Error, Header, QPackDecoder, Res};
     use crate::QpackSettings;
-    use neqo_transport::StreamType;
-    use std::convert::TryInto;
+    use neqo_transport::{StreamId, StreamType};
+    use std::convert::TryFrom;
     use std::mem;
     use test_fixture::now;
 
+    const STREAM_0: StreamId = StreamId::new(0);
+
     struct TestDecoder {
         decoder: QPackDecoder,
-        send_stream_id: u64,
-        recv_stream_id: u64,
+        send_stream_id: StreamId,
+        recv_stream_id: StreamId,
         conn: Connection,
         peer_conn: Connection,
     }
@@ -336,7 +342,7 @@ mod tests {
         decoder: &mut TestDecoder,
         header_block: &[u8],
         headers: &[Header],
-        stream_id: u64,
+        stream_id: StreamId,
     ) {
         let decoded_headers = decoder
             .decoder
@@ -486,7 +492,7 @@ mod tests {
 
         recv_instruction(&mut decoder, second_encoder_inst, &Ok(()));
 
-        decode_headers(&mut decoder, header_block, &headers, 0);
+        decode_headers(&mut decoder, header_block, &headers, STREAM_0);
 
         send_instructions_and_check(&mut decoder, &[0x80, 0x1]);
     }
@@ -522,7 +528,7 @@ mod tests {
 
         recv_instruction(&mut decoder, second_encoder_inst, &Ok(()));
 
-        decode_headers(&mut decoder, header_block, &headers, 0);
+        decode_headers(&mut decoder, header_block, &headers, STREAM_0);
 
         send_instructions_and_check(&mut decoder, &[0x80]);
     }
@@ -548,7 +554,7 @@ mod tests {
 
         recv_instruction(&mut decoder, encoder_inst, &Ok(()));
 
-        decode_headers(&mut decoder, header_block, &headers, 0);
+        decode_headers(&mut decoder, header_block, &headers, STREAM_0);
 
         send_instructions_and_check(&mut decoder, &[0x03, 0x80]);
     }
@@ -572,7 +578,7 @@ mod tests {
 
         recv_instruction(&mut decoder, encoder_inst, &Ok(()));
 
-        decode_headers(&mut decoder, header_block, &headers, 0);
+        decode_headers(&mut decoder, header_block, &headers, STREAM_0);
 
         send_instructions_and_check(&mut decoder, &[0x03, 0x80, 0x01]);
     }
@@ -649,7 +655,7 @@ mod tests {
                 &mut decoder,
                 t.header_block,
                 &t.headers,
-                i.try_into().unwrap(),
+                StreamId::from(u64::try_from(i).unwrap()),
             );
         }
 
@@ -727,7 +733,7 @@ mod tests {
                 &mut decoder,
                 t.header_block,
                 &t.headers,
-                i.try_into().unwrap(),
+                StreamId::from(u64::try_from(i).unwrap()),
             );
         }
 
@@ -760,11 +766,11 @@ mod tests {
 
         recv_instruction(&mut decoder, ENCODER_INST, &Ok(()));
 
-        decode_headers(&mut decoder, HEADER_BLOCK_1, &headers, 0);
+        decode_headers(&mut decoder, HEADER_BLOCK_1, &headers, STREAM_0);
 
         let headers = vec![Header::new("my-headera", "my-valuea")];
 
-        decode_headers(&mut decoder, HEADER_BLOCK_2, &headers, 0);
+        decode_headers(&mut decoder, HEADER_BLOCK_2, &headers, STREAM_0);
     }
 
     #[test]
@@ -791,6 +797,6 @@ mod tests {
 
         recv_instruction(&mut decoder, ENCODER_INST, &Ok(()));
 
-        decode_headers(&mut decoder, HEADER_BLOCK, &headers, 0);
+        decode_headers(&mut decoder, HEADER_BLOCK, &headers, STREAM_0);
     }
 }

--- a/neqo-qpack/src/decoder_instructions.rs
+++ b/neqo-qpack/src/decoder_instructions.rs
@@ -11,22 +11,27 @@ use crate::qpack_send_buf::QpackData;
 use crate::reader::{IntReader, ReadByte};
 use crate::Res;
 use neqo_common::{qdebug, qtrace};
+use neqo_transport::StreamId;
 use std::mem;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum DecoderInstruction {
     InsertCountIncrement { increment: u64 },
-    HeaderAck { stream_id: u64 },
-    StreamCancellation { stream_id: u64 },
+    HeaderAck { stream_id: StreamId },
+    StreamCancellation { stream_id: StreamId },
     NoInstruction,
 }
 
 impl DecoderInstruction {
     fn get_instruction(b: u8) -> Self {
         if DECODER_HEADER_ACK.cmp_prefix(b) {
-            Self::HeaderAck { stream_id: 0 }
+            Self::HeaderAck {
+                stream_id: StreamId::from(0),
+            }
         } else if DECODER_STREAM_CANCELLATION.cmp_prefix(b) {
-            Self::StreamCancellation { stream_id: 0 }
+            Self::StreamCancellation {
+                stream_id: StreamId::from(0),
+            }
         } else if DECODER_INSERT_COUNT_INCREMENT.cmp_prefix(b) {
             Self::InsertCountIncrement { increment: 0 }
         } else {
@@ -40,10 +45,10 @@ impl DecoderInstruction {
                 enc.encode_prefixed_encoded_int(DECODER_INSERT_COUNT_INCREMENT, *increment);
             }
             Self::HeaderAck { stream_id } => {
-                enc.encode_prefixed_encoded_int(DECODER_HEADER_ACK, *stream_id);
+                enc.encode_prefixed_encoded_int(DECODER_HEADER_ACK, stream_id.as_u64());
             }
             Self::StreamCancellation { stream_id } => {
-                enc.encode_prefixed_encoded_int(DECODER_STREAM_CANCELLATION, *stream_id);
+                enc.encode_prefixed_encoded_int(DECODER_STREAM_CANCELLATION, stream_id.as_u64());
             }
             Self::NoInstruction => {}
         }
@@ -102,10 +107,17 @@ impl DecoderInstructionReader {
                     let val = reader.read(recv)?;
                     qtrace!([self], "varint read {}", val);
                     match &mut self.instruction {
-                        DecoderInstruction::InsertCountIncrement { increment: v }
-                        | DecoderInstruction::HeaderAck { stream_id: v }
-                        | DecoderInstruction::StreamCancellation { stream_id: v } => {
+                        DecoderInstruction::InsertCountIncrement { increment: v } => {
                             *v = val;
+                            self.state = DecoderInstructionReaderState::ReadInstruction;
+                            break Ok(mem::replace(
+                                &mut self.instruction,
+                                DecoderInstruction::NoInstruction,
+                            ));
+                        }
+                        DecoderInstruction::HeaderAck { stream_id: v }
+                        | DecoderInstruction::StreamCancellation { stream_id: v } => {
+                            *v = StreamId::from(val);
                             self.state = DecoderInstructionReaderState::ReadInstruction;
                             break Ok(mem::replace(
                                 &mut self.instruction,
@@ -128,6 +140,7 @@ mod test {
     use super::{DecoderInstruction, DecoderInstructionReader, QpackData};
     use crate::reader::test_receiver::TestReceiver;
     use crate::Error;
+    use neqo_transport::StreamId;
 
     fn test_encoding_decoding(instruction: DecoderInstruction) {
         let mut buf = QpackData::default();
@@ -146,11 +159,19 @@ mod test {
         test_encoding_decoding(DecoderInstruction::InsertCountIncrement { increment: 1 });
         test_encoding_decoding(DecoderInstruction::InsertCountIncrement { increment: 10_000 });
 
-        test_encoding_decoding(DecoderInstruction::HeaderAck { stream_id: 1 });
-        test_encoding_decoding(DecoderInstruction::HeaderAck { stream_id: 10_000 });
+        test_encoding_decoding(DecoderInstruction::HeaderAck {
+            stream_id: StreamId::new(1),
+        });
+        test_encoding_decoding(DecoderInstruction::HeaderAck {
+            stream_id: StreamId::new(10_000),
+        });
 
-        test_encoding_decoding(DecoderInstruction::StreamCancellation { stream_id: 1 });
-        test_encoding_decoding(DecoderInstruction::StreamCancellation { stream_id: 10_000 });
+        test_encoding_decoding(DecoderInstruction::StreamCancellation {
+            stream_id: StreamId::new(1),
+        });
+        test_encoding_decoding(DecoderInstruction::StreamCancellation {
+            stream_id: StreamId::new(10_000),
+        });
     }
 
     fn test_encoding_decoding_slow_reader(instruction: DecoderInstruction) {
@@ -177,9 +198,11 @@ mod test {
         test_encoding_decoding_slow_reader(DecoderInstruction::InsertCountIncrement {
             increment: 10_000,
         });
-        test_encoding_decoding_slow_reader(DecoderInstruction::HeaderAck { stream_id: 10_000 });
+        test_encoding_decoding_slow_reader(DecoderInstruction::HeaderAck {
+            stream_id: StreamId::new(10_000),
+        });
         test_encoding_decoding_slow_reader(DecoderInstruction::StreamCancellation {
-            stream_id: 10_000,
+            stream_id: StreamId::new(10_000),
         });
     }
 

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -8,7 +8,7 @@ use crate::huffman::decode_huffman;
 use crate::prefix::Prefix;
 use crate::{Error, Res};
 use neqo_common::{qdebug, qerror};
-use neqo_transport::Connection;
+use neqo_transport::{Connection, StreamId};
 use std::convert::TryInto;
 use std::mem;
 use std::str;
@@ -29,7 +29,7 @@ pub trait Reader {
 
 pub(crate) struct ReceiverConnWrapper<'a> {
     conn: &'a mut Connection,
-    stream_id: u64,
+    stream_id: StreamId,
 }
 
 impl<'a> ReadByte for ReceiverConnWrapper<'a> {
@@ -53,7 +53,7 @@ impl<'a> Reader for ReceiverConnWrapper<'a> {
 }
 
 impl<'a> ReceiverConnWrapper<'a> {
-    pub fn new(conn: &'a mut Connection, stream_id: u64) -> Self {
+    pub fn new(conn: &'a mut Connection, stream_id: StreamId) -> Self {
         Self { conn, stream_id }
     }
 }

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -14,7 +14,9 @@ use crate::events::ConnectionEvent;
 use crate::path::PATH_MTU_V6;
 use crate::recovery::ACK_ONLY_SIZE_LIMIT;
 use crate::stats::{FrameStats, Stats, MAX_PTO_COUNTS};
-use crate::{ConnectionIdDecoder, ConnectionIdGenerator, ConnectionParameters, Error, StreamType};
+use crate::{
+    ConnectionIdDecoder, ConnectionIdGenerator, ConnectionParameters, Error, StreamId, StreamType,
+};
 
 use std::cell::RefCell;
 use std::cmp::min;
@@ -287,7 +289,7 @@ fn connect_force_idle(client: &mut Connection, server: &mut Connection) {
     connect_rtt_idle(client, server, Duration::new(0, 0));
 }
 
-fn fill_stream(c: &mut Connection, stream: u64) {
+fn fill_stream(c: &mut Connection, stream: StreamId) {
     const BLOCK_SIZE: usize = 4_096;
     loop {
         let bytes_sent = c.stream_send(stream, &[0x42; BLOCK_SIZE]).unwrap();
@@ -304,7 +306,7 @@ fn fill_stream(c: &mut Connection, stream: u64) {
 /// from the return value whether a timeout is an ACK delay, PTO, or
 /// pacing, this looks at the congestion window to tell when to stop.
 /// Returns a list of datagrams and the new time.
-fn fill_cwnd(c: &mut Connection, stream: u64, mut now: Instant) -> (Vec<Datagram>, Instant) {
+fn fill_cwnd(c: &mut Connection, stream: StreamId, mut now: Instant) -> (Vec<Datagram>, Instant) {
     // Train wreck function to get the remaining congestion window on the primary path.
     fn cwnd(c: &Connection) -> usize {
         c.paths.primary().borrow().sender().cwnd_avail()
@@ -343,7 +345,7 @@ fn fill_cwnd(c: &mut Connection, stream: u64, mut now: Instant) -> (Vec<Datagram
 fn increase_cwnd(
     sender: &mut Connection,
     receiver: &mut Connection,
-    stream: u64,
+    stream: StreamId,
     mut now: Instant,
 ) -> Instant {
     fill_stream(sender, stream);
@@ -377,7 +379,7 @@ fn increase_cwnd(
 /// The caller is responsible for ensuring that `dest` has received
 /// enough data that it wants to generate an ACK.  This panics if
 /// no ACK frame is generated.
-fn ack_bytes<D>(dest: &mut Connection, stream: u64, in_dgrams: D, now: Instant) -> Datagram
+fn ack_bytes<D>(dest: &mut Connection, stream: StreamId, in_dgrams: D, now: Instant) -> Datagram
 where
     D: IntoIterator<Item = Datagram>,
     D::IntoIter: ExactSizeIterator,
@@ -412,7 +414,7 @@ fn cwnd_avail(c: &Connection) -> usize {
 fn induce_persistent_congestion(
     client: &mut Connection,
     server: &mut Connection,
-    stream: u64,
+    stream: StreamId,
     mut now: Instant,
 ) -> Instant {
     // Note: wait some arbitrary time that should be longer than pto

--- a/neqo-transport/src/connection/tests/priority.rs
+++ b/neqo-transport/src/connection/tests/priority.rs
@@ -8,7 +8,7 @@ use super::super::{Connection, Error, Output};
 use super::{connect, default_client, default_server, fill_cwnd, maybe_authenticate};
 use crate::addr_valid::{AddressValidation, ValidateAddress};
 use crate::send_stream::{RetransmissionPriority, TransmissionPriority};
-use crate::{ConnectionEvent, StreamType};
+use crate::{ConnectionEvent, StreamId, StreamType};
 
 use neqo_common::event::Provider;
 use std::cell::RefCell;
@@ -18,7 +18,7 @@ use test_fixture::{self, now};
 
 const BLOCK_SIZE: usize = 4_096;
 
-fn fill_stream(c: &mut Connection, id: u64) {
+fn fill_stream(c: &mut Connection, id: StreamId) {
     loop {
         if c.stream_send(id, &[0x42; BLOCK_SIZE]).unwrap() < BLOCK_SIZE {
             return;

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -344,8 +344,9 @@ fn pto_handshake_frames() {
     now += Duration::from_millis(10);
     client.authenticated(AuthenticationStatus::Ok, now);
 
-    assert_eq!(client.stream_create(StreamType::UniDi).unwrap(), 2);
-    assert_eq!(client.stream_send(2, b"zero").unwrap(), 4);
+    let stream = client.stream_create(StreamType::UniDi).unwrap();
+    assert_eq!(stream, 2);
+    assert_eq!(client.stream_send(stream, b"zero").unwrap(), 4);
     qdebug!("---- client: SH..FIN -> FIN and 1RTT packet");
     let pkt1 = client.process(None, now).dgram();
     assert!(pkt1.is_some());

--- a/neqo-transport/src/stream_id.rs
+++ b/neqo-transport/src/stream_id.rs
@@ -113,6 +113,12 @@ impl PartialEq<u64> for StreamId {
     }
 }
 
+impl AsRef<u64> for StreamId {
+    fn as_ref(&self) -> &u64 {
+        &self.0
+    }
+}
+
 impl ::std::fmt::Display for StreamId {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "{}", self.as_u64())

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -377,7 +377,7 @@ impl Streams {
         ))
     }
 
-    pub fn stream_create(&mut self, st: StreamType) -> Res<u64> {
+    pub fn stream_create(&mut self, st: StreamType) -> Res<StreamId> {
         match self.local_stream_limits.take_stream_id(st) {
             None => Err(Error::StreamLimitError),
             Some(new_id) => {
@@ -416,7 +416,7 @@ impl Streams {
                         ),
                     );
                 }
-                Ok(new_id.as_u64())
+                Ok(new_id)
             }
         }
     }

--- a/neqo-transport/tests/sim/connection.rs
+++ b/neqo-transport/tests/sim/connection.rs
@@ -184,14 +184,13 @@ impl SendData {
         if self.stream_id.is_none() {
             if let Ok(stream_id) = c.stream_create(StreamType::UniDi) {
                 qdebug!([c], "made stream {} for sending", stream_id);
-                self.stream_id = Some(StreamId::new(stream_id));
+                self.stream_id = Some(stream_id);
             }
         }
     }
 
     fn send(&mut self, c: &mut Connection, stream_id: StreamId) -> GoalStatus {
         const DATA: &[u8] = &[0; 4096];
-        let stream_id = stream_id.as_u64();
         let mut status = GoalStatus::Waiting;
         loop {
             let end = min(self.remaining, DATA.len());
@@ -266,7 +265,7 @@ impl ReceiveData {
         let mut status = GoalStatus::Waiting;
         loop {
             let end = min(self.remaining, buf.len());
-            let (recvd, _) = c.stream_recv(stream_id.as_u64(), &mut buf[..end]).unwrap();
+            let (recvd, _) = c.stream_recv(stream_id, &mut buf[..end]).unwrap();
             qtrace!("received {} remaining {}", recvd, self.remaining);
             if recvd == 0 {
                 return status;
@@ -288,7 +287,7 @@ impl ConnectionGoal for ReceiveData {
         _now: Instant,
     ) -> GoalStatus {
         if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
-            self.recv(c, StreamId::new(*stream_id))
+            self.recv(c, *stream_id)
         } else {
             GoalStatus::Waiting
         }


### PR DESCRIPTION
This makes basically all uses of u64 for stream IDs use the wrapper type.

This will affect gecko, but I hope not that much.  I've been meaning to do this for a while and it wasn't particularly hard or time-consuming.

Closes #346.