### PR TITLE
feat(qlog): log version_information on server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ members = [
   "neqo-interop",
   "test-fixture",
 ]
+
+[patch.crates-io]
+qlog = { git = "https://github.com/cloudflare/quiche", branch = "master" }

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -164,10 +164,14 @@ pub fn client_version_information_negotiated(
     });
 }
 
-pub fn server_version_information_failed(qlog: &mut NeqoQlog, server: &[Version], client: Version) {
+pub fn server_version_information_failed(
+    qlog: &mut NeqoQlog,
+    server: &[Version],
+    client: WireVersion,
+) {
     qlog.add_event_data(|| {
         Some(EventData::VersionInformation(VersionInformation {
-            client_versions: Some(vec![format!("{:02x}", client.wire_version())]),
+            client_versions: Some(vec![format!("{client:02x}")]),
             server_versions: Some(
                 server
                     .iter()

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -17,7 +17,7 @@ use qlog::events::{
     connectivity::{ConnectionStarted, ConnectionState, ConnectionStateUpdated},
     quic::{
         AckedRanges, ErrorSpace, MetricsUpdated, PacketDropped, PacketHeader, PacketLost,
-        PacketReceived, PacketSent, QuicFrame, StreamType,
+        PacketReceived, PacketSent, QuicFrame, StreamType, VersionInformation,
     },
     Event, EventData, RawInfo,
 };
@@ -33,6 +33,7 @@ use crate::{
     stream_id::StreamType as NeqoStreamType,
     tparams::{self, TransportParametersHandler},
     tracking::SentPacket,
+    version::Version,
 };
 
 pub fn connection_tparams_set(qlog: &mut NeqoQlog, tph: &TransportParametersHandler) {
@@ -125,6 +126,21 @@ pub fn connection_state_updated(qlog: &mut NeqoQlog, new: &State) {
 
         Some(ev_data)
     })
+}
+
+pub fn server_version_information_failed(qlog: &mut NeqoQlog, server: &[Version], client: Version) {
+    qlog.add_event_data(|| {
+        Some(EventData::VersionInformation(VersionInformation {
+            client_versions: Some(vec![format!("{:02x}", client.wire_version())]),
+            server_versions: Some(
+                server
+                    .iter()
+                    .map(|v| format!("{:02x}", v.wire_version()))
+                    .collect(),
+            ),
+            chosen_version: None,
+        }))
+    });
 }
 
 pub fn packet_sent(

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -506,7 +506,7 @@ impl Server {
                     crate::qlog::server_version_information_failed(
                         &mut self.create_qlog_trace(&attempt_key),
                         self.conn_params.get_versions().all(),
-                        initial.version,
+                        initial.version.wire_version(),
                     )
                 }
                 None
@@ -590,9 +590,7 @@ impl Server {
                     odcid: packet.dcid().into(),
                 }),
                 self.conn_params.get_versions().all(),
-                packet
-                    .version()
-                    .expect("version on `OtherVersion` and `Initial` to be set"),
+                packet.wire_version(),
             );
 
             return Some(Datagram::new(dgram.destination(), dgram.source(), vn));


### PR DESCRIPTION
This commit adds support for the qlog [`version_information` QUIC event](https://quicwg.org/qlog/draft-ietf-quic-qlog-quic-events.html#name-version_information) on the server.

See https://github.com/mozilla/neqo/pull/1505 for the client side.

~~Depends on `qlog` patch release with https://github.com/cloudflare/quiche/pull/1684~~ :heavy_check_mark: 

Meta issue: https://github.com/mozilla/neqo/issues/528

Fixes https://github.com/mozilla/neqo/issues/1549