### PR TITLE
refactor: inline format args

### DIFF
--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -178,11 +178,11 @@ impl Handler for H9Handler {
     fn handle(&mut self, client: &mut Connection) -> bool {
         let mut data = vec![0; 4000];
         while let Some(event) = client.next_event() {
-            eprintln!("Event: {:?}", event);
+            eprintln!("Event: {event:?}");
             match event {
                 ConnectionEvent::RecvStreamReadable { stream_id } => {
                     if !self.streams.contains(&stream_id) {
-                        eprintln!("Data on unexpected stream: {}", stream_id);
+                        eprintln!("Data on unexpected stream: {stream_id}");
                         return false;
                     }
 
@@ -190,20 +190,20 @@ impl Handler for H9Handler {
                         .stream_recv(stream_id, &mut data)
                         .expect("Read should succeed");
                     data.truncate(sz);
-                    eprintln!("Length={}", sz);
+                    eprintln!("Length={sz}");
                     self.rbytes += sz;
                     if fin {
-                        eprintln!("<FIN[{}]>", stream_id);
+                        eprintln!("<FIN[{stream_id}]>");
                         client.close(Instant::now(), 0, "kthxbye!");
                         self.rsfin = true;
                         return false;
                     }
                 }
                 ConnectionEvent::SendStreamWritable { stream_id } => {
-                    eprintln!("stream {} writable", stream_id)
+                    eprintln!("stream {stream_id} writable")
                 }
                 _ => {
-                    eprintln!("Unexpected event {:?}", event);
+                    eprintln!("Unexpected event {event:?}");
                 }
             }
         }
@@ -328,15 +328,15 @@ impl H3Handler {
                     ..
                 } => {
                     if !self.streams.contains(&stream_id) {
-                        eprintln!("Data on unexpected stream: {}", stream_id);
+                        eprintln!("Data on unexpected stream: {stream_id}");
                         return false;
                     }
 
-                    eprintln!("READ HEADERS[{}]: fin={} {:?}", stream_id, fin, headers);
+                    eprintln!("READ HEADERS[{stream_id}]: fin={fin} {headers:?}");
                 }
                 Http3ClientEvent::DataReadable { stream_id } => {
                     if !self.streams.contains(&stream_id) {
-                        eprintln!("Data on unexpected stream: {}", stream_id);
+                        eprintln!("Data on unexpected stream: {stream_id}");
                         return false;
                     }
 
@@ -345,12 +345,12 @@ impl H3Handler {
                         .read_data(Instant::now(), stream_id, &mut data)
                         .expect("Read should succeed");
                     if let Ok(txt) = String::from_utf8(data.clone()) {
-                        eprintln!("READ[{}]: {}", stream_id, txt);
+                        eprintln!("READ[{stream_id}]: {txt}");
                     } else {
                         eprintln!("READ[{}]: 0x{}", stream_id, hex(&data));
                     }
                     if fin {
-                        eprintln!("<FIN[{}]>", stream_id);
+                        eprintln!("<FIN[{stream_id}]>");
                         if close {
                             self.h3.close(Instant::now(), 0, "kthxbye!");
                         }
@@ -472,14 +472,14 @@ fn test_connect(nctx: &NetworkCtx, test: &Test, peer: &Peer) -> Result<Connectio
     let st = match res {
         Ok(st) => st,
         Err(e) => {
-            return Err(format!("ERROR: {}", e));
+            return Err(format!("ERROR: {e}"));
         }
     };
 
     if st.connected() {
         Ok(client)
     } else {
-        Err(format!("{:?}", st))
+        Err(format!("{st:?}"))
     }
 }
 
@@ -494,7 +494,7 @@ fn test_h9(nctx: &NetworkCtx, client: &mut Connection) -> Result<(), String> {
     let res = process_loop(nctx, client, &mut hc);
 
     if let Err(e) = res {
-        return Err(format!("ERROR: {}", e));
+        return Err(format!("ERROR: {e}"));
     }
     if hc.rbytes == 0 {
         return Err(String::from("Empty response"));
@@ -522,7 +522,7 @@ fn connect_h3(nctx: &NetworkCtx, peer: &Peer, client: Connection) -> Result<H3Ha
     };
 
     if let Err(e) = process_loop_h3(nctx, &mut hc, true, false) {
-        return Err(format!("ERROR: {}", e));
+        return Err(format!("ERROR: {e}"));
     }
     Ok(hc)
 }
@@ -544,7 +544,7 @@ fn test_h3(nctx: &NetworkCtx, peer: &Peer, client: Connection, test: &Test) -> R
 
     hc.streams.insert(client_stream_id);
     if let Err(e) = process_loop_h3(nctx, &mut hc, false, *test != Test::D) {
-        return Err(format!("ERROR: {}", e));
+        return Err(format!("ERROR: {e}"));
     }
 
     if *test == Test::D {
@@ -562,7 +562,7 @@ fn test_h3(nctx: &NetworkCtx, peer: &Peer, client: Connection, test: &Test) -> R
         hc.h3.stream_close_send(client_stream_id).unwrap();
         hc.streams.insert(client_stream_id);
         if let Err(e) = process_loop_h3(nctx, &mut hc, false, true) {
-            return Err(format!("ERROR: {}", e));
+            return Err(format!("ERROR: {e}"));
         }
 
         if hc.h3.qpack_decoder_stats().dynamic_table_references == 0 {
@@ -600,7 +600,7 @@ fn test_h3_rz(
 
     hc.streams.insert(client_stream_id);
     if let Err(e) = process_loop_h3(nctx, &mut hc, false, true) {
-        return Err(format!("ERROR: {}", e));
+        return Err(format!("ERROR: {e}"));
     }
 
     // get resumption ticket
@@ -652,7 +652,7 @@ fn test_h3_rz(
         mem::drop(hc.h3.stream_close_send(client_stream_id));
         hc.streams.insert(client_stream_id);
         if let Err(e) = process_loop_h3(nctx, &mut hc, false, true) {
-            return Err(format!("ERROR: {}", e));
+            return Err(format!("ERROR: {e}"));
         }
 
         let recvd_0rtt_reject = |e| e == Http3ClientEvent::ZeroRttRejected;
@@ -662,7 +662,7 @@ fn test_h3_rz(
     } else {
         println!("Test resumption");
         if let Err(e) = process_loop_h3(nctx, &mut hc, true, true) {
-            return Err(format!("ERROR: {}", e));
+            return Err(format!("ERROR: {e}"));
         }
     }
 

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -85,7 +85,7 @@ impl From<neqo_transport::Error> for ServerError {
 
 impl Display for ServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Error: {:?}", self)?;
+        write!(f, "Error: {self:?}")?;
         Ok(())
     }
 }
@@ -343,7 +343,7 @@ fn qns_read_response(filename: &str) -> Option<Vec<u8>> {
                     Some(data)
                 }
                 Err(e) => {
-                    eprintln!("Error reading data: {:?}", e);
+                    eprintln!("Error reading data: {e:?}");
                     None
                 }
             }
@@ -479,7 +479,7 @@ impl HttpServer for SimpleServer {
                     headers,
                     fin,
                 } => {
-                    println!("Headers (request={} fin={}): {:?}", stream, fin, headers);
+                    println!("Headers (request={stream} fin={fin}): {headers:?}");
 
                     let post = if let Some(method) = headers.iter().find(|&h| h.name() == ":method")
                     {
@@ -592,7 +592,7 @@ fn read_dgram(
     let (sz, remote_addr) = match socket.recv_from(&mut buf[..]) {
         Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => return Ok(None),
         Err(err) => {
-            eprintln!("UDP recv error: {:?}", err);
+            eprintln!("UDP recv error: {err:?}");
             return Err(err);
         }
         Ok(res) => res,
@@ -652,7 +652,7 @@ impl ServersRunner {
         for (i, host) in self.hosts.iter().enumerate() {
             let socket = match UdpSocket::bind(host) {
                 Err(err) => {
-                    eprintln!("Unable to bind UDP socket: {}", err);
+                    eprintln!("Unable to bind UDP socket: {err}");
                     return Err(err);
                 }
                 Ok(s) => s,
@@ -660,7 +660,7 @@ impl ServersRunner {
 
             let local_addr = match socket.local_addr() {
                 Err(err) => {
-                    eprintln!("Socket local address not bound: {}", err);
+                    eprintln!("Socket local address not bound: {err}");
                     return Err(err);
                 }
                 Ok(s) => s,
@@ -671,10 +671,7 @@ impl ServersRunner {
             } else {
                 " as well as V4"
             };
-            println!(
-                "Server waiting for connection on: {:?}{}",
-                local_addr, also_v4
-            );
+            println!("Server waiting for connection on: {local_addr:?}{also_v4}");
 
             self.poll.register(
                 &socket,

--- a/neqo-server/src/old_https.rs
+++ b/neqo-server/src/old_https.rs
@@ -158,7 +158,7 @@ impl Http09Server {
             }
             Some(path) => {
                 let path = path.as_str();
-                eprintln!("Path = '{}'", path);
+                eprintln!("Path = '{path}'");
                 if args.qns_test.is_some() {
                     qns_read_response(path)
                 } else {
@@ -173,7 +173,7 @@ impl Http09Server {
     fn stream_writable(&mut self, stream_id: StreamId, conn: &mut ActiveConnectionRef) {
         match self.write_state.get_mut(&stream_id) {
             None => {
-                eprintln!("Unknown stream {}, ignoring event", stream_id);
+                eprintln!("Unknown stream {stream_id}, ignoring event");
             }
             Some(stream_state) => {
                 stream_state.writable = true;
@@ -186,7 +186,7 @@ impl Http09Server {
                     *offset += sent;
                     self.server.add_to_waiting(conn.clone());
                     if *offset == data.len() {
-                        eprintln!("Sent {} on {}, closing", sent, stream_id);
+                        eprintln!("Sent {sent} on {stream_id}, closing");
                         conn.borrow_mut().stream_close_send(stream_id).unwrap();
                         self.write_state.remove(&stream_id);
                     } else {
@@ -211,7 +211,7 @@ impl HttpServer for Http09Server {
                     None => break,
                     Some(e) => e,
                 };
-                eprintln!("Event {:?}", event);
+                eprintln!("Event {event:?}");
                 match event {
                     ConnectionEvent::NewStream { stream_id } => {
                         self.write_state
@@ -231,7 +231,7 @@ impl HttpServer for Http09Server {
                     }
                     ConnectionEvent::StateChange(_)
                     | ConnectionEvent::SendStreamComplete { .. } => (),
-                    e => eprintln!("unhandled event {:?}", e),
+                    e => eprintln!("unhandled event {e:?}"),
                 }
             }
         }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -421,7 +421,7 @@ impl Connection {
             #[cfg(test)]
             test_frame_writer: None,
         };
-        c.stats.borrow_mut().init(format!("{}", c));
+        c.stats.borrow_mut().init(format!("{c}"));
         Ok(c)
     }
 
@@ -817,7 +817,7 @@ impl Connection {
     ) -> Res<T> {
         if let Err(v) = &res {
             #[cfg(debug_assertions)]
-            let msg = format!("{:?}", v);
+            let msg = format!("{v:?}");
             #[cfg(not(debug_assertions))]
             let msg = "";
             let error = ConnectionError::Transport(v.clone());

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -368,7 +368,7 @@ impl<'a> Frame<'a> {
             )),
             Self::Padding => None,
             Self::Datagram { data, .. } => Some(format!("Datagram {{ len: {} }}", data.len())),
-            _ => Some(format!("{:?}", self)),
+            _ => Some(format!("{self:?}")),
         }
     }
 

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -186,7 +186,7 @@ impl ::std::error::Error for Error {
 
 impl ::std::fmt::Display for Error {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Transport error: {:?}", self)
+        write!(f, "Transport error: {self:?}")
     }
 }
 

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -771,7 +771,7 @@ mod tests {
         let tps2 = TransportParameters::decode(&mut enc.as_decoder()).expect("Couldn't decode");
         assert_eq!(tps, tps2);
 
-        println!("TPS = {:?}", tps);
+        println!("TPS = {tps:?}");
         assert_eq!(tps2.get_integer(IDLE_TIMEOUT), 0); // Default
         assert_eq!(tps2.get_integer(MAX_ACK_DELAY), 25); // Default
         assert_eq!(tps2.get_integer(ACTIVE_CONNECTION_ID_LIMIT), 2); // Default


### PR DESCRIPTION
Inline variables into format strings wherever possible.

https://rust-lang.github.io/rust-clippy/master/index.html#/uninlined_format_args

---

Breaking https://github.com/mozilla/neqo/pull/1532 into smaller pull requests to ease review and reduce merge conflicts.

Meta issue: https://github.com/mozilla/neqo/issues/553