### PR TITLE
refactor: use let-else

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -1036,12 +1036,9 @@ fn main() -> Res<()> {
                     (SocketAddr::V4(..), false, true) | (SocketAddr::V6(..), true, false)
                 )
             });
-        let remote_addr = match remote_addr {
-            Some(a) => a,
-            None => {
-                eprintln!("No compatible address found for: {}", host);
-                exit(1);
-            }
+        let Some(remote_addr) = remote_addr else {
+            eprintln!("No compatible address found for: {}", host);
+            exit(1);
         };
 
         let local_addr = match remote_addr {

--- a/neqo-server/src/old_https.rs
+++ b/neqo-server/src/old_https.rs
@@ -138,9 +138,7 @@ impl Http09Server {
             data
         };
 
-        let msg = if let Ok(s) = std::str::from_utf8(&buf[..]) {
-            s
-        } else {
+        let Ok(msg) = std::str::from_utf8(&buf[..]) else {
             self.save_partial(stream_id, buf, conn);
             return;
         };

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1859,12 +1859,9 @@ impl Connection {
         let grease_quic_bit = self.can_grease_quic_bit();
         let version = self.version();
         for space in PacketNumberSpace::iter() {
-            let (cspace, tx) =
-                if let Some(crypto) = self.crypto.states.select_tx_mut(self.version, *space) {
-                    crypto
-                } else {
-                    continue;
-                };
+            let Some((cspace, tx)) = self.crypto.states.select_tx_mut(self.version, *space) else {
+                continue;
+            };
 
             let path = close.path().borrow();
             let (_, mut builder) = Self::build_packet_header(
@@ -2147,12 +2144,9 @@ impl Connection {
         let mut encoder = Encoder::with_capacity(profile.limit());
         for space in PacketNumberSpace::iter() {
             // Ensure we have tx crypto state for this epoch, or skip it.
-            let (cspace, tx) =
-                if let Some(crypto) = self.crypto.states.select_tx_mut(self.version, *space) {
-                    crypto
-                } else {
-                    continue;
-                };
+            let Some((cspace, tx)) = self.crypto.states.select_tx_mut(self.version, *space) else {
+                continue;
+            };
 
             let header_start = encoder.len();
             let (pt, mut builder) = Self::build_packet_header(
@@ -3108,13 +3102,11 @@ impl Connection {
             return Err(Error::NotAvailable);
         }
         let version = self.version();
-        let (cspace, tx) = if let Some(crypto) = self
+        let Some((cspace, tx)) = self
             .crypto
             .states
             .select_tx(self.version, PacketNumberSpace::ApplicationData)
-        {
-            crypto
-        } else {
+        else {
             return Err(Error::NotAvailable);
         };
         let path = self.paths.primary_fallible().ok_or(Error::NotAvailable)?;

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -245,9 +245,7 @@ impl Crypto {
 
     fn install_handshake_keys(&mut self) -> Res<bool> {
         qtrace!([self], "Attempt to install handshake keys");
-        let write_secret = if let Some(secret) = self.tls.write_secret(TLS_EPOCH_HANDSHAKE) {
-            secret
-        } else {
+        let Some(write_secret) = self.tls.write_secret(TLS_EPOCH_HANDSHAKE) else {
             // No keys is fine.
             return Ok(false);
         };

--- a/neqo-transport/src/dump.rs
+++ b/neqo-transport/src/dump.rs
@@ -31,12 +31,9 @@ pub fn dump_packet(
     let mut s = String::from("");
     let mut d = Decoder::from(payload);
     while d.remaining() > 0 {
-        let f = match Frame::decode(&mut d) {
-            Ok(f) => f,
-            Err(_) => {
-                s.push_str(" [broken]...");
-                break;
-            }
+        let Ok(f) = Frame::decode(&mut d) else {
+            s.push_str(" [broken]...");
+            break;
         };
         if let Some(x) = f.dump() {
             write!(&mut s, "\n  {} {}", dir, &x).unwrap();

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -599,9 +599,7 @@ impl<'a> PublicPacket<'a> {
         }
 
         // Check that this is a long header from a supported version.
-        let version = if let Ok(v) = Version::try_from(version) {
-            v
-        } else {
+        let Ok(version) = Version::try_from(version) else {
             return Ok((
                 Self {
                     packet_type: PacketType::OtherVersion,

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -332,9 +332,7 @@ impl Server {
                     dgram.source(),
                     now,
                 );
-                let token = if let Ok(t) = res {
-                    t
-                } else {
+                let Ok(token) = res else {
                     qerror!([self], "unable to generate token, dropping packet");
                     return None;
                 };
@@ -539,12 +537,9 @@ impl Server {
         // This is only looking at the first packet header in the datagram.
         // All packets in the datagram are routed to the same connection.
         let res = PublicPacket::decode(&dgram[..], self.cid_generator.borrow().as_decoder());
-        let (packet, _remainder) = match res {
-            Ok(res) => res,
-            _ => {
-                qtrace!([self], "Discarding {:?}", dgram);
-                return None;
-            }
+        let Ok((packet, _remainder)) = res else {
+            qtrace!([self], "Discarding {:?}", dgram);
+            return None;
         };
 
         // Finding an existing connection. Should be the most common case.

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -726,16 +726,12 @@ where
             return ZeroRttCheckResult::Reject;
         }
         let mut dec = Decoder::from(token);
-        let tpslice = if let Some(v) = dec.decode_vvec() {
-            v
-        } else {
+        let Some(tpslice) = dec.decode_vvec() else {
             qinfo!("0-RTT: token code error");
             return ZeroRttCheckResult::Fail;
         };
         let mut dec_tp = Decoder::from(tpslice);
-        let remembered = if let Ok(v) = TransportParameters::decode(&mut dec_tp) {
-            v
-        } else {
+        let Ok(remembered) = TransportParameters::decode(&mut dec_tp) else {
             qinfo!("0-RTT: transport parameter decode error");
             return ZeroRttCheckResult::Fail;
         };

--- a/neqo-transport/tests/connection.rs
+++ b/neqo-transport/tests/connection.rs
@@ -140,7 +140,7 @@ fn overflow_crypto() {
         decode_initial_header(client_initial.as_ref().unwrap(), Role::Client);
     let client_dcid = client_dcid.to_owned();
 
-    let server_packet = server.process(client_initial, now()).dgram();
+    let server_packet = server.process(client_initial.as_ref(), now()).dgram();
     let (server_initial, _) = split_datagram(server_packet.as_ref().unwrap());
 
     // Now decrypt the server packet to get AEAD and HP instances.
@@ -184,7 +184,7 @@ fn overflow_crypto() {
             server_initial.destination(),
             packet,
         );
-        client.process_input(dgram, now());
+        client.process_input(&dgram, now());
         if let State::Closing { error, .. } = client.state() {
             assert!(
                 matches!(


### PR DESCRIPTION
Use Rust's (`>= v1.65`) new let-else feature whereever possible.

https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html

https://rust-lang.github.io/rust-clippy/master/index.html#/manual_let_else

---

Breaking https://github.com/mozilla/neqo/pull/1532 into smaller pull requests to ease review and reduce merge conflicts.

Meta issue: https://github.com/mozilla/neqo/issues/553