### PR TITLE
fix(clippy): new lints introduced in Rust v1.75

### DIFF
--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -93,9 +93,7 @@ impl ActivePushStreams {
             None | Some(PushState::Closed) => None,
             Some(s) => {
                 let res = mem::replace(s, PushState::Closed);
-                while self.push_streams.get(0).is_some()
-                    && *self.push_streams.get(0).unwrap() == PushState::Closed
-                {
+                while let Some(PushState::Closed) = self.push_streams.front() {
                     self.push_streams.pop_front();
                     self.first_push_id += 1;
                 }

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -50,7 +50,7 @@ impl QPackDecoder {
             send_buf,
             local_stream_id: None,
             max_table_size: qpack_settings.max_table_size_decoder,
-            max_blocked_streams: usize::try_from(qpack_settings.max_blocked_streams).unwrap(),
+            max_blocked_streams: usize::from(qpack_settings.max_blocked_streams),
             blocked_streams: Vec::new(),
             stats: Stats::default(),
         }

--- a/neqo-qpack/src/prefix.rs
+++ b/neqo-qpack/src/prefix.rs
@@ -6,6 +6,8 @@
 
 #[derive(Copy, Clone, Debug)]
 pub struct Prefix {
+    #[allow(unknown_lints)] // available with Rust v1.75
+    #[allow(clippy::struct_field_names)]
     prefix: u8,
     len: u8,
     mask: u8,

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -22,6 +22,7 @@ use crate::{
     sender::PACING_BURST_SIZE,
     tracking::SentPacket,
 };
+#[rustfmt::skip] // to keep `::` and thus prevent conflict with `crate::qlog`
 use ::qlog::events::{quic::CongestionStateUpdated, EventData};
 use neqo_common::{const_max, const_min, qdebug, qinfo, qlog::NeqoQlog, qtrace};
 

--- a/neqo-transport/src/cc/cubic.rs
+++ b/neqo-transport/src/cc/cubic.rs
@@ -39,9 +39,9 @@ const EXPONENTIAL_GROWTH_REDUCTION: f64 = 2.0;
 /// This has the effect of reducing larger values to `1<<53`.
 /// If you have a congestion window that large, something is probably wrong.
 fn convert_to_f64(v: usize) -> f64 {
-    let mut f_64 = f64::try_from(u32::try_from(v >> 21).unwrap_or(u32::MAX)).unwrap();
+    let mut f_64 = f64::from(u32::try_from(v >> 21).unwrap_or(u32::MAX));
     f_64 *= 2_097_152.0; // f_64 <<= 21
-    f_64 += f64::try_from(u32::try_from(v & 0x1f_ffff).unwrap()).unwrap();
+    f_64 += f64::from(u32::try_from(v & 0x1f_ffff).unwrap());
     f_64
 }
 

--- a/neqo-transport/src/cc/mod.rs
+++ b/neqo-transport/src/cc/mod.rs
@@ -20,7 +20,9 @@ mod classic_cc;
 mod cubic;
 mod new_reno;
 
-pub use classic_cc::{ClassicCongestionControl, CWND_INITIAL, CWND_INITIAL_PKTS, CWND_MIN};
+pub use classic_cc::ClassicCongestionControl;
+#[cfg(test)]
+pub use classic_cc::{CWND_INITIAL, CWND_INITIAL_PKTS, CWND_MIN};
 pub use cubic::Cubic;
 pub use new_reno::NewReno;
 

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -76,9 +76,7 @@ fn packet_lost(cc: &mut ClassicCongestionControl<Cubic>, pn: u64) {
 }
 
 fn expected_tcp_acks(cwnd_rtt_start: usize) -> u64 {
-    (f64::try_from(i32::try_from(cwnd_rtt_start).unwrap()).unwrap()
-        / MAX_DATAGRAM_SIZE_F64
-        / CUBIC_ALPHA)
+    (f64::from(i32::try_from(cwnd_rtt_start).unwrap()) / MAX_DATAGRAM_SIZE_F64 / CUBIC_ALPHA)
         .round() as u64
 }
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -67,7 +67,9 @@ mod state;
 pub mod test_internal;
 
 pub use crate::send_stream::{RetransmissionPriority, SendStreamStats, TransmissionPriority};
-pub use params::{ConnectionParameters, ACK_RATIO_SCALE};
+pub use params::ConnectionParameters;
+#[cfg(test)]
+pub use params::ACK_RATIO_SCALE;
 pub use state::{ClosingFrame, State};
 
 use idle::IdleTimeout;

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -156,7 +156,7 @@ fn sendorder_test(order_of_sendorder: &[Option<SendOrder>]) {
     assert_eq!(*client.state(), State::Confirmed);
 
     qdebug!("---- server receives");
-    for (_, d) in datagrams.into_iter().enumerate() {
+    for d in datagrams {
         let out = server.process(Some(d), now());
         qdebug!("Output={:0x?}", out.as_dgram_ref());
     }

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -56,6 +56,8 @@ pub type PathRef = Rc<RefCell<Path>>;
 #[derive(Debug, Default)]
 pub struct Paths {
     /// All of the paths.  All of these paths will be permanent.
+    #[allow(unknown_lints)] // available with Rust v1.75
+    #[allow(clippy::struct_field_names)]
     paths: Vec<PathRef>,
     /// This is the primary path.  This will only be `None` initially, so
     /// care needs to be taken regarding that only during the handshake.


### PR DESCRIPTION
CI is currently failing with `stable` Rust, given a couple of new clippy lints in Rust v1.75. This pull requests fixes the lints.

See https://github.com/mozilla/neqo/actions/runs/7363919275/job/20043828874?pr=1533 for a sample failure.