### PR TITLE
Eliminate use of `#[macro_use]`

### DIFF
--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -24,9 +24,6 @@ pub use self::incrdecoder::{
     IncrementalDecoderBuffer, IncrementalDecoderIgnore, IncrementalDecoderUint,
 };
 
-#[macro_use]
-extern crate lazy_static;
-
 use std::fmt::Write;
 
 #[must_use]

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -6,11 +6,11 @@
 
 #![allow(clippy::module_name_repetitions)]
 
+use env_logger::Builder;
+use lazy_static::lazy_static;
 use std::io::Write;
 use std::sync::Once;
 use std::time::Instant;
-use env_logger::Builder;
-use lazy_static::lazy_static;
 
 #[macro_export]
 macro_rules! do_log {

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -9,6 +9,8 @@
 use std::io::Write;
 use std::sync::Once;
 use std::time::Instant;
+use env_logger::Builder;
+use lazy_static::lazy_static;
 
 #[macro_export]
 macro_rules! do_log {
@@ -40,8 +42,6 @@ macro_rules! log_subject {
         }
     }};
 }
-
-use env_logger::Builder;
 
 static INIT_ONCE: Once = Once::new();
 

--- a/neqo-transport/tests/network.rs
+++ b/neqo-transport/tests/network.rs
@@ -7,7 +7,6 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::pedantic)]
 
-#[macro_use]
 mod sim;
 
 use neqo_transport::{ConnectionError, ConnectionParameters, Error, State};


### PR DESCRIPTION
This is a relic of an older rust edition.  Macros are available to the crate in which they are defined and used like functions otherwise.