### PR TITLE
Minor improvement to neqo-crypto build script

### DIFF
--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -91,7 +91,12 @@ fn setup_clang() {
 
 fn nss_dir() -> PathBuf {
     let dir = if let Ok(dir) = env::var("NSS_DIR") {
-        PathBuf::from(dir.trim())
+        let path = PathBuf::from(dir.trim());
+        if path.is_relative() {
+            panic!("The NSS_DIR environment variable is expected to be an absolute path.");
+        }
+
+        path
     } else {
         let out_dir = env::var("OUT_DIR").unwrap();
         let dir = Path::new(&out_dir).join("nss");


### PR DESCRIPTION
If the NSS_DIR environment variable is absolute the user may be
presented with confusing error messages later in the build
script.

 - The NSS_DIR environment variable (if relative) is expected to be relative to `neqo-crypto`
 - The path added to the search path will not be correct, so the user will see a failure to find a needed lib

We could throw a warning and rely on the user to set the `LD_LIBRARY_PATH`
correctly, but it seems easier to just expect a absolute path.