### PR TITLE
Remove let from _ bindings

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -23,18 +23,20 @@ use neqo_transport::{
     EmptyConnectionIdGenerator, Error as TransportError, StreamId, StreamType, Version,
 };
 
-use std::collections::{HashMap, VecDeque};
-use std::convert::TryFrom;
-use std::fmt::{self, Display};
-use std::fs::{create_dir_all, File, OpenOptions};
-use std::io::{self, ErrorKind, Write};
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs, UdpSocket};
-use std::path::PathBuf;
-use std::process::exit;
-use std::rc::Rc;
-use std::str::FromStr;
-use std::time::Instant;
-use std::{cell::RefCell, time::Duration};
+use std::{
+    cell::RefCell,
+    collections::{HashMap, VecDeque},
+    convert::TryFrom,
+    fmt::{self, Display},
+    fs::{create_dir_all, File, OpenOptions},
+    io::{self, ErrorKind, Write},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs, UdpSocket},
+    path::PathBuf,
+    process::exit,
+    rc::Rc,
+    str::FromStr,
+    time::{Duration, Instant},
+};
 
 use structopt::StructOpt;
 use url::{Origin, Url};
@@ -861,15 +863,17 @@ fn main() -> Res<()> {
 }
 
 mod old {
-    use std::cell::RefCell;
-    use std::collections::{HashMap, VecDeque};
-    use std::fs::File;
-    use std::io::{ErrorKind, Write};
-    use std::net::{SocketAddr, UdpSocket};
-    use std::path::PathBuf;
-    use std::process::exit;
-    use std::rc::Rc;
-    use std::time::Instant;
+    use std::{
+        cell::RefCell,
+        collections::{HashMap, VecDeque},
+        fs::File,
+        io::{ErrorKind, Write},
+        net::{SocketAddr, UdpSocket},
+        path::PathBuf,
+        process::exit,
+        rc::Rc,
+        time::Instant,
+    };
 
     use url::Url;
 
@@ -921,7 +925,7 @@ mod old {
                 Ok(client_stream_id) => {
                     println!("Created stream {} for {}", client_stream_id, url);
                     let req = format!("GET {}\r\n", url.path());
-                    let _ = client
+                    _ = client
                         .stream_send(client_stream_id, req.as_bytes())
                         .unwrap();
                     client.stream_close_send(client_stream_id).unwrap();

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -4,8 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::convert::TryFrom;
-use std::fmt::Debug;
+use std::{convert::TryFrom, fmt::Debug};
 
 use crate::hex_with_len;
 
@@ -614,7 +613,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn encoded_length_oob() {
-        let _ = Encoder::varint_len(1 << 62);
+        _ = Encoder::varint_len(1 << 62);
     }
 
     #[test]
@@ -631,7 +630,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn encoded_vvec_length_oob() {
-        let _ = Encoder::vvec_len(1 << 62);
+        _ = Encoder::vvec_len(1 << 62);
     }
 
     #[test]

--- a/neqo-common/src/hrtime.rs
+++ b/neqo-common/src/hrtime.rs
@@ -4,10 +4,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::cell::RefCell;
-use std::convert::TryFrom;
-use std::rc::{Rc, Weak};
-use std::time::Duration;
+use std::{
+    cell::RefCell,
+    convert::TryFrom,
+    rc::{Rc, Weak},
+    time::Duration,
+};
 
 #[cfg(windows)]
 use winapi::shared::minwindef::UINT;
@@ -80,8 +82,7 @@ impl PeriodSet {
 #[cfg(target_os = "macos")]
 #[allow(non_camel_case_types)]
 mod mac {
-    use std::mem::size_of;
-    use std::ptr::addr_of_mut;
+    use std::{mem::size_of, ptr::addr_of_mut};
 
     // These are manually extracted from the many bindings generated
     // by bindgen when provided with the simple header:
@@ -158,7 +159,7 @@ mod mac {
 
     /// Set a thread time policy.
     pub fn set_thread_policy(mut policy: thread_time_constraint_policy) {
-        let _ = unsafe {
+        _ = unsafe {
             thread_policy_set(
                 pthread_mach_thread_np(pthread_self()),
                 THREAD_TIME_CONSTRAINT_POLICY,
@@ -193,7 +194,7 @@ mod mac {
         let mut policy = thread_time_constraint_policy::default();
         let mut count = THREAD_TIME_CONSTRAINT_POLICY_COUNT;
         let mut get_default = 0;
-        let _ = unsafe {
+        _ = unsafe {
             thread_policy_get(
                 pthread_mach_thread_np(pthread_self()),
                 THREAD_TIME_CONSTRAINT_POLICY,
@@ -372,8 +373,10 @@ impl Drop for Time {
 #[cfg(test)]
 mod test {
     use super::Time;
-    use std::thread::{sleep, spawn};
-    use std::time::{Duration, Instant};
+    use std::{
+        thread::{sleep, spawn},
+        time::{Duration, Instant},
+    };
 
     const ONE: Duration = Duration::from_millis(1);
     const ONE_AND_A_BIT: Duration = Duration::from_micros(1500);

--- a/neqo-common/src/incrdecoder.rs
+++ b/neqo-common/src/incrdecoder.rs
@@ -4,8 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::cmp::min;
-use std::mem;
+use std::{cmp::min, mem};
 
 use crate::codec::Decoder;
 
@@ -124,7 +123,7 @@ impl IncrementalDecoderIgnore {
 
     pub fn consume(&mut self, dv: &mut Decoder) -> bool {
         let amount = min(self.remaining, dv.remaining());
-        let _ = dv.decode(amount);
+        _ = dv.decode(amount);
         self.remaining -= amount;
         self.remaining == 0
     }

--- a/neqo-crypto/src/result.rs
+++ b/neqo-crypto/src/result.rs
@@ -4,15 +4,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::err::{
-    nspr, Error, PR_ErrorToName, PR_ErrorToString, PR_GetError, Res, PR_LANGUAGE_I_DEFAULT,
+use crate::{
+    err::{nspr, Error, PR_ErrorToName, PR_ErrorToString, PR_GetError, Res, PR_LANGUAGE_I_DEFAULT},
+    ssl,
 };
-use crate::ssl;
 
 use std::ffi::CStr;
 
 pub fn result(rv: ssl::SECStatus) -> Res<()> {
-    let _ = result_helper(rv, false)?;
+    _ = result_helper(rv, false)?;
     Ok(())
 }
 
@@ -54,8 +54,10 @@ fn result_helper(rv: ssl::SECStatus, allow_blocked: bool) -> Res<bool> {
 #[cfg(test)]
 mod tests {
     use super::{result, result_or_blocked};
-    use crate::err::{self, nspr, Error, PRErrorCode, PR_SetError};
-    use crate::ssl;
+    use crate::{
+        err::{self, nspr, Error, PRErrorCode, PR_SetError},
+        ssl,
+    };
     use test_fixture::fixture_init;
 
     fn set_error_code(code: PRErrorCode) {
@@ -90,7 +92,7 @@ mod tests {
 
     #[test]
     fn is_err_zero_code() {
-    // This code doesn't work without initializing NSS first.
+        // This code doesn't work without initializing NSS first.
         fixture_init();
 
         set_error_code(0);

--- a/neqo-crypto/src/time.rs
+++ b/neqo-crypto/src/time.rs
@@ -6,17 +6,21 @@
 
 #![allow(clippy::upper_case_acronyms)]
 
-use crate::agentio::as_c_void;
-use crate::err::{Error, Res};
-use crate::once::OnceResult;
-use crate::ssl::{PRFileDesc, SSLTimeFunc};
+use crate::{
+    agentio::as_c_void,
+    err::{Error, Res},
+    once::OnceResult,
+    ssl::{PRFileDesc, SSLTimeFunc},
+};
 
-use std::boxed::Box;
-use std::convert::{TryFrom, TryInto};
-use std::ops::Deref;
-use std::os::raw::c_void;
-use std::pin::Pin;
-use std::time::{Duration, Instant};
+use std::{
+    boxed::Box,
+    convert::{TryFrom, TryInto},
+    ops::Deref,
+    os::raw::c_void,
+    pin::Pin,
+    time::{Duration, Instant},
+};
 
 include!(concat!(env!("OUT_DIR"), "/nspr_time.rs"));
 
@@ -74,7 +78,7 @@ fn get_base() -> &'static TimeZero {
 }
 
 pub(crate) fn init() {
-    let _ = get_base();
+    _ = get_base();
 }
 
 /// Time wraps Instant and provides conversion functions into `PRTime`.
@@ -95,7 +99,7 @@ impl From<Instant> for Time {
     fn from(t: Instant) -> Self {
         // Call `TimeZero::baseline(t)` so that time zero can be set.
         let f = || TimeZero::baseline(t);
-        let _ = unsafe { BASE_TIME.call_once(f) };
+        _ = unsafe { BASE_TIME.call_once(f) };
         Self { t }
     }
 }
@@ -205,8 +209,10 @@ impl Default for TimeHolder {
 mod test {
     use super::{get_base, init, Interval, PRTime, Time};
     use crate::err::Res;
-    use std::convert::{TryFrom, TryInto};
-    use std::time::{Duration, Instant};
+    use std::{
+        convert::{TryFrom, TryInto},
+        time::{Duration, Instant},
+    };
 
     #[test]
     fn convert_stable() {

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -4,14 +4,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::client_events::{Http3ClientEvent, Http3ClientEvents};
-use crate::connection::{Http3Connection, Http3State, RequestDescription};
-use crate::frames::HFrame;
-use crate::push_controller::{PushController, RecvPushEvents};
-use crate::recv_message::{RecvMessage, RecvMessageInfo};
-use crate::request_target::AsRequestTarget;
-use crate::settings::HSettings;
 use crate::{
+    client_events::{Http3ClientEvent, Http3ClientEvents},
+    connection::{Http3Connection, Http3State, RequestDescription},
+    frames::HFrame,
+    push_controller::{PushController, RecvPushEvents},
+    recv_message::{RecvMessage, RecvMessageInfo},
+    request_target::AsRequestTarget,
+    settings::HSettings,
     Http3Parameters, Http3StreamType, NewStreamType, Priority, PriorityHandler, ReceiveOutput,
 };
 use neqo_common::{
@@ -24,14 +24,15 @@ use neqo_transport::{
     AppError, Connection, ConnectionEvent, ConnectionId, ConnectionIdGenerator, DatagramTracking,
     Output, Stats as TransportStats, StreamId, StreamType, Version, ZeroRttState,
 };
-use std::cell::RefCell;
-use std::convert::TryFrom;
-use std::fmt::Debug;
-use std::fmt::Display;
-use std::mem;
-use std::net::SocketAddr;
-use std::rc::Rc;
-use std::time::Instant;
+use std::{
+    cell::RefCell,
+    convert::TryFrom,
+    fmt::{Debug, Display},
+    mem,
+    net::SocketAddr,
+    rc::Rc,
+    time::Instant,
+};
 
 use crate::{Error, Res};
 
@@ -807,7 +808,7 @@ impl Http3Client {
             Http3State::Closed { .. } => {}
             _ => {
                 let res = self.check_connection_events();
-                let _ = self.check_result(now, &res);
+                _ = self.check_result(now, &res);
             }
         }
     }
@@ -1181,10 +1182,12 @@ mod tests {
         AuthenticationStatus, Connection, Error, HSettings, Header, Http3Client, Http3ClientEvent,
         Http3Parameters, Http3State, Rc, RefCell,
     };
-    use crate::frames::{HFrame, H3_FRAME_TYPE_SETTINGS, H3_RESERVED_FRAME_TYPES};
-    use crate::qpack_encoder_receiver::EncoderRecvStream;
-    use crate::settings::{HSetting, HSettingType, H3_RESERVED_SETTINGS};
-    use crate::{Http3Server, Priority, RecvStream};
+    use crate::{
+        frames::{HFrame, H3_FRAME_TYPE_SETTINGS, H3_RESERVED_FRAME_TYPES},
+        qpack_encoder_receiver::EncoderRecvStream,
+        settings::{HSetting, HSettingType, H3_RESERVED_SETTINGS},
+        Http3Server, Priority, RecvStream,
+    };
     use neqo_common::{event::Provider, qtrace, Datagram, Decoder, Encoder};
     use neqo_crypto::{AllowZeroRtt, AntiReplay, ResumptionToken};
     use neqo_qpack::{encoder::QPackEncoder, QpackSettings};
@@ -1192,9 +1195,7 @@ mod tests {
         ConnectionError, ConnectionEvent, ConnectionParameters, Output, State, StreamId,
         StreamType, Version, RECV_BUFFER_SIZE, SEND_BUFFER_SIZE,
     };
-    use std::convert::TryFrom;
-    use std::mem;
-    use std::time::Duration;
+    use std::{convert::TryFrom, mem, time::Duration};
     use test_fixture::{
         addr, anti_replay, default_server_h3, fixture_init, new_server, now,
         CountingConnectionIdGenerator, DEFAULT_ALPN_H3, DEFAULT_KEYS, DEFAULT_SERVER_NAME,
@@ -1776,7 +1777,7 @@ mod tests {
         response: impl AsRef<[u8]>,
         close_stream: bool,
     ) {
-        let _ = server
+        _ = server
             .conn
             .stream_send(stream_id, response.as_ref())
             .unwrap();
@@ -1811,7 +1812,7 @@ mod tests {
         };
         let mut d = Encoder::default();
         frame.encode(&mut d);
-        let _ = conn.stream_send(stream_id, d.as_ref()).unwrap();
+        _ = conn.stream_send(stream_id, d.as_ref()).unwrap();
     }
 
     fn send_push_data_and_exchange_packets(
@@ -1892,9 +1893,9 @@ mod tests {
         close_push_stream: bool,
     ) {
         // send data
-        let _ = conn.stream_send(push_stream_id, PUSH_STREAM_TYPE).unwrap();
-        let _ = conn.stream_send(push_stream_id, &[push_id]).unwrap();
-        let _ = conn.stream_send(push_stream_id, data.as_ref()).unwrap();
+        _ = conn.stream_send(push_stream_id, PUSH_STREAM_TYPE).unwrap();
+        _ = conn.stream_send(push_stream_id, &[push_id]).unwrap();
+        _ = conn.stream_send(push_stream_id, data.as_ref()).unwrap();
         if close_push_stream {
             conn.stream_close_send(push_stream_id).unwrap();
         }
@@ -2149,7 +2150,7 @@ mod tests {
         let (mut client, mut server) = connect();
 
         // send a frame that is not allowed on the control stream.
-        let _ = server
+        _ = server
             .conn
             .stream_send(server.control_stream_id.unwrap(), v)
             .unwrap();
@@ -2197,11 +2198,11 @@ mod tests {
         let push_stream_id = server.conn.stream_create(StreamType::UniDi).unwrap();
 
         // Send the push stream type byte, push_id and frame v.
-        let _ = server
+        _ = server
             .conn
             .stream_send(push_stream_id, &[0x01, 0x0])
             .unwrap();
-        let _ = server.conn.stream_send(push_stream_id, v).unwrap();
+        _ = server.conn.stream_send(push_stream_id, v).unwrap();
 
         let out = server.conn.process(None, now());
         let out = client.process(out.dgram(), now());
@@ -2259,7 +2260,7 @@ mod tests {
 
         // create a stream with unknown type.
         let new_stream_id = server.conn.stream_create(StreamType::UniDi).unwrap();
-        let _ = server
+        _ = server
             .conn
             .stream_send(new_stream_id, &[0x41, 0x19, 0x4, 0x4, 0x6, 0x0, 0x8, 0x0])
             .unwrap();
@@ -2288,7 +2289,7 @@ mod tests {
     fn test_wrong_frame_on_request_stream(v: &[u8]) {
         let (mut client, mut server, request_stream_id) = connect_and_send_request(false);
 
-        let _ = server.conn.stream_send(request_stream_id, v).unwrap();
+        _ = server.conn.stream_send(request_stream_id, v).unwrap();
 
         // Generate packet with the above bad h3 input
         let out = server.conn.process(None, now());
@@ -2479,7 +2480,7 @@ mod tests {
         // to send `MAX_STREAMS`, which would prevent it from becoming idle.
         fn dgram(c: &mut Connection) -> Datagram {
             let stream = c.stream_create(StreamType::UniDi).unwrap();
-            let _ = c.stream_send(stream, &[0xc0]).unwrap();
+            _ = c.stream_send(stream, &[0xc0]).unwrap();
             c.process_output(now()).dgram().unwrap()
         }
 
@@ -2589,7 +2590,7 @@ mod tests {
 
                     // send response - 200  Content-Length: 3
                     // with content: 'abc'.
-                    let _ = server.conn.stream_send(stream_id, HTTP_RESPONSE_2).unwrap();
+                    _ = server.conn.stream_send(stream_id, HTTP_RESPONSE_2).unwrap();
                     server.conn.stream_close_send(stream_id).unwrap();
                 }
                 _ => {}
@@ -2645,7 +2646,7 @@ mod tests {
 
                     // send response - 200  Content-Length: 3
                     // with content: 'abc'.
-                    let _ = server.conn.stream_send(stream_id, HTTP_RESPONSE_2).unwrap();
+                    _ = server.conn.stream_send(stream_id, HTTP_RESPONSE_2).unwrap();
                     server.conn.stream_close_send(stream_id).unwrap();
                 }
             }
@@ -2750,7 +2751,7 @@ mod tests {
 
                     // send response - 200  Content-Length: 3
                     // with content: 'abc'.
-                    let _ = server.conn.stream_send(stream_id, HTTP_RESPONSE_2).unwrap();
+                    _ = server.conn.stream_send(stream_id, HTTP_RESPONSE_2).unwrap();
                     server.conn.stream_close_send(stream_id).unwrap();
                 }
             }
@@ -3255,7 +3256,7 @@ mod tests {
         let out = client.process(None, now());
         mem::drop(server.conn.process(out.dgram(), now()));
 
-        let _ = server
+        _ = server
             .conn
             .stream_send(server.control_stream_id.unwrap(), &[0x7, 0x1, 0x8])
             .unwrap();
@@ -3264,12 +3265,12 @@ mod tests {
         while let Some(e) = server.conn.next_event() {
             if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
                 let mut buf = [0_u8; 100];
-                let _ = server.conn.stream_recv(stream_id, &mut buf).unwrap();
+                _ = server.conn.stream_recv(stream_id, &mut buf).unwrap();
                 if (stream_id == request_stream_id_1) || (stream_id == request_stream_id_2) {
                     // send response - 200  Content-Length: 7
                     // with content: 'abcdefg'.
                     // The content will be send in 2 DATA frames.
-                    let _ = server.conn.stream_send(stream_id, HTTP_RESPONSE_1).unwrap();
+                    _ = server.conn.stream_send(stream_id, HTTP_RESPONSE_1).unwrap();
                     server.conn.stream_close_send(stream_id).unwrap();
                 }
             }
@@ -3340,7 +3341,7 @@ mod tests {
         mem::drop(server.conn.process(out.dgram(), now()));
 
         // First send a Goaway frame with an higher number
-        let _ = server
+        _ = server
             .conn
             .stream_send(server.control_stream_id.unwrap(), &[0x7, 0x1, 0x8])
             .unwrap();
@@ -3368,7 +3369,7 @@ mod tests {
         assert_eq!(client.state(), Http3State::GoingAway(StreamId::new(8)));
 
         // Server sends another GOAWAY frame
-        let _ = server
+        _ = server
             .conn
             .stream_send(server.control_stream_id.unwrap(), &[0x7, 0x1, 0x4])
             .unwrap();
@@ -3426,7 +3427,7 @@ mod tests {
         assert_eq!(request_stream_id_3, 8);
 
         // First send a Goaway frame with a smaller number
-        let _ = server
+        _ = server
             .conn
             .stream_send(server.control_stream_id.unwrap(), &[0x7, 0x1, 0x4])
             .unwrap();
@@ -3437,7 +3438,7 @@ mod tests {
         assert_eq!(client.state(), Http3State::GoingAway(StreamId::new(4)));
 
         // Now send a Goaway frame with an higher number
-        let _ = server
+        _ = server
             .conn
             .stream_send(server.control_stream_id.unwrap(), &[0x7, 0x1, 0x8])
             .unwrap();
@@ -3452,7 +3453,7 @@ mod tests {
     fn goaway_wrong_stream_id() {
         let (mut client, mut server) = connect();
 
-        let _ = server
+        _ = server
             .conn
             .stream_send(server.control_stream_id.unwrap(), &[0x7, 0x1, 0x9])
             .unwrap();
@@ -3603,12 +3604,12 @@ mod tests {
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
 
         // Send headers.
-        let _ = server
+        _ = server
             .conn
             .stream_send(request_stream_id, HTTP_RESPONSE_HEADER_ONLY_2)
             .unwrap();
         // Send an empty data frame.
-        let _ = server
+        _ = server
             .conn
             .stream_send(request_stream_id, &[0x00, 0x00])
             .unwrap();
@@ -3656,12 +3657,12 @@ mod tests {
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
         // Send some good data wo fin
         // Send headers.
-        let _ = server
+        _ = server
             .conn
             .stream_send(request_stream_id, HTTP_RESPONSE_HEADER_ONLY_2)
             .unwrap();
         // Send an empty data frame.
-        let _ = server
+        _ = server
             .conn
             .stream_send(request_stream_id, &[0x00, 0x00])
             .unwrap();
@@ -3835,7 +3836,7 @@ mod tests {
         enc.encode_varint(UNKNOWN_FRAME_LEN as u64);
         let mut buf: Vec<_> = enc.into();
         buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
-        let _ = server.conn.stream_send(request_stream_id, &buf).unwrap();
+        _ = server.conn.stream_send(request_stream_id, &buf).unwrap();
 
         // Send a headers and a data frame with fin
         server_send_response_and_exchange_packet(
@@ -4820,7 +4821,7 @@ mod tests {
             false,
         );
         // Send a zero-length frame at the end of the stream.
-        let _ = server.conn.stream_send(request_stream_id, &[0, 0]).unwrap();
+        _ = server.conn.stream_send(request_stream_id, &[0, 0]).unwrap();
         server.conn.stream_close_send(request_stream_id).unwrap();
         let dgram = server.conn.process_output(now()).dgram();
         client.process_input(dgram.unwrap(), now());
@@ -4883,7 +4884,7 @@ mod tests {
         let d_frame = HFrame::Data { len: 3 };
         d_frame.encode(&mut d);
         d.encode(&[0x61, 0x62, 0x63]);
-        let _ = server
+        _ = server
             .conn
             .stream_send(request_stream_id, d.as_ref())
             .unwrap();
@@ -4911,7 +4912,7 @@ mod tests {
         send_push_promise(&mut server.conn, request_stream_id, 0);
 
         // create a push stream.
-        let _ = send_push_data(&mut server.conn, 0, true);
+        _ = send_push_data(&mut server.conn, 0, true);
 
         server_send_response_and_exchange_packet(
             &mut client,
@@ -4970,7 +4971,7 @@ mod tests {
         assert_eq!(client.process_output(now()).callback(), idle_timeout);
 
         // Reading push data will stop the client from being idle.
-        let _ = send_push_data(&mut server.conn, 0, false);
+        _ = send_push_data(&mut server.conn, 0, false);
         let dgram = server.conn.process_output(now()).dgram();
         client.process_input(dgram.unwrap(), now());
 
@@ -4993,10 +4994,10 @@ mod tests {
         send_push_promise(&mut server.conn, request_stream_id, 1);
 
         // create a push stream.
-        let _ = send_push_data(&mut server.conn, 0, true);
+        _ = send_push_data(&mut server.conn, 0, true);
 
         // create a second push stream.
-        let _ = send_push_data(&mut server.conn, 1, true);
+        _ = send_push_data(&mut server.conn, 1, true);
 
         server_send_response_and_exchange_packet(
             &mut client,
@@ -5035,7 +5036,7 @@ mod tests {
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
 
         // Send response headers
-        let _ = server
+        _ = server
             .conn
             .stream_send(request_stream_id, HTTP_RESPONSE_HEADER_ONLY_2)
             .unwrap();
@@ -5044,7 +5045,7 @@ mod tests {
         send_push_promise(&mut server.conn, request_stream_id, 0);
 
         // create a push stream.
-        let _ = send_push_data(&mut server.conn, 0, true);
+        _ = send_push_data(&mut server.conn, 0, true);
 
         // Send response data
         server_send_response_and_exchange_packet(
@@ -5074,7 +5075,7 @@ mod tests {
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
 
         // Send response headers and data frames
-        let _ = server
+        _ = server
             .conn
             .stream_send(request_stream_id, HTTP_RESPONSE_2)
             .unwrap();
@@ -6099,7 +6100,7 @@ mod tests {
         // Read response that will make stream change to closed state.
         assert!(check_header_ready(&mut client));
         let mut buf = [0_u8; 100];
-        let _ = client
+        _ = client
             .read_data(now(), request_stream_id, &mut buf)
             .unwrap();
 
@@ -6454,7 +6455,7 @@ mod tests {
             let (mut client, mut server) = connect_only_transport();
             let control_stream = server.conn.stream_create(StreamType::UniDi).unwrap();
             // Send the control stream type(0x0).
-            let _ = server
+            _ = server
                 .conn
                 .stream_send(control_stream, CONTROL_STREAM_TYPE)
                 .unwrap();
@@ -6931,7 +6932,7 @@ mod tests {
         assert!(client.events().any(zerortt_event));
 
         // Make a request that uses the dynamic table.
-        let _ = make_request(&mut client, true, &[Header::new("myheaders", "myvalue")]);
+        _ = make_request(&mut client, true, &[Header::new("myheaders", "myvalue")]);
         // Assert that the request has used dynamic table. That will trigger a header_ack.
         assert_eq!(client.qpack_encoder_stats().dynamic_table_references, 1);
 
@@ -6995,11 +6996,11 @@ mod tests {
 
         // Create a push stream
         let push_stream_id = server.conn.stream_create(StreamType::UniDi).unwrap();
-        let _ = server
+        _ = server
             .conn
             .stream_send(push_stream_id, PUSH_STREAM_TYPE)
             .unwrap();
-        let _ = server.conn.stream_send(push_stream_id, &[0]).unwrap();
+        _ = server.conn.stream_send(push_stream_id, &[0]).unwrap();
         server.conn.stream_close_send(push_stream_id).unwrap();
         let out = server.conn.process(None, now());
         client.process(out.dgram(), now());

--- a/neqo-http3/src/headers_checks.rs
+++ b/neqo-http3/src/headers_checks.rs
@@ -108,7 +108,7 @@ pub fn headers_valid(headers: &[Header], message_type: MessageType) -> Res<()> {
             } else if header.name() == ":scheme" {
                 scheme_value = Some(header.value());
             }
-            let _ = bytes.next();
+            _ = bytes.next();
         }
 
         if bytes.any(|b| matches!(b, 0 | 0x10 | 0x13 | 0x3a | 0x41..=0x5a)) {

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -6,24 +6,29 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use crate::connection::Http3State;
-use crate::connection_server::Http3ServerHandler;
-use crate::server_connection_events::Http3ServerConnEvent;
-use crate::server_events::{
-    Http3OrWebTransportStream, Http3ServerEvent, Http3ServerEvents, WebTransportRequest,
+use crate::{
+    connection::Http3State,
+    connection_server::Http3ServerHandler,
+    server_connection_events::Http3ServerConnEvent,
+    server_events::{
+        Http3OrWebTransportStream, Http3ServerEvent, Http3ServerEvents, WebTransportRequest,
+    },
+    settings::HttpZeroRttChecker,
+    Http3Parameters, Http3StreamInfo, Res,
 };
-use crate::settings::HttpZeroRttChecker;
-use crate::{Http3Parameters, Http3StreamInfo, Res};
 use neqo_common::{qtrace, Datagram};
 use neqo_crypto::{AntiReplay, Cipher, PrivateKey, PublicKey, ZeroRttChecker};
-use neqo_transport::server::{ActiveConnectionRef, Server, ValidateAddress};
-use neqo_transport::{ConnectionIdGenerator, Output};
-use std::cell::RefCell;
-use std::cell::RefMut;
-use std::collections::HashMap;
-use std::path::PathBuf;
-use std::rc::Rc;
-use std::time::Instant;
+use neqo_transport::{
+    server::{ActiveConnectionRef, Server, ValidateAddress},
+    ConnectionIdGenerator, Output,
+};
+use std::{
+    cell::{RefCell, RefMut},
+    collections::HashMap,
+    path::PathBuf,
+    rc::Rc,
+    time::Instant,
+};
 
 type HandlerRef = Rc<RefCell<Http3ServerHandler>>;
 
@@ -306,16 +311,17 @@ fn prepare_data(
 mod tests {
     use super::{Http3Server, Http3ServerEvent, Http3State, Rc, RefCell};
     use crate::{Error, HFrame, Header, Http3Parameters, Priority};
-    use neqo_common::event::Provider;
-    use neqo_common::Encoder;
+    use neqo_common::{event::Provider, Encoder};
     use neqo_crypto::{AuthenticationStatus, ZeroRttCheckResult, ZeroRttChecker};
     use neqo_qpack::{encoder::QPackEncoder, QpackSettings};
     use neqo_transport::{
         Connection, ConnectionError, ConnectionEvent, State, StreamId, StreamType, ZeroRttState,
     };
-    use std::collections::HashMap;
-    use std::mem;
-    use std::ops::{Deref, DerefMut};
+    use std::{
+        collections::HashMap,
+        mem,
+        ops::{Deref, DerefMut},
+    };
     use test_fixture::{
         anti_replay, default_client, fixture_init, now, CountingConnectionIdGenerator,
         DEFAULT_ALPN, DEFAULT_KEYS,
@@ -697,7 +703,7 @@ mod tests {
 
         // create a stream with unknown type.
         let new_stream_id = peer_conn.stream_create(StreamType::UniDi).unwrap();
-        let _ = peer_conn
+        _ = peer_conn
             .stream_send(new_stream_id, &[0x41, 0x19, 0x4, 0x4, 0x6, 0x0, 0x8, 0x0])
             .unwrap();
         let out = peer_conn.process(None, now());
@@ -730,7 +736,7 @@ mod tests {
 
         // create a push stream.
         let push_stream_id = peer_conn.stream_create(StreamType::UniDi).unwrap();
-        let _ = peer_conn.stream_send(push_stream_id, &[0x1]).unwrap();
+        _ = peer_conn.stream_send(push_stream_id, &[0x1]).unwrap();
         let out = peer_conn.process(None, now());
         let out = hconn.process(out.dgram(), now());
         mem::drop(peer_conn.conn.process(out.dgram(), now()));

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -51,7 +51,7 @@ fn connect_with(client: &mut Http3Client, server: &mut Http3Server) {
     let out = client.process(out.dgram(), now());
     let out = server.process(out.dgram(), now());
     let out = client.process(out.dgram(), now());
-    let _ = server.process(out.dgram(), now());
+    _ = server.process(out.dgram(), now());
 }
 
 fn connect() -> (Http3Client, Http3Server) {

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -4,14 +4,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::decoder_instructions::DecoderInstruction;
-use crate::encoder_instructions::{DecodedEncoderInstruction, EncoderInstructionReader};
-use crate::header_block::{HeaderDecoder, HeaderDecoderResult};
-use crate::qpack_send_buf::QpackData;
-use crate::reader::ReceiverConnWrapper;
-use crate::stats::Stats;
-use crate::table::HeaderTable;
-use crate::{Error, QpackSettings, Res};
+use crate::{
+    decoder_instructions::DecoderInstruction,
+    encoder_instructions::{DecodedEncoderInstruction, EncoderInstructionReader},
+    header_block::{HeaderDecoder, HeaderDecoderResult},
+    qpack_send_buf::QpackData,
+    reader::ReceiverConnWrapper,
+    stats::Stats,
+    table::HeaderTable,
+    Error, QpackSettings, Res,
+};
 use neqo_common::{qdebug, Header};
 use neqo_transport::{Connection, StreamId};
 use std::convert::TryFrom;
@@ -274,8 +276,7 @@ mod tests {
     use crate::QpackSettings;
     use neqo_common::Header;
     use neqo_transport::{StreamId, StreamType};
-    use std::convert::TryFrom;
-    use std::mem;
+    use std::{convert::TryFrom, mem};
     use test_fixture::now;
 
     const STREAM_0: StreamId = StreamId::new(0);
@@ -313,7 +314,7 @@ mod tests {
     }
 
     fn recv_instruction(decoder: &mut TestDecoder, encoder_instruction: &[u8], res: &Res<()>) {
-        let _ = decoder
+        _ = decoder
             .peer_conn
             .stream_send(decoder.recv_stream_id, encoder_instruction)
             .unwrap();

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -7,24 +7,25 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::use_self)]
 
-use std::cell::RefCell;
-use std::cmp::min;
-use std::collections::{HashMap, HashSet};
-use std::convert::TryFrom;
-use std::fmt::{self, Display};
-use std::fs::OpenOptions;
-use std::io;
-use std::io::Read;
-use std::mem;
-use std::net::{SocketAddr, ToSocketAddrs};
-use std::path::PathBuf;
-use std::process::exit;
-use std::rc::Rc;
-use std::str::FromStr;
-use std::time::{Duration, Instant};
+use std::{
+    cell::RefCell,
+    cmp::min,
+    collections::{HashMap, HashSet},
+    convert::TryFrom,
+    fmt::{self, Display},
+    fs::OpenOptions,
+    io,
+    io::Read,
+    mem,
+    net::{SocketAddr, ToSocketAddrs},
+    path::PathBuf,
+    process::exit,
+    rc::Rc,
+    str::FromStr,
+    time::{Duration, Instant},
+};
 
-use mio::net::UdpSocket;
-use mio::{Events, Poll, PollOpt, Ready, Token};
+use mio::{net::UdpSocket, Events, Poll, PollOpt, Ready, Token};
 use mio_extras::timer::{Builder, Timeout, Timer};
 use neqo_transport::ConnectionIdGenerator;
 use structopt::StructOpt;
@@ -729,10 +730,10 @@ impl ServersRunner {
                     if dgram.is_none() {
                         break;
                     }
-                    let _ = self.process(inx, dgram);
+                    _ = self.process(inx, dgram);
                 }
             } else {
-                let _ = self.process(inx, None);
+                _ = self.process(inx, None);
             }
             self.server.process_events(&self.args, self.args.now());
             if self.process(inx, None) {

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -7,19 +7,23 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_sign_loss)]
 
-use crate::cc::{
-    classic_cc::{ClassicCongestionControl, CWND_INITIAL},
-    cubic::{
-        Cubic, CUBIC_ALPHA, CUBIC_BETA_USIZE_DIVISOR, CUBIC_BETA_USIZE_QUOTIENT, CUBIC_C,
-        CUBIC_FAST_CONVERGENCE,
+use crate::{
+    cc::{
+        classic_cc::{ClassicCongestionControl, CWND_INITIAL},
+        cubic::{
+            Cubic, CUBIC_ALPHA, CUBIC_BETA_USIZE_DIVISOR, CUBIC_BETA_USIZE_QUOTIENT, CUBIC_C,
+            CUBIC_FAST_CONVERGENCE,
+        },
+        CongestionControl, MAX_DATAGRAM_SIZE, MAX_DATAGRAM_SIZE_F64,
     },
-    CongestionControl, MAX_DATAGRAM_SIZE, MAX_DATAGRAM_SIZE_F64,
+    packet::PacketType,
+    tracking::SentPacket,
 };
-use crate::packet::PacketType;
-use crate::tracking::SentPacket;
-use std::convert::TryFrom;
-use std::ops::Sub;
-use std::time::{Duration, Instant};
+use std::{
+    convert::TryFrom,
+    ops::Sub,
+    time::{Duration, Instant},
+};
 use test_fixture::now;
 
 const RTT: Duration = Duration::from_millis(100);
@@ -233,7 +237,7 @@ fn assert_within<T: Sub<Output = T> + PartialOrd + Copy>(value: T, expected: T, 
 fn congestion_event_slow_start() {
     let mut cubic = ClassicCongestionControl::new(Cubic::default());
 
-    let _ = fill_cwnd(&mut cubic, 0, now());
+    _ = fill_cwnd(&mut cubic, 0, now());
     ack_packet(&mut cubic, 0, now());
 
     assert_within(cubic.last_max_cwnd(), 0.0, f64::EPSILON);
@@ -263,7 +267,7 @@ fn congestion_event_congestion_avoidance() {
     // Set last_max_cwnd to something smaller than cwnd so that the fast convergence is not triggered.
     cubic.set_last_max_cwnd(3.0 * MAX_DATAGRAM_SIZE_F64);
 
-    let _ = fill_cwnd(&mut cubic, 0, now());
+    _ = fill_cwnd(&mut cubic, 0, now());
     ack_packet(&mut cubic, 0, now());
 
     assert_eq!(cubic.cwnd(), CWND_INITIAL);
@@ -285,7 +289,7 @@ fn congestion_event_congestion_avoidance_2() {
     // Set last_max_cwnd to something higher than cwnd so that the fast convergence is triggered.
     cubic.set_last_max_cwnd(CWND_INITIAL_10_F64);
 
-    let _ = fill_cwnd(&mut cubic, 0, now());
+    _ = fill_cwnd(&mut cubic, 0, now());
     ack_packet(&mut cubic, 0, now());
 
     assert_within(cubic.last_max_cwnd(), CWND_INITIAL_10_F64, f64::EPSILON);
@@ -313,7 +317,7 @@ fn congestion_event_congestion_avoidance_test_no_overflow() {
     // Set last_max_cwnd to something higher than cwnd so that the fast convergence is triggered.
     cubic.set_last_max_cwnd(CWND_INITIAL_10_F64);
 
-    let _ = fill_cwnd(&mut cubic, 0, now());
+    _ = fill_cwnd(&mut cubic, 0, now());
     ack_packet(&mut cubic, 1, now());
 
     assert_within(cubic.last_max_cwnd(), CWND_INITIAL_10_F64, f64::EPSILON);

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -6,15 +6,17 @@
 
 // The class implementing a QUIC connection.
 
-use std::cell::RefCell;
-use std::cmp::{max, min};
-use std::convert::TryFrom;
-use std::fmt::{self, Debug};
-use std::mem;
-use std::net::{IpAddr, SocketAddr};
-use std::ops::RangeInclusive;
-use std::rc::{Rc, Weak};
-use std::time::{Duration, Instant};
+use std::{
+    cell::RefCell,
+    cmp::{max, min},
+    convert::TryFrom,
+    fmt::{self, Debug},
+    mem,
+    net::{IpAddr, SocketAddr},
+    ops::RangeInclusive,
+    rc::{Rc, Weak},
+    time::{Duration, Instant},
+};
 
 use smallvec::SmallVec;
 
@@ -28,34 +30,40 @@ use neqo_crypto::{
     Server, ZeroRttChecker,
 };
 
-use crate::addr_valid::{AddressValidation, NewTokenState};
-use crate::cid::{
-    ConnectionId, ConnectionIdEntry, ConnectionIdGenerator, ConnectionIdManager, ConnectionIdRef,
-    ConnectionIdStore, LOCAL_ACTIVE_CID_LIMIT,
+use crate::{
+    addr_valid::{AddressValidation, NewTokenState},
+    cid::{
+        ConnectionId, ConnectionIdEntry, ConnectionIdGenerator, ConnectionIdManager,
+        ConnectionIdRef, ConnectionIdStore, LOCAL_ACTIVE_CID_LIMIT,
+    },
 };
 
-use crate::crypto::{Crypto, CryptoDxState, CryptoSpace};
-use crate::dump::*;
-use crate::events::{ConnectionEvent, ConnectionEvents, OutgoingDatagramOutcome};
-use crate::frame::{
-    CloseError, Frame, FrameType, FRAME_TYPE_CONNECTION_CLOSE_APPLICATION,
-    FRAME_TYPE_CONNECTION_CLOSE_TRANSPORT,
-};
-use crate::packet::{DecryptedPacket, PacketBuilder, PacketNumber, PacketType, PublicPacket};
-use crate::path::{Path, PathRef, Paths};
-use crate::quic_datagrams::{DatagramTracking, QuicDatagrams};
-use crate::recovery::{LossRecovery, RecoveryToken, SendProfile};
-use crate::rtt::GRANULARITY;
 pub use crate::send_stream::{RetransmissionPriority, TransmissionPriority};
-use crate::stats::{Stats, StatsCell};
-use crate::stream_id::StreamType;
-use crate::streams::Streams;
-use crate::tparams::{
-    self, TransportParameter, TransportParameterId, TransportParameters, TransportParametersHandler,
+use crate::{
+    crypto::{Crypto, CryptoDxState, CryptoSpace},
+    dump::*,
+    events::{ConnectionEvent, ConnectionEvents, OutgoingDatagramOutcome},
+    frame::{
+        CloseError, Frame, FrameType, FRAME_TYPE_CONNECTION_CLOSE_APPLICATION,
+        FRAME_TYPE_CONNECTION_CLOSE_TRANSPORT,
+    },
+    packet::{DecryptedPacket, PacketBuilder, PacketNumber, PacketType, PublicPacket},
+    path::{Path, PathRef, Paths},
+    qlog,
+    quic_datagrams::{DatagramTracking, QuicDatagrams},
+    recovery::{LossRecovery, RecoveryToken, SendProfile},
+    rtt::GRANULARITY,
+    stats::{Stats, StatsCell},
+    stream_id::StreamType,
+    streams::Streams,
+    tparams::{
+        self, TransportParameter, TransportParameterId, TransportParameters,
+        TransportParametersHandler,
+    },
+    tracking::{AckTracker, PacketNumberSpace, SentPacket},
+    version::{Version, WireVersion},
+    AppError, ConnectionError, Error, Res, StreamId,
 };
-use crate::tracking::{AckTracker, PacketNumberSpace, SentPacket};
-use crate::version::{Version, WireVersion};
-use crate::{qlog, AppError, ConnectionError, Error, Res, StreamId};
 
 mod idle;
 pub mod params;
@@ -1856,7 +1864,7 @@ impl Connection {
                 version,
                 grease_quic_bit,
             );
-            let _ = Self::add_packet_number(
+            _ = Self::add_packet_number(
                 &mut builder,
                 tx,
                 self.loss_recovery.largest_acknowledged_pn(*space),
@@ -3064,7 +3072,7 @@ impl Connection {
             version,
             false,
         );
-        let _ = Self::add_packet_number(
+        _ = Self::add_packet_number(
             &mut builder,
             tx,
             self.loss_recovery

--- a/neqo-transport/src/connection/tests/ackrate.rs
+++ b/neqo-transport/src/connection/tests/ackrate.rs
@@ -4,15 +4,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::super::{ConnectionParameters, ACK_RATIO_SCALE};
 use super::{
+    super::{ConnectionParameters, ACK_RATIO_SCALE},
     ack_bytes, connect_rtt_idle, default_client, default_server, fill_cwnd, increase_cwnd,
     induce_persistent_congestion, new_client, new_server, send_something, DEFAULT_RTT,
 };
 use crate::stream_id::StreamType;
 
-use std::mem;
-use std::time::Duration;
+use std::{mem, time::Duration};
 use test_fixture::{addr_v4, assertions};
 
 /// With the default RTT here (100ms) and default ratio (4), endpoints won't send
@@ -21,7 +20,7 @@ use test_fixture::{addr_v4, assertions};
 fn ack_rate_default() {
     let mut client = default_client();
     let mut server = default_server();
-    let _ = connect_rtt_idle(&mut client, &mut server, DEFAULT_RTT);
+    _ = connect_rtt_idle(&mut client, &mut server, DEFAULT_RTT);
 
     assert_eq!(client.stats().frame_tx.ack_frequency, 0);
     assert_eq!(server.stats().frame_tx.ack_frequency, 0);
@@ -38,7 +37,7 @@ fn ack_rate_slow_start() {
     let stream = client.stream_create(StreamType::UniDi).unwrap();
     let now = increase_cwnd(&mut client, &mut server, stream, now);
     let now = increase_cwnd(&mut client, &mut server, stream, now);
-    let _ = increase_cwnd(&mut client, &mut server, stream, now);
+    _ = increase_cwnd(&mut client, &mut server, stream, now);
 
     // The client should not have sent an ACK_FREQUENCY frame, even
     // though the value would have updated.

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -4,21 +4,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::super::{Connection, ConnectionParameters, IdleTimeout, Output, State};
 use super::{
+    super::{Connection, ConnectionParameters, IdleTimeout, Output, State},
     connect, connect_force_idle, connect_rtt_idle, connect_with_rtt, default_client,
     default_server, maybe_authenticate, new_client, new_server, send_and_receive, send_something,
     AT_LEAST_PTO, DEFAULT_STREAM_DATA,
 };
-use crate::packet::PacketBuilder;
-use crate::stats::FrameStats;
-use crate::stream_id::{StreamId, StreamType};
-use crate::tparams::{self, TransportParameter};
-use crate::tracking::PacketNumberSpace;
+use crate::{
+    packet::PacketBuilder,
+    stats::FrameStats,
+    stream_id::{StreamId, StreamType},
+    tparams::{self, TransportParameter},
+    tracking::PacketNumberSpace,
+};
 
 use neqo_common::{qtrace, Encoder};
-use std::mem;
-use std::time::{Duration, Instant};
+use std::{
+    mem,
+    time::{Duration, Instant},
+};
 use test_fixture::{self, now, split_datagram};
 
 fn default_timeout() -> Duration {
@@ -367,15 +371,15 @@ fn create_stream_idle_rtt(
 
     // Exchange a message each way on a stream.
     let stream = initiator.stream_create(StreamType::BiDi).unwrap();
-    let _ = initiator.stream_send(stream, DEFAULT_STREAM_DATA).unwrap();
+    _ = initiator.stream_send(stream, DEFAULT_STREAM_DATA).unwrap();
     let req = initiator.process_output(now).dgram();
     now += rtt / 2;
     responder.process_input(req.unwrap(), now);
 
     // Reordering two packets from the responder forces the initiator to be idle.
-    let _ = responder.stream_send(stream, DEFAULT_STREAM_DATA).unwrap();
+    _ = responder.stream_send(stream, DEFAULT_STREAM_DATA).unwrap();
     let resp1 = responder.process_output(now).dgram();
-    let _ = responder.stream_send(stream, DEFAULT_STREAM_DATA).unwrap();
+    _ = responder.stream_send(stream, DEFAULT_STREAM_DATA).unwrap();
     let resp2 = responder.process_output(now).dgram();
 
     now += rtt / 2;
@@ -654,7 +658,7 @@ fn keep_alive_uni() {
 
     let stream = client.stream_create(StreamType::UniDi).unwrap();
     client.stream_keep_alive(stream, true).unwrap_err();
-    let _ = client.stream_send(stream, DEFAULT_STREAM_DATA).unwrap();
+    _ = client.stream_send(stream, DEFAULT_STREAM_DATA).unwrap();
     let dgram = client.process_output(now()).dgram();
 
     server.process_input(dgram.unwrap(), now());
@@ -690,7 +694,7 @@ fn keep_alive_with_ack_eliciting_packet_lost() {
     assert_idle(&mut client, now, IDLE_TIMEOUT / 2);
 
     // Send data on the stream that will be lost.
-    let _ = client.stream_send(stream, DEFAULT_STREAM_DATA).unwrap();
+    _ = client.stream_send(stream, DEFAULT_STREAM_DATA).unwrap();
     let _lost_packet = client.process_output(now).dgram();
 
     let pto = client.process_output(now).callback();

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -7,24 +7,26 @@
 #![deny(clippy::pedantic)]
 
 use super::{Connection, ConnectionError, ConnectionId, Output, State};
-use crate::addr_valid::{AddressValidation, ValidateAddress};
-use crate::cc::{CWND_INITIAL_PKTS, CWND_MIN};
-use crate::cid::ConnectionIdRef;
-use crate::events::ConnectionEvent;
-use crate::path::PATH_MTU_V6;
-use crate::recovery::ACK_ONLY_SIZE_LIMIT;
-use crate::stats::{FrameStats, Stats, MAX_PTO_COUNTS};
 use crate::{
+    addr_valid::{AddressValidation, ValidateAddress},
+    cc::{CWND_INITIAL_PKTS, CWND_MIN},
+    cid::ConnectionIdRef,
+    events::ConnectionEvent,
+    path::PATH_MTU_V6,
+    recovery::ACK_ONLY_SIZE_LIMIT,
+    stats::{FrameStats, Stats, MAX_PTO_COUNTS},
     ConnectionIdDecoder, ConnectionIdGenerator, ConnectionParameters, Error, StreamId, StreamType,
     Version,
 };
 
-use std::cell::RefCell;
-use std::cmp::min;
-use std::convert::TryFrom;
-use std::mem;
-use std::rc::Rc;
-use std::time::{Duration, Instant};
+use std::{
+    cell::RefCell,
+    cmp::min,
+    convert::TryFrom,
+    mem,
+    rc::Rc,
+    time::{Duration, Instant},
+};
 
 use neqo_common::{event::Provider, qdebug, qtrace, Datagram, Decoder, Role};
 use neqo_crypto::{random, AllowZeroRtt, AuthenticationStatus, ResumptionToken};
@@ -164,7 +166,7 @@ fn handshake(
     };
 
     while !is_done(a) {
-        let _ = maybe_authenticate(a);
+        _ = maybe_authenticate(a);
         let had_input = input.is_some();
         let output = a.process(input, now).dgram();
         assert!(had_input || output.is_some());
@@ -283,8 +285,8 @@ fn connect_rtt_idle(client: &mut Connection, server: &mut Connection, rtt: Durat
     let now = connect_with_rtt(client, server, now(), rtt);
     let now = force_idle(client, server, rtt, now);
     // Drain events from both as well.
-    let _ = client.events().count();
-    let _ = server.events().count();
+    _ = client.events().count();
+    _ = server.events().count();
     qtrace!("----- connected and idle with RTT {:?}", rtt);
     now
 }

--- a/neqo-transport/src/connection/tests/priority.rs
+++ b/neqo-transport/src/connection/tests/priority.rs
@@ -4,16 +4,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::super::{Connection, Error, Output};
-use super::{connect, default_client, default_server, fill_cwnd, maybe_authenticate};
-use crate::addr_valid::{AddressValidation, ValidateAddress};
-use crate::send_stream::{RetransmissionPriority, TransmissionPriority};
-use crate::{ConnectionEvent, StreamId, StreamType};
+use super::{
+    super::{Connection, Error, Output},
+    connect, default_client, default_server, fill_cwnd, maybe_authenticate,
+};
+use crate::{
+    addr_valid::{AddressValidation, ValidateAddress},
+    send_stream::{RetransmissionPriority, TransmissionPriority},
+    ConnectionEvent, StreamId, StreamType,
+};
 
 use neqo_common::event::Provider;
-use std::cell::RefCell;
-use std::mem;
-use std::rc::Rc;
+use std::{cell::RefCell, mem, rc::Rc};
 use test_fixture::{self, now};
 
 const BLOCK_SIZE: usize = 4_096;
@@ -169,7 +171,7 @@ fn repairing_loss() {
 
     // Generate an ACK.  The first packet is now considered lost.
     let ack = server.process_output(now).dgram();
-    let _ = server.events().count(); // Drain events.
+    _ = server.events().count(); // Drain events.
 
     let id_normal = client.stream_create(StreamType::UniDi).unwrap();
     fill_stream(&mut client, id_normal);

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -4,23 +4,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::super::State;
 use super::{
-    assert_error, connect, connect_force_idle, default_client, default_server, maybe_authenticate,
-    new_client, new_server, send_something, DEFAULT_STREAM_DATA,
+    super::State, assert_error, connect, connect_force_idle, default_client, default_server,
+    maybe_authenticate, new_client, new_server, send_something, DEFAULT_STREAM_DATA,
 };
-use crate::events::ConnectionEvent;
-use crate::recv_stream::RECV_BUFFER_SIZE;
-use crate::send_stream::{SendStreamState, SEND_BUFFER_SIZE};
-use crate::tparams::{self, TransportParameter};
-use crate::tracking::DEFAULT_ACK_PACKET_TOLERANCE;
-use crate::{Connection, ConnectionError, ConnectionParameters};
-use crate::{Error, StreamType};
+use crate::{
+    events::ConnectionEvent,
+    recv_stream::RECV_BUFFER_SIZE,
+    send_stream::{SendStreamState, SEND_BUFFER_SIZE},
+    tparams::{self, TransportParameter},
+    tracking::DEFAULT_ACK_PACKET_TOLERANCE,
+    Connection, ConnectionError, ConnectionParameters, Error, StreamType,
+};
 
 use neqo_common::{event::Provider, qdebug};
-use std::cmp::max;
-use std::convert::TryFrom;
-use std::mem;
+use std::{cmp::max, convert::TryFrom, mem};
 use test_fixture::now;
 
 #[test]
@@ -492,7 +490,7 @@ fn stream_data_blocked_generates_max_stream_data() {
 
     // Send some data and consume some flow control.
     let stream_id = server.stream_create(StreamType::UniDi).unwrap();
-    let _ = server.stream_send(stream_id, DEFAULT_STREAM_DATA).unwrap();
+    _ = server.stream_send(stream_id, DEFAULT_STREAM_DATA).unwrap();
     let dgram = server.process(None, now).dgram();
     assert!(dgram.is_some());
 
@@ -551,7 +549,7 @@ fn max_streams_after_bidi_closed() {
         // Exhaust the stream limit.
     }
     // Write on the one stream and send that out.
-    let _ = client.stream_send(stream_id, REQUEST).unwrap();
+    _ = client.stream_send(stream_id, REQUEST).unwrap();
     client.stream_close_send(stream_id).unwrap();
     let dgram = client.process(None, now()).dgram();
 

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -4,14 +4,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::cell::RefCell;
-use std::cmp::{max, min};
-use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::mem;
-use std::ops::{Index, IndexMut, Range};
-use std::rc::Rc;
-use std::time::Instant;
+use std::{
+    cell::RefCell,
+    cmp::{max, min},
+    collections::HashMap,
+    convert::TryFrom,
+    mem,
+    ops::{Index, IndexMut, Range},
+    rc::Rc,
+    time::Instant,
+};
 
 use neqo_common::{hex, hex_snip_middle, qdebug, qinfo, qtrace, Encoder, Role};
 
@@ -23,16 +25,18 @@ use neqo_crypto::{
     TLS_VERSION_1_3,
 };
 
-use crate::cid::ConnectionIdRef;
-use crate::packet::{PacketBuilder, PacketNumber};
-use crate::recovery::RecoveryToken;
-use crate::recv_stream::RxStreamOrderer;
-use crate::send_stream::TxBuffer;
-use crate::stats::FrameStats;
-use crate::tparams::{TpZeroRttChecker, TransportParameters, TransportParametersHandler};
-use crate::tracking::PacketNumberSpace;
-use crate::version::Version;
-use crate::{Error, Res};
+use crate::{
+    cid::ConnectionIdRef,
+    packet::{PacketBuilder, PacketNumber},
+    recovery::RecoveryToken,
+    recv_stream::RxStreamOrderer,
+    send_stream::TxBuffer,
+    stats::FrameStats,
+    tparams::{TpZeroRttChecker, TransportParameters, TransportParametersHandler},
+    tracking::PacketNumberSpace,
+    version::Version,
+    Error, Res,
+};
 
 const MAX_AUTH_TAG: usize = 32;
 /// The number of invocations remaining on a write cipher before we try
@@ -1155,7 +1159,7 @@ impl CryptoStates {
         // because they aren't allowed to update without first having received
         // something from us. If the ACK isn't in the packet that triggered this
         // key update, it must be in some other packet they have sent.
-        let _ = self.maybe_update_write()?;
+        _ = self.maybe_update_write()?;
 
         // We shouldn't have 0-RTT keys at this point, but if we do, dump them.
         debug_assert_eq!(self.read_update_time.is_some(), self.has_0rtt_read());

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -7,22 +7,25 @@
 // Tracks possibly-redundant flow control signals from other code and converts
 // into flow control frames needing to be sent to the remote.
 
-use crate::frame::{
-    FRAME_TYPE_DATA_BLOCKED, FRAME_TYPE_MAX_DATA, FRAME_TYPE_MAX_STREAMS_BIDI,
-    FRAME_TYPE_MAX_STREAMS_UNIDI, FRAME_TYPE_MAX_STREAM_DATA, FRAME_TYPE_STREAMS_BLOCKED_BIDI,
-    FRAME_TYPE_STREAMS_BLOCKED_UNIDI, FRAME_TYPE_STREAM_DATA_BLOCKED,
+use crate::{
+    frame::{
+        FRAME_TYPE_DATA_BLOCKED, FRAME_TYPE_MAX_DATA, FRAME_TYPE_MAX_STREAMS_BIDI,
+        FRAME_TYPE_MAX_STREAMS_UNIDI, FRAME_TYPE_MAX_STREAM_DATA, FRAME_TYPE_STREAMS_BLOCKED_BIDI,
+        FRAME_TYPE_STREAMS_BLOCKED_UNIDI, FRAME_TYPE_STREAM_DATA_BLOCKED,
+    },
+    packet::PacketBuilder,
+    recovery::{RecoveryToken, StreamRecoveryToken},
+    stats::FrameStats,
+    stream_id::{StreamId, StreamType},
+    Error, Res,
 };
-use crate::packet::PacketBuilder;
-use crate::recovery::{RecoveryToken, StreamRecoveryToken};
-use crate::stats::FrameStats;
-use crate::stream_id::{StreamId, StreamType};
-use crate::{Error, Res};
 use neqo_common::{qtrace, Role};
 
-use std::convert::TryFrom;
-use std::fmt::Debug;
-use std::ops::{Deref, DerefMut};
-use std::ops::{Index, IndexMut};
+use std::{
+    convert::TryFrom,
+    fmt::Debug,
+    ops::{Deref, DerefMut, Index, IndexMut},
+};
 
 #[derive(Debug)]
 pub struct SenderFlowControl<T>
@@ -573,10 +576,12 @@ impl IndexMut<StreamType> for LocalStreamLimits {
 #[cfg(test)]
 mod test {
     use super::{LocalStreamLimits, ReceiverFlowControl, RemoteStreamLimits, SenderFlowControl};
-    use crate::packet::PacketBuilder;
-    use crate::stats::FrameStats;
-    use crate::stream_id::{StreamId, StreamType};
-    use crate::Error;
+    use crate::{
+        packet::PacketBuilder,
+        stats::FrameStats,
+        stream_id::{StreamId, StreamType},
+        Error,
+    };
     use neqo_common::{Encoder, Role};
 
     #[test]
@@ -859,7 +864,7 @@ mod test {
         let mut fc = RemoteStreamLimits::new(2, 1, Role::Client);
         assert_eq!(fc[StreamType::BiDi].take_stream_id(), StreamId::from(1));
         assert_eq!(fc[StreamType::BiDi].take_stream_id(), StreamId::from(5));
-        let _ = fc[StreamType::BiDi].take_stream_id();
+        _ = fc[StreamType::BiDi].take_stream_id();
     }
 
     fn local_stream_limits(role: Role, bidi: u64, unidi: u64) {

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -6,28 +6,32 @@
 
 // Buffering data to send until it is acked.
 
-use std::cell::RefCell;
-use std::cmp::{max, min, Ordering};
-use std::collections::{BTreeMap, VecDeque};
-use std::convert::TryFrom;
-use std::mem;
-use std::ops::Add;
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    cmp::{max, min, Ordering},
+    collections::{BTreeMap, VecDeque},
+    convert::TryFrom,
+    mem,
+    ops::Add,
+    rc::Rc,
+};
 
 use indexmap::IndexMap;
 use smallvec::SmallVec;
 
 use neqo_common::{qdebug, qerror, qinfo, qtrace, Encoder, Role};
 
-use crate::events::ConnectionEvents;
-use crate::fc::SenderFlowControl;
-use crate::frame::{Frame, FRAME_TYPE_RESET_STREAM};
-use crate::packet::PacketBuilder;
-use crate::recovery::{RecoveryToken, StreamRecoveryToken};
-use crate::stats::FrameStats;
-use crate::stream_id::StreamId;
-use crate::tparams::{self, TransportParameters};
-use crate::{AppError, Error, Res};
+use crate::{
+    events::ConnectionEvents,
+    fc::SenderFlowControl,
+    frame::{Frame, FRAME_TYPE_RESET_STREAM},
+    packet::PacketBuilder,
+    recovery::{RecoveryToken, StreamRecoveryToken},
+    stats::FrameStats,
+    stream_id::StreamId,
+    tparams::{self, TransportParameters},
+    AppError, Error, Res,
+};
 
 pub const SEND_BUFFER_SIZE: usize = 0x10_0000; // 1 MiB
 
@@ -1859,7 +1863,7 @@ mod tests {
         s.set_max_stream_data(len_u64);
 
         // Send all the data, then the fin.
-        let _ = s.send(MESSAGE).unwrap();
+        _ = s.send(MESSAGE).unwrap();
         s.mark_as_sent(0, MESSAGE.len(), false);
         s.close();
         s.mark_as_sent(len_u64, 0, true);
@@ -1883,7 +1887,7 @@ mod tests {
         s.set_max_stream_data(len_u64);
 
         // Send all the data, then the fin.
-        let _ = s.send(MESSAGE).unwrap();
+        _ = s.send(MESSAGE).unwrap();
         s.mark_as_sent(0, MESSAGE.len(), false);
         s.close();
         s.mark_as_sent(len_u64, 0, true);

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -6,20 +6,20 @@
 
 // Stream management for a connection.
 
-use crate::fc::{LocalStreamLimits, ReceiverFlowControl, RemoteStreamLimits, SenderFlowControl};
-use crate::frame::Frame;
-use crate::packet::PacketBuilder;
-use crate::recovery::{RecoveryToken, StreamRecoveryToken};
-use crate::recv_stream::{RecvStream, RecvStreams};
-use crate::send_stream::{SendStream, SendStreams, TransmissionPriority};
-use crate::stats::FrameStats;
-use crate::stream_id::{StreamId, StreamType};
-use crate::tparams::{self, TransportParametersHandler};
-use crate::ConnectionEvents;
-use crate::{Error, Res};
+use crate::{
+    fc::{LocalStreamLimits, ReceiverFlowControl, RemoteStreamLimits, SenderFlowControl},
+    frame::Frame,
+    packet::PacketBuilder,
+    recovery::{RecoveryToken, StreamRecoveryToken},
+    recv_stream::{RecvStream, RecvStreams},
+    send_stream::{SendStream, SendStreams, TransmissionPriority},
+    stats::FrameStats,
+    stream_id::{StreamId, StreamType},
+    tparams::{self, TransportParametersHandler},
+    ConnectionEvents, Error, Res,
+};
 use neqo_common::{qtrace, qwarn, Role};
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
 pub struct Streams {
     role: Role,
@@ -441,13 +441,13 @@ impl Streams {
     }
 
     pub fn set_initial_limits(&mut self) {
-        let _ = self.local_stream_limits[StreamType::BiDi].update(
+        _ = self.local_stream_limits[StreamType::BiDi].update(
             self.tps
                 .borrow()
                 .remote()
                 .get_integer(tparams::INITIAL_MAX_STREAMS_BIDI),
         );
-        let _ = self.local_stream_limits[StreamType::UniDi].update(
+        _ = self.local_stream_limits[StreamType::UniDi].update(
             self.tps
                 .borrow()
                 .remote()

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -6,22 +6,26 @@
 
 // Transport parameters. See -transport section 7.3.
 
-use crate::cid::{
-    ConnectionId, ConnectionIdEntry, CONNECTION_ID_SEQNO_PREFERRED, MAX_CONNECTION_ID_LEN,
+use crate::{
+    cid::{ConnectionId, ConnectionIdEntry, CONNECTION_ID_SEQNO_PREFERRED, MAX_CONNECTION_ID_LEN},
+    version::{Version, VersionConfig, WireVersion},
+    Error, Res,
 };
-use crate::version::{Version, VersionConfig, WireVersion};
-use crate::{Error, Res};
 
 use neqo_common::{hex, qdebug, qinfo, qtrace, Decoder, Encoder, Role};
-use neqo_crypto::constants::{TLS_HS_CLIENT_HELLO, TLS_HS_ENCRYPTED_EXTENSIONS};
-use neqo_crypto::ext::{ExtensionHandler, ExtensionHandlerResult, ExtensionWriterResult};
-use neqo_crypto::{random, HandshakeMessage, ZeroRttCheckResult, ZeroRttChecker};
+use neqo_crypto::{
+    constants::{TLS_HS_CLIENT_HELLO, TLS_HS_ENCRYPTED_EXTENSIONS},
+    ext::{ExtensionHandler, ExtensionHandlerResult, ExtensionWriterResult},
+    random, HandshakeMessage, ZeroRttCheckResult, ZeroRttChecker,
+};
 
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    convert::TryFrom,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    rc::Rc,
+};
 
 pub type TransportParameterId = u64;
 macro_rules! tpids {
@@ -940,7 +944,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn preferred_address_v4_unspecified() {
-        let _ = PreferredAddress::new(
+        _ = PreferredAddress::new(
             Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::from(0)), 443)),
             None,
         );
@@ -949,7 +953,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn preferred_address_v4_zero_port() {
-        let _ = PreferredAddress::new(
+        _ = PreferredAddress::new(
             Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::from(0xc000_0201)), 0)),
             None,
         );
@@ -958,7 +962,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn preferred_address_v6_unspecified() {
-        let _ = PreferredAddress::new(
+        _ = PreferredAddress::new(
             None,
             Some(SocketAddr::new(IpAddr::V6(Ipv6Addr::from(0)), 443)),
         );
@@ -967,7 +971,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn preferred_address_v6_zero_port() {
-        let _ = PreferredAddress::new(
+        _ = PreferredAddress::new(
             None,
             Some(SocketAddr::new(IpAddr::V6(Ipv6Addr::from(1)), 0)),
         );
@@ -976,7 +980,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn preferred_address_v4_is_v6() {
-        let _ = PreferredAddress::new(
+        _ = PreferredAddress::new(
             Some(SocketAddr::new(IpAddr::V6(Ipv6Addr::from(1)), 443)),
             None,
         );
@@ -985,7 +989,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn preferred_address_v6_is_v4() {
-        let _ = PreferredAddress::new(
+        _ = PreferredAddress::new(
             None,
             Some(SocketAddr::new(
                 IpAddr::V4(Ipv4Addr::from(0xc000_0201)),

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -8,19 +8,23 @@
 
 #![deny(clippy::pedantic)]
 
-use std::cmp::min;
-use std::collections::VecDeque;
-use std::convert::TryFrom;
-use std::ops::{Index, IndexMut};
-use std::time::{Duration, Instant};
+use std::{
+    cmp::min,
+    collections::VecDeque,
+    convert::TryFrom,
+    ops::{Index, IndexMut},
+    time::{Duration, Instant},
+};
 
 use neqo_common::{qdebug, qinfo, qtrace, qwarn};
 use neqo_crypto::{Epoch, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL};
 
-use crate::packet::{PacketBuilder, PacketNumber, PacketType};
-use crate::recovery::RecoveryToken;
-use crate::stats::FrameStats;
-use crate::{Error, Res};
+use crate::{
+    packet::{PacketBuilder, PacketNumber, PacketType},
+    recovery::RecoveryToken,
+    stats::FrameStats,
+    Error, Res,
+};
 
 use smallvec::{smallvec, SmallVec};
 
@@ -742,9 +746,11 @@ mod tests {
         AckTracker, Duration, Instant, PacketNumberSpace, PacketNumberSpaceSet, RecoveryToken,
         RecvdPackets, MAX_TRACKED_RANGES,
     };
-    use crate::frame::Frame;
-    use crate::packet::{PacketBuilder, PacketNumber};
-    use crate::stats::FrameStats;
+    use crate::{
+        frame::Frame,
+        packet::{PacketBuilder, PacketNumber},
+        stats::FrameStats,
+    };
     use lazy_static::lazy_static;
     use neqo_common::Encoder;
     use std::collections::HashSet;
@@ -1125,7 +1131,7 @@ mod tests {
         assert_eq!(stats.ack, 1);
 
         let mut dec = builder.as_decoder();
-        let _ = dec.decode_byte().unwrap(); // Skip the short header.
+        _ = dec.decode_byte().unwrap(); // Skip the short header.
         let frame = Frame::decode(&mut dec).unwrap();
         if let Frame::Ack { ack_ranges, .. } = frame {
             assert_eq!(ack_ranges.len(), 0);

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -27,12 +27,7 @@ use test_fixture::{
     CountingConnectionIdGenerator,
 };
 
-use std::cell::RefCell;
-use std::convert::TryFrom;
-use std::mem;
-use std::net::SocketAddr;
-use std::rc::Rc;
-use std::time::Duration;
+use std::{cell::RefCell, convert::TryFrom, mem, net::SocketAddr, rc::Rc, time::Duration};
 
 /// Take a pair of connections in any state and complete the handshake.
 /// The `datagram` argument is a packet that was received from the server.
@@ -51,7 +46,7 @@ pub fn complete_connection(
         )
     };
     while !is_done(client) {
-        let _ = test_fixture::maybe_authenticate(client);
+        _ = test_fixture::maybe_authenticate(client);
         let out = client.process(datagram, now());
         let out = server.process(out.dgram(), now());
         datagram = out.dgram();
@@ -725,7 +720,7 @@ fn max_streams_after_0rtt_rejection() {
 
     let mut client = default_client();
     client.enable_resumption(now(), &token).unwrap();
-    let _ = client.stream_create(StreamType::BiDi).unwrap();
+    _ = client.stream_create(StreamType::BiDi).unwrap();
     let dgram = client.process_output(now()).dgram();
     let dgram = server.process(dgram, now()).dgram();
     let dgram = client.process(dgram, now()).dgram();

--- a/neqo-transport/tests/sim/connection.rs
+++ b/neqo-transport/tests/sim/connection.rs
@@ -12,9 +12,11 @@ use neqo_crypto::AuthenticationStatus;
 use neqo_transport::{
     Connection, ConnectionEvent, ConnectionParameters, Output, State, StreamId, StreamType,
 };
-use std::cmp::min;
-use std::fmt::{self, Debug};
-use std::time::Instant;
+use std::{
+    cmp::min,
+    fmt::{self, Debug},
+    time::Instant,
+};
 
 /// The status of the processing of an event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -116,7 +118,7 @@ impl Node for ConnectionNode {
     }
 
     fn process(&mut self, mut d: Option<Datagram>, now: Instant) -> Output {
-        let _ = self.process_goals(|goal, c| goal.process(c, now));
+        _ = self.process_goals(|goal, c| goal.process(c, now));
         loop {
             let res = self.c.process(d.take(), now);
 

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -16,13 +16,15 @@ use neqo_transport::{
     ConnectionIdGenerator, ConnectionIdRef, ConnectionParameters, State, Version,
 };
 
-use std::cell::RefCell;
-use std::cmp::max;
-use std::convert::TryFrom;
-use std::mem;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::rc::Rc;
-use std::time::{Duration, Instant};
+use std::{
+    cell::RefCell,
+    cmp::max,
+    convert::TryFrom,
+    mem,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    rc::Rc,
+    time::{Duration, Instant},
+};
 
 use lazy_static::lazy_static;
 
@@ -195,7 +197,7 @@ pub fn handshake(client: &mut Connection, server: &mut Connection) {
         )
     };
     while !is_done(a) {
-        let _ = maybe_authenticate(a);
+        _ = maybe_authenticate(a);
         let d = a.process(datagram, now());
         datagram = d.dgram();
         mem::swap(&mut a, &mut b);


### PR DESCRIPTION
This is the preferred way to ignore a return value now, apparently.

The alternative is `let _: ReturnType =`, which is nice in the sense that it ensures that the type remains stable, but that is verbose and mostly these are just in test code.