### PR TITLE
Fix detection whether packet was sent after recovery start

### DIFF
--- a/neqo-transport/src/cc/tests/new_reno.rs
+++ b/neqo-transport/src/cc/tests/new_reno.rs
@@ -9,7 +9,7 @@
 
 use crate::cc::new_reno::NewReno;
 use crate::cc::{ClassicCongestionControl, CongestionControl, CWND_INITIAL, MAX_DATAGRAM_SIZE};
-use crate::packet::PacketType;
+use crate::packet::{PacketNumber, PacketType};
 use crate::tracking::SentPacket;
 use std::time::Duration;
 use test_fixture::now;
@@ -128,4 +128,84 @@ fn issue_876() {
     assert_eq!(cc.acked_bytes(), sent_packets[6].size);
     cwnd_is_halved(&cc);
     assert_eq!(cc.bytes_in_flight(), 4 * MAX_DATAGRAM_SIZE);
+}
+
+#[test]
+// https://github.com/mozilla/neqo/pull/1465
+fn issue_1465() {
+    let mut cc = ClassicCongestionControl::new(NewReno::default());
+    let mut pn = 0;
+    let mut now = now();
+    let next_packet = |pn: &mut PacketNumber, now| {
+        let p = SentPacket::new(
+            PacketType::Short,
+            *pn,               // pn
+            now,               // time_sent
+            true,              // ack eliciting
+            Vec::new(),        // tokens
+            MAX_DATAGRAM_SIZE, // size
+        );
+        *pn += 1;
+        p
+    };
+    let send_next = |cc: &mut ClassicCongestionControl<NewReno>, pn: &mut PacketNumber, now| {
+        let p = next_packet(pn, now);
+        cc.on_packet_sent(&p);
+        p
+    };
+
+    let p1 = send_next(&mut cc, &mut pn, now);
+    let p2 = send_next(&mut cc, &mut pn, now);
+    let p3 = send_next(&mut cc, &mut pn, now);
+
+    assert_eq!(cc.acked_bytes(), 0);
+    cwnd_is_default(&cc);
+    assert_eq!(cc.bytes_in_flight(), 3 * MAX_DATAGRAM_SIZE);
+
+    // advance one rtt to detect lost packet there this simplifies the timers, because on_packet_loss
+    // would only be called after RTO, but that is not relevant to the problem
+    now += RTT;
+    cc.on_packets_lost(Some(now), None, PTO, &[p1]);
+
+    // We are now in recovery
+    assert!(cc.recovery_packet());
+    assert_eq!(cc.acked_bytes(), 0);
+    cwnd_is_halved(&cc);
+    assert_eq!(cc.bytes_in_flight(), 2 * MAX_DATAGRAM_SIZE);
+
+    // Don't reduce the cwnd again on second packet loss
+    cc.on_packets_lost(Some(now), None, PTO, &[p3]);
+    assert_eq!(cc.acked_bytes(), 0);
+    cwnd_is_halved(&cc); // still the same as after first packet loss
+    assert_eq!(cc.bytes_in_flight(), MAX_DATAGRAM_SIZE);
+
+    // the acked packets before on_packet_sent were the cause of
+    // https://github.com/mozilla/neqo/pull/1465
+    cc.on_packets_acked(&[p2], RTT, now);
+
+    assert_eq!(cc.bytes_in_flight(), 0);
+
+    // send out recovery packet and get it acked to get out of recovery state
+    let p4 = send_next(&mut cc, &mut pn, now);
+    cc.on_packet_sent(&p4);
+    now += RTT;
+    cc.on_packets_acked(&[p4], RTT, now);
+
+    // do the same as in the first rtt but now the bug appears
+    let p5 = send_next(&mut cc, &mut pn, now);
+    let p6 = send_next(&mut cc, &mut pn, now);
+    now += RTT;
+
+    let cur_cwnd = cc.cwnd();
+    cc.on_packets_lost(Some(now), None, PTO, &[p5]);
+
+    // go back into recovery
+    assert!(cc.recovery_packet());
+    assert_eq!(cc.cwnd(), cur_cwnd / 2);
+    assert_eq!(cc.acked_bytes(), 0);
+    assert_eq!(cc.bytes_in_flight(), 2 * MAX_DATAGRAM_SIZE);
+
+    // this shouldn't introduce further cwnd reduction, but it did before https://github.com/mozilla/neqo/pull/1465
+    cc.on_packets_lost(Some(now), None, PTO, &[p6]);
+    assert_eq!(cc.cwnd(), cur_cwnd / 2);
 }


### PR DESCRIPTION
Before this patch, the congestion window was reduced multiple times per round trip time (RTT) on multiple packet loss. Not it is capped to one per RTT.

The recovery_start variable is only updated after transitioning from RECOVERY_START to RECOVERY when sending out packets after the recovery event. So if the state is RECOVERY_START (transient), all packets are from before the RECOVERY. Therefore we must only check the recovery_start time after trasitioning to the RECOVERY state.

If we haven't encountered a packet loss, the packets always count as after recovery_start.

This is to fix the congestion algorithm to be [spec aligned][1]:

> The recovery period aims to limit congestion window reduction to once
> per round trip. Therefore, during a recovery period, the congestion
> window does not change in response to new losses or increases in the
> ECN-CE count.
>
> A recovery period ends and the sender enters congestion avoidance when
> a packet sent during the recovery period is acknowledged. This is
> slightly different from TCP's definition of recovery, which ends when
> the lost segment that started recovery is acknowledged [RFC5681].

This was found when investigating [Bug 1852924][2], but doesn't fix the upload speed issue.

[1]: https://www.rfc-editor.org/rfc/rfc9002.html#section-7.3.2
[2]: https://bugzilla.mozilla.org/show_bug.cgi?id=1852924