### PR TITLE
Delete misleading error output by client

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -490,10 +490,9 @@ impl<'a> Handler<'a> {
                 self.streams.insert(client_stream_id, out_file);
                 true
             }
-            e @ Err(Error::TransportError(TransportError::StreamLimitError))
-            | e @ Err(Error::StreamLimitError)
-            | e @ Err(Error::Unavailable) => {
-                println!("Cannot create stream {:?}", e);
+            _e @ Err(Error::TransportError(TransportError::StreamLimitError))
+            | _e @ Err(Error::StreamLimitError)
+            | _e @ Err(Error::Unavailable) => {
                 self.url_queue.push_front(url);
                 false
             }

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -490,9 +490,9 @@ impl<'a> Handler<'a> {
                 self.streams.insert(client_stream_id, out_file);
                 true
             }
-            _e @ Err(Error::TransportError(TransportError::StreamLimitError))
-            | _e @ Err(Error::StreamLimitError)
-            | _e @ Err(Error::Unavailable) => {
+            Err(Error::TransportError(TransportError::StreamLimitError))
+            | Err(Error::StreamLimitError)
+            | Err(Error::Unavailable) => {
                 self.url_queue.push_front(url);
                 false
             }


### PR DESCRIPTION
# Related Issue https://github.com/mozilla/neqo/issues/1334

# Changes
- Delete `println!("Cannot create stream {:?}", e);`.