### PR TITLE
refactor: accept Datagrams by reference, not value

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -432,7 +432,7 @@ fn process_loop(
             };
         }
         if !datagrams.is_empty() {
-            client.process_multiple_input(datagrams.iter(), Instant::now());
+            client.process_multiple_input(&datagrams, Instant::now());
             handler.maybe_key_update(client)?;
         }
 

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -432,7 +432,7 @@ fn process_loop(
             };
         }
         if !datagrams.is_empty() {
-            client.process_multiple_input(datagrams, Instant::now());
+            client.process_multiple_input(datagrams.iter(), Instant::now());
             handler.maybe_key_update(client)?;
         }
 
@@ -1364,7 +1364,7 @@ mod old {
                         }
                         if sz > 0 {
                             let d = Datagram::new(remote, *local_addr, &buf[..sz]);
-                            client.process_input(d, Instant::now());
+                            client.process_input(&d, Instant::now());
                             handler.maybe_key_update(client)?;
                         }
                     }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -804,7 +804,7 @@ impl Http3Client {
     }
 
     /// This function combines  `process_input` and `process_output` function.
-    pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
+    pub fn process(&mut self, dgram: Option<&Datagram>, now: Instant) -> Output {
         qtrace!([self], "Process.");
         if let Some(d) = dgram {
             self.process_input(d, now);
@@ -822,15 +822,20 @@ impl Http3Client {
     /// packets need to be sent or if a timer needs to be updated.
     ///
     /// [1]: ../neqo_transport/enum.ConnectionEvent.html
-    pub fn process_input(&mut self, dgram: Datagram, now: Instant) {
+    pub fn process_input(&mut self, dgram: &Datagram, now: Instant) {
         qtrace!([self], "Process input.");
         self.conn.process_input(dgram, now);
         self.process_http3(now);
     }
 
-    pub fn process_multiple_input(&mut self, dgrams: Vec<Datagram>, now: Instant) {
+    pub fn process_multiple_input<'a>(
+        &mut self,
+        // TODO: Need ExactSizeIterator for qtrace below. Worth the type restriction?
+        dgrams: impl ExactSizeIterator<Item = &'a Datagram>,
+        now: Instant,
+    ) {
         qtrace!([self], "Process multiple datagrams, len={}", dgrams.len());
-        if dgrams.is_empty() {
+        if dgrams.len() == 0 {
             return;
         }
         self.conn.process_multiple_input(dgrams, now);
@@ -1589,11 +1594,11 @@ mod tests {
         assert_eq!(client.state(), Http3State::Initializing);
 
         assert_eq!(*server.conn.state(), State::Init);
-        let out = server.conn.process(out.dgram(), now());
+        let out = server.conn.process(out.as_dgram_ref(), now());
         assert_eq!(*server.conn.state(), State::Handshaking);
 
-        let out = client.process(out.dgram(), now());
-        let out = server.conn.process(out.dgram(), now());
+        let out = client.process(out.as_dgram_ref(), now());
+        let out = server.conn.process(out.as_dgram_ref(), now());
         assert!(out.as_dgram_ref().is_none());
 
         let authentication_needed = |e| matches!(e, Http3ClientEvent::AuthenticationNeeded);
@@ -1606,12 +1611,14 @@ mod tests {
     fn connect_only_transport_with(client: &mut Http3Client, server: &mut TestServer) {
         let out = handshake_only(client, server);
 
-        let out = client.process(out.dgram(), now());
+        let out = client.process(out.as_dgram_ref(), now());
         let connected = |e| matches!(e, Http3ClientEvent::StateChange(Http3State::Connected));
         assert!(client.events().any(connected));
 
         assert_eq!(client.state(), Http3State::Connected);
-        server.conn.process_input(out.dgram().unwrap(), now());
+        server
+            .conn
+            .process_input(out.as_dgram_ref().unwrap(), now());
         assert!(server.conn.state().connected());
     }
 
@@ -1625,8 +1632,10 @@ mod tests {
 
     fn send_and_receive_client_settings(client: &mut Http3Client, server: &mut TestServer) {
         // send and receive client settings
-        let dgram = client.process(None, now()).dgram();
-        server.conn.process_input(dgram.unwrap(), now());
+        let out = client.process(None, now());
+        server
+            .conn
+            .process_input(out.as_dgram_ref().unwrap(), now());
         server.check_client_control_qpack_streams_no_resumption();
     }
 
@@ -1640,8 +1649,8 @@ mod tests {
 
         server.create_qpack_streams();
         // Send the server's control and qpack streams data.
-        let dgram = server.conn.process(None, now()).dgram();
-        client.process_input(dgram.unwrap(), now());
+        let out = server.conn.process(None, now());
+        client.process_input(out.as_dgram_ref().unwrap(), now());
 
         // assert no error occured.
         assert_eq!(client.state(), Http3State::Connected);
@@ -1783,8 +1792,10 @@ mod tests {
     ) -> StreamId {
         let request_stream_id = make_request(client, close_sending_side, &[]);
 
-        let dgram = client.process(None, now()).dgram();
-        server.conn.process_input(dgram.unwrap(), now());
+        let out = client.process(None, now());
+        server
+            .conn
+            .process_input(out.as_dgram_ref().unwrap(), now());
 
         // find the new request/response stream and send frame v on it.
         while let Some(e) = server.conn.next_event() {
@@ -1814,7 +1825,7 @@ mod tests {
         }
         let dgram = server.conn.process_output(now()).dgram();
         if let Some(d) = dgram {
-            client.process_input(d, now());
+            client.process_input(&d, now());
         }
         request_stream_id
     }
@@ -1843,8 +1854,8 @@ mod tests {
             server.conn.stream_close_send(stream_id).unwrap();
         }
         let out = server.conn.process(None, now());
-        let out = client.process(out.dgram(), now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        let out = client.process(out.as_dgram_ref(), now());
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
     }
 
     const PUSH_PROMISE_DATA: &[u8] = &[
@@ -1882,8 +1893,8 @@ mod tests {
         let push_stream_id = send_push_data(&mut server.conn, push_id, close_push_stream);
 
         let out = server.conn.process(None, now());
-        let out = client.process(out.dgram(), now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        let out = client.process(out.as_dgram_ref(), now());
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         push_stream_id
     }
@@ -1897,8 +1908,8 @@ mod tests {
         send_push_promise(&mut server.conn, stream_id, push_id);
 
         let out = server.conn.process(None, now());
-        let out = client.process(out.dgram(), now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        let out = client.process(out.as_dgram_ref(), now());
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
     }
 
     fn send_cancel_push_and_exchange_packets(
@@ -1915,8 +1926,8 @@ mod tests {
             .unwrap();
 
         let out = server.conn.process(None, now());
-        let out = client.process(out.dgram(), now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        let out = client.process(out.as_dgram_ref(), now());
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
     }
 
     const PUSH_DATA: &[u8] = &[
@@ -2083,7 +2094,7 @@ mod tests {
             .stream_close_send(server.control_stream_id.unwrap())
             .unwrap();
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
         assert_closed(&client, &Error::HttpClosedCriticalStream);
     }
 
@@ -2097,7 +2108,7 @@ mod tests {
             .stream_reset_send(server.control_stream_id.unwrap(), Error::HttpNoError.code())
             .unwrap();
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
         assert_closed(&client, &Error::HttpClosedCriticalStream);
     }
 
@@ -2111,7 +2122,7 @@ mod tests {
             .stream_reset_send(server.encoder_stream_id.unwrap(), Error::HttpNoError.code())
             .unwrap();
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
         assert_closed(&client, &Error::HttpClosedCriticalStream);
     }
 
@@ -2125,7 +2136,7 @@ mod tests {
             .stream_reset_send(server.decoder_stream_id.unwrap(), Error::HttpNoError.code())
             .unwrap();
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
         assert_closed(&client, &Error::HttpClosedCriticalStream);
     }
 
@@ -2139,7 +2150,7 @@ mod tests {
             .stream_stop_sending(CLIENT_SIDE_CONTROL_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
         assert_closed(&client, &Error::HttpClosedCriticalStream);
     }
 
@@ -2153,7 +2164,7 @@ mod tests {
             .stream_stop_sending(CLIENT_SIDE_ENCODER_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
         assert_closed(&client, &Error::HttpClosedCriticalStream);
     }
 
@@ -2167,7 +2178,7 @@ mod tests {
             .stream_stop_sending(CLIENT_SIDE_DECODER_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
         assert_closed(&client, &Error::HttpClosedCriticalStream);
     }
 
@@ -2184,7 +2195,7 @@ mod tests {
             .stream_send(control_stream, &[0x0, 0x1, 0x3, 0x0, 0x1, 0x2]);
         assert_eq!(sent, Ok(6));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
         assert_closed(&client, &Error::HttpMissingSettings);
     }
 
@@ -2200,7 +2211,7 @@ mod tests {
         );
         assert_eq!(sent, Ok(8));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
         assert_closed(&client, &Error::HttpFrameUnexpected);
     }
 
@@ -2214,7 +2225,7 @@ mod tests {
             .unwrap();
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         assert_closed(&client, &Error::HttpFrameUnexpected);
     }
@@ -2263,8 +2274,8 @@ mod tests {
         _ = server.conn.stream_send(push_stream_id, v).unwrap();
 
         let out = server.conn.process(None, now());
-        let out = client.process(out.dgram(), now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        let out = client.process(out.as_dgram_ref(), now());
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         assert_closed(&client, &Error::HttpFrameUnexpected);
     }
@@ -2323,8 +2334,8 @@ mod tests {
             .stream_send(new_stream_id, &[0x41, 0x19, 0x4, 0x4, 0x6, 0x0, 0x8, 0x0])
             .unwrap();
         let out = server.conn.process(None, now());
-        let out = client.process(out.dgram(), now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        let out = client.process(out.as_dgram_ref(), now());
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         // check for stop-sending with Error::HttpStreamCreation.
         let mut stop_sending_event_found = false;
@@ -2352,7 +2363,7 @@ mod tests {
         // Generate packet with the above bad h3 input
         let out = server.conn.process(None, now());
         // Process bad input and close the connection.
-        mem::drop(client.process(out.dgram(), now()));
+        mem::drop(client.process(out.as_dgram_ref(), now()));
 
         assert_closed(&client, &Error::HttpFrameUnexpected);
     }
@@ -2399,38 +2410,38 @@ mod tests {
         let mut sent = server.conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         // start sending SETTINGS frame
         sent = server.conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         sent = server.conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         sent = server.conn.stream_send(control_stream, &[0x6]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         sent = server.conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         sent = server.conn.stream_send(control_stream, &[0x8]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         sent = server.conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         assert_eq!(client.state(), Http3State::Connected);
 
@@ -2438,37 +2449,37 @@ mod tests {
         sent = server.conn.stream_send(control_stream, &[0x5]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         sent = server.conn.stream_send(control_stream, &[0x5]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         sent = server.conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         sent = server.conn.stream_send(control_stream, &[0x61]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         sent = server.conn.stream_send(control_stream, &[0x62]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         sent = server.conn.stream_send(control_stream, &[0x63]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         sent = server.conn.stream_send(control_stream, &[0x64]);
         assert_eq!(sent, Ok(1));
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         // PUSH_PROMISE on a control stream will cause an error
         assert_closed(&client, &Error::HttpFrameUnexpected);
@@ -2544,14 +2555,14 @@ mod tests {
 
         let d1 = dgram(&mut client.conn);
         let d2 = dgram(&mut client.conn);
-        server.conn.process_input(d2, now());
-        server.conn.process_input(d1, now());
+        server.conn.process_input(&d2, now());
+        server.conn.process_input(&d1, now());
         let d3 = dgram(&mut server.conn);
         let d4 = dgram(&mut server.conn);
-        client.process_input(d4, now());
-        client.process_input(d3, now());
+        client.process_input(&d4, now());
+        client.process_input(&d3, now());
         let ack = client.process_output(now()).dgram();
-        server.conn.process_input(ack.unwrap(), now());
+        server.conn.process_input(&ack.unwrap(), now());
     }
 
     /// The client should keep a connection alive if it has unanswered requests.
@@ -2571,7 +2582,7 @@ mod tests {
         request_stream_id: StreamId,
     ) {
         let out = server.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         while let Some(e) = client.next_event() {
             match e {
@@ -2627,7 +2638,7 @@ mod tests {
         client.stream_close_send(request_stream_id).unwrap();
 
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         // find the new request/response stream and send response on it.
         while let Some(e) = server.conn.next_event() {
@@ -2675,8 +2686,8 @@ mod tests {
         // We need to loop a bit until all data has been sent.
         let mut out = client.process(None, now());
         for _i in 0..20 {
-            out = server.conn.process(out.dgram(), now());
-            out = client.process(out.dgram(), now());
+            out = server.conn.process(out.as_dgram_ref(), now());
+            out = client.process(out.as_dgram_ref(), now());
         }
 
         // check request body is received.
@@ -2768,8 +2779,8 @@ mod tests {
         // We need to loop a bit until all data has been sent. Once for every 1K
         // of data.
         for _i in 0..SEND_BUFFER_SIZE / 1000 {
-            out = server.conn.process(out.dgram(), now());
-            out = client.process(out.dgram(), now());
+            out = server.conn.process(out.as_dgram_ref(), now());
+            out = client.process(out.as_dgram_ref(), now());
         }
 
         //  check received frames and send a response.
@@ -2983,7 +2994,7 @@ mod tests {
         );
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         let mut reset = false;
         let mut stop_sending = false;
@@ -3039,7 +3050,7 @@ mod tests {
         );
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         let mut stop_sending = false;
 
@@ -3103,7 +3114,7 @@ mod tests {
         );
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         let mut reset = false;
 
@@ -3170,7 +3181,7 @@ mod tests {
         );
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         let mut stop_sending = false;
         let mut header_ready = false;
@@ -3222,7 +3233,7 @@ mod tests {
         );
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         let mut reset = false;
 
@@ -3312,7 +3323,7 @@ mod tests {
         assert_eq!(request_stream_id_3, 8);
 
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         _ = server
             .conn
@@ -3334,7 +3345,7 @@ mod tests {
             }
         }
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         let mut stream_reset = false;
         while let Some(e) = client.next_event() {
@@ -3396,7 +3407,7 @@ mod tests {
         assert_eq!(request_stream_id_3, 8);
 
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         // First send a Goaway frame with an higher number
         _ = server
@@ -3405,7 +3416,7 @@ mod tests {
             .unwrap();
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         // Check that there is one reset for stream_id 8
         let mut stream_reset_1 = 0;
@@ -3491,7 +3502,7 @@ mod tests {
             .unwrap();
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         assert_eq!(client.state(), Http3State::GoingAway(StreamId::new(4)));
 
@@ -3502,7 +3513,7 @@ mod tests {
             .unwrap();
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         assert_closed(&client, &Error::HttpGeneralProtocol);
     }
@@ -3517,7 +3528,7 @@ mod tests {
             .unwrap();
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         assert_closed(&client, &Error::HttpId);
     }
@@ -3530,7 +3541,7 @@ mod tests {
         server.conn.stream_close_send(request_stream_id).unwrap();
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         // Recv HeaderReady wo headers with fin.
         let e = client.events().next().unwrap();
@@ -3628,7 +3639,7 @@ mod tests {
         server.conn.stream_close_send(request_stream_id).unwrap();
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         // Recv DataReadable wo data with fin
         while let Some(e) = client.next_event() {
@@ -3675,7 +3686,7 @@ mod tests {
         server.conn.stream_close_send(request_stream_id).unwrap();
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         // Recv HeaderReady with fin.
         while let Some(e) = client.next_event() {
@@ -3726,7 +3737,7 @@ mod tests {
             .unwrap();
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         // Recv headers wo fin
         while let Some(e) = client.next_event() {
@@ -3753,7 +3764,7 @@ mod tests {
         server.conn.stream_close_send(request_stream_id).unwrap();
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         // Recv no data, but do get fin
         while let Some(e) = client.next_event() {
@@ -3823,7 +3834,7 @@ mod tests {
         // ok NOW send fin
         server.conn.stream_close_send(request_stream_id).unwrap();
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         // fin wo data should generate DataReadable
         let e = client.events().next().unwrap();
@@ -3968,10 +3979,10 @@ mod tests {
         assert!(!client.events().any(header_ready_event));
 
         // Let client receive the encoder instructions.
-        mem::drop(client.process(encoder_inst_pkt.dgram(), now()));
+        mem::drop(client.process(encoder_inst_pkt.as_dgram_ref(), now()));
 
         let out = server.conn.process(None, now());
-        mem::drop(client.process(out.dgram(), now()));
+        mem::drop(client.process(out.as_dgram_ref(), now()));
         mem::drop(client.process(None, now()));
 
         let mut recv_header = false;
@@ -4033,7 +4044,7 @@ mod tests {
         assert!(!hconn.events().any(header_ready_event));
 
         // Let client receive the encoder instructions.
-        let _out = hconn.process(encoder_inst_pkt.dgram(), now());
+        let _out = hconn.process(encoder_inst_pkt.as_dgram_ref(), now());
 
         let mut recv_header = false;
         // Now the stream is unblocked. After headers we will receive a fin.
@@ -4061,7 +4072,7 @@ mod tests {
         server.send_ticket(now(), &[]).expect("can send ticket");
         let out = server.process_output(now());
         assert!(out.as_dgram_ref().is_some());
-        client.process_input(out.dgram().unwrap(), now());
+        client.process_input(out.as_dgram_ref().unwrap(), now());
         // We do not have a token so we need to wait for a resumption token timer to trigger.
         client.process_output(now() + Duration::from_millis(250));
         assert_eq!(client.state(), Http3State::Connected);
@@ -4105,7 +4116,7 @@ mod tests {
 
         assert_eq!(client.state(), Http3State::ZeroRtt);
         assert_eq!(*server.conn.state(), State::Init);
-        let out = server.conn.process(out.dgram(), now());
+        let out = server.conn.process(out.as_dgram_ref(), now());
 
         // Check that control and qpack streams are received and a
         // SETTINGS frame has been received.
@@ -4118,10 +4129,10 @@ mod tests {
         );
 
         assert_eq!(*server.conn.state(), State::Handshaking);
-        let out = client.process(out.dgram(), now());
+        let out = client.process(out.as_dgram_ref(), now());
         assert_eq!(client.state(), Http3State::Connected);
 
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
         assert!(server.conn.state().connected());
 
         assert!(client.tls_info().unwrap().resumed());
@@ -4140,7 +4151,7 @@ mod tests {
 
         assert_eq!(client.state(), Http3State::ZeroRtt);
         assert_eq!(*server.conn.state(), State::Init);
-        let out = server.conn.process(out.dgram(), now());
+        let out = server.conn.process(out.as_dgram_ref(), now());
 
         // Check that control and qpack streams are received and a
         // SETTINGS frame has been received.
@@ -4153,11 +4164,11 @@ mod tests {
         );
 
         assert_eq!(*server.conn.state(), State::Handshaking);
-        let out = client.process(out.dgram(), now());
+        let out = client.process(out.as_dgram_ref(), now());
         assert_eq!(client.state(), Http3State::Connected);
-        let out = server.conn.process(out.dgram(), now());
+        let out = server.conn.process(out.as_dgram_ref(), now());
         assert!(server.conn.state().connected());
-        let out = client.process(out.dgram(), now());
+        let out = client.process(out.as_dgram_ref(), now());
         assert!(out.as_dgram_ref().is_none());
 
         // After the server has been connected, send a response.
@@ -4224,9 +4235,9 @@ mod tests {
         let client_0rtt = client.process(None, now());
         assert!(client_0rtt.as_dgram_ref().is_some());
 
-        let server_hs = server.process(client_hs.dgram(), now());
+        let server_hs = server.process(client_hs.as_dgram_ref(), now());
         assert!(server_hs.as_dgram_ref().is_some()); // Should produce ServerHello etc...
-        let server_ignored = server.process(client_0rtt.dgram(), now());
+        let server_ignored = server.process(client_0rtt.as_dgram_ref(), now());
         assert!(server_ignored.as_dgram_ref().is_none());
 
         // The server shouldn't receive that 0-RTT data.
@@ -4234,7 +4245,7 @@ mod tests {
         assert!(!server.events().any(recvd_stream_evt));
 
         // Client should get a rejection.
-        let client_out = client.process(server_hs.dgram(), now());
+        let client_out = client.process(server_hs.as_dgram_ref(), now());
         assert!(client_out.as_dgram_ref().is_some());
         let recvd_0rtt_reject = |e| e == Http3ClientEvent::ZeroRttRejected;
         assert!(client.events().any(recvd_0rtt_reject));
@@ -4245,7 +4256,7 @@ mod tests {
         assert_eq!(res.unwrap_err(), Error::InvalidStreamId);
 
         // Client will send Setting frame and open new qpack streams.
-        mem::drop(server.process(client_out.dgram(), now()));
+        mem::drop(server.process(client_out.as_dgram_ref(), now()));
         TestServer::new_with_conn(server).check_client_control_qpack_streams_no_resumption();
 
         // Check that we can send a request and that the stream_id starts again from 0.
@@ -4276,7 +4287,7 @@ mod tests {
 
         assert_eq!(client.state(), Http3State::ZeroRtt);
         assert_eq!(*server.conn.state(), State::Init);
-        let out = server.conn.process(out.dgram(), now());
+        let out = server.conn.process(out.as_dgram_ref(), now());
 
         // Check that control and qpack streams anda SETTINGS frame are received.
         // Also qpack encoder stream will send "change capacity" instruction because it has
@@ -4288,10 +4299,10 @@ mod tests {
         );
 
         assert_eq!(*server.conn.state(), State::Handshaking);
-        let out = client.process(out.dgram(), now());
+        let out = client.process(out.as_dgram_ref(), now());
         assert_eq!(client.state(), Http3State::Connected);
 
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
         assert!(server.conn.state().connected());
 
         assert!(client.tls_info().unwrap().resumed());
@@ -4307,7 +4318,7 @@ mod tests {
         assert_eq!(sent.unwrap(), enc.len());
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         assert_eq!(&client.state(), expected_client_state);
         assert!(server.conn.state().connected());
@@ -4667,7 +4678,7 @@ mod tests {
         server.conn.stream_close_send(request_stream_id).unwrap();
 
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         let events: Vec<Http3ClientEvent> = client.events().collect();
 
@@ -4882,7 +4893,7 @@ mod tests {
         _ = server.conn.stream_send(request_stream_id, &[0, 0]).unwrap();
         server.conn.stream_close_send(request_stream_id).unwrap();
         let dgram = server.conn.process_output(now()).dgram();
-        client.process_input(dgram.unwrap(), now());
+        client.process_input(&dgram.unwrap(), now());
 
         let data_readable_event = |e: &_| matches!(e, Http3ClientEvent::DataReadable { stream_id } if *stream_id == request_stream_id);
         assert_eq!(client.events().filter(data_readable_event).count(), 1);
@@ -4906,7 +4917,7 @@ mod tests {
         server.create_control_stream();
         // Send the server's control stream data.
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         server.create_qpack_streams();
         let qpack_pkt1 = server.conn.process(None, now());
@@ -4914,7 +4925,7 @@ mod tests {
 
         let request_stream_id = make_request(&mut client, true, &[]);
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         setup_server_side_encoder(&mut client, &mut server);
 
@@ -4934,7 +4945,7 @@ mod tests {
 
         // Send the encoder instructions,
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
 
         // Send response
         let mut d = Encoder::default();
@@ -4949,13 +4960,13 @@ mod tests {
         server.conn.stream_close_send(request_stream_id).unwrap();
 
         let out = server.conn.process(None, now());
-        mem::drop(client.process(out.dgram(), now()));
+        mem::drop(client.process(out.as_dgram_ref(), now()));
 
         let header_ready_event = |e| matches!(e, Http3ClientEvent::HeaderReady { .. });
         assert!(!client.events().any(header_ready_event));
 
         // Let client receive the encoder instructions.
-        mem::drop(client.process(qpack_pkt1.dgram(), now()));
+        mem::drop(client.process(qpack_pkt1.as_dgram_ref(), now()));
 
         assert!(client.events().any(header_ready_event));
     }
@@ -5030,8 +5041,8 @@ mod tests {
 
         // Reading push data will stop the client from being idle.
         _ = send_push_data(&mut server.conn, 0, false);
-        let dgram = server.conn.process_output(now()).dgram();
-        client.process_input(dgram.unwrap(), now());
+        let out = server.conn.process_output(now());
+        client.process_input(out.as_dgram_ref().unwrap(), now());
 
         let mut buf = [0; 16];
         let (read, fin) = client.push_read_data(now(), 0, &mut buf).unwrap();
@@ -5340,7 +5351,7 @@ mod tests {
         assert_eq!(request_stream_id_2, 4);
 
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         send_push_promise_and_exchange_packets(&mut client, &mut server, request_stream_id_2, 5);
 
@@ -5376,7 +5387,7 @@ mod tests {
         assert_eq!(request_stream_id_2, 4);
 
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         send_push_promise_and_exchange_packets(&mut client, &mut server, request_stream_id_2, 5);
 
@@ -5424,7 +5435,7 @@ mod tests {
         assert_eq!(request_stream_id_2, 4);
 
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         send_push_promise_and_exchange_packets(&mut client, &mut server, request_stream_id_2, 5);
 
@@ -5517,7 +5528,7 @@ mod tests {
         );
 
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         // Check max_push_id frame has been received
         let control_stream_readable =
@@ -5535,8 +5546,8 @@ mod tests {
         send_push_data(&mut server.conn, 8, true);
 
         let out = server.conn.process(None, now());
-        let out = client.process(out.dgram(), now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        let out = client.process(out.as_dgram_ref(), now());
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         assert_eq!(client.state(), Http3State::Connected);
 
@@ -5698,8 +5709,8 @@ mod tests {
             .conn
             .stream_reset_send(push_stream_id, Error::HttpRequestCancelled.code())
             .unwrap();
-        let out = server.conn.process(None, now()).dgram();
-        client.process(out, now());
+        let out = server.conn.process(None, now());
+        client.process(out.as_dgram_ref(), now());
 
         // Assert that we do not have any push event.
         assert!(!check_push_events(&mut client));
@@ -5724,8 +5735,8 @@ mod tests {
             .conn
             .stream_reset_send(push_stream_id, Error::HttpRequestCancelled.code())
             .unwrap();
-        let out = server.conn.process(None, now()).dgram();
-        client.process(out, now());
+        let out = server.conn.process(None, now());
+        client.process(out.as_dgram_ref(), now());
 
         send_push_promise_and_exchange_packets(&mut client, &mut server, request_stream_id, 0);
 
@@ -5768,8 +5779,8 @@ mod tests {
             send_push_data_and_exchange_packets(&mut client, &mut server, 0, false);
 
         assert!(client.cancel_push(0).is_ok());
-        let out = client.process(None, now()).dgram();
-        mem::drop(server.conn.process(out, now()));
+        let out = client.process(None, now());
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         // Assert that we do not have any push event.
         assert!(!check_push_events(&mut client));
@@ -5798,8 +5809,8 @@ mod tests {
             send_push_data_and_exchange_packets(&mut client, &mut server, 0, false);
 
         assert!(client.cancel_push(0).is_ok());
-        let out = client.process(None, now()).dgram();
-        mem::drop(server.conn.process(out, now()));
+        let out = client.process(None, now());
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         send_push_promise_and_exchange_packets(&mut client, &mut server, request_stream_id, 0);
 
@@ -5840,7 +5851,7 @@ mod tests {
             .send_encoder_updates(&mut server.conn)
             .unwrap();
         let out = server.conn.process(None, now());
-        mem::drop(client.process(out.dgram(), now()));
+        mem::drop(client.process(out.as_dgram_ref(), now()));
     }
 
     fn setup_server_side_encoder(client: &mut Http3Client, server: &mut TestServer) {
@@ -5912,7 +5923,7 @@ mod tests {
         assert!(!check_push_events(&mut client));
 
         // Let client receive the encoder instructions.
-        let _out = client.process(encoder_inst_pkt, now());
+        let _out = client.process(encoder_inst_pkt.as_ref(), now());
 
         // PushPromise is blocked wathing for encoder instructions.
         assert!(check_push_events(&mut client));
@@ -5952,7 +5963,7 @@ mod tests {
         assert!(check_data_readable(&mut client));
 
         // Let client receive the encoder instructions.
-        let _out = client.process(encoder_inst_pkt, now());
+        let _out = client.process(encoder_inst_pkt.as_ref(), now());
 
         // PushPromise is blocked wathing for encoder instructions.
         assert!(check_push_events(&mut client));
@@ -5994,7 +6005,7 @@ mod tests {
         assert!(check_header_ready(&mut client));
 
         // Let client receive the encoder instructions.
-        let _out = client.process(encoder_inst_pkt, now());
+        let _out = client.process(encoder_inst_pkt.as_ref(), now());
 
         // PushPromise is blocked wathing for encoder instructions.
         assert!(check_push_events(&mut client));
@@ -6015,7 +6026,7 @@ mod tests {
             .send_and_insert(&mut server.conn, b"content-length", b"1234")
             .unwrap();
         let encoder_inst_pkt1 = server.conn.process(None, now()).dgram();
-        let _out = client.process(encoder_inst_pkt1, now());
+        let _out = client.process(encoder_inst_pkt1.as_ref(), now());
 
         // Send a PushPromise that is blocked until encoder_inst_pkt2 is process by the client.
         let encoder_inst_pkt2 =
@@ -6050,7 +6061,7 @@ mod tests {
         assert!(!check_header_ready(&mut client));
 
         // Let client receive the encoder instructions.
-        let _out = client.process(encoder_inst_pkt2, now());
+        let _out = client.process(encoder_inst_pkt2.as_ref(), now());
 
         // The response headers are blocked.
         assert!(check_header_ready_and_push_promise(&mut client));
@@ -6123,12 +6134,12 @@ mod tests {
         assert!(!check_header_ready(&mut client));
 
         // Let client receive the encoder instructions.
-        let _out = client.process(encoder_inst_pkt1, now());
+        let _out = client.process(encoder_inst_pkt1.as_ref(), now());
 
         assert!(check_push_events(&mut client));
 
         // Let client receive the encoder instructions.
-        let _out = client.process(encoder_inst_pkt2, now());
+        let _out = client.process(encoder_inst_pkt2.as_ref(), now());
 
         assert!(check_header_ready_and_push_promise(&mut client));
     }
@@ -6163,7 +6174,7 @@ mod tests {
             .unwrap();
 
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
         // Check that encoder got stream_canceled instruction.
         let mut inst = [0_u8; 100];
         let (amount, fin) = server
@@ -6227,7 +6238,7 @@ mod tests {
         );
 
         // Now read headers.
-        mem::drop(client.process(encoder_insts.dgram(), now()));
+        mem::drop(client.process(encoder_insts.as_dgram_ref(), now()));
     }
 
     #[test]
@@ -6238,7 +6249,7 @@ mod tests {
         mem::drop(client.cancel_fetch(request_stream_id, Error::HttpRequestCancelled.code()));
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
         mem::drop(server.encoder_receiver.receive(&mut server.conn));
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 1);
     }
@@ -6286,8 +6297,8 @@ mod tests {
             .unwrap();
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
         let out = server.conn.process(None, now());
-        let out = client.process(out.dgram(), now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        let out = client.process(out.as_dgram_ref(), now());
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
         mem::drop(server.encoder_receiver.receive(&mut server.conn));
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 1);
     }
@@ -6323,7 +6334,7 @@ mod tests {
 
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
         mem::drop(server.encoder_receiver.receive(&mut server.conn).unwrap());
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 1);
     }
@@ -6347,7 +6358,7 @@ mod tests {
         );
 
         // Exchange encoder instructions
-        mem::drop(client.process(encoder_instruct, now()));
+        mem::drop(client.process(encoder_instruct.as_ref(), now()));
 
         let header_ready_event = |e| matches!(e, Http3ClientEvent::HeaderReady { .. });
         assert!(client.events().any(header_ready_event));
@@ -6360,7 +6371,7 @@ mod tests {
 
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
         mem::drop(server.encoder_receiver.receive(&mut server.conn).unwrap());
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
     }
@@ -6386,7 +6397,7 @@ mod tests {
 
         // Send the encoder instructions.
         let out = server.conn.process(None, now());
-        mem::drop(client.process(out.dgram(), now()));
+        mem::drop(client.process(out.as_dgram_ref(), now()));
 
         // Send PushPromise that will be blocked waiting for decoder instructions.
         mem::drop(
@@ -6416,7 +6427,7 @@ mod tests {
             .unwrap();
 
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
         mem::drop(server.encoder_receiver.receive(&mut server.conn).unwrap());
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 1);
     }
@@ -6430,7 +6441,7 @@ mod tests {
             .unwrap();
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
         let out = client.process(None, now());
-        mem::drop(server.conn.process(out.dgram(), now()));
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
         mem::drop(server.encoder_receiver.receive(&mut server.conn).unwrap());
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
     }
@@ -6483,7 +6494,7 @@ mod tests {
         assert!(!client.events().any(header_ready_event));
 
         // Now make the encoder instructions available.
-        mem::drop(client.process(encoder_insts.dgram(), now()));
+        mem::drop(client.process(encoder_insts.as_dgram_ref(), now()));
 
         // Header blocks for both streams should be ready.
         let mut count_responses = 0;
@@ -6527,7 +6538,7 @@ mod tests {
             let sent = server.conn.stream_send(control_stream, enc.as_ref());
             assert_eq!(sent, Ok(4));
             let out = server.conn.process(None, now());
-            client.process(out.dgram(), now());
+            client.process(out.as_dgram_ref(), now());
             assert_closed(&client, &Error::HttpSettings);
         }
     }
@@ -6627,8 +6638,8 @@ mod tests {
             }
         );
 
-        let out = client.process(None, now()).dgram();
-        mem::drop(server.conn.process(out, now()));
+        let out = client.process(None, now());
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         // Check that server has received a reset.
         let stop_sending_event = |e| {
@@ -6760,8 +6771,8 @@ mod tests {
 
         assert!(client.events().any(push_reset_event));
 
-        let out = client.process(None, now()).dgram();
-        mem::drop(server.conn.process(out, now()));
+        let out = client.process(None, now());
+        mem::drop(server.conn.process(out.as_dgram_ref(), now()));
 
         // Check that server has received a reset.
         let stop_sending_event = |e| {
@@ -6775,7 +6786,7 @@ mod tests {
 
     fn handshake_client_error(client: &mut Http3Client, server: &mut TestServer, error: &Error) {
         let out = handshake_only(client, server);
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
         assert_closed(client, error);
     }
 
@@ -6936,14 +6947,14 @@ mod tests {
         let is_done = |c: &Http3Client| matches!(c.state(), Http3State::Connected);
         while !is_done(&mut client) {
             maybe_authenticate(&mut client);
-            datagram = client.process(datagram, now()).dgram();
-            datagram = server.process(datagram, now()).dgram();
+            datagram = client.process(datagram.as_ref(), now()).dgram();
+            datagram = server.process(datagram.as_ref(), now()).dgram();
         }
 
         // exchange qpack settings, server will send a token as well.
-        datagram = client.process(datagram, now()).dgram();
-        datagram = server.process(datagram, now()).dgram();
-        mem::drop(client.process(datagram, now()).dgram());
+        datagram = client.process(datagram.as_ref(), now()).dgram();
+        datagram = server.process(datagram.as_ref(), now()).dgram();
+        mem::drop(client.process(datagram.as_ref(), now()).dgram());
 
         client
             .events()
@@ -6997,15 +7008,15 @@ mod tests {
         // Exchange packets until header-ack is received.
         // These many packet exchange is needed, to get a header-ack.
         // TODO this may be optimize at Http3Server.
-        let out = client.process(None, now()).dgram();
-        let out = server.process(out, now()).dgram();
-        let out = client.process(out, now()).dgram();
-        let out = server.process(out, now()).dgram();
-        let out = client.process(out, now()).dgram();
-        let out = server.process(out, now()).dgram();
-        let out = client.process(out, now()).dgram();
-        let out = server.process(out, now()).dgram();
-        mem::drop(client.process(out, now()));
+        let out = client.process(None, now());
+        let out = server.process(out.as_dgram_ref(), now());
+        let out = client.process(out.as_dgram_ref(), now());
+        let out = server.process(out.as_dgram_ref(), now());
+        let out = client.process(out.as_dgram_ref(), now());
+        let out = server.process(out.as_dgram_ref(), now());
+        let out = client.process(out.as_dgram_ref(), now());
+        let out = server.process(out.as_dgram_ref(), now());
+        mem::drop(client.process(out.as_dgram_ref(), now()));
 
         // The header ack for the first request has been received.
         assert_eq!(client.qpack_encoder_stats().header_acks_recv, 1);
@@ -7061,7 +7072,7 @@ mod tests {
         _ = server.conn.stream_send(push_stream_id, &[0]).unwrap();
         server.conn.stream_close_send(push_stream_id).unwrap();
         let out = server.conn.process(None, now());
-        client.process(out.dgram(), now());
+        client.process(out.as_dgram_ref(), now());
         assert_closed(&client, &Error::HttpGeneralProtocol);
     }
 
@@ -7085,14 +7096,14 @@ mod tests {
         let md_before = server.conn.stats().frame_tx.max_data;
 
         // sending the http request and most most of the request data
-        let out = client.process(None, now()).dgram();
-        let out = server.conn.process(out, now()).dgram();
+        let out = client.process(None, now());
+        let out = server.conn.process(out.as_dgram_ref(), now());
 
         // the server responses with an ack, but the max_data didn't change
         assert_eq!(md_before, server.conn.stats().frame_tx.max_data);
 
-        let out = client.process(out, now()).dgram();
-        let out = server.conn.process(out, now()).dgram();
+        let out = client.process(out.as_dgram_ref(), now());
+        let out = server.conn.process(out.as_dgram_ref(), now());
 
         // the server increased the max_data during the second read if that isn't the case
         // in the future and therefore this asserts fails, the request data on stream 0 could be read
@@ -7107,8 +7118,10 @@ mod tests {
         );
 
         // the client now sends the priority update
-        let out = client.process(out, now()).dgram();
-        server.conn.process_input(out.unwrap(), now());
+        let out = client.process(out.as_dgram_ref(), now());
+        server
+            .conn
+            .process_input(out.as_dgram_ref().unwrap(), now());
 
         // check that the priority_update arrived at the client control stream
         let num_read = server.conn.stream_recv(StreamId::new(2), &mut buf).unwrap();
@@ -7154,7 +7167,7 @@ mod tests {
         );
 
         // Let client receive the encoder instructions.
-        client.process_input(encoder_inst_pkt.dgram().unwrap(), now());
+        client.process_input(encoder_inst_pkt.as_dgram_ref().unwrap(), now());
 
         let reset_event = |e| matches!(e, Http3ClientEvent::Reset { stream_id, .. } if stream_id == request_stream_id);
         assert!(client.events().any(reset_event));

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -828,12 +828,12 @@ impl Http3Client {
         self.process_http3(now);
     }
 
-    pub fn process_multiple_input<'a>(
-        &mut self,
-        // TODO: Need ExactSizeIterator for qtrace below. Worth the type restriction?
-        dgrams: impl ExactSizeIterator<Item = &'a Datagram>,
-        now: Instant,
-    ) {
+    pub fn process_multiple_input<'a, I>(&mut self, dgrams: I, now: Instant)
+    where
+        I: IntoIterator<Item = &'a Datagram>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let dgrams = dgrams.into_iter();
         qtrace!([self], "Process multiple datagrams, len={}", dgrams.len());
         if dgrams.len() == 0 {
             return;

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -64,8 +64,8 @@ pub fn default_http3_server(server_params: Http3Parameters) -> Http3Server {
 fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
     let mut out = None;
     loop {
-        out = client.process(out, now()).dgram();
-        out = server.process(out, now()).dgram();
+        out = client.process(out.as_ref(), now()).dgram();
+        out = server.process(out.as_ref(), now()).dgram();
         if out.is_none() {
             break;
         }
@@ -78,28 +78,28 @@ fn connect_with(client: &mut Http3Client, server: &mut Http3Server) {
     let out = client.process(None, now());
     assert_eq!(client.state(), Http3State::Initializing);
 
-    let out = server.process(out.dgram(), now());
-    let out = client.process(out.dgram(), now());
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
+    let out = client.process(out.as_dgram_ref(), now());
+    let out = server.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_none());
 
     let authentication_needed = |e| matches!(e, Http3ClientEvent::AuthenticationNeeded);
     assert!(client.events().any(authentication_needed));
     client.authenticated(AuthenticationStatus::Ok, now());
 
-    let out = client.process(out.dgram(), now());
+    let out = client.process(out.as_dgram_ref(), now());
     let connected = |e| matches!(e, Http3ClientEvent::StateChange(Http3State::Connected));
     assert!(client.events().any(connected));
 
     assert_eq!(client.state(), Http3State::Connected);
 
     // Exchange H3 setttings
-    let out = server.process(out.dgram(), now());
-    let out = client.process(out.dgram(), now());
-    let out = server.process(out.dgram(), now());
-    let out = client.process(out.dgram(), now());
-    let out = server.process(out.dgram(), now());
-    std::mem::drop(client.process(out.dgram(), now()));
+    let out = server.process(out.as_dgram_ref(), now());
+    let out = client.process(out.as_dgram_ref(), now());
+    let out = server.process(out.as_dgram_ref(), now());
+    let out = client.process(out.as_dgram_ref(), now());
+    let out = server.process(out.as_dgram_ref(), now());
+    std::mem::drop(client.process(out.as_dgram_ref(), now()));
 }
 
 fn connect(
@@ -201,10 +201,10 @@ impl WtTest {
         let mut now = now();
         loop {
             now += RTT / 2;
-            out = self.client.process(out, now).dgram();
+            out = self.client.process(out.as_ref(), now).dgram();
             let client_none = out.is_none();
             now += RTT / 2;
-            out = self.server.process(out, now).dgram();
+            out = self.server.process(out.as_ref(), now).dgram();
             if client_none && out.is_none() {
                 break;
             }

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/negotiation.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/negotiation.rs
@@ -86,7 +86,7 @@ fn zero_rtt(
     // exchange token
     let out = server.process(None, now());
     // We do not have a token so we need to wait for a resumption token timer to trigger.
-    std::mem::drop(client.process(out.dgram(), now() + Duration::from_millis(250)));
+    std::mem::drop(client.process(out.as_dgram_ref(), now() + Duration::from_millis(250)));
     assert_eq!(client.state(), Http3State::Connected);
     let token = client
         .events()
@@ -234,8 +234,8 @@ fn zero_rtt_wt_settings() {
 fn exchange_packets2(client: &mut Http3Client, server: &mut Connection) {
     let mut out = None;
     loop {
-        out = client.process(out, now()).dgram();
-        out = server.process(out, now()).dgram();
+        out = client.process(out.as_ref(), now()).dgram();
+        out = server.process(out.as_ref(), now()).dgram();
         if out.is_none() {
             break;
         }

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -419,18 +419,18 @@ fn wt_close_session_cannot_be_sent_at_once() {
         Err(Error::InvalidStreamId)
     );
 
-    let out = wt.server.process(None, now()).dgram();
-    let out = wt.client.process(out, now()).dgram();
+    let out = wt.server.process(None, now());
+    let out = wt.client.process(out.as_dgram_ref(), now());
 
     // Client has not received the full CloseSession frame and it can create more streams.
     let unidi_client = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::UniDi);
 
-    let out = wt.server.process(out, now()).dgram();
-    let out = wt.client.process(out, now()).dgram();
-    let out = wt.server.process(out, now()).dgram();
-    let out = wt.client.process(out, now()).dgram();
-    let out = wt.server.process(out, now()).dgram();
-    let _out = wt.client.process(out, now()).dgram();
+    let out = wt.server.process(out.as_dgram_ref(), now());
+    let out = wt.client.process(out.as_dgram_ref(), now());
+    let out = wt.server.process(out.as_dgram_ref(), now());
+    let out = wt.client.process(out.as_dgram_ref(), now());
+    let out = wt.server.process(out.as_dgram_ref(), now());
+    let _out = wt.client.process(out.as_dgram_ref(), now());
 
     wt.check_events_after_closing_session_client(
         &[],

--- a/neqo-http3/src/frames/tests/mod.rs
+++ b/neqo-http3/src/frames/tests/mod.rs
@@ -22,12 +22,12 @@ pub(crate) fn enc_dec<T: FrameDecoder<T>>(d: &Encoder, st: &str, remaining: usiz
     let mut conn_c = default_client();
     let mut conn_s = default_server();
     let out = conn_c.process(None, now());
-    let out = conn_s.process(out.dgram(), now());
-    let out = conn_c.process(out.dgram(), now());
-    mem::drop(conn_s.process(out.dgram(), now()));
+    let out = conn_s.process(out.as_dgram_ref(), now());
+    let out = conn_c.process(out.as_dgram_ref(), now());
+    mem::drop(conn_s.process(out.as_dgram_ref(), now()));
     conn_c.authenticated(AuthenticationStatus::Ok, now());
     let out = conn_c.process(None, now());
-    mem::drop(conn_s.process(out.dgram(), now()));
+    mem::drop(conn_s.process(out.as_dgram_ref(), now()));
 
     // create a stream
     let stream_id = conn_s.stream_create(StreamType::BiDi).unwrap();
@@ -38,7 +38,7 @@ pub(crate) fn enc_dec<T: FrameDecoder<T>>(d: &Encoder, st: &str, remaining: usiz
     let buf = Encoder::from_hex(st);
     conn_s.stream_send(stream_id, buf.as_ref()).unwrap();
     let out = conn_s.process(None, now());
-    mem::drop(conn_c.process(out.dgram(), now()));
+    mem::drop(conn_c.process(out.as_dgram_ref(), now()));
 
     let (frame, fin) = fr
         .receive::<T>(&mut StreamReaderConnectionWrapper::new(

--- a/neqo-http3/src/frames/tests/reader.rs
+++ b/neqo-http3/src/frames/tests/reader.rs
@@ -39,7 +39,7 @@ impl FrameReaderTest {
     fn process<T: FrameDecoder<T>>(&mut self, v: &[u8]) -> Option<T> {
         self.conn_s.stream_send(self.stream_id, v).unwrap();
         let out = self.conn_s.process(None, now());
-        mem::drop(self.conn_c.process(out.dgram(), now()));
+        mem::drop(self.conn_c.process(out.as_dgram_ref(), now()));
         let (frame, fin) = self
             .fr
             .receive::<T>(&mut StreamReaderConnectionWrapper::new(
@@ -230,12 +230,12 @@ fn test_reading_frame<T: FrameDecoder<T> + PartialEq + Debug>(
     }
 
     let out = fr.conn_s.process(None, now());
-    mem::drop(fr.conn_c.process(out.dgram(), now()));
+    mem::drop(fr.conn_c.process(out.as_dgram_ref(), now()));
 
     if let FrameReadingTestSend::DataThenFin = test_to_send {
         fr.conn_s.stream_close_send(fr.stream_id).unwrap();
         let out = fr.conn_s.process(None, now());
-        mem::drop(fr.conn_c.process(out.dgram(), now()));
+        mem::drop(fr.conn_c.process(out.as_dgram_ref(), now()));
     }
 
     let rv = fr.fr.receive::<T>(&mut StreamReaderConnectionWrapper::new(
@@ -478,11 +478,11 @@ fn test_frame_reading_when_stream_is_closed_before_sending_data() {
 
     fr.conn_s.stream_send(fr.stream_id, &[0x00]).unwrap();
     let out = fr.conn_s.process(None, now());
-    mem::drop(fr.conn_c.process(out.dgram(), now()));
+    mem::drop(fr.conn_c.process(out.as_dgram_ref(), now()));
 
     assert_eq!(Ok(()), fr.conn_c.stream_close_send(fr.stream_id));
     let out = fr.conn_c.process(None, now());
-    mem::drop(fr.conn_s.process(out.dgram(), now()));
+    mem::drop(fr.conn_s.process(out.as_dgram_ref(), now()));
     assert_eq!(
         Ok((None, true)),
         fr.fr
@@ -501,11 +501,11 @@ fn test_wt_frame_reading_when_stream_is_closed_before_sending_data() {
 
     fr.conn_s.stream_send(fr.stream_id, &[0x00]).unwrap();
     let out = fr.conn_s.process(None, now());
-    mem::drop(fr.conn_c.process(out.dgram(), now()));
+    mem::drop(fr.conn_c.process(out.as_dgram_ref(), now()));
 
     assert_eq!(Ok(()), fr.conn_c.stream_close_send(fr.stream_id));
     let out = fr.conn_c.process(None, now());
-    mem::drop(fr.conn_s.process(out.dgram(), now()));
+    mem::drop(fr.conn_s.process(out.as_dgram_ref(), now()));
     assert_eq!(
         Ok((None, true)),
         fr.fr

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -109,7 +109,7 @@ impl Http3Server {
         self.server.ech_config()
     }
 
-    pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
+    pub fn process(&mut self, dgram: Option<&Datagram>, now: Instant) -> Output {
         qtrace!([self], "Process.");
         let out = self.server.process(dgram, now);
         self.process_http3(now);
@@ -119,7 +119,7 @@ impl Http3Server {
                 qtrace!([self], "Send packet: {:?}", d);
                 Output::Datagram(d)
             }
-            _ => self.server.process(None, now),
+            _ => self.server.process(Option::<&Datagram>::None, now),
         }
     }
 
@@ -399,29 +399,29 @@ mod tests {
     const SERVER_SIDE_DECODER_STREAM_ID: StreamId = StreamId::new(11);
 
     fn connect_transport(server: &mut Http3Server, client: &mut Connection, resume: bool) {
-        let c1 = client.process(None, now()).dgram();
-        let s1 = server.process(c1, now()).dgram();
-        let c2 = client.process(s1, now()).dgram();
+        let c1 = client.process(None, now());
+        let s1 = server.process(c1.as_dgram_ref(), now());
+        let c2 = client.process(s1.as_dgram_ref(), now());
         let needs_auth = client
             .events()
             .any(|e| e == ConnectionEvent::AuthenticationNeeded);
         let c2 = if needs_auth {
             assert!(!resume);
             // c2 should just be an ACK, so absorb that.
-            let s_ack = server.process(c2, now()).dgram();
-            assert!(s_ack.is_none());
+            let s_ack = server.process(c2.as_dgram_ref(), now());
+            assert!(s_ack.as_dgram_ref().is_none());
 
             client.authenticated(AuthenticationStatus::Ok, now());
-            client.process(None, now()).dgram()
+            client.process(None, now())
         } else {
             assert!(resume);
             c2
         };
         assert!(client.state().connected());
-        let s2 = server.process(c2, now()).dgram();
+        let s2 = server.process(c2.as_dgram_ref(), now());
         assert_connected(server);
-        let c3 = client.process(s2, now()).dgram();
-        assert!(c3.is_none());
+        let c3 = client.process(s2.as_dgram_ref(), now());
+        assert!(c3.as_dgram_ref().is_none());
     }
 
     // Start a client/server and check setting frame.
@@ -556,8 +556,8 @@ mod tests {
         sent = neqo_trans_conn.stream_send(decoder_stream, &[0x3]);
         assert_eq!(sent, Ok(1));
         let out1 = neqo_trans_conn.process(None, now());
-        let out2 = server.process(out1.dgram(), now());
-        mem::drop(neqo_trans_conn.process(out2.dgram(), now()));
+        let out2 = server.process(out1.as_dgram_ref(), now());
+        mem::drop(neqo_trans_conn.process(out2.as_dgram_ref(), now()));
 
         // assert no error occured.
         assert_not_closed(server);
@@ -588,7 +588,7 @@ mod tests {
         let control = peer_conn.control_stream_id;
         peer_conn.stream_close_send(control).unwrap();
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
         assert_closed(&mut hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -603,7 +603,7 @@ mod tests {
         let sent = neqo_trans_conn.stream_send(control_stream, &[0x0, 0xd, 0x1, 0xf]);
         assert_eq!(sent, Ok(4));
         let out = neqo_trans_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
         assert_closed(&mut hconn, &Error::HttpMissingSettings);
     }
 
@@ -615,7 +615,7 @@ mod tests {
         // send the second SETTINGS frame.
         peer_conn.control_send(&[0x4, 0x6, 0x1, 0x40, 0x64, 0x7, 0x40, 0x64]);
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
         assert_closed(&mut hconn, &Error::HttpFrameUnexpected);
     }
 
@@ -630,7 +630,7 @@ mod tests {
         frame.encode(&mut e);
         peer_conn.control_send(e.as_ref());
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
         // check if the given connection got closed on invalid stream ids
         if valid {
             assert_not_closed(&mut hconn);
@@ -673,7 +673,7 @@ mod tests {
         peer_conn.control_send(v);
 
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
         assert_closed(&mut hconn, &Error::HttpFrameUnexpected);
     }
 
@@ -707,10 +707,10 @@ mod tests {
             .stream_send(new_stream_id, &[0x41, 0x19, 0x4, 0x4, 0x6, 0x0, 0x8, 0x0])
             .unwrap();
         let out = peer_conn.process(None, now());
-        let out = hconn.process(out.dgram(), now());
-        mem::drop(peer_conn.process(out.dgram(), now()));
+        let out = hconn.process(out.as_dgram_ref(), now());
+        mem::drop(peer_conn.process(out.as_dgram_ref(), now()));
         let out = hconn.process(None, now());
-        mem::drop(peer_conn.process(out.dgram(), now()));
+        mem::drop(peer_conn.process(out.as_dgram_ref(), now()));
 
         // check for stop-sending with Error::HttpStreamCreation.
         let mut stop_sending_event_found = false;
@@ -738,8 +738,8 @@ mod tests {
         let push_stream_id = peer_conn.stream_create(StreamType::UniDi).unwrap();
         _ = peer_conn.stream_send(push_stream_id, &[0x1]).unwrap();
         let out = peer_conn.process(None, now());
-        let out = hconn.process(out.dgram(), now());
-        mem::drop(peer_conn.conn.process(out.dgram(), now()));
+        let out = hconn.process(out.as_dgram_ref(), now());
+        mem::drop(peer_conn.conn.process(out.as_dgram_ref(), now()));
         assert_closed(&mut hconn, &Error::HttpStreamCreation);
     }
 
@@ -755,38 +755,38 @@ mod tests {
         let mut sent = peer_conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         // start sending SETTINGS frame
         sent = peer_conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x6]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x8]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         assert_not_closed(&mut hconn);
 
@@ -794,37 +794,37 @@ mod tests {
         sent = peer_conn.stream_send(control_stream, &[0x5]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x5]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x61]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x62]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x63]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x64]);
         assert_eq!(sent, Ok(1));
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         // PUSH_PROMISE on a control stream will cause an error
         assert_closed(&mut hconn, &Error::HttpFrameUnexpected);
@@ -840,7 +840,7 @@ mod tests {
         peer_conn.stream_close_send(stream_id).unwrap();
 
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         assert_closed(&mut hconn, &Error::HttpFrame);
     }
@@ -892,7 +892,7 @@ mod tests {
         peer_conn.stream_close_send(stream_id).unwrap();
 
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         // Check connection event. There should be 1 Header and 2 data events.
         let mut headers_frames = 0;
@@ -943,7 +943,7 @@ mod tests {
             .unwrap();
 
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         // Check connection event. There should be 1 Header and no data events.
         let mut headers_frames = 0;
@@ -987,8 +987,8 @@ mod tests {
             .unwrap();
         peer_conn.stream_close_send(stream_id).unwrap();
 
-        let out = peer_conn.process(out.dgram(), now());
-        hconn.process(out.dgram(), now());
+        let out = peer_conn.process(out.as_dgram_ref(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         while let Some(event) = hconn.next_event() {
             match event {
@@ -1020,7 +1020,7 @@ mod tests {
             .unwrap();
 
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         // Check connection event. There should be 1 Header and no data events.
         // The server will reset the stream.
@@ -1052,8 +1052,8 @@ mod tests {
         }
         let out = hconn.process(None, now());
 
-        let out = peer_conn.process(out.dgram(), now());
-        hconn.process(out.dgram(), now());
+        let out = peer_conn.process(out.as_dgram_ref(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         // Check that STOP_SENDING and REET has been received.
         let mut reset = 0;
@@ -1085,7 +1085,7 @@ mod tests {
             .stream_reset_send(CLIENT_SIDE_CONTROL_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
         assert_closed(&mut hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -1098,7 +1098,7 @@ mod tests {
             .stream_reset_send(CLIENT_SIDE_ENCODER_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
         assert_closed(&mut hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -1111,7 +1111,7 @@ mod tests {
             .stream_reset_send(CLIENT_SIDE_DECODER_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
         assert_closed(&mut hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -1125,7 +1125,7 @@ mod tests {
             .stream_stop_sending(SERVER_SIDE_CONTROL_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
         assert_closed(&mut hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -1138,7 +1138,7 @@ mod tests {
             .stream_stop_sending(SERVER_SIDE_ENCODER_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
         assert_closed(&mut hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -1151,7 +1151,7 @@ mod tests {
             .stream_stop_sending(SERVER_SIDE_DECODER_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
         assert_closed(&mut hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -1259,7 +1259,7 @@ mod tests {
             .unwrap();
 
         let out = peer_conn.process(None, now());
-        hconn.process(out.dgram(), now());
+        hconn.process(out.as_dgram_ref(), now());
 
         let mut requests = HashMap::new();
         while let Some(event) = hconn.next_event() {

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -262,7 +262,7 @@ mod tests {
             // create a stream
             let stream_id = conn_s.stream_create(stream_type).unwrap();
             let out = conn_s.process(None, now());
-            mem::drop(conn_c.process(out.dgram(), now()));
+            mem::drop(conn_c.process(out.as_dgram_ref(), now()));
 
             Self {
                 conn_c,
@@ -285,7 +285,7 @@ mod tests {
                     .stream_send(self.stream_id, &enc[i..=i])
                     .unwrap();
                 let out = self.conn_s.process(None, now());
-                mem::drop(self.conn_c.process(out.dgram(), now()));
+                mem::drop(self.conn_c.process(out.as_dgram_ref(), now()));
                 assert_eq!(
                     self.decoder.receive(&mut self.conn_c).unwrap(),
                     (ReceiveOutput::NoOutput, false)
@@ -299,7 +299,7 @@ mod tests {
                 self.conn_s.stream_close_send(self.stream_id).unwrap();
             }
             let out = self.conn_s.process(None, now());
-            mem::drop(self.conn_c.process(out.dgram(), now()));
+            mem::drop(self.conn_c.process(out.dgram().as_ref(), now()));
             assert_eq!(&self.decoder.receive(&mut self.conn_c), outcome);
             assert_eq!(self.decoder.done(), done);
         }

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -94,19 +94,19 @@ fn process_client_events(conn: &mut Http3Client) {
 fn connect_peers(hconn_c: &mut Http3Client, hconn_s: &mut Http3Server) -> Option<Datagram> {
     assert_eq!(hconn_c.state(), Http3State::Initializing);
     let out = hconn_c.process(None, now()); // Initial
-    let out = hconn_s.process(out.dgram(), now()); // Initial + Handshake
-    let out = hconn_c.process(out.dgram(), now()); // ACK
-    mem::drop(hconn_s.process(out.dgram(), now())); //consume ACK
+    let out = hconn_s.process(out.as_dgram_ref(), now()); // Initial + Handshake
+    let out = hconn_c.process(out.as_dgram_ref(), now()); // ACK
+    mem::drop(hconn_s.process(out.as_dgram_ref(), now())); //consume ACK
     let authentication_needed = |e| matches!(e, Http3ClientEvent::AuthenticationNeeded);
     assert!(hconn_c.events().any(authentication_needed));
     hconn_c.authenticated(AuthenticationStatus::Ok, now());
     let out = hconn_c.process(None, now()); // Handshake
     assert_eq!(hconn_c.state(), Http3State::Connected);
-    let out = hconn_s.process(out.dgram(), now()); // Handshake
-    let out = hconn_c.process(out.dgram(), now());
-    let out = hconn_s.process(out.dgram(), now());
+    let out = hconn_s.process(out.as_dgram_ref(), now()); // Handshake
+    let out = hconn_c.process(out.as_dgram_ref(), now());
+    let out = hconn_s.process(out.as_dgram_ref(), now());
     // assert!(hconn_s.settings_received);
-    let out = hconn_c.process(out.dgram(), now());
+    let out = hconn_c.process(out.as_dgram_ref(), now());
     // assert!(hconn_c.settings_received);
 
     out.dgram()
@@ -122,11 +122,11 @@ fn connect_peers_with_network_propagation_delay(
     let mut now = now();
     let out = hconn_c.process(None, now); // Initial
     now += net_delay;
-    let out = hconn_s.process(out.dgram(), now); // Initial + Handshake
+    let out = hconn_s.process(out.as_dgram_ref(), now); // Initial + Handshake
     now += net_delay;
-    let out = hconn_c.process(out.dgram(), now); // ACK
+    let out = hconn_c.process(out.as_dgram_ref(), now); // ACK
     now += net_delay;
-    let out = hconn_s.process(out.dgram(), now); //consume ACK
+    let out = hconn_s.process(out.as_dgram_ref(), now); //consume ACK
     assert!(out.dgram().is_none());
     let authentication_needed = |e| matches!(e, Http3ClientEvent::AuthenticationNeeded);
     assert!(hconn_c.events().any(authentication_needed));
@@ -135,13 +135,13 @@ fn connect_peers_with_network_propagation_delay(
     let out = hconn_c.process(None, now); // Handshake
     assert_eq!(hconn_c.state(), Http3State::Connected);
     now += net_delay;
-    let out = hconn_s.process(out.dgram(), now); // HANDSHAKE_DONE
+    let out = hconn_s.process(out.as_dgram_ref(), now); // HANDSHAKE_DONE
     now += net_delay;
-    let out = hconn_c.process(out.dgram(), now); // Consume HANDSHAKE_DONE, send control streams.
+    let out = hconn_c.process(out.as_dgram_ref(), now); // Consume HANDSHAKE_DONE, send control streams.
     now += net_delay;
-    let out = hconn_s.process(out.dgram(), now); // consume and send control streams.
+    let out = hconn_s.process(out.as_dgram_ref(), now); // consume and send control streams.
     now += net_delay;
-    let out = hconn_c.process(out.dgram(), now); // consume control streams.
+    let out = hconn_c.process(out.as_dgram_ref(), now); // consume control streams.
     (out.dgram(), now)
 }
 
@@ -156,8 +156,8 @@ fn connect() -> (Http3Client, Http3Server, Option<Datagram>) {
 fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server, out_ex: Option<Datagram>) {
     let mut out = out_ex;
     loop {
-        out = client.process(out, now()).dgram();
-        out = server.process(out, now()).dgram();
+        out = client.process(out.as_ref(), now()).dgram();
+        out = server.process(out.as_ref(), now()).dgram();
         if out.is_none() {
             break;
         }
@@ -185,17 +185,17 @@ fn test_fetch() {
         .unwrap();
     assert_eq!(req, 0);
     hconn_c.stream_close_send(req).unwrap();
-    let out = hconn_c.process(dgram, now());
+    let out = hconn_c.process(dgram.as_ref(), now());
     qtrace!("-----server");
-    let out = hconn_s.process(out.dgram(), now());
-    mem::drop(hconn_c.process(out.dgram(), now()));
+    let out = hconn_s.process(out.as_dgram_ref(), now());
+    mem::drop(hconn_c.process(out.as_dgram_ref(), now()));
     process_server_events(&mut hconn_s);
     let out = hconn_s.process(None, now());
 
     qtrace!("-----client");
-    mem::drop(hconn_c.process(out.dgram(), now()));
+    mem::drop(hconn_c.process(out.as_dgram_ref(), now()));
     let out = hconn_s.process(None, now());
-    mem::drop(hconn_c.process(out.dgram(), now()));
+    mem::drop(hconn_c.process(out.as_dgram_ref(), now()));
     process_client_events(&mut hconn_c);
 }
 
@@ -214,10 +214,10 @@ fn test_103_response() {
         .unwrap();
     assert_eq!(req, 0);
     hconn_c.stream_close_send(req).unwrap();
-    let out = hconn_c.process(dgram, now());
+    let out = hconn_c.process(dgram.as_ref(), now());
 
-    let out = hconn_s.process(out.dgram(), now());
-    mem::drop(hconn_c.process(out.dgram(), now()));
+    let out = hconn_s.process(out.as_dgram_ref(), now());
+    mem::drop(hconn_c.process(out.as_dgram_ref(), now()));
     let mut request = receive_request(&mut hconn_s).unwrap();
 
     let info_headers = [
@@ -228,7 +228,7 @@ fn test_103_response() {
     request.send_headers(&info_headers).unwrap();
     let out = hconn_s.process(None, now());
 
-    mem::drop(hconn_c.process(out.dgram(), now()));
+    mem::drop(hconn_c.process(out.as_dgram_ref(), now()));
 
     let info_headers_event = |e| {
         matches!(e, Http3ClientEvent::HeaderReady { headers,
@@ -239,7 +239,7 @@ fn test_103_response() {
 
     set_response(&mut request);
     let out = hconn_s.process(None, now());
-    mem::drop(hconn_c.process(out.dgram(), now()));
+    mem::drop(hconn_c.process(out.as_dgram_ref(), now()));
     process_client_events(&mut hconn_c)
 }
 
@@ -371,8 +371,8 @@ fn zerortt() {
         .unwrap();
     hconn_c.stream_close_send(req).unwrap();
 
-    let out = hconn_c.process(dgram, now());
-    let out = hconn_s.process(out.dgram(), now());
+    let out = hconn_c.process(dgram.as_ref(), now());
+    let out = hconn_s.process(out.as_dgram_ref(), now());
 
     let mut request_stream = None;
     let mut zerortt_state_change = false;
@@ -436,7 +436,7 @@ fn fetch_noresponse_will_idletimeout() {
         .unwrap();
     assert_eq!(req, 0);
     hconn_c.stream_close_send(req).unwrap();
-    let _out = hconn_c.process(dgram, now);
+    let _out = hconn_c.process(dgram.as_ref(), now);
     qtrace!("-----server");
 
     let mut done = false;

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -17,9 +17,9 @@ use test_fixture::*;
 fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
     let mut out = None;
     loop {
-        out = client.process(out, now()).dgram();
+        out = client.process(out.as_ref(), now()).dgram();
         let client_done = out.is_none();
-        out = server.process(out, now()).dgram();
+        out = server.process(out.as_ref(), now()).dgram();
         if out.is_none() && client_done {
             break;
         }
@@ -32,26 +32,26 @@ fn connect_with(client: &mut Http3Client, server: &mut Http3Server) {
     let out = client.process(None, now());
     assert_eq!(client.state(), Http3State::Initializing);
 
-    let out = server.process(out.dgram(), now());
-    let out = client.process(out.dgram(), now());
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
+    let out = client.process(out.as_dgram_ref(), now());
+    let out = server.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_none());
 
     let authentication_needed = |e| matches!(e, Http3ClientEvent::AuthenticationNeeded);
     assert!(client.events().any(authentication_needed));
     client.authenticated(AuthenticationStatus::Ok, now());
 
-    let out = client.process(out.dgram(), now());
+    let out = client.process(out.as_dgram_ref(), now());
     let connected = |e| matches!(e, Http3ClientEvent::StateChange(Http3State::Connected));
     assert!(client.events().any(connected));
 
     assert_eq!(client.state(), Http3State::Connected);
     // Exchange H3 setttings
-    let out = server.process(out.dgram(), now());
-    let out = client.process(out.dgram(), now());
-    let out = server.process(out.dgram(), now());
-    let out = client.process(out.dgram(), now());
-    _ = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
+    let out = client.process(out.as_dgram_ref(), now());
+    let out = server.process(out.as_dgram_ref(), now());
+    let out = client.process(out.as_dgram_ref(), now());
+    _ = server.process(out.as_dgram_ref(), now());
 }
 
 fn connect() -> (Http3Client, Http3Server) {

--- a/neqo-http3/tests/send_message.rs
+++ b/neqo-http3/tests/send_message.rs
@@ -28,8 +28,8 @@ lazy_static! {
 fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
     let mut out = None;
     loop {
-        out = client.process(out, now()).dgram();
-        out = server.process(out, now()).dgram();
+        out = client.process(out.as_ref(), now()).dgram();
+        out = server.process(out.as_ref(), now()).dgram();
         if out.is_none() {
             break;
         }

--- a/neqo-http3/tests/webtransport.rs
+++ b/neqo-http3/tests/webtransport.rs
@@ -44,16 +44,16 @@ fn connect() -> (Http3Client, Http3Server) {
     let out = client.process(None, now());
     assert_eq!(client.state(), Http3State::Initializing);
 
-    let out = server.process(out.dgram(), now());
-    let out = client.process(out.dgram(), now());
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
+    let out = client.process(out.as_dgram_ref(), now());
+    let out = server.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_none());
 
     let authentication_needed = |e| matches!(e, Http3ClientEvent::AuthenticationNeeded);
     assert!(client.events().any(authentication_needed));
     client.authenticated(AuthenticationStatus::Ok, now());
 
-    let mut out = client.process(out.dgram(), now()).dgram();
+    let mut out = client.process(out.as_dgram_ref(), now()).dgram();
     let connected = |e| matches!(e, Http3ClientEvent::StateChange(Http3State::Connected));
     assert!(client.events().any(connected));
 
@@ -61,9 +61,9 @@ fn connect() -> (Http3Client, Http3Server) {
 
     // Exchange H3 setttings
     loop {
-        out = server.process(out, now()).dgram();
+        out = server.process(out.as_ref(), now()).dgram();
         let dgram_present = out.is_some();
-        out = client.process(out, now()).dgram();
+        out = client.process(out.as_ref(), now()).dgram();
         if out.is_none() && !dgram_present {
             break;
         }
@@ -74,8 +74,8 @@ fn connect() -> (Http3Client, Http3Server) {
 fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
     let mut out = None;
     loop {
-        out = client.process(out, now()).dgram();
-        out = server.process(out, now()).dgram();
+        out = client.process(out.as_ref(), now()).dgram();
+        out = server.process(out.as_ref(), now()).dgram();
         if out.is_none() {
             break;
         }

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -149,7 +149,7 @@ fn process_loop(
         }
         if sz > 0 {
             let received = Datagram::new(nctx.remote_addr, nctx.local_addr, &buf[..sz]);
-            client.process_input(received, Instant::now());
+            client.process_input(&received, Instant::now());
         }
     }
 }
@@ -310,7 +310,7 @@ fn process_loop_h3(
         }
         if sz > 0 {
             let received = Datagram::new(nctx.remote_addr, nctx.local_addr, &buf[..sz]);
-            handler.h3.process_input(received, Instant::now());
+            handler.h3.process_input(&received, Instant::now());
         }
     }
 }

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -319,7 +319,7 @@ mod tests {
             .stream_send(decoder.recv_stream_id, encoder_instruction)
             .unwrap();
         let out = decoder.peer_conn.process(None, now());
-        mem::drop(decoder.conn.process(out.dgram(), now()));
+        mem::drop(decoder.conn.process(out.as_dgram_ref(), now()));
         assert_eq!(
             decoder
                 .decoder
@@ -331,7 +331,7 @@ mod tests {
     fn send_instructions_and_check(decoder: &mut TestDecoder, decoder_instruction: &[u8]) {
         decoder.decoder.send(&mut decoder.conn).unwrap();
         let out = decoder.conn.process(None, now());
-        mem::drop(decoder.peer_conn.process(out.dgram(), now()));
+        mem::drop(decoder.peer_conn.process(out.as_dgram_ref(), now()));
         let mut buf = [0_u8; 100];
         let (amount, fin) = decoder
             .peer_conn

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -556,8 +556,8 @@ mod tests {
         pub fn send_instructions(&mut self, encoder_instruction: &[u8]) {
             self.encoder.send_encoder_updates(&mut self.conn).unwrap();
             let out = self.conn.process(None, now());
-            let out2 = self.peer_conn.process(out.dgram(), now());
-            mem::drop(self.conn.process(out2.dgram(), now()));
+            let out2 = self.peer_conn.process(out.as_dgram_ref(), now());
+            mem::drop(self.conn.process(out2.as_dgram_ref(), now()));
             let mut buf = [0_u8; 100];
             let (amount, fin) = self
                 .peer_conn
@@ -619,7 +619,7 @@ mod tests {
             .stream_send(encoder.recv_stream_id, decoder_instruction)
             .unwrap();
         let out = encoder.peer_conn.process(None, now());
-        mem::drop(encoder.conn.process(out.dgram(), now()));
+        mem::drop(encoder.conn.process(out.as_dgram_ref(), now()));
         assert!(encoder
             .encoder
             .read_instructions(&mut encoder.conn, encoder.recv_stream_id)
@@ -1540,7 +1540,7 @@ mod tests {
 
         // exchange a flow control update.
         let out = encoder.peer_conn.process(None, now());
-        mem::drop(encoder.conn.process(out.dgram(), now()));
+        mem::drop(encoder.conn.process(out.as_dgram_ref(), now()));
 
         // Try writing a new header block. Now, headers will be added to the dynamic table again, because
         // instructions can be sent.
@@ -1587,7 +1587,7 @@ mod tests {
             .send_encoder_updates(&mut encoder.conn)
             .unwrap();
         let out = encoder.conn.process(None, now());
-        mem::drop(encoder.peer_conn.process(out.dgram(), now()));
+        mem::drop(encoder.peer_conn.process(out.as_dgram_ref(), now()));
         // receive an insert count increment.
         recv_instruction(&mut encoder, &[0x01]);
 

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -351,7 +351,7 @@ fn qns_read_response(filename: &str) -> Option<Vec<u8>> {
 }
 
 trait HttpServer: Display {
-    fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output;
+    fn process(&mut self, dgram: Option<&Datagram>, now: Instant) -> Output;
     fn process_events(&mut self, args: &Args, now: Instant);
     fn set_qlog_dir(&mut self, dir: Option<PathBuf>);
     fn set_ciphers(&mut self, ciphers: &[Cipher]);
@@ -467,7 +467,7 @@ impl Display for SimpleServer {
 }
 
 impl HttpServer for SimpleServer {
-    fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
+    fn process(&mut self, dgram: Option<&Datagram>, now: Instant) -> Output {
         self.server.process(dgram, now)
     }
 
@@ -734,7 +734,7 @@ impl ServersRunner {
             .unwrap_or(first)
     }
 
-    fn process(&mut self, inx: usize, dgram: Option<Datagram>) -> bool {
+    fn process(&mut self, inx: usize, dgram: Option<&Datagram>) -> bool {
         match self.server.process(dgram, self.args.now()) {
             Output::Datagram(dgram) => {
                 let socket = self.find_socket(dgram.source());
@@ -770,7 +770,7 @@ impl ServersRunner {
                     if dgram.is_none() {
                         break;
                     }
-                    _ = self.process(inx, dgram);
+                    _ = self.process(inx, dgram.as_ref());
                 }
             } else {
                 _ = self.process(inx, None);

--- a/neqo-server/src/old_https.rs
+++ b/neqo-server/src/old_https.rs
@@ -199,7 +199,7 @@ impl Http09Server {
 }
 
 impl HttpServer for Http09Server {
-    fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
+    fn process(&mut self, dgram: Option<&Datagram>, now: Instant) -> Output {
         self.server.process(dgram, now)
     }
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -924,13 +924,13 @@ impl Connection {
     }
 
     /// Process new input datagrams on the connection.
-    pub fn process_multiple_input<'a>(
-        &mut self,
-        dgrams: impl IntoIterator<Item = &'a Datagram>,
-        now: Instant,
-    ) {
-        let mut dgrams = dgrams.into_iter().peekable();
-        if dgrams.peek().is_none() {
+    pub fn process_multiple_input<'a, I>(&mut self, dgrams: I, now: Instant)
+    where
+        I: IntoIterator<Item = &'a Datagram>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let dgrams = dgrams.into_iter();
+        if dgrams.len() == 0 {
             return;
         }
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1151,7 +1151,6 @@ impl Connection {
             let d = Datagram::new(d.source(), d.destination(), &d[d.len() - remaining..]);
             self.saved_datagrams.save(cspace, d, now);
         } else {
-            // TODO: Sane?
             self.saved_datagrams.save(cspace, d.clone(), now);
         };
         self.stats.borrow_mut().saved_datagrams += 1;

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1147,12 +1147,12 @@ impl Connection {
     /// In case a datagram arrives that we can only partially process, save any
     /// part that we don't have keys for.
     fn save_datagram(&mut self, cspace: CryptoSpace, d: &Datagram, remaining: usize, now: Instant) {
-        if remaining < d.len() {
-            let d = Datagram::new(d.source(), d.destination(), &d[d.len() - remaining..]);
-            self.saved_datagrams.save(cspace, d, now);
+        let d = if remaining < d.len() {
+            Datagram::new(d.source(), d.destination(), &d[d.len() - remaining..])
         } else {
-            self.saved_datagrams.save(cspace, d.clone(), now);
+            d.clone()
         };
+        self.saved_datagrams.save(cspace, d, now);
         self.stats.borrow_mut().saved_datagrams += 1;
     }
 

--- a/neqo-transport/src/connection/tests/ackrate.rs
+++ b/neqo-transport/src/connection/tests/ackrate.rs
@@ -71,7 +71,7 @@ fn ack_rate_exit_slow_start() {
     // and to send ACK_FREQUENCY.
     now += DEFAULT_RTT / 2;
     assert_eq!(client.stats().frame_tx.ack_frequency, 0);
-    let af = client.process(Some(ack), now).dgram();
+    let af = client.process(Some(&ack), now).dgram();
     assert!(af.is_some());
     assert_eq!(client.stats().frame_tx.ack_frequency, 1);
 }
@@ -120,11 +120,11 @@ fn ack_rate_client_one_rtt() {
     // The first packet will elicit an immediate ACK however, so do this twice.
     let d = send_something(&mut client, now);
     now += RTT / 2;
-    let ack = server.process(Some(d), now).dgram();
+    let ack = server.process(Some(&d), now).dgram();
     assert!(ack.is_some());
     let d = send_something(&mut client, now);
     now += RTT / 2;
-    let delay = server.process(Some(d), now).callback();
+    let delay = server.process(Some(&d), now).callback();
     assert_eq!(delay, RTT);
 
     assert_eq!(client.stats().frame_tx.ack_frequency, 1);
@@ -143,11 +143,11 @@ fn ack_rate_server_half_rtt() {
     now += RTT / 2;
     // The client now will acknowledge immediately because it has been more than
     // an RTT since it last sent an acknowledgment.
-    let ack = client.process(Some(d), now);
+    let ack = client.process(Some(&d), now);
     assert!(ack.as_dgram_ref().is_some());
     let d = send_something(&mut server, now);
     now += RTT / 2;
-    let delay = client.process(Some(d), now).callback();
+    let delay = client.process(Some(&d), now).callback();
     assert_eq!(delay, RTT / 2);
 
     assert_eq!(server.stats().frame_tx.ack_frequency, 1);
@@ -171,7 +171,7 @@ fn migrate_ack_delay() {
     let client2 = send_something(&mut client, now);
     assertions::assert_v4_path(&client2, false); // Doesn't.  Is dropped.
     now += DEFAULT_RTT / 2;
-    server.process_input(client1, now);
+    server.process_input(&client1, now);
 
     let stream = client.stream_create(StreamType::UniDi).unwrap();
     let now = increase_cwnd(&mut client, &mut server, stream, now);
@@ -187,7 +187,7 @@ fn migrate_ack_delay() {
     // After noticing this new loss, the client sends ACK_FREQUENCY.
     // It has sent a few before (as we dropped `client2`), so ignore those.
     let ad_before = client.stats().frame_tx.ack_frequency;
-    let af = client.process(Some(ack), now).dgram();
+    let af = client.process(Some(&ack), now).dgram();
     assert!(af.is_some());
     assert_eq!(client.stats().frame_tx.ack_frequency, ad_before + 1);
 }

--- a/neqo-transport/src/connection/tests/cc.rs
+++ b/neqo-transport/src/connection/tests/cc.rs
@@ -66,7 +66,7 @@ fn cc_slow_start_to_cong_avoidance_recovery_period() {
 
     // Client: Process ack
     now += DEFAULT_RTT / 2;
-    client.process_input(s_ack, now);
+    client.process_input(&s_ack, now);
     assert_eq!(
         client.stats().frame_rx.largest_acknowledged,
         flight1_largest
@@ -88,7 +88,7 @@ fn cc_slow_start_to_cong_avoidance_recovery_period() {
 
     // Client: Process ack
     now += DEFAULT_RTT / 2;
-    client.process_input(s_ack, now);
+    client.process_input(&s_ack, now);
     assert_eq!(
         client.stats().frame_rx.largest_acknowledged,
         flight2_largest
@@ -118,7 +118,7 @@ fn cc_cong_avoidance_recovery_period_unchanged() {
 
     // Server: Receive and generate ack
     let s_ack = ack_bytes(&mut server, stream_id, c_tx_dgrams, now);
-    client.process_input(s_ack, now);
+    client.process_input(&s_ack, now);
 
     let cwnd1 = cwnd(&client);
 
@@ -126,7 +126,7 @@ fn cc_cong_avoidance_recovery_period_unchanged() {
     let s_ack = ack_bytes(&mut server, stream_id, c_tx_dgrams2, now);
 
     // ACK more packets but they were sent before end of recovery period
-    client.process_input(s_ack, now);
+    client.process_input(&s_ack, now);
 
     // cwnd should not have changed since ACKed packets were sent before
     // recovery period expired
@@ -156,12 +156,12 @@ fn single_packet_on_recovery() {
 
     // Acknowledge just one packet and cause one packet to be declared lost.
     // The length is the amount of credit the client should have.
-    let ack = server.process(Some(delivered), now).dgram();
+    let ack = server.process(Some(&delivered), now).dgram();
     assert!(ack.is_some());
 
     // The client should see the loss and enter recovery.
     // As there are many outstanding packets, there should be no available cwnd.
-    client.process_input(ack.unwrap(), now);
+    client.process_input(&ack.unwrap(), now);
     assert_eq!(cwnd_avail(&client), 0);
 
     // The client should send one packet, ignoring the cwnd.
@@ -193,7 +193,7 @@ fn cc_cong_avoidance_recovery_period_to_cong_avoidance() {
 
     // Client: Process ack
     now += DEFAULT_RTT / 2;
-    client.process_input(s_ack, now);
+    client.process_input(&s_ack, now);
 
     // Should be in CARP now.
     now += DEFAULT_RTT / 2;
@@ -227,7 +227,7 @@ fn cc_cong_avoidance_recovery_period_to_cong_avoidance() {
         let most = c_tx_dgrams.len() - usize::try_from(DEFAULT_ACK_PACKET_TOLERANCE).unwrap() - 1;
         let s_ack = ack_bytes(&mut server, stream_id, c_tx_dgrams.drain(..most), now);
         assert_eq!(cwnd(&client), expected_cwnd);
-        client.process_input(s_ack, now);
+        client.process_input(&s_ack, now);
         // make sure to fill cwnd again.
         let (mut new_pkts, next_now) = fill_cwnd(&mut client, stream_id, now);
         now = next_now;
@@ -235,7 +235,7 @@ fn cc_cong_avoidance_recovery_period_to_cong_avoidance() {
 
         let s_ack = ack_bytes(&mut server, stream_id, c_tx_dgrams, now);
         assert_eq!(cwnd(&client), expected_cwnd);
-        client.process_input(s_ack, now);
+        client.process_input(&s_ack, now);
         // make sure to fill cwnd again.
         let (mut new_pkts, next_now) = fill_cwnd(&mut client, stream_id, now);
         now = next_now;
@@ -287,7 +287,7 @@ fn cc_slow_start_to_persistent_congestion_some_acks() {
     let s_ack = ack_bytes(&mut server, stream, c_tx_dgrams, now);
 
     now += Duration::from_millis(100);
-    client.process_input(s_ack, now);
+    client.process_input(&s_ack, now);
 
     // send bytes that will be lost
     let (_, next_now) = fill_cwnd(&mut client, stream, now);
@@ -333,7 +333,7 @@ fn cc_persistent_congestion_to_slow_start() {
 
     // No longer in CARP. (pkts acked from after start of CARP)
     // Should be in slow start now.
-    client.process_input(s_ack, now);
+    client.process_input(&s_ack, now);
 
     // ACKing 2 packets should let client send 4.
     let (c_tx_dgrams, _) = fill_cwnd(&mut client, stream, now);
@@ -371,11 +371,11 @@ fn ack_are_not_cc() {
 
     // The client can ack the server packet even if cc windows is full.
     qdebug!([client], "Process ack-eliciting");
-    let ack_pkt = client.process(ack_eliciting_packet, now).dgram();
+    let ack_pkt = client.process(ack_eliciting_packet.as_ref(), now).dgram();
     assert!(ack_pkt.is_some());
     qdebug!([server], "Handle ACK");
     let prev_ack_count = server.stats().frame_rx.ack;
-    server.process_input(ack_pkt.unwrap(), now);
+    server.process_input(&ack_pkt.unwrap(), now);
     assert_eq!(server.stats().frame_rx.ack, prev_ack_count + 1);
 }
 

--- a/neqo-transport/src/connection/tests/close.rs
+++ b/neqo-transport/src/connection/tests/close.rs
@@ -38,7 +38,7 @@ fn connection_close() {
 
     let out = client.process(None, now);
 
-    server.process_input(out.dgram().unwrap(), now);
+    server.process_input(&out.dgram().unwrap(), now);
     assert_draining(&server, &Error::PeerApplicationError(42));
 }
 
@@ -55,7 +55,7 @@ fn connection_close_with_long_reason_string() {
 
     let out = client.process(None, now);
 
-    server.process_input(out.dgram().unwrap(), now);
+    server.process_input(&out.dgram().unwrap(), now);
     assert_draining(&server, &Error::PeerApplicationError(42));
 }
 
@@ -68,7 +68,7 @@ fn early_application_close() {
     // One flight each.
     let dgram = client.process(None, now()).dgram();
     assert!(dgram.is_some());
-    let dgram = server.process(dgram, now()).dgram();
+    let dgram = server.process(dgram.as_ref(), now()).dgram();
     assert!(dgram.is_some());
 
     server.close(now(), 77, String::new());
@@ -76,7 +76,7 @@ fn early_application_close() {
     let dgram = server.process(None, now()).dgram();
     assert!(dgram.is_some());
 
-    client.process_input(dgram.unwrap(), now());
+    client.process_input(&dgram.unwrap(), now());
     assert_draining(&client, &Error::PeerError(ERROR_APPLICATION_CLOSE));
 }
 
@@ -93,13 +93,13 @@ fn bad_tls_version() {
 
     let dgram = client.process(None, now()).dgram();
     assert!(dgram.is_some());
-    let dgram = server.process(dgram, now()).dgram();
+    let dgram = server.process(dgram.as_ref(), now()).dgram();
     assert_eq!(
         *server.state(),
         State::Closed(ConnectionError::Transport(Error::ProtocolViolation))
     );
     assert!(dgram.is_some());
-    client.process_input(dgram.unwrap(), now());
+    client.process_input(&dgram.unwrap(), now());
     assert_draining(&client, &Error::PeerError(Error::ProtocolViolation.code()));
 }
 
@@ -116,11 +116,11 @@ fn closing_timers_interation() {
     // We're going to induce time-based loss recovery so that timer is set.
     let _p1 = send_something(&mut client, now);
     let p2 = send_something(&mut client, now);
-    let ack = server.process(Some(p2), now).dgram();
+    let ack = server.process(Some(&p2), now).dgram();
     assert!(ack.is_some()); // This is an ACK.
 
     // After processing the ACK, we should be on the loss recovery timer.
-    let cb = client.process(ack, now).callback();
+    let cb = client.process(ack.as_ref(), now).callback();
     assert_ne!(cb, Duration::from_secs(0));
     now += cb;
 
@@ -153,7 +153,7 @@ fn closing_and_draining() {
 
     // The client will spit out the same packet in response to anything it receives.
     let p3 = send_something(&mut server, now());
-    let client_close2 = client.process(Some(p3), now()).dgram();
+    let client_close2 = client.process(Some(&p3), now()).dgram();
     assert_eq!(
         client_close.as_ref().unwrap().len(),
         client_close2.as_ref().unwrap().len()
@@ -168,14 +168,14 @@ fn closing_and_draining() {
     );
 
     // When the server receives the close, it too should generate CONNECTION_CLOSE.
-    let server_close = server.process(client_close, now()).dgram();
+    let server_close = server.process(client_close.as_ref(), now()).dgram();
     assert!(server.state().closed());
     assert!(server_close.is_some());
     // .. but it ignores any further close packets.
-    let server_close_timer = server.process(client_close2, now()).callback();
+    let server_close_timer = server.process(client_close2.as_ref(), now()).callback();
     assert_ne!(server_close_timer, Duration::from_secs(0));
     // Even a legitimate packet without a close in it.
-    let server_close_timer2 = server.process(Some(p1), now()).callback();
+    let server_close_timer2 = server.process(Some(&p1), now()).callback();
     assert_eq!(server_close_timer, server_close_timer2);
 
     let end = server.process(None, now() + server_close_timer);
@@ -201,6 +201,6 @@ fn stateless_reset_client() {
         .unwrap();
     connect_force_idle(&mut client, &mut server);
 
-    client.process_input(Datagram::new(addr(), addr(), vec![77; 21]), now());
+    client.process_input(&Datagram::new(addr(), addr(), vec![77; 21]), now());
     assert_draining(&client, &Error::StatelessReset);
 }

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -80,7 +80,7 @@ fn datagram_enabled_on_client() {
     let out = server.process_output(now()).dgram().unwrap();
     assert_eq!(server.stats().frame_tx.datagram, dgram_sent + 1);
 
-    client.process_input(out, now());
+    client.process_input(&out, now());
     assert!(matches!(
         client.next_event().unwrap(),
         ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU
@@ -108,7 +108,7 @@ fn datagram_enabled_on_server() {
     let out = client.process_output(now()).dgram().unwrap();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
-    server.process_input(out, now());
+    server.process_input(&out, now());
     assert!(matches!(
         server.next_event().unwrap(),
         ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU
@@ -205,7 +205,7 @@ fn datagram_acked() {
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
 
     let dgram_received = server.stats().frame_rx.datagram;
-    server.process_input(out.unwrap(), now());
+    server.process_input(&out.unwrap(), now());
     assert_eq!(server.stats().frame_rx.datagram, dgram_received + 1);
     let now = now() + AT_LEAST_PTO;
     // Ack should be sent
@@ -218,7 +218,7 @@ fn datagram_acked() {
         ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU
     ));
 
-    client.process_input(out.unwrap(), now);
+    client.process_input(&out.unwrap(), now);
     assert!(matches!(
         client.next_event().unwrap(),
         ConnectionEvent::OutgoingDatagramOutcome { id, outcome } if id == 1 && outcome == OutgoingDatagramOutcome::Acked
@@ -230,7 +230,7 @@ fn send_packet_and_get_server_event(
     server: &mut Connection,
 ) -> ConnectionEvent {
     let out = client.process_output(now()).dgram();
-    server.process_input(out.unwrap(), now());
+    server.process_input(&out.unwrap(), now());
     let mut events: Vec<_> = server
         .events()
         .filter_map(|evt| match evt {
@@ -358,7 +358,7 @@ fn dgram_no_allowed() {
     let out = server.process_output(now()).dgram().unwrap();
     server.test_frame_writer = None;
 
-    client.process_input(out, now());
+    client.process_input(&out, now());
 
     assert_error(
         &client,
@@ -379,7 +379,7 @@ fn dgram_too_big() {
     let out = server.process_output(now()).dgram().unwrap();
     server.test_frame_writer = None;
 
-    client.process_input(out, now());
+    client.process_input(&out, now());
 
     assert_error(
         &client,
@@ -414,7 +414,7 @@ fn outgoing_datagram_queue_full() {
     // Send DATA_SMALLER_THAN_MTU_2 datagram
     let out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
-    server.process_input(out.unwrap(), now());
+    server.process_input(&out.unwrap(), now());
     assert!(matches!(
         server.next_event().unwrap(),
         ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU_2
@@ -424,7 +424,7 @@ fn outgoing_datagram_queue_full() {
     let dgram_sent2 = client.stats().frame_tx.datagram;
     let out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent2 + 1);
-    server.process_input(out.unwrap(), now());
+    server.process_input(&out.unwrap(), now());
     assert!(matches!(
         server.next_event().unwrap(),
         ConnectionEvent::Datagram(data) if data == DATA_MTU
@@ -438,7 +438,7 @@ fn send_datagram(sender: &mut Connection, receiver: &mut Connection, data: &[u8]
     assert_eq!(sender.stats().frame_tx.datagram, dgram_sent + 1);
 
     let dgram_received = receiver.stats().frame_rx.datagram;
-    receiver.process_input(out, now());
+    receiver.process_input(&out, now());
     assert_eq!(receiver.stats().frame_rx.datagram, dgram_received + 1);
 }
 
@@ -552,7 +552,7 @@ fn multiple_quic_datagrams_in_one_packet() {
 
     let out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 2);
-    server.process_input(out.unwrap(), now());
+    server.process_input(&out.unwrap(), now());
     let datagram = |e: &_| matches!(e, ConnectionEvent::Datagram(..));
     assert_eq!(server.events().filter(datagram).count(), 2);
 }

--- a/neqo-transport/src/connection/tests/fuzzing.rs
+++ b/neqo-transport/src/connection/tests/fuzzing.rs
@@ -27,7 +27,7 @@ fn no_encryption() {
     let client_pkt = client.process_output(now()).dgram().unwrap();
     assert!(client_pkt[..client_pkt.len() - FIXED_TAG_FUZZING.len()].ends_with(DATA_CLIENT));
 
-    server.process_input(client_pkt, now());
+    server.process_input(&client_pkt, now());
     let mut buf = vec![0; 100];
     let (len, _) = server.stream_recv(stream_id, &mut buf).unwrap();
     assert_eq!(len, DATA_CLIENT.len());
@@ -36,7 +36,7 @@ fn no_encryption() {
     let server_pkt = server.process_output(now()).dgram().unwrap();
     assert!(server_pkt[..server_pkt.len() - FIXED_TAG_FUZZING.len()].ends_with(DATA_SERVER));
 
-    client.process_input(server_pkt, now());
+    client.process_input(&server_pkt, now());
     let (len, _) = client.stream_recv(stream_id, &mut buf).unwrap();
     assert_eq!(len, DATA_SERVER.len());
     assert_eq!(&buf[..len], DATA_SERVER);

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -45,31 +45,31 @@ fn full_handshake() {
 
     qdebug!("---- server: CH -> SH, EE, CERT, CV, FIN");
     let mut server = default_server();
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_some());
     assert_eq!(out.as_dgram_ref().unwrap().len(), PATH_MTU_V6);
 
     qdebug!("---- client: cert verification");
-    let out = client.process(out.dgram(), now());
+    let out = client.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_some());
 
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_none());
 
     assert!(maybe_authenticate(&mut client));
 
     qdebug!("---- client: SH..FIN -> FIN");
-    let out = client.process(out.dgram(), now());
+    let out = client.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_some());
     assert_eq!(*client.state(), State::Connected);
 
     qdebug!("---- server: FIN -> ACKS");
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_some());
     assert_eq!(*server.state(), State::Confirmed);
 
     qdebug!("---- client: ACKS -> 0");
-    let out = client.process(out.dgram(), now());
+    let out = client.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_none());
     assert_eq!(*client.state(), State::Confirmed);
 }
@@ -83,14 +83,14 @@ fn handshake_failed_authentication() {
 
     qdebug!("---- server: CH -> SH, EE, CERT, CV, FIN");
     let mut server = default_server();
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_some());
 
     qdebug!("---- client: cert verification");
-    let out = client.process(out.dgram(), now());
+    let out = client.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_some());
 
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_none());
 
     let authentication_needed = |e| matches!(e, ConnectionEvent::AuthenticationNeeded);
@@ -103,7 +103,7 @@ fn handshake_failed_authentication() {
     assert!(out.as_dgram_ref().is_some());
 
     qdebug!("---- server: Alert(certificate_revoked)");
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_some());
     assert_error(&client, &ConnectionError::Transport(Error::CryptoAlert(44)));
     assert_error(&server, &ConnectionError::Transport(Error::PeerError(300)));
@@ -145,16 +145,16 @@ fn dup_server_flight1() {
 
     qdebug!("---- server: CH -> SH, EE, CERT, CV, FIN");
     let mut server = default_server();
-    let out_to_rep = server.process(out.dgram(), now());
+    let out_to_rep = server.process(out.as_dgram_ref(), now());
     assert!(out_to_rep.as_dgram_ref().is_some());
     qdebug!("Output={:0x?}", out_to_rep.as_dgram_ref());
 
     qdebug!("---- client: cert verification");
-    let out = client.process(Some(out_to_rep.as_dgram_ref().unwrap().clone()), now());
+    let out = client.process(Some(out_to_rep.as_dgram_ref().unwrap()), now());
     assert!(out.as_dgram_ref().is_some());
     qdebug!("Output={:0x?}", out.as_dgram_ref());
 
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_none());
 
     assert!(maybe_authenticate(&mut client));
@@ -169,7 +169,7 @@ fn dup_server_flight1() {
     assert_eq!(1, client.stats().dropped_rx);
 
     qdebug!("---- Dup, ignored");
-    let out = client.process(out_to_rep.dgram(), now());
+    let out = client.process(out_to_rep.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_none());
     qdebug!("Output={:0x?}", out.as_dgram_ref());
 
@@ -199,12 +199,12 @@ fn crypto_frame_split() {
 
     // The entire server flight doesn't fit in a single packet because the
     // certificate is large, therefore the server will produce 2 packets.
-    let server1 = server.process(client1.dgram(), now());
+    let server1 = server.process(client1.as_dgram_ref(), now());
     assert!(server1.as_dgram_ref().is_some());
     let server2 = server.process(None, now());
     assert!(server2.as_dgram_ref().is_some());
 
-    let client2 = client.process(server1.dgram(), now());
+    let client2 = client.process(server1.as_dgram_ref(), now());
     // This is an ack.
     assert!(client2.as_dgram_ref().is_some());
     // The client might have the certificate now, so we can't guarantee that
@@ -213,11 +213,11 @@ fn crypto_frame_split() {
     assert_eq!(*client.state(), State::Handshaking);
 
     // let server process the ack for the first packet.
-    let server3 = server.process(client2.dgram(), now());
+    let server3 = server.process(client2.as_dgram_ref(), now());
     assert!(server3.as_dgram_ref().is_none());
 
     // Consume the second packet from the server.
-    let client3 = client.process(server2.dgram(), now());
+    let client3 = client.process(server2.as_dgram_ref(), now());
 
     // Check authentication.
     let auth2 = maybe_authenticate(&mut client);
@@ -225,13 +225,13 @@ fn crypto_frame_split() {
     // Now client has all data to finish handshake.
     assert_eq!(*client.state(), State::Connected);
 
-    let client4 = client.process(server3.dgram(), now());
+    let client4 = client.process(server3.as_dgram_ref(), now());
     // One of these will contain data depending on whether Authentication was completed
     // after the first or second server packet.
     assert!(client3.as_dgram_ref().is_some() ^ client4.as_dgram_ref().is_some());
 
-    mem::drop(server.process(client3.dgram(), now()));
-    mem::drop(server.process(client4.dgram(), now()));
+    mem::drop(server.process(client3.as_dgram_ref(), now()));
+    mem::drop(server.process(client4.as_dgram_ref(), now()));
 
     assert_eq!(*client.state(), State::Connected);
     assert_eq!(*server.state(), State::Confirmed);
@@ -263,19 +263,19 @@ fn send_05rtt() {
 
     let c1 = client.process(None, now()).dgram();
     assert!(c1.is_some());
-    let s1 = server.process(c1, now()).dgram().unwrap();
+    let s1 = server.process(c1.as_ref(), now()).dgram().unwrap();
     assert_eq!(s1.len(), PATH_MTU_V6);
 
     // The server should accept writes at this point.
     let s2 = send_something(&mut server, now());
 
     // Complete the handshake at the client.
-    client.process_input(s1, now());
+    client.process_input(&s1, now());
     maybe_authenticate(&mut client);
     assert_eq!(*client.state(), State::Connected);
 
     // The client should receive the 0.5-RTT data now.
-    client.process_input(s2, now());
+    client.process_input(&s2, now());
     let mut buf = vec![0; DEFAULT_STREAM_DATA.len() + 1];
     let stream_id = client
         .events()
@@ -300,19 +300,19 @@ fn reorder_05rtt() {
 
     let c1 = client.process(None, now()).dgram();
     assert!(c1.is_some());
-    let s1 = server.process(c1, now()).dgram().unwrap();
+    let s1 = server.process(c1.as_ref(), now()).dgram().unwrap();
 
     // The server should accept writes at this point.
     let s2 = send_something(&mut server, now());
 
     // We can't use the standard facility to complete the handshake, so
     // drive it as aggressively as possible.
-    client.process_input(s2, now());
+    client.process_input(&s2, now());
     assert_eq!(client.stats().saved_datagrams, 1);
 
     // After processing the first packet, the client should go back and
     // process the 0.5-RTT packet data, which should make data available.
-    client.process_input(s1, now());
+    client.process_input(&s1, now());
     // We can't use `maybe_authenticate` here as that consumes events.
     client.authenticated(AuthenticationStatus::Ok, now());
     assert_eq!(*client.state(), State::Connected);
@@ -350,7 +350,7 @@ fn reorder_05rtt_with_0rtt() {
     server.send_ticket(now, &[]).unwrap();
     let ticket = server.process_output(now).dgram().unwrap();
     now += RTT / 2;
-    client.process_input(ticket, now);
+    client.process_input(&ticket, now);
 
     let token = get_tokens(&mut client).pop().unwrap();
     let mut client = default_client();
@@ -367,14 +367,14 @@ fn reorder_05rtt_with_0rtt() {
 
     // Handle the first packet and send 0.5-RTT in response.  Drop the response.
     now += RTT / 2;
-    mem::drop(server.process(Some(c1), now).dgram().unwrap());
+    mem::drop(server.process(Some(&c1), now).dgram().unwrap());
     // The gap in 0-RTT will result in this 0.5 RTT containing an ACK.
-    server.process_input(c2, now);
+    server.process_input(&c2, now);
     let s2 = send_something(&mut server, now);
 
     // Save the 0.5 RTT.
     now += RTT / 2;
-    client.process_input(s2, now);
+    client.process_input(&s2, now);
     assert_eq!(client.stats().saved_datagrams, 1);
 
     // Now PTO at the client and cause the server to re-send handshake packets.
@@ -382,20 +382,20 @@ fn reorder_05rtt_with_0rtt() {
     let c3 = client.process(None, now).dgram();
 
     now += RTT / 2;
-    let s3 = server.process(c3, now).dgram().unwrap();
+    let s3 = server.process(c3.as_ref(), now).dgram().unwrap();
     assertions::assert_no_1rtt(&s3[..]);
 
     // The client should be able to process the 0.5 RTT now.
     // This should contain an ACK, so we are processing an ACK from the past.
     now += RTT / 2;
-    client.process_input(s3, now);
+    client.process_input(&s3, now);
     maybe_authenticate(&mut client);
     let c4 = client.process(None, now).dgram();
     assert_eq!(*client.state(), State::Connected);
     assert_eq!(client.paths.rtt(), RTT);
 
     now += RTT / 2;
-    server.process_input(c4.unwrap(), now);
+    server.process_input(&c4.unwrap(), now);
     assert_eq!(*server.state(), State::Confirmed);
     // Don't check server RTT as it will be massively inflated by a
     // poor initial estimate received when the server dropped the
@@ -416,7 +416,7 @@ fn coalesce_05rtt() {
     let c1 = client.process(None, now).dgram();
     assert!(c1.is_some());
     now += RTT / 2;
-    let s1 = server.process(c1, now).dgram();
+    let s1 = server.process(c1.as_ref(), now).dgram();
     assert!(s1.is_some());
 
     // Drop the server flight.  Then send some data.
@@ -431,7 +431,7 @@ fn coalesce_05rtt() {
     let c2 = client.process(None, now).dgram();
     assert!(c2.is_some());
     now += RTT / 2;
-    let s2 = server.process(c2, now).dgram();
+    let s2 = server.process(c2.as_ref(), now).dgram();
     // Even though there is a 1-RTT packet at the end of the datagram, the
     // flight should be padded to full size.
     assert_eq!(s2.as_ref().unwrap().len(), PATH_MTU_V6);
@@ -440,7 +440,7 @@ fn coalesce_05rtt() {
     // packet until authentication completes though.  So it saves it.
     now += RTT / 2;
     assert_eq!(client.stats().dropped_rx, 0);
-    mem::drop(client.process(s2, now).dgram());
+    mem::drop(client.process(s2.as_ref(), now).dgram());
     // This packet will contain an ACK, but we can ignore it.
     assert_eq!(client.stats().dropped_rx, 0);
     assert_eq!(client.stats().packets_rx, 3);
@@ -457,11 +457,11 @@ fn coalesce_05rtt() {
 
     // Allow the handshake to complete.
     now += RTT / 2;
-    let s3 = server.process(c3, now).dgram();
+    let s3 = server.process(c3.as_ref(), now).dgram();
     assert!(s3.is_some());
     assert_eq!(*server.state(), State::Confirmed);
     now += RTT / 2;
-    mem::drop(client.process(s3, now).dgram());
+    mem::drop(client.process(s3.as_ref(), now).dgram());
     assert_eq!(*client.state(), State::Confirmed);
 
     assert_eq!(client.stats().dropped_rx, 0); // No dropped packets.
@@ -478,7 +478,7 @@ fn reorder_handshake() {
     assert!(c1.is_some());
 
     now += RTT / 2;
-    let s1 = server.process(c1, now).dgram();
+    let s1 = server.process(c1.as_ref(), now).dgram();
     assert!(s1.is_some());
 
     // Drop the Initial packet from this.
@@ -488,7 +488,7 @@ fn reorder_handshake() {
     // Pass just the handshake packet in and the client can't handle it yet.
     // It can only send another Initial packet.
     now += RTT / 2;
-    let dgram = client.process(s_hs, now).dgram();
+    let dgram = client.process(s_hs.as_ref(), now).dgram();
     assertions::assert_initial(dgram.as_ref().unwrap(), false);
     assert_eq!(client.stats().saved_datagrams, 1);
     assert_eq!(client.stats().packets_rx, 1);
@@ -499,7 +499,7 @@ fn reorder_handshake() {
     now += AT_LEAST_PTO;
     let c2 = client.process(None, now).dgram();
     now += RTT / 2;
-    let s2 = server.process(c2, now).dgram();
+    let s2 = server.process(c2.as_ref(), now).dgram();
     assert!(s2.is_some());
 
     let (s_init, s_hs) = split_datagram(&s2.unwrap());
@@ -507,11 +507,11 @@ fn reorder_handshake() {
 
     // Processing the Handshake packet first should save it.
     now += RTT / 2;
-    client.process_input(s_hs.unwrap(), now);
+    client.process_input(&s_hs.unwrap(), now);
     assert_eq!(client.stats().saved_datagrams, 2);
     assert_eq!(client.stats().packets_rx, 2);
 
-    client.process_input(s_init, now);
+    client.process_input(&s_init, now);
     // Each saved packet should now be "received" again.
     assert_eq!(client.stats().packets_rx, 7);
     maybe_authenticate(&mut client);
@@ -521,14 +521,14 @@ fn reorder_handshake() {
     // Note that though packets were saved and processed very late,
     // they don't cause the RTT to change.
     now += RTT / 2;
-    let s3 = server.process(c3, now).dgram();
+    let s3 = server.process(c3.as_ref(), now).dgram();
     assert_eq!(*server.state(), State::Confirmed);
     // Don't check server RTT estimate as it will be inflated due to
     // it making a guess based on retransmissions when it dropped
     // the Initial packet number space.
 
     now += RTT / 2;
-    client.process_input(s3.unwrap(), now);
+    client.process_input(&s3.unwrap(), now);
     assert_eq!(*client.state(), State::Confirmed);
     assert_eq!(client.paths.rtt(), RTT);
 }
@@ -545,11 +545,11 @@ fn reorder_1rtt() {
     assert!(c1.is_some());
 
     now += RTT / 2;
-    let s1 = server.process(c1, now).dgram();
+    let s1 = server.process(c1.as_ref(), now).dgram();
     assert!(s1.is_some());
 
     now += RTT / 2;
-    client.process_input(s1.unwrap(), now);
+    client.process_input(&s1.unwrap(), now);
     maybe_authenticate(&mut client);
     let c2 = client.process(None, now).dgram();
     assert!(c2.is_some());
@@ -558,7 +558,7 @@ fn reorder_1rtt() {
     // Give them to the server before giving it `c2`.
     for _ in 0..PACKETS {
         let d = send_something(&mut client, now);
-        server.process_input(d, now + RTT / 2);
+        server.process_input(&d, now + RTT / 2);
     }
     // The server has now received those packets, and saved them.
     // The two extra received are Initial + the junk we use for padding.
@@ -567,7 +567,7 @@ fn reorder_1rtt() {
     assert_eq!(server.stats().dropped_rx, 1);
 
     now += RTT / 2;
-    let s2 = server.process(c2, now).dgram();
+    let s2 = server.process(c2.as_ref(), now).dgram();
     // The server has now received those packets, and saved them.
     // The two additional are a Handshake and a 1-RTT (w/ NEW_CONNECTION_ID).
     assert_eq!(server.stats().packets_rx, PACKETS * 2 + 4);
@@ -577,7 +577,7 @@ fn reorder_1rtt() {
     assert_eq!(server.paths.rtt(), RTT);
 
     now += RTT / 2;
-    client.process_input(s2.unwrap(), now);
+    client.process_input(&s2.unwrap(), now);
     assert_eq!(client.paths.rtt(), RTT);
 
     // All the stream data that was sent should now be available.
@@ -616,7 +616,7 @@ fn corrupted_initial() {
         .unwrap();
     corrupted[idx] ^= 0x76;
     let dgram = Datagram::new(d.source(), d.destination(), corrupted);
-    server.process_input(dgram, now());
+    server.process_input(&dgram, now());
     // The server should have received two packets,
     // the first should be dropped, the second saved.
     assert_eq!(server.stats().packets_rx, 2);
@@ -654,7 +654,7 @@ fn extra_initial_hs() {
     let c_init = client.process(None, now).dgram();
     assert!(c_init.is_some());
     now += DEFAULT_RTT / 2;
-    let s_init = server.process(c_init, now).dgram();
+    let s_init = server.process(c_init.as_ref(), now).dgram();
     assert!(s_init.is_some());
     now += DEFAULT_RTT / 2;
 
@@ -666,13 +666,13 @@ fn extra_initial_hs() {
     // Do that EXTRA_INITIALS times and each time the client will emit
     // another Initial packet.
     for _ in 0..=super::super::EXTRA_INITIALS {
-        let c_init = client.process(undecryptable.clone(), now).dgram();
+        let c_init = client.process(undecryptable.as_ref(), now).dgram();
         assertions::assert_initial(c_init.as_ref().unwrap(), false);
         now += DEFAULT_RTT / 10;
     }
 
     // After EXTRA_INITIALS, the client stops sending Initial packets.
-    let nothing = client.process(undecryptable, now).dgram();
+    let nothing = client.process(undecryptable.as_ref(), now).dgram();
     assert!(nothing.is_none());
 
     // Until PTO, where another Initial can be used to complete the handshake.
@@ -680,14 +680,14 @@ fn extra_initial_hs() {
     let c_init = client.process(None, now).dgram();
     assertions::assert_initial(c_init.as_ref().unwrap(), false);
     now += DEFAULT_RTT / 2;
-    let s_init = server.process(c_init, now).dgram();
+    let s_init = server.process(c_init.as_ref(), now).dgram();
     now += DEFAULT_RTT / 2;
-    client.process_input(s_init.unwrap(), now);
+    client.process_input(&s_init.unwrap(), now);
     maybe_authenticate(&mut client);
     let c_fin = client.process_output(now).dgram();
     assert_eq!(*client.state(), State::Connected);
     now += DEFAULT_RTT / 2;
-    server.process_input(c_fin.unwrap(), now);
+    server.process_input(&c_fin.unwrap(), now);
     assert_eq!(*server.state(), State::Confirmed);
 }
 
@@ -700,7 +700,7 @@ fn extra_initial_invalid_cid() {
     let c_init = client.process(None, now).dgram();
     assert!(c_init.is_some());
     now += DEFAULT_RTT / 2;
-    let s_init = server.process(c_init, now).dgram();
+    let s_init = server.process(c_init.as_ref(), now).dgram();
     assert!(s_init.is_some());
     now += DEFAULT_RTT / 2;
 
@@ -712,7 +712,7 @@ fn extra_initial_invalid_cid() {
     assert_ne!(copy[5], 0); // The DCID should be non-zero length.
     copy[6] ^= 0xc4;
     let dgram_copy = Datagram::new(hs.destination(), hs.source(), copy);
-    let nothing = client.process(Some(dgram_copy), now).dgram();
+    let nothing = client.process(Some(&dgram_copy), now).dgram();
     assert!(nothing.is_none());
 }
 
@@ -761,7 +761,7 @@ fn anti_amplification() {
 
     let c_init = client.process_output(now).dgram();
     now += DEFAULT_RTT / 2;
-    let s_init1 = server.process(c_init, now).dgram().unwrap();
+    let s_init1 = server.process(c_init.as_ref(), now).dgram().unwrap();
     assert_eq!(s_init1.len(), PATH_MTU_V6);
     let s_init2 = server.process_output(now).dgram().unwrap();
     assert_eq!(s_init2.len(), PATH_MTU_V6);
@@ -777,11 +777,11 @@ fn anti_amplification() {
     assert_ne!(cb, Duration::new(0, 0));
 
     now += DEFAULT_RTT / 2;
-    client.process_input(s_init1, now);
-    client.process_input(s_init2, now);
+    client.process_input(&s_init1, now);
+    client.process_input(&s_init2, now);
     let ack_count = client.stats().frame_tx.ack;
     let frame_count = client.stats().frame_tx.all;
-    let ack = client.process(Some(s_init3), now).dgram().unwrap();
+    let ack = client.process(Some(&s_init3), now).dgram().unwrap();
     assert!(!maybe_authenticate(&mut client)); // No need yet.
 
     // The client sends a padded datagram, with just ACK for Handshake.
@@ -790,16 +790,16 @@ fn anti_amplification() {
     assert_ne!(ack.len(), PATH_MTU_V6); // Not padded (it includes Handshake).
 
     now += DEFAULT_RTT / 2;
-    let remainder = server.process(Some(ack), now).dgram();
+    let remainder = server.process(Some(&ack), now).dgram();
 
     now += DEFAULT_RTT / 2;
-    client.process_input(remainder.unwrap(), now);
+    client.process_input(&remainder.unwrap(), now);
     assert!(maybe_authenticate(&mut client)); // OK, we have all of it.
     let fin = client.process_output(now).dgram();
     assert_eq!(*client.state(), State::Connected);
 
     now += DEFAULT_RTT / 2;
-    server.process_input(fin.unwrap(), now);
+    server.process_input(&fin.unwrap(), now);
     assert_eq!(*server.state(), State::Confirmed);
 }
 
@@ -815,7 +815,7 @@ fn garbage_initial() {
     corrupted.push(initial[initial.len() - 1] ^ 0xb7);
     corrupted.extend_from_slice(rest.as_ref().map_or(&[], |r| &r[..]));
     let garbage = Datagram::new(addr(), addr(), corrupted);
-    assert_eq!(Output::None, server.process(Some(garbage), now()));
+    assert_eq!(Output::None, server.process(Some(&garbage), now()));
 }
 
 #[test]
@@ -825,7 +825,7 @@ fn drop_initial_packet_from_wrong_address() {
     assert!(out.as_dgram_ref().is_some());
 
     let mut server = default_server();
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_some());
 
     let p = out.dgram().unwrap();
@@ -835,7 +835,7 @@ fn drop_initial_packet_from_wrong_address() {
         &p[..],
     );
 
-    let out = client.process(Some(dgram), now());
+    let out = client.process(Some(&dgram), now());
     assert!(out.as_dgram_ref().is_none());
 }
 
@@ -846,13 +846,13 @@ fn drop_handshake_packet_from_wrong_address() {
     assert!(out.as_dgram_ref().is_some());
 
     let mut server = default_server();
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
     assert!(out.as_dgram_ref().is_some());
 
     let (s_in, s_hs) = split_datagram(&out.dgram().unwrap());
 
     // Pass the initial packet.
-    mem::drop(client.process(Some(s_in), now()).dgram());
+    mem::drop(client.process(Some(&s_in), now()).dgram());
 
     let p = s_hs.unwrap();
     let dgram = Datagram::new(
@@ -861,7 +861,7 @@ fn drop_handshake_packet_from_wrong_address() {
         &p[..],
     );
 
-    let out = client.process(Some(dgram), now());
+    let out = client.process(Some(&dgram), now());
     assert!(out.as_dgram_ref().is_none());
 }
 
@@ -910,8 +910,8 @@ fn ech_retry() {
         .unwrap();
 
     let dgram = client.process_output(now()).dgram();
-    let dgram = server.process(dgram, now()).dgram();
-    client.process_input(dgram.unwrap(), now());
+    let dgram = server.process(dgram.as_ref(), now()).dgram();
+    client.process_input(&dgram.unwrap(), now());
     let auth_event = ConnectionEvent::EchFallbackAuthenticationNeeded {
         public_name: String::from(ECH_PUBLIC_NAME),
     };
@@ -921,7 +921,7 @@ fn ech_retry() {
 
     // Tell the server about the error.
     let dgram = client.process_output(now()).dgram();
-    server.process_input(dgram.unwrap(), now());
+    server.process_input(&dgram.unwrap(), now());
     assert_eq!(
         server.state().error(),
         Some(&ConnectionError::Transport(Error::PeerError(0x100 + 121)))
@@ -965,8 +965,8 @@ fn ech_retry_fallback_rejected() {
         .unwrap();
 
     let dgram = client.process_output(now()).dgram();
-    let dgram = server.process(dgram, now()).dgram();
-    client.process_input(dgram.unwrap(), now());
+    let dgram = server.process(dgram.as_ref(), now()).dgram();
+    client.process_input(&dgram.unwrap(), now());
     let auth_event = ConnectionEvent::EchFallbackAuthenticationNeeded {
         public_name: String::from(ECH_PUBLIC_NAME),
     };
@@ -980,7 +980,7 @@ fn ech_retry_fallback_rejected() {
 
     // Pass the error on.
     let dgram = client.process_output(now()).dgram();
-    server.process_input(dgram.unwrap(), now());
+    server.process_input(&dgram.unwrap(), now());
     assert_eq!(
         server.state().error(),
         Some(&ConnectionError::Transport(Error::PeerError(298)))
@@ -999,13 +999,13 @@ fn bad_min_ack_delay() {
     let mut client = default_client();
 
     let dgram = client.process_output(now()).dgram();
-    let dgram = server.process(dgram, now()).dgram();
-    client.process_input(dgram.unwrap(), now());
+    let dgram = server.process(dgram.as_ref(), now()).dgram();
+    client.process_input(&dgram.unwrap(), now());
     client.authenticated(AuthenticationStatus::Ok, now());
     assert_eq!(client.state().error(), Some(&EXPECTED_ERROR));
     let dgram = client.process_output(now()).dgram();
 
-    server.process_input(dgram.unwrap(), now());
+    server.process_input(&dgram.unwrap(), now());
     assert_eq!(
         server.state().error(),
         Some(&ConnectionError::Transport(Error::PeerError(
@@ -1025,7 +1025,7 @@ fn only_server_initial() {
     let client_dgram = client.process_output(now).dgram();
 
     // Now fetch two flights of messages from the server.
-    let server_dgram1 = server.process(client_dgram, now).dgram();
+    let server_dgram1 = server.process(client_dgram.as_ref(), now).dgram();
     let server_dgram2 = server.process_output(now + AT_LEAST_PTO).dgram();
 
     // Only pass on the Initial from the first.  We should get a Handshake in return.
@@ -1035,7 +1035,7 @@ fn only_server_initial() {
     // The client will not acknowledge the Initial as it discards keys.
     // It sends a Handshake probe instead, containing just a PING frame.
     assert_eq!(client.stats().frame_tx.ping, 0);
-    let probe = client.process(Some(initial), now).dgram();
+    let probe = client.process(Some(&initial), now).dgram();
     assertions::assert_handshake(&probe.unwrap());
     assert_eq!(client.stats().dropped_rx, 0);
     assert_eq!(client.stats().frame_tx.ping, 1);
@@ -1047,17 +1047,17 @@ fn only_server_initial() {
     now += AT_LEAST_PTO;
     assert_eq!(client.stats().frame_tx.ping, 1);
     let discarded = client.stats().dropped_rx;
-    let probe = client.process(Some(initial), now).dgram();
+    let probe = client.process(Some(&initial), now).dgram();
     assertions::assert_handshake(&probe.unwrap());
     assert_eq!(client.stats().frame_tx.ping, 2);
     assert_eq!(client.stats().dropped_rx, discarded + 1);
 
     // Pass the Handshake packet and complete the handshake.
-    client.process_input(handshake.unwrap(), now);
+    client.process_input(&handshake.unwrap(), now);
     maybe_authenticate(&mut client);
     let dgram = client.process_output(now).dgram();
-    let dgram = server.process(dgram, now).dgram();
-    client.process_input(dgram.unwrap(), now);
+    let dgram = server.process(dgram.as_ref(), now).dgram();
+    client.process_input(&dgram.unwrap(), now);
 
     assert_eq!(*client.state(), State::Confirmed);
     assert_eq!(*server.state(), State::Confirmed);
@@ -1083,25 +1083,25 @@ fn no_extra_probes_after_confirmed() {
     // Finally, run the handshake.
     now += AT_LEAST_PTO * 2;
     let dgram = client.process_output(now).dgram();
-    let dgram = server.process(dgram, now).dgram();
+    let dgram = server.process(dgram.as_ref(), now).dgram();
 
     // The server should have dropped the Initial keys now, so passing in the Initial
     // should elicit a retransmit rather than having it completely ignored.
-    let spare_handshake = server.process(Some(replay_initial), now).dgram();
+    let spare_handshake = server.process(Some(&replay_initial), now).dgram();
     assert!(spare_handshake.is_some());
 
-    client.process_input(dgram.unwrap(), now);
+    client.process_input(&dgram.unwrap(), now);
     maybe_authenticate(&mut client);
     let dgram = client.process_output(now).dgram();
-    let dgram = server.process(dgram, now).dgram();
-    client.process_input(dgram.unwrap(), now);
+    let dgram = server.process(dgram.as_ref(), now).dgram();
+    client.process_input(&dgram.unwrap(), now);
 
     assert_eq!(*client.state(), State::Confirmed);
     assert_eq!(*server.state(), State::Confirmed);
 
-    let probe = server.process(spare_initial, now).dgram();
+    let probe = server.process(spare_initial.as_ref(), now).dgram();
     assert!(probe.is_none());
-    let probe = client.process(spare_handshake, now).dgram();
+    let probe = client.process(spare_handshake.as_ref(), now).dgram();
     assert!(probe.is_none());
 }
 
@@ -1114,12 +1114,12 @@ fn implicit_rtt_server() {
 
     let dgram = client.process_output(now).dgram();
     now += RTT / 2;
-    let dgram = server.process(dgram, now).dgram();
+    let dgram = server.process(dgram.as_ref(), now).dgram();
     now += RTT / 2;
-    let dgram = client.process(dgram, now).dgram();
+    let dgram = client.process(dgram.as_ref(), now).dgram();
     assertions::assert_handshake(dgram.as_ref().unwrap());
     now += RTT / 2;
-    server.process_input(dgram.unwrap(), now);
+    server.process_input(&dgram.unwrap(), now);
 
     // The server doesn't receive any acknowledgments, but it can infer
     // an RTT estimate from having discarded the Initial packet number space.

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -107,15 +107,18 @@ fn asymmetric_idle_timeout() {
     connect(&mut client, &mut server);
     let c1 = send_something(&mut client, now());
     let c2 = send_something(&mut client, now());
-    server.process_input(c2, now());
-    server.process_input(c1, now());
+    server.process_input(&c2, now());
+    server.process_input(&c1, now());
     let s1 = send_something(&mut server, now());
     let s2 = send_something(&mut server, now());
-    client.process_input(s2, now());
-    let ack = client.process(Some(s1), now()).dgram();
+    client.process_input(&s2, now());
+    let ack = client.process(Some(&s1), now()).dgram();
     assert!(ack.is_some());
     // Now both should have received ACK frames so should be idle.
-    assert_eq!(server.process(ack, now()), Output::Callback(LOWER_TIMEOUT));
+    assert_eq!(
+        server.process(ack.as_ref(), now()),
+        Output::Callback(LOWER_TIMEOUT)
+    );
     assert_eq!(client.process(None, now()), Output::Callback(LOWER_TIMEOUT));
 }
 
@@ -144,13 +147,13 @@ fn tiny_idle_timeout() {
     let c1 = send_something(&mut client, now);
     let c2 = send_something(&mut client, now);
     now += RTT / 2;
-    server.process_input(c2, now);
-    server.process_input(c1, now);
+    server.process_input(&c2, now);
+    server.process_input(&c1, now);
     let s1 = send_something(&mut server, now);
     let s2 = send_something(&mut server, now);
     now += RTT / 2;
-    client.process_input(s2, now);
-    let ack = client.process(Some(s1), now).dgram();
+    client.process_input(&s2, now);
+    let ack = client.process(Some(&s1), now).dgram();
     assert!(ack.is_some());
 
     // The client should be idle now, but with a different timer.
@@ -162,7 +165,7 @@ fn tiny_idle_timeout() {
 
     // The server should go idle after the ACK, but again with a larger timeout.
     now += RTT / 2;
-    if let Output::Callback(t) = client.process(ack, now) {
+    if let Output::Callback(t) = client.process(ack.as_ref(), now) {
         assert!(t > LOWER_TIMEOUT);
     } else {
         panic!("Client not idle");
@@ -257,11 +260,11 @@ fn idle_recv_packet() {
     // Otherwise, the eventual timeout will be extended (and we're not testing that).
     now += Duration::from_secs(10);
     let out = client.process(None, now);
-    server.process_input(out.dgram().unwrap(), now);
+    server.process_input(&out.dgram().unwrap(), now);
     assert_eq!(server.stream_send(stream, b"world").unwrap(), 5);
     let out = server.process_output(now);
     assert_ne!(out.as_dgram_ref(), None);
-    mem::drop(client.process(out.dgram(), now));
+    mem::drop(client.process(out.as_dgram_ref(), now));
     assert!(matches!(client.state(), State::Confirmed));
 
     // Add a little less than the idle timeout and we're still connected.
@@ -288,9 +291,9 @@ fn idle_caching() {
     // Perform the first round trip, but drop the Initial from the server.
     // The client then caches the Handshake packet.
     let dgram = client.process_output(start).dgram();
-    let dgram = server.process(dgram, start).dgram();
+    let dgram = server.process(dgram.as_ref(), start).dgram();
     let (_, handshake) = split_datagram(&dgram.unwrap());
-    client.process_input(handshake.unwrap(), start);
+    client.process_input(&handshake.unwrap(), start);
 
     // Perform an exchange and keep the connection alive.
     // Only allow a packet containing a PING to pass.
@@ -303,7 +306,7 @@ fn idle_caching() {
     // Now let the server process the client PING.  This causes the server
     // to send CRYPTO frames again, so manually extract and discard those.
     let ping_before_s = server.stats().frame_rx.ping;
-    server.process_input(dgram.unwrap(), middle);
+    server.process_input(&dgram.unwrap(), middle);
     assert_eq!(server.stats().frame_rx.ping, ping_before_s + 1);
     let mut tokens = Vec::new();
     server
@@ -336,7 +339,7 @@ fn idle_caching() {
     let (initial, _) = split_datagram(&dgram.unwrap());
     let ping_before_c = client.stats().frame_rx.ping;
     let ack_before = client.stats().frame_rx.ack;
-    client.process_input(initial, middle);
+    client.process_input(&initial, middle);
     assert_eq!(client.stats().frame_rx.ping, ping_before_c + 1);
     assert_eq!(client.stats().frame_rx.ack, ack_before + 1);
 
@@ -345,11 +348,11 @@ fn idle_caching() {
     let dgram = server.process_output(end).dgram();
     let (initial, _) = split_datagram(&dgram.unwrap());
     neqo_common::qwarn!("client ingests initial, finally");
-    mem::drop(client.process(Some(initial), end));
+    mem::drop(client.process(Some(&initial), end));
     maybe_authenticate(&mut client);
     let dgram = client.process_output(end).dgram();
-    let dgram = server.process(dgram, end).dgram();
-    client.process_input(dgram.unwrap(), end);
+    let dgram = server.process(dgram.as_ref(), end).dgram();
+    client.process_input(&dgram.unwrap(), end);
     assert_eq!(*client.state(), State::Confirmed);
     assert_eq!(*server.state(), State::Confirmed);
 }
@@ -378,7 +381,7 @@ fn create_stream_idle_rtt(
     _ = initiator.stream_send(stream, DEFAULT_STREAM_DATA).unwrap();
     let req = initiator.process_output(now).dgram();
     now += rtt / 2;
-    responder.process_input(req.unwrap(), now);
+    responder.process_input(&req.unwrap(), now);
 
     // Reordering two packets from the responder forces the initiator to be idle.
     _ = responder.stream_send(stream, DEFAULT_STREAM_DATA).unwrap();
@@ -387,15 +390,15 @@ fn create_stream_idle_rtt(
     let resp2 = responder.process_output(now).dgram();
 
     now += rtt / 2;
-    initiator.process_input(resp2.unwrap(), now);
-    initiator.process_input(resp1.unwrap(), now);
+    initiator.process_input(&resp2.unwrap(), now);
+    initiator.process_input(&resp1.unwrap(), now);
     let ack = initiator.process_output(now).dgram();
     assert!(ack.is_some());
     check_idle(initiator, now);
 
     // Receiving the ACK should return the responder to idle too.
     now += rtt / 2;
-    responder.process_input(ack.unwrap(), now);
+    responder.process_input(&ack.unwrap(), now);
     check_idle(responder, now);
 
     (now, stream)
@@ -431,9 +434,9 @@ fn keep_alive_initiator() {
     assert_eq!(server.stats().frame_tx.ping, pings_before + 1);
 
     // Exchange ack for the PING.
-    let out = client.process(ping, now).dgram();
-    let out = server.process(out, now).dgram();
-    assert!(client.process(out, now).dgram().is_none());
+    let out = client.process(ping.as_ref(), now).dgram();
+    let out = server.process(out.as_ref(), now).dgram();
+    assert!(client.process(out.as_ref(), now).dgram().is_none());
 
     // Check that there will be next keep-alive ping after default_timeout() / 2.
     assert_idle(&mut server, now, default_timeout() / 2);
@@ -473,12 +476,12 @@ fn keep_alive_lost() {
     assert_eq!(server.stats().frame_tx.ping, pings_before2 + 1);
 
     // Exchange ack for the PING.
-    let out = client.process(ping, now).dgram();
+    let out = client.process(ping.as_ref(), now).dgram();
 
     now += Duration::from_millis(20);
-    let out = server.process(out, now).dgram();
+    let out = server.process(out.as_ref(), now).dgram();
 
-    assert!(client.process(out, now).dgram().is_none());
+    assert!(client.process(out.as_ref(), now).dgram().is_none());
 
     // TODO: if we run server.process with current value of now, the server will
     // return some small timeout for the recovry although it does not have
@@ -531,10 +534,10 @@ fn keep_alive_unmark() {
 fn transfer_force_idle(sender: &mut Connection, receiver: &mut Connection) {
     let dgram = sender.process_output(now()).dgram();
     let chaff = send_something(sender, now());
-    receiver.process_input(chaff, now());
-    receiver.process_input(dgram.unwrap(), now());
+    receiver.process_input(&chaff, now());
+    receiver.process_input(&dgram.unwrap(), now());
     let ack = receiver.process_output(now()).dgram();
-    sender.process_input(ack.unwrap(), now());
+    sender.process_input(&ack.unwrap(), now());
 }
 
 /// Receiving the end of the stream stops keep-alives for that stream.
@@ -602,7 +605,7 @@ fn keep_alive_stop_sending() {
     // The server will have sent RESET_STREAM, which the client will
     // want to acknowledge, so force that out.
     let junk = send_something(&mut server, now());
-    let ack = client.process(Some(junk), now()).dgram();
+    let ack = client.process(Some(&junk), now()).dgram();
     assert!(ack.is_some());
 
     // Now the client should be idle.
@@ -665,7 +668,7 @@ fn keep_alive_uni() {
     _ = client.stream_send(stream, DEFAULT_STREAM_DATA).unwrap();
     let dgram = client.process_output(now()).dgram();
 
-    server.process_input(dgram.unwrap(), now());
+    server.process_input(&dgram.unwrap(), now());
     server.stream_keep_alive(stream, true).unwrap();
 }
 

--- a/neqo-transport/src/connection/tests/keys.rs
+++ b/neqo-transport/src/connection/tests/keys.rs
@@ -20,7 +20,7 @@ use test_fixture::{self, now};
 
 fn check_discarded(
     peer: &mut Connection,
-    pkt: Datagram,
+    pkt: &Datagram,
     response: bool,
     dropped: usize,
     dups: usize,
@@ -59,11 +59,11 @@ fn discarded_initial_keys() {
 
     qdebug!("---- server: CH -> SH, EE, CERT, CV, FIN");
     let mut server = default_server();
-    let init_pkt_s = server.process(init_pkt_c.clone(), now()).dgram();
+    let init_pkt_s = server.process(init_pkt_c.as_ref(), now()).dgram();
     assert!(init_pkt_s.is_some());
 
     qdebug!("---- client: cert verification");
-    let out = client.process(init_pkt_s.clone(), now()).dgram();
+    let out = client.process(init_pkt_s.as_ref(), now()).dgram();
     assert!(out.is_some());
 
     // The client has received a handshake packet. It will remove the Initial keys.
@@ -71,7 +71,7 @@ fn discarded_initial_keys() {
     // The initial packet should be dropped. The packet contains a Handshake packet as well, which
     // will be marked as dup.  And it will contain padding, which will be "dropped".
     // The client will generate a Handshake packet here to avoid stalling.
-    check_discarded(&mut client, init_pkt_s.unwrap(), true, 2, 1);
+    check_discarded(&mut client, &init_pkt_s.unwrap(), true, 2, 1);
 
     assert!(maybe_authenticate(&mut client));
 
@@ -79,7 +79,7 @@ fn discarded_initial_keys() {
     // packet from the client.
     // We will check this by processing init_pkt_c a second time.
     // The dropped packet is padding. The Initial packet has been mark dup.
-    check_discarded(&mut server, init_pkt_c.clone().unwrap(), false, 1, 1);
+    check_discarded(&mut server, &init_pkt_c.clone().unwrap(), false, 1, 1);
 
     qdebug!("---- client: SH..FIN -> FIN");
     let out = client.process(None, now()).dgram();
@@ -87,14 +87,14 @@ fn discarded_initial_keys() {
 
     // The server will process the first Handshake packet.
     // After this the Initial keys will be dropped.
-    let out = server.process(out, now()).dgram();
+    let out = server.process(out.as_ref(), now()).dgram();
     assert!(out.is_some());
 
     // Check that the Initial keys are dropped at the server
     // We will check this by processing init_pkt_c a third time.
     // The Initial packet has been dropped and padding that follows it.
     // There is no dups, everything has been dropped.
-    check_discarded(&mut server, init_pkt_c.unwrap(), false, 1, 0);
+    check_discarded(&mut server, &init_pkt_c.unwrap(), false, 1, 0);
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn key_update_client() {
     // The previous PTO packet (see above) was dropped, so we should get an ACK here.
     let dgram = send_and_receive(&mut client, &mut server, now);
     assert!(dgram.is_some());
-    let res = client.process(dgram, now);
+    let res = client.process(dgram.as_ref(), now);
     // This is the first packet that the client has received from the server
     // with new keys, so its read timer just started.
     if let Output::Callback(t) = res {
@@ -190,7 +190,7 @@ fn key_update_consecutive() {
     assert_eq!(client.get_epochs(), (Some(4), Some(3)));
 
     // Have the server process the ACK.
-    if let Output::Callback(_) = server.process(dgram, now) {
+    if let Output::Callback(_) = server.process(dgram.as_ref(), now) {
         assert_eq!(server.get_epochs(), (Some(4), Some(3)));
         // Now move the server temporarily into the future so that it
         // rotates the keys.  The client stays in the present.
@@ -208,7 +208,7 @@ fn key_update_consecutive() {
 
     // However, as the server didn't wait long enough to update again, the
     // client hasn't rotated its keys, so the packet gets dropped.
-    check_discarded(&mut client, dgram, false, 1, 0);
+    check_discarded(&mut client, &dgram, false, 1, 0);
 }
 
 // Key updates can't be initiated too early.
@@ -225,12 +225,12 @@ fn key_update_before_confirmed() {
     assert_update_blocked(&mut client);
 
     // Server Initial + Handshake
-    let dgram = server.process(dgram, now()).dgram();
+    let dgram = server.process(dgram.as_ref(), now()).dgram();
     assert!(dgram.is_some());
     assert_update_blocked(&mut server);
 
     // Client Handshake
-    client.process_input(dgram.unwrap(), now());
+    client.process_input(&dgram.unwrap(), now());
     assert_update_blocked(&mut client);
 
     assert!(maybe_authenticate(&mut client));
@@ -241,12 +241,12 @@ fn key_update_before_confirmed() {
     assert_update_blocked(&mut client);
 
     // Server HANDSHAKE_DONE
-    let dgram = server.process(dgram, now()).dgram();
+    let dgram = server.process(dgram.as_ref(), now()).dgram();
     assert!(dgram.is_some());
     assert!(server.initiate_key_update().is_ok());
 
     // Client receives HANDSHAKE_DONE
-    let dgram = client.process(dgram, now()).dgram();
+    let dgram = client.process(dgram.as_ref(), now()).dgram();
     assert!(dgram.is_none());
     assert!(client.initiate_key_update().is_ok());
 }
@@ -277,13 +277,13 @@ fn exhaust_read_keys() {
     let dgram = send_something(&mut client, now());
 
     overwrite_invocations(0);
-    let dgram = server.process(Some(dgram), now()).dgram();
+    let dgram = server.process(Some(&dgram), now()).dgram();
     assert!(matches!(
         server.state(),
         State::Closed(ConnectionError::Transport(Error::KeysExhausted))
     ));
 
-    client.process_input(dgram.unwrap(), now());
+    client.process_input(&dgram.unwrap(), now());
     assert!(matches!(
         client.state(),
         State::Draining {

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -81,7 +81,7 @@ fn rebinding_port() {
     let dgram = send_something(&mut client, now());
     let dgram = change_source_port(&dgram);
 
-    server.process_input(dgram, now());
+    server.process_input(&dgram, now());
     // Have the server send something so that it generates a packet.
     let stream_id = server.stream_create(StreamType::UniDi).unwrap();
     server.stream_close_send(stream_id).unwrap();
@@ -103,7 +103,7 @@ fn path_forwarding_attack() {
 
     let dgram = send_something(&mut client, now);
     let dgram = change_path(&dgram, addr_v4());
-    server.process_input(dgram, now);
+    server.process_input(&dgram, now);
 
     // The server now probes the new (primary) path.
     let new_probe = server.process_output(now).dgram().unwrap();
@@ -123,14 +123,14 @@ fn path_forwarding_attack() {
 
     // The client should respond to the challenge on the new path.
     // The server couldn't pad, so the client is also amplification limited.
-    let new_resp = client.process(Some(new_probe), now).dgram().unwrap();
+    let new_resp = client.process(Some(&new_probe), now).dgram().unwrap();
     assert_eq!(client.stats().frame_rx.path_challenge, 1);
     assert_eq!(client.stats().frame_tx.path_challenge, 1);
     assert_eq!(client.stats().frame_tx.path_response, 1);
     assert_v4_path(&new_resp, false);
 
     // The client also responds to probes on the old path.
-    let old_resp = client.process(Some(old_probe), now).dgram().unwrap();
+    let old_resp = client.process(Some(&old_probe), now).dgram().unwrap();
     assert_eq!(client.stats().frame_rx.path_challenge, 2);
     assert_eq!(client.stats().frame_tx.path_challenge, 1);
     assert_eq!(client.stats().frame_tx.path_response, 2);
@@ -143,12 +143,12 @@ fn path_forwarding_attack() {
     // Receiving the PATH_RESPONSE from the client opens the amplification
     // limit enough for the server to respond.
     // This is padded because it includes PATH_CHALLENGE.
-    let server_data1 = server.process(Some(new_resp), now).dgram().unwrap();
+    let server_data1 = server.process(Some(&new_resp), now).dgram().unwrap();
     assert_v4_path(&server_data1, true);
     assert_eq!(server.stats().frame_tx.path_challenge, 3);
 
     // The client responds to this probe on the new path.
-    client.process_input(server_data1, now);
+    client.process_input(&server_data1, now);
     let stream_before = client.stats().frame_tx.stream;
     let padded_resp = send_something(&mut client, now);
     assert_eq!(stream_before, client.stats().frame_tx.stream);
@@ -164,7 +164,7 @@ fn path_forwarding_attack() {
     assert_v4_path(&server_data2, false);
 
     // Until new data is received from the client on the old path.
-    server.process_input(client_data2, now);
+    server.process_input(&client_data2, now);
     // The server sends a probe on the "old" path.
     let server_data3 = send_something(&mut server, now);
     assert_v4_path(&server_data3, true);
@@ -192,7 +192,7 @@ fn migrate_immediate() {
     let server_delayed = send_something(&mut server, now);
 
     // The server accepts the first packet and migrates (but probes).
-    let server1 = server.process(Some(client1), now).dgram().unwrap();
+    let server1 = server.process(Some(&client1), now).dgram().unwrap();
     assert_v4_path(&server1, true);
     let server2 = server.process_output(now).dgram().unwrap();
     assert_v6_path(&server2, true);
@@ -200,13 +200,13 @@ fn migrate_immediate() {
     // The second packet has no real effect, it just elicits an ACK.
     let all_before = server.stats().frame_tx.all;
     let ack_before = server.stats().frame_tx.ack;
-    let server3 = server.process(Some(client2), now).dgram();
+    let server3 = server.process(Some(&client2), now).dgram();
     assert!(server3.is_some());
     assert_eq!(server.stats().frame_tx.all, all_before + 1);
     assert_eq!(server.stats().frame_tx.ack, ack_before + 1);
 
     // Receiving a packet sent by the server before migration doesn't change path.
-    client.process_input(server_delayed, now);
+    client.process_input(&server_delayed, now);
     // The client has sent two unpaced packets and this new path has no RTT estimate
     // so this might be paced.
     let (client3, _t) = send_something_paced(&mut client, now, true);
@@ -293,13 +293,13 @@ fn migrate_same() {
     assert_v6_path(&probe, true); // Contains PATH_CHALLENGE.
     assert_eq!(client.stats().frame_tx.path_challenge, 1);
 
-    let resp = server.process(Some(probe), now).dgram().unwrap();
+    let resp = server.process(Some(&probe), now).dgram().unwrap();
     assert_v6_path(&resp, true);
     assert_eq!(server.stats().frame_tx.path_response, 1);
     assert_eq!(server.stats().frame_tx.path_challenge, 0);
 
     // Everything continues happily.
-    client.process_input(resp, now);
+    client.process_input(&resp, now);
     let contd = send_something(&mut client, now);
     assert_v6_path(&contd, false);
 }
@@ -376,7 +376,7 @@ fn migration(mut client: Connection) {
     assert_eq!(client.stats().frame_tx.path_challenge, 1);
     let probe_cid = ConnectionId::from(&get_cid(&probe));
 
-    let resp = server.process(Some(probe), now).dgram().unwrap();
+    let resp = server.process(Some(&probe), now).dgram().unwrap();
     assert_v4_path(&resp, true);
     assert_eq!(server.stats().frame_tx.path_response, 1);
     assert_eq!(server.stats().frame_tx.path_challenge, 1);
@@ -385,12 +385,12 @@ fn migration(mut client: Connection) {
     let client_data = send_something(&mut client, now);
     assert_ne!(get_cid(&client_data), probe_cid);
     assert_v6_path(&client_data, false);
-    server.process_input(client_data, now);
+    server.process_input(&client_data, now);
     let server_data = send_something(&mut server, now);
     assert_v6_path(&server_data, false);
 
     // Once the client receives the probe response, it migrates to the new path.
-    client.process_input(resp, now);
+    client.process_input(&resp, now);
     assert_eq!(client.stats().frame_rx.path_challenge, 1);
     let migrate_client = send_something(&mut client, now);
     assert_v4_path(&migrate_client, true); // Responds to server probe.
@@ -399,7 +399,7 @@ fn migration(mut client: Connection) {
     // However, it will probe the old path again, even though it has just
     // received a response to its last probe, because it needs to verify
     // that the migration is genuine.
-    server.process_input(migrate_client, now);
+    server.process_input(&migrate_client, now);
     let stream_before = server.stats().frame_tx.stream;
     let probe_old_server = send_something(&mut server, now);
     // This is just the double-check probe; no STREAM frames.
@@ -414,8 +414,8 @@ fn migration(mut client: Connection) {
     assert_eq!(server.stats().frame_tx.stream, stream_before + 1);
 
     // The client receives these checks and responds to the probe, but uses the new path.
-    client.process_input(migrate_server, now);
-    client.process_input(probe_old_server, now);
+    client.process_input(&migrate_server, now);
+    client.process_input(&probe_old_server, now);
     let old_probe_resp = send_something(&mut client, now);
     assert_v6_path(&old_probe_resp, true);
     let client_confirmation = client.process_output(now).dgram().unwrap();
@@ -455,11 +455,11 @@ fn migration_client_empty_cid() {
 /// Returns the packet containing `HANDSHAKE_DONE` from the server.
 fn fast_handshake(client: &mut Connection, server: &mut Connection) -> Option<Datagram> {
     let dgram = client.process_output(now()).dgram();
-    let dgram = server.process(dgram, now()).dgram();
-    client.process_input(dgram.unwrap(), now());
+    let dgram = server.process(dgram.as_ref(), now()).dgram();
+    client.process_input(&dgram.unwrap(), now());
     assert!(maybe_authenticate(client));
     let dgram = client.process_output(now()).dgram();
-    server.process(dgram, now()).dgram()
+    server.process(dgram.as_ref(), now()).dgram()
 }
 
 fn preferred_address(hs_client: SocketAddr, hs_server: SocketAddr, preferred: SocketAddr) {
@@ -518,7 +518,7 @@ fn preferred_address(hs_client: SocketAddr, hs_server: SocketAddr, preferred: So
 
     // The client is about to process HANDSHAKE_DONE.
     // It should start probing toward the server's preferred address.
-    let probe = client.process(dgram, now()).dgram().unwrap();
+    let probe = client.process(dgram.as_ref(), now()).dgram().unwrap();
     assert_toward_spa(&probe, true);
     assert_eq!(client.stats().frame_tx.path_challenge, 1);
     assert_ne!(client.process_output(now()).callback(), Duration::new(0, 0));
@@ -528,26 +528,26 @@ fn preferred_address(hs_client: SocketAddr, hs_server: SocketAddr, preferred: So
     assert_orig_path(&data, false);
 
     // The server responds to the probe.
-    let resp = server.process(Some(probe), now()).dgram().unwrap();
+    let resp = server.process(Some(&probe), now()).dgram().unwrap();
     assert_from_spa(&resp, true);
     assert_eq!(server.stats().frame_tx.path_challenge, 1);
     assert_eq!(server.stats().frame_tx.path_response, 1);
 
     // Data continues on the main path for the server.
-    server.process_input(data, now());
+    server.process_input(&data, now());
     let data = send_something(&mut server, now());
     assert_orig_path(&data, false);
 
     // Client gets the probe response back and it migrates.
-    client.process_input(resp, now());
-    client.process_input(data, now());
+    client.process_input(&resp, now());
+    client.process_input(&data, now());
     let data = send_something(&mut client, now());
     assert_toward_spa(&data, true);
     assert_eq!(client.stats().frame_tx.stream, 2);
     assert_eq!(client.stats().frame_tx.path_response, 1);
 
     // The server sees the migration and probes the old path.
-    let probe = server.process(Some(data), now()).dgram().unwrap();
+    let probe = server.process(Some(&data), now()).dgram().unwrap();
     assert_orig_path(&probe, true);
     assert_eq!(server.stats().frame_tx.path_challenge, 2);
 
@@ -589,7 +589,7 @@ fn expect_no_migration(client: &mut Connection, server: &mut Connection) {
     let dgram = fast_handshake(client, server);
 
     // The client won't probe now, though it could; it remains idle.
-    let out = client.process(dgram, now());
+    let out = client.process(dgram.as_ref(), now());
     assert_ne!(out.callback(), Duration::new(0, 0));
 
     // Data continues on the main path for the client.
@@ -716,12 +716,12 @@ fn migration_invalid_state() {
         .is_err());
     let close = client.process(None, now()).dgram();
 
-    let dgram = server.process(close, now()).dgram();
+    let dgram = server.process(close.as_ref(), now()).dgram();
     assert!(server
         .migrate(Some(addr()), Some(addr()), false, now())
         .is_err());
 
-    client.process_input(dgram.unwrap(), now());
+    client.process_input(&dgram.unwrap(), now());
     assert!(client
         .migrate(Some(addr()), Some(addr()), false, now())
         .is_err());
@@ -822,7 +822,7 @@ fn retire_all() {
 
     let new_cid_before = client.stats().frame_rx.new_connection_id;
     let retire_cid_before = client.stats().frame_tx.retire_connection_id;
-    client.process_input(ncid, now());
+    client.process_input(&ncid, now());
     let retire = send_something(&mut client, now());
     assert_eq!(
         client.stats().frame_rx.new_connection_id,
@@ -871,17 +871,17 @@ fn retire_prior_to_migration_failure() {
     let retire_all = send_something(&mut server, now());
     server.test_frame_writer = None;
 
-    let resp = server.process(Some(probe), now()).dgram().unwrap();
+    let resp = server.process(Some(&probe), now()).dgram().unwrap();
     assert_v4_path(&resp, true);
     assert_eq!(server.stats().frame_tx.path_response, 1);
     assert_eq!(server.stats().frame_tx.path_challenge, 1);
 
     // Have the client receive the NEW_CONNECTION_ID with Retire Prior To.
-    client.process_input(retire_all, now());
+    client.process_input(&retire_all, now());
     // This packet contains the probe response, which should be fine, but it
     // also includes PATH_CHALLENGE for the new path, and the client can't
     // respond without a connection ID.  We treat this as a connection error.
-    client.process_input(resp, now());
+    client.process_input(&resp, now());
     assert!(matches!(
         client.state(),
         State::Closing {
@@ -926,15 +926,15 @@ fn retire_prior_to_migration_success() {
     let retire_all = send_something(&mut server, now());
     server.test_frame_writer = None;
 
-    let resp = server.process(Some(probe), now()).dgram().unwrap();
+    let resp = server.process(Some(&probe), now()).dgram().unwrap();
     assert_v4_path(&resp, true);
     assert_eq!(server.stats().frame_tx.path_response, 1);
     assert_eq!(server.stats().frame_tx.path_challenge, 1);
 
     // Have the client receive the NEW_CONNECTION_ID with Retire Prior To second.
     // As this occurs in a very specific order, migration succeeds.
-    client.process_input(resp, now());
-    client.process_input(retire_all, now());
+    client.process_input(&resp, now());
+    client.process_input(&retire_all, now());
 
     // Migration succeeds and the new path gets the last connection ID.
     let dgram = send_something(&mut client, now());

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -168,7 +168,7 @@ fn handshake(
     while !is_done(a) {
         _ = maybe_authenticate(a);
         let had_input = input.is_some();
-        let output = a.process(input, now).dgram();
+        let output = a.process(input.as_ref(), now).dgram();
         assert!(had_input || output.is_some());
         input = output;
         qtrace!("handshake: t += {:?}", rtt / 2);
@@ -176,7 +176,7 @@ fn handshake(
         mem::swap(&mut a, &mut b);
     }
     if let Some(d) = input {
-        a.process_input(d, now);
+        a.process_input(&d, now);
     }
     now
 }
@@ -237,7 +237,7 @@ fn exchange_ticket(
     server.send_ticket(now, &[]).expect("can send ticket");
     let ticket = server.process_output(now).dgram();
     assert!(ticket.is_some());
-    client.process_input(ticket.unwrap(), now);
+    client.process_input(&ticket.unwrap(), now);
     assert_eq!(*client.state(), State::Confirmed);
     get_tokens(client).pop().expect("should have token")
 }
@@ -257,8 +257,8 @@ fn force_idle(
     let c1 = send_something(client, now);
     let c2 = send_something(client, now);
     now += rtt / 2;
-    server.process_input(c2, now);
-    server.process_input(c1, now);
+    server.process_input(&c2, now);
+    server.process_input(&c1, now);
 
     // Now do the same for the server.  (The ACK is in the first one.)
     qtrace!("force_idle: send reordered server packets");
@@ -266,17 +266,20 @@ fn force_idle(
     let s2 = send_something(server, now);
     now += rtt / 2;
     // Delivering s2 first at the client causes it to want to ACK.
-    client.process_input(s2, now);
+    client.process_input(&s2, now);
     // Delivering s1 should not have the client change its mind about the ACK.
-    let ack = client.process(Some(s1), now).dgram();
-    assert!(ack.is_some());
+    let ack = client.process(Some(&s1), now);
+    assert!(ack.as_dgram_ref().is_some());
     let idle_timeout = min(
         client.conn_params.get_idle_timeout(),
         server.conn_params.get_idle_timeout(),
     );
     assert_eq!(client.process_output(now), Output::Callback(idle_timeout));
     now += rtt / 2;
-    assert_eq!(server.process(ack, now), Output::Callback(idle_timeout));
+    assert_eq!(
+        server.process(ack.as_dgram_ref(), now),
+        Output::Callback(idle_timeout)
+    );
     now
 }
 
@@ -359,7 +362,7 @@ fn increase_cwnd(
         let pkt = sender.process_output(now);
         match pkt {
             Output::Datagram(dgram) => {
-                receiver.process_input(dgram, now + DEFAULT_RTT / 2);
+                receiver.process_input(&dgram, now + DEFAULT_RTT / 2);
             }
             Output::Callback(t) => {
                 if t < DEFAULT_RTT {
@@ -376,7 +379,7 @@ fn increase_cwnd(
     now += DEFAULT_RTT / 2;
     let ack = receiver.process_output(now).dgram();
     now += DEFAULT_RTT / 2;
-    sender.process_input(ack.unwrap(), now);
+    sender.process_input(&ack.unwrap(), now);
     now
 }
 
@@ -395,7 +398,7 @@ where
     let in_dgrams = in_dgrams.into_iter();
     qdebug!([dest], "ack_bytes {} datagrams", in_dgrams.len());
     for dgram in in_dgrams {
-        dest.process_input(dgram, now);
+        dest.process_input(&dgram, now);
     }
 
     loop {
@@ -461,7 +464,7 @@ fn induce_persistent_congestion(
 
     // An ACK for the third PTO causes persistent congestion.
     let s_ack = ack_bytes(server, stream, c_tx_dgrams, now);
-    client.process_input(s_ack, now);
+    client.process_input(&s_ack, now);
     assert_eq!(cwnd(client), CWND_MIN);
     now
 }
@@ -542,7 +545,7 @@ fn send_and_receive(
     now: Instant,
 ) -> Option<Datagram> {
     let dgram = send_something(sender, now);
-    receiver.process(Some(dgram), now).dgram()
+    receiver.process(Some(&dgram), now).dgram()
 }
 
 fn get_tokens(client: &mut Connection) -> Vec<ResumptionToken> {

--- a/neqo-transport/src/connection/tests/priority.rs
+++ b/neqo-transport/src/connection/tests/priority.rs
@@ -40,7 +40,7 @@ fn receive_stream() {
     assert_eq!(MESSAGE.len(), client.stream_send(id, MESSAGE).unwrap());
     let dgram = client.process_output(now()).dgram();
 
-    server.process_input(dgram.unwrap(), now());
+    server.process_input(&dgram.unwrap(), now());
     assert_eq!(
         server
             .stream_priority(
@@ -82,7 +82,7 @@ fn relative() {
         .unwrap();
 
     let dgram = client.process_output(now()).dgram();
-    server.process_input(dgram.unwrap(), now());
+    server.process_input(&dgram.unwrap(), now());
 
     // The "id_normal" stream will get a `NewStream` event, but no data.
     for e in server.events() {
@@ -113,7 +113,7 @@ fn reprioritize() {
         .unwrap();
 
     let dgram = client.process_output(now()).dgram();
-    server.process_input(dgram.unwrap(), now());
+    server.process_input(&dgram.unwrap(), now());
 
     // The "id_normal" stream will get a `NewStream` event, but no data.
     for e in server.events() {
@@ -132,7 +132,7 @@ fn reprioritize() {
         )
         .unwrap();
     let dgram = client.process_output(now()).dgram();
-    server.process_input(dgram.unwrap(), now());
+    server.process_input(&dgram.unwrap(), now());
 
     for e in server.events() {
         if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
@@ -163,7 +163,7 @@ fn repairing_loss() {
     let _lost = client.process_output(now).dgram();
     for _ in 0..5 {
         match client.process_output(now) {
-            Output::Datagram(d) => server.process_input(d, now),
+            Output::Datagram(d) => server.process_input(&d, now),
             Output::Callback(delay) => now += delay,
             Output::None => unreachable!(),
         }
@@ -176,9 +176,9 @@ fn repairing_loss() {
     let id_normal = client.stream_create(StreamType::UniDi).unwrap();
     fill_stream(&mut client, id_normal);
 
-    let dgram = client.process(ack, now).dgram();
+    let dgram = client.process(ack.as_ref(), now).dgram();
     assert_eq!(client.stats().lost, 1); // Client should have noticed the loss.
-    server.process_input(dgram.unwrap(), now);
+    server.process_input(&dgram.unwrap(), now);
 
     // Only the low priority stream has data as the retransmission of the data from
     // the lost packet is now more important than new data from the high priority stream.
@@ -194,7 +194,7 @@ fn repairing_loss() {
     // the retransmitted data into a second packet, it will also contain data from the
     // normal priority stream.
     let dgram = client.process_output(now).dgram();
-    server.process_input(dgram.unwrap(), now);
+    server.process_input(&dgram.unwrap(), now);
     assert!(server.events().any(
         |e| matches!(e, ConnectionEvent::RecvStreamReadable { stream_id } if stream_id == id_normal),
     ));
@@ -209,8 +209,8 @@ fn critical() {
     // Rather than connect, send stream data in 0.5-RTT.
     // That allows this to test that critical streams pre-empt most frame types.
     let dgram = client.process_output(now).dgram();
-    let dgram = server.process(dgram, now).dgram();
-    client.process_input(dgram.unwrap(), now);
+    let dgram = server.process(dgram.as_ref(), now).dgram();
+    client.process_input(&dgram.unwrap(), now);
     maybe_authenticate(&mut client);
 
     let id = server.stream_create(StreamType::UniDi).unwrap();
@@ -237,8 +237,8 @@ fn critical() {
     assert_eq!(stats_after.handshake_done, 0);
 
     // Complete the handshake.
-    let dgram = client.process(dgram, now).dgram();
-    server.process_input(dgram.unwrap(), now);
+    let dgram = client.process(dgram.as_ref(), now).dgram();
+    server.process_input(&dgram.unwrap(), now);
 
     // Critical beats everything but HANDSHAKE_DONE.
     let stats_before = server.stats().frame_tx;
@@ -260,8 +260,8 @@ fn important() {
     // Rather than connect, send stream data in 0.5-RTT.
     // That allows this to test that important streams pre-empt most frame types.
     let dgram = client.process_output(now).dgram();
-    let dgram = server.process(dgram, now).dgram();
-    client.process_input(dgram.unwrap(), now);
+    let dgram = server.process(dgram.as_ref(), now).dgram();
+    client.process_input(&dgram.unwrap(), now);
     maybe_authenticate(&mut client);
 
     let id = server.stream_create(StreamType::UniDi).unwrap();
@@ -289,8 +289,8 @@ fn important() {
     assert_eq!(stats_after.stream, stats_before.stream + 1);
 
     // Complete the handshake.
-    let dgram = client.process(dgram, now).dgram();
-    server.process_input(dgram.unwrap(), now);
+    let dgram = client.process(dgram.as_ref(), now).dgram();
+    server.process_input(&dgram.unwrap(), now);
 
     // Important beats everything but flow control.
     let stats_before = server.stats().frame_tx;
@@ -313,8 +313,8 @@ fn high_normal() {
     // Rather than connect, send stream data in 0.5-RTT.
     // That allows this to test that important streams pre-empt most frame types.
     let dgram = client.process_output(now).dgram();
-    let dgram = server.process(dgram, now).dgram();
-    client.process_input(dgram.unwrap(), now);
+    let dgram = server.process(dgram.as_ref(), now).dgram();
+    client.process_input(&dgram.unwrap(), now);
     maybe_authenticate(&mut client);
 
     let id = server.stream_create(StreamType::UniDi).unwrap();
@@ -342,8 +342,8 @@ fn high_normal() {
     assert_eq!(stats_after.stream, stats_before.stream + 1);
 
     // Complete the handshake.
-    let dgram = client.process(dgram, now).dgram();
-    server.process_input(dgram.unwrap(), now);
+    let dgram = client.process(dgram.as_ref(), now).dgram();
+    server.process_input(&dgram.unwrap(), now);
 
     // High or Normal doesn't beat NEW_CONNECTION_ID,
     // but they beat CRYPTO/NEW_TOKEN.

--- a/neqo-transport/src/connection/tests/resumption.rs
+++ b/neqo-transport/src/connection/tests/resumption.rs
@@ -55,7 +55,7 @@ fn remember_smoothed_rtt() {
     let ticket = server.process_output(now).dgram();
     assert!(ticket.is_some());
     now += RTT1 / 2;
-    client.process_input(ticket.unwrap(), now);
+    client.process_input(&ticket.unwrap(), now);
     let token = get_tokens(&mut client).pop().unwrap();
 
     let mut client = default_client();
@@ -122,7 +122,7 @@ fn two_tickets_on_timer() {
     let pkt = send_something(&mut server, now());
 
     // process() will return an ack first
-    assert!(client.process(Some(pkt), now()).dgram().is_some());
+    assert!(client.process(Some(&pkt), now()).dgram().is_some());
     // We do not have a ResumptionToken event yet, because NEW_TOKEN was not sent.
     assert_eq!(get_tokens(&mut client).len(), 0);
 
@@ -163,7 +163,7 @@ fn two_tickets_with_new_token() {
     server.send_ticket(now(), &[]).expect("send ticket2");
     let pkt = send_something(&mut server, now());
 
-    client.process_input(pkt, now());
+    client.process_input(&pkt, now());
     let mut all_tokens = get_tokens(&mut client);
     assert_eq!(all_tokens.len(), 2);
     let token1 = all_tokens.pop().unwrap();
@@ -184,7 +184,7 @@ fn take_token() {
 
     server.send_ticket(now(), &[]).unwrap();
     let dgram = server.process(None, now()).dgram();
-    client.process_input(dgram.unwrap(), now());
+    client.process_input(&dgram.unwrap(), now());
 
     // There should be no ResumptionToken event here.
     let tokens = get_tokens(&mut client);

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -34,10 +34,10 @@ fn stream_create() {
 
     let out = client.process(None, now());
     let mut server = default_server();
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
 
-    let out = client.process(out.dgram(), now());
-    mem::drop(server.process(out.dgram(), now()));
+    let out = client.process(out.as_dgram_ref(), now());
+    mem::drop(server.process(out.as_dgram_ref(), now()));
     assert!(maybe_authenticate(&mut client));
     let out = client.process(None, now());
 
@@ -47,7 +47,7 @@ fn stream_create() {
     assert_eq!(client.stream_create(StreamType::BiDi).unwrap(), 0);
     assert_eq!(client.stream_create(StreamType::BiDi).unwrap(), 4);
 
-    mem::drop(server.process(out.dgram(), now()));
+    mem::drop(server.process(out.as_dgram_ref(), now()));
     // server now in State::Connected
     assert_eq!(server.stream_create(StreamType::UniDi).unwrap(), 3);
     assert_eq!(server.stream_create(StreamType::UniDi).unwrap(), 7);
@@ -86,7 +86,7 @@ fn transfer() {
 
     qdebug!("---- server receives");
     for d in datagrams {
-        let out = server.process(Some(d), now());
+        let out = server.process(Some(&d), now());
         // With an RTT of zero, the server will acknowledge every packet immediately.
         assert!(out.as_dgram_ref().is_some());
         qdebug!("Output={:0x?}", out.as_dgram_ref());
@@ -157,7 +157,7 @@ fn sendorder_test(order_of_sendorder: &[Option<SendOrder>]) {
 
     qdebug!("---- server receives");
     for d in datagrams {
-        let out = server.process(Some(d), now());
+        let out = server.process(Some(&d), now());
         qdebug!("Output={:0x?}", out.as_dgram_ref());
     }
     assert_eq!(*server.state(), State::Confirmed);
@@ -324,11 +324,11 @@ fn report_fin_when_stream_closed_wo_data() {
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
     let out = client.process(None, now());
-    mem::drop(server.process(out.dgram(), now()));
+    mem::drop(server.process(out.as_dgram_ref(), now()));
 
     server.stream_close_send(stream_id).unwrap();
     let out = server.process(None, now());
-    mem::drop(client.process(out.dgram(), now()));
+    mem::drop(client.process(out.as_dgram_ref(), now()));
     let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
     assert!(client.events().any(stream_readable));
 }
@@ -336,9 +336,9 @@ fn report_fin_when_stream_closed_wo_data() {
 fn exchange_data(client: &mut Connection, server: &mut Connection) {
     let mut input = None;
     loop {
-        let out = client.process(input, now()).dgram();
+        let out = client.process(input.as_ref(), now()).dgram();
         let c_done = out.is_none();
-        let out = server.process(out, now()).dgram();
+        let out = server.process(out.as_ref(), now()).dgram();
         if out.is_none() && c_done {
             break;
         }
@@ -380,7 +380,7 @@ fn sending_max_data() {
     assert!(!fin);
 
     let out = server.process(None, now()).dgram();
-    client.process_input(out.unwrap(), now());
+    client.process_input(&out.unwrap(), now());
 
     assert_eq!(
         client
@@ -521,7 +521,7 @@ fn do_not_accept_data_after_stop_sending() {
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
     let out = client.process(None, now());
-    mem::drop(server.process(out.dgram(), now()));
+    mem::drop(server.process(out.as_dgram_ref(), now()));
 
     let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
     assert!(server.events().any(stream_readable));
@@ -538,10 +538,10 @@ fn do_not_accept_data_after_stop_sending() {
 
     // Receive the second data frame. The frame should be ignored and
     // DataReadable events shouldn't be posted.
-    let out = server.process(out_second_data_frame.dgram(), now());
+    let out = server.process(out_second_data_frame.as_dgram_ref(), now());
     assert!(!server.events().any(stream_readable));
 
-    mem::drop(client.process(out.dgram(), now()));
+    mem::drop(client.process(out.as_dgram_ref(), now()));
     assert_eq!(
         Err(Error::FinalSizeError),
         client.stream_send(stream_id, &[0x00])
@@ -559,7 +559,7 @@ fn simultaneous_stop_sending_and_reset() {
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
     let out = client.process(None, now());
-    let ack = server.process(out.dgram(), now()).dgram();
+    let ack = server.process(out.as_dgram_ref(), now()).dgram();
 
     let stream_readable =
         |e| matches!(e, ConnectionEvent::RecvStreamReadable { stream_id: id } if id == stream_id);
@@ -568,23 +568,23 @@ fn simultaneous_stop_sending_and_reset() {
     // The client resets the stream. The packet with reset should arrive after the server
     // has already requested stop_sending.
     client.stream_reset_send(stream_id, 0).unwrap();
-    let out_reset_frame = client.process(ack, now()).dgram();
+    let out_reset_frame = client.process(ack.as_ref(), now()).dgram();
 
     // Send something out of order to force the server to generate an
     // acknowledgment at the next opportunity.
     let force_ack = send_something(&mut client, now());
-    server.process_input(force_ack, now());
+    server.process_input(&force_ack, now());
 
     // Call stop sending.
     server.stream_stop_sending(stream_id, 0).unwrap();
     // Receive the second data frame. The frame should be ignored and
     // DataReadable events shouldn't be posted.
-    let ack = server.process(out_reset_frame, now()).dgram();
+    let ack = server.process(out_reset_frame.as_ref(), now()).dgram();
     assert!(ack.is_some());
     assert!(!server.events().any(stream_readable));
 
     // The client gets the STOP_SENDING frame.
-    client.process_input(ack.unwrap(), now());
+    client.process_input(&ack.unwrap(), now());
     assert_eq!(
         Err(Error::InvalidStreamId),
         client.stream_send(stream_id, &[0x00])
@@ -600,13 +600,13 @@ fn client_fin_reorder() {
     let client_hs = client.process(None, now());
     assert!(client_hs.as_dgram_ref().is_some());
 
-    let server_hs = server.process(client_hs.dgram(), now());
+    let server_hs = server.process(client_hs.as_dgram_ref(), now());
     assert!(server_hs.as_dgram_ref().is_some()); // ServerHello, etc...
 
-    let client_ack = client.process(server_hs.dgram(), now());
+    let client_ack = client.process(server_hs.as_dgram_ref(), now());
     assert!(client_ack.as_dgram_ref().is_some());
 
-    let server_out = server.process(client_ack.dgram(), now());
+    let server_out = server.process(client_ack.as_dgram_ref(), now());
     assert!(server_out.as_dgram_ref().is_none());
 
     assert!(maybe_authenticate(&mut client));
@@ -621,11 +621,11 @@ fn client_fin_reorder() {
     assert!(client_stream_data.as_dgram_ref().is_some());
 
     // Now stream data gets before client_fin
-    let server_out = server.process(client_stream_data.dgram(), now());
+    let server_out = server.process(client_stream_data.as_dgram_ref(), now());
     assert!(server_out.as_dgram_ref().is_none()); // the packet will be discarded
 
     assert_eq!(*server.state(), State::Handshaking);
-    let server_out = server.process(client_fin.dgram(), now());
+    let server_out = server.process(client_fin.as_dgram_ref(), now());
     assert!(server_out.as_dgram_ref().is_some());
 }
 
@@ -641,7 +641,7 @@ fn after_fin_is_read_conn_events_for_stream_should_be_removed() {
     let out = server.process(None, now()).dgram();
     assert!(out.is_some());
 
-    mem::drop(client.process(out, now()));
+    mem::drop(client.process(out.as_ref(), now()));
 
     // read from the stream before checking connection events.
     let mut buf = vec![0; 4000];
@@ -666,7 +666,7 @@ fn after_stream_stop_sending_is_called_conn_events_for_stream_should_be_removed(
     let out = server.process(None, now()).dgram();
     assert!(out.is_some());
 
-    mem::drop(client.process(out, now()));
+    mem::drop(client.process(out.as_ref(), now()));
 
     // send stop seending.
     client
@@ -695,7 +695,7 @@ fn stream_data_blocked_generates_max_stream_data() {
     assert!(dgram.is_some());
 
     // Consume the data.
-    client.process_input(dgram.unwrap(), now);
+    client.process_input(&dgram.unwrap(), now);
     let mut buf = [0; 10];
     let (count, end) = client.stream_recv(stream_id, &mut buf[..]).unwrap();
     assert_eq!(count, DEFAULT_STREAM_DATA.len());
@@ -712,14 +712,14 @@ fn stream_data_blocked_generates_max_stream_data() {
     assert!(dgram.is_some());
 
     let sdb_before = client.stats().frame_rx.stream_data_blocked;
-    let dgram = client.process(dgram, now).dgram();
+    let dgram = client.process(dgram.as_ref(), now).dgram();
     assert_eq!(client.stats().frame_rx.stream_data_blocked, sdb_before + 1);
     assert!(dgram.is_some());
 
     // Client should have sent a MAX_STREAM_DATA frame with just a small increase
     // on the default window size.
     let msd_before = server.stats().frame_rx.max_stream_data;
-    server.process_input(dgram.unwrap(), now);
+    server.process_input(&dgram.unwrap(), now);
     assert_eq!(server.stats().frame_rx.max_stream_data, msd_before + 1);
 
     // Test that the entirety of the receive buffer is available now.
@@ -754,19 +754,19 @@ fn max_streams_after_bidi_closed() {
     let dgram = client.process(None, now()).dgram();
 
     // Now handle the stream and send an incomplete response.
-    server.process_input(dgram.unwrap(), now());
+    server.process_input(&dgram.unwrap(), now());
     server.stream_send(stream_id, RESPONSE).unwrap();
     let dgram = server.process_output(now()).dgram();
 
     // The server shouldn't have released more stream credit.
-    client.process_input(dgram.unwrap(), now());
+    client.process_input(&dgram.unwrap(), now());
     let e = client.stream_create(StreamType::BiDi).unwrap_err();
     assert!(matches!(e, Error::StreamLimitError));
 
     // Closing the stream isn't enough.
     server.stream_close_send(stream_id).unwrap();
     let dgram = server.process_output(now()).dgram();
-    client.process_input(dgram.unwrap(), now());
+    client.process_input(&dgram.unwrap(), now());
     assert!(client.stream_create(StreamType::BiDi).is_err());
 
     // The server needs to see an acknowledgment from the client for its
@@ -780,12 +780,12 @@ fn max_streams_after_bidi_closed() {
     // We need an ACK from the client now, but that isn't guaranteed,
     // so give the client one more packet just in case.
     let dgram = send_something(&mut server, now());
-    client.process_input(dgram, now());
+    client.process_input(&dgram, now());
 
     // Now get the client to send the ACK and have the server handle that.
     let dgram = send_something(&mut client, now());
-    let dgram = server.process(Some(dgram), now()).dgram();
-    client.process_input(dgram.unwrap(), now());
+    let dgram = server.process(Some(&dgram), now()).dgram();
+    client.process_input(&dgram.unwrap(), now());
     assert!(client.stream_create(StreamType::BiDi).is_ok());
     assert!(client.stream_create(StreamType::BiDi).is_err());
 }
@@ -800,7 +800,7 @@ fn no_dupdata_readable_events() {
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
     let out = client.process(None, now());
-    mem::drop(server.process(out.dgram(), now()));
+    mem::drop(server.process(out.as_dgram_ref(), now()));
 
     // We have a data_readable event.
     let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
@@ -810,7 +810,7 @@ fn no_dupdata_readable_events() {
     // therefore there should not be a new DataReadable event.
     client.stream_send(stream_id, &[0x00]).unwrap();
     let out_second_data_frame = client.process(None, now());
-    mem::drop(server.process(out_second_data_frame.dgram(), now()));
+    mem::drop(server.process(out_second_data_frame.as_dgram_ref(), now()));
     assert!(!server.events().any(stream_readable));
 
     // One more frame with a fin will not produce a new DataReadable event, because the
@@ -818,7 +818,7 @@ fn no_dupdata_readable_events() {
     client.stream_send(stream_id, &[0x00]).unwrap();
     client.stream_close_send(stream_id).unwrap();
     let out_third_data_frame = client.process(None, now());
-    mem::drop(server.process(out_third_data_frame.dgram(), now()));
+    mem::drop(server.process(out_third_data_frame.as_dgram_ref(), now()));
     assert!(!server.events().any(stream_readable));
 }
 
@@ -832,7 +832,7 @@ fn no_dupdata_readable_events_empty_last_frame() {
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
     let out = client.process(None, now());
-    mem::drop(server.process(out.dgram(), now()));
+    mem::drop(server.process(out.as_dgram_ref(), now()));
 
     // We have a data_readable event.
     let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
@@ -842,7 +842,7 @@ fn no_dupdata_readable_events_empty_last_frame() {
     // the previous stream data has not been read yet.
     client.stream_close_send(stream_id).unwrap();
     let out_second_data_frame = client.process(None, now());
-    mem::drop(server.process(out_second_data_frame.dgram(), now()));
+    mem::drop(server.process(out_second_data_frame.as_dgram_ref(), now()));
     assert!(!server.events().any(stream_readable));
 }
 
@@ -864,14 +864,14 @@ fn change_flow_control(stream_type: StreamType, new_fc: u64) {
 
     // Send the stream to the client.
     let out = server.process(None, now());
-    mem::drop(client.process(out.dgram(), now()));
+    mem::drop(client.process(out.as_dgram_ref(), now()));
 
     // change max_stream_data for stream_id.
     client.set_stream_max_data(stream_id, new_fc).unwrap();
 
     // server should receive a MAX_SREAM_DATA frame if the flow control window is updated.
     let out2 = client.process(None, now());
-    let out3 = server.process(out2.dgram(), now());
+    let out3 = server.process(out2.as_dgram_ref(), now());
     let expected = usize::from(RECV_BUFFER_START < new_fc);
     assert_eq!(server.stats().frame_rx.max_stream_data, expected);
 
@@ -884,9 +884,9 @@ fn change_flow_control(stream_type: StreamType, new_fc: u64) {
     }
 
     // Exchange packets so that client gets all data.
-    let out4 = client.process(out3.dgram(), now());
-    let out5 = server.process(out4.dgram(), now());
-    mem::drop(client.process(out5.dgram(), now()));
+    let out4 = client.process(out3.as_dgram_ref(), now());
+    let out5 = server.process(out4.as_dgram_ref(), now());
+    mem::drop(client.process(out5.as_dgram_ref(), now()));
 
     // read all data by client
     let mut buf = [0x0; 10000];
@@ -894,7 +894,7 @@ fn change_flow_control(stream_type: StreamType, new_fc: u64) {
     assert_eq!(u64::try_from(read).unwrap(), max(RECV_BUFFER_START, new_fc));
 
     let out4 = client.process(None, now());
-    mem::drop(server.process(out4.dgram(), now()));
+    mem::drop(server.process(out4.as_dgram_ref(), now()));
 
     let written3 = server.stream_send(stream_id, &[0x0; 10000]).unwrap();
     assert_eq!(u64::try_from(written3).unwrap(), new_fc);
@@ -949,12 +949,12 @@ fn session_flow_control_stop_sending_state_recv() {
     // The server sends STOP_SENDING -> the client sends RESET -> the server
     // sends MAX_DATA.
     let out = server.process(None, now()).dgram();
-    let out = client.process(out, now()).dgram();
+    let out = client.process(out.as_ref(), now()).dgram();
     // the client is still limited.
     let stream_id2 = client.stream_create(StreamType::UniDi).unwrap();
     assert_eq!(client.stream_avail_send_space(stream_id2).unwrap(), 0);
-    let out = server.process(out, now()).dgram();
-    client.process_input(out.unwrap(), now());
+    let out = server.process(out.as_ref(), now()).dgram();
+    client.process_input(&out.unwrap(), now());
     assert_eq!(
         client.stream_avail_send_space(stream_id2).unwrap(),
         SMALL_MAX_DATA
@@ -991,7 +991,7 @@ fn session_flow_control_stop_sending_state_size_known() {
     client.stream_close_send(stream_id).unwrap();
     let out2 = client.process(None, now()).dgram();
 
-    server.process_input(out2.unwrap(), now());
+    server.process_input(&out2.unwrap(), now());
 
     server
         .stream_stop_sending(stream_id, Error::NoError.code())
@@ -1000,8 +1000,8 @@ fn session_flow_control_stop_sending_state_size_known() {
     // In this case the final size is known when stream_stop_sending is called
     // and the server releases flow control immediately and sends STOP_SENDING and
     // MAX_DATA in the same packet.
-    let out = server.process(out1, now()).dgram();
-    client.process_input(out.unwrap(), now());
+    let out = server.process(out1.as_ref(), now()).dgram();
+    client.process_input(&out.unwrap(), now());
 
     // The flow control should have been updated and the client can again send
     // SMALL_MAX_DATA.
@@ -1123,10 +1123,10 @@ fn connect_w_different_limit(bidi_limit: u64, unidi_limit: u64) {
             .max_streams(StreamType::BiDi, bidi_limit)
             .max_streams(StreamType::UniDi, unidi_limit),
     );
-    let out = server.process(out.dgram(), now());
+    let out = server.process(out.as_dgram_ref(), now());
 
-    let out = client.process(out.dgram(), now());
-    mem::drop(server.process(out.dgram(), now()));
+    let out = client.process(out.as_dgram_ref(), now());
+    mem::drop(server.process(out.as_dgram_ref(), now()));
 
     assert!(maybe_authenticate(&mut client));
 

--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -30,7 +30,7 @@ fn unknown_version() {
     let mut unknown_version_packet = vec![0x80, 0x1a, 0x1a, 0x1a, 0x1a];
     unknown_version_packet.resize(1200, 0x0);
     mem::drop(client.process(
-        Some(Datagram::new(addr(), addr(), unknown_version_packet)),
+        Some(&Datagram::new(addr(), addr(), unknown_version_packet)),
         now(),
     ));
     assert_eq!(1, client.stats().dropped_rx);
@@ -45,7 +45,7 @@ fn server_receive_unknown_first_packet() {
 
     assert_eq!(
         server.process(
-            Some(Datagram::new(addr(), addr(), unknown_version_packet,)),
+            Some(&Datagram::new(addr(), addr(), unknown_version_packet,)),
             now(),
         ),
         Output::None
@@ -87,7 +87,7 @@ fn version_negotiation_current_version() {
     );
 
     let dgram = Datagram::new(addr(), addr(), vn);
-    let delay = client.process(Some(dgram), now()).callback();
+    let delay = client.process(Some(&dgram), now()).callback();
     assert_eq!(delay, INITIAL_PTO);
     assert_eq!(*client.state(), State::WaitInitial);
     assert_eq!(1, client.stats().dropped_rx);
@@ -106,7 +106,7 @@ fn version_negotiation_version0() {
     let vn = create_vn(&initial_pkt, &[0, 0x1a1a_1a1a]);
 
     let dgram = Datagram::new(addr(), addr(), vn);
-    let delay = client.process(Some(dgram), now()).callback();
+    let delay = client.process(Some(&dgram), now()).callback();
     assert_eq!(delay, INITIAL_PTO);
     assert_eq!(*client.state(), State::WaitInitial);
     assert_eq!(1, client.stats().dropped_rx);
@@ -125,7 +125,7 @@ fn version_negotiation_only_reserved() {
     let vn = create_vn(&initial_pkt, &[0x1a1a_1a1a, 0x2a2a_2a2a]);
 
     let dgram = Datagram::new(addr(), addr(), vn);
-    assert_eq!(client.process(Some(dgram), now()), Output::None);
+    assert_eq!(client.process(Some(&dgram), now()), Output::None);
     match client.state() {
         State::Closed(err) => {
             assert_eq!(*err, ConnectionError::Transport(Error::VersionNegotiation));
@@ -147,7 +147,7 @@ fn version_negotiation_corrupted() {
     let vn = create_vn(&initial_pkt, &[0x1a1a_1a1a, 0x2a2a_2a2a]);
 
     let dgram = Datagram::new(addr(), addr(), &vn[..vn.len() - 1]);
-    let delay = client.process(Some(dgram), now()).callback();
+    let delay = client.process(Some(&dgram), now()).callback();
     assert_eq!(delay, INITIAL_PTO);
     assert_eq!(*client.state(), State::WaitInitial);
     assert_eq!(1, client.stats().dropped_rx);
@@ -166,7 +166,7 @@ fn version_negotiation_empty() {
     let vn = create_vn(&initial_pkt, &[]);
 
     let dgram = Datagram::new(addr(), addr(), vn);
-    let delay = client.process(Some(dgram), now()).callback();
+    let delay = client.process(Some(&dgram), now()).callback();
     assert_eq!(delay, INITIAL_PTO);
     assert_eq!(*client.state(), State::WaitInitial);
     assert_eq!(1, client.stats().dropped_rx);
@@ -184,7 +184,7 @@ fn version_negotiation_not_supported() {
 
     let vn = create_vn(&initial_pkt, &[0x1a1a_1a1a, 0x2a2a_2a2a, 0xff00_0001]);
     let dgram = Datagram::new(addr(), addr(), vn);
-    assert_eq!(client.process(Some(dgram), now()), Output::None);
+    assert_eq!(client.process(Some(&dgram), now()), Output::None);
     match client.state() {
         State::Closed(err) => {
             assert_eq!(*err, ConnectionError::Transport(Error::VersionNegotiation));
@@ -207,7 +207,7 @@ fn version_negotiation_bad_cid() {
     let vn = create_vn(&initial_pkt, &[0x1a1a_1a1a, 0x2a2a_2a2a, 0xff00_0001]);
 
     let dgram = Datagram::new(addr(), addr(), vn);
-    let delay = client.process(Some(dgram), now()).callback();
+    let delay = client.process(Some(&dgram), now()).callback();
     assert_eq!(delay, INITIAL_PTO);
     assert_eq!(*client.state(), State::WaitInitial);
     assert_eq!(1, client.stats().dropped_rx);
@@ -244,11 +244,11 @@ fn compatible_upgrade_large_initial() {
     // Each should elicit a Version 1 ACK from the server.
     let dgram = client.process_output(now()).dgram();
     assert!(dgram.is_some());
-    let dgram = server.process(dgram, now()).dgram();
+    let dgram = server.process(dgram.as_ref(), now()).dgram();
     assert!(dgram.is_some());
     // The following uses the Version from *outside* this crate.
     assertions::assert_version(dgram.as_ref().unwrap(), Version::Version1.wire_version());
-    client.process_input(dgram.unwrap(), now());
+    client.process_input(&dgram.unwrap(), now());
 
     connect(&mut client, &mut server);
     assert_eq!(client.version(), Version::Version2);
@@ -312,7 +312,7 @@ fn version_negotiation_downgrade() {
     let initial = client.process_output(now()).dgram().unwrap();
     let vn = create_vn(&initial, &[DOWNGRADE.wire_version()]);
     let dgram = Datagram::new(addr(), addr(), vn);
-    client.process_input(dgram, now());
+    client.process_input(&dgram, now());
 
     connect_fail(
         &mut client,
@@ -332,7 +332,7 @@ fn invalid_server_version() {
         new_server(ConnectionParameters::default().versions(Version::Version2, Version::all()));
 
     let dgram = client.process_output(now()).dgram();
-    server.process_input(dgram.unwrap(), now());
+    server.process_input(&dgram.unwrap(), now());
 
     // One packet received.
     assert_eq!(server.stats().packets_rx, 1);
@@ -463,7 +463,7 @@ fn compatible_upgrade_0rtt_rejected() {
     let initial = send_something(&mut client, now());
     assertions::assert_version(&initial, Version::Version1.wire_version());
     assertions::assert_coalesced_0rtt(&initial);
-    server.process_input(initial, now());
+    server.process_input(&initial, now());
     assert!(!server
         .events()
         .any(|e| matches!(e, ConnectionEvent::NewStream { .. })));
@@ -471,9 +471,9 @@ fn compatible_upgrade_0rtt_rejected() {
     // Finalize the connection.  Don't use connect() because it uses
     // maybe_authenticate() too liberally and that eats the events we want to check.
     let dgram = server.process_output(now()).dgram(); // ServerHello flight
-    let dgram = client.process(dgram, now()).dgram(); // Client Finished (note: no authentication)
-    let dgram = server.process(dgram, now()).dgram(); // HANDSHAKE_DONE
-    client.process_input(dgram.unwrap(), now());
+    let dgram = client.process(dgram.as_ref(), now()).dgram(); // Client Finished (note: no authentication)
+    let dgram = server.process(dgram.as_ref(), now()).dgram(); // HANDSHAKE_DONE
+    client.process_input(&dgram.unwrap(), now());
 
     assert!(matches!(client.state(), State::Confirmed));
     assert!(matches!(server.state(), State::Confirmed));

--- a/neqo-transport/src/connection/tests/zerortt.rs
+++ b/neqo-transport/src/connection/tests/zerortt.rs
@@ -62,12 +62,12 @@ fn zero_rtt_send_recv() {
     // 0-RTT packets on their own shouldn't be padded to 1200.
     assert!(client_0rtt.as_dgram_ref().unwrap().len() < 1200);
 
-    let server_hs = server.process(client_hs.dgram(), now());
+    let server_hs = server.process(client_hs.as_dgram_ref(), now());
     assert!(server_hs.as_dgram_ref().is_some()); // ServerHello, etc...
 
     let all_frames = server.stats().frame_tx.all;
     let ack_frames = server.stats().frame_tx.ack;
-    let server_process_0rtt = server.process(client_0rtt.dgram(), now());
+    let server_process_0rtt = server.process(client_0rtt.as_dgram_ref(), now());
     assert!(server_process_0rtt.as_dgram_ref().is_some());
     assert_eq!(server.stats().frame_tx.all, all_frames + 1);
     assert_eq!(server.stats().frame_tx.ack, ack_frames + 1);
@@ -104,7 +104,7 @@ fn zero_rtt_send_coalesce() {
 
     assertions::assert_coalesced_0rtt(&client_0rtt.as_dgram_ref().unwrap()[..]);
 
-    let server_hs = server.process(client_0rtt.dgram(), now());
+    let server_hs = server.process(client_0rtt.as_dgram_ref(), now());
     assert!(server_hs.as_dgram_ref().is_some()); // Should produce ServerHello etc...
 
     let server_stream_id = server
@@ -161,9 +161,9 @@ fn zero_rtt_send_reject() {
     let client_0rtt = client.process(None, now());
     assert!(client_0rtt.as_dgram_ref().is_some());
 
-    let server_hs = server.process(client_hs.dgram(), now());
+    let server_hs = server.process(client_hs.as_dgram_ref(), now());
     assert!(server_hs.as_dgram_ref().is_some()); // Should produce ServerHello etc...
-    let server_ignored = server.process(client_0rtt.dgram(), now());
+    let server_ignored = server.process(client_0rtt.as_dgram_ref(), now());
     assert!(server_ignored.as_dgram_ref().is_none());
 
     // The server shouldn't receive that 0-RTT data.
@@ -171,14 +171,14 @@ fn zero_rtt_send_reject() {
     assert!(!server.events().any(recvd_stream_evt));
 
     // Client should get a rejection.
-    let client_fin = client.process(server_hs.dgram(), now());
+    let client_fin = client.process(server_hs.as_dgram_ref(), now());
     let recvd_0rtt_reject = |e| e == ConnectionEvent::ZeroRttRejected;
     assert!(client.events().any(recvd_0rtt_reject));
 
     // Server consume client_fin
-    let server_ack = server.process(client_fin.dgram(), now());
+    let server_ack = server.process(client_fin.as_dgram_ref(), now());
     assert!(server_ack.as_dgram_ref().is_some());
-    let client_out = client.process(server_ack.dgram(), now());
+    let client_out = client.process(server_ack.as_dgram_ref(), now());
     assert!(client_out.as_dgram_ref().is_none());
 
     // ...and the client stream should be gone.
@@ -194,7 +194,7 @@ fn zero_rtt_send_reject() {
     assert!(client_after_reject.is_some());
 
     // The server should receive new stream
-    server.process_input(client_after_reject.unwrap(), now());
+    server.process_input(&client_after_reject.unwrap(), now());
     assert!(server.events().any(recvd_stream_evt));
 }
 
@@ -233,8 +233,8 @@ fn zero_rtt_update_flow_control() {
     assert!(!client.stream_send_atomic(bidi_stream, MESSAGE).unwrap());
 
     // Now get the server transport parameters.
-    let server_hs = server.process(client_hs, now()).dgram();
-    client.process_input(server_hs.unwrap(), now());
+    let server_hs = server.process(client_hs.as_ref(), now()).dgram();
+    client.process_input(&server_hs.unwrap(), now());
 
     // The streams should report a writeable event.
     let mut uni_stream_event = false;

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -259,7 +259,7 @@ impl Server {
     fn process_connection(
         &mut self,
         c: StateRef,
-        dgram: Option<Datagram>,
+        dgram: Option<&Datagram>,
         now: Instant,
     ) -> Option<Datagram> {
         qtrace!([self], "Process connection {:?}", c);
@@ -310,7 +310,7 @@ impl Server {
     fn handle_initial(
         &mut self,
         initial: InitialDetails,
-        dgram: Datagram,
+        dgram: &Datagram,
         now: Instant,
     ) -> Option<Datagram> {
         qdebug!([self], "Handle initial");
@@ -364,7 +364,7 @@ impl Server {
     fn connection_attempt(
         &mut self,
         initial: InitialDetails,
-        dgram: Datagram,
+        dgram: &Datagram,
         orig_dcid: Option<ConnectionId>,
         now: Instant,
     ) -> Option<Datagram> {
@@ -465,7 +465,7 @@ impl Server {
         &mut self,
         attempt_key: AttemptKey,
         initial: InitialDetails,
-        dgram: Datagram,
+        dgram: &Datagram,
         orig_dcid: Option<ConnectionId>,
         now: Instant,
     ) -> Option<Datagram> {
@@ -511,7 +511,7 @@ impl Server {
     /// receives a connection ID from the server.
     fn handle_0rtt(
         &mut self,
-        dgram: Datagram,
+        dgram: &Datagram,
         dcid: ConnectionId,
         now: Instant,
     ) -> Option<Datagram> {
@@ -533,7 +533,7 @@ impl Server {
         }
     }
 
-    fn process_input(&mut self, dgram: Datagram, now: Instant) -> Option<Datagram> {
+    fn process_input(&mut self, dgram: &Datagram, now: Instant) -> Option<Datagram> {
         qtrace!("Process datagram: {}", hex(&dgram[..]));
 
         // This is only looking at the first packet header in the datagram.
@@ -629,7 +629,7 @@ impl Server {
         }
     }
 
-    pub fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
+    pub fn process(&mut self, dgram: Option<&Datagram>, now: Instant) -> Output {
         let out = if let Some(d) = dgram {
             self.process_input(d, now)
         } else {

--- a/neqo-transport/tests/common/mod.rs
+++ b/neqo-transport/tests/common/mod.rs
@@ -63,28 +63,28 @@ pub fn connect(client: &mut Connection, server: &mut Server) -> ActiveConnection
     server.set_validation(ValidateAddress::Never);
 
     assert_eq!(*client.state(), State::Init);
-    let dgram = client.process(None, now()).dgram(); // ClientHello
-    assert!(dgram.is_some());
-    let dgram = server.process(dgram, now()).dgram(); // ServerHello...
-    assert!(dgram.is_some());
+    let out = client.process(None, now()); // ClientHello
+    assert!(out.as_dgram_ref().is_some());
+    let out = server.process(out.as_dgram_ref(), now()); // ServerHello...
+    assert!(out.as_dgram_ref().is_some());
 
     // Ingest the server Certificate.
-    let dgram = client.process(dgram, now()).dgram();
-    assert!(dgram.is_some()); // This should just be an ACK.
-    let dgram = server.process(dgram, now()).dgram();
-    assert!(dgram.is_none()); // So the server should have nothing to say.
+    let out = client.process(out.as_dgram_ref(), now());
+    assert!(out.as_dgram_ref().is_some()); // This should just be an ACK.
+    let out = server.process(out.as_dgram_ref(), now());
+    assert!(out.as_dgram_ref().is_none()); // So the server should have nothing to say.
 
     // Now mark the server as authenticated.
     client.authenticated(AuthenticationStatus::Ok, now());
-    let dgram = client.process(None, now()).dgram();
-    assert!(dgram.is_some());
+    let out = client.process(None, now());
+    assert!(out.as_dgram_ref().is_some());
     assert_eq!(*client.state(), State::Connected);
-    let dgram = server.process(dgram, now()).dgram();
-    assert!(dgram.is_some()); // ACK + HANDSHAKE_DONE + NST
+    let out = server.process(out.as_dgram_ref(), now());
+    assert!(out.as_dgram_ref().is_some()); // ACK + HANDSHAKE_DONE + NST
 
     // Have the client process the HANDSHAKE_DONE.
-    let dgram = client.process(dgram, now()).dgram();
-    assert!(dgram.is_none());
+    let out = client.process(out.as_dgram_ref(), now());
+    assert!(out.as_dgram_ref().is_none());
     assert_eq!(*client.state(), State::Confirmed);
 
     connected_server(server)
@@ -225,14 +225,14 @@ pub fn generate_ticket(server: &mut Server) -> ResumptionToken {
     let mut server_conn = connect(&mut client, server);
 
     server_conn.borrow_mut().send_ticket(now(), &[]).unwrap();
-    let dgram = server.process(None, now()).dgram();
-    client.process_input(dgram.unwrap(), now()); // Consume ticket, ignore output.
+    let out = server.process(None, now());
+    client.process_input(out.as_dgram_ref().unwrap(), now()); // Consume ticket, ignore output.
     let ticket = find_ticket(&mut client);
 
     // Have the client close the connection and then let the server clean up.
     client.close(now(), 0, "got a ticket");
-    let dgram = client.process_output(now()).dgram();
-    mem::drop(server.process(dgram, now()));
+    let out = client.process_output(now());
+    mem::drop(server.process(out.as_dgram_ref(), now()));
     // Calling active_connections clears the set of active connections.
     assert_eq!(server.active_connections().len(), 1);
     ticket

--- a/neqo-transport/tests/conn_vectors.rs
+++ b/neqo-transport/tests/conn_vectors.rs
@@ -267,7 +267,7 @@ fn process_client_initial(v: Version, packet: &[u8]) {
 
     let dgram = Datagram::new(addr(), addr(), packet);
     assert_eq!(*server.state(), State::Init);
-    let out = server.process(Some(dgram), now());
+    let out = server.process(Some(&dgram), now());
     assert_eq!(*server.state(), State::Handshaking);
     assert!(out.dgram().is_some());
 }

--- a/neqo-transport/tests/connection.rs
+++ b/neqo-transport/tests/connection.rs
@@ -26,13 +26,13 @@ fn truncate_long_packet() {
     let mut client = default_client();
     let mut server = default_server();
 
-    let dgram = client.process(None, now()).dgram();
-    assert!(dgram.is_some());
-    let dgram = server.process(dgram, now()).dgram();
-    assert!(dgram.is_some());
+    let out = client.process(None, now());
+    assert!(out.as_dgram_ref().is_some());
+    let out = server.process(out.as_dgram_ref(), now());
+    assert!(out.as_dgram_ref().is_some());
 
     // This will truncate the Handshake packet from the server.
-    let dupe = dgram.as_ref().unwrap().clone();
+    let dupe = out.as_dgram_ref().unwrap().clone();
     // Count the padding in the packet, plus 1.
     let tail = dupe.iter().rev().take_while(|b| **b == 0).count() + 1;
     let truncated = Datagram::new(
@@ -40,19 +40,19 @@ fn truncate_long_packet() {
         dupe.destination(),
         &dupe[..(dupe.len() - tail)],
     );
-    let hs_probe = client.process(Some(truncated), now()).dgram();
+    let hs_probe = client.process(Some(&truncated), now()).dgram();
     assert!(hs_probe.is_some());
 
     // Now feed in the untruncated packet.
-    let dgram = client.process(dgram, now()).dgram();
-    assert!(dgram.is_some()); // Throw this ACK away.
+    let out = client.process(out.as_dgram_ref(), now());
+    assert!(out.as_dgram_ref().is_some()); // Throw this ACK away.
     assert!(test_fixture::maybe_authenticate(&mut client));
-    let dgram = client.process(None, now()).dgram();
-    assert!(dgram.is_some());
+    let out = client.process(None, now());
+    assert!(out.as_dgram_ref().is_some());
 
     assert!(client.state().connected());
-    let dgram = server.process(dgram, now()).dgram();
-    assert!(dgram.is_some());
+    let out = server.process(out.as_dgram_ref(), now());
+    assert!(out.as_dgram_ref().is_some());
     assert!(server.state().connected());
 }
 
@@ -67,12 +67,12 @@ fn reorder_server_initial() {
     );
     let mut server = default_server();
 
-    let client_initial = client.process_output(now()).dgram();
+    let client_initial = client.process_output(now());
     let (_, client_dcid, _, _) =
-        decode_initial_header(client_initial.as_ref().unwrap(), Role::Client);
+        decode_initial_header(client_initial.as_dgram_ref().unwrap(), Role::Client);
     let client_dcid = client_dcid.to_owned();
 
-    let server_packet = server.process(client_initial, now()).dgram();
+    let server_packet = server.process(client_initial.as_dgram_ref(), now()).dgram();
     let (server_initial, server_hs) = split_datagram(server_packet.as_ref().unwrap());
     let (protected_header, _, _, payload) = decode_initial_header(&server_initial, Role::Server);
 
@@ -113,15 +113,15 @@ fn reorder_server_initial() {
     // Now a connection can be made successfully.
     // Though we modified the server's Initial packet, we get away with it.
     // TLS only authenticates the content of the CRYPTO frame, which was untouched.
-    client.process_input(reordered, now());
-    client.process_input(server_hs.unwrap(), now());
+    client.process_input(&reordered, now());
+    client.process_input(&server_hs.unwrap(), now());
     assert!(test_fixture::maybe_authenticate(&mut client));
-    let finished = client.process_output(now()).dgram();
+    let finished = client.process_output(now());
     assert_eq!(*client.state(), State::Connected);
 
-    let done = server.process(finished, now()).dgram();
+    let done = server.process(finished.as_dgram_ref(), now());
     assert_eq!(*server.state(), State::Confirmed);
 
-    client.process_input(done.unwrap(), now());
+    client.process_input(done.as_dgram_ref().unwrap(), now());
     assert_eq!(*client.state(), State::Confirmed);
 }

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -47,8 +47,8 @@ pub fn complete_connection(
     };
     while !is_done(client) {
         _ = test_fixture::maybe_authenticate(client);
-        let out = client.process(datagram, now());
-        let out = server.process(out.dgram(), now());
+        let out = client.process(datagram.as_ref(), now());
+        let out = server.process(out.as_dgram_ref(), now());
         datagram = out.dgram();
     }
 
@@ -109,11 +109,11 @@ fn connect_single_version_server() {
 
         if client.version() != version {
             // Run the version negotiation exchange if necessary.
-            let dgram = client.process_output(now()).dgram();
-            assert!(dgram.is_some());
-            let dgram = server.process(dgram, now()).dgram();
+            let out = client.process_output(now());
+            assert!(out.as_dgram_ref().is_some());
+            let dgram = server.process(out.as_dgram_ref(), now()).dgram();
             assertions::assert_vn(dgram.as_ref().unwrap());
-            client.process_input(dgram.unwrap(), now());
+            client.process_input(&dgram.unwrap(), now());
         }
 
         let server_conn = connect(&mut client, &mut server);
@@ -133,14 +133,14 @@ fn duplicate_initial() {
     let mut client = default_client();
 
     assert_eq!(*client.state(), State::Init);
-    let initial = client.process(None, now()).dgram();
-    assert!(initial.is_some());
+    let initial = client.process(None, now());
+    assert!(initial.as_dgram_ref().is_some());
 
     // The server should ignore a packets with the same remote address and
     // destination connection ID as an existing connection attempt.
-    let server_initial = server.process(initial.clone(), now()).dgram();
+    let server_initial = server.process(initial.as_dgram_ref(), now()).dgram();
     assert!(server_initial.is_some());
-    let dgram = server.process(initial, now()).dgram();
+    let dgram = server.process(initial.as_dgram_ref(), now()).dgram();
     assert!(dgram.is_none());
 
     assert_eq!(server.active_connections().len(), 1);
@@ -161,10 +161,10 @@ fn duplicate_initial_new_path() {
     );
 
     // The server should respond to both as these came from different addresses.
-    let dgram = server.process(Some(other), now()).dgram();
+    let dgram = server.process(Some(&other), now()).dgram();
     assert!(dgram.is_some());
 
-    let server_initial = server.process(Some(initial), now()).dgram();
+    let server_initial = server.process(Some(&initial), now()).dgram();
     assert!(server_initial.is_some());
 
     assert_eq!(server.active_connections().len(), 2);
@@ -177,16 +177,20 @@ fn different_initials_same_path() {
     let mut client1 = default_client();
     let mut client2 = default_client();
 
-    let client_initial1 = client1.process(None, now()).dgram();
-    assert!(client_initial1.is_some());
-    let client_initial2 = client2.process(None, now()).dgram();
-    assert!(client_initial2.is_some());
+    let client_initial1 = client1.process(None, now());
+    assert!(client_initial1.as_dgram_ref().is_some());
+    let client_initial2 = client2.process(None, now());
+    assert!(client_initial2.as_dgram_ref().is_some());
 
     // The server should respond to both as these came from different addresses.
-    let server_initial1 = server.process(client_initial1, now()).dgram();
+    let server_initial1 = server
+        .process(client_initial1.as_dgram_ref(), now())
+        .dgram();
     assert!(server_initial1.is_some());
 
-    let server_initial2 = server.process(client_initial2, now()).dgram();
+    let server_initial2 = server
+        .process(client_initial2.as_dgram_ref(), now())
+        .dgram();
     assert!(server_initial2.is_some());
 
     assert_eq!(server.active_connections().len(), 2);
@@ -199,10 +203,10 @@ fn same_initial_after_connected() {
     let mut server = default_server();
     let mut client = default_client();
 
-    let client_initial = client.process(None, now()).dgram();
-    assert!(client_initial.is_some());
+    let client_initial = client.process(None, now());
+    assert!(client_initial.as_dgram_ref().is_some());
 
-    let server_initial = server.process(client_initial.clone(), now()).dgram();
+    let server_initial = server.process(client_initial.as_dgram_ref(), now()).dgram();
     assert!(server_initial.is_some());
     complete_connection(&mut client, &mut server, server_initial);
     // This removes the connection from the active set until something happens to it.
@@ -210,7 +214,7 @@ fn same_initial_after_connected() {
 
     // Now make a new connection using the exact same initial as before.
     // The server should respond to an attempt to connect with the same Initial.
-    let dgram = server.process(client_initial, now()).dgram();
+    let dgram = server.process(client_initial.as_dgram_ref(), now()).dgram();
     assert!(dgram.is_some());
     // The server should make a new connection object.
     assert_eq!(server.active_connections().len(), 1);
@@ -232,7 +236,7 @@ fn drop_non_initial() {
     bogus_data.resize(1200, 66);
 
     let bogus = Datagram::new(test_fixture::addr(), test_fixture::addr(), bogus_data);
-    assert!(server.process(Some(bogus), now()).dgram().is_none());
+    assert!(server.process(Some(&bogus), now()).dgram().is_none());
 }
 
 #[test]
@@ -251,7 +255,7 @@ fn drop_short_initial() {
     bogus_data.resize(1199, 66);
 
     let bogus = Datagram::new(test_fixture::addr(), test_fixture::addr(), bogus_data);
-    assert!(server.process(Some(bogus), now()).dgram().is_none());
+    assert!(server.process(Some(&bogus), now()).dgram().is_none());
 }
 
 /// Verify that the server can read 0-RTT properly.  A more robust server would buffer
@@ -296,12 +300,12 @@ fn zero_rtt() {
     let c4 = client_send();
 
     // 0-RTT packets that arrive before the handshake get dropped.
-    mem::drop(server.process(Some(c2), now));
+    mem::drop(server.process(Some(&c2), now));
     assert!(server.active_connections().is_empty());
 
     // Now handshake and let another 0-RTT packet in.
-    let shs = server.process(Some(c1), now).dgram();
-    mem::drop(server.process(Some(c3), now));
+    let shs = server.process(Some(&c1), now);
+    mem::drop(server.process(Some(&c3), now));
     // The server will have received two STREAM frames now if it processed both packets.
     let active = server.active_connections();
     assert_eq!(active.len(), 1);
@@ -310,11 +314,11 @@ fn zero_rtt() {
     // Complete the handshake.  As the client was pacing 0-RTT packets, extend the time
     // a little so that the pacer doesn't prevent the Finished from being sent.
     now += now - start_time;
-    let cfin = client.process(shs, now).dgram();
-    mem::drop(server.process(cfin, now));
+    let cfin = client.process(shs.as_dgram_ref(), now);
+    mem::drop(server.process(cfin.as_dgram_ref(), now));
 
     // The server will drop this last 0-RTT packet.
-    mem::drop(server.process(Some(c4), now));
+    mem::drop(server.process(Some(&c4), now));
     let active = server.active_connections();
     assert_eq!(active.len(), 1);
     assert_eq!(active[0].borrow().stats().frame_rx.stream, 2);
@@ -332,21 +336,21 @@ fn new_token_0rtt() {
     let client_stream = client.stream_create(StreamType::UniDi).unwrap();
     client.stream_send(client_stream, &[1, 2, 3]).unwrap();
 
-    let dgram = client.process(None, now()).dgram(); // Initial w/0-RTT
-    assert!(dgram.is_some());
-    assertions::assert_initial(dgram.as_ref().unwrap(), true);
-    assertions::assert_coalesced_0rtt(dgram.as_ref().unwrap());
-    let dgram = server.process(dgram, now()).dgram(); // Initial
-    assert!(dgram.is_some());
-    assertions::assert_initial(dgram.as_ref().unwrap(), false);
+    let out = client.process(None, now()); // Initial w/0-RTT
+    assert!(out.as_dgram_ref().is_some());
+    assertions::assert_initial(out.as_dgram_ref().unwrap(), true);
+    assertions::assert_coalesced_0rtt(out.as_dgram_ref().unwrap());
+    let out = server.process(out.as_dgram_ref(), now()); // Initial
+    assert!(out.as_dgram_ref().is_some());
+    assertions::assert_initial(out.as_dgram_ref().unwrap(), false);
 
-    let dgram = client.process(dgram, now()).dgram();
+    let dgram = client.process(out.as_dgram_ref(), now());
     // Note: the client doesn't need to authenticate the server here
     // as there is no certificate; authentication is based on the ticket.
-    assert!(dgram.is_some());
+    assert!(out.as_dgram_ref().is_some());
     assert_eq!(*client.state(), State::Connected);
-    let dgram = server.process(dgram, now()).dgram(); // (done)
-    assert!(dgram.is_some());
+    let dgram = server.process(dgram.as_dgram_ref(), now()); // (done)
+    assert!(dgram.as_dgram_ref().is_some());
     connected_server(&mut server);
     assert!(client.tls_info().unwrap().resumed());
 }
@@ -368,7 +372,7 @@ fn new_token_different_port() {
     let d = dgram.unwrap();
     let src = SocketAddr::new(d.source().ip(), d.source().port() + 1);
     let dgram = Some(Datagram::new(src, d.destination(), &d[..]));
-    let dgram = server.process(dgram, now()).dgram(); // Retry
+    let dgram = server.process(dgram.as_ref(), now()).dgram(); // Retry
     assert!(dgram.is_some());
     assertions::assert_initial(dgram.as_ref().unwrap(), false);
 }
@@ -425,7 +429,7 @@ fn bad_client_initial() {
     let bad_dgram = Datagram::new(dgram.source(), dgram.destination(), ciphertext);
 
     // The server should reject this.
-    let response = server.process(Some(bad_dgram), now());
+    let response = server.process(Some(&bad_dgram), now());
     let close_dgram = response.dgram().unwrap();
     // The resulting datagram might contain multiple packets, but each is small.
     let (initial_close, rest) = split_datagram(&close_dgram);
@@ -439,7 +443,7 @@ fn bad_client_initial() {
 
     // The client should accept this new and stop trying to connect.
     // It will generate a CONNECTION_CLOSE first though.
-    let response = client.process(Some(close_dgram), now()).dgram();
+    let response = client.process(Some(&close_dgram), now()).dgram();
     assert!(response.is_some());
     // The client will now wait out its closing period.
     let delay = client.process(None, now()).callback();
@@ -471,7 +475,7 @@ fn version_negotiation_ignored() {
     let mut input = dgram.to_vec();
     input[1] ^= 0x12;
     let damaged = Datagram::new(dgram.source(), dgram.destination(), input.clone());
-    let vn = server.process(Some(damaged), now()).dgram();
+    let vn = server.process(Some(&damaged), now()).dgram();
 
     let mut dec = Decoder::from(&input[5..]); // Skip past version.
     let d_cid = dec.decode_vec(1).expect("client DCID").to_vec();
@@ -492,7 +496,7 @@ fn version_negotiation_ignored() {
     assert!(found, "valid version not found");
 
     // Client ignores VN packet that contain negotiated version.
-    let res = client.process(Some(vn), now());
+    let res = client.process(Some(&vn), now());
     assert!(res.callback() > Duration::new(0, 120));
     assert_eq!(client.state(), &State::WaitInitial);
 }
@@ -512,9 +516,9 @@ fn version_negotiation() {
     // `connect()` runs a fixed exchange, so manually run the Version Negotiation.
     let dgram = client.process_output(now()).dgram();
     assert!(dgram.is_some());
-    let dgram = server.process(dgram, now()).dgram();
+    let dgram = server.process(dgram.as_ref(), now()).dgram();
     assertions::assert_vn(dgram.as_ref().unwrap());
-    client.process_input(dgram.unwrap(), now());
+    client.process_input(&dgram.unwrap(), now());
 
     let sconn = connect(&mut client, &mut server);
     assert_eq!(client.version(), VN_VERSION);
@@ -548,22 +552,22 @@ fn version_negotiation_and_compatible() {
     let dgram = client.process_output(now()).dgram();
     assert!(dgram.is_some());
     assertions::assert_version(dgram.as_ref().unwrap(), ORIG_VERSION.wire_version());
-    let dgram = server.process(dgram, now()).dgram();
+    let dgram = server.process(dgram.as_ref(), now()).dgram();
     assertions::assert_vn(dgram.as_ref().unwrap());
-    client.process_input(dgram.unwrap(), now());
+    client.process_input(&dgram.unwrap(), now());
 
     let dgram = client.process(None, now()).dgram(); // ClientHello
     assertions::assert_version(dgram.as_ref().unwrap(), VN_VERSION.wire_version());
-    let dgram = server.process(dgram, now()).dgram(); // ServerHello...
+    let dgram = server.process(dgram.as_ref(), now()).dgram(); // ServerHello...
     assertions::assert_version(dgram.as_ref().unwrap(), COMPAT_VERSION.wire_version());
-    client.process_input(dgram.unwrap(), now());
+    client.process_input(&dgram.unwrap(), now());
 
     client.authenticated(AuthenticationStatus::Ok, now());
     let dgram = client.process_output(now()).dgram();
     assertions::assert_version(dgram.as_ref().unwrap(), COMPAT_VERSION.wire_version());
     assert_eq!(*client.state(), State::Connected);
-    let dgram = server.process(dgram, now()).dgram(); // ACK + HANDSHAKE_DONE + NST
-    client.process_input(dgram.unwrap(), now());
+    let dgram = server.process(dgram.as_ref(), now()).dgram(); // ACK + HANDSHAKE_DONE + NST
+    client.process_input(&dgram.unwrap(), now());
     assert_eq!(*client.state(), State::Confirmed);
 
     let sconn = connected_server(&mut server);
@@ -596,7 +600,7 @@ fn compatible_upgrade_resumption_and_vn() {
 
     server_conn.borrow_mut().send_ticket(now(), &[]).unwrap();
     let dgram = server.process(None, now()).dgram();
-    client.process_input(dgram.unwrap(), now()); // Consume ticket, ignore output.
+    client.process_input(&dgram.unwrap(), now()); // Consume ticket, ignore output.
     let ticket = find_ticket(&mut client);
 
     // This new server will reject the ticket, but it will also generate a VN packet.
@@ -610,9 +614,9 @@ fn compatible_upgrade_resumption_and_vn() {
     let dgram = client.process_output(now()).dgram();
     assert!(dgram.is_some());
     assertions::assert_version(dgram.as_ref().unwrap(), COMPAT_VERSION.wire_version());
-    let dgram = server.process(dgram, now()).dgram();
+    let dgram = server.process(dgram.as_ref(), now()).dgram();
     assertions::assert_vn(dgram.as_ref().unwrap());
-    client.process_input(dgram.unwrap(), now());
+    client.process_input(&dgram.unwrap(), now());
 
     let server_conn = connect(&mut client, &mut server);
     assert_eq!(client.version(), RESUMPTION_VERSION);
@@ -722,8 +726,8 @@ fn max_streams_after_0rtt_rejection() {
     client.enable_resumption(now(), &token).unwrap();
     _ = client.stream_create(StreamType::BiDi).unwrap();
     let dgram = client.process_output(now()).dgram();
-    let dgram = server.process(dgram, now()).dgram();
-    let dgram = client.process(dgram, now()).dgram();
+    let dgram = server.process(dgram.as_ref(), now()).dgram();
+    let dgram = client.process(dgram.as_ref(), now()).dgram();
     assert!(dgram.is_some()); // We're far enough along to complete the test now.
 
     // Make sure that we can create MAX_STREAMS uni- and bidirectional streams.

--- a/neqo-transport/tests/sim/connection.rs
+++ b/neqo-transport/tests/sim/connection.rs
@@ -120,7 +120,7 @@ impl Node for ConnectionNode {
     fn process(&mut self, mut d: Option<Datagram>, now: Instant) -> Output {
         _ = self.process_goals(|goal, c| goal.process(c, now));
         loop {
-            let res = self.c.process(d.take(), now);
+            let res = self.c.process(d.take().as_ref(), now);
 
             let mut active = false;
             while let Some(e) = self.c.next_event() {

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -203,7 +203,7 @@ pub fn handshake(client: &mut Connection, server: &mut Connection) {
     };
     while !is_done(a) {
         _ = maybe_authenticate(a);
-        let d = a.process(datagram, now());
+        let d = a.process(datagram.as_ref(), now());
         datagram = d.dgram();
         mem::swap(&mut a, &mut b);
     }


### PR DESCRIPTION
Fixes https://github.com/mozilla/neqo/issues/1538.

See discussion in https://github.com/mozilla/neqo/issues/1538#issuecomment-1879731931.