### PR TITLE
fix(transport/qlog): map State::Closing onto ConnectionState::Closing

### DIFF
--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -117,7 +117,7 @@ pub fn connection_state_updated(qlog: &mut NeqoQlog, new: &State) {
                 State::WaitVersion | State::Handshaking => ConnectionState::HandshakeStarted,
                 State::Connected => ConnectionState::HandshakeCompleted,
                 State::Confirmed => ConnectionState::HandshakeConfirmed,
-                State::Closing { .. } => ConnectionState::Draining,
+                State::Closing { .. } => ConnectionState::Closing,
                 State::Draining { .. } => ConnectionState::Draining,
                 State::Closed { .. } => ConnectionState::Closed,
             },


### PR DESCRIPTION
Map `State::Closing` to `ConnectionState::Closing` instead of `ConnectionState::Draining`.

Assuming that this is a typo.

CI Clippy failures are unrelated. See https://github.com/mozilla/neqo/pull/1534 for a fix.