### PR TITLE
Implement sending of 1xx responses and refactor SendMessage

### DIFF
--- a/neqo-common/src/headers.rs
+++ b/neqo-common/src/headers.rs
@@ -1,0 +1,153 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::{Error, Header, MessageType, Res};
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+const PSEUDO_HEADER_STATUS: u8 = 0x1;
+const PSEUDO_HEADER_METHOD: u8 = 0x2;
+const PSEUDO_HEADER_SCHEME: u8 = 0x4;
+const PSEUDO_HEADER_AUTHORITY: u8 = 0x8;
+const PSEUDO_HEADER_PATH: u8 = 0x10;
+const REGULAR_HEADER: u8 = 0x80;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Headers {
+    headers: Vec<Header>,
+}
+
+impl Default for Headers {
+    fn default() -> Self {
+        Self {
+            headers: Vec::new(),
+        }
+    }
+}
+
+impl Headers {
+    pub fn new(headers: &[Header]) -> Self {
+        Self {
+            headers: headers.to_vec(),
+        }
+    }
+
+    pub fn is_interim(&self) -> Res<bool> {
+        let status = self.headers.iter().find(|h| h.name() == ":status");
+        if let Some(h) = status {
+            #[allow(clippy::map_err_ignore)]
+            let status_code = h.value().parse::<i32>().map_err(|_| Error::InvalidHeader)?;
+            Ok((100..200).contains(&status_code))
+        } else {
+            Err(Error::InvalidHeader)
+        }
+    }
+
+    fn track_pseudo(name: &str, state: &mut u8, message_type: MessageType) -> Res<bool> {
+        let (pseudo, bit) = if name.starts_with(':') {
+            if *state & REGULAR_HEADER != 0 {
+                return Err(Error::InvalidHeader);
+            }
+            let bit = match message_type {
+                MessageType::Response => match name {
+                    ":status" => PSEUDO_HEADER_STATUS,
+                    _ => return Err(Error::InvalidHeader),
+                },
+                MessageType::Request => match name {
+                    ":method" => PSEUDO_HEADER_METHOD,
+                    ":scheme" => PSEUDO_HEADER_SCHEME,
+                    ":authority" => PSEUDO_HEADER_AUTHORITY,
+                    ":path" => PSEUDO_HEADER_PATH,
+                    _ => return Err(Error::InvalidHeader),
+                },
+            };
+            (true, bit)
+        } else {
+            (false, REGULAR_HEADER)
+        };
+
+        if *state & bit == 0 || !pseudo {
+            *state |= bit;
+            Ok(pseudo)
+        } else {
+            Err(Error::InvalidHeader)
+        }
+    }
+
+    pub fn headers_valid(&self, message_type: MessageType) -> Res<()> {
+        let mut method_value: Option<&str> = None;
+        let mut pseudo_state = 0;
+        for header in &self.headers {
+            let is_pseudo = Self::track_pseudo(header.name(), &mut pseudo_state, message_type)?;
+
+            let mut bytes = header.name().bytes();
+            if is_pseudo {
+                if header.name() == ":method" {
+                    method_value = Some(header.value());
+                }
+                let _ = bytes.next();
+            }
+
+            if bytes.any(|b| matches!(b, 0 | 0x10 | 0x13 | 0x3a | 0x41..=0x5a)) {
+                return Err(Error::InvalidHeader); // illegal characters.
+            }
+        }
+        // Clear the regular header bit, since we only check pseudo headers below.
+        pseudo_state &= !REGULAR_HEADER;
+        let pseudo_header_mask = match message_type {
+            MessageType::Response => PSEUDO_HEADER_STATUS,
+            MessageType::Request => {
+                if method_value == Some(&"CONNECT".to_string()) {
+                    PSEUDO_HEADER_METHOD | PSEUDO_HEADER_AUTHORITY
+                } else {
+                    PSEUDO_HEADER_METHOD | PSEUDO_HEADER_SCHEME | PSEUDO_HEADER_PATH
+                }
+            }
+        };
+        if pseudo_state & pseudo_header_mask != pseudo_header_mask {
+            return Err(Error::InvalidHeader);
+        }
+
+        Ok(())
+    }
+
+    pub fn retain_valid_for_response(&mut self) {
+        self.headers.retain(Header::is_allowed_for_response);
+    }
+}
+
+impl From<&[Header]> for Headers {
+    fn from(h: &[Header]) -> Self {
+        Headers::new(h)
+    }
+}
+
+impl From<Vec<Header>> for Headers {
+    fn from(headers: Vec<Header>) -> Self {
+        Self { headers }
+    }
+}
+
+impl DerefMut for Headers {
+    #[must_use]
+    fn deref_mut(&mut self) -> &mut Vec<Header> {
+        &mut self.headers
+    }
+}
+
+impl Deref for Headers {
+    type Target = Vec<Header>;
+    #[must_use]
+    fn deref(&self) -> &Self::Target {
+        &self.headers
+    }
+}
+
+impl AsRef<[Header]> for Headers {
+    fn as_ref(&self) -> &[Header] {
+        &self.headers
+    }
+}

--- a/neqo-common/src/headers.rs
+++ b/neqo-common/src/headers.rs
@@ -39,7 +39,7 @@ impl Headers {
     /// Check whether the response is informational(1xx).
     /// # Errors
     /// Returns an error if response headers do not contain
-    /// a status header or if the value of the header cannot be parsed. 
+    /// a status header or if the value of the header cannot be parsed.
     pub fn is_interim(&self) -> Res<bool> {
         let status = self.headers.iter().find(|h| h.name() == ":status");
         if let Some(h) = status {

--- a/neqo-common/src/headers.rs
+++ b/neqo-common/src/headers.rs
@@ -29,12 +29,17 @@ impl Default for Headers {
 }
 
 impl Headers {
+    #[must_use]
     pub fn new(headers: &[Header]) -> Self {
         Self {
             headers: headers.to_vec(),
         }
     }
 
+    /// Check whether the response is informational(1xx).
+    /// # Errors
+    /// Returns an error if response headers do not contain
+    /// a status header or if the value of the header cannot be parsed. 
     pub fn is_interim(&self) -> Res<bool> {
         let status = self.headers.iter().find(|h| h.name() == ":status");
         if let Some(h) = status {
@@ -77,6 +82,10 @@ impl Headers {
         }
     }
 
+    /// Checks if request/response headers are well formed, i.e. contain
+    /// allowed pseudo headers and in a right order, etc.
+    /// # Errors
+    /// Returns an error if headers are not well formed.
     pub fn headers_valid(&self, message_type: MessageType) -> Res<()> {
         let mut method_value: Option<&str> = None;
         let mut pseudo_state = 0;
@@ -114,6 +123,10 @@ impl Headers {
         Ok(())
     }
 
+    /// Checks if trailers are well formed, i.e. pseudo headers are not
+    /// allowed in trailers.
+    /// # Errors
+    /// Returns an error if trailers are not well formed.
     pub fn trailers_valid(&self) -> Res<()> {
         for header in &self.headers {
             if header.name().starts_with(':') {

--- a/neqo-common/src/headers.rs
+++ b/neqo-common/src/headers.rs
@@ -114,6 +114,15 @@ impl Headers {
         Ok(())
     }
 
+    pub fn trailers_valid(&self) -> Res<()> {
+        for header in &self.headers {
+            if header.name().starts_with(':') {
+                return Err(Error::InvalidHeader);
+            }
+        }
+        Ok(())
+    }
+
     pub fn retain_valid_for_response(&mut self) {
         self.headers.retain(Header::is_allowed_for_response);
     }

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -11,6 +11,7 @@ mod codec;
 mod datagram;
 pub mod event;
 pub mod header;
+pub mod headers;
 pub mod hrtime;
 mod incrdecoder;
 pub mod log;
@@ -20,9 +21,16 @@ pub mod timer;
 pub use self::codec::{Decoder, Encoder};
 pub use self::datagram::Datagram;
 pub use self::header::Header;
+pub use self::headers::Headers;
 pub use self::incrdecoder::{
     IncrementalDecoderBuffer, IncrementalDecoderIgnore, IncrementalDecoderUint,
 };
+
+type Res<T> = Result<T, Error>;
+
+pub enum Error {
+    InvalidHeader,
+}
 
 #[macro_use]
 extern crate lazy_static;
@@ -97,4 +105,10 @@ impl ::std::fmt::Display for Role {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "{:?}", self)
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageType {
+    Request,
+    Response,
 }

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -15,6 +15,7 @@ smallvec = "1.0.0"
 qlog = "0.4.0"
 sfv = "0.9.1"
 url = "2.0"
+lazy_static = "1.3.0"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-http3/src/buffered_send_stream.rs
+++ b/neqo-http3/src/buffered_send_stream.rs
@@ -91,6 +91,15 @@ impl BufferedStream {
             Ok(false)
         }
     }
+
+    #[must_use]
+    pub fn has_buffered_data(&self) -> bool {
+        if let Self::Initialized { buf, .. } = self {
+            !buf.is_empty()
+        } else {
+            false
+        }
+    }
 }
 
 impl From<&BufferedStream> for Option<StreamId> {

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -8,7 +8,7 @@
 
 use crate::connection::Http3State;
 use crate::settings::HSettingType;
-use crate::{CloseType, Header, HttpRecvStreamEvents, RecvStreamEvents, SendStreamEvents};
+use crate::{CloseType, Headers, HttpRecvStreamEvents, RecvStreamEvents, SendStreamEvents};
 use neqo_common::event::Provider as EventProvider;
 use neqo_crypto::ResumptionToken;
 use neqo_transport::{AppError, StreamId, StreamType};
@@ -22,7 +22,7 @@ pub enum Http3ClientEvent {
     /// Response headers are received.
     HeaderReady {
         stream_id: StreamId,
-        headers: Vec<Header>,
+        headers: Headers,
         interim: bool,
         fin: bool,
     },
@@ -45,12 +45,12 @@ pub enum Http3ClientEvent {
     PushPromise {
         push_id: u64,
         request_stream_id: StreamId,
-        headers: Vec<Header>,
+        headers: Headers,
     },
     /// A push response headers are ready.
     PushHeaderReady {
         push_id: u64,
-        headers: Vec<Header>,
+        headers: Headers,
         interim: bool,
         fin: bool,
     },
@@ -121,7 +121,7 @@ impl RecvStreamEvents for Http3ClientEvents {
 
 impl HttpRecvStreamEvents for Http3ClientEvents {
     /// Add a new `HeaderReady` event.
-    fn header_ready(&self, stream_id: StreamId, headers: Vec<Header>, interim: bool, fin: bool) {
+    fn header_ready(&self, stream_id: StreamId, headers: Headers, interim: bool, fin: bool) {
         self.insert(Http3ClientEvent::HeaderReady {
             stream_id,
             headers,
@@ -146,7 +146,7 @@ impl SendStreamEvents for Http3ClientEvents {
 }
 
 impl Http3ClientEvents {
-    pub fn push_promise(&self, push_id: u64, request_stream_id: StreamId, headers: Vec<Header>) {
+    pub fn push_promise(&self, push_id: u64, request_stream_id: StreamId, headers: Headers) {
         self.insert(Http3ClientEvent::PushPromise {
             push_id,
             request_stream_id,

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -313,7 +313,7 @@ impl Http3Connection {
         );
 
         if let Some(mut s) = self.send_streams.remove(&stream_id) {
-            s.stop_sending(CloseType::ResetRemote(app_error));
+            s.handle_stop_sending(CloseType::ResetRemote(app_error));
             Ok(())
         } else if self.send_stream_is_critical(stream_id) {
             Err(Error::HttpClosedCriticalStream)
@@ -556,7 +556,7 @@ impl Http3Connection {
         }
 
         if let Some(mut s) = self.send_streams.remove(&stream_id) {
-            s.stop_sending(CloseType::ResetApp(error));
+            s.handle_stop_sending(CloseType::ResetApp(error));
         }
         conn.stream_reset_send(stream_id, error)?;
         Ok(())

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -298,16 +298,16 @@ impl Http3Client {
         final_headers.extend_from_slice(headers);
 
         let mut send_message = SendMessage::new(
+            MessageType::Request,
             id,
             self.base_handler.qpack_encoder.clone(),
             Box::new(self.events.clone()),
         );
 
-        // SendMessage implements http_stream so ith will not panic.
         send_message
             .http_stream()
             .unwrap()
-            .send_headers(final_headers, &mut self.conn);
+            .send_headers(final_headers, &mut self.conn)?;
 
         self.base_handler.add_streams(
             id,

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -6211,14 +6211,14 @@ mod tests {
 
         let mut d = Encoder::default();
         let headers1xx: &[Header] = &[Header::new(":status", "101")];
-        server.encode_headers(push_stream_id, &headers1xx, &mut d);
+        server.encode_headers(push_stream_id, headers1xx, &mut d);
 
         let headers200: &[Header] = &[
             Header::new(":status", "200"),
             Header::new("my-header", "my-header"),
             Header::new("content-length", "3"),
         ];
-        server.encode_headers(push_stream_id, &headers200, &mut d);
+        server.encode_headers(push_stream_id, headers200, &mut d);
 
         // create a push stream.
         send_data_on_push(

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -6,11 +6,12 @@
 
 use crate::connection::{Http3Connection, Http3State};
 use crate::hframe::HFrame;
-use crate::recv_message::{MessageType, RecvMessage};
+use crate::recv_message::RecvMessage;
 use crate::send_message::SendMessage;
 use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents};
 use crate::{
-    Error, Header, Http3Parameters, NewStreamType, Priority, PriorityHandler, ReceiveOutput, Res,
+    Error, Header, Headers, Http3Parameters, MessageType, NewStreamType, Priority, PriorityHandler,
+    ReceiveOutput, Res,
 };
 use neqo_common::{event::Provider, qdebug, qinfo, qtrace, Role};
 use neqo_transport::{AppError, Connection, ConnectionEvent, StreamId};
@@ -68,7 +69,7 @@ impl Http3ServerHandler {
             .ok_or(Error::InvalidStreamId)?
             .http_stream()
             .ok_or(Error::InvalidStreamId)?
-            .send_headers(headers, conn);
+            .send_headers(Headers::from(headers), conn);
         self.base_handler.stream_has_pending_data(stream_id);
         Ok(())
     }

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -74,9 +74,9 @@ impl Http3ServerHandler {
         Ok(())
     }
 
-    /// This is call when application is done sending a request.
+    /// This is called when application is done sending a request.
     /// # Errors
-    /// An error will be return if stream does not exist.
+    /// An error will be returned if stream does not exist.
     pub fn stream_close_send(&mut self, stream_id: StreamId, conn: &mut Connection) -> Res<()> {
         qinfo!([self], "Close sending side stream={}.", stream_id);
         self.base_handler.stream_close_send(conn, stream_id)?;

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -378,14 +378,18 @@ pub trait SendStream: Stream {
     /// # Errors
     /// It may happen that the transport stream is already close. This is unlikely.
     fn close(&mut self, conn: &mut Connection) -> Res<()>;
-    fn stop_sending(&mut self, close_type: CloseType);
+    /// This function is called when sending side is closed abruptly by the pear or
+    /// the application.
+    fn handle_stop_sending(&mut self, close_type: CloseType);
     fn http_stream(&mut self) -> Option<&mut dyn HttpSendStream> {
         None
     }
 }
 
 pub trait HttpSendStream: SendStream {
-    /// This function sets informational response.
+    /// This function is used to supply headers to a http message. The
+    /// function is used for request headers, response headers, 1xx response and
+    /// trailers.
     /// # Errors
     /// This can also return an error if the underlying stream is closed.
     fn send_headers(&mut self, headers: Headers, conn: &mut Connection) -> Res<()>;

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -50,7 +50,7 @@ pub use server_events::{ClientRequestStream, Http3ServerEvent};
 pub use settings::HttpZeroRttChecker;
 pub use stream_type_reader::NewStreamType;
 
-type Res<T> = Result<T, Error>;
+pub type Res<T> = Result<T, Error>;
 
 #[derive(Clone, Debug, PartialEq)]
 #[allow(
@@ -388,7 +388,7 @@ pub trait HttpSendStream: SendStream {
     /// This function sets informational response.
     /// # Errors
     /// This can also return an error if the underlying stream is closed.
-    fn send_headers(&mut self, headers: Headers, conn: &mut Connection);
+    fn send_headers(&mut self, headers: Headers, conn: &mut Connection) -> Res<()>;
 }
 
 pub trait SendStreamEvents: Debug {

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -157,12 +157,13 @@ impl Error {
     /// # Panics
     /// On unexpected errors, in debug mode.
     #[must_use]
-    pub fn map_stream_send_errors(err: &TransportError) -> Self {
+    pub fn map_stream_send_errors(err: &Error) -> Self {
         match err {
-            TransportError::InvalidStreamId | TransportError::FinalSizeError => {
+            Self::TransportError(TransportError::InvalidStreamId)
+            | Self::TransportError(TransportError::FinalSizeError) => {
                 Error::TransportStreamDoesNotExist
             }
-            TransportError::InvalidInput => Error::InvalidInput,
+            Self::TransportError(TransportError::InvalidInput) => Error::InvalidInput,
             _ => {
                 debug_assert!(false, "Unexpected error");
                 Error::TransportStreamDoesNotExist
@@ -376,14 +377,10 @@ pub trait SendStream: Stream {
 }
 
 pub trait HttpSendStream: SendStream {
+    /// This function sets informational response.
     /// # Errors
-    /// Error my occure during sending data, e.g. protocol error, etc.
-    fn set_message(
-        &mut self,
-        headers: &[Header],
-        data: Option<&[u8]>,
-        conn: &mut Connection,
-    ) -> Res<()>;
+    /// This can also return an error if the underlying stream is closed.
+    fn send_headers(&mut self, headers: &[Header], conn: &mut Connection);
 }
 
 pub trait SendStreamEvents: Debug {

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -50,7 +50,7 @@ pub use server_events::{ClientRequestStream, Http3ServerEvent};
 pub use settings::HttpZeroRttChecker;
 pub use stream_type_reader::NewStreamType;
 
-pub type Res<T> = Result<T, Error>;
+type Res<T> = Result<T, Error>;
 
 #[derive(Clone, Debug, PartialEq)]
 #[allow(
@@ -378,7 +378,7 @@ pub trait SendStream: Stream {
     /// # Errors
     /// It may happen that the transport stream is already close. This is unlikely.
     fn close(&mut self, conn: &mut Connection) -> Res<()>;
-    /// This function is called when sending side is closed abruptly by the pear or
+    /// This function is called when sending side is closed abruptly by the peer or
     /// the application.
     fn handle_stop_sending(&mut self, close_type: CloseType);
     fn http_stream(&mut self) -> Option<&mut dyn HttpSendStream> {

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -43,7 +43,7 @@ pub use conn_params::Http3Parameters;
 pub use connection::Http3State;
 pub use connection_client::Http3Client;
 pub use hframe::{HFrame, HFrameReader};
-pub use neqo_common::Header;
+pub use neqo_common::{Error as CommonError, Header, Headers, MessageType};
 pub use priority::Priority;
 pub use server::Http3Server;
 pub use server_events::{ClientRequestStream, Http3ServerEvent};
@@ -240,6 +240,14 @@ impl From<QpackError> for Error {
     }
 }
 
+impl From<CommonError> for Error {
+    fn from(err: CommonError) -> Self {
+        match err {
+            CommonError::InvalidHeader => Error::InvalidHeader,
+        }
+    }
+}
+
 impl From<AppError> for Error {
     fn from(error: AppError) -> Self {
         match error {
@@ -354,7 +362,7 @@ pub trait RecvStreamEvents: Debug {
 }
 
 pub(crate) trait HttpRecvStreamEvents: RecvStreamEvents {
-    fn header_ready(&self, stream_id: StreamId, headers: Vec<Header>, interim: bool, fin: bool);
+    fn header_ready(&self, stream_id: StreamId, headers: Headers, interim: bool, fin: bool);
 }
 
 pub trait SendStream: Stream {
@@ -380,7 +388,7 @@ pub trait HttpSendStream: SendStream {
     /// This function sets informational response.
     /// # Errors
     /// This can also return an error if the underlying stream is closed.
-    fn send_headers(&mut self, headers: &[Header], conn: &mut Connection);
+    fn send_headers(&mut self, headers: Headers, conn: &mut Connection);
 }
 
 pub trait SendStreamEvents: Debug {

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -7,7 +7,7 @@ use crate::client_events::{Http3ClientEvent, Http3ClientEvents};
 use crate::connection::Http3Connection;
 use crate::hframe::HFrame;
 use crate::{CloseType, HttpRecvStreamEvents, RecvStreamEvents};
-use crate::{Error, Header, Res};
+use crate::{Error, Headers, Res};
 use neqo_common::{qerror, qinfo, qtrace};
 use neqo_transport::{Connection, StreamId};
 use std::cell::RefCell;
@@ -32,7 +32,7 @@ use std::slice::SliceIndex;
 enum PushState {
     Init,
     PushPromise {
-        headers: Vec<Header>,
+        headers: Headers,
     },
     OnlyPushStream {
         stream_id: StreamId,
@@ -40,7 +40,7 @@ enum PushState {
     },
     Active {
         stream_id: StreamId,
-        headers: Vec<Header>,
+        headers: Headers,
     },
     Closed,
 }
@@ -178,7 +178,7 @@ impl PushController {
         &mut self,
         push_id: u64,
         ref_stream_id: StreamId,
-        new_headers: Vec<Header>,
+        new_headers: Headers,
     ) -> Res<()> {
         qtrace!(
             [self],
@@ -490,7 +490,7 @@ impl RecvStreamEvents for RecvPushEvents {
 }
 
 impl HttpRecvStreamEvents for RecvPushEvents {
-    fn header_ready(&self, _stream_id: StreamId, headers: Vec<Header>, interim: bool, fin: bool) {
+    fn header_ready(&self, _stream_id: StreamId, headers: Headers, interim: bool, fin: bool) {
         self.push_handler.borrow_mut().new_stream_event(
             self.push_id,
             Http3ClientEvent::PushHeaderReady {

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -265,7 +265,7 @@ impl SendStream for SendMessage {
         Ok(())
     }
 
-    fn stop_sending(&mut self, close_type: CloseType) {
+    fn handle_stop_sending(&mut self, close_type: CloseType) {
         if !self.state.done() {
             self.conn_events.send_closed(self.stream_id(), close_type);
         }

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -6,7 +6,7 @@
 
 use crate::hframe::HFrame;
 use crate::{
-    qlog, BufferedStream, CloseType, Error, Header, Http3StreamType, HttpSendStream, Res,
+    qlog, BufferedStream, CloseType, Error, Header, Headers, Http3StreamType, HttpSendStream, Res,
     SendStream, SendStreamEvents, Stream,
 };
 
@@ -199,10 +199,10 @@ impl SendStream for SendMessage {
 }
 
 impl HttpSendStream for SendMessage {
-    fn send_headers(&mut self, headers: &[Header], conn: &mut Connection) {
+    fn send_headers(&mut self, headers: Headers, conn: &mut Connection) {
         let buf = SendMessage::encode(
             &mut self.encoder.borrow_mut(),
-            headers,
+            &headers,
             conn,
             self.stream_id(),
         );

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -864,14 +864,12 @@ mod tests {
                     assert_eq!(data, REQUEST_BODY);
                     assert!(fin);
                     request
-                        .set_response(
-                            &[
-                                Header::new(":status", "200"),
-                                Header::new("content-length", "3"),
-                            ],
-                            RESPONSE_BODY,
-                        )
+                        .send_headers(&[
+                            Header::new(":status", "200"),
+                            Header::new("content-length", "3"),
+                        ])
                         .unwrap();
+                    request.send_data(RESPONSE_BODY).unwrap();
                     data_received += 1;
                 }
                 Http3ServerEvent::StateChange { .. } | Http3ServerEvent::PriorityUpdate { .. } => {}
@@ -910,14 +908,12 @@ mod tests {
                         .stream_stop_sending(Error::HttpNoError.code())
                         .unwrap();
                     request
-                        .set_response(
-                            &[
-                                Header::new(":status", "200"),
-                                Header::new("content-length", "3"),
-                            ],
-                            RESPONSE_BODY,
-                        )
+                        .send_headers(&[
+                            Header::new(":status", "200"),
+                            Header::new("content-length", "3"),
+                        ])
                         .unwrap();
+                    request.send_data(RESPONSE_BODY).unwrap();
                 }
                 Http3ServerEvent::Data { .. } => {
                     panic!("We should not have a Data event");

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -6,7 +6,7 @@
 
 use crate::connection::Http3State;
 use crate::{
-    CloseType, Header, HttpRecvStreamEvents, Priority, RecvStreamEvents, SendStreamEvents,
+    CloseType, Headers, HttpRecvStreamEvents, Priority, RecvStreamEvents, SendStreamEvents,
 };
 
 use neqo_transport::StreamId;
@@ -19,7 +19,7 @@ pub(crate) enum Http3ServerConnEvent {
     /// Headers are ready.
     Headers {
         stream_id: StreamId,
-        headers: Vec<Header>,
+        headers: Headers,
         fin: bool,
     },
     PriorityUpdate {
@@ -57,7 +57,7 @@ impl RecvStreamEvents for Http3ServerConnEvents {
 
 impl HttpRecvStreamEvents for Http3ServerConnEvents {
     /// Add a new `HeaderReady` event.
-    fn header_ready(&self, stream_id: StreamId, headers: Vec<Header>, _interim: bool, fin: bool) {
+    fn header_ready(&self, stream_id: StreamId, headers: Headers, _interim: bool, fin: bool) {
         self.insert(Http3ServerConnEvent::Headers {
             stream_id,
             headers,

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -48,6 +48,15 @@ impl ClientRequestStream {
         }
     }
 
+    /// Supply a response header to a request.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn send_headers(&mut self, headers: &[Header]) -> Res<()> {
+        self.handler
+            .borrow_mut()
+            .send_headers(self.stream_id, headers, &mut self.conn.borrow_mut())
+    }
+
     /// Supply response data to a request.
     /// # Errors
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
@@ -56,15 +65,6 @@ impl ClientRequestStream {
         self.handler
             .borrow_mut()
             .send_data(self.stream_id, data, &mut self.conn.borrow_mut())
-    }
-
-    /// Supply a response header to a request.
-    /// # Errors
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn send_headers(&mut self, headers: &[Header]) -> Res<()> {
-        self.handler
-            .borrow_mut()
-            .send_headers(self.stream_id, headers, &mut self.conn.borrow_mut())
     }
 
     /// Close senidng side of the stream.

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -8,7 +8,7 @@
 
 use crate::connection::Http3State;
 use crate::connection_server::Http3ServerHandler;
-use crate::{Header, Priority, Res};
+use crate::{Header, Headers, Priority, Res};
 use neqo_common::{qdebug, qinfo};
 use neqo_transport::server::ActiveConnectionRef;
 use neqo_transport::{AppError, Connection, StreamId};
@@ -126,7 +126,7 @@ pub enum Http3ServerEvent {
     /// Headers are ready.
     Headers {
         request: ClientRequestStream,
-        headers: Vec<Header>,
+        headers: Headers,
         fin: bool,
     },
     /// Request data is ready.
@@ -172,7 +172,7 @@ impl Http3ServerEvents {
     }
 
     /// Insert a `Headers` event.
-    pub(crate) fn headers(&self, request: ClientRequestStream, headers: Vec<Header>, fin: bool) {
+    pub(crate) fn headers(&self, request: ClientRequestStream, headers: Headers, fin: bool) {
         self.insert(Http3ServerEvent::Headers {
             request,
             headers,

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -48,17 +48,32 @@ impl ClientRequestStream {
         }
     }
 
-    /// Supply a response to a request.
+    /// Supply response data to a request.
     /// # Errors
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn set_response(&mut self, headers: &[Header], data: &[u8]) -> Res<()> {
+    pub fn send_data(&mut self, data: &[u8]) -> Res<()> {
         qinfo!([self], "Set new response.");
-        self.handler.borrow_mut().set_response(
-            self.stream_id,
-            headers,
-            data,
-            &mut self.conn.borrow_mut(),
-        )
+        self.handler
+            .borrow_mut()
+            .send_data(self.stream_id, data, &mut self.conn.borrow_mut())
+    }
+
+    /// Supply a response header to a request.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn send_headers(&mut self, headers: &[Header]) -> Res<()> {
+        self.handler
+            .borrow_mut()
+            .send_headers(self.stream_id, headers, &mut self.conn.borrow_mut())
+    }
+
+    /// Close senidng side of the stream.
+    /// # Errors
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn close_send(&mut self) -> Res<()> {
+        self.handler
+            .borrow_mut()
+            .stream_close_send(self.stream_id, &mut self.conn.borrow_mut())
     }
 
     /// Request a peer to stop sending a request.

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -181,7 +181,7 @@ fn test_103_response() {
     let info_headers_event = |e| {
         matches!(e, Http3ClientEvent::HeaderReady { headers,
                     interim,
-                    fin, .. } if !fin && interim && &headers.as_ref() == &info_headers)
+                    fin, .. } if !fin && interim && headers.as_ref() == info_headers)
     };
     assert!(hconn_c.events().any(info_headers_event));
 

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -26,8 +26,8 @@ fn receive_request(server: &mut Http3Server) -> Option<ClientRequestStream> {
         } = event
         {
             assert_eq!(
-                headers,
-                vec![
+                headers.as_ref(),
+                &[
                     Header::new(":method", "GET"),
                     Header::new(":scheme", "https"),
                     Header::new(":authority", "something.com"),
@@ -64,8 +64,8 @@ fn process_client_events(conn: &mut Http3Client) {
         match event {
             Http3ClientEvent::HeaderReady { headers, fin, .. } => {
                 assert_eq!(
-                    headers,
-                    vec![
+                    headers.as_ref(),
+                    &[
                         Header::new(":status", "200"),
                         Header::new("content-length", "3"),
                     ]
@@ -181,7 +181,7 @@ fn test_103_response() {
     let info_headers_event = |e| {
         matches!(e, Http3ClientEvent::HeaderReady { headers,
                     interim,
-                    fin, .. } if !fin && interim && headers == info_headers)
+                    fin, .. } if !fin && interim && &headers.as_ref() == &info_headers)
     };
     assert!(hconn_c.events().any(info_headers_event));
 

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -122,14 +122,14 @@ fn priority_update() {
             headers,
             fin,
         } => {
-            let expected_headers = vec![
+            let expected_headers = &[
                 Header::new(":method", "GET"),
                 Header::new(":scheme", "https"),
                 Header::new(":authority", "something.com"),
                 Header::new(":path", "/"),
                 Header::new("priority", "u=4,i"),
             ];
-            assert_eq!(headers, expected_headers);
+            assert_eq!(&headers.as_ref(), &expected_headers);
             assert!(!fin);
         }
         other => panic!("unexpected server event: {:?}", other),

--- a/neqo-http3/tests/send_message.rs
+++ b/neqo-http3/tests/send_message.rs
@@ -1,0 +1,291 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use neqo_common::event::Provider;
+use neqo_crypto::AuthenticationStatus;
+use neqo_http3::{
+    ClientRequestStream, Error, Header, Http3Client, Http3ClientEvent, Http3Server,
+    Http3ServerEvent, Priority, Res,
+};
+use test_fixture::*;
+
+const RESPONSE_DATA: &[u8] = &[0x61, 0x62, 0x63];
+
+fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
+    let mut out = None;
+    loop {
+        out = client.process(out, now()).dgram();
+        out = server.process(out, now()).dgram();
+        if out.is_none() {
+            break;
+        }
+    }
+}
+
+fn receive_request(server: &mut Http3Server) -> Option<ClientRequestStream> {
+    while let Some(event) = server.next_event() {
+        if let Http3ServerEvent::Headers {
+            request,
+            headers,
+            fin,
+        } = event
+        {
+            assert_eq!(
+                headers.as_ref(),
+                &[
+                    Header::new(":method", "GET"),
+                    Header::new(":scheme", "https"),
+                    Header::new(":authority", "something.com"),
+                    Header::new(":path", "/")
+                ]
+            );
+            assert!(fin);
+            return Some(request);
+        }
+    }
+    None
+}
+
+fn send_trailers(request: &mut ClientRequestStream) -> Res<()> {
+    request.send_headers(&[
+        Header::new("something1", "something"),
+        Header::new("something2", "3"),
+    ])
+}
+
+fn send_headers(request: &mut ClientRequestStream) -> Res<()> {
+    request.send_headers(&[
+        Header::new(":status", "200"),
+        Header::new("content-length", "3"),
+    ])
+}
+
+fn process_client_events(conn: &mut Http3Client) {
+    let mut response_header_found = false;
+    let mut response_data_found = false;
+    while let Some(event) = conn.next_event() {
+        match event {
+            Http3ClientEvent::HeaderReady { headers, fin, .. } => {
+                assert_eq!(
+                    headers.as_ref(),
+                    &[
+                        Header::new(":status", "200"),
+                        Header::new("content-length", "3"),
+                    ]
+                );
+                assert!(!fin);
+                response_header_found = true;
+            }
+            Http3ClientEvent::DataReadable { stream_id } => {
+                let mut buf = [0u8; 100];
+                let (amount, fin) = conn.read_response_data(now(), stream_id, &mut buf).unwrap();
+                assert!(fin);
+                assert_eq!(amount, RESPONSE_DATA.len());
+                assert_eq!(&buf[..RESPONSE_DATA.len()], RESPONSE_DATA);
+                response_data_found = true;
+            }
+            _ => {}
+        }
+    }
+    assert!(response_header_found);
+    assert!(response_data_found);
+}
+
+fn process_client_events_no_data(conn: &mut Http3Client) {
+    let mut response_header_found = false;
+    let mut fin_received = false;
+    while let Some(event) = conn.next_event() {
+        match event {
+            Http3ClientEvent::HeaderReady { headers, fin, .. } => {
+                assert_eq!(
+                    headers.as_ref(),
+                    &[Header::new(":status", "200"), Header::new("something", "3"),]
+                );
+                fin_received = fin;
+                response_header_found = true;
+            }
+            Http3ClientEvent::DataReadable { stream_id } => {
+                let mut buf = [0u8; 100];
+                let (amount, fin) = conn.read_response_data(now(), stream_id, &mut buf).unwrap();
+                assert!(fin);
+                fin_received = true;
+                assert_eq!(amount, 0);
+            }
+            _ => {}
+        }
+    }
+    assert!(response_header_found);
+    assert!(fin_received);
+}
+
+fn connect_send_and_receive_request() -> (Http3Client, Http3Server, ClientRequestStream) {
+    let mut hconn_c = default_http3_client();
+    let mut hconn_s = default_http3_server();
+
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    let authentication_needed = |e| matches!(e, Http3ClientEvent::AuthenticationNeeded);
+    assert!(hconn_c.events().any(authentication_needed));
+    hconn_c.authenticated(AuthenticationStatus::Ok, now());
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+
+    let req = hconn_c
+        .fetch(
+            now(),
+            "GET",
+            &("https", "something.com", "/"),
+            &[],
+            Priority::default(),
+        )
+        .unwrap();
+    assert_eq!(req, 0);
+    hconn_c.stream_close_send(req).unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+
+    let request = receive_request(&mut hconn_s).unwrap();
+
+    (hconn_c, hconn_s, request)
+}
+
+#[test]
+fn response_trailers1() {
+    let (mut hconn_c, mut hconn_s, mut request) = connect_send_and_receive_request();
+    send_headers(&mut request).unwrap();
+    request.send_data(RESPONSE_DATA).unwrap();
+    send_trailers(&mut request).unwrap();
+    request.close_send().unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    process_client_events(&mut hconn_c);
+}
+
+#[test]
+fn response_trailers2() {
+    let (mut hconn_c, mut hconn_s, mut request) = connect_send_and_receive_request();
+    send_headers(&mut request).unwrap();
+    request.send_data(RESPONSE_DATA).unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    send_trailers(&mut request).unwrap();
+    request.close_send().unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    process_client_events(&mut hconn_c);
+}
+
+#[test]
+fn response_trailers3() {
+    let (mut hconn_c, mut hconn_s, mut request) = connect_send_and_receive_request();
+    send_headers(&mut request).unwrap();
+    request.send_data(RESPONSE_DATA).unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    send_trailers(&mut request).unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    request.close_send().unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    process_client_events(&mut hconn_c);
+}
+
+#[test]
+fn response_trailers_no_data() {
+    let (mut hconn_c, mut hconn_s, mut request) = connect_send_and_receive_request();
+    request
+        .send_headers(&[Header::new(":status", "200"), Header::new("something", "3")])
+        .unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    send_trailers(&mut request).unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    request.close_send().unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    process_client_events_no_data(&mut hconn_c);
+}
+
+#[test]
+fn multiple_response_trailers() {
+    let (mut hconn_c, mut hconn_s, mut request) = connect_send_and_receive_request();
+    send_headers(&mut request).unwrap();
+    request.send_data(RESPONSE_DATA).unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    send_trailers(&mut request).unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+
+    assert_eq!(send_trailers(&mut request), Err(Error::InvalidInput));
+
+    request.close_send().unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    process_client_events(&mut hconn_c);
+}
+
+#[test]
+fn data_after_tralier() {
+    let (mut hconn_c, mut hconn_s, mut request) = connect_send_and_receive_request();
+    send_headers(&mut request).unwrap();
+    request.send_data(RESPONSE_DATA).unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    send_trailers(&mut request).unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+
+    assert_eq!(request.send_data(RESPONSE_DATA), Err(Error::InvalidInput));
+
+    request.close_send().unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    process_client_events(&mut hconn_c);
+}
+
+#[test]
+fn trailers_after_close() {
+    let (mut hconn_c, mut hconn_s, mut request) = connect_send_and_receive_request();
+    send_headers(&mut request).unwrap();
+    request.send_data(RESPONSE_DATA).unwrap();
+    request.close_send().unwrap();
+
+    assert_eq!(send_trailers(&mut request), Err(Error::InvalidStreamId));
+
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    process_client_events(&mut hconn_c);
+}
+
+#[test]
+fn multiple_response_headers() {
+    let (mut hconn_c, mut hconn_s, mut request) = connect_send_and_receive_request();
+    request
+        .send_headers(&[Header::new(":status", "200"), Header::new("something", "3")])
+        .unwrap();
+
+    assert_eq!(
+        request.send_headers(&[Header::new(":status", "200"), Header::new("something", "3"),]),
+        Err(Error::InvalidHeader)
+    );
+
+    request.close_send().unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    process_client_events_no_data(&mut hconn_c);
+}
+
+#[test]
+fn non_trailers_headers_after_data() {
+    let (mut hconn_c, mut hconn_s, mut request) = connect_send_and_receive_request();
+    send_headers(&mut request).unwrap();
+    request.send_data(RESPONSE_DATA).unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+
+    assert_eq!(
+        request.send_headers(&[Header::new(":status", "200"), Header::new("something", "3"),]),
+        Err(Error::InvalidHeader)
+    );
+
+    request.close_send().unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    process_client_events(&mut hconn_c);
+}
+
+#[test]
+fn data_before_headers() {
+    let (mut hconn_c, mut hconn_s, mut request) = connect_send_and_receive_request();
+    assert_eq!(request.send_data(RESPONSE_DATA), Err(Error::InvalidInput));
+
+    send_headers(&mut request).unwrap();
+    request.send_data(RESPONSE_DATA).unwrap();
+    request.close_send().unwrap();
+    exchange_packets(&mut hconn_c, &mut hconn_s);
+    process_client_events(&mut hconn_c);
+}

--- a/neqo-http3/tests/send_message.rs
+++ b/neqo-http3/tests/send_message.rs
@@ -86,7 +86,7 @@ fn process_client_events(conn: &mut Http3Client) {
             Http3ClientEvent::HeaderReady { headers, fin, .. } => {
                 assert!(
                     (headers.as_ref()
-                        == &[
+                        == [
                             Header::new(":status", "200"),
                             Header::new("content-length", "3"),
                         ])

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -12,7 +12,7 @@ use crate::reader::ReceiverConnWrapper;
 use crate::stats::Stats;
 use crate::table::HeaderTable;
 use crate::{Error, QpackSettings, Res};
-use neqo_common::{qdebug, Header};
+use neqo_common::{qdebug, Headers};
 use neqo_transport::{Connection, StreamId};
 use std::convert::TryFrom;
 
@@ -195,11 +195,7 @@ impl QPackDecoder {
     /// May return `DecompressionFailed` if header block is incorrect or incomplete.
     /// # Panics
     /// When there is a programming error.
-    pub fn decode_header_block(
-        &mut self,
-        buf: &[u8],
-        stream_id: StreamId,
-    ) -> Res<Option<Vec<Header>>> {
+    pub fn decode_header_block(&mut self, buf: &[u8], stream_id: StreamId) -> Res<Option<Headers>> {
         qdebug!([self], "decode header block.");
         let mut decoder = HeaderDecoder::new(buf);
 
@@ -269,8 +265,9 @@ fn map_error(err: &Error) -> Error {
 
 #[cfg(test)]
 mod tests {
-    use super::{Connection, Error, Header, QPackDecoder, Res};
+    use super::{Connection, Error, QPackDecoder, Res};
     use crate::QpackSettings;
+    use neqo_common::Header;
     use neqo_transport::{StreamId, StreamType};
     use std::convert::TryFrom;
     use std::mem;
@@ -349,7 +346,7 @@ mod tests {
             .decode_header_block(header_block, stream_id)
             .unwrap();
         let h = decoded_headers.unwrap();
-        assert_eq!(h, headers);
+        assert_eq!(h.as_ref(), headers);
     }
 
     fn test_instruction(

--- a/neqo-qpack/src/header_block.rs
+++ b/neqo-qpack/src/header_block.rs
@@ -14,7 +14,7 @@ use crate::qpack_send_buf::QpackData;
 use crate::reader::{to_string, ReceiverBufferWrapper};
 use crate::table::HeaderTable;
 use crate::{Error, Res};
-use neqo_common::{qtrace, Header};
+use neqo_common::{qtrace, Header, Headers};
 use std::mem;
 use std::ops::{Deref, Div};
 
@@ -180,7 +180,7 @@ impl<'a> ::std::fmt::Display for HeaderDecoder<'a> {
 #[derive(Debug, PartialEq)]
 pub enum HeaderDecoderResult {
     Blocked(u64),
-    Headers(Vec<Header>),
+    Headers(Headers),
 }
 
 impl<'a> HeaderDecoder<'a> {
@@ -223,7 +223,7 @@ impl<'a> HeaderDecoder<'a> {
             );
             return Ok(HeaderDecoderResult::Blocked(self.req_insert_cnt));
         }
-        let mut h: Vec<Header> = Vec::new();
+        let mut h = Headers::default();
 
         while !self.buf.done() {
             let b = Error::map_error(self.buf.peek(), Error::DecompressionFailed)?;

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -301,14 +301,13 @@ impl HttpServer for Http3Server {
                     let response = response.unwrap();
 
                     request
-                        .set_response(
-                            &[
-                                Header::new(":status", "200"),
-                                Header::new("content-length", response.len()),
-                            ],
-                            &response,
-                        )
+                        .send_headers(&[
+                            Header::new(":status", "200"),
+                            Header::new("content-length", response.len()),
+                        ])
                         .unwrap();
+                    request.send_data(&response).unwrap();
+                    request.close_send().unwrap();
                 }
                 Http3ServerEvent::Data { request, data, fin } => {
                     println!("Data (request={} fin={}): {:?}", request, fin, data);


### PR DESCRIPTION
The biggest change is that SendMessage uses BufferedStream and does not need states. The header blocks are added using send_headers and they are buffered into the BufferedStream. There may be multiple header blocks, but the code does not enforce or check that only server can send multiple headers blocks or that the multiple 1xx header blocks are followed by a non-1xx header block. This is left for the application to enforce.

The server and client API are unified, both sides use send_header, send_data  and close_send functions.