### PR TITLE
SendMessage refactor

### DIFF
--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -176,7 +176,7 @@ impl Http3Connection {
         self.send_non_control_streams(conn)?;
 
         self.qpack_decoder.borrow_mut().send(conn)?;
-        match self.qpack_encoder.borrow_mut().send(conn) {
+        match self.qpack_encoder.borrow_mut().send_encoder_updates(conn) {
             Ok(())
             | Err(neqo_qpack::Error::EncoderStreamBlocked)
             | Err(neqo_qpack::Error::DynamicTableFull) => {}

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -917,7 +917,10 @@ mod tests {
             self.encoder
                 .borrow_mut()
                 .add_send_stream(self.encoder_stream_id.unwrap());
-            self.encoder.borrow_mut().send(&mut self.conn).unwrap();
+            self.encoder
+                .borrow_mut()
+                .send_encoder_updates(&mut self.conn)
+                .unwrap();
 
             // Create decoder stream
             self.decoder_stream_id = Some(self.conn.stream_create(StreamType::UniDi).unwrap());
@@ -5370,7 +5373,11 @@ mod tests {
             .borrow_mut()
             .set_max_blocked_streams(100)
             .unwrap();
-        server.encoder.borrow_mut().send(&mut server.conn).unwrap();
+        server
+            .encoder
+            .borrow_mut()
+            .send_encoder_updates(&mut server.conn)
+            .unwrap();
         let out = server.conn.process(None, now());
         mem::drop(client.process(out.dgram(), now()));
     }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -296,9 +296,10 @@ impl Http3Client {
             id,
             Box::new(SendMessage::new_with_headers(
                 id,
-                final_headers,
+                &final_headers,
                 self.base_handler.qpack_encoder.clone(),
                 Box::new(self.events.clone()),
+                &mut self.conn,
             )),
             Box::new(RecvMessage::new(
                 MessageType::Response,

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -1083,11 +1083,10 @@ mod tests {
             headers: &[Header],
             encoder: &mut Encoder,
         ) {
-            let header_block = self
-                .encoder
-                .borrow_mut()
-                .encode_header_block(&mut self.conn, headers, stream_id)
-                .unwrap();
+            let header_block =
+                self.encoder
+                    .borrow_mut()
+                    .encode_header_block(&mut self.conn, headers, stream_id);
             let hframe = HFrame::Headers {
                 header_block: header_block.to_vec(),
             };
@@ -3477,11 +3476,11 @@ mod tests {
             Header::new("my-header", "my-header"),
             Header::new("content-length", "3"),
         ];
-        let encoded_headers = server
-            .encoder
-            .borrow_mut()
-            .encode_header_block(&mut server.conn, &headers, request_stream_id)
-            .unwrap();
+        let encoded_headers = server.encoder.borrow_mut().encode_header_block(
+            &mut server.conn,
+            &headers,
+            request_stream_id,
+        );
         let hframe = HFrame::Headers {
             header_block: encoded_headers.to_vec(),
         };
@@ -3545,11 +3544,11 @@ mod tests {
             Header::new("my-header", "my-header"),
             Header::new("content-length", "0"),
         ];
-        let encoded_headers = server
-            .encoder
-            .borrow_mut()
-            .encode_header_block(&mut server.conn, &sent_headers, request_stream_id)
-            .unwrap();
+        let encoded_headers = server.encoder.borrow_mut().encode_header_block(
+            &mut server.conn,
+            &sent_headers,
+            request_stream_id,
+        );
         let hframe = HFrame::Headers {
             header_block: encoded_headers.to_vec(),
         };
@@ -4462,11 +4461,11 @@ mod tests {
             Header::new("my-header", "my-header"),
             Header::new("content-length", "3"),
         ];
-        let encoded_headers = server
-            .encoder
-            .borrow_mut()
-            .encode_header_block(&mut server.conn, &headers, request_stream_id)
-            .unwrap();
+        let encoded_headers = server.encoder.borrow_mut().encode_header_block(
+            &mut server.conn,
+            &headers,
+            request_stream_id,
+        );
         let hframe = HFrame::Headers {
             header_block: encoded_headers.to_vec(),
         };
@@ -5410,11 +5409,11 @@ mod tests {
         ];
         headers.push(additional_header);
 
-        let encoded_headers = server
-            .encoder
-            .borrow_mut()
-            .encode_header_block(&mut server.conn, &headers, stream_id)
-            .unwrap();
+        let encoded_headers =
+            server
+                .encoder
+                .borrow_mut()
+                .encode_header_block(&mut server.conn, &headers, stream_id);
         let push_promise_frame = HFrame::PushPromise {
             push_id,
             header_block: encoded_headers.to_vec(),
@@ -5560,11 +5559,11 @@ mod tests {
             Header::new(":status", "200"),
             Header::new("content-length", "1234"),
         ];
-        let encoded_headers = server
-            .encoder
-            .borrow_mut()
-            .encode_header_block(&mut server.conn, &response_headers, request_stream_id)
-            .unwrap();
+        let encoded_headers = server.encoder.borrow_mut().encode_header_block(
+            &mut server.conn,
+            &response_headers,
+            request_stream_id,
+        );
         let header_hframe = HFrame::Headers {
             header_block: encoded_headers.to_vec(),
         };
@@ -5633,11 +5632,11 @@ mod tests {
             Header::new("content-length", "1234"),
             Header::new("myn3", "myv3"),
         ];
-        let encoded_headers = server
-            .encoder
-            .borrow_mut()
-            .encode_header_block(&mut server.conn, &response_headers, request_stream_id)
-            .unwrap();
+        let encoded_headers = server.encoder.borrow_mut().encode_header_block(
+            &mut server.conn,
+            &response_headers,
+            request_stream_id,
+        );
         let header_hframe = HFrame::Headers {
             header_block: encoded_headers.to_vec(),
         };
@@ -5718,11 +5717,11 @@ mod tests {
             Header::new("my-header", "my-header"),
             Header::new("content-length", "0"),
         ];
-        let encoded_headers = server
-            .encoder
-            .borrow_mut()
-            .encode_header_block(&mut server.conn, &headers, request_stream_id)
-            .unwrap();
+        let encoded_headers = server.encoder.borrow_mut().encode_header_block(
+            &mut server.conn,
+            &headers,
+            request_stream_id,
+        );
         let hframe = HFrame::Headers {
             header_block: encoded_headers.to_vec(),
         };
@@ -5782,11 +5781,11 @@ mod tests {
         headers: &[Header],
         data: &[u8],
     ) -> Option<Datagram> {
-        let encoded_headers = server
-            .encoder
-            .borrow_mut()
-            .encode_header_block(&mut server.conn, headers, request_stream_id)
-            .unwrap();
+        let encoded_headers = server.encoder.borrow_mut().encode_header_block(
+            &mut server.conn,
+            headers,
+            request_stream_id,
+        );
         let hframe = HFrame::Headers {
             header_block: encoded_headers.to_vec(),
         };
@@ -5907,11 +5906,11 @@ mod tests {
             Header::new(":status", "200"),
             Header::new("content-length", "3"),
         ];
-        let encoded_headers = server
-            .encoder
-            .borrow_mut()
-            .encode_header_block(&mut server.conn, &headers, request_stream_id)
-            .unwrap();
+        let encoded_headers = server.encoder.borrow_mut().encode_header_block(
+            &mut server.conn,
+            &headers,
+            request_stream_id,
+        );
         let hframe = HFrame::Headers {
             header_block: encoded_headers.to_vec(),
         };
@@ -5978,11 +5977,11 @@ mod tests {
             Header::new("my-header", "my-header"),
             Header::new("content-length", "0"),
         ];
-        let encoded_headers = server
-            .encoder
-            .borrow_mut()
-            .encode_header_block(&mut server.conn, &headers, request_stream_id)
-            .unwrap();
+        let encoded_headers = server.encoder.borrow_mut().encode_header_block(
+            &mut server.conn,
+            &headers,
+            request_stream_id,
+        );
         let hframe = HFrame::Headers {
             header_block: encoded_headers.to_vec(),
         };
@@ -6659,11 +6658,11 @@ mod tests {
             Header::new("my-header", "my-header"),
             Header::new("content-length", "3"),
         ];
-        let encoded_headers = server
-            .encoder
-            .borrow_mut()
-            .encode_header_block(&mut server.conn, &headers, request_stream_id)
-            .unwrap();
+        let encoded_headers = server.encoder.borrow_mut().encode_header_block(
+            &mut server.conn,
+            &headers,
+            request_stream_id,
+        );
         let hframe = HFrame::Headers {
             header_block: encoded_headers.to_vec(),
         };

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -45,6 +45,7 @@ impl Http3ServerHandler {
         stream_id: StreamId,
         headers: &[Header],
         data: &[u8],
+        conn: &mut Connection,
     ) -> Res<()> {
         self.base_handler
             .send_streams
@@ -52,7 +53,7 @@ impl Http3ServerHandler {
             .ok_or(Error::InvalidStreamId)?
             .http_stream()
             .ok_or(Error::InvalidStreamId)?
-            .set_message(headers, Some(data))?;
+            .set_message(headers, Some(data), conn)?;
         self.base_handler.stream_has_pending_data(stream_id);
         Ok(())
     }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -378,7 +378,12 @@ pub trait SendStream: Stream {
 pub trait HttpSendStream: SendStream {
     /// # Errors
     /// Error my occure during sending data, e.g. protocol error, etc.
-    fn set_message(&mut self, headers: &[Header], data: Option<&[u8]>) -> Res<()>;
+    fn set_message(
+        &mut self,
+        headers: &[Header],
+        data: Option<&[u8]>,
+        conn: &mut Connection,
+    ) -> Res<()>;
 }
 
 pub trait SendStreamEvents: Debug {

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -118,13 +118,13 @@ impl SendMessage {
     /// # Errors
     /// `ClosedCriticalStream` if the encoder stream is closed.
     /// `InternalError` if an unexpected error occurred.
-    fn ensure_encoded(&mut self, conn: &mut Connection) -> Res<()> {
+    fn ensure_encoded(&mut self, conn: &mut Connection) {
         if let SendMessageState::Initialized { headers, data, fin } = &self.state {
             qdebug!([self], "Encoding headers");
             let header_block =
                 self.encoder
                     .borrow_mut()
-                    .encode_header_block(conn, headers, self.stream_id)?;
+                    .encode_header_block(conn, headers, self.stream_id);
             let hframe = HFrame::Headers {
                 header_block: header_block.to_vec(),
             };
@@ -144,7 +144,6 @@ impl SendMessage {
                 fin: *fin,
             };
         }
-        Ok(())
     }
 }
 
@@ -231,7 +230,7 @@ impl SendStream for SendMessage {
     /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if `process_output`
     /// has not been called when needed, and HTTP3 layer has not picked up the info that the stream has been closed.)
     fn send(&mut self, conn: &mut Connection) -> Res<()> {
-        self.ensure_encoded(conn)?;
+        self.ensure_encoded(conn);
 
         let label = if ::log::log_enabled!(::log::Level::Debug) {
             format!("{}", self)

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -503,7 +503,7 @@ mod tests {
             true,
         );
         encoder.add_send_stream(neqo_trans_conn.stream_create(StreamType::UniDi).unwrap());
-        encoder.send(&mut neqo_trans_conn).unwrap();
+        encoder.send_encoder_updates(&mut neqo_trans_conn).unwrap();
         let decoder_stream = neqo_trans_conn.stream_create(StreamType::UniDi).unwrap();
         sent = neqo_trans_conn.stream_send(decoder_stream, &[0x3]);
         assert_eq!(sent, Ok(1));

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -53,9 +53,12 @@ impl ClientRequestStream {
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn set_response(&mut self, headers: &[Header], data: &[u8]) -> Res<()> {
         qinfo!([self], "Set new response.");
-        self.handler
-            .borrow_mut()
-            .set_response(self.stream_id, headers, data)
+        self.handler.borrow_mut().set_response(
+            self.stream_id,
+            headers,
+            data,
+            &mut self.conn.borrow_mut(),
+        )
     }
 
     /// Request a peer to stop sending a request.


### PR DESCRIPTION
There are to change sets.
1) encode_header_block does not need to return an error:
This will simplify SendMessage code. Any error during the encode_header_block call will be ignored and they will be picked up by the main loop, i.e. process() calls.

2) Encode headers when they are set:
The function encode_header_block does not produce any errors that need to be picked up by the main processing loop. This was change in the previous change set. Therefore the encoding can be performed immediately.

This PR will change current behavior regarding the order in which the encoder instructions and header blocks are sent.