### PR TITLE
Fix terminology in cubic beta variable

### DIFF
--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -494,7 +494,7 @@ mod tests {
     use super::{
         ClassicCongestionControl, WindowAdjustment, CWND_INITIAL, CWND_MIN, PERSISTENT_CONG_THRESH,
     };
-    use crate::cc::cubic::{Cubic, CUBIC_BETA_USIZE_DIVISOR, CUBIC_BETA_USIZE_QUOTIENT};
+    use crate::cc::cubic::{Cubic, CUBIC_BETA_USIZE_DIVIDEND, CUBIC_BETA_USIZE_DIVISOR};
     use crate::cc::new_reno::NewReno;
     use crate::cc::{
         CongestionControl, CongestionControlAlgorithm, CWND_INITIAL_PKTS, MAX_DATAGRAM_SIZE,
@@ -580,7 +580,7 @@ mod tests {
         );
         persistent_congestion_by_algorithm(
             CongestionControlAlgorithm::Cubic,
-            CWND_INITIAL * CUBIC_BETA_USIZE_QUOTIENT / CUBIC_BETA_USIZE_DIVISOR,
+            CWND_INITIAL * CUBIC_BETA_USIZE_DIVIDEND / CUBIC_BETA_USIZE_DIVISOR,
             lost_packets,
             persistent_expected,
         );

--- a/neqo-transport/src/cc/cubic.rs
+++ b/neqo-transport/src/cc/cubic.rs
@@ -21,7 +21,7 @@ pub const CUBIC_C: f64 = 0.4;
 pub const CUBIC_ALPHA: f64 = 3.0 * (1.0 - 0.7) / (1.0 + 0.7);
 
 // CUBIC_BETA = 0.7;
-pub const CUBIC_BETA_USIZE_QUOTIENT: usize = 7;
+pub const CUBIC_BETA_USIZE_DIVIDEND: usize = 7;
 pub const CUBIC_BETA_USIZE_DIVISOR: usize = 10;
 
 /// The fast convergence ratio further reduces the congestion window when a congestion event
@@ -188,8 +188,8 @@ impl WindowAdjustment for Cubic {
         };
         self.ca_epoch_start = None;
         (
-            curr_cwnd * CUBIC_BETA_USIZE_QUOTIENT / CUBIC_BETA_USIZE_DIVISOR,
-            acked_bytes * CUBIC_BETA_USIZE_QUOTIENT / CUBIC_BETA_USIZE_DIVISOR,
+            curr_cwnd * CUBIC_BETA_USIZE_DIVIDEND / CUBIC_BETA_USIZE_DIVISOR,
+            acked_bytes * CUBIC_BETA_USIZE_DIVIDEND / CUBIC_BETA_USIZE_DIVISOR,
         )
     }
 

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -11,7 +11,7 @@ use crate::{
     cc::{
         classic_cc::{ClassicCongestionControl, CWND_INITIAL},
         cubic::{
-            Cubic, CUBIC_ALPHA, CUBIC_BETA_USIZE_DIVISOR, CUBIC_BETA_USIZE_QUOTIENT, CUBIC_C,
+            Cubic, CUBIC_ALPHA, CUBIC_BETA_USIZE_DIVIDEND, CUBIC_BETA_USIZE_DIVISOR, CUBIC_C,
             CUBIC_FAST_CONVERGENCE,
         },
         CongestionControl, MAX_DATAGRAM_SIZE, MAX_DATAGRAM_SIZE_F64,
@@ -30,9 +30,9 @@ const RTT: Duration = Duration::from_millis(100);
 const CWND_INITIAL_F64: f64 = 10.0 * MAX_DATAGRAM_SIZE_F64;
 const CWND_INITIAL_10_F64: f64 = 10.0 * CWND_INITIAL_F64;
 const CWND_INITIAL_10: usize = 10 * CWND_INITIAL;
-const CWND_AFTER_LOSS: usize = CWND_INITIAL * CUBIC_BETA_USIZE_QUOTIENT / CUBIC_BETA_USIZE_DIVISOR;
+const CWND_AFTER_LOSS: usize = CWND_INITIAL * CUBIC_BETA_USIZE_DIVIDEND / CUBIC_BETA_USIZE_DIVISOR;
 const CWND_AFTER_LOSS_SLOW_START: usize =
-    (CWND_INITIAL + MAX_DATAGRAM_SIZE) * CUBIC_BETA_USIZE_QUOTIENT / CUBIC_BETA_USIZE_DIVISOR;
+    (CWND_INITIAL + MAX_DATAGRAM_SIZE) * CUBIC_BETA_USIZE_DIVIDEND / CUBIC_BETA_USIZE_DIVISOR;
 
 fn fill_cwnd(cc: &mut ClassicCongestionControl<Cubic>, mut next_pn: u64, now: Instant) -> u64 {
     while cc.bytes_in_flight() < cc.cwnd() {


### PR DESCRIPTION
The variables were used correctly, so no actual bug was fixed.

    Dividend ÷ Divisor = Quotient
    7 ÷ 10 = 0.7

https://en.wikipedia.org/w/index.php?title=Quotient&oldid=1175290601#Notation