### PR TITLE
Fix header check for webtransport session creation

### DIFF
--- a/neqo-http3/src/headers_checks.rs
+++ b/neqo-http3/src/headers_checks.rs
@@ -93,6 +93,8 @@ fn track_pseudo(
 /// Returns an error if headers are not well formed.
 pub fn headers_valid(headers: &[Header], message_type: MessageType) -> Res<()> {
     let mut method_value: Option<&str> = None;
+    let mut protocol_value: Option<&str> = None;
+    let mut scheme_value: Option<&str> = None;
     let mut pseudo_state = EnumSet::new();
     for header in headers {
         let is_pseudo = track_pseudo(header.name(), &mut pseudo_state, message_type)?;
@@ -101,6 +103,10 @@ pub fn headers_valid(headers: &[Header], message_type: MessageType) -> Res<()> {
         if is_pseudo {
             if header.name() == ":method" {
                 method_value = Some(header.value());
+            } else if header.name() == ":protocol" {
+                protocol_value = Some(header.value());
+            } else if header.name() == ":scheme" {
+                scheme_value = Some(header.value());
             }
             let _ = bytes.next();
         }
@@ -115,7 +121,18 @@ pub fn headers_valid(headers: &[Header], message_type: MessageType) -> Res<()> {
         MessageType::Response => enum_set!(PseudoHeaderState::Status),
         MessageType::Request => {
             if method_value == Some("CONNECT") {
-                PseudoHeaderState::Method | PseudoHeaderState::Authority
+                let connect_mask = PseudoHeaderState::Method | PseudoHeaderState::Authority;
+                if let Some(protocol) = protocol_value {
+                    // For a webtransport CONNECT, the :scheme field must be set to https.
+                    if protocol == "webtransport" && scheme_value != Some("https") {
+                        return Err(Error::InvalidHeader);
+                    }
+                    // The CONNECT request for with :protocol included must have the scheme,
+                    // authority, and path set.
+                    connect_mask | PseudoHeaderState::Scheme | PseudoHeaderState::Path
+                } else {
+                    connect_mask
+                }
             } else {
                 PseudoHeaderState::Method | PseudoHeaderState::Scheme | PseudoHeaderState::Path
             }
@@ -147,4 +164,59 @@ pub fn trailers_valid(headers: &[Header]) -> Res<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::headers_valid;
+    use crate::MessageType;
+    use neqo_common::Header;
+
+    fn create_connect_headers() -> Vec<Header> {
+        vec![
+            Header::new(":method", "CONNECT"),
+            Header::new(":protocol", "webtransport"),
+            Header::new(":scheme", "https"),
+            Header::new(":authority", "something.com"),
+            Header::new(":path", "/here"),
+        ]
+    }
+
+    fn create_connect_headers_without_field(field: &str) -> Vec<Header> {
+        create_connect_headers()
+            .into_iter()
+            .filter(|header| header.name() != field)
+            .collect()
+    }
+
+    #[test]
+    fn connect_with_missing_header() {
+        for field in &[":scheme", ":path", ":authority"] {
+            assert!(headers_valid(
+                &create_connect_headers_without_field(field),
+                MessageType::Request
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn invalid_scheme_webtransport_connect() {
+        assert!(headers_valid(
+            &[
+                Header::new(":method", "CONNECT"),
+                Header::new(":protocol", "webtransport"),
+                Header::new(":authority", "something.com"),
+                Header::new(":scheme", "http"),
+                Header::new(":path", "/here"),
+            ],
+            MessageType::Request
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn valid_webtransport_connect() {
+        assert!(headers_valid(&create_connect_headers(), MessageType::Request).is_ok());
+    }
 }


### PR DESCRIPTION
When creating a new webtransport session the CONNECT request must have the scheme, authority, and path set.

Fixes: https://github.com/mozilla/neqo/issues/1365