### PR TITLE
Use AsRef and AsMut instead of Deref

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -6,7 +6,6 @@
 
 use std::convert::TryFrom;
 use std::fmt::Debug;
-use std::ops::{Deref, DerefMut};
 
 use crate::hex_with_len;
 
@@ -159,18 +158,18 @@ impl<'a> Decoder<'a> {
     }
 }
 
-// Implement `Deref` for `Decoder` so that values can be examined without moving the cursor.
-impl<'a> Deref for Decoder<'a> {
-    type Target = [u8];
+// Implement `AsRef` for `Decoder` so that values can be examined without
+// moving the cursor.
+impl<'a> AsRef<[u8]> for Decoder<'a> {
     #[must_use]
-    fn deref(&self) -> &[u8] {
+    fn as_ref(&self) -> &'a [u8] {
         &self.buf[self.offset..]
     }
 }
 
 impl<'a> Debug for Decoder<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(&hex_with_len(&self[..]))
+        f.write_str(&hex_with_len(self.as_ref()))
     }
 }
 
@@ -248,11 +247,24 @@ impl Encoder {
         self.buf.capacity()
     }
 
+    /// Get the length of the underlying buffer: the number of bytes that have
+    /// been written to the buffer.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Returns true if the encoder buffer contains no elements.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.buf.is_empty()
+    }
+
     /// Create a view of the current contents of the buffer.
     /// Note: for a view of a slice, use `Decoder::new(&enc[s..e])`
     #[must_use]
     pub fn as_decoder(&self) -> Decoder {
-        Decoder::new(self)
+        Decoder::new(self.as_ref())
     }
 
     /// Don't use this except in testing.
@@ -275,7 +287,7 @@ impl Encoder {
 
     /// Generic encode routine for arbitrary data.
     pub fn encode(&mut self, data: &[u8]) -> &mut Self {
-        self.buf.extend_from_slice(data);
+        self.buf.extend_from_slice(data.as_ref());
         self
     }
 
@@ -317,7 +329,7 @@ impl Encoder {
     /// # Panics
     /// When `v` is longer than 2^64.
     pub fn encode_vec(&mut self, n: usize, v: &[u8]) -> &mut Self {
-        self.encode_uint(n, u64::try_from(v.len()).unwrap())
+        self.encode_uint(n, u64::try_from(v.as_ref().len()).unwrap())
             .encode(v)
     }
 
@@ -341,7 +353,7 @@ impl Encoder {
     /// # Panics
     /// When `v` is longer than 2^64.
     pub fn encode_vvec(&mut self, v: &[u8]) -> &mut Self {
-        self.encode_varint(u64::try_from(v.len()).unwrap())
+        self.encode_varint(u64::try_from(v.as_ref().len()).unwrap())
             .encode(v)
     }
 
@@ -411,6 +423,12 @@ impl AsRef<[u8]> for Encoder {
     }
 }
 
+impl AsMut<[u8]> for Encoder {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.buf.as_mut()
+    }
+}
+
 impl<'a> From<Decoder<'a>> for Encoder {
     #[must_use]
     fn from(dec: Decoder<'a>) -> Self {
@@ -431,20 +449,6 @@ impl From<Encoder> for Vec<u8> {
     #[must_use]
     fn from(buf: Encoder) -> Self {
         buf.buf
-    }
-}
-
-impl Deref for Encoder {
-    type Target = [u8];
-    #[must_use]
-    fn deref(&self) -> &[u8] {
-        &self.buf[..]
-    }
-}
-
-impl DerefMut for Encoder {
-    fn deref_mut(&mut self) -> &mut [u8] {
-        &mut self.buf[..]
     }
 }
 
@@ -749,7 +753,7 @@ mod tests {
     fn encode_vec_with() {
         let mut enc = Encoder::default();
         enc.encode_vec_with(2, |enc_inner| {
-            enc_inner.encode(&Encoder::from_hex("02"));
+            enc_inner.encode(Encoder::from_hex("02").as_ref());
         });
         assert_eq!(enc, Encoder::from_hex("000102"));
     }
@@ -774,7 +778,7 @@ mod tests {
     fn encode_vvec_with() {
         let mut enc = Encoder::default();
         enc.encode_vvec_with(|enc_inner| {
-            enc_inner.encode(&Encoder::from_hex("02"));
+            enc_inner.encode(Encoder::from_hex("02").as_ref());
         });
         assert_eq!(enc, Encoder::from_hex("0102"));
     }
@@ -794,7 +798,7 @@ mod tests {
     fn encode_builder() {
         let mut enc = Encoder::from_hex("ff");
         let enc2 = Encoder::from_hex("010234");
-        enc.encode(&enc2);
+        enc.encode(enc2.as_ref());
         assert_eq!(enc, Encoder::from_hex("ff010234"));
     }
 
@@ -804,14 +808,14 @@ mod tests {
         let mut enc = Encoder::from_hex("ff");
         let enc2 = Encoder::from_hex("010234");
         let v = enc2.as_decoder();
-        enc.encode(&v);
+        enc.encode(v.as_ref());
         assert_eq!(enc, Encoder::from_hex("ff010234"));
     }
 
     #[test]
     fn encode_mutate() {
         let mut enc = Encoder::from_hex("010234");
-        enc[0] = 0xff;
+        enc.as_mut()[0] = 0xff;
         assert_eq!(enc, Encoder::from_hex("ff0234"));
     }
 

--- a/neqo-common/src/incrdecoder.rs
+++ b/neqo-common/src/incrdecoder.rs
@@ -178,7 +178,7 @@ mod tests {
 
             for tail in 1..db.len() {
                 let split = db.len() - tail;
-                let mut dv = Decoder::from(&db[0..split]);
+                let mut dv = Decoder::from(&db.as_ref()[0..split]);
                 eprintln!("  split at {}: {:?}", split, dv);
 
                 // Clone the basic decoder for each iteration of the loop.
@@ -192,7 +192,7 @@ mod tests {
                 if tail > 1 {
                     assert_eq!(res, None);
                     assert!(dec.min_remaining() > 0);
-                    let mut dv = Decoder::from(&db[split..]);
+                    let mut dv = Decoder::from(&db.as_ref()[split..]);
                     eprintln!("  split remainder {}: {:?}", split, dv);
                     res = dec.consume(&mut dv);
                     assert_eq!(dv.remaining(), 1);
@@ -230,7 +230,7 @@ mod tests {
     #[test]
     fn zero_len() {
         let enc = Encoder::from_hex("ff");
-        let mut dec = Decoder::new(&enc);
+        let mut dec = Decoder::new(enc.as_ref());
         let mut incr = IncrementalDecoderBuffer::new(0);
         assert_eq!(incr.consume(&mut dec), Some(Vec::new()));
         assert_eq!(dec.remaining(), enc.len());
@@ -244,7 +244,7 @@ mod tests {
 
         for tail in 1..db.len() {
             let split = db.len() - tail;
-            let mut dv = Decoder::from(&db[0..split]);
+            let mut dv = Decoder::from(&db.as_ref()[0..split]);
             eprintln!("  split at {}: {:?}", split, dv);
 
             // Clone the basic decoder for each iteration of the loop.
@@ -256,7 +256,7 @@ mod tests {
             if tail > 1 {
                 assert!(!res);
                 assert!(dec.min_remaining() > 0);
-                let mut dv = Decoder::from(&db[split..]);
+                let mut dv = Decoder::from(&db.as_ref()[split..]);
                 eprintln!("  split remainder {}: {:?}", split, dv);
                 res = dec.consume(&mut dv);
                 assert_eq!(dv.remaining(), 1);

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -92,10 +92,10 @@ fn setup_clang() {
 fn nss_dir() -> PathBuf {
     let dir = if let Ok(dir) = env::var("NSS_DIR") {
         let path = PathBuf::from(dir.trim());
-        if path.is_relative() {
-            panic!("The NSS_DIR environment variable is expected to be an absolute path.");
-        }
-
+        assert!(
+            !path.is_relative(),
+            "The NSS_DIR environment variable is expected to be an absolute path."
+        );
         path
     } else {
         let out_dir = env::var("OUT_DIR").unwrap();

--- a/neqo-crypto/src/selfencrypt.rs
+++ b/neqo-crypto/src/selfencrypt.rs
@@ -90,7 +90,7 @@ impl SelfEncrypt {
         let offset = enc.len();
         let mut output: Vec<u8> = enc.into();
         output.resize(encoded_len, 0);
-        cipher.encrypt(0, &extended_aad, plaintext, &mut output[offset..])?;
+        cipher.encrypt(0, extended_aad.as_ref(), plaintext, &mut output[offset..])?;
         qtrace!(
             ["SelfEncrypt"],
             "seal {} {} -> {}",
@@ -139,7 +139,8 @@ impl SelfEncrypt {
         // NSS insists on having extra space available for decryption.
         let padded_len = ciphertext.len() - offset;
         let mut output = vec![0; padded_len];
-        let decrypted = aead.decrypt(0, &extended_aad, &ciphertext[offset..], &mut output)?;
+        let decrypted =
+            aead.decrypt(0, extended_aad.as_ref(), &ciphertext[offset..], &mut output)?;
         let final_len = decrypted.len();
         output.truncate(final_len);
         qtrace!(

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -39,7 +39,7 @@ impl ControlStreamLocal {
     pub fn queue_frame(&mut self, f: &HFrame) {
         let mut enc = Encoder::default();
         f.encode(&mut enc);
-        self.stream.buffer(&enc);
+        self.stream.buffer(enc.as_ref());
     }
 
     pub fn queue_update_priority(&mut self, stream_id: StreamId) {
@@ -80,7 +80,7 @@ impl ControlStreamLocal {
             if let Some(hframe) = stream.priority_update_frame() {
                 let mut enc = Encoder::new();
                 hframe.encode(&mut enc);
-                if self.stream.send_atomic(conn, &enc)? {
+                if self.stream.send_atomic(conn, enc.as_ref())? {
                     stream.priority_update_sent();
                 } else {
                     self.outstanding_priority_update.push_front(update_id);

--- a/neqo-http3/src/features/extended_connect/webtransport_session.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_session.rs
@@ -377,7 +377,8 @@ impl WebTransportSession {
         };
         let mut encoder = Encoder::default();
         close_frame.encode(&mut encoder);
-        self.control_stream_send.send_data_atomic(conn, &encoder)?;
+        self.control_stream_send
+            .send_data_atomic(conn, encoder.as_ref())?;
         self.control_stream_send.close(conn)?;
         self.state = if self.control_stream_send.done() {
             SessionState::Done

--- a/neqo-http3/src/frames/hframe.rs
+++ b/neqo-http3/src/frames/hframe.rs
@@ -138,7 +138,7 @@ impl HFrame {
 
                 update_frame.encode(&priority_enc);
                 enc.encode_varint(update_frame.len() as u64);
-                enc.encode(&update_frame);
+                enc.encode(update_frame.as_ref());
             }
         }
     }

--- a/neqo-http3/src/frames/tests/mod.rs
+++ b/neqo-http3/src/frames/tests/mod.rs
@@ -17,7 +17,7 @@ use test_fixture::{default_client, default_server, now};
 pub fn enc_dec<T: FrameDecoder<T>>(d: &Encoder, st: &str, remaining: usize) -> T {
     // For data, headers and push_promise we do not read all bytes from the buffer
     let d2 = Encoder::from_hex(st);
-    assert_eq!(&d[..], &d2[..d.len()]);
+    assert_eq!(d.as_ref(), &d2.as_ref()[..d.as_ref().len()]);
 
     let mut conn_c = default_client();
     let mut conn_s = default_server();
@@ -36,7 +36,7 @@ pub fn enc_dec<T: FrameDecoder<T>>(d: &Encoder, st: &str, remaining: usize) -> T
 
     // conver string into u8 vector
     let buf = Encoder::from_hex(st);
-    conn_s.stream_send(stream_id, &buf[..]).unwrap();
+    conn_s.stream_send(stream_id, buf.as_ref()).unwrap();
     let out = conn_s.process(None, now());
     mem::drop(conn_c.process(out.dgram(), now()));
 

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -210,7 +210,7 @@ impl SendStream for SendMessage {
         data_frame.encode(&mut enc);
         let sent_fh = self
             .stream
-            .send_atomic(conn, &enc)
+            .send_atomic(conn, enc.as_ref())
             .map_err(|e| Error::map_stream_send_errors(&e))?;
         debug_assert!(sent_fh);
 
@@ -300,7 +300,7 @@ impl SendStream for SendMessage {
         };
         let mut enc = Encoder::default();
         data_frame.encode(&mut enc);
-        self.stream.buffer(&enc);
+        self.stream.buffer(enc.as_ref());
         self.stream.buffer(buf);
         mem::drop(self.stream.send_buffer(conn)?);
         Ok(())

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -611,7 +611,7 @@ mod tests {
         };
         let mut e = Encoder::default();
         frame.encode(&mut e);
-        peer_conn.control_send(&e);
+        peer_conn.control_send(e.as_ref());
         let out = peer_conn.process(None, now());
         hconn.process(out.dgram(), now());
         // check if the given connection got closed on invalid stream ids

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -317,7 +317,7 @@ mod tests {
             for i in to_encode {
                 enc.encode_varint(*i);
             }
-            self.decode_buffer(&enc[..], fin, outcome, done);
+            self.decode_buffer(enc.as_ref(), fin, outcome, done);
         }
     }
 

--- a/neqo-http3/tests/webtransport/negotiation.rs
+++ b/neqo-http3/tests/webtransport/negotiation.rs
@@ -139,8 +139,8 @@ fn wrong_setting_value() {
     };
     settings.encode(&mut enc);
     assert_eq!(
-        server.stream_send(control, &enc[..]).unwrap(),
-        enc[..].len()
+        server.stream_send(control, enc.as_ref()).unwrap(),
+        enc.as_ref().len()
     );
 
     exchange_packets2(&mut client, &mut server);

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -127,7 +127,7 @@ impl AddressValidation {
 
         // Include the token identifier ("Retry"/~) in the AAD, then keep it for plaintext.
         let mut buf = Self::encode_aad(peer_address, retry);
-        let encrypted = self.self_encrypt.seal(&buf, &data)?;
+        let encrypted = self.self_encrypt.seal(buf.as_ref(), data.as_ref())?;
         buf.truncate(TOKEN_IDENTIFIER_RETRY.len());
         buf.encode(&encrypted);
         Ok(buf.into())
@@ -165,7 +165,7 @@ impl AddressValidation {
         now: Instant,
     ) -> Option<ConnectionId> {
         let peer_addr = Self::encode_aad(peer_address, retry);
-        let data = self.self_encrypt.open(&peer_addr, token).ok()?;
+        let data = self.self_encrypt.open(peer_addr.as_ref(), token).ok()?;
         let mut dec = Decoder::new(&data);
         match dec.decode_uint(4) {
             Some(d) => {

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -715,7 +715,7 @@ impl Connection {
                 tps.borrow().local.encode(enc_inner);
             });
             enc.encode(extra);
-            let records = s.send_ticket(now, &enc)?;
+            let records = s.send_ticket(now, enc.as_ref())?;
             qinfo!([self], "send session ticket {}", hex(&enc));
             self.crypto.buffer_records(records)?;
         } else {
@@ -2128,13 +2128,20 @@ impl Connection {
                 continue;
             }
 
-            dump_packet(self, path, "TX ->", pt, pn, &builder[payload_start..]);
+            dump_packet(
+                self,
+                path,
+                "TX ->",
+                pt,
+                pn,
+                &builder.as_ref()[payload_start..],
+            );
             qlog::packet_sent(
                 &mut self.qlog,
                 pt,
                 pn,
                 builder.len() - header_start + aead_expansion,
-                &builder[payload_start..],
+                &builder.as_ref()[payload_start..],
             );
 
             self.stats.borrow_mut().packets_tx += 1;

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -355,7 +355,7 @@ impl Crypto {
                 });
                 enc.encode_vvec(new_token.unwrap_or(&[]));
                 enc.encode(t.as_ref());
-                qinfo!("resumption token {}", hex_snip_middle(&enc[..]));
+                qinfo!("resumption token {}", hex_snip_middle(enc.as_ref()));
                 Some(ResumptionToken::new(enc.into(), t.expiration_time()))
             } else {
                 None

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -210,7 +210,7 @@ impl PacketBuilder {
     }
 
     fn is_long(&self) -> bool {
-        self[self.header.start] & 0x80 == PACKET_BIT_LONG
+        self.as_ref()[self.header.start] & 0x80 == PACKET_BIT_LONG
     }
 
     /// This stores a value that can be used as a limit.  This does not cause
@@ -267,7 +267,7 @@ impl PacketBuilder {
         let mask = if quic_bit { PACKET_BIT_FIXED_QUIC } else { 0 }
             | if self.is_long() { 0 } else { PACKET_BIT_SPIN };
         let first = self.header.start;
-        self[first] ^= random(1)[0] & mask;
+        self.encoder.as_mut()[first] ^= random(1)[0] & mask;
     }
 
     /// For an Initial packet, encode the token.
@@ -306,15 +306,15 @@ impl PacketBuilder {
         self.offsets.pn = pn_offset..self.encoder.len();
 
         // Now encode the packet number length and save the header length.
-        self.encoder[self.header.start] |= u8::try_from(pn_len - 1).unwrap();
+        self.encoder.as_mut()[self.header.start] |= u8::try_from(pn_len - 1).unwrap();
         self.header.end = self.encoder.len();
         self.pn = pn;
     }
 
     fn write_len(&mut self, expansion: usize) {
         let len = self.encoder.len() - (self.offsets.len + 2) + expansion;
-        self.encoder[self.offsets.len] = 0x40 | ((len >> 8) & 0x3f) as u8;
-        self.encoder[self.offsets.len + 1] = (len & 0xff) as u8;
+        self.encoder.as_mut()[self.offsets.len] = 0x40 | ((len >> 8) & 0x3f) as u8;
+        self.encoder.as_mut()[self.offsets.len + 1] = (len & 0xff) as u8;
     }
 
     fn pad_for_crypto(&mut self, crypto: &mut CryptoDxState) {
@@ -360,8 +360,8 @@ impl PacketBuilder {
             self.write_len(crypto.expansion());
         }
 
-        let hdr = &self.encoder[self.header.clone()];
-        let body = &self.encoder[self.header.end..];
+        let hdr = &self.encoder.as_ref()[self.header.clone()];
+        let body = &self.encoder.as_ref()[self.header.end..];
         qtrace!(
             "Packet build pn={} hdr={} body={}",
             self.pn,
@@ -377,9 +377,9 @@ impl PacketBuilder {
         let mask = crypto.compute_mask(sample)?;
 
         // Apply the mask.
-        self.encoder[self.header.start] ^= mask[0] & self.offsets.first_byte_mask;
+        self.encoder.as_mut()[self.header.start] ^= mask[0] & self.offsets.first_byte_mask;
         for (i, j) in (1..=self.offsets.pn.len()).zip(self.offsets.pn) {
-            self.encoder[j] ^= mask[i];
+            self.encoder.as_mut()[j] ^= mask[i];
         }
 
         // Finally, cut off the plaintext and add back the ciphertext.
@@ -429,7 +429,7 @@ impl PacketBuilder {
         encoder.encode(token);
         let tag = retry::use_aead(version, |aead| {
             let mut buf = vec![0; aead.expansion()];
-            Ok(aead.encrypt(0, &encoder, &[], &mut buf)?.to_vec())
+            Ok(aead.encrypt(0, encoder.as_ref(), &[], &mut buf)?.to_vec())
         })?;
         encoder.encode(&tag);
         let mut complete: Vec<u8> = encoder.into();
@@ -646,7 +646,7 @@ impl<'a> PublicPacket<'a> {
         encoder.encode(header);
         retry::use_aead(version, |aead| {
             let mut buf = vec![0; expansion];
-            Ok(aead.decrypt(0, &encoder, tag, &mut buf)?.is_empty())
+            Ok(aead.decrypt(0, encoder.as_ref(), tag, &mut buf)?.is_empty())
         })
         .unwrap_or(false)
     }
@@ -906,7 +906,7 @@ mod tests {
         builder.pn(1, 2);
         builder.encode(SAMPLE_INITIAL_PAYLOAD);
         let packet = builder.build(&mut prot).expect("build");
-        assert_eq!(&packet[..], SAMPLE_INITIAL);
+        assert_eq!(packet.as_ref(), SAMPLE_INITIAL);
     }
 
     #[test]
@@ -938,7 +938,7 @@ mod tests {
         enc.encode_vec(1, &[]);
         enc.encode(&[0xff; 40]); // junk
 
-        assert!(PublicPacket::decode(&enc, &cid_mgr()).is_err());
+        assert!(PublicPacket::decode(enc.as_ref(), &cid_mgr()).is_err());
     }
 
     #[test]
@@ -950,7 +950,7 @@ mod tests {
         enc.encode_vec(1, &[0x00; MAX_CONNECTION_ID_LEN + 2]);
         enc.encode(&[0xff; 40]); // junk
 
-        assert!(PublicPacket::decode(&enc, &cid_mgr()).is_err());
+        assert!(PublicPacket::decode(enc.as_ref(), &cid_mgr()).is_err());
     }
 
     const SAMPLE_SHORT: &[u8] = &[
@@ -969,7 +969,7 @@ mod tests {
         let packet = builder
             .build(&mut CryptoDxState::test_default())
             .expect("build");
-        assert_eq!(&packet[..], SAMPLE_SHORT);
+        assert_eq!(packet.as_ref(), SAMPLE_SHORT);
     }
 
     #[test]
@@ -981,7 +981,7 @@ mod tests {
                 PacketBuilder::short(Encoder::new(), true, &ConnectionId::from(SERVER_CID));
             builder.scramble(true);
             builder.pn(0, 1);
-            firsts.push(builder[0]);
+            firsts.push(builder.as_ref()[0]);
         }
         let is_set = |bit| move |v| v & bit == bit;
         // There should be at least one value with the QUIC bit set:
@@ -1054,8 +1054,8 @@ mod tests {
         builder.encode(&[0]); // Minimal size (packet number is big enough).
         let encoder = builder.build(&mut prot).expect("build");
         assert_eq!(
-            &first[..],
-            &encoder[..first.len()],
+            first.as_ref(),
+            &encoder.as_ref()[..first.len()],
             "the first packet should be a prefix"
         );
         assert_eq!(encoder.len(), 45 + 29);
@@ -1080,7 +1080,7 @@ mod tests {
         builder.pn(0, 1);
         builder.encode(&[1, 2, 3]);
         let packet = builder.build(&mut CryptoDxState::test_default()).unwrap();
-        assert_eq!(&packet[..], EXPECTED);
+        assert_eq!(packet.as_ref(), EXPECTED);
     }
 
     #[test]
@@ -1098,7 +1098,7 @@ mod tests {
             );
             builder.pn(0, 1);
             builder.scramble(true);
-            if (builder[0] & PACKET_BIT_FIXED_QUIC) == 0 {
+            if (builder.as_ref()[0] & PACKET_BIT_FIXED_QUIC) == 0 {
                 found_unset = true;
             } else {
                 found_set = true;
@@ -1381,7 +1381,7 @@ mod tests {
         enc.encode_uint(4, 0x5a6a_7a8a_u64);
 
         let (packet, remainder) =
-            PublicPacket::decode(&enc, &EmptyConnectionIdGenerator::default()).unwrap();
+            PublicPacket::decode(enc.as_ref(), &EmptyConnectionIdGenerator::default()).unwrap();
         assert!(remainder.is_empty());
         assert_eq!(&packet.dcid[..], BIG_DCID);
         assert!(packet.scid.is_some());

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1966,7 +1966,10 @@ mod tests {
             &mut tokens,
             &mut stats,
         );
-        qtrace!("STREAM frame: {}", hex_with_len(&builder[header_len..]));
+        qtrace!(
+            "STREAM frame: {}",
+            hex_with_len(&builder.as_ref()[header_len..])
+        );
         stats.stream > 0
     }
 

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -657,7 +657,7 @@ impl ExtensionHandler for TransportParametersHandler {
         let mut enc = Encoder::default();
         self.local.encode(&mut enc);
         assert!(enc.len() <= d.len());
-        d[..enc.len()].copy_from_slice(&enc);
+        d[..enc.len()].copy_from_slice(enc.as_ref());
         ExtensionWriterResult::Write(enc.len())
     }
 
@@ -811,7 +811,7 @@ mod tests {
         let spa = make_spa();
         let mut enc = Encoder::new();
         spa.encode(&mut enc, PREFERRED_ADDRESS);
-        assert_eq!(&enc[..], ENCODED);
+        assert_eq!(enc.as_ref(), ENCODED);
 
         let mut dec = enc.as_decoder();
         let (id, decoded) = TransportParameter::decode(&mut dec).unwrap().unwrap();
@@ -905,7 +905,7 @@ mod tests {
         let spa = make_spa();
         let mut enc = Encoder::new();
         spa.encode(&mut enc, PREFERRED_ADDRESS);
-        let mut dec = Decoder::from(&enc[..enc.len() - 1]);
+        let mut dec = Decoder::from(&enc.as_ref()[..enc.len() - 1]);
         assert_eq!(
             TransportParameter::decode(&mut dec).unwrap_err(),
             Error::NoMoreData
@@ -1097,7 +1097,7 @@ mod tests {
 
         let mut enc = Encoder::new();
         vn.encode(&mut enc, VERSION_NEGOTIATION);
-        assert_eq!(&enc[..], ENCODED);
+        assert_eq!(enc.as_ref(), ENCODED);
 
         let mut dec = enc.as_decoder();
         let (id, decoded) = TransportParameter::decode(&mut dec).unwrap().unwrap();

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -375,12 +375,13 @@ fn mitm_retry() {
         .encode_vvec(&[])
         .encode_varint(u64::try_from(payload.len()).unwrap());
     let pn_offset = enc.len();
-    let notoken_header = enc.encode_uint(pn_len, pn).to_vec();
+    let notoken_header = enc.encode_uint(pn_len, pn).as_ref().to_vec();
     qtrace!("notoken_header={}", hex_with_len(&notoken_header));
 
     // Encrypt.
     let mut notoken_packet = Encoder::with_capacity(1200)
         .encode(&notoken_header)
+        .as_ref()
         .to_vec();
     notoken_packet.resize_with(1200, u8::default);
     aead.encrypt(

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -409,13 +409,13 @@ fn bad_client_initial() {
         .encode_varint(u64::try_from(payload_enc.len() + aead.expansion() + 1).unwrap())
         .encode_byte(u8::try_from(pn).unwrap());
 
-    let mut ciphertext = header_enc.to_vec();
+    let mut ciphertext = header_enc.as_ref().to_vec();
     ciphertext.resize(header_enc.len() + payload_enc.len() + aead.expansion(), 0);
     let v = aead
         .encrypt(
             pn,
-            &header_enc,
-            &payload_enc,
+            header_enc.as_ref(),
+            payload_enc.as_ref(),
             &mut ciphertext[header_enc.len()..],
         )
         .unwrap();

--- a/neqo-transport/tests/sim/mod.rs
+++ b/neqo-transport/tests/sim/mod.rs
@@ -149,7 +149,7 @@ impl Simulator {
     /// Though this is convenient, it panics if this isn't a 64 character hex string.
     pub fn seed_str(&mut self, seed: impl AsRef<str>) {
         let seed = Encoder::from_hex(seed);
-        self.seed(<[u8; 32]>::try_from(&seed[..]).unwrap());
+        self.seed(<[u8; 32]>::try_from(seed.as_ref()).unwrap());
     }
 
     fn next_time(&self, now: Instant) -> Instant {


### PR DESCRIPTION
Use the `AsRef` and `AsMut` traits instead of `Deref` to access the `Encoder`
and `Decoder` internal buffers.