### PR TITLE
Undo the restriction on the time dependency.

### DIFF
--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -12,7 +12,7 @@ log = {version = "0.4.0", default-features = false}
 env_logger = {version = "0.10", default-features = false}
 lazy_static = "1.3.0"
 qlog = "0.10.0"
-time = {version = "=0.3.23", features = ["formatting"]}
+time = {version = "0.3", features = ["formatting"]}
 
 [features]
 deny-warnings = []


### PR DESCRIPTION
It was done because of time's MSRV, but neqo's MSRV was raised to 1.70.0, which now more recent than what any version of time requires.