### PR TITLE
docs(README): escape IPv6 address

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 To run test HTTP/3 programs (neqo-client and neqo-server):
 
 * `cargo build`
-* `./target/debug/neqo-server [::]:12345 --db ./test-fixture/db`
+* `./target/debug/neqo-server '[::]:12345' --db ./test-fixture/db`
 * `./target/debug/neqo-client http://127.0.0.1:12345/`
 
 If a "Failure to load dynamic library" error happens at runtime, do


### PR DESCRIPTION
Escape IPv6 address with single quotes.

Prevents shells from interpreting IPv6 address as file pattern:

```
zsh: no matches found: [::]:1234
```

Also makes it consistent with `neqo-*` commands in `### QUIC Logging`.