### PR TITLE
General maintenance

### DIFF
--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -12,7 +12,7 @@ log = {version = "0.4.0", default-features = false}
 env_logger = {version = "0.10", default-features = false}
 lazy_static = "1.3.0"
 qlog = "0.4.0"
-time = {version = "0.3", features = ["formatting"]}
+time = {version = "0.3.23", features = ["formatting"]}
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -12,7 +12,7 @@ log = {version = "0.4.0", default-features = false}
 env_logger = {version = "0.10", default-features = false}
 lazy_static = "1.3.0"
 qlog = "0.4.0"
-time = {version = "0.3.23", features = ["formatting"]}
+time = {version = "=0.3.23", features = ["formatting"]}
 
 [features]
 default = ["deny-warnings"]

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -107,7 +107,6 @@ impl<'a> Decoder<'a> {
     }
 
     /// Decodes a QUIC varint.
-    #[allow(clippy::missing_panics_doc)] // See https://github.com/rust-lang/rust-clippy/issues/6699
     pub fn decode_varint(&mut self) -> Option<u64> {
         let Some(b1) = self.decode_byte() else {
             return None;

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -109,7 +109,9 @@ impl<'a> Decoder<'a> {
     /// Decodes a QUIC varint.
     #[allow(clippy::missing_panics_doc)] // See https://github.com/rust-lang/rust-clippy/issues/6699
     pub fn decode_varint(&mut self) -> Option<u64> {
-        let Some(b1) = self.decode_byte() else { return None };
+        let Some(b1) = self.decode_byte() else {
+            return None;
+        };
         match b1 >> 6 {
             0 => Some(u64::from(b1 & 0x3f)),
             1 => Some((u64::from(b1 & 0x3f) << 8) | self.decode_uint(1)?),

--- a/neqo-common/src/header.rs
+++ b/neqo-common/src/header.rs
@@ -11,11 +11,14 @@ pub struct Header {
 }
 
 impl Header {
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn new(name: impl ToString, value: impl ToString) -> Self {
+    pub fn new<N, V>(name: N, value: V) -> Self
+    where
+        N: Into<String> + ?Sized,
+        V: Into<String> + ?Sized,
+    {
         Self {
-            name: name.to_string(),
-            value: value.to_string(),
+            name: name.into(),
+            value: value.into(),
         }
     }
 

--- a/neqo-common/src/incrdecoder.rs
+++ b/neqo-common/src/incrdecoder.rs
@@ -21,7 +21,8 @@ impl IncrementalDecoderUint {
     }
 
     /// Consume some data.
-    #[allow(clippy::missing_panics_doc)] // See https://github.com/rust-lang/rust-clippy/issues/6699
+    /// # Panics
+    /// Never, but this is not something the compiler can tell.
     pub fn consume(&mut self, dv: &mut Decoder) -> Option<u64> {
         if let Some(r) = &mut self.remaining {
             let amount = min(*r, dv.remaining());

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -29,7 +29,7 @@ macro_rules! do_log {
             );
         }
     });
-    ($lvl:expr, $($arg:tt)+) => ($crate::do_log!(target: ::log::__log_module_path!(), $lvl, $($arg)+))
+    ($lvl:expr, $($arg:tt)+) => ($crate::do_log!(target: module_path!(), $lvl, $($arg)+))
 }
 
 #[macro_export]

--- a/neqo-common/src/timer.rs
+++ b/neqo-common/src/timer.rs
@@ -151,7 +151,10 @@ impl<T> Timer<T> {
             return None;
         }
         let bucket = self.time_bucket(time);
-        let Ok(start_index) = self.items[bucket].binary_search_by_key(&time, TimerItem::time) else { return None };
+        let Ok(start_index) = self.items[bucket].binary_search_by_key(&time, TimerItem::time)
+        else {
+            return None;
+        };
         // start_index is just one of potentially many items with the same time.
         // Search backwards for a match, ...
         for i in (0..=start_index).rev() {

--- a/neqo-common/src/timer.rs
+++ b/neqo-common/src/timer.rs
@@ -75,7 +75,7 @@ impl<T> Timer<T> {
     #[inline]
     #[allow(clippy::cast_possible_truncation)] // guarded by assertion
     fn delta(&self, time: Instant) -> usize {
-        // This really should use Instant::div_duration(), but it can't yet.
+        // This really should use Duration::div_duration_f??(), but it can't yet.
         ((time - self.now).as_nanos() / self.granularity.as_nanos()) as usize
     }
 

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -716,6 +716,8 @@ impl SecretAgent {
         Ok(*Pin::into_inner(records))
     }
 
+    /// # Panics
+    /// If setup fails.
     #[allow(unknown_lints, clippy::branches_sharing_code)]
     pub fn close(&mut self) {
         // It should be safe to close multiple times.

--- a/neqo-crypto/src/hp.rs
+++ b/neqo-crypto/src/hp.rs
@@ -164,9 +164,9 @@ impl HpKey {
 
             Self::Chacha(key) => {
                 let params: CK_CHACHA20_PARAMS = CK_CHACHA20_PARAMS {
-                    pBlockCounter: sample.as_ptr() as *mut u8,
+                    pBlockCounter: sample.as_ptr().cast_mut(),
                     blockCounterBits: 32,
-                    pNonce: sample[4..Self::SAMPLE_SIZE].as_ptr() as *mut _,
+                    pNonce: sample[4..Self::SAMPLE_SIZE].as_ptr().cast_mut(),
                     ulNonceBits: 96,
                 };
                 let mut output_len: c_uint = 0;

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -120,6 +120,8 @@ fn version_check() {
 }
 
 /// Initialize NSS.  This only executes the initialization routines once, so if there is any chance that
+/// # Panics
+/// When NSS initialization fails.
 pub fn init() {
     // Set time zero.
     time::init();

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -237,7 +237,7 @@ impl Item {
     pub fn wrap(buf: &[u8]) -> SECItem {
         SECItem {
             type_: SECItemType::siBuffer,
-            data: buf.as_ptr() as *mut u8,
+            data: buf.as_ptr().cast_mut(),
             len: c_uint::try_from(buf.len()).unwrap(),
         }
     }
@@ -247,9 +247,10 @@ impl Item {
     /// Minimally, it can only be passed as a `const SECItem*` argument to functions,
     /// or those that treat their argument as `const`.
     pub fn wrap_struct<T>(v: &T) -> SECItem {
+        let data: *const T = v;
         SECItem {
             type_: SECItemType::siBuffer,
-            data: (v as *const T as *mut T).cast(),
+            data: data.cast_mut().cast(),
             len: c_uint::try_from(mem::size_of::<T>()).unwrap(),
         }
     }

--- a/neqo-crypto/tests/agent.rs
+++ b/neqo-crypto/tests/agent.rs
@@ -439,7 +439,7 @@ fn ech_retry() {
         HandshakeState::EchFallbackAuthenticationPending(String::from(PUBLIC_NAME))
     );
     client.authenticated(AuthenticationStatus::Ok);
-    let Err(Error::EchRetry(updated_config)) = client.handshake_raw(now(), None)  else {
+    let Err(Error::EchRetry(updated_config)) = client.handshake_raw(now(), None) else {
         panic!(
             "Handshake should fail with EchRetry, state is instead {:?}",
             client.state()

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -338,7 +338,7 @@ impl Http3ClientEvents {
     }
 
     pub fn has_push(&self, push_id: u64) -> bool {
-        for iter in self.events.borrow().iter() {
+        for iter in &*self.events.borrow() {
             if matches!(iter, Http3ClientEvent::PushPromise{push_id:x, ..} if *x == push_id) {
                 return true;
             }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -399,6 +399,8 @@ impl Http3Client {
 
     /// Get the connection id, which is useful for disambiguating connections to
     /// the same origin.
+    /// # Panics
+    /// Never, because clients always have this field.
     #[must_use]
     pub fn connection_id(&self) -> &ConnectionId {
         self.conn.odcid().expect("Client always has odcid")
@@ -445,7 +447,9 @@ impl Http3Client {
             return Err(Error::InvalidState);
         }
         let mut dec = Decoder::from(token.as_ref());
-        let Some(settings_slice) = dec.decode_vvec() else { return Err(Error::InvalidResumptionToken) };
+        let Some(settings_slice) = dec.decode_vvec() else {
+            return Err(Error::InvalidResumptionToken);
+        };
         qtrace!([self], "  settings {}", hex_with_len(settings_slice));
         let mut dec_settings = Decoder::from(settings_slice);
         let mut settings = HSettings::default();

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -63,7 +63,9 @@ impl ControlStreamLocal {
     ) -> Res<()> {
         // send all necessary priority updates
         while let Some(update_id) = self.outstanding_priority_update.pop_front() {
-            let Some(update_stream) = recv_conn.get_mut(&update_id) else { continue };
+            let Some(update_stream) = recv_conn.get_mut(&update_id) else {
+                continue;
+            };
 
             // can assert and unwrap here, because priority updates can only be added to
             // HttpStreams in [Http3Connection::queue_update_priority}

--- a/neqo-http3/src/frames/wtframe.rs
+++ b/neqo-http3/src/frames/wtframe.rs
@@ -42,7 +42,9 @@ impl FrameDecoder<WebTransportFrame> for WebTransportFrame {
                 }
                 let error =
                     u32::try_from(dec.decode_uint(4).ok_or(Error::HttpMessageError)?).unwrap();
-                let Ok(message) = String::from_utf8(dec.decode_remainder().to_vec()) else { return Err(Error::HttpMessageError) };
+                let Ok(message) = String::from_utf8(dec.decode_remainder().to_vec()) else {
+                    return Err(Error::HttpMessageError);
+                };
                 Ok(Some(WebTransportFrame::CloseSession { error, message }))
             } else {
                 Ok(None)

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -376,7 +376,7 @@ impl QPackEncoder {
 
         let mut ref_entries = HashSet::new();
 
-        for iter in h.iter() {
+        for iter in h {
             let name = iter.name().as_bytes().to_vec();
             let value = iter.value().as_bytes().to_vec();
             qtrace!("encoding {:x?} {:x?}.", name, value);

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -50,7 +50,7 @@ pub enum Error {
     NeedMoreData, // Return when an input stream does not have more data that a decoder needs.(It does not mean that a stream is closed.)
     HeaderLookup,
     HuffmanDecompressionFailed,
-    ToStringFailed,
+    BadUtf8,
     ChangeCapacity,
     DynamicTableFull,
     IncrementAck,

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -197,7 +197,7 @@ impl HeaderTable {
             can_block
         );
         let mut name_match = None;
-        for iter in HEADER_STATIC_TABLE.iter() {
+        for iter in HEADER_STATIC_TABLE {
             if iter.name() == name {
                 if iter.value() == value {
                     return Some(LookupResult {

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -492,7 +492,7 @@ impl HttpServer for SimpleServer {
                     stream
                         .send_headers(&[
                             Header::new(":status", "200"),
-                            Header::new("content-length", response.remaining),
+                            Header::new("content-length", response.remaining.to_string()),
                         ])
                         .unwrap();
                     response.send(&mut stream);

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -927,12 +927,13 @@ fn ech_retry() {
         Some(&ConnectionError::Transport(Error::PeerError(0x100 + 121)))
     );
 
-    let Some(ConnectionError::Transport(Error::EchRetry(updated_config))) = client.state().error() else {
-            panic!(
-                "Client state should be failed with EchRetry, is {:?}",
-                client.state()
-            );
-        };
+    let Some(ConnectionError::Transport(Error::EchRetry(updated_config))) = client.state().error()
+    else {
+        panic!(
+            "Client state should be failed with EchRetry, is {:?}",
+            client.state()
+        );
+    };
 
     let mut server = default_server();
     server

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -991,7 +991,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::single_range_in_vec_init)] // Because that lint makes no sense here.
+    #[allow(unknown_lints, clippy::single_range_in_vec_init)] // Because that lint makes no sense here.
     fn recv_noncontiguous() {
         // Non-contiguous with the start, no data available.
         recv_ranges(&[10..20], 0);

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -991,6 +991,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::single_range_in_vec_init)] // Because that lint makes no sense here.
     fn recv_noncontiguous() {
         // Non-contiguous with the start, no data available.
         recv_ranges(&[10..20], 0);
@@ -1109,7 +1110,7 @@ mod tests {
         s.inbound_frame(offset, &[0; EXTRA_SIZE]);
 
         // Read, providing only enough space for the first.
-        let mut buf = vec![0; 100];
+        let mut buf = [0; 100];
         let count = s.read(&mut buf[..CHUNK_SIZE]);
         assert_eq!(count, CHUNK_SIZE);
         let count = s.read(&mut buf[..]);

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1807,7 +1807,7 @@ mod tests {
 
         // Mark all as sent. Get nothing
         txb.mark_as_sent(0, SEND_BUFFER_SIZE);
-        assert!(matches!(txb.next_bytes(), None));
+        assert!(txb.next_bytes().is_none());
 
         // Mark as lost. Get it again
         txb.mark_as_lost(one_byte_from_end, 1);
@@ -1908,7 +1908,7 @@ mod tests {
 
         // No more bytes.
         txb.mark_as_sent(range_a_end, 60);
-        assert!(matches!(txb.next_bytes(), None));
+        assert!(txb.next_bytes().is_none());
     }
 
     #[test]

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -124,6 +124,9 @@ impl ConnectionIdGenerator for CountingConnectionIdGenerator {
     }
 }
 
+/// Create a new client.
+/// # Panics
+/// If this doesn't work.
 #[must_use]
 pub fn new_client(params: ConnectionParameters) -> Connection {
     fixture_init();
@@ -158,6 +161,8 @@ pub fn default_server_h3() -> Connection {
 }
 
 /// Create a transport server with a configuration.
+/// # Panics
+/// If this doesn't work.
 #[must_use]
 pub fn new_server(alpn: &[impl AsRef<str>], params: ConnectionParameters) -> Connection {
     fixture_init();


### PR DESCRIPTION
Several things:

1. https://github.com/rust-lang/log/commit/9d052b17d3ddf9b5894740c6d82899c531c789ee changed the internal-only APIs used by the `log` crate.  This was always just a roundabout way of doing `module_path!()`, so we're good.
2. The `time` crate moved to a minimum version of rust beyond the one we support, so pin its version.
3. Clippy errors are being generated as a result of new rust versions.  There are a fair number of these:
   1. Remove some `clippy::missing_panics_doc` overrides.
   2. Some functions were really missing `Panics` docs.
   3. Some pointer casts were changed from `as *mut T` to `cast_mut()` or `as *const T` to `cast()`.
   4. Some calls to `.iter()` were unnecessary.
   5. A new `clippy::single_range_in_vec_init` lint was added, but with a false positive.
 6. Clippy complained about `Header::new` not taking a reference, but we explicitly want a value, so use `Into` rather than `ToString`.