### PR TITLE
Only warn on warnings and don't deny compiling during development

### DIFF
--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -19,5 +19,4 @@ url = "2.0"
 qlog = "0.9.0"
 
 [features]
-default = ["deny-warnings"]
 deny-warnings = []

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -15,7 +15,6 @@ qlog = "0.9.0"
 time = {version = "=0.3.23", features = ["formatting"]}
 
 [features]
-default = ["deny-warnings"]
 deny-warnings = []
 
 [target."cfg(windows)".dependencies.winapi]

--- a/neqo-crypto/Cargo.toml
+++ b/neqo-crypto/Cargo.toml
@@ -22,7 +22,6 @@ mozbuild = {version = "0.1", optional = true}
 test-fixture = { path = "../test-fixture" }
 
 [features]
-default = ["deny-warnings"]
 deny-warnings = []
 gecko = ["mozbuild"]
 fuzzing = []

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -23,6 +23,5 @@ enumset = "1.0.8"
 test-fixture = { path = "../test-fixture" }
 
 [features]
-default = ["deny-warnings"]
 deny-warnings = []
 fuzzing = ["neqo-transport/fuzzing", "neqo-crypto/fuzzing"]

--- a/neqo-interop/Cargo.toml
+++ b/neqo-interop/Cargo.toml
@@ -17,5 +17,4 @@ structopt = "0.3.7"
 lazy_static = "1.3.0"
 
 [features]
-default = ["deny-warnings"]
 deny-warnings = []

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -19,5 +19,4 @@ lazy_static = "1.3.0"
 test-fixture = { path = "../test-fixture" }
 
 [features]
-default = ["deny-warnings"]
 deny-warnings = []

--- a/neqo-server/Cargo.toml
+++ b/neqo-server/Cargo.toml
@@ -20,5 +20,4 @@ log = {version = "0.4.0", default-features = false}
 qlog = "0.9.0"
 
 [features]
-default = ["deny-warnings"]
 deny-warnings = []

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -19,6 +19,5 @@ indexmap = "1.0"
 test-fixture = { path = "../test-fixture" }
 
 [features]
-default = ["deny-warnings"]
 deny-warnings = []
 fuzzing = ["neqo-crypto/fuzzing"]

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -16,5 +16,4 @@ log = {version = "0.4.0", default-features = false}
 lazy_static = "1.3.0"
 
 [features]
-default = ["deny-warnings"]
 deny-warnings = []


### PR DESCRIPTION
Denying in the source makes developing neqo a bit cumbersome. It also makes it harder to compile neqo with future versions of Rust. We do have a CI pipeline for clippy denying all warnings. That should be enough to keep all the warnings out.