### PR TITLE
Add support for WebTransport SendOrder to neqo (issue  #1432)

### DIFF
--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -232,7 +232,7 @@ possible if there is no buffered data.
 If a stream has buffered data it will be registered in the `streams_with_pending_data` queue and
 actual sending will be performed in the `process_sending` function call. (This is done in this way,
 i.e. data is buffered first and then sent, for 2 reasons: in this way, sending will happen in a
-single function,  therefore error handling and clean up is easier and the QUIIC layer may not be
+single function,  therefore error handling and clean up is easier and the QUIC layer may not be
 able to accept all data and being able to buffer data is required in any case.)
 
 The `send` and `send_data` functions may detect that the stream is closed and all outstanding data
@@ -920,7 +920,7 @@ impl Http3Connection {
         );
 
         // Call immediately send so that at least headers get sent. This will make Firefox faster, since
-        // it can send request body immediatly in most cases and does not need to do a complete process loop.
+        // it can send request body immediately in most cases and does not need to do a complete process loop.
         self.send_streams
             .get_mut(&stream_id)
             .ok_or(Error::InvalidStreamId)?
@@ -993,6 +993,17 @@ impl Http3Connection {
         // Stream may be already be closed and we may get an error here, but we do not care.
         conn.stream_stop_sending(stream_id, error)?;
         Ok(())
+    }
+
+    pub fn stream_set_sendorder(
+        &mut self,
+        conn: &mut Connection,
+        stream_id: StreamId,
+	sendorder: Option<i64>) -> Res<()> {
+        let send_stream = self.send_streams.get_mut(&stream_id)
+	                .ok_or(Error::InvalidStreamId)?;
+	send_stream.set_sendorder(conn, sendorder);
+	Ok(())
     }
 
     pub fn cancel_fetch(

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -754,6 +754,16 @@ impl Http3Client {
             - u64::try_from(Encoder::varint_len(session_id.as_u64())).unwrap())
     }
 
+    /// Sets the SendOrder for a given stream
+    /// # Errors
+    /// XXX No errors are returned
+    /// # Panics
+    /// This cannot panic.
+    pub fn webtransport_set_sendorder(&mut self, stream_id: StreamId, sendorder: i64) {
+	self.base_handler
+	    .stream_set_sendorder(&mut self.conn, stream_id, Some(sendorder)).ok();
+    }
+
     /// This function combines  `process_input` and `process_output` function.
     pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
         qtrace!([self], "Process.");

--- a/neqo-http3/src/features/extended_connect/webtransport_session.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_session.rs
@@ -486,6 +486,10 @@ impl SendStream for Rc<RefCell<WebTransportSession>> {
         self.borrow_mut().has_data_to_send()
     }
 
+    fn set_sendorder(&mut self, _conn: &mut Connection, _sendorder: Option<i64>) {
+//	self.borrow_mut().set_sendorder(conn, sendorder);
+    }
+    
     fn stream_writable(&self) {}
 
     fn done(&self) -> bool {

--- a/neqo-http3/src/features/extended_connect/webtransport_streams.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_streams.rs
@@ -185,6 +185,10 @@ impl SendStream for WebTransportSendStream {
         }
     }
 
+    fn set_sendorder(&mut self, conn: &mut Connection, sendorder: Option<i64>) {
+	conn.stream_sendorder(self.stream_id, sendorder);
+    }
+
     fn handle_stop_sending(&mut self, close_type: CloseType) {
         self.set_done(close_type);
     }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -550,6 +550,7 @@ trait SendStream: Stream {
     fn has_data_to_send(&self) -> bool;
     fn stream_writable(&self);
     fn done(&self) -> bool;
+    fn set_sendorder(&mut self, conn: &mut Connection, sendorder: Option<i64>);
     /// # Errors
     /// Error my occure during sending data, e.g. protocol error, etc.
     fn send_data(&mut self, _conn: &mut Connection, _buf: &[u8]) -> Res<usize>;

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -271,6 +271,10 @@ impl SendStream for SendMessage {
         self.stream.has_buffered_data()
     }
 
+    fn set_sendorder(&mut self, _conn: &mut Connection, _sendorder: Option<i64>) {
+//	self.stream.set_sendorder(conn, sendorder);
+    }
+    
     fn close(&mut self, conn: &mut Connection) -> Res<()> {
         self.state.fin()?;
         if !self.stream.has_buffered_data() {

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1911,9 +1911,13 @@ impl Connection {
             }
         }
 
+	// datagrams are best-effort and unreliable.  Let streams starve them for now
         // Check if there is a Datagram to be written
         self.quic_datagrams
             .write_frames(builder, tokens, &mut self.stats.borrow_mut());
+        if builder.is_full() {
+            return Ok(());
+        }
 
         let stats = &mut self.stats.borrow_mut().frame_tx;
 
@@ -1945,8 +1949,25 @@ impl Connection {
             return Ok(());
         }
 
-        self.streams
-            .write_frames(TransmissionPriority::Normal, builder, tokens, stats);
+        // WebTransport data (which is Normal) may have a SendOrder
+	// priority attached.  The spec states (6.3 write-chunk 6.1):
+
+        // If stream.[[SendOrder]] is null then this sending MUST NOT
+	// starve except for flow control reasons or error.  If
+	// stream.[[SendOrder]] is not null then this sending MUST starve
+	// until all bytes queued for sending on WebTransportSendStreams
+	// with a non-null and higher [[SendOrder]], that are neither
+	// errored nor blocked by flow control, have been sent.
+
+	// So data without SendOrder goes first.   Then the highest priority
+	// SendOrdered streams.   Round-robining the data at the same priority
+	// isn't required (currently) by the spec, but would be good to do in the future.
+	// "ordered()" returns a chained hash that iterates all the streams in the order
+	// described above.
+	let stream_ids = self.streams.ordered().copied().collect::<Vec<StreamId>>();
+	for stream_id in stream_ids.iter() {
+	    self.streams.get_send_stream_mut(*stream_id).unwrap().write_frames(TransmissionPriority::Normal, builder, tokens, stats);
+        }
         if builder.is_full() {
             return Ok(());
         }
@@ -2939,6 +2960,17 @@ impl Connection {
             .get_send_stream_mut(stream_id)?
             .set_priority(transmission, retransmission);
         Ok(())
+    }
+
+    /// Set the SendOrder of a stream.  Re-enqueues to keep the ordering correct
+    /// # Errors
+    /// `InvalidStreamId` the stream does not exist.
+    pub fn stream_sendorder(
+        &mut self,
+        stream_id: StreamId,
+        sendorder: Option<i64>,
+    ) {
+	self.streams.set_sendorder(stream_id, sendorder).ok();
     }
 
     /// Send data on a stream.

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -5,6 +5,8 @@
 // except according to those terms.
 
 // Stream management for a connection.
+use std::collections::BTreeMap;
+use std::collections::HashSet;
 
 use crate::{
     fc::{LocalStreamLimits, ReceiverFlowControl, RemoteStreamLimits, SenderFlowControl},
@@ -20,6 +22,32 @@ use crate::{
 };
 use neqo_common::{qtrace, qwarn, Role};
 use std::{cell::RefCell, rc::Rc};
+use std::cmp::Ordering;
+
+struct StreamOrder {
+    sendorder: Option<i64>,
+}
+
+impl Ord for StreamOrder {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.sendorder.cmp(&other.sendorder)
+    }
+}
+
+impl PartialOrd for StreamOrder {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for StreamOrder {
+    fn eq(&self, other: &Self) -> bool {
+        self.sendorder == other.sendorder
+    }
+}
+
+impl Eq for StreamOrder {}
+
 
 pub struct Streams {
     role: Role,
@@ -31,6 +59,21 @@ pub struct Streams {
     local_stream_limits: LocalStreamLimits,
     pub(crate) send: SendStreams,
     pub(crate) recv: RecvStreams,
+    // What we really want is a Priority Queue that we can do arbitrary removes
+    // from (so we can reprioritize). BinaryHeap doesn't work, because there's no
+    // remove().  BTreeMap doesn't work, since you can't duplicate keys.
+    // PriorityQueue does have what we need, except for an ordered iterator that doesn't consume the queue.
+
+    // So we use a HashSet for the unordered streams (that's usually all of
+    // them), and then a BTreeMap of an entry for each SendOrder value, and
+    // for each of those entries a HashSet of the stream_ids at that
+    // sendorder.  In most cases (such as stream-per-frame), there will be
+    // a single stream at a given sendorder.
+    
+    // These both store stream_ids, which need to be looked up in 'send'.  This avoids the complexity
+    // of trying to hold references to the Streams which are owned by the send IndexMap.
+    ordered_send: BTreeMap<StreamOrder, HashSet<StreamId>>,
+    unordered_send: HashSet<StreamId>, // streams with no SendOrder set
 }
 
 impl Streams {
@@ -58,6 +101,8 @@ impl Streams {
             local_stream_limits: LocalStreamLimits::new(role),
             send: SendStreams::default(),
             recv: RecvStreams::default(),
+	    ordered_send: BTreeMap::new(),
+	    unordered_send: HashSet::new(),
         }
     }
 
@@ -68,6 +113,8 @@ impl Streams {
     pub fn zero_rtt_rejected(&mut self) {
         self.send.clear();
         self.recv.clear();
+	self.ordered_send.clear();
+	self.unordered_send.clear();
         debug_assert_eq!(
             self.remote_stream_limits[StreamType::BiDi].max_active(),
             self.tps
@@ -292,10 +339,21 @@ impl Streams {
     pub fn clear_streams(&mut self) {
         self.send.clear();
         self.recv.clear();
+	self.ordered_send.clear();
+	self.unordered_send.clear();
     }
 
     pub fn cleanup_closed_streams(&mut self) {
-        self.send.clear_terminal();
+	let clean_list = self.send.get_terminal();
+	for stream_id in clean_list.iter() {
+	    // Not sure which one it's in
+	    self.unordered_send.remove(stream_id);
+	    for (_, set) in self.ordered_send.iter_mut() {
+		set.remove(stream_id);
+	    }
+	    self.send.remove(stream_id);
+	}
+
         let send = &self.send;
         let (removed_bidi, removed_uni) = self.recv.clear_terminal(send, self.role);
 
@@ -377,6 +435,42 @@ impl Streams {
         ))
     }
 
+    pub fn set_sendorder(&mut self, stream_id: StreamId, sendorder: Option<i64>) -> Res<()> {
+	// don't grab stream here; causes borrow errors
+        let old_sendorder = self.get_send_stream(stream_id).unwrap().sendorder();
+	if old_sendorder != sendorder {
+	    // we have to remove it from the list it was in, and reinsert it with the new
+	    // sendorder key
+            if old_sendorder == None {
+		self.unordered_send.remove(&stream_id);
+            } else {
+		let order = StreamOrder { sendorder: old_sendorder };
+		self.ordered_send.get_mut(&order).unwrap().remove(&stream_id);
+	    }
+            self.get_send_stream_mut(stream_id).unwrap().set_sendorder(sendorder);
+	    if sendorder == None {
+		self.unordered_send.insert(stream_id);
+	    } else {
+		let mut set = self.ordered_send.get_mut(&StreamOrder { sendorder });
+		if set == None {
+		    // new sendorder; create a hash for it
+		    let hash = HashSet::<StreamId>::new();
+		    self.ordered_send.insert(StreamOrder { sendorder }, hash);
+		    set = self.ordered_send.get_mut(&StreamOrder { sendorder });
+		}
+		set.unwrap().insert(stream_id);
+	    }
+	}
+	Ok(())
+    }
+
+    // ordered iterator that iterates over the unordered streams and then
+    // the ordered streams, from highest to lowest.   Note: no attempt at
+    // fairness is made here.
+    pub fn ordered(&mut self) -> impl Iterator<Item = &StreamId> {
+	self.unordered_send.iter().chain(self.ordered_send.values().flatten())
+    }
+
     pub fn stream_create(&mut self, st: StreamType) -> Res<StreamId> {
         match self.local_stream_limits.take_stream_id(st) {
             None => Err(Error::StreamLimitError),
@@ -386,15 +480,17 @@ impl Streams {
                     StreamType::BiDi => tparams::INITIAL_MAX_STREAM_DATA_BIDI_REMOTE,
                 };
                 let send_limit = self.tps.borrow().remote().get_integer(send_limit_tp);
-                self.send.insert(
-                    new_id,
-                    SendStream::new(
+		let stream = SendStream::new(
                         new_id,
                         send_limit,
                         Rc::clone(&self.sender_fc),
                         self.events.clone(),
-                    ),
+                    );
+                self.send.insert(
+                    new_id, stream,
                 );
+                self.unordered_send.insert(new_id);
+
                 if st == StreamType::BiDi {
                     // From the local perspective, this is a local- originated BiDi stream. From the
                     // remote perspective, this is a remote-originated BiDi stream. Therefore, look at


### PR DESCRIPTION
 No attempt at fairness within a sendorder (or for unordered streams) is attempted.

A few typos are corrected as well