### PR TITLE
`aead_fuzzing::Aead::new`: Don't panic in release builds.

### DIFF
--- a/neqo-crypto/src/aead_fuzzing.rs
+++ b/neqo-crypto/src/aead_fuzzing.rs
@@ -15,9 +15,6 @@ pub struct Aead {}
 #[allow(clippy::unused_self)]
 impl Aead {
     pub fn new(_version: Version, _cipher: Cipher, _secret: &SymKey, _prefix: &str) -> Res<Self> {
-        #[cfg(not(debug_assertions))]
-        panic!("Trying to run a non-debug fuzzing build.");
-
         Ok(Self {})
     }
 


### PR DESCRIPTION
The original rationale for this panic was to ensure we never ship users a Firefox with a crypto-disabled version of aead. However, it is common for Firefox fuzzing builds to be optimized: fuzzing is often combined with LLVM's Address Sanitizer, whose docs recommend optimized builds. Such Firefox builds crash the moment anything tries to initialize Aead.

There are other safeguards in place that prevent Mozilla from shipping fuzzing-enabled builds, so this one can be removed.

[edit:] This solution to the problem was discussed in [Bug 1743672](https://bugzilla.mozilla.org/show_bug.cgi?id=1743672#c11).