### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Martin Thomson <mt@lowentropy.net>",
 	"Andy Grover <agrover@mozilla.com>"]
 edition = "2018"
 rust-version = "1.65.0"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 neqo-crypto = { path = "./../neqo-crypto" }

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.5"
 authors = ["Bobby Holley <bobbyholley@gmail.com>"]
 edition = "2018"
 rust-version = "1.65.0"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 build = "build.rs"
 
 [dependencies]

--- a/neqo-crypto/Cargo.toml
+++ b/neqo-crypto/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Martin Thomson <mt@lowentropy.net>"]
 edition = "2018"
 rust-version = "1.65.0"
 build = "build.rs"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 neqo-common = { path = "../neqo-common" }

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.5"
 authors = ["Dragana Damjanovic <dragana.damjano@gmail.com>"]
 edition = "2018"
 rust-version = "1.65.0"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 neqo-common = { path = "./../neqo-common" }

--- a/neqo-interop/Cargo.toml
+++ b/neqo-interop/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.5"
 authors = ["EKR <ekr@rtfm.com>"]
 edition = "2018"
 rust-version = "1.65.0"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 neqo-crypto = { path = "./../neqo-crypto" }

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.5"
 authors = ["Dragana Damjanovic <dragana.damjano@gmail.com>"]
 edition = "2018"
 rust-version = "1.65.0"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 neqo-common = { path = "./../neqo-common" }

--- a/neqo-server/Cargo.toml
+++ b/neqo-server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.5"
 authors = ["Dragana Damjanovic <dragana.damjano@gmail.com>"]
 edition = "2018"
 rust-version = "1.65.0"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 neqo-crypto = { path = "./../neqo-crypto" }

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.5"
 authors = ["EKR <ekr@rtfm.com>", "Andy Grover <agrover@mozilla.com>"]
 edition = "2018"
 rust-version = "1.65.0"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 neqo-crypto = { path = "../neqo-crypto" }

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.5"
 authors = ["Martin Thomson <mt@lowentropy.net>"]
 edition = "2018"
 rust-version = "1.65.0"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 neqo-common = { path = "../neqo-common" }


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields