### PR TITLE
Don't send small Initial packets

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -247,6 +247,8 @@ pub struct Connection {
     /// when they are either just reordered or we haven't been able to install keys yet.
     /// In particular, this occurs when asynchronous certificate validation happens.
     saved_datagrams: SavedDatagrams,
+    /// Some packets were received, but not tracked.
+    received_untracked: bool,
 
     /// This is responsible for the QuicDatagrams' handling:
     /// https://datatracker.ietf.org/doc/html/draft-ietf-quic-datagram
@@ -393,6 +395,7 @@ impl Connection {
             remote_initial_source_cid: None,
             original_destination_cid: None,
             saved_datagrams: SavedDatagrams::default(),
+            received_untracked: false,
             crypto,
             acks: AckTracker::default(),
             idle_timeout: IdleTimeout::new(conn_params.get_idle_timeout()),
@@ -1020,7 +1023,7 @@ impl Connection {
         self.process_output(now)
     }
 
-    fn handle_retry(&mut self, packet: &PublicPacket) {
+    fn handle_retry(&mut self, packet: &PublicPacket, now: Instant) {
         qinfo!([self], "received Retry");
         if matches!(self.address_validation, AddressValidationInfo::Retry { .. }) {
             self.stats.borrow_mut().pkt_dropped("Extra Retry");
@@ -1049,7 +1052,7 @@ impl Connection {
             retry_scid
         );
 
-        let lost_packets = self.loss_recovery.retry(&path);
+        let lost_packets = self.loss_recovery.retry(&path, now);
         self.handle_lost_packets(&lost_packets);
 
         self.crypto.states.init(
@@ -1254,7 +1257,7 @@ impl Connection {
                 }
             }
             (PacketType::Retry, State::WaitInitial, Role::Client) => {
-                self.handle_retry(packet);
+                self.handle_retry(packet, now);
                 return Ok(PreprocessResult::Next);
             }
             (PacketType::Handshake, State::WaitInitial, Role::Client)
@@ -1430,6 +1433,12 @@ impl Connection {
                             // Exhausting read keys is fatal.
                             return Err(e);
                         }
+                        Error::KeysDiscarded(cspace) => {
+                            // This was a valid-appearing Initial packet, maybe probe with
+                            // a Handshake packet to keep the server happy.
+                            self.received_untracked =
+                                self.role == Role::Client && cspace == CryptoSpace::Initial;
+                        }
                         _ => (),
                     }
                     // Decryption failure, or not having keys is not fatal.
@@ -1487,11 +1496,26 @@ impl Connection {
                 self.capture_error(Some(Rc::clone(path)), now, t, Err(e))?;
             }
         }
-        let largest_received = self
+
+        let largest_received = if let Some(space) = self
             .acks
             .get_mut(PacketNumberSpace::from(packet.packet_type()))
-            .unwrap()
-            .set_received(now, packet.pn(), ack_eliciting);
+        {
+            space.set_received(now, packet.pn(), ack_eliciting)
+        } else {
+            qdebug!(
+                [self],
+                "processed a {:?} packet without tracking it",
+                packet.packet_type(),
+            );
+            // This was a valid packet that caused the same packet number to be
+            // discarded.  This happens when the client discards the Initial packet
+            // number space after receiving the ServerHello.  Remember this so
+            // that we guarantee that we send a Handshake packet.
+            self.received_untracked = true;
+            // We don't migrate during the handshake, so return false.
+            false
+        };
 
         Ok(largest_received && !probing)
     }
@@ -1953,13 +1977,18 @@ impl Connection {
         tokens: &mut Vec<RecoveryToken>,
         now: Instant,
     ) -> bool {
+        let untracked = self.received_untracked && !self.state.connected();
+        self.received_untracked = false;
+
         // Anything written after an ACK already elicits acknowledgment.
         // If we need to probe and nothing has been written, send a PING.
         if builder.len() > ack_end {
             return true;
         }
-        let probe = if force_probe {
-            // The packet might be empty, but we need to probe.
+
+        let probe = if untracked && builder.packet_empty() || force_probe {
+            // If we received an untracked packet and we aren't probing already
+            // or the PTO timer fired: probe.
             true
         } else {
             let pto = path.borrow().rtt().pto(PacketNumberSpace::ApplicationData);
@@ -2169,14 +2198,13 @@ impl Connection {
                 self.loss_recovery.on_packet_sent(path, sent);
             }
 
-            if *space == PacketNumberSpace::Handshake {
-                if self.role == Role::Client {
-                    // Client can send Handshake packets -> discard Initial keys and states
-                    self.discard_keys(PacketNumberSpace::Initial, now);
-                } else if self.state == State::Confirmed {
-                    // We could discard handshake keys in set_state, but wait until after sending an ACK.
-                    self.discard_keys(PacketNumberSpace::Handshake, now);
-                }
+            if *space == PacketNumberSpace::Handshake
+                && self.role == Role::Server
+                && self.state == State::Confirmed
+            {
+                // We could discard handshake keys in set_state,
+                // but wait until after sending an ACK.
+                self.discard_keys(PacketNumberSpace::Handshake, now);
             }
         }
 
@@ -2502,6 +2530,11 @@ impl Connection {
                 self.set_initial_limits();
             }
             if self.crypto.install_keys(self.role)? {
+                if self.role == Role::Client {
+                    // We won't acknowledge Initial packets as a result of this, but the
+                    // server can rely on implicit acknowledgment.
+                    self.discard_keys(PacketNumberSpace::Initial, now);
+                }
                 self.saved_datagrams.make_available(CryptoSpace::Handshake);
             }
         }
@@ -2771,14 +2804,14 @@ impl Connection {
     }
 
     /// When the server rejects 0-RTT we need to drop a bunch of stuff.
-    fn client_0rtt_rejected(&mut self) {
+    fn client_0rtt_rejected(&mut self, now: Instant) {
         if !matches!(self.zero_rtt_state, ZeroRttState::Sending) {
             return;
         }
         qdebug!([self], "0-RTT rejected");
 
         // Tell 0-RTT packets that they were "lost".
-        let dropped = self.loss_recovery.drop_0rtt(&self.paths.primary());
+        let dropped = self.loss_recovery.drop_0rtt(&self.paths.primary(), now);
         self.handle_lost_packets(&dropped);
 
         self.streams.zero_rtt_rejected();
@@ -2806,7 +2839,7 @@ impl Connection {
             self.zero_rtt_state = if self.crypto.tls.info().unwrap().early_data_accepted() {
                 ZeroRttState::AcceptedClient
             } else {
-                self.client_0rtt_rejected();
+                self.client_0rtt_rejected(now);
                 ZeroRttState::Rejected
             };
         }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1434,9 +1434,9 @@ impl Connection {
                             return Err(e);
                         }
                         Error::KeysDiscarded(cspace) => {
-                            // This was a valid-appearing Initial packet, maybe probe with
-                            // a Handshake packet to keep the server happy.
-                            self.received_untracked =
+                            // This was a valid-appearing Initial packet: maybe probe with
+                            // a Handshake packet to keep the handshake moving.
+                            self.received_untracked |=
                                 self.role == Role::Client && cspace == CryptoSpace::Initial;
                         }
                         _ => (),

--- a/neqo-transport/src/connection/tests/keys.rs
+++ b/neqo-transport/src/connection/tests/keys.rs
@@ -18,13 +18,19 @@ use neqo_common::{qdebug, Datagram};
 use std::mem;
 use test_fixture::{self, now};
 
-fn check_discarded(peer: &mut Connection, pkt: Datagram, dropped: usize, dups: usize) {
+fn check_discarded(
+    peer: &mut Connection,
+    pkt: Datagram,
+    response: bool,
+    dropped: usize,
+    dups: usize,
+) {
     // Make sure to flush any saved datagrams before doing this.
     mem::drop(peer.process_output(now()));
 
     let before = peer.stats();
     let out = peer.process(Some(pkt), now());
-    assert!(out.as_dgram_ref().is_none());
+    assert_eq!(out.as_dgram_ref().is_some(), response);
     let after = peer.stats();
     assert_eq!(dropped, after.dropped_rx - before.dropped_rx);
     assert_eq!(dups, after.dups_rx - before.dups_rx);
@@ -60,11 +66,12 @@ fn discarded_initial_keys() {
     let out = client.process(init_pkt_s.clone(), now()).dgram();
     assert!(out.is_some());
 
-    // The client has received handshake packet. It will remove the Initial keys.
+    // The client has received a handshake packet. It will remove the Initial keys.
     // We will check this by processing init_pkt_s a second time.
     // The initial packet should be dropped. The packet contains a Handshake packet as well, which
     // will be marked as dup.  And it will contain padding, which will be "dropped".
-    check_discarded(&mut client, init_pkt_s.unwrap(), 2, 1);
+    // The client will generate a Handshake packet here to avoid stalling.
+    check_discarded(&mut client, init_pkt_s.unwrap(), true, 2, 1);
 
     assert!(maybe_authenticate(&mut client));
 
@@ -72,7 +79,7 @@ fn discarded_initial_keys() {
     // packet from the client.
     // We will check this by processing init_pkt_c a second time.
     // The dropped packet is padding. The Initial packet has been mark dup.
-    check_discarded(&mut server, init_pkt_c.clone().unwrap(), 1, 1);
+    check_discarded(&mut server, init_pkt_c.clone().unwrap(), false, 1, 1);
 
     qdebug!("---- client: SH..FIN -> FIN");
     let out = client.process(None, now()).dgram();
@@ -87,7 +94,7 @@ fn discarded_initial_keys() {
     // We will check this by processing init_pkt_c a third time.
     // The Initial packet has been dropped and padding that follows it.
     // There is no dups, everything has been dropped.
-    check_discarded(&mut server, init_pkt_c.unwrap(), 1, 0);
+    check_discarded(&mut server, init_pkt_c.unwrap(), false, 1, 0);
 }
 
 #[test]
@@ -200,7 +207,7 @@ fn key_update_consecutive() {
 
     // However, as the server didn't wait long enough to update again, the
     // client hasn't rotated its keys, so the packet gets dropped.
-    check_discarded(&mut client, dgram, 1, 0);
+    check_discarded(&mut client, dgram, false, 1, 0);
 }
 
 // Key updates can't be initiated too early.

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -97,7 +97,7 @@ pub enum Error {
     InvalidResumptionToken,
     InvalidRetry,
     InvalidStreamId,
-    KeysDiscarded,
+    KeysDiscarded(crypto::CryptoSpace),
     /// Packet protection keys are exhausted.
     /// Also used when too many key updates have happened.
     KeysExhausted,

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -791,7 +791,7 @@ impl<'a> PublicPacket<'a> {
             Err(Error::KeysPending(cspace))
         } else {
             qtrace!("keys for {:?} already discarded", cspace);
-            Err(Error::KeysDiscarded)
+            Err(Error::KeysDiscarded(cspace))
         }
     }
 

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -539,6 +539,9 @@ pub struct Path {
     received_bytes: usize,
     /// The number of bytes sent on this path.
     sent_bytes: usize,
+
+    /// For logging of events.
+    qlog: NeqoQlog,
 }
 
 impl Path {
@@ -552,7 +555,7 @@ impl Path {
         now: Instant,
     ) -> Self {
         let mut sender = PacketSender::new(cc, Self::mtu_by_addr(remote.ip()), now);
-        sender.set_qlog(qlog);
+        sender.set_qlog(qlog.clone());
         Self {
             local,
             remote,
@@ -566,6 +569,7 @@ impl Path {
             sender,
             received_bytes: 0,
             sent_bytes: 0,
+            qlog,
         }
     }
 
@@ -928,7 +932,27 @@ impl Path {
     }
 
     /// Discard a packet that previously might have been in-flight.
-    pub fn discard_packet(&mut self, sent: &SentPacket) {
+    pub fn discard_packet(&mut self, sent: &SentPacket, now: Instant) {
+        if self.rtt.first_sample_time().is_none() {
+            // When discarding a packet there might not be a good RTT estimate.
+            // But discards only occur after receiving something, so that means
+            // that there is some RTT information, which is better than nothing.
+            // Two cases: 1. at the client when handling a Retry and
+            // 2. at the server when disposing the Initial packet number space.
+            qinfo!(
+                [self],
+                "discarding a packet without an RTT estimate; guessing RTT={:?}",
+                now - sent.time_sent
+            );
+            self.rtt.update(
+                &mut self.qlog,
+                now - sent.time_sent,
+                Duration::new(0, 0),
+                false,
+                now,
+            );
+        }
+
         self.sender.discard(sent);
     }
 

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -590,7 +590,7 @@ impl LossRecovery {
         self.qlog = qlog;
     }
 
-    pub fn drop_0rtt(&mut self, primary_path: &PathRef) -> Vec<SentPacket> {
+    pub fn drop_0rtt(&mut self, primary_path: &PathRef, now: Instant) -> Vec<SentPacket> {
         // The largest acknowledged or loss_time should still be unset.
         // The client should not have received any ACK frames when it drops 0-RTT.
         assert!(self
@@ -607,7 +607,7 @@ impl LossRecovery {
             .collect::<Vec<_>>();
         let mut path = primary_path.borrow_mut();
         for p in &mut dropped {
-            path.discard_packet(p);
+            path.discard_packet(p, now);
         }
         dropped
     }
@@ -737,7 +737,7 @@ impl LossRecovery {
 
     /// When receiving a retry, get all the sent packets so that they can be flushed.
     /// We also need to pretend that they never happened for the purposes of congestion control.
-    pub fn retry(&mut self, primary_path: &PathRef) -> Vec<SentPacket> {
+    pub fn retry(&mut self, primary_path: &PathRef, now: Instant) -> Vec<SentPacket> {
         self.pto_state = None;
         let mut dropped = self
             .spaces
@@ -746,7 +746,7 @@ impl LossRecovery {
             .collect::<Vec<_>>();
         let mut path = primary_path.borrow_mut();
         for p in &mut dropped {
-            path.discard_packet(p);
+            path.discard_packet(p, now);
         }
         dropped
     }
@@ -779,7 +779,7 @@ impl LossRecovery {
         qdebug!([self], "Reset loss recovery state for {}", space);
         let mut path = primary_path.borrow_mut();
         for p in self.spaces.drop_space(space) {
-            path.discard_packet(&p);
+            path.discard_packet(&p, now);
         }
 
         // We just made progress, so discard PTO count.
@@ -1494,6 +1494,25 @@ mod tests {
     #[test]
     fn rearm_pto_after_confirmed() {
         let mut lr = Fixture::default();
+        lr.on_packet_sent(SentPacket::new(
+            PacketType::Initial,
+            0,
+            now(),
+            true,
+            Vec::new(),
+            ON_SENT_SIZE,
+        ));
+        // Set the RTT to the initial value so that discarding doesn't
+        // alter the estimate.
+        let rtt = lr.path.borrow().rtt().estimate();
+        lr.on_ack_received(
+            PacketNumberSpace::Initial,
+            0,
+            vec![0..=0],
+            Duration::new(0, 0),
+            now() + rtt,
+        );
+
         lr.on_packet_sent(SentPacket::new(
             PacketType::Handshake,
             0,

--- a/neqo-transport/tests/connection.rs
+++ b/neqo-transport/tests/connection.rs
@@ -34,8 +34,8 @@ fn truncate_long_packet() {
         dupe.destination(),
         &dupe[..(dupe.len() - tail)],
     );
-    let dupe_ack = client.process(Some(truncated), now()).dgram();
-    assert!(dupe_ack.is_some());
+    let hs_probe = client.process(Some(truncated), now()).dgram();
+    assert!(hs_probe.is_some());
 
     // Now feed in the untruncated packet.
     let dgram = client.process(dgram, now()).dgram();

--- a/test-fixture/src/assertions.rs
+++ b/test-fixture/src/assertions.rs
@@ -93,6 +93,16 @@ pub fn assert_initial(payload: &[u8], expect_token: bool) {
     assert_eq!(expect_token, !token.is_empty());
 }
 
+/// Assert that this is a Handshake packet.
+/// # Panics
+/// If the tests fail.
+pub fn assert_handshake(payload: &[u8]) {
+    let mut dec = Decoder::from(payload);
+    let t = dec.decode_byte().unwrap();
+    let version = assert_default_version(&mut dec);
+    assert_long_packet_type(t, 0b1010_0000, version);
+}
+
 /// # Panics
 /// If the tests fail.
 pub fn assert_no_1rtt(payload: &[u8]) {


### PR DESCRIPTION
This turned out to be a little fiddly, but it should also improve
handshake reliability (in rare scenarios, admittedly).

Changes:

1. At the client, discard the Initial packet number space when the
Handshake keys are installed.

2. Because Initial packets from the client are not sent in its second
flight, the server won't get an ACK, which otherwise drives the RTT
estimate.  Rather than disrupt all the tests, when the server discards
its Initial packet number space it will add an implicit RTT sample.

Note: The server will not increase its congestion window as a result of
this.  We might consider doing something about that later.

3. Because the client might only receive Initial packets from the
server, if it discards the Initial packet number space there will be
nothing to send.  No Initial packets and no Handshake packets, not even
acknowledgments.  So, to prevent deadlocks, if *either* endpoint
receives a packet from a space in which it has discarded keys, it will
probe in the next available space when it next sends something.  It will
only do this prior to connection establishment, meaning that it won't
probe with Application packets.

Closes #1336.