### PR TITLE
add instructions on how to solve the failure to load dynamic library at run time

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ To run test HTTP/3 programs (neqo-client and neqo-server):
 * `./target/debug/neqo-server [::]:12345 --db ./test-fixture/db`
 * `./target/debug/neqo-client http://127.0.0.1:12345/`
 
+If a "Failure to load dynamic library" error happens at runtime, do
+export [DY]LD\_LIBRARY\_PATH="$(dirname "$(find . -name libssl3.so -print)")"
+
 ## Faster Builds with Separate NSS/NSPR
 
 You can clone NSS (https://hg.mozilla.org/projects/nss) and NSPR

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ To run test HTTP/3 programs (neqo-client and neqo-server):
 * `./target/debug/neqo-client http://127.0.0.1:12345/`
 
 If a "Failure to load dynamic library" error happens at runtime, do
-export [DY]LD\_LIBRARY\_PATH="$(dirname "$(find . -name libssl3.so -print)")"
+```
+export LD_LIBRARY_PATH="$(dirname "$(find . -name libssl3.so -print | head -1)")"
+```
+On a mac, use `DYLD_LIBRARY_PATH` instead.
 
 ## Faster Builds with Separate NSS/NSPR
 


### PR DESCRIPTION
my take is this issue happens often to users installing and using this software. And one get an hint with the info in the next paragraph, but that is not clear it is also for any kind of installation. And it is not easy to do the right command as the solution is finding the temp dir used at build time. Hence the need to specify the information clearly for people.

reference to issue #1045 