### PR TITLE
Make neqo-client support upload test

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -478,7 +478,7 @@ impl StreamHandlerType {
     ) -> Box<dyn StreamHandler> {
         match handler_type {
             Self::Download => {
-                let out_file = get_output_file(&url, &args.output_dir, all_paths);
+                let out_file = get_output_file(url, &args.output_dir, all_paths);
                 Box::new(DownloadStreamHandler { out_file })
             }
             Self::Upload => Box::new(UploadStreamHandler {

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -420,6 +420,7 @@ struct SimpleServer {
     server: Http3Server,
     /// Progress writing to each stream.
     remaining_data: HashMap<StreamId, ResponseData>,
+    posts: HashMap<Http3OrWebTransportStream, usize>,
 }
 
 impl SimpleServer {
@@ -454,6 +455,7 @@ impl SimpleServer {
         Self {
             server,
             remaining_data: HashMap::new(),
+            posts: HashMap::new(),
         }
     }
 }
@@ -478,6 +480,17 @@ impl HttpServer for SimpleServer {
                     fin,
                 } => {
                     println!("Headers (request={} fin={}): {:?}", stream, fin, headers);
+
+                    let post = if let Some(method) = headers.iter().find(|&h| h.name() == ":method")
+                    {
+                        method.value() == "POST"
+                    } else {
+                        false
+                    };
+                    if post {
+                        self.posts.insert(stream, 0);
+                        continue;
+                    }
 
                     let mut response =
                         if let Some(path) = headers.iter().find(|&h| h.name() == ":path") {
@@ -515,17 +528,38 @@ impl HttpServer for SimpleServer {
                     }
                 }
                 Http3ServerEvent::DataWritable { mut stream } => {
-                    if let Some(remaining) = self.remaining_data.get_mut(&stream.stream_id()) {
-                        remaining.send(&mut stream);
-                        if remaining.done() {
-                            self.remaining_data.remove(&stream.stream_id());
-                            stream.stream_close_send().unwrap();
+                    if self.posts.get_mut(&stream).is_none() {
+                        if let Some(remaining) = self.remaining_data.get_mut(&stream.stream_id()) {
+                            remaining.send(&mut stream);
+                            if remaining.done() {
+                                self.remaining_data.remove(&stream.stream_id());
+                                stream.stream_close_send().unwrap();
+                            }
                         }
                     }
                 }
 
-                Http3ServerEvent::Data { stream, data, fin } => {
-                    println!("Data (request={} fin={}): {:?}", stream, fin, data);
+                Http3ServerEvent::Data {
+                    mut stream,
+                    data,
+                    fin,
+                } => {
+                    if let Some(r) = self.posts.get_mut(&stream) {
+                        *r += data.len();
+                    }
+                    if fin {
+                        if let Some(r) = self.posts.remove(&stream) {
+                            let msg = format!("{}", r).as_bytes().to_vec();
+                            stream
+                                .send_headers(&[
+                                    Header::new(":status", "200"),
+                                    Header::new("content-length", msg.len().to_string()),
+                                ])
+                                .unwrap();
+                            stream.send_data(&msg).unwrap();
+                            stream.stream_close_send().unwrap();
+                        }
+                    }
                 }
                 _ => {}
             }

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -548,12 +548,11 @@ impl HttpServer for SimpleServer {
                         *r += data.len();
                     }
                     if fin {
-                        if let Some(r) = self.posts.remove(&stream) {
-                            let msg = format!("{}", r).as_bytes().to_vec();
+                        if let Some(received) = self.posts.remove(&stream) {
+                            let msg = received.to_string().as_bytes().to_vec();
                             stream
                                 .send_headers(&[
                                     Header::new(":status", "200"),
-                                    Header::new("content-length", msg.len().to_string()),
                                 ])
                                 .unwrap();
                             stream.send_data(&msg).unwrap();

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -544,16 +544,14 @@ impl HttpServer for SimpleServer {
                     data,
                     fin,
                 } => {
-                    if let Some(r) = self.posts.get_mut(&stream) {
-                        *r += data.len();
+                    if let Some(received) = self.posts.get_mut(&stream) {
+                        *received += data.len();
                     }
                     if fin {
                         if let Some(received) = self.posts.remove(&stream) {
                             let msg = received.to_string().as_bytes().to_vec();
                             stream
-                                .send_headers(&[
-                                    Header::new(":status", "200"),
-                                ])
+                                .send_headers(&[Header::new(":status", "200")])
                                 .unwrap();
                             stream.send_data(&msg).unwrap();
                             stream.stream_close_send().unwrap();


### PR DESCRIPTION
This PR makes neqo-client support doing upload test.
The command is `./target/release/neqo-client http://127.0.0.1:4433/  --test upload  --upload-size 104857600`.