### PR TITLE
zero-length unknown frame payloads

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -92,6 +92,7 @@ jobs:
         env:
            LD_LIBRARY_PATH: ${{ github.workspace }}/dist/Debug/lib
            RUST_BACKTRACE: 1
+           RUST_LOG: neqo=debug
 
       - name: Check formatting
         run: cargo +${{ matrix.rust-toolchain }} fmt --all -- --check

--- a/neqo-common/src/incrdecoder.rs
+++ b/neqo-common/src/incrdecoder.rs
@@ -108,8 +108,12 @@ pub struct IncrementalDecoderIgnore {
 }
 
 impl IncrementalDecoderIgnore {
+    /// Make a new ignoring decoder.
+    /// # Panics
+    /// If the amount to ignore is zero.
     #[must_use]
     pub fn new(n: usize) -> Self {
+        assert_ne!(n, 0);
         Self { remaining: n }
     }
 

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -210,7 +210,7 @@ impl Http3ServerHandler {
             self.needs_processing = false;
             return true;
         }
-        self.base_handler.has_data_to_send() | self.events.has_events()
+        self.base_handler.has_data_to_send() || self.events.has_events()
     }
 
     // This function takes the provided result and check for an error.

--- a/neqo-http3/src/control_stream_remote.rs
+++ b/neqo-http3/src/control_stream_remote.rs
@@ -40,7 +40,10 @@ impl ControlStreamRemote {
                 self.stream_id,
             ))? {
             (_, true) => Err(Error::HttpClosedCriticalStream),
-            (s, false) => Ok(s),
+            (s, false) => {
+                qdebug!([self], "received {:?}", s);
+                Ok(s)
+            }
         }
     }
 }

--- a/neqo-http3/src/frames/hframe.rs
+++ b/neqo-http3/src/frames/hframe.rs
@@ -158,7 +158,7 @@ impl FrameDecoder<HFrame> for HFrame {
         } else if let Some(payload) = data {
             let mut dec = Decoder::from(payload);
             Ok(match frame_type {
-                H3_FRAME_TYPE_DATA => unreachable!("DATA frame has beee handled already."),
+                H3_FRAME_TYPE_DATA => unreachable!("DATA frame has been handled already."),
                 H3_FRAME_TYPE_HEADERS => Some(HFrame::Headers {
                     header_block: dec.decode_remainder().to_vec(),
                 }),

--- a/neqo-http3/src/frames/reader.rs
+++ b/neqo-http3/src/frames/reader.rs
@@ -250,6 +250,8 @@ impl FrameReader {
                     usize::try_from(len).or(Err(Error::HttpFrame))?,
                 ),
             };
+        } else if self.frame_len == 0 {
+            self.reset();
         } else {
             self.state = FrameReaderState::UnknownFrameDischargeData {
                 decoder: IncrementalDecoderIgnore::new(

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -107,23 +107,20 @@ fn priority_update() {
     client.priority_update(stream_id, update_priority).unwrap();
     exchange_packets(&mut client, &mut server);
 
-    let priority_event = loop {
-        let event = server.next_event().unwrap();
-        if matches!(event, Http3ServerEvent::PriorityUpdate { .. }) {
-            break event;
-        }
-    };
-
-    match priority_event {
-        Http3ServerEvent::PriorityUpdate {
+    let found = server.events().any(|e| {
+        if let Http3ServerEvent::PriorityUpdate {
             stream_id: update_id,
             priority,
-        } => {
+        } = e
+        {
             assert_eq!(update_id, stream_id);
             assert_eq!(priority, update_priority);
+            true
+        } else {
+            false
         }
-        other => panic!("unexpected server event: {:?}", other),
-    }
+    });
+    assert!(found);
 }
 
 #[test]

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -16,12 +16,11 @@ use test_fixture::*;
 
 fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
     let mut out = None;
-    let mut client_data;
     loop {
         out = client.process(out, now()).dgram();
-        client_data = out.is_none();
+        let client_done = out.is_none();
         out = server.process(out, now()).dgram();
-        if out.is_none() && client_data {
+        if out.is_none() && client_done {
             break;
         }
     }


### PR DESCRIPTION
Don't try to read the payload of empty frames, it doesn't work.

The real fix is in neqo-http3/src/frames/reader.rs

This includes a few other changes:

* I made the incremental ignoring decoder not work for zero-length
things.  This is the source of the problem.  Fixing this doesn't help in
this case, but it should block similar mistakes.

* Enable RUST_LOG for running in CI.  The test runner now captures
output, so we are able to get per-test logs when they fail.

* Use || instead of | for a boolean condition.

* Fixed a typo in comments/logs.

* Improved exchange_packets.

* Streamlined the event handling in priority_update.