### PR TITLE
Fix classic_cc debug output

### DIFF
--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -263,7 +263,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
 
         for pkt in lost_packets.iter().filter(|pkt| pkt.cc_in_flight()) {
             qinfo!(
-                "packet_lost this={:?}, pn={}, ps={}",
+                "packet_lost this={:p}, pn={}, ps={}",
                 self,
                 pkt.pn,
                 pkt.size


### PR DESCRIPTION
print pointer of self instead of debug print internal variables. Used to identify same congestion controller when having multiple concurrent connections. Sorry that I missed this during the initial PR #1484. I tested all other messages now as well and they look fine and I can generate the same graphs out of them.