### PR TITLE
Add the DataWritable event to the server side

### DIFF
--- a/neqo-http3/src/conn_params.rs
+++ b/neqo-http3/src/conn_params.rs
@@ -5,6 +5,7 @@
 // except according to those terms.
 
 use neqo_qpack::QpackSettings;
+use neqo_transport::ConnectionParameters;
 use std::cmp::min;
 
 const QPACK_MAX_TABLE_SIZE_DEFAULT: u64 = 65536;
@@ -15,6 +16,7 @@ const WEBTRANSPORT_DEFAULT: bool = false;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Http3Parameters {
+    conn_params: ConnectionParameters,
     qpack_settings: QpackSettings,
     max_concurrent_push_streams: u64,
     webtransport: bool,
@@ -23,6 +25,7 @@ pub struct Http3Parameters {
 impl Default for Http3Parameters {
     fn default() -> Self {
         Self {
+            conn_params: ConnectionParameters::default(),
             qpack_settings: QpackSettings {
                 max_table_size_encoder: QPACK_MAX_TABLE_SIZE_DEFAULT,
                 max_table_size_decoder: QPACK_MAX_TABLE_SIZE_DEFAULT,
@@ -35,6 +38,17 @@ impl Default for Http3Parameters {
 }
 
 impl Http3Parameters {
+    #[must_use]
+    pub fn get_connection_parameters(&self) -> &ConnectionParameters {
+        &self.conn_params
+    }
+
+    #[must_use]
+    pub fn connection_parameters(mut self, conn_params: ConnectionParameters) -> Self {
+        self.conn_params = conn_params;
+        self
+    }
+
     /// # Panics
     /// The table size must be smaller than 1 << 30 by the spec.
     #[must_use]

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -245,12 +245,16 @@ impl Http3ServerHandler {
                             .connection_state_change(self.base_handler.state());
                     }
                 }
+                ConnectionEvent::SendStreamWritable { stream_id } => {
+                    if let Some(s) = self.base_handler.send_streams.get_mut(&stream_id) {
+                        s.stream_writable();
+                    }
+                }
                 ConnectionEvent::AuthenticationNeeded
                 | ConnectionEvent::EchFallbackAuthenticationNeeded { .. }
                 | ConnectionEvent::ZeroRttRejected
                 | ConnectionEvent::ResumptionToken(..) => return Err(Error::HttpInternal(4)),
-                ConnectionEvent::SendStreamWritable { .. }
-                | ConnectionEvent::SendStreamComplete { .. }
+                ConnectionEvent::SendStreamComplete { .. }
                 | ConnectionEvent::SendStreamCreatable { .. }
                 | ConnectionEvent::Datagram { .. }
                 | ConnectionEvent::OutgoingDatagramOutcome { .. }

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -32,6 +32,9 @@ pub(crate) enum Http3ServerConnEvent {
     DataReadable {
         stream_info: Http3StreamInfo,
     },
+    DataWritable {
+        stream_info: Http3StreamInfo,
+    },
     StreamReset {
         stream_info: Http3StreamInfo,
         error: AppError,
@@ -67,6 +70,10 @@ impl SendStreamEvents for Http3ServerConnEvents {
                 error: close_type.error().unwrap(),
             });
         }
+    }
+
+    fn data_writable(&self, stream_info: Http3StreamInfo) {
+        self.insert(Http3ServerConnEvent::DataWritable { stream_info });
     }
 }
 

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -333,6 +333,9 @@ pub enum Http3ServerEvent {
         data: Vec<u8>,
         fin: bool,
     },
+    DataWritable {
+        stream: Http3OrWebTransportStream,
+    },
     StreamReset {
         stream: Http3OrWebTransportStream,
         error: AppError,
@@ -410,6 +413,17 @@ impl Http3ServerEvents {
             stream: Http3OrWebTransportStream::new(conn, handler, stream_info),
             data,
             fin,
+        });
+    }
+
+    pub(crate) fn data_writable(
+        &self,
+        conn: ActiveConnectionRef,
+        handler: Rc<RefCell<Http3ServerHandler>>,
+        stream_info: Http3StreamInfo,
+    ) {
+        self.insert(Http3ServerEvent::DataWritable {
+            stream: Http3OrWebTransportStream::new(conn, handler, stream_info),
         });
     }
 

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -8,43 +8,11 @@ use neqo_common::event::Provider;
 
 use neqo_crypto::AuthenticationStatus;
 use neqo_http3::{
-    Header, Http3Client, Http3ClientEvent, Http3Parameters, Http3Server, Http3ServerEvent,
-    Http3State, Priority,
+    Header, Http3Client, Http3ClientEvent, Http3Server, Http3ServerEvent, Http3State, Priority,
 };
-use neqo_transport::ConnectionParameters;
-use std::cell::RefCell;
-
-use std::rc::Rc;
 
 use std::time::Instant;
 use test_fixture::*;
-
-pub fn default_http3_client() -> Http3Client {
-    fixture_init();
-    Http3Client::new(
-        DEFAULT_SERVER_NAME,
-        Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
-        addr(),
-        addr(),
-        ConnectionParameters::default(),
-        Http3Parameters::default().max_concurrent_push_streams(5),
-        now(),
-    )
-    .expect("create a default client")
-}
-
-pub fn default_http3_server() -> Http3Server {
-    Http3Server::new(
-        now(),
-        DEFAULT_KEYS,
-        DEFAULT_ALPN_H3,
-        anti_replay(),
-        Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
-        Http3Parameters::default(),
-        None,
-    )
-    .expect("create a server")
-}
 
 fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
     let mut out = None;

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -609,7 +609,6 @@ fn test_h3_rz(
         Rc::new(RefCell::new(EmptyConnectionIdGenerator::default())),
         nctx.local_addr,
         nctx.remote_addr,
-        ConnectionParameters::default(),
         Http3Parameters::default()
             .max_table_size_encoder(16384)
             .max_table_size_decoder(16384)

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -28,7 +28,7 @@ const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_QUEUED_DATAGRAMS_DEFAULT: usize = 10;
 
 /// What to do with preferred addresses.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum PreferredAddressConfig {
     /// Disabled, whether for client or server.
     Disabled,
@@ -41,7 +41,7 @@ pub enum PreferredAddressConfig {
 /// ConnectionParameters use for setting intitial value for QUIC parameters.
 /// This collects configuration like initial limits, protocol version, and
 /// congestion control algorithm.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ConnectionParameters {
     quic_version: QuicVersion,
     cc_algorithm: CongestionControlAlgorithm,

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -491,7 +491,7 @@ impl Server {
             &self.certs,
             &self.protocols,
             Rc::clone(&cid_mgr) as _,
-            self.conn_params.clone().quic_version(initial.quic_version),
+            self.conn_params.quic_version(initial.quic_version),
         );
 
         if let Ok(mut c) = sconn {

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -51,7 +51,7 @@ tpids! {
     MAX_DATAGRAM_FRAME_SIZE = 0x0020,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 pub struct PreferredAddress {
     v4: Option<SocketAddr>,
     v6: Option<SocketAddr>,
@@ -761,6 +761,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn preferred_address_neither() {
+        #[allow(clippy::drop_copy)]
         mem::drop(PreferredAddress::new(None, None));
     }
 

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -235,7 +235,6 @@ pub fn default_http3_client() -> Http3Client {
         Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
         addr(),
         addr(),
-        ConnectionParameters::default(),
         Http3Parameters::default()
             .max_table_size_encoder(100)
             .max_table_size_decoder(100)
@@ -244,6 +243,23 @@ pub fn default_http3_client() -> Http3Client {
         now(),
     )
     .expect("create a default client")
+}
+
+/// Create a http3 client.
+/// # Panics
+/// When the client can't be created.
+#[must_use]
+pub fn http3_client_with_params(params: Http3Parameters) -> Http3Client {
+    fixture_init();
+    Http3Client::new(
+        DEFAULT_SERVER_NAME,
+        Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
+        addr(),
+        addr(),
+        params,
+        now(),
+    )
+    .expect("create a client")
 }
 
 /// Create a http3 server with default configuration.


### PR DESCRIPTION
PR #1270 refactored the server side API. Instead of set_response that used to accept all data supply, now there are 3 functions: send_headers, send_data and stream_close_send. Important change is also that send_data does not accept more data than the flow control allows. To be able to write larger responses DataWritable events are needed to to trigger writes when more flow control credit is available.

Additional changes:
To write a test for the event it was necessary to change transport level parameters when creating a Http3Server. To avoid hitting the limit of the number of parameters in a function, ConnectionParameters are added to Http3Parameters. This will fix #1251.