### PR TITLE
Implement closing of WebTransport streams if sessions are closed or cancelled.

### DIFF
--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -179,6 +179,8 @@ impl ExtendedConnectEvents for Http3ClientEvents {
             self.insert(Http3ClientEvent::WebTransport(WebTransportEvent::Session(
                 stream_id,
             )));
+        } else {
+            unreachable!("There is only ExtendedConnectType::WebTransport.");
         }
     }
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -320,7 +320,7 @@ impl Http3Client {
     /// # Errors
     /// An error will be return if a stream does not exist.
     pub fn stream_reset_send(&mut self, stream_id: StreamId, error: AppError) -> Res<()> {
-        qinfo!([self], "stream_reset {} error={}.", stream_id, error);
+        qinfo!([self], "stream_reset_send {} error={}.", stream_id, error);
         self.base_handler
             .stream_reset_send(&mut self.conn, stream_id, error)
     }
@@ -436,7 +436,7 @@ impl Http3Client {
     }
 
     /// # Errors
-    /// This may return an error if the particula session does not exist
+    /// This may return an error if the particular session does not exist
     /// or the connection is not in the active state.
     pub fn webtransport_create_stream(
         &mut self,

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -42,7 +42,7 @@ impl Http3ServerHandler {
 
     /// Supply a response for a request.
     /// # Errors
-    /// `InvalidStreamId` if thee stream does not exist,
+    /// `InvalidStreamId` if the stream does not exist,
     /// `AlreadyClosed` if the stream has already been closed.
     /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if `process_output`
     /// has not been called when needed, and HTTP3 layer has not picked up the info that the stream has been closed.)
@@ -102,7 +102,7 @@ impl Http3ServerHandler {
         error: AppError,
         conn: &mut Connection,
     ) -> Res<()> {
-        qinfo!([self], "reset_stream {} error={}.", stream_id, error);
+        qinfo!([self], "cancel_fetch {} error={}.", stream_id, error);
         self.needs_processing = true;
         self.base_handler.cancel_fetch(stream_id, error, conn)
     }

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -227,14 +227,14 @@ impl Http3ServerHandler {
                     app_error,
                 } => {
                     self.base_handler
-                        .handle_stream_reset(stream_id, app_error)?;
+                        .handle_stream_reset(stream_id, app_error, conn)?;
                 }
                 ConnectionEvent::SendStreamStopSending {
                     stream_id,
                     app_error,
                 } => self
                     .base_handler
-                    .handle_stream_stop_sending(stream_id, app_error)?,
+                    .handle_stream_stop_sending(stream_id, app_error, conn)?,
                 ConnectionEvent::StateChange(state) => {
                     if self.base_handler.handle_state_change(conn, &state)? {
                         if self.base_handler.state() == Http3State::Connected {
@@ -268,6 +268,7 @@ impl Http3ServerHandler {
                     stream_id,
                     Box::new(SendMessage::new(
                         MessageType::Response,
+                        Http3StreamType::Http,
                         stream_id,
                         self.base_handler.qpack_encoder.clone(),
                         Box::new(self.events.clone()),

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -16,6 +16,7 @@ use crate::{Http3StreamInfo, Http3StreamType};
 use neqo_transport::{AppError, StreamId};
 pub use session::ExtendedConnectSession;
 use std::cell::RefCell;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::rc::Rc;
@@ -106,5 +107,14 @@ impl ExtendedConnectFeature {
     #[must_use]
     pub fn enabled(&self) -> bool {
         self.feature_negotiation.enabled()
+    }
+
+    pub fn remove(
+        &mut self,
+        stream_id: StreamId,
+    ) -> Option<(BTreeSet<StreamId>, BTreeSet<StreamId>)> {
+        self.sessions
+            .remove(&stream_id)
+            .and_then(|ec| ec.borrow_mut().take_sub_streams())
     }
 }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -401,8 +401,8 @@ impl Http3StreamInfo {
 }
 
 pub trait RecvStreamEvents: Debug {
-    fn data_readable(&self, stream_id: Http3StreamInfo);
-    fn recv_closed(&self, _stream_id: Http3StreamInfo, _close_type: CloseType) {}
+    fn data_readable(&self, stream_info: Http3StreamInfo);
+    fn recv_closed(&self, _stream_info: Http3StreamInfo, _close_type: CloseType) {}
 }
 
 pub trait HttpRecvStreamEvents: RecvStreamEvents {
@@ -448,8 +448,8 @@ pub trait HttpSendStream: SendStream {
 }
 
 pub trait SendStreamEvents: Debug {
-    fn send_closed(&self, _stream_id: Http3StreamInfo, _close_type: CloseType) {}
-    fn data_writable(&self, _stream_id: Http3StreamInfo) {}
+    fn send_closed(&self, _stream_info: Http3StreamInfo, _close_type: CloseType) {}
+    fn data_writable(&self, _stream_info: Http3StreamInfo) {}
 }
 
 /// This enum is used to mark a different type of closing a stream:

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -300,6 +300,7 @@ pub enum Http3StreamType {
     NewStream,
     Http,
     Push,
+    ExtendedConnect,
     WebTransport(StreamId),
     Unknown,
 }

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -106,6 +106,7 @@ impl MessageState {
 pub(crate) struct SendMessage {
     state: MessageState,
     message_type: MessageType,
+    stream_type: Http3StreamType,
     stream: BufferedStream,
     encoder: Rc<RefCell<QPackEncoder>>,
     conn_events: Box<dyn SendStreamEvents>,
@@ -114,6 +115,7 @@ pub(crate) struct SendMessage {
 impl SendMessage {
     pub fn new(
         message_type: MessageType,
+        stream_type: Http3StreamType,
         stream_id: StreamId,
         encoder: Rc<RefCell<QPackEncoder>>,
         conn_events: Box<dyn SendStreamEvents>,
@@ -122,6 +124,7 @@ impl SendMessage {
         Self {
             state: MessageState::WaitingForHeaders,
             message_type,
+            stream_type,
             stream: BufferedStream::new(stream_id),
             encoder,
             conn_events,
@@ -158,7 +161,7 @@ impl SendMessage {
 
 impl Stream for SendMessage {
     fn stream_type(&self) -> Http3StreamType {
-        Http3StreamType::Http
+        self.stream_type
     }
 }
 impl SendStream for SendMessage {

--- a/neqo-http3/tests/webtransport/mod.rs
+++ b/neqo-http3/tests/webtransport/mod.rs
@@ -133,7 +133,7 @@ impl WtTest {
                     wt_server_session = Some(session);
                 }
                 Http3ServerEvent::Data { .. } => {
-                    panic!("There should not be ane data events!");
+                    panic!("There should not be any data events!");
                 }
                 _ => {}
             }


### PR DESCRIPTION
The most important part of the patch is that the function take_sub_streams takes the 2 list of WebTransport streams that are associated with an extended connect session. Http3Connection will remove and close the streams.