### PR TITLE
Placate clippy.

### DIFF
--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -27,11 +27,13 @@ pub use self::incrdecoder::{
 #[macro_use]
 extern crate lazy_static;
 
+use std::fmt::Write;
+
 #[must_use]
 pub fn hex(buf: impl AsRef<[u8]>) -> String {
     let mut ret = String::with_capacity(buf.as_ref().len() * 2);
     for b in buf.as_ref() {
-        ret.push_str(&format!("{:02x}", b));
+        write!(&mut ret, "{:02x}", b).unwrap();
     }
     ret
 }
@@ -44,13 +46,13 @@ pub fn hex_snip_middle(buf: impl AsRef<[u8]>) -> String {
         hex_with_len(buf)
     } else {
         let mut ret = String::with_capacity(SHOW_LEN * 2 + 16);
-        ret.push_str(&format!("[{}]: ", buf.len()));
+        write!(&mut ret, "[{}]: ", buf.len()).unwrap();
         for b in &buf[..SHOW_LEN] {
-            ret.push_str(&format!("{:02x}", b));
+            write!(&mut ret, "{:02x}", b).unwrap();
         }
         ret.push_str("..");
         for b in &buf[buf.len() - SHOW_LEN..] {
-            ret.push_str(&format!("{:02x}", b));
+            write!(&mut ret, "{:02x}", b).unwrap();
         }
         ret
     }
@@ -60,9 +62,9 @@ pub fn hex_snip_middle(buf: impl AsRef<[u8]>) -> String {
 pub fn hex_with_len(buf: impl AsRef<[u8]>) -> String {
     let buf = buf.as_ref();
     let mut ret = String::with_capacity(10 + buf.len() * 2);
-    ret.push_str(&format!("[{}]: ", buf.len()));
+    write!(&mut ret, "[{}]: ", buf.len()).unwrap();
     for b in buf {
-        ret.push_str(&format!("{:02x}", b));
+        write!(&mut ret, "{:02x}", b).unwrap();
     }
     ret
 }

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(clippy::module_name_repetitions)]
+
 use std::io::Write;
 use std::sync::Once;
 use std::time::Instant;

--- a/neqo-transport/src/dump.rs
+++ b/neqo-transport/src/dump.rs
@@ -13,6 +13,8 @@ use crate::packet::{PacketNumber, PacketType};
 use crate::path::PathRef;
 use neqo_common::{qdebug, Decoder};
 
+use std::fmt::Write;
+
 #[allow(clippy::module_name_repetitions)]
 pub fn dump_packet(
     conn: &Connection,
@@ -37,7 +39,7 @@ pub fn dump_packet(
             }
         };
         if let Some(x) = f.dump() {
-            s.push_str(&format!("\n  {} {}", dir, &x));
+            write!(&mut s, "\n  {} {}", dir, &x).unwrap();
         }
     }
     qdebug!([conn], "pn={} type={:?} {}{}", pn, pt, path.borrow(), s);

--- a/neqo-transport/tests/sim/mod.rs
+++ b/neqo-transport/tests/sim/mod.rs
@@ -59,7 +59,7 @@ macro_rules! simulate {
         #[test]
         fn $n() {
             let fixture = $setup;
-            let mut nodes: Vec<Box<dyn crate::sim::Node>> = Vec::new();
+            let mut nodes: Vec<Box<dyn $crate::sim::Node>> = Vec::new();
             $(
                 let f: Box<dyn FnOnce(&_) -> _> = Box::new($v);
                 nodes.push(Box::new(f(&fixture)));


### PR DESCRIPTION
Use the `write!` macro to extend strings with formatted text.

Allow clippy::module_name_repetitions in the `log` module.