### PR TITLE
deps(qlog): update to qlog v0.10.0

### DIFF
--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -16,7 +16,7 @@ neqo-http3 = { path = "./../neqo-http3" }
 neqo-qpack = { path = "./../neqo-qpack" }
 structopt = "0.3.7"
 url = "2.0"
-qlog = "0.9.0"
+qlog = "0.10.0"
 
 [features]
 deny-warnings = []

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 log = {version = "0.4.0", default-features = false}
 env_logger = {version = "0.10", default-features = false}
 lazy_static = "1.3.0"
-qlog = "0.9.0"
+qlog = "0.10.0"
 time = {version = "=0.3.23", features = ["formatting"]}
 
 [features]

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -13,7 +13,7 @@ neqo-transport = { path = "./../neqo-transport" }
 neqo-qpack = { path = "./../neqo-qpack" }
 log = {version = "0.4.0", default-features = false}
 smallvec = "1.0.0"
-qlog = "0.9.0"
+qlog = "0.10.0"
 sfv = "0.9.1"
 url = "2.0"
 lazy_static = "1.3.0"

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -12,7 +12,7 @@ neqo-transport = { path = "./../neqo-transport" }
 neqo-crypto = { path = "./../neqo-crypto" }
 log = {version = "0.4.0", default-features = false}
 static_assertions = "1.1.0"
-qlog = "0.9.0"
+qlog = "0.10.0"
 lazy_static = "1.3.0"
 
 [dev-dependencies]

--- a/neqo-server/Cargo.toml
+++ b/neqo-server/Cargo.toml
@@ -17,7 +17,7 @@ regex = "1"
 mio = "0.6.17"
 mio-extras = "2.0.5"
 log = {version = "0.4.0", default-features = false}
-qlog = "0.9.0"
+qlog = "0.10.0"
 
 [features]
 deny-warnings = []

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -12,7 +12,7 @@ neqo-common = { path = "../neqo-common" }
 lazy_static = "1.3.0"
 log = {version = "0.4.0", default-features = false}
 smallvec = "1.0.0"
-qlog = "0.9.0"
+qlog = "0.10.0"
 indexmap = "1.0"
 
 [dev-dependencies]

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -136,7 +136,7 @@ pub fn packet_sent(
 ) {
     qlog.add_event_with_stream(|stream| {
         let mut d = Decoder::from(body);
-        let header = PacketHeader::with_type(to_qlog_pkt_type(pt), pn, None, None, None);
+        let header = PacketHeader::with_type(to_qlog_pkt_type(pt), Some(pn), None, None, None);
         let raw = RawInfo {
             length: None,
             payload_length: Some(plen as u64),
@@ -175,9 +175,13 @@ pub fn packet_sent(
 
 pub fn packet_dropped(qlog: &mut NeqoQlog, payload: &PublicPacket) {
     qlog.add_event_data(|| {
-        // TODO: packet number is optional in the spec but qlog crate doesn't support that, so use a placeholder value of 0
-        let header =
-            PacketHeader::with_type(to_qlog_pkt_type(payload.packet_type()), 0, None, None, None);
+        let header = PacketHeader::with_type(
+            to_qlog_pkt_type(payload.packet_type()),
+            None,
+            None,
+            None,
+            None,
+        );
         let raw = RawInfo {
             length: None,
             payload_length: Some(payload.len() as u64),
@@ -200,7 +204,7 @@ pub fn packets_lost(qlog: &mut NeqoQlog, pkts: &[SentPacket]) {
     qlog.add_event_with_stream(|stream| {
         for pkt in pkts {
             let header =
-                PacketHeader::with_type(to_qlog_pkt_type(pkt.pt), pkt.pn, None, None, None);
+                PacketHeader::with_type(to_qlog_pkt_type(pkt.pt), Some(pkt.pn), None, None, None);
 
             let ev_data = EventData::PacketLost(PacketLost {
                 header: Some(header),
@@ -224,7 +228,7 @@ pub fn packet_received(
 
         let header = PacketHeader::with_type(
             to_qlog_pkt_type(public_packet.packet_type()),
-            payload.pn(),
+            Some(payload.pn()),
             None,
             None,
             None,


### PR DESCRIPTION
This commit upgrades all `neqo-*` crates to use `qlog` `v0.10.0`.

See also `qlog` `v0.10.0` release pull request https://github.com/cloudflare/quiche/pull/1647

Could as well be defined as a [workspace dependency](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table) to reduce duplication.