### PR TITLE
Introduce Output::PacedCallback to indicate if this is caused by the pacer

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -404,7 +404,7 @@ fn process_loop(
                         break;
                     }
                 }
-                Output::Callback(duration) => {
+                Output::Callback(duration) | Output::PacedCallback(duration) => {
                     socket.set_read_timeout(Some(duration)).unwrap();
                     break;
                 }
@@ -1095,7 +1095,7 @@ mod old {
                             break;
                         }
                     }
-                    Output::Callback(duration) => {
+                    Output::Callback(duration) | Output::PacedCallback(duration) => {
                         socket.set_read_timeout(Some(duration)).unwrap();
                         break;
                     }

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -118,7 +118,7 @@ fn process_loop(
                     let dgram = handler.rewrite_out(&dgram).unwrap_or(dgram);
                     emit_datagram(&nctx.socket, dgram);
                 }
-                Output::Callback(duration) => {
+                Output::Callback(duration) | Output::PacedCallback(duration) => {
                     let delay = min(timer.check()?, duration);
                     nctx.socket.set_read_timeout(Some(delay)).unwrap();
                     break;
@@ -280,7 +280,7 @@ fn process_loop_h3(
             let output = handler.h3.conn().process_output(Instant::now());
             match output {
                 Output::Datagram(dgram) => emit_datagram(&nctx.socket, dgram),
-                Output::Callback(duration) => {
+                Output::Callback(duration) | Output::PacedCallback(duration) => {
                     let delay = min(timer.check()?, duration);
                     nctx.socket.set_read_timeout(Some(delay)).unwrap();
                     break;

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -713,7 +713,7 @@ impl ServersRunner {
                 emit_packet(socket, dgram);
                 true
             }
-            Output::Callback(new_timeout) => {
+            Output::Callback(new_timeout) | Output::PacedCallback(new_timeout) => {
                 if let Some(to) = &self.timeout {
                     self.timer.cancel_timeout(to);
                 }

--- a/neqo-transport/src/connection/tests/cc.rs
+++ b/neqo-transport/src/connection/tests/cc.rs
@@ -407,7 +407,7 @@ fn pace() {
     assert_ne!(gap, Duration::new(0, 0));
     for _ in (1 + PACING_BURST_SIZE)..cwnd_packets(POST_HANDSHAKE_CWND) {
         match client.process_output(now) {
-            Output::Callback(t) => assert_eq!(t, gap),
+            Output::Callback(t) | Output::PacedCallback(t) => assert_eq!(t, gap),
             Output::Datagram(_) => {
                 // The last packet might not be paced.
                 count += 1;

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -329,7 +329,7 @@ fn fill_cwnd(c: &mut Connection, stream: StreamId, mut now: Instant) -> (Vec<Dat
             Output::Datagram(dgram) => {
                 total_dgrams.push(dgram);
             }
-            Output::Callback(t) => {
+            Output::Callback(t) | Output::PacedCallback(t) => {
                 if cwnd(c) < ACK_ONLY_SIZE_LIMIT {
                     break;
                 }
@@ -361,7 +361,7 @@ fn increase_cwnd(
             Output::Datagram(dgram) => {
                 receiver.process_input(dgram, now + DEFAULT_RTT / 2);
             }
-            Output::Callback(t) => {
+            Output::Callback(t) | Output::PacedCallback(t) => {
                 if t < DEFAULT_RTT {
                     now += t;
                 } else {

--- a/neqo-transport/src/connection/tests/priority.rs
+++ b/neqo-transport/src/connection/tests/priority.rs
@@ -164,7 +164,7 @@ fn repairing_loss() {
     for _ in 0..5 {
         match client.process_output(now) {
             Output::Datagram(d) => server.process_input(d, now),
-            Output::Callback(delay) => now += delay,
+            Output::Callback(delay) | Output::PacedCallback(delay) => now += delay,
             Output::None => unreachable!(),
         }
     }

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -279,7 +279,7 @@ fn zero_rtt() {
         client.stream_send(client_stream, &[1, 2, 3]).unwrap();
         match client.process(None, now) {
             Output::Datagram(d) => d,
-            Output::Callback(t) => {
+            Output::Callback(t) | Output::PacedCallback(t) => {
                 // Pacing...
                 now += t;
                 client.process(None, now).dgram().unwrap()

--- a/neqo-transport/tests/sim/mod.rs
+++ b/neqo-transport/tests/sim/mod.rs
@@ -191,7 +191,7 @@ impl Simulator {
                         dgram = Some(d);
                         Active
                     }
-                    Output::Callback(delay) => {
+                    Output::Callback(delay) | Output::PacedCallback(delay) => {
                         qtrace!([self.name], " => callback {:?}", delay);
                         assert_ne!(delay, Duration::new(0, 0));
                         Waiting(now + delay)


### PR DESCRIPTION
This is for the suggested change in https://github.com/mozilla/neqo/pull/1467#pullrequestreview-1681017489.

Please also take a look at the change at calling side [here](https://phabricator.services.mozilla.com/D191325).
Thanks!