### PR TITLE
refactor: match single variant over wildcard

### DIFF
--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -202,7 +202,7 @@ impl ConnectionError {
     pub fn app_code(&self) -> Option<AppError> {
         match self {
             Self::Application(e) => Some(*e),
-            _ => None,
+            Self::Transport(_) => None,
         }
     }
 }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -751,7 +751,7 @@ impl SendStream {
                 final_written,
                 ..
             } => *final_retired + *final_written,
-            _ => 0,
+            SendStreamState::Ready { .. } => 0,
         }
     }
 
@@ -763,7 +763,7 @@ impl SendStream {
             SendStreamState::DataRecvd { retired, .. } => *retired,
             SendStreamState::ResetSent { final_retired, .. }
             | SendStreamState::ResetRecvd { final_retired, .. } => *final_retired,
-            _ => 0,
+            SendStreamState::Ready { .. } => 0,
         }
     }
 

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -278,7 +278,7 @@ impl Server {
                     self.timers.add(next, Rc::clone(&c));
                 }
             }
-            _ => {
+            Output::None => {
                 self.remove_timer(&c);
             }
         }


### PR DESCRIPTION
Replace match wildcard whereever it is matching a single variant only.

https://rust-lang.github.io/rust-clippy/master/index.html#/match_wildcard_for_single_variants

---

Breaking https://github.com/mozilla/neqo/pull/1532 into smaller pull requests to ease review and reduce merge conflicts.

Meta issue: https://github.com/mozilla/neqo/issues/553