### PR TITLE
chore: turn on clippy::pedantic

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -116,7 +116,7 @@ jobs:
         if: success() || failure()
 
       - name: Clippy
-        run: cargo +${{ matrix.rust-toolchain }} clippy -v --tests -- -D warnings
+        run: cargo +${{ matrix.rust-toolchain }} clippy -v --tests -- -D warnings -D clippy::pedantic
         if: success() || failure()
 
       - name: Upload coverage reports to Codecov

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -6,6 +6,7 @@
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::use_self)]
+#![deny(clippy::pedantic)]
 
 use qlog::{events::EventImportance, streamer::QlogStreamer};
 

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
-#![warn(clippy::pedantic)]
+#![deny(clippy::pedantic)]
 
 mod codec;
 mod datagram;

--- a/neqo-crypto/src/aead_fuzzing.rs
+++ b/neqo-crypto/src/aead_fuzzing.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(clippy::missing_errors_doc)]
+
 use crate::constants::{Cipher, Version};
 use crate::err::{sec::SEC_ERROR_BAD_DATA, Error, Res};
 use crate::p11::SymKey;

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
-#![warn(clippy::pedantic)]
+#![deny(clippy::pedantic)]
 // Bindgen auto generated code
 // won't adhere to the clippy rules below
 #![allow(clippy::module_name_repetitions)]

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
-#![warn(clippy::pedantic)]
+#![deny(clippy::pedantic)]
 
 /*!
 

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -6,6 +6,7 @@
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::use_self)]
+#![deny(clippy::pedantic)]
 
 use neqo_common::{event::Provider, hex, Datagram};
 use neqo_crypto::{init, AuthenticationStatus, ResumptionToken};

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
-#![warn(clippy::pedantic)]
+#![deny(clippy::pedantic)]
 // This is because of Encoder and Decoder structs. TODO: think about a better namings for crate and structs.
 #![allow(clippy::module_name_repetitions)]
 

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -6,6 +6,7 @@
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::use_self)]
+#![deny(clippy::pedantic)]
 
 use std::{
     cell::RefCell,

--- a/neqo-transport/src/ackrate.rs
+++ b/neqo-transport/src/ackrate.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 // Management of the peer's ack rate.
-#![deny(clippy::pedantic)]
 
 use crate::connection::params::ACK_RATIO_SCALE;
 use crate::frame::FRAME_TYPE_ACK_FREQUENCY;

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -23,15 +23,15 @@ use std::convert::TryFrom;
 use std::net::{IpAddr, SocketAddr};
 use std::time::{Duration, Instant};
 
-/// A prefix we add to Retry tokens to distinguish them from NEW_TOKEN tokens.
+/// A prefix we add to Retry tokens to distinguish them from `NEW_TOKEN` tokens.
 const TOKEN_IDENTIFIER_RETRY: &[u8] = &[0x52, 0x65, 0x74, 0x72, 0x79];
-/// A prefix on NEW_TOKEN tokens, that is maximally Hamming distant from NEW_TOKEN.
+/// A prefix on `NEW_TOKEN` tokens, that is maximally Hamming distant from `NEW_TOKEN`.
 /// Together, these need to have a low probability of collision, even if there is
 /// corruption of individual bits in transit.
 const TOKEN_IDENTIFIER_NEW_TOKEN: &[u8] = &[0xad, 0x9a, 0x8b, 0x8d, 0x86];
 
-/// The maximum number of tokens we'll save from NEW_TOKEN frames.
-/// This should be the same as the value of MAX_TICKETS in neqo-crypto.
+/// The maximum number of tokens we'll save from `NEW_TOKEN` frames.
+/// This should be the same as the value of `MAX_TICKETS` in neqo-crypto.
 const MAX_NEW_TOKEN: usize = 4;
 /// The number of tokens we'll track for the purposes of looking for duplicates.
 /// This is based on how many might be received over a period where could be
@@ -44,9 +44,9 @@ const MAX_SAVED_TOKENS: usize = 8;
 pub enum ValidateAddress {
     /// Require address validation never.
     Never,
-    /// Require address validation unless a NEW_TOKEN token is provided.
+    /// Require address validation unless a `NEW_TOKEN` token is provided.
     NoToken,
-    /// Require address validation even if a NEW_TOKEN token is provided.
+    /// Require address validation even if a `NEW_TOKEN` token is provided.
     Always,
 }
 
@@ -143,7 +143,7 @@ impl AddressValidation {
         self.generate_token(Some(dcid), peer_address, now)
     }
 
-    /// This generates a token for use with NEW_TOKEN.
+    /// This generates a token for use with `NEW_TOKEN`.
     pub fn generate_new_token(&self, peer_address: SocketAddr, now: Instant) -> Res<Vec<u8>> {
         self.generate_token(None, peer_address, now)
     }
@@ -184,7 +184,7 @@ impl AddressValidation {
     /// Less than one difference per byte indicates that it is likely not a Retry.
     /// This generous interpretation allows for a lot of damage in transit.
     /// Note that if this check fails, then the token will be treated like it came
-    /// from NEW_TOKEN instead.  If there truly is corruption of packets that causes
+    /// from `NEW_TOKEN` instead.  If there truly is corruption of packets that causes
     /// validation failure, it will be a failure that we try to recover from.
     fn is_likely_retry(token: &[u8]) -> bool {
         let mut difference = 0;
@@ -210,10 +210,10 @@ impl AddressValidation {
             if self.validation == ValidateAddress::Never {
                 qinfo!("AddressValidation: no token; accepting");
                 return AddressValidationResult::Pass;
-            } else {
-                qinfo!("AddressValidation: no token; validating");
-                return AddressValidationResult::Validate;
             }
+
+            qinfo!("AddressValidation: no token; validating");
+            return AddressValidationResult::Validate;
         }
         if token.len() <= TOKEN_IDENTIFIER_RETRY.len() {
             // Treat bad tokens strictly.
@@ -234,16 +234,16 @@ impl AddressValidation {
                     panic!("AddressValidation: Retry token with small CID {}", cid);
                 }
             } else if cid.is_empty() {
-                // An empty connection ID means NEW_TOKEN.
+                // An empty connection ID means `NEW_TOKEN`.
                 if self.validation == ValidateAddress::Always {
-                    qinfo!("AddressValidation: valid NEW_TOKEN token; validating again");
+                    qinfo!("AddressValidation: valid `NEW_TOKEN` token; validating again");
                     AddressValidationResult::Validate
                 } else {
-                    qinfo!("AddressValidation: valid NEW_TOKEN token; accepting");
+                    qinfo!("AddressValidation: valid `NEW_TOKEN` token; accepting");
                     AddressValidationResult::Pass
                 }
             } else {
-                panic!("AddressValidation: NEW_TOKEN token with CID {}", cid);
+                panic!("AddressValidation: `NEW_TOKEN` token with CID {}", cid);
             }
         } else {
             // From here on, we have a token that we couldn't decrypt.
@@ -254,12 +254,12 @@ impl AddressValidation {
                 AddressValidationResult::Invalid
             } else if self.validation == ValidateAddress::Never {
                 // We don't require validation, so OK.
-                qinfo!("AddressValidation: invalid NEW_TOKEN token; accepting");
+                qinfo!("AddressValidation: invalid `NEW_TOKEN` token; accepting");
                 AddressValidationResult::Pass
             } else {
-                // This might be an invalid NEW_TOKEN token, or a valid one
+                // This might be an invalid `NEW_TOKEN` token, or a valid one
                 // for which we have since lost the keys.  Check again.
-                qinfo!("AddressValidation: invalid NEW_TOKEN token; validating again");
+                qinfo!("AddressValidation: invalid `NEW_TOKEN` token; validating again");
                 AddressValidationResult::Validate
             }
         }
@@ -330,7 +330,7 @@ impl NewTokenState {
         {
             for t in old.iter().rev().chain(pending.iter().rev()) {
                 if t == &token {
-                    qinfo!("NewTokenState discarding duplicate NEW_TOKEN");
+                    qinfo!("NewTokenState discarding duplicate `NEW_TOKEN`");
                     return;
                 }
             }
@@ -358,7 +358,7 @@ impl NewTokenState {
         Ok(())
     }
 
-    /// If this a server, buffer a NEW_TOKEN for sending.
+    /// If this a server, buffer a `NEW_TOKEN` for sending.
     /// If this is a client, panic.
     pub fn send_new_token(&mut self, token: Vec<u8>) {
         if let Self::Server(ref mut sender) = self {
@@ -368,7 +368,7 @@ impl NewTokenState {
         }
     }
 
-    /// If this a server, process a lost signal for a NEW_TOKEN frame.
+    /// If this a server, process a lost signal for a `NEW_TOKEN` frame.
     /// If this is a client, panic.
     pub fn lost(&mut self, seqno: usize) {
         if let Self::Server(ref mut sender) = self {
@@ -378,7 +378,7 @@ impl NewTokenState {
         }
     }
 
-    /// If this a server, process remove the acknowledged NEW_TOKEN frame.
+    /// If this a server, process remove the acknowledged `NEW_TOKEN` frame.
     /// If this is a client, panic.
     pub fn acked(&mut self, seqno: usize) {
         if let Self::Server(ref mut sender) = self {
@@ -403,7 +403,7 @@ impl NewTokenFrameStatus {
 
 #[derive(Default)]
 pub struct NewTokenSender {
-    /// The unacknowledged NEW_TOKEN frames we are yet to send.
+    /// The unacknowledged `NEW_TOKEN` frames we are yet to send.
     tokens: Vec<NewTokenFrameStatus>,
     /// A sequence number that is used to track individual tokens
     /// by reference (so that recovery tokens can be simple).
@@ -427,7 +427,7 @@ impl NewTokenSender {
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) -> Res<()> {
-        for t in self.tokens.iter_mut() {
+        for t in &mut self.tokens {
             if t.needs_sending && t.len() <= builder.remaining() {
                 t.needs_sending = false;
 
@@ -445,7 +445,7 @@ impl NewTokenSender {
     }
 
     pub fn lost(&mut self, seqno: usize) {
-        for t in self.tokens.iter_mut() {
+        for t in &mut self.tokens {
             if t.seqno == seqno {
                 t.needs_sending = true;
                 break;

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 // Congestion control
-#![deny(clippy::pedantic)]
 
 use std::{
     cmp::{max, min},
@@ -22,6 +21,7 @@ use crate::{
     sender::PACING_BURST_SIZE,
     tracking::SentPacket,
 };
+#[rustfmt::skip] // to keep `::` and thus prevent conflict with `crate::qlog`
 use ::qlog::events::{quic::CongestionStateUpdated, EventData};
 use neqo_common::{const_max, const_min, qdebug, qinfo, qlog::NeqoQlog, qtrace};
 

--- a/neqo-transport/src/cc/cubic.rs
+++ b/neqo-transport/src/cc/cubic.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(clippy::pedantic)]
-
 use std::fmt::{self, Display};
 use std::time::{Duration, Instant};
 
@@ -39,9 +37,9 @@ const EXPONENTIAL_GROWTH_REDUCTION: f64 = 2.0;
 /// This has the effect of reducing larger values to `1<<53`.
 /// If you have a congestion window that large, something is probably wrong.
 fn convert_to_f64(v: usize) -> f64 {
-    let mut f_64 = f64::try_from(u32::try_from(v >> 21).unwrap_or(u32::MAX)).unwrap();
+    let mut f_64 = f64::from(u32::try_from(v >> 21).unwrap_or(u32::MAX));
     f_64 *= 2_097_152.0; // f_64 <<= 21
-    f_64 += f64::try_from(u32::try_from(v & 0x1f_ffff).unwrap()).unwrap();
+    f_64 += f64::from(u32::try_from(v & 0x1f_ffff).unwrap());
     f_64
 }
 

--- a/neqo-transport/src/cc/mod.rs
+++ b/neqo-transport/src/cc/mod.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 // Congestion control
-#![deny(clippy::pedantic)]
 
 use crate::{path::PATH_MTU_V6, tracking::SentPacket, Error};
 use neqo_common::qlog::NeqoQlog;

--- a/neqo-transport/src/cc/new_reno.rs
+++ b/neqo-transport/src/cc/new_reno.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 // Congestion control
-#![deny(clippy::pedantic)]
 
 use std::fmt::{self, Display};
 

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -202,7 +202,7 @@ impl ConnectionIdGenerator for EmptyConnectionIdGenerator {
     }
 }
 
-/// An RandomConnectionIdGenerator produces connection IDs of
+/// An [`RandomConnectionIdGenerator`] produces connection IDs of
 /// a fixed length and random content.  No effort is made to
 /// prevent collisions.
 pub struct RandomConnectionIdGenerator {
@@ -513,7 +513,6 @@ impl ConnectionIdManager {
     }
 
     fn write_entry(
-        &mut self,
         entry: &ConnectionIdEntry<[u8; 16]>,
         builder: &mut PacketBuilder,
         stats: &mut FrameStats,
@@ -548,7 +547,7 @@ impl ConnectionIdManager {
         }
 
         while let Some(entry) = self.lost_new_connection_id.pop() {
-            if self.write_entry(&entry, builder, stats)? {
+            if Self::write_entry(&entry, builder, stats)? {
                 tokens.push(RecoveryToken::NewConnectionId(entry));
             } else {
                 // This shouldn't happen often.
@@ -573,7 +572,7 @@ impl ConnectionIdManager {
                     .add_local(ConnectionIdEntry::new(seqno, cid.clone(), ()));
 
                 let entry = ConnectionIdEntry::new(seqno, cid, srt);
-                debug_assert!(self.write_entry(&entry, builder, stats)?);
+                debug_assert!(Self::write_entry(&entry, builder, stats)?);
                 tokens.push(RecoveryToken::NewConnectionId(entry));
             }
         }

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -40,7 +40,7 @@ pub enum PreferredAddressConfig {
     Address(PreferredAddress),
 }
 
-/// ConnectionParameters use for setting intitial value for QUIC parameters.
+/// `ConnectionParameters` use for setting intitial value for QUIC parameters.
 /// This collects configuration like initial limits, protocol version, and
 /// congestion control algorithm.
 #[derive(Debug, Clone)]

--- a/neqo-transport/src/connection/state.rs
+++ b/neqo-transport/src/connection/state.rs
@@ -206,7 +206,7 @@ impl StateSignaling {
             debug_assert!(false, "StateSignaling must be in Idle state.");
             return;
         }
-        *self = Self::HandshakeDone
+        *self = Self::HandshakeDone;
     }
 
     pub fn write_done(&mut self, builder: &mut PacketBuilder) -> Res<Option<RecoveryToken>> {

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -245,9 +245,7 @@ impl Crypto {
 
     fn install_handshake_keys(&mut self) -> Res<bool> {
         qtrace!([self], "Attempt to install handshake keys");
-        let write_secret = if let Some(secret) = self.tls.write_secret(TLS_EPOCH_HANDSHAKE) {
-            secret
-        } else {
+        let Some(write_secret) = self.tls.write_secret(TLS_EPOCH_HANDSHAKE) else {
             // No keys is fine.
             return Ok(false);
         };

--- a/neqo-transport/src/dump.rs
+++ b/neqo-transport/src/dump.rs
@@ -28,15 +28,12 @@ pub fn dump_packet(
         return;
     }
 
-    let mut s = String::from("");
+    let mut s = String::new();
     let mut d = Decoder::from(payload);
     while d.remaining() > 0 {
-        let f = match Frame::decode(&mut d) {
-            Ok(f) => f,
-            Err(_) => {
-                s.push_str(" [broken]...");
-                break;
-            }
+        let Ok(f) = Frame::decode(&mut d) else {
+            s.push_str(" [broken]...");
+            break;
         };
         if let Some(x) = f.dump() {
             write!(&mut s, "\n  {} {}", dir, &x).unwrap();

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -235,7 +235,7 @@ impl ConnectionEvents {
     where
         F: Fn(&ConnectionEvent) -> bool,
     {
-        self.events.borrow_mut().retain(|evt| !f(evt))
+        self.events.borrow_mut().retain(|evt| !f(evt));
     }
 }
 

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -368,7 +368,7 @@ impl<'a> Frame<'a> {
             )),
             Self::Padding => None,
             Self::Datagram { data, .. } => Some(format!("Datagram {{ len: {} }}", data.len())),
-            _ => Some(format!("{:?}", self)),
+            _ => Some(format!("{self:?}")),
         }
     }
 

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -6,6 +6,18 @@
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::use_self)]
+#![deny(clippy::pedantic)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::return_self_not_must_use)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::needless_pass_by_value)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::single_match_else)]
+#![allow(clippy::if_not_else)]
+#![allow(clippy::match_wild_err_arm)]
 
 use neqo_common::qinfo;
 use neqo_crypto::Error as CryptoError;
@@ -176,7 +188,7 @@ impl From<std::num::TryFromIntError> for Error {
 }
 
 impl ::std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::CryptoError(e) => Some(e),
             _ => None,
@@ -186,7 +198,7 @@ impl ::std::error::Error for Error {
 
 impl ::std::fmt::Display for Error {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Transport error: {:?}", self)
+        write!(f, "Transport error: {self:?}")
     }
 }
 
@@ -202,7 +214,7 @@ impl ConnectionError {
     pub fn app_code(&self) -> Option<AppError> {
         match self {
             Self::Application(e) => Some(*e),
-            _ => None,
+            Self::Transport(_) => None,
         }
     }
 }

--- a/neqo-transport/src/pace.rs
+++ b/neqo-transport/src/pace.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 // Pacer
-#![deny(clippy::pedantic)]
 
 use neqo_common::qtrace;
 

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -173,6 +173,7 @@ impl PacketBuilder {
     ///
     /// See `short()` for more on how to handle this in cases where there is no space.
     #[allow(clippy::reversed_empty_ranges)] // For initializing an empty range.
+    #[allow(clippy::similar_names)] // dcid is similar to scid.
     pub fn long(
         mut encoder: Encoder,
         pt: PacketType,
@@ -241,7 +242,7 @@ impl PacketBuilder {
 
     /// Adjust the limit to ensure that no more data is added.
     pub fn mark_full(&mut self) {
-        self.limit = self.encoder.len()
+        self.limit = self.encoder.len();
     }
 
     /// Mark the packet as needing padding (or not).
@@ -406,6 +407,7 @@ impl PacketBuilder {
     /// As this is a simple packet, this is just an associated function.
     /// As Retry is odd (it has to be constructed with leading bytes),
     /// this returns a Vec<u8> rather than building on an encoder.
+    #[allow(clippy::similar_names)] // dcid is similar to scid.
     pub fn retry(
         version: Version,
         dcid: &[u8],
@@ -437,6 +439,7 @@ impl PacketBuilder {
     }
 
     /// Make a Version Negotiation packet.
+    #[allow(clippy::similar_names)] // dcid is similar to scid.
     pub fn version_negotiation(
         dcid: &[u8],
         scid: &[u8],
@@ -548,6 +551,7 @@ impl<'a> PublicPacket<'a> {
 
     /// Decode the common parts of a packet.  This provides minimal parsing and validation.
     /// Returns a tuple of a `PublicPacket` and a slice with any remainder from the datagram.
+    #[allow(clippy::similar_names)] // dcid is similar to scid.
     pub fn decode(data: &'a [u8], dcid_decoder: &dyn ConnectionIdDecoder) -> Res<(Self, &'a [u8])> {
         let mut decoder = Decoder::new(data);
         let first = Self::opt(decoder.decode_byte())?;
@@ -599,9 +603,7 @@ impl<'a> PublicPacket<'a> {
         }
 
         // Check that this is a long header from a supported version.
-        let version = if let Ok(v) = Version::try_from(version) {
-            v
-        } else {
+        let Ok(version) = Version::try_from(version) else {
             return Ok((
                 Self {
                     packet_type: PacketType::OtherVersion,

--- a/neqo-transport/src/packet/retry.rs
+++ b/neqo-transport/src/packet/retry.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(clippy::pedantic)]
-
 use crate::version::Version;
 use crate::{Error, Res};
 

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -4,7 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
 use std::cell::RefCell;

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -74,15 +74,15 @@ pub fn connection_tparams_set(qlog: &mut NeqoQlog, tph: &TransportParametersHand
 
         // This event occurs very early, so just mark the time as 0.0.
         Some(Event::with_time(0.0, ev_data))
-    })
+    });
 }
 
 pub fn server_connection_started(qlog: &mut NeqoQlog, path: &PathRef) {
-    connection_started(qlog, path)
+    connection_started(qlog, path);
 }
 
 pub fn client_connection_started(qlog: &mut NeqoQlog, path: &PathRef) {
-    connection_started(qlog, path)
+    connection_started(qlog, path);
 }
 
 fn connection_started(qlog: &mut NeqoQlog, path: &PathRef) {
@@ -104,7 +104,7 @@ fn connection_started(qlog: &mut NeqoQlog, path: &PathRef) {
         });
 
         Some(ev_data)
-    })
+    });
 }
 
 pub fn connection_state_updated(qlog: &mut NeqoQlog, new: &State) {
@@ -112,8 +112,7 @@ pub fn connection_state_updated(qlog: &mut NeqoQlog, new: &State) {
         let ev_data = EventData::ConnectionStateUpdated(ConnectionStateUpdated {
             old: None,
             new: match new {
-                State::Init => ConnectionState::Attempted,
-                State::WaitInitial => ConnectionState::Attempted,
+                State::Init | State::WaitInitial => ConnectionState::Attempted,
                 State::WaitVersion | State::Handshaking => ConnectionState::HandshakeStarted,
                 State::Connected => ConnectionState::HandshakeCompleted,
                 State::Confirmed => ConnectionState::HandshakeConfirmed,
@@ -124,7 +123,7 @@ pub fn connection_state_updated(qlog: &mut NeqoQlog, new: &State) {
         });
 
         Some(ev_data)
-    })
+    });
 }
 
 pub fn packet_sent(
@@ -170,7 +169,7 @@ pub fn packet_sent(
         });
 
         stream.add_event_data_now(ev_data)
-    })
+    });
 }
 
 pub fn packet_dropped(qlog: &mut NeqoQlog, payload: &PublicPacket) {
@@ -197,7 +196,7 @@ pub fn packet_dropped(qlog: &mut NeqoQlog, payload: &PublicPacket) {
         });
 
         Some(ev_data)
-    })
+    });
 }
 
 pub fn packets_lost(qlog: &mut NeqoQlog, pkts: &[SentPacket]) {
@@ -215,7 +214,7 @@ pub fn packets_lost(qlog: &mut NeqoQlog, pkts: &[SentPacket]) {
             stream.add_event_data_now(ev_data)?;
         }
         Ok(())
-    })
+    });
 }
 
 pub fn packet_received(
@@ -264,7 +263,7 @@ pub fn packet_received(
         });
 
         stream.add_event_data_now(ev_data)
-    })
+    });
 }
 
 #[allow(dead_code)]
@@ -306,7 +305,7 @@ pub fn metrics_updated(qlog: &mut NeqoQlog, updated_metrics: &[QlogMetric]) {
                 QlogMetric::RttVariance(v) => rtt_variance = Some(*v as f32),
                 QlogMetric::PtoCount(v) => pto_count = Some(u16::try_from(*v).unwrap()),
                 QlogMetric::CongestionWindow(v) => {
-                    congestion_window = Some(u64::try_from(*v).unwrap())
+                    congestion_window = Some(u64::try_from(*v).unwrap());
                 }
                 QlogMetric::BytesInFlight(v) => bytes_in_flight = Some(u64::try_from(*v).unwrap()),
                 QlogMetric::SsThresh(v) => ssthresh = Some(u64::try_from(*v).unwrap()),
@@ -330,7 +329,7 @@ pub fn metrics_updated(qlog: &mut NeqoQlog, updated_metrics: &[QlogMetric]) {
         });
 
         Some(ev_data)
-    })
+    });
 }
 
 // Helper functions

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -6,8 +6,6 @@
 
 // Tracking of sent packets and detecting their loss.
 
-#![deny(clippy::pedantic)]
-
 use std::cmp::{max, min};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -215,16 +215,15 @@ impl RxStreamOrderer {
                 let truncate_to = new_data.len() - usize::try_from(overlap).unwrap();
                 to_add = &new_data[..truncate_to];
                 break;
-            } else {
-                qtrace!(
-                    "New frame {}-{} spans entire next frame {}-{}, replacing",
-                    new_start,
-                    new_end,
-                    next_start,
-                    next_end
-                );
-                to_remove.push(next_start);
             }
+            qtrace!(
+                "New frame {}-{} spans entire next frame {}-{}, replacing",
+                new_start,
+                new_end,
+                next_start,
+                next_end
+            );
+            to_remove.push(next_start);
         }
 
         for start in to_remove {
@@ -652,12 +651,12 @@ impl RecvStream {
             | RecvStreamState::AbortReading { .. }
             | RecvStreamState::WaitForReset { .. }
             | RecvStreamState::ResetRecvd { .. } => {
-                qtrace!("data received when we are in state {}", self.state.name())
+                qtrace!("data received when we are in state {}", self.state.name());
             }
         }
 
         if !already_data_ready && (self.data_ready() || self.needs_to_inform_app_about_fin()) {
-            self.conn_events.recv_stream_readable(self.stream_id)
+            self.conn_events.recv_stream_readable(self.stream_id);
         }
 
         Ok(())
@@ -837,7 +836,7 @@ impl RecvStream {
                     err,
                     final_received: received,
                     final_read: read,
-                })
+                });
             }
             RecvStreamState::DataRecvd {
                 fc,

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -6,8 +6,6 @@
 
 // Tracking of sent packets and detecting their loss.
 
-#![deny(clippy::pedantic)]
-
 use std::cmp::{max, min};
 use std::time::{Duration, Instant};
 

--- a/neqo-transport/src/sender.rs
+++ b/neqo-transport/src/sender.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 // Congestion control
-#![deny(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
 use crate::cc::{

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 // Tracking of some useful statistics.
-#![deny(clippy::pedantic)]
 
 use crate::packet::PacketNumber;
 use neqo_common::qinfo;

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -269,7 +269,7 @@ impl Streams {
             StreamRecoveryToken::Stream(st) => self.send.lost(st),
             StreamRecoveryToken::ResetStream { stream_id } => self.send.reset_lost(*stream_id),
             StreamRecoveryToken::StreamDataBlocked { stream_id, limit } => {
-                self.send.blocked_lost(*stream_id, *limit)
+                self.send.blocked_lost(*stream_id, *limit);
             }
             StreamRecoveryToken::MaxStreamData {
                 stream_id,
@@ -294,10 +294,10 @@ impl Streams {
                 self.remote_stream_limits[*stream_type].frame_lost(*max_streams);
             }
             StreamRecoveryToken::DataBlocked(limit) => {
-                self.sender_fc.borrow_mut().frame_lost(*limit)
+                self.sender_fc.borrow_mut().frame_lost(*limit);
             }
             StreamRecoveryToken::MaxData(maximum_data) => {
-                self.receiver_fc.borrow_mut().frame_lost(*maximum_data)
+                self.receiver_fc.borrow_mut().frame_lost(*maximum_data);
             }
         }
     }

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -6,8 +6,6 @@
 
 // Tracking of received packets and generating acks thereof.
 
-#![deny(clippy::pedantic)]
-
 use std::{
     cmp::min,
     collections::VecDeque,

--- a/neqo-transport/src/version.rs
+++ b/neqo-transport/src/version.rs
@@ -23,7 +23,7 @@ pub enum Version {
 impl Version {
     pub const fn wire_version(self) -> WireVersion {
         match self {
-            Self::Version2 => 0x6b3343cf,
+            Self::Version2 => 0x6b33_43cf,
             Self::Version1 => 1,
             Self::Draft29 => 0xff00_0000 + 29,
             Self::Draft30 => 0xff00_0000 + 30,
@@ -131,7 +131,7 @@ impl TryFrom<WireVersion> for Version {
     fn try_from(wire: WireVersion) -> Res<Self> {
         if wire == 1 {
             Ok(Self::Version1)
-        } else if wire == 0x6b3343cf {
+        } else if wire == 0x6b33_43cf {
             Ok(Self::Version2)
         } else if wire == 0xff00_0000 + 29 {
             Ok(Self::Draft29)


### PR DESCRIPTION
Enable clippy's _pedantic_ lint category.

- Adjusts CI check accordingly.
- Adds `#![deny(clippy::pedantic)]` to all (but tests) top level crate files.
- Fixes various lint failures.
- Removes module `#![deny(clippy::pedantic)]` whereever it is already enabled at the crate level.

Fixes https://github.com/mozilla/neqo/issues/553

More work needed here. _Draft_ for now.