### PR TITLE
ACK immediately after an RTT

### DIFF
--- a/neqo-transport/src/connection/idle.rs
+++ b/neqo-transport/src/connection/idle.rs
@@ -5,8 +5,11 @@
 // except according to those terms.
 
 use crate::recovery::RecoveryToken;
-use std::cmp::{max, min};
-use std::time::{Duration, Instant};
+use neqo_common::qtrace;
+use std::{
+    cmp::{max, min},
+    time::{Duration, Instant},
+};
 
 #[derive(Debug, Clone)]
 /// There's a little bit of different behavior for resetting idle timeout. See
@@ -53,6 +56,10 @@ impl IdleTimeout {
         } else {
             max(self.timeout, pto * 3)
         };
+        qtrace!(
+            "IdleTimeout::expiry@{now:?} pto={pto:?}, ka={keep_alive} => {t:?}",
+            t = start + delay
+        );
         start + delay
     }
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2049,8 +2049,14 @@ impl Connection {
 
         if primary {
             let stats = &mut self.stats.borrow_mut().frame_tx;
-            self.acks
-                .write_frame(space, now, builder, &mut tokens, stats)?;
+            self.acks.write_frame(
+                space,
+                now,
+                path.borrow().rtt().estimate(),
+                builder,
+                &mut tokens,
+                stats,
+            )?;
         }
         let ack_end = builder.len();
 

--- a/neqo-transport/src/connection/tests/ackrate.rs
+++ b/neqo-transport/src/connection/tests/ackrate.rs
@@ -117,6 +117,11 @@ fn ack_rate_client_one_rtt() {
 
     // A single packet from the client will cause the server to engage its delayed
     // acknowledgment timer, which should now be equal to RTT.
+    // The first packet will elicit an immediate ACK however, so do this twice.
+    let d = send_something(&mut client, now);
+    now += RTT / 2;
+    let ack = server.process(Some(d), now).dgram();
+    assert!(ack.is_some());
     let d = send_something(&mut client, now);
     now += RTT / 2;
     let delay = server.process(Some(d), now).callback();
@@ -133,6 +138,13 @@ fn ack_rate_server_half_rtt() {
     let mut server = new_server(ConnectionParameters::default().ack_ratio(ACK_RATIO_SCALE * 2));
     let mut now = connect_rtt_idle(&mut client, &mut server, RTT);
 
+    // The server now sends something.
+    let d = send_something(&mut server, now);
+    now += RTT / 2;
+    // The client now will acknowledge immediately because it has been more than
+    // an RTT since it last sent an acknowledgment.
+    let ack = client.process(Some(d), now);
+    assert!(ack.as_dgram_ref().is_some());
     let d = send_something(&mut server, now);
     now += RTT / 2;
     let delay = client.process(Some(d), now).callback();

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -183,7 +183,7 @@ fn idle_send_packet1() {
 
     now += Duration::from_secs(10);
     let dgram = send_and_receive(&mut client, &mut server, now);
-    assert!(dgram.is_none());
+    assert!(dgram.is_some()); // the server will want to ACK, we can drop that.
 
     // Still connected after 39 seconds because idle timer reset by the
     // outgoing packet.
@@ -237,11 +237,13 @@ fn idle_send_packet2() {
 
 #[test]
 fn idle_recv_packet() {
+    const FUDGE: Duration = Duration::from_millis(10);
+
     let mut client = default_client();
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
 
-    let now = now();
+    let mut now = now();
 
     let res = client.process(None, now);
     assert_eq!(res, Output::Callback(default_timeout()));
@@ -250,23 +252,25 @@ fn idle_recv_packet() {
     assert_eq!(stream, 0);
     assert_eq!(client.stream_send(stream, b"hello").unwrap(), 5);
 
-    // Respond with another packet
-    let out = client.process(None, now + Duration::from_secs(10));
-    server.process_input(out.dgram().unwrap(), now + Duration::from_secs(10));
+    // Respond with another packet.
+    // Note that it is important that this not result in the RTT increasing above 0.
+    // Otherwise, the eventual timeout will be extended (and we're not testing that).
+    now += Duration::from_secs(10);
+    let out = client.process(None, now);
+    server.process_input(out.dgram().unwrap(), now);
     assert_eq!(server.stream_send(stream, b"world").unwrap(), 5);
-    let out = server.process_output(now + Duration::from_secs(10));
+    let out = server.process_output(now);
     assert_ne!(out.as_dgram_ref(), None);
-
-    mem::drop(client.process(out.dgram(), now + Duration::from_secs(20)));
+    mem::drop(client.process(out.dgram(), now));
     assert!(matches!(client.state(), State::Confirmed));
 
-    // Still connected after 49 seconds because idle timer reset by received
-    // packet
-    mem::drop(client.process(None, now + default_timeout() + Duration::from_secs(19)));
+    // Add a little less than the idle timeout and we're still connected.
+    now += default_timeout() - FUDGE;
+    mem::drop(client.process(None, now));
     assert!(matches!(client.state(), State::Confirmed));
 
-    // Not connected after 50 seconds.
-    mem::drop(client.process(None, now + default_timeout() + Duration::from_secs(20)));
+    now += FUDGE;
+    mem::drop(client.process(None, now));
 
     assert!(matches!(client.state(), State::Closed(_)));
 }

--- a/neqo-transport/src/connection/tests/keys.rs
+++ b/neqo-transport/src/connection/tests/keys.rs
@@ -116,7 +116,8 @@ fn key_update_client() {
     assert_eq!(client.get_epochs(), (Some(4), Some(3)));
 
     // Send something to propagate the update.
-    assert!(send_and_receive(&mut client, &mut server, now).is_none());
+    // Note that the server will acknowledge immediately when RTT is zero.
+    assert!(send_and_receive(&mut client, &mut server, now).is_some());
 
     // The server should now be waiting to discharge read keys.
     assert_eq!(server.get_epochs(), (Some(4), Some(3)));

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -501,16 +501,37 @@ fn assert_full_cwnd(packets: &[Datagram], cwnd: usize) {
     assert_eq!(last.len(), last_packet(cwnd));
 }
 
-/// Send something on a stream from `sender` to `receiver`.
-/// Return the resulting datagram.
+/// Send something on a stream from `sender` to `receiver`, maybe allowing for pacing.
+/// Return the resulting datagram and the new time.
 #[must_use]
-fn send_something(sender: &mut Connection, now: Instant) -> Datagram {
+fn send_something_paced(
+    sender: &mut Connection,
+    mut now: Instant,
+    allow_pacing: bool,
+) -> (Datagram, Instant) {
     let stream_id = sender.stream_create(StreamType::UniDi).unwrap();
     assert!(sender.stream_send(stream_id, DEFAULT_STREAM_DATA).is_ok());
     assert!(sender.stream_close_send(stream_id).is_ok());
     qdebug!([sender], "send_something on {}", stream_id);
-    let dgram = sender.process(None, now).dgram();
-    dgram.expect("should have something to send")
+    let dgram = match sender.process_output(now) {
+        Output::Callback(t) => {
+            assert!(allow_pacing, "send_something: unexpected delay");
+            now += t;
+            sender
+                .process_output(now)
+                .dgram()
+                .expect("send_something: should have something to send")
+        }
+        Output::Datagram(d) => d,
+        Output::None => panic!("send_something: got Output::None"),
+    };
+    (dgram, now)
+}
+
+/// Send something on a stream from `sender` to `receiver`.
+/// Return the resulting datagram.
+fn send_something(sender: &mut Connection, now: Instant) -> Datagram {
+    send_something_paced(sender, now, false).0
 }
 
 /// Send something on a stream from `sender` to `receiver`.

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -11,12 +11,16 @@ use super::{
 use crate::{
     events::ConnectionEvent,
     recv_stream::RECV_BUFFER_SIZE,
-    send_stream::OrderGroup,
-    send_stream::{SendStreamState, SEND_BUFFER_SIZE},
+    send_stream::{OrderGroup, SendStreamState, SEND_BUFFER_SIZE},
     streams::{SendOrder, StreamOrder},
     tparams::{self, TransportParameter},
-    tracking::DEFAULT_ACK_PACKET_TOLERANCE,
-    Connection, ConnectionError, ConnectionParameters, Error, StreamId, StreamType,
+    // tracking::DEFAULT_ACK_PACKET_TOLERANCE,
+    Connection,
+    ConnectionError,
+    ConnectionParameters,
+    Error,
+    StreamId,
+    StreamType,
 };
 use std::collections::HashMap;
 
@@ -81,12 +85,10 @@ fn transfer() {
     assert_eq!(*client.state(), State::Confirmed);
 
     qdebug!("---- server receives");
-    for (d_num, d) in datagrams.into_iter().enumerate() {
+    for d in datagrams {
         let out = server.process(Some(d), now());
-        assert_eq!(
-            out.as_dgram_ref().is_some(),
-            (d_num + 1) % usize::try_from(DEFAULT_ACK_PACKET_TOLERANCE + 1).unwrap() == 0
-        );
+        // With an RTT of zero, the server will acknowledge every packet immediately.
+        assert!(out.as_dgram_ref().is_some());
         qdebug!("Output={:0x?}", out.as_dgram_ref());
     }
     assert_eq!(*server.state(), State::Confirmed);

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -916,7 +916,7 @@ mod tests {
 
         // Receiving the next packet won't elicit an ACK.
         rp.set_received(*NOW, 2, true);
-        assert!(!rp.ack_now(*NOW, RTT))
+        assert!(!rp.ack_now(*NOW, RTT));
     }
 
     #[test]

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -366,6 +366,8 @@ pub struct RecvdPackets {
     largest_pn_time: Option<Instant>,
     /// The time that we should be sending an ACK.
     ack_time: Option<Instant>,
+    /// The time we last sent an ACK.
+    last_ack_time: Option<Instant>,
     /// The current ACK frequency sequence number.
     ack_frequency_seqno: u64,
     /// The time to delay after receiving the first packet that is
@@ -391,6 +393,7 @@ impl RecvdPackets {
             min_tracked: 0,
             largest_pn_time: None,
             ack_time: None,
+            last_ack_time: None,
             ack_frequency_seqno: 0,
             ack_delay: DEFAULT_ACK_DELAY,
             unacknowledged_count: 0,
@@ -424,11 +427,13 @@ impl RecvdPackets {
     }
 
     /// Returns true if an ACK frame should be sent now.
-    fn ack_now(&self, now: Instant) -> bool {
-        match self.ack_time {
-            Some(t) => t <= now,
-            None => false,
-        }
+    fn ack_now(&self, now: Instant, rtt: Duration) -> bool {
+        // If ack_time is Some, then we have something to acknowledge.
+        // In that case, either ack because `now >= ack_time`, or
+        // because it is more than an RTT since the last time we sent an ack.
+        self.ack_time.map_or(false, |next| {
+            next <= now || self.last_ack_time.map_or(false, |last| last + rtt <= now)
+        })
     }
 
     // A simple addition of a packet number to the tracked set.
@@ -558,6 +563,7 @@ impl RecvdPackets {
     fn write_frame(
         &mut self,
         now: Instant,
+        rtt: Duration,
         builder: &mut PacketBuilder,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
@@ -567,7 +573,7 @@ impl RecvdPackets {
         const LONGEST_ACK_HEADER: usize = 1 + 8 + 8 + 1 + 8;
 
         // Check that we aren't delaying ACKs.
-        if !self.ack_now(now) {
+        if !self.ack_now(now, rtt) {
             return;
         }
 
@@ -618,6 +624,7 @@ impl RecvdPackets {
 
         // We've sent an ACK, reset the timer.
         self.ack_time = None;
+        self.last_ack_time = Some(now);
         self.unacknowledged_count = 0;
 
         tokens.push(RecoveryToken::Ack(AckToken {
@@ -714,12 +721,13 @@ impl AckTracker {
         &mut self,
         pn_space: PacketNumberSpace,
         now: Instant,
+        rtt: Duration,
         builder: &mut PacketBuilder,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) -> Res<()> {
         if let Some(space) = self.get_mut(pn_space) {
-            space.write_frame(now, builder, tokens, stats);
+            space.write_frame(now, rtt, builder, tokens, stats);
             if builder.len() > builder.limit() {
                 return Err(Error::InternalError(24));
             }
@@ -755,6 +763,7 @@ mod tests {
     use neqo_common::Encoder;
     use std::collections::HashSet;
 
+    const RTT: Duration = Duration::from_millis(100);
     lazy_static! {
         static ref NOW: Instant = Instant::now();
     }
@@ -838,7 +847,7 @@ mod tests {
         // Only application data packets are delayed.
         let mut rp = RecvdPackets::new(PacketNumberSpace::ApplicationData);
         assert!(rp.ack_time().is_none());
-        assert!(!rp.ack_now(*NOW));
+        assert!(!rp.ack_now(*NOW, RTT));
 
         rp.ack_freq(0, COUNT, DELAY, false);
 
@@ -846,14 +855,14 @@ mod tests {
         for i in 0..COUNT {
             rp.set_received(*NOW, i, true);
             assert_eq!(Some(*NOW + DELAY), rp.ack_time());
-            assert!(!rp.ack_now(*NOW));
-            assert!(rp.ack_now(*NOW + DELAY));
+            assert!(!rp.ack_now(*NOW, RTT));
+            assert!(rp.ack_now(*NOW + DELAY, RTT));
         }
 
         // Exceeding COUNT will move the ACK time to now.
         rp.set_received(*NOW, COUNT, true);
         assert_eq!(Some(*NOW), rp.ack_time());
-        assert!(rp.ack_now(*NOW));
+        assert!(rp.ack_now(*NOW, RTT));
     }
 
     #[test]
@@ -861,12 +870,12 @@ mod tests {
         for space in &[PacketNumberSpace::Initial, PacketNumberSpace::Handshake] {
             let mut rp = RecvdPackets::new(*space);
             assert!(rp.ack_time().is_none());
-            assert!(!rp.ack_now(*NOW));
+            assert!(!rp.ack_now(*NOW, RTT));
 
             // Any packet in these spaces is acknowledged straight away.
             rp.set_received(*NOW, 0, true);
             assert_eq!(Some(*NOW), rp.ack_time());
-            assert!(rp.ack_now(*NOW));
+            assert!(rp.ack_now(*NOW, RTT));
         }
     }
 
@@ -874,19 +883,19 @@ mod tests {
     fn ooo_no_ack_delay_new() {
         let mut rp = RecvdPackets::new(PacketNumberSpace::ApplicationData);
         assert!(rp.ack_time().is_none());
-        assert!(!rp.ack_now(*NOW));
+        assert!(!rp.ack_now(*NOW, RTT));
 
         // Anything other than packet 0 is acknowledged immediately.
         rp.set_received(*NOW, 1, true);
         assert_eq!(Some(*NOW), rp.ack_time());
-        assert!(rp.ack_now(*NOW));
+        assert!(rp.ack_now(*NOW, RTT));
     }
 
     fn write_frame(rp: &mut RecvdPackets) {
         let mut builder = PacketBuilder::short(Encoder::new(), false, []);
         let mut stats = FrameStats::default();
         let mut tokens = Vec::new();
-        rp.write_frame(*NOW, &mut builder, &mut tokens, &mut stats);
+        rp.write_frame(*NOW, RTT, &mut builder, &mut tokens, &mut stats);
         assert!(!tokens.is_empty());
         assert_eq!(stats.ack, 1);
     }
@@ -900,7 +909,7 @@ mod tests {
         // Filling in behind the largest acknowledged causes immediate ACK.
         rp.set_received(*NOW, 0, true);
         assert_eq!(Some(*NOW), rp.ack_time());
-        assert!(rp.ack_now(*NOW));
+        assert!(rp.ack_now(*NOW, RTT));
     }
 
     #[test]
@@ -1032,6 +1041,7 @@ mod tests {
             .write_frame(
                 PacketNumberSpace::Initial,
                 *NOW,
+                RTT,
                 &mut builder,
                 &mut tokens,
                 &mut stats,
@@ -1059,6 +1069,7 @@ mod tests {
             .write_frame(
                 PacketNumberSpace::Initial,
                 *NOW,
+                RTT,
                 &mut builder,
                 &mut tokens,
                 &mut stats,
@@ -1091,6 +1102,7 @@ mod tests {
             .write_frame(
                 PacketNumberSpace::Initial,
                 *NOW,
+                RTT,
                 &mut builder,
                 &mut Vec::new(),
                 &mut stats,
@@ -1123,6 +1135,7 @@ mod tests {
             .write_frame(
                 PacketNumberSpace::Initial,
                 *NOW,
+                RTT,
                 &mut builder,
                 &mut Vec::new(),
                 &mut stats,


### PR DESCRIPTION
This should improve loss recovery performance if we haven't been active for a short while.

The actual change is fairly trivial, but the tests needed to be tweaked in several ways to deal with a few places where we generated an immediate acknowledgment.

I also found a test where I couldn't work out why it ever passed before.  One of the migration tests was sending multiple packets without acknowledgment on a new path, which had the default RTT.  It was therefore pacing for the third packet.  I don't know how that ever passed.