### PR TITLE
More CI fixes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust-toolchain }}
-          components: rustfmt, clippy
+          components: rustfmt, clippy, llvm-tools-preview
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
Explicitly install `llvm-tools-preview` via `rustup` instead of indirectly during the coverage run.