### PR TITLE
Update CI dependencies

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,8 +37,8 @@ jobs:
             ssh \
             zlib1g-dev \
             --no-install-recommends
-          [ -d /usr/lib/llvm-10/lib ] # Expect clang 10
-          echo "LIBCLANG_DIR=/usr/lib/llvm-10/lib" >> "$GITHUB_ENV"
+          [ -d /usr/lib/llvm-14/lib ] # Expect clang 14
+          echo "LIBCLANG_DIR=/usr/lib/llvm-14/lib" >> "$GITHUB_ENV"
 
       # Rust installation cribbed from Dockerfiles at https://github.com/rust-lang/docker-rust
       - name: Install Rust

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Install Packages
         env:
           DEBIAN_FRONTEND: noninteractive
+          llvm_version: 14
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -29,7 +30,8 @@ jobs:
             libclang-dev \
             libssl-dev \
             lld \
-            llvm \
+            llvm-"$llvm_version" \
+            llvm-"$llvm_version"-runtime \
             make \
             mercurial \
             ninja-build \
@@ -37,8 +39,8 @@ jobs:
             ssh \
             zlib1g-dev \
             --no-install-recommends
-          [ -d /usr/lib/llvm-14/lib ] # Expect clang 14
-          echo "LIBCLANG_DIR=/usr/lib/llvm-14/lib" >> "$GITHUB_ENV"
+          [ -d "/usr/lib/llvm-$llvm_version/lib" ]
+          echo "LIBCLANG_DIR=/usr/lib/llvm-$llvm_version/lib" >> "$GITHUB_ENV"
 
       # Rust installation cribbed from Dockerfiles at https://github.com/rust-lang/docker-rust
       - name: Install Rust

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,7 @@ env:
 jobs:
   check:
     name: Neqo Build and Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       RUSTFLAGS: -C link-arg=-fuse-ld=lld
     strategy:
@@ -63,12 +63,12 @@ jobs:
           echo "CARGO_HOME=$CARGO_HOME" >> "$GITHUB_ENV"
           echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
         env:
-          rustup_version: 1.24.3
+          rustup_version: 1.26.0
           rustup_host: x86_64-unknown-linux-gnu
-          rustup_hash: 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
+          rustup_hash: 0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # This step might be removed if the distro included a recent enough
       # version of NSS.  Ubuntu 20.04 only has 3.49, which is far too old.


### PR DESCRIPTION
Ubuntu version 20.04 -> 22.04
checkout action v2 -> v3
rustup 1.24.3 -> 1.26.0
LLVM 10 -> 14 (comes with the Ubuntu change)

The only one that is urgent is the action update, which will result in builds failing if we don't fix it.  The others are just so that we don't drop too far behind.

Definitely don't commit this until CI passes, which means that I need to fix the `EnumSet` thing.