### PR TITLE
Update enumset dependency

### DIFF
--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -17,7 +17,7 @@ qlog = "0.9.0"
 sfv = "0.9.1"
 url = "2.0"
 lazy_static = "1.3.0"
-enumset = "1.0.8"
+enumset = "1.1.2"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }


### PR DESCRIPTION
This matches the latest in gecko and avoids a clippy warning.