### PR TITLE
Make the external set_sendorder() take an Option<SendOrder>

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -767,9 +767,9 @@ impl Http3Client {
     pub fn webtransport_set_sendorder(
         &mut self,
         stream_id: StreamId,
-        sendorder: SendOrder,
+        sendorder: Option<SendOrder>,
     ) -> Res<()> {
-        Http3Connection::stream_set_sendorder(&mut self.conn, stream_id, Some(sendorder))
+        Http3Connection::stream_set_sendorder(&mut self.conn, stream_id, sendorder)
     }
 
     /// Sets the `Fairness` for a given stream


### PR DESCRIPTION
The spec added this since the original SendOrder work started