### PR TITLE
Don't fail CI if Codecov upload fails

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -124,6 +124,6 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           file: lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov seems flaky often.