### PR TITLE
Version Negotiation do not repeat client initial version

### DIFF
--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -573,6 +573,7 @@ impl Server {
             let vn = PacketBuilder::version_negotiation(
                 packet.scid(),
                 packet.dcid(),
+                packet.version().unwrap().as_u32(),
                 self.conn_params.get_versions().all(),
             );
             return Some(Datagram::new(dgram.destination(), dgram.source(), vn));


### PR DESCRIPTION
Avoid repeating the clients initial version in the supported versions
listed in the Version Negotiation packet.

Fixes: #1331 