### PR TITLE
Add idle timeout flag to command-line tools

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -23,7 +23,6 @@ use neqo_transport::{
     EmptyConnectionIdGenerator, Error as TransportError, StreamId, StreamType, Version,
 };
 
-use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::convert::TryFrom;
 use std::fmt::{self, Display};
@@ -35,6 +34,7 @@ use std::process::exit;
 use std::rc::Rc;
 use std::str::FromStr;
 use std::time::Instant;
+use std::{cell::RefCell, time::Duration};
 
 use structopt::StructOpt;
 use url::{Origin, Url};
@@ -290,6 +290,10 @@ struct QuicParameters {
     /// Set the MAX_STREAMS_UNI limit.
     max_streams_uni: u64,
 
+    #[structopt(long = "idle", default_value = "30")]
+    /// The idle timeout for connections, in seconds.
+    idle_timeout: u64,
+
     #[structopt(long = "cc", default_value = "newreno")]
     /// The congestion controller to use.
     congestion_control: CongestionControlAlgorithm,
@@ -300,6 +304,7 @@ impl QuicParameters {
         let params = ConnectionParameters::default()
             .max_streams(StreamType::BiDi, self.max_streams_bidi)
             .max_streams(StreamType::UniDi, self.max_streams_uni)
+            .idle_timeout(Duration::from_secs(self.idle_timeout))
             .cc_algorithm(self.congestion_control);
 
         if let Some(&first) = self.quic_version.first() {

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -232,6 +232,10 @@ struct QuicParameters {
     /// Set the MAX_STREAMS_UNI limit.
     max_streams_uni: u64,
 
+    #[structopt(long = "idle", default_value = "30")]
+    /// The idle timeout for connections, in seconds.
+    idle_timeout: u64,
+
     #[structopt(long = "cc", default_value = "newreno")]
     /// The congestion controller to use.
     congestion_control: CongestionControlAlgorithm,
@@ -287,6 +291,7 @@ impl QuicParameters {
         let mut params = ConnectionParameters::default()
             .max_streams(StreamType::BiDi, self.max_streams_bidi)
             .max_streams(StreamType::UniDi, self.max_streams_uni)
+            .idle_timeout(Duration::from_secs(self.idle_timeout))
             .cc_algorithm(self.congestion_control);
         if let Some(pa) = self.preferred_address() {
             params = params.preferred_address(pa);


### PR DESCRIPTION
Based on a request I'm fielding about this, it seems like it would be helpful to add this.

For a later date, we might consider consolidating some of this code.  The duplication is a problem.  We'd probably want to add that to the mainline code, but under a feature flag, so that we don't pull in all the dependencies unless we're building the command-line tools as well.