### PR TITLE
Use map for encoding resumption token

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -167,14 +167,12 @@ impl Http3Client {
     }
 
     fn encode_resumption_token(&self, token: &ResumptionToken) -> Option<ResumptionToken> {
-        if let Some(settings) = self.base_handler.get_settings() {
+        self.base_handler.get_settings().map(|settings| {
             let mut enc = Encoder::default();
             settings.encode_frame_contents(&mut enc);
             enc.encode(token.as_ref());
-            Some(ResumptionToken::new(enc.into(), token.expiration_time()))
-        } else {
-            None
-        }
+            ResumptionToken::new(enc.into(), token.expiration_time())
+        })
     }
 
     /// Get a resumption token.  The correct way to obtain a resumption token is


### PR DESCRIPTION
I was going to just commit this and push directly as it is trivial, but
I wanted to share...

Clippy generated an error with this code, suggesting that it use
`.map_or(None, |x| ...)`.  Then it suggested that that
was better replaced with `.and_then(|x| ...)`.  Finally, it suggested
that a simple `.map(|x| foo)` was better than the `.and_then(|x|
Some(foo))` there.

In any case, here we are after three separate clippy lints.
Obvious in retrospect, had I bothered to think at all.