### PR TITLE
Fix qlog issues to enable correct qvis rendering

### DIFF
--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -8,13 +8,14 @@ license = "MIT OR Apache-2.0"
 build = "build.rs"
 
 [dependencies]
-log = {version = "0.4.0", default-features = false}
-env_logger = {version = "0.10", default-features = false}
+log = { version = "0.4.0", default-features = false }
+env_logger = { version = "0.10", default-features = false }
 lazy_static = "1.3.0"
 qlog = "0.11.0"
-time = {version = "0.3", features = ["formatting"]}
+time = { version = "0.3", features = ["formatting"] }
 
 [dev-dependencies]
+const_format = "~0.2.32"
 test-fixture = { path = "../test-fixture" }
 
 [features]

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -15,7 +15,6 @@ qlog = "0.11.0"
 time = { version = "0.3", features = ["formatting"] }
 
 [dev-dependencies]
-const_format = "~0.2.32"
 test-fixture = { path = "../test-fixture" }
 
 [features]

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -14,6 +14,9 @@ lazy_static = "1.3.0"
 qlog = "0.11.0"
 time = {version = "0.3", features = ["formatting"]}
 
+[dev-dependencies]
+test-fixture = { path = "../test-fixture" }
+
 [features]
 deny-warnings = []
 ci = []

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -29,12 +29,6 @@ pub struct NeqoQlogShared {
     streamer: QlogStreamer,
 }
 
-impl NeqoQlogShared {
-    pub fn streamer(&mut self) -> &mut QlogStreamer {
-        &mut self.streamer
-    }
-}
-
 impl NeqoQlog {
     /// Create an enabled `NeqoQlog` configuration.
     /// # Errors
@@ -159,7 +153,7 @@ pub fn new_trace(role: Role) -> qlog::TraceSeq {
 #[cfg(test)]
 mod test {
     use qlog::events::Event;
-    use test_fixture::{neqo_qlog_contents, new_neqo_qlog, EXPECTED_LOG_HEADER};
+    use test_fixture::{new_neqo_qlog, EXPECTED_LOG_HEADER};
 
     const EV_DATA: qlog::events::EventData =
         qlog::events::EventData::SpinBitUpdated(qlog::events::connectivity::SpinBitUpdated {
@@ -171,7 +165,7 @@ mod test {
     #[test]
     fn test_new_neqo_qlog() {
         let (_log, contents) = new_neqo_qlog();
-        assert_eq!(neqo_qlog_contents(&contents), EXPECTED_LOG_HEADER);
+        assert_eq!(contents.to_string(), EXPECTED_LOG_HEADER);
     }
 
     #[test]
@@ -179,7 +173,7 @@ mod test {
         let (mut log, contents) = new_neqo_qlog();
         log.add_event(|| Some(Event::with_time(1.1, EV_DATA)));
         assert_eq!(
-            neqo_qlog_contents(&contents),
+            contents.to_string(),
             format!(
                 "{EXPECTED_LOG_HEADER}{}",
                 EXPECTED_LOG_EVENT.replace("\"time\":0.0,", "\"time\":1.1,")

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -50,7 +50,7 @@ impl NeqoQlog {
 
     #[must_use]
     pub fn inner(&self) -> Rc<RefCell<Option<NeqoQlogShared>>> {
-        self.inner.clone()
+        Rc::clone(&self.inner)
     }
 
     /// Create a disabled `NeqoQlog` configuration.

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -170,16 +170,16 @@ mod test {
 
     #[test]
     fn test_new_neqo_qlog() {
-        let log = new_neqo_qlog();
-        assert_eq!(neqo_qlog_contents(&log), EXPECTED_LOG_HEADER);
+        let (_log, contents) = new_neqo_qlog();
+        assert_eq!(neqo_qlog_contents(&contents), EXPECTED_LOG_HEADER);
     }
 
     #[test]
     fn test_add_event() {
-        let mut log = new_neqo_qlog();
+        let (mut log, contents) = new_neqo_qlog();
         log.add_event(|| Some(Event::with_time(1.1, EV_DATA)));
         assert_eq!(
-            neqo_qlog_contents(&log),
+            neqo_qlog_contents(&contents),
             format!(
                 "{EXPECTED_LOG_HEADER}{}",
                 EXPECTED_LOG_EVENT.replace("\"time\":0.0,", "\"time\":1.1,")

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -152,6 +152,7 @@ pub fn new_trace(role: Role) -> qlog::TraceSeq {
 
 #[cfg(test)]
 mod test {
+    use const_format::concatcp;
     use qlog::events::Event;
     use test_fixture::{new_neqo_qlog, EXPECTED_LOG_HEADER};
 
@@ -160,7 +161,11 @@ mod test {
             state: true,
         });
 
-    const EXPECTED_LOG_EVENT: &str = "\u{1e}{\"time\":0.0,\"name\":\"connectivity:spin_bit_updated\",\"data\":{\"state\":true}}\n";
+    const EXPECTED_LOG_EVENT: &str = concatcp!(
+        "\u{1e}",
+        r#"{"time":0.0,"name":"connectivity:spin_bit_updated","data":{"state":true}}"#,
+        "\n"
+    );
 
     #[test]
     fn test_new_neqo_qlog() {

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -180,8 +180,8 @@ mod test {
         assert_eq!(
             contents.to_string(),
             format!(
-                "{EXPECTED_LOG_HEADER}{}",
-                EXPECTED_LOG_EVENT.replace("\"time\":0.0,", "\"time\":1.1,")
+                "{EXPECTED_LOG_HEADER}{e}",
+                e = EXPECTED_LOG_EVENT.replace("\"time\":0.0,", "\"time\":1.1,")
             )
         );
     }

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -184,7 +184,10 @@ mod test {
     }
 
     fn log_contents(log: &NeqoQlog) -> String {
+        // TODO: Figure out a way to make this less ugly.
+        #[allow(clippy::borrowed_box)]
         let w: &Box<std::io::Cursor<Vec<u8>>> = unsafe {
+            #[allow(clippy::transmute_ptr_to_ptr)]
             std::mem::transmute(log.inner.borrow_mut().as_mut().unwrap().streamer.writer())
         };
         String::from_utf8(w.as_ref().get_ref().clone()).unwrap()

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -168,7 +168,7 @@ mod test {
     );
 
     #[test]
-    fn test_new_neqo_qlog() {
+    fn new_neqo_qlog() {
         let (_log, contents) = new_neqo_qlog();
         assert_eq!(contents.to_string(), EXPECTED_LOG_HEADER);
     }

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -56,7 +56,7 @@ impl NeqoQlog {
 
     #[must_use]
     pub fn inner(&self) -> Rc<RefCell<Option<NeqoQlogShared>>> {
-        Rc::clone(&self.inner)
+        self.inner.clone()
     }
 
     /// Create a disabled `NeqoQlog` configuration.

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -174,7 +174,7 @@ mod test {
     }
 
     #[test]
-    fn test_add_event() {
+    fn add_event() {
         let (mut log, contents) = new_neqo_qlog();
         log.add_event(|| Some(Event::with_time(1.1, EV_DATA)));
         assert_eq!(

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -152,16 +152,15 @@ pub fn new_trace(role: Role) -> qlog::TraceSeq {
 
 #[cfg(test)]
 mod test {
-    use const_format::concatcp;
     use qlog::events::Event;
-    use test_fixture::{new_neqo_qlog, EXPECTED_LOG_HEADER};
+    use test_fixture::EXPECTED_LOG_HEADER;
 
     const EV_DATA: qlog::events::EventData =
         qlog::events::EventData::SpinBitUpdated(qlog::events::connectivity::SpinBitUpdated {
             state: true,
         });
 
-    const EXPECTED_LOG_EVENT: &str = concatcp!(
+    const EXPECTED_LOG_EVENT: &str = concat!(
         "\u{1e}",
         r#"{"time":0.0,"name":"connectivity:spin_bit_updated","data":{"state":true}}"#,
         "\n"
@@ -169,13 +168,13 @@ mod test {
 
     #[test]
     fn new_neqo_qlog() {
-        let (_log, contents) = new_neqo_qlog();
+        let (_log, contents) = test_fixture::new_neqo_qlog();
         assert_eq!(contents.to_string(), EXPECTED_LOG_HEADER);
     }
 
     #[test]
     fn add_event() {
-        let (mut log, contents) = new_neqo_qlog();
+        let (mut log, contents) = test_fixture::new_neqo_qlog();
         log.add_event(|| Some(Event::with_time(1.1, EV_DATA)));
         assert_eq!(
             contents.to_string(),

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -324,6 +324,10 @@ impl<SRT: Clone + PartialEq> ConnectionIdEntry<SRT> {
     pub fn connection_id(&self) -> &ConnectionId {
         &self.cid
     }
+
+    pub fn reset_token(&self) -> &SRT {
+        &self.srt
+    }
 }
 
 pub type RemoteConnectionIdEntry = ConnectionIdEntry<[u8; 16]>;

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -30,7 +30,7 @@ use std::{
 use test_fixture::{
     self, addr, addr_v4,
     assertions::{assert_v4_path, assert_v6_path},
-    fixture_init, now,
+    fixture_init, new_neqo_qlog, now,
 };
 
 /// This should be a valid-seeming transport parameter.
@@ -498,6 +498,7 @@ fn preferred_address(hs_client: SocketAddr, hs_server: SocketAddr, preferred: So
     };
 
     fixture_init();
+    let (log, _contents) = new_neqo_qlog();
     let mut client = Connection::new_client(
         test_fixture::DEFAULT_SERVER_NAME,
         test_fixture::DEFAULT_ALPN,
@@ -508,6 +509,7 @@ fn preferred_address(hs_client: SocketAddr, hs_server: SocketAddr, preferred: So
         now(),
     )
     .unwrap();
+    client.set_qlog(log);
     let spa = match preferred {
         SocketAddr::V6(v6) => PreferredAddress::new(None, Some(v6)),
         SocketAddr::V4(v4) => PreferredAddress::new(Some(v4), None),

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -30,6 +30,7 @@ use crate::{
     frame::{CloseError, Frame},
     packet::{DecryptedPacket, PacketNumber, PacketType, PublicPacket},
     path::PathRef,
+    stream_id::StreamType as NeqoStreamType,
     tparams::{self, TransportParametersHandler},
     tracking::SentPacket,
     version::{Version, VersionConfig, WireVersion},

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -19,7 +19,7 @@ use qlog::events::{
         AckedRanges, ErrorSpace, MetricsUpdated, PacketDropped, PacketHeader, PacketLost,
         PacketReceived, PacketSent, QuicFrame, StreamType, VersionInformation,
     },
-    EventData, RawInfo,
+    Event, EventData, RawInfo,
 };
 
 use neqo_common::{hex, qinfo, qlog::NeqoQlog, Decoder};
@@ -30,14 +30,13 @@ use crate::{
     frame::{CloseError, Frame},
     packet::{DecryptedPacket, PacketNumber, PacketType, PublicPacket},
     path::PathRef,
-    stream_id::StreamType as NeqoStreamType,
     tparams::{self, TransportParametersHandler},
     tracking::SentPacket,
     version::{Version, VersionConfig, WireVersion},
 };
 
 pub fn connection_tparams_set(qlog: &mut NeqoQlog, tph: &TransportParametersHandler) {
-    qlog.add_event_data(|| {
+    qlog.add_event(|| {
         let remote = tph.remote();
         let ev_data = EventData::TransportParametersSet(
             qlog::events::quic::TransportParametersSet {
@@ -61,20 +60,31 @@ pub fn connection_tparams_set(qlog: &mut NeqoQlog, tph: &TransportParametersHand
                 max_udp_payload_size: Some(remote.get_integer(tparams::MAX_UDP_PAYLOAD_SIZE) as u32),
                 ack_delay_exponent: Some(remote.get_integer(tparams::ACK_DELAY_EXPONENT) as u16),
                 max_ack_delay: Some(remote.get_integer(tparams::MAX_ACK_DELAY) as u16),
-                // TODO(hawkinsw@obs.cr): We do not yet handle ACTIVE_CONNECTION_ID_LIMIT in tparams yet.
-                active_connection_id_limit: None,
+                active_connection_id_limit: Some(remote.get_integer(tparams::ACTIVE_CONNECTION_ID_LIMIT) as u32),
                 initial_max_data: Some(remote.get_integer(tparams::INITIAL_MAX_DATA)),
                 initial_max_stream_data_bidi_local: Some(remote.get_integer(tparams::INITIAL_MAX_STREAM_DATA_BIDI_LOCAL)),
                 initial_max_stream_data_bidi_remote: Some(remote.get_integer(tparams::INITIAL_MAX_STREAM_DATA_BIDI_REMOTE)),
                 initial_max_stream_data_uni: Some(remote.get_integer(tparams::INITIAL_MAX_STREAM_DATA_UNI)),
                 initial_max_streams_bidi: Some(remote.get_integer(tparams::INITIAL_MAX_STREAMS_BIDI)),
                 initial_max_streams_uni: Some(remote.get_integer(tparams::INITIAL_MAX_STREAMS_UNI)),
-                // TODO(hawkinsw@obs.cr): We do not yet handle PREFERRED_ADDRESS in tparams yet.
-                preferred_address: None,
+                preferred_address: {
+                    match remote.get_preferred_address() {
+                        Some((paddr, cid)) => {
+                            Some(qlog::events::quic::PreferredAddress {
+                                ip_v4: paddr.ipv4()?.ip().to_string(),
+                                ip_v6: paddr.ipv6()?.ip().to_string(),
+                                port_v4: paddr.ipv4()?.port(),
+                                port_v6: paddr.ipv6()?.port(),
+                                connection_id: cid.connection_id().to_string(),
+                                stateless_reset_token: hex(cid.reset_token()),
+                            })
+                        }
+                        None => None,
+                    }
+                },
             });
 
-        // This event occurs very early, so just mark the time as 0.0.
-        Some(Event::with_time(0.0, ev_data))
+        Some(ev_data))
     });
 }
 

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -77,7 +77,7 @@ pub fn connection_tparams_set(qlog: &mut NeqoQlog, tph: &TransportParametersHand
                         connection_id: cid.connection_id().to_string(),
                         stateless_reset_token: hex(cid.reset_token()),
                     })
-                },
+                }),
             });
 
         Some(ev_data)

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -85,7 +85,7 @@ pub fn connection_tparams_set(qlog: &mut NeqoQlog, tph: &TransportParametersHand
                 },
             });
 
-        Some(ev_data))
+        Some(ev_data)
     });
 }
 
@@ -556,15 +556,20 @@ fn to_qlog_pkt_type(ptype: PacketType) -> qlog::events::quic::PacketType {
 
 #[cfg(test)]
 mod test {
-    // use crate::qlog::connection_started;
-    use test_fixture::{default_client, neqo_qlog_contents, new_neqo_qlog};
+    use test_fixture::{
+        default_client, default_server, handshake, neqo_qlog_contents, new_neqo_qlog,
+        EXPECTED_LOG_HEADER,
+    };
 
     #[test]
     fn test_connection_started() {
-        let mut log = new_neqo_qlog();
-        assert_eq!(neqo_qlog_contents(&log), "");
-        // let client = default_client();
-        // let path = test_fixture::new_test_path();
-        // connection_started(&mut log, client.paths.primary());
+        const CONNECTION_STARTED: &str = "\"name\":\"connectivity:connection_started\"";
+        let (log, contents) = new_neqo_qlog();
+        let mut client = default_client();
+        client.set_qlog(log);
+        handshake(&mut client, &mut default_server());
+        let c = neqo_qlog_contents(&contents);
+        assert!(c.starts_with(EXPECTED_LOG_HEADER));
+        assert!(c.contains(CONNECTION_STARTED));
     }
 }

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -68,20 +68,15 @@ pub fn connection_tparams_set(qlog: &mut NeqoQlog, tph: &TransportParametersHand
                 initial_max_stream_data_uni: Some(remote.get_integer(tparams::INITIAL_MAX_STREAM_DATA_UNI)),
                 initial_max_streams_bidi: Some(remote.get_integer(tparams::INITIAL_MAX_STREAMS_BIDI)),
                 initial_max_streams_uni: Some(remote.get_integer(tparams::INITIAL_MAX_STREAMS_UNI)),
-                preferred_address: {
-                    match remote.get_preferred_address() {
-                        Some((paddr, cid)) => {
-                            Some(qlog::events::quic::PreferredAddress {
-                                ip_v4: paddr.ipv4()?.ip().to_string(),
-                                ip_v6: paddr.ipv6()?.ip().to_string(),
-                                port_v4: paddr.ipv4()?.port(),
-                                port_v6: paddr.ipv6()?.port(),
-                                connection_id: cid.connection_id().to_string(),
-                                stateless_reset_token: hex(cid.reset_token()),
-                            })
-                        }
-                        None => None,
-                    }
+                preferred_address: remote.get_preferred_address().and_then(|(paddr, cid)| {
+                    Some(qlog::events::quic::PreferredAddress {
+                        ip_v4: paddr.ipv4()?.ip().to_string(),
+                        ip_v6: paddr.ipv6()?.ip().to_string(),
+                        port_v4: paddr.ipv4()?.port(),
+                        port_v6: paddr.ipv6()?.port(),
+                        connection_id: cid.connection_id().to_string(),
+                        stateless_reset_token: hex(cid.reset_token()),
+                    })
                 },
             });
 

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -19,7 +19,7 @@ use qlog::events::{
         AckedRanges, ErrorSpace, MetricsUpdated, PacketDropped, PacketHeader, PacketLost,
         PacketReceived, PacketSent, QuicFrame, StreamType, VersionInformation,
     },
-    Event, EventData, RawInfo,
+    EventData, RawInfo,
 };
 
 use neqo_common::{hex, qinfo, qlog::NeqoQlog, Decoder};
@@ -37,7 +37,7 @@ use crate::{
 };
 
 pub fn connection_tparams_set(qlog: &mut NeqoQlog, tph: &TransportParametersHandler) {
-    qlog.add_event(|| {
+    qlog.add_event_data(|| {
         let remote = tph.remote();
         let ev_data = EventData::TransportParametersSet(
             qlog::events::quic::TransportParametersSet {
@@ -552,69 +552,4 @@ fn to_qlog_pkt_type(ptype: PacketType) -> qlog::events::quic::PacketType {
         PacketType::VersionNegotiation => qlog::events::quic::PacketType::VersionNegotiation,
         PacketType::OtherVersion => qlog::events::quic::PacketType::Unknown,
     }
-}
-
-#[cfg(test)]
-mod test {
-    // #[test]
-    // fn test_qlog() {
-    //     // Adapted from https://github.com/cloudflare/quiche/blob/master/qlog/README.md
-    //     let mut trace = qlog::Trace::new(
-    //         qlog::VantagePoint {
-    //             name: Some("Test vantage point".to_string()),
-    //             ty: qlog::VantagePointType::Client,
-    //             flow: None,
-    //         },
-    //         Some("Test trace".to_string()),
-    //         Some("Test trace description".to_string()),
-    //         Some(qlog::Configuration {
-    //             time_offset: Some(0.0),
-    //             original_uris: None,
-    //         }),
-    //         None,
-    //     );
-
-    //     let scid = [0x7e, 0x37, 0xe4, 0xdc, 0xc6, 0x68, 0x2d, 0xa8];
-    //     let dcid = [0x36, 0xce, 0x10, 0x4e, 0xee, 0x50, 0x10, 0x1c];
-
-    //     let pkt_hdr = qlog::events::quic::PacketHeader::new(
-    //         qlog::events::quic::PacketType::Initial,
-    //         Some(0),          // packet_number
-    //         None,             // flags
-    //         None,             // token
-    //         None,             // length
-    //         Some(0x00000001), // version
-    //         Some(&scid),
-    //         Some(&dcid),
-    //     );
-
-    //     let frames = vec![qlog::events::quic::QuicFrame::Crypto {
-    //         offset: 0,
-    //         length: 0,
-    //     }];
-
-    //     let raw = qlog::events::RawInfo {
-    //         length: Some(1251),
-    //         payload_length: Some(1224),
-    //         data: None,
-    //     };
-
-    //     let event_data = qlog::events::EventData::PacketSent(qlog::events::quic::PacketSent {
-    //         header: pkt_hdr,
-    //         frames: Some(frames.into()),
-    //         is_coalesced: None,
-    //         retry_token: None,
-    //         stateless_reset_token: None,
-    //         supported_versions: None,
-    //         raw: Some(raw),
-    //         datagram_id: None,
-    //         trigger: None,
-    //         send_at_time: None,
-    //     });
-
-    //     trace.push_event(qlog::events::Event::with_time(0.0, event_data));
-
-    //     let json = serde_json::to_string_pretty(&trace).unwrap();
-    //     println!("{}", json);
-    // }
 }

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -553,23 +553,3 @@ fn to_qlog_pkt_type(ptype: PacketType) -> qlog::events::quic::PacketType {
         PacketType::OtherVersion => qlog::events::quic::PacketType::Unknown,
     }
 }
-
-#[cfg(test)]
-mod test {
-    use test_fixture::{
-        default_client, default_server, handshake, neqo_qlog_contents, new_neqo_qlog,
-        EXPECTED_LOG_HEADER,
-    };
-
-    #[test]
-    fn test_connection_started() {
-        const CONNECTION_STARTED: &str = "\"name\":\"connectivity:connection_started\"";
-        let (log, contents) = new_neqo_qlog();
-        let mut client = default_client();
-        client.set_qlog(log);
-        handshake(&mut client, &mut default_server());
-        let c = neqo_qlog_contents(&contents);
-        assert!(c.starts_with(EXPECTED_LOG_HEADER));
-        assert!(c.contains(CONNECTION_STARTED));
-    }
-}

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -553,3 +553,18 @@ fn to_qlog_pkt_type(ptype: PacketType) -> qlog::events::quic::PacketType {
         PacketType::OtherVersion => qlog::events::quic::PacketType::Unknown,
     }
 }
+
+#[cfg(test)]
+mod test {
+    // use crate::qlog::connection_started;
+    use test_fixture::{default_client, neqo_qlog_contents, new_neqo_qlog};
+
+    #[test]
+    fn test_connection_started() {
+        let mut log = new_neqo_qlog();
+        assert_eq!(neqo_qlog_contents(&log), "");
+        // let client = default_client();
+        // let path = test_fixture::new_test_path();
+        // connection_started(&mut log, client.paths.primary());
+    }
+}

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -19,7 +19,7 @@ use qlog::events::{
         AckedRanges, ErrorSpace, MetricsUpdated, PacketDropped, PacketHeader, PacketLost,
         PacketReceived, PacketSent, QuicFrame, StreamType, VersionInformation,
     },
-    Event, EventData, RawInfo,
+    EventData, RawInfo,
 };
 
 use neqo_common::{hex, qinfo, qlog::NeqoQlog, Decoder};
@@ -37,7 +37,7 @@ use crate::{
 };
 
 pub fn connection_tparams_set(qlog: &mut NeqoQlog, tph: &TransportParametersHandler) {
-    qlog.add_event(|| {
+    qlog.add_event_data(|| {
         let remote = tph.remote();
         let ev_data = EventData::TransportParametersSet(
             qlog::events::quic::TransportParametersSet {
@@ -541,4 +541,69 @@ fn to_qlog_pkt_type(ptype: PacketType) -> qlog::events::quic::PacketType {
         PacketType::VersionNegotiation => qlog::events::quic::PacketType::VersionNegotiation,
         PacketType::OtherVersion => qlog::events::quic::PacketType::Unknown,
     }
+}
+
+#[cfg(test)]
+mod test {
+    // #[test]
+    // fn test_qlog() {
+    //     // Adapted from https://github.com/cloudflare/quiche/blob/master/qlog/README.md
+    //     let mut trace = qlog::Trace::new(
+    //         qlog::VantagePoint {
+    //             name: Some("Test vantage point".to_string()),
+    //             ty: qlog::VantagePointType::Client,
+    //             flow: None,
+    //         },
+    //         Some("Test trace".to_string()),
+    //         Some("Test trace description".to_string()),
+    //         Some(qlog::Configuration {
+    //             time_offset: Some(0.0),
+    //             original_uris: None,
+    //         }),
+    //         None,
+    //     );
+
+    //     let scid = [0x7e, 0x37, 0xe4, 0xdc, 0xc6, 0x68, 0x2d, 0xa8];
+    //     let dcid = [0x36, 0xce, 0x10, 0x4e, 0xee, 0x50, 0x10, 0x1c];
+
+    //     let pkt_hdr = qlog::events::quic::PacketHeader::new(
+    //         qlog::events::quic::PacketType::Initial,
+    //         Some(0),          // packet_number
+    //         None,             // flags
+    //         None,             // token
+    //         None,             // length
+    //         Some(0x00000001), // version
+    //         Some(&scid),
+    //         Some(&dcid),
+    //     );
+
+    //     let frames = vec![qlog::events::quic::QuicFrame::Crypto {
+    //         offset: 0,
+    //         length: 0,
+    //     }];
+
+    //     let raw = qlog::events::RawInfo {
+    //         length: Some(1251),
+    //         payload_length: Some(1224),
+    //         data: None,
+    //     };
+
+    //     let event_data = qlog::events::EventData::PacketSent(qlog::events::quic::PacketSent {
+    //         header: pkt_hdr,
+    //         frames: Some(frames.into()),
+    //         is_coalesced: None,
+    //         retry_token: None,
+    //         stateless_reset_token: None,
+    //         supported_versions: None,
+    //         raw: Some(raw),
+    //         datagram_id: None,
+    //         trigger: None,
+    //         send_at_time: None,
+    //     });
+
+    //     trace.push_event(qlog::events::Event::with_time(0.0, event_data));
+
+    //     let json = serde_json::to_string_pretty(&trace).unwrap();
+    //     println!("{}", json);
+    // }
 }

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -175,8 +175,8 @@ pub fn packet_sent(
         let mut d = Decoder::from(body);
         let header = PacketHeader::with_type(to_qlog_pkt_type(pt), Some(pn), None, None, None);
         let raw = RawInfo {
-            length: None,
-            payload_length: Some(plen as u64),
+            length: Some(plen as u64),
+            payload_length: None,
             data: None,
         };
 
@@ -210,18 +210,18 @@ pub fn packet_sent(
     });
 }
 
-pub fn packet_dropped(qlog: &mut NeqoQlog, payload: &PublicPacket) {
+pub fn packet_dropped(qlog: &mut NeqoQlog, public_packet: &PublicPacket) {
     qlog.add_event_data(|| {
         let header = PacketHeader::with_type(
-            to_qlog_pkt_type(payload.packet_type()),
+            to_qlog_pkt_type(public_packet.packet_type()),
             None,
             None,
             None,
             None,
         );
         let raw = RawInfo {
-            length: None,
-            payload_length: Some(payload.len() as u64),
+            length: Some(public_packet.len() as u64),
+            payload_length: None,
             data: None,
         };
 
@@ -271,8 +271,8 @@ pub fn packet_received(
             None,
         );
         let raw = RawInfo {
-            length: None,
-            payload_length: Some(public_packet.len() as u64),
+            length: Some(public_packet.len() as u64),
+            payload_length: None,
             data: None,
         };
 

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -7,13 +7,14 @@ rust-version = "1.70.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+const_format = "~0.2.32"
+lazy_static = "1.3.0"
+log = {version = "0.4.0", default-features = false}
 neqo-common = { path = "../neqo-common" }
 neqo-crypto = { path = "../neqo-crypto" }
 neqo-http3 = { path = "../neqo-http3" }
 neqo-qpack = { path = "../neqo-qpack" }
 neqo-transport = { path = "../neqo-transport" }
-log = {version = "0.4.0", default-features = false}
-lazy_static = "1.3.0"
 qlog = "0.11.0"
 
 [features]

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -7,7 +7,6 @@ rust-version = "1.70.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-const_format = "~0.2.32"
 lazy_static = "1.3.0"
 log = {version = "0.4.0", default-features = false}
 neqo-common = { path = "../neqo-common" }

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -14,6 +14,7 @@ neqo-qpack = { path = "../neqo-qpack" }
 neqo-transport = { path = "../neqo-transport" }
 log = {version = "0.4.0", default-features = false}
 lazy_static = "1.3.0"
+qlog = "0.11.0"
 
 [features]
 deny-warnings = []

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -35,6 +35,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use const_format::concatcp;
 use lazy_static::lazy_static;
 
 pub mod assertions;
@@ -385,4 +386,8 @@ pub fn new_neqo_qlog() -> (NeqoQlog, SharedVec) {
     )
 }
 
-pub const EXPECTED_LOG_HEADER: &str = "\u{1e}{\"qlog_version\":\"0.3\",\"qlog_format\":\"JSON-SEQ\",\"trace\":{\"vantage_point\":{\"name\":\"neqo-Client\",\"type\":\"client\"},\"title\":\"neqo-Client trace\",\"description\":\"Example qlog trace description\",\"configuration\":{\"time_offset\":0.0},\"common_fields\":{\"reference_time\":0.0,\"time_format\":\"relative\"}}}\n";
+pub const EXPECTED_LOG_HEADER: &str = concatcp!(
+    "\u{1e}",
+    r#"{"qlog_version":"0.3","qlog_format":"JSON-SEQ","trace":{"vantage_point":{"name":"neqo-Client","type":"client"},"title":"neqo-Client trace","description":"Example qlog trace description","configuration":{"time_offset":0.0},"common_fields":{"reference_time":0.0,"time_format":"relative"}}}"#,
+    "\n"
+);

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -381,8 +381,7 @@ pub fn new_neqo_qlog() -> (NeqoQlog, Arc<Mutex<Cursor<Vec<u8>>>>) {
         Box::new(SharedVec { buf }),
     );
     let log = NeqoQlog::enabled(streamer, "");
-    assert!(log.is_ok());
-    (log.unwrap(), contents)
+    (log.expect("to be able to write to new log"), contents)
 }
 
 pub const EXPECTED_LOG_HEADER: &str = "\u{1e}{\"qlog_version\":\"0.3\",\"qlog_format\":\"JSON-SEQ\",\"trace\":{\"vantage_point\":{\"name\":\"neqo-Client\",\"type\":\"client\"},\"title\":\"neqo-Client trace\",\"description\":\"Example qlog trace description\",\"configuration\":{\"time_offset\":0.0},\"common_fields\":{\"reference_time\":0.0,\"time_format\":\"relative\"}}}\n";

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -338,7 +338,7 @@ pub fn split_datagram(d: &Datagram) -> (Datagram, Option<Datagram>) {
 }
 
 #[derive(Clone)]
-struct SharedVec {
+pub struct SharedVec {
     buf: Arc<Mutex<Cursor<Vec<u8>>>>,
 }
 
@@ -352,9 +352,9 @@ impl Write for SharedVec {
 }
 
 impl ToString for SharedVec {
-  fn to_string(&self) -> String {
-    String::from_utf8(log.lock().unwrap().clone().into_inner()).unwrap()
-  }
+    fn to_string(&self) -> String {
+        String::from_utf8(self.buf.lock().unwrap().clone().into_inner()).unwrap()
+    }
 }
 
 /// Returns a pair of new enabled `NeqoQlog` that is backed by a Vec<u8> together with a
@@ -379,7 +379,10 @@ pub fn new_neqo_qlog() -> (NeqoQlog, SharedVec) {
         Box::new(SharedVec { buf }),
     );
     let log = NeqoQlog::enabled(streamer, "");
-    (log.expect("to be able to write to new log"), contents)
+    (
+        log.expect("to be able to write to new log"),
+        SharedVec { buf: contents },
+    )
 }
 
 pub const EXPECTED_LOG_HEADER: &str = "\u{1e}{\"qlog_version\":\"0.3\",\"qlog_format\":\"JSON-SEQ\",\"trace\":{\"vantage_point\":{\"name\":\"neqo-Client\",\"type\":\"client\"},\"title\":\"neqo-Client trace\",\"description\":\"Example qlog trace description\",\"configuration\":{\"time_offset\":0.0},\"common_fields\":{\"reference_time\":0.0,\"time_format\":\"relative\"}}}\n";

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -378,7 +378,7 @@ pub fn new_neqo_qlog() -> (NeqoQlog, SharedVec) {
         std::time::Instant::now(),
         trace,
         EventImportance::Base,
-        Box::new(buf.clone()),
+        Box::new(buf),
     );
     let log = NeqoQlog::enabled(streamer, "");
     (log.expect("to be able to write to new log"), contents)

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -351,12 +351,10 @@ impl Write for SharedVec {
     }
 }
 
-/// Return the contents of the log.
-/// # Panics
-/// Panics if the log cannot be accessed.
-#[must_use]
-pub fn neqo_qlog_contents(log: &Arc<Mutex<Cursor<Vec<u8>>>>) -> String {
+impl ToString for SharedVec {
+  fn to_string(&self) -> String {
     String::from_utf8(log.lock().unwrap().clone().into_inner()).unwrap()
+  }
 }
 
 /// Returns a pair of new enabled `NeqoQlog` that is backed by a Vec<u8> together with a
@@ -364,7 +362,7 @@ pub fn neqo_qlog_contents(log: &Arc<Mutex<Cursor<Vec<u8>>>>) -> String {
 /// # Panics
 /// Panics if the log cannot be created.
 #[must_use]
-pub fn new_neqo_qlog() -> (NeqoQlog, Arc<Mutex<Cursor<Vec<u8>>>>) {
+pub fn new_neqo_qlog() -> (NeqoQlog, SharedVec) {
     let mut trace = new_trace(Role::Client);
     // Set reference time to 0.0 for testing.
     trace.common_fields.as_mut().unwrap().reference_time = Some(0.0);


### PR DESCRIPTION
Fixes include:
* Change `raw.payload_length` to `raw.length`  - the information logged was the raw (total) length already, but the label incorrectly stated it was the _payload_ length.
* Log transport parameters with a valid (in-sequence) timestamp.
* Log `ACTIVE_CONNECTION_ID_LIMIT` and `PREFERRED_ADDRESS` to qlog.

Also:
* Add some tests to `neqo-common::qlog`