### PR TITLE
Fix changes to VN

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1229,7 +1229,7 @@ impl Connection {
                 match packet.supported_versions() {
                     Ok(versions) => {
                         if versions.is_empty()
-                            || versions.contains(&self.version().as_u32())
+                            || versions.contains(&self.version().wire_version())
                             || versions.contains(&0)
                             || packet.scid() != self.odcid().unwrap()
                             || matches!(
@@ -2396,7 +2396,7 @@ impl Connection {
             qtrace!(
                 [self],
                 "validate_versions: current={:x} chosen={:x} other={:x?}",
-                self.version.as_u32(),
+                self.version.wire_version(),
                 current,
                 other,
             );
@@ -2406,7 +2406,7 @@ impl Connection {
                 // All we need to do is confirm that the transport parameter
                 // was provided.
                 Ok(())
-            } else if self.version().as_u32() != current {
+            } else if self.version().wire_version() != current {
                 qinfo!([self], "validate_versions: current version mismatch");
                 Err(Error::VersionNegotiation)
             } else if self

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -348,7 +348,7 @@ impl Crypto {
             if let Some(ref t) = c.resumption_token() {
                 qtrace!("TLS token {}", hex(t.as_ref()));
                 let mut enc = Encoder::default();
-                enc.encode_uint(4, version.as_u32());
+                enc.encode_uint(4, version.wire_version());
                 enc.encode_varint(rtt);
                 enc.encode_vvec_with(|enc_inner| {
                     tps.encode(enc_inner);

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -98,7 +98,7 @@ fn connection_started(qlog: &mut NeqoQlog, path: &PathRef) {
             Some("QUIC".into()),
             p.local_address().port().into(),
             p.remote_address().port().into(),
-            Some(format!("{:x}", Version::default().as_u32())),
+            Some(format!("{:x}", Version::default().wire_version())),
             Some(format!("{}", p.local_cid())),
             Some(format!("{}", p.remote_cid())),
         ))

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -569,11 +569,11 @@ impl Server {
                 return None;
             }
 
-            qdebug!([self], "Unsupported version: {:?}", packet.version());
+            qdebug!([self], "Unsupported version: {:x}", packet.wire_version());
             let vn = PacketBuilder::version_negotiation(
                 packet.scid(),
                 packet.dcid(),
-                packet.version().unwrap().as_u32(),
+                packet.wire_version(),
                 self.conn_params.get_versions().all(),
             );
             return Some(Datagram::new(dgram.destination(), dgram.source(), vn));

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -439,9 +439,9 @@ impl TransportParameters {
             if role == Role::Client && !versions.initial().is_compatible(v) {
                 continue;
             }
-            other.push(v.as_u32());
+            other.push(v.wire_version());
         }
-        let current = versions.initial().as_u32();
+        let current = versions.initial().wire_version();
         self.set(
             VERSION_NEGOTIATION,
             TransportParameter::Versions { current, other },
@@ -453,7 +453,7 @@ impl TransportParameters {
             ref mut current, ..
         }) = self.params.get_mut(&VERSION_NEGOTIATION)
         {
-            *current = v.as_u32();
+            *current = v.wire_version();
         } else {
             unreachable!("Compatible upgrade without transport parameters set!");
         }
@@ -609,16 +609,16 @@ impl TransportParametersHandler {
                     qinfo!(
                         "Chosen version {:x} is not compatible with initial version {:x}",
                         current,
-                        self.versions.initial().as_u32(),
+                        self.versions.initial().wire_version(),
                     );
                     Err(Error::TransportParameterError)
                 }
             } else {
-                if current != self.versions.initial().as_u32() {
+                if current != self.versions.initial().wire_version() {
                     qinfo!(
                         "Current version {:x} != own version {:x}",
                         current,
-                        self.versions.initial().as_u32(),
+                        self.versions.initial().wire_version(),
                     );
                     return Err(Error::TransportParameterError);
                 }
@@ -1091,7 +1091,7 @@ mod tests {
             0x6a, 0x7a, 0x8a,
         ];
         let vn = TransportParameter::Versions {
-            current: Version::Version1.as_u32(),
+            current: Version::Version1.wire_version(),
             other: vec![0x1a2a_3a4a, 0x5a6a_7a8a],
         };
 
@@ -1143,7 +1143,7 @@ mod tests {
         current.set(
             VERSION_NEGOTIATION,
             TransportParameter::Versions {
-                current: Version::Version1.as_u32(),
+                current: Version::Version1.wire_version(),
                 other: vec![0x1a2a_3a4a],
             },
         );
@@ -1158,7 +1158,7 @@ mod tests {
         remembered.set(
             VERSION_NEGOTIATION,
             TransportParameter::Versions {
-                current: Version::Version1.as_u32(),
+                current: Version::Version1.wire_version(),
                 other: vec![0x5a6a_7a8a, 0x9aaa_baca],
             },
         );
@@ -1169,7 +1169,7 @@ mod tests {
         remembered.set(
             VERSION_NEGOTIATION,
             TransportParameter::Versions {
-                current: Version::Version1.as_u32() + 1,
+                current: Version::Version1.wire_version() + 1,
                 other: vec![],
             },
         );

--- a/neqo-transport/src/version.rs
+++ b/neqo-transport/src/version.rs
@@ -21,7 +21,7 @@ pub enum Version {
 }
 
 impl Version {
-    pub const fn as_u32(self) -> WireVersion {
+    pub const fn wire_version(self) -> WireVersion {
         match self {
             Self::Version2 => 0x709a50c4,
             Self::Version1 => 1,
@@ -208,7 +208,7 @@ impl VersionConfig {
         vn: &[WireVersion],
     ) -> Option<Version> {
         for v in preferences {
-            if vn.contains(&v.as_u32()) {
+            if vn.contains(&v.wire_version()) {
                 return Some(*v);
             }
         }


### PR DESCRIPTION
CI not working really hid a major problem here.  Let's not let this rot
so much again...

The code didn't work here because we weren't saving the wire version
when we parsed the packet header for a packet that had an unsupported
version.  Now we do, so we can correctly generate a VN packet.

I took the liberty of renaming as_u32 to wire_version so that we are
more consistent with the naming of the version functions.