### PR TITLE
Suppress borrow_as_ptr warnings

### DIFF
--- a/neqo-common/src/hrtime.rs
+++ b/neqo-common/src/hrtime.rs
@@ -163,7 +163,7 @@ mod mac {
             thread_policy_set(
                 pthread_mach_thread_np(pthread_self()),
                 THREAD_TIME_CONSTRAINT_POLICY,
-                addr_of_mut!(policy),
+                addr_of_mut!(policy) as _, // horror!
                 THREAD_TIME_CONSTRAINT_POLICY_COUNT,
             )
         };
@@ -198,7 +198,7 @@ mod mac {
             thread_policy_get(
                 pthread_mach_thread_np(pthread_self()),
                 THREAD_TIME_CONSTRAINT_POLICY,
-                addr_of_mut!(policy),
+                addr_of_mut!(policy) as _, // horror!
                 &mut count,
                 &mut get_default,
             )

--- a/neqo-common/src/hrtime.rs
+++ b/neqo-common/src/hrtime.rs
@@ -82,6 +82,7 @@ impl PeriodSet {
 #[allow(non_camel_case_types)]
 mod mac {
     use std::mem::size_of;
+    use std::ptr::addr_of_mut;
 
     // These are manually extracted from the many bindings generated
     // by bindgen when provided with the simple header:
@@ -162,7 +163,7 @@ mod mac {
             thread_policy_set(
                 pthread_mach_thread_np(pthread_self()),
                 THREAD_TIME_CONSTRAINT_POLICY,
-                &mut policy as *mut thread_time_constraint_policy as *mut _,
+                addr_of_mut!(policy),
                 THREAD_TIME_CONSTRAINT_POLICY_COUNT,
             )
         };
@@ -197,7 +198,7 @@ mod mac {
             thread_policy_get(
                 pthread_mach_thread_np(pthread_self()),
                 THREAD_TIME_CONSTRAINT_POLICY,
-                &mut policy as *mut thread_time_constraint_policy as *mut _,
+                addr_of_mut!(policy),
                 &mut count,
                 &mut get_default,
             )

--- a/neqo-crypto/src/cert.rs
+++ b/neqo-crypto/src/cert.rs
@@ -5,9 +5,7 @@
 // except according to those terms.
 
 use crate::err::secstatus_to_res;
-use crate::p11::{
-    CERTCertListNode, CERT_GetCertificateDer, CertList, Item, PRCList, SECItem, SECItemArray,
-};
+use crate::p11::{CERTCertListNode, CERT_GetCertificateDer, CertList, Item, SECItem, SECItemArray};
 use crate::ssl::{
     PRFileDesc, SSL_PeerCertificateChain, SSL_PeerSignedCertTimestamps,
     SSL_PeerStapledOCSPResponses,
@@ -15,7 +13,7 @@ use crate::ssl::{
 use neqo_common::qerror;
 
 use std::convert::TryFrom;
-use std::ptr::NonNull;
+use std::ptr::{addr_of, NonNull};
 
 use std::slice;
 
@@ -90,7 +88,7 @@ impl CertificateInfo {
 
     fn head(certs: &CertList) -> *const CERTCertListNode {
         // Three stars: one for the reference, one for the wrapper, one to deference the pointer.
-        unsafe { (&(***certs).list as *const PRCList).cast() }
+        unsafe { addr_of!((***certs).list).cast() }
     }
 }
 

--- a/neqo-crypto/src/ech.rs
+++ b/neqo-crypto/src/ech.rs
@@ -14,7 +14,7 @@ use neqo_common::qtrace;
 use std::convert::TryFrom;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_uint};
-use std::ptr::null_mut;
+use std::ptr::{addr_of_mut, null_mut};
 
 pub use crate::p11::{HpkeAeadId as AeadId, HpkeKdfId as KdfId, HpkeKemId as KemId};
 pub use crate::ssl::HpkeSymmetricSuite as SymmetricSuite;
@@ -98,6 +98,7 @@ pub fn generate_keys() -> Res<(PrivateKey, PublicKey)> {
     params.extend_from_slice(oid_slc);
 
     let mut public_ptr: *mut SECKEYPublicKey = null_mut();
+    let mut param_item = Item::wrap(&params);
 
     // If we have tracing on, try to ensure that key data can be read.
     let insensitive_secret_ptr = if log::log_enabled!(log::Level::Trace) {
@@ -105,7 +106,7 @@ pub fn generate_keys() -> Res<(PrivateKey, PublicKey)> {
             p11::PK11_GenerateKeyPairWithOpFlags(
                 *slot,
                 p11::CK_MECHANISM_TYPE::from(p11::CKM_EC_KEY_PAIR_GEN),
-                (&mut Item::wrap(&params) as *mut SECItem).cast(),
+                addr_of_mut!(param_item).cast(),
                 &mut public_ptr,
                 p11::PK11_ATTR_SESSION | p11::PK11_ATTR_INSENSITIVE | p11::PK11_ATTR_PUBLIC,
                 p11::CK_FLAGS::from(p11::CKF_DERIVE),
@@ -122,7 +123,7 @@ pub fn generate_keys() -> Res<(PrivateKey, PublicKey)> {
             p11::PK11_GenerateKeyPairWithOpFlags(
                 *slot,
                 p11::CK_MECHANISM_TYPE::from(p11::CKM_EC_KEY_PAIR_GEN),
-                (&mut Item::wrap(&params) as *mut SECItem).cast(),
+                addr_of_mut!(param_item).cast(),
                 &mut public_ptr,
                 p11::PK11_ATTR_SESSION | p11::PK11_ATTR_SENSITIVE | p11::PK11_ATTR_PRIVATE,
                 p11::CK_FLAGS::from(p11::CKF_DERIVE),

--- a/neqo-crypto/src/hp.rs
+++ b/neqo-crypto/src/hp.rs
@@ -18,7 +18,7 @@ use std::cell::RefCell;
 use std::convert::TryFrom;
 use std::fmt::{self, Debug};
 use std::os::raw::{c_char, c_int, c_uint};
-use std::ptr::{null, null_mut};
+use std::ptr::{addr_of_mut, null, null_mut};
 use std::rc::Rc;
 
 experimental_api!(SSL_HkdfExpandLabelWithMech(
@@ -166,11 +166,12 @@ impl HpKey {
                     ulNonceBits: 96,
                 };
                 let mut output_len: c_uint = 0;
+                let mut param_item = Item::wrap_struct(&params);
                 secstatus_to_res(unsafe {
                     PK11_Encrypt(
                         **key,
                         CK_MECHANISM_TYPE::from(CKM_CHACHA20),
-                        &Item::wrap_struct(&params) as *const _ as *mut _,
+                        addr_of_mut!(param_item),
                         (&mut output[..]).as_mut_ptr(),
                         &mut output_len,
                         c_uint::try_from(output.len())?,

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -77,6 +77,7 @@ const MINIMUM_NSS_VERSION: &str = "3.74";
 
 #[allow(non_upper_case_globals, clippy::redundant_static_lifetimes)]
 #[allow(clippy::upper_case_acronyms)]
+#[allow(unknown_lints, clippy::borrow_as_ptr)]
 mod nss {
     include!(concat!(env!("OUT_DIR"), "/nss_init.rs"));
 }

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -22,6 +22,7 @@ use std::ptr::null_mut;
 #[allow(clippy::upper_case_acronyms)]
 #[allow(unknown_lints, deref_nullptr)] // Until bindgen#1651 is fixed.
 #[allow(clippy::unreadable_literal)]
+#[allow(unknown_lints, clippy::borrow_as_ptr)]
 mod nss_p11 {
     include!(concat!(env!("OUT_DIR"), "/nss_p11.rs"));
 }

--- a/neqo-crypto/src/prio.rs
+++ b/neqo-crypto/src/prio.rs
@@ -13,6 +13,7 @@
     clippy::cognitive_complexity,
     clippy::empty_enum,
     clippy::too_many_lines,
+    unknown_lints,
     clippy::borrow_as_ptr
 )]
 

--- a/neqo-crypto/src/prio.rs
+++ b/neqo-crypto/src/prio.rs
@@ -12,7 +12,8 @@
     non_snake_case,
     clippy::cognitive_complexity,
     clippy::empty_enum,
-    clippy::too_many_lines
+    clippy::too_many_lines,
+    clippy::borrow_as_ptr
 )]
 
 include!(concat!(env!("OUT_DIR"), "/nspr_io.rs"));

--- a/neqo-crypto/src/ssl.rs
+++ b/neqo-crypto/src/ssl.rs
@@ -11,6 +11,7 @@
     clippy::cognitive_complexity,
     clippy::too_many_lines,
     clippy::upper_case_acronyms,
+    unknown_lints,
     clippy::borrow_as_ptr
 )]
 #![allow(unknown_lints, deref_nullptr)] // Until bindgen#1651 is fixed.

--- a/neqo-crypto/src/ssl.rs
+++ b/neqo-crypto/src/ssl.rs
@@ -10,7 +10,8 @@
     non_snake_case,
     clippy::cognitive_complexity,
     clippy::too_many_lines,
-    clippy::upper_case_acronyms
+    clippy::upper_case_acronyms,
+    clippy::borrow_as_ptr
 )]
 #![allow(unknown_lints, deref_nullptr)] // Until bindgen#1651 is fixed.
 


### PR DESCRIPTION
bindgen makes a hash of these, but so did we in a few places