### PR TITLE
refactor: clippy `match-same-arms` & `unnested-or-patterns`

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -332,6 +332,7 @@ impl QuicParameters {
             };
             params.versions(first.0, all.iter().map(|&x| x.0).collect())
         } else {
+            #[allow(clippy::match_same_arms)]
             let version = match alpn {
                 "h3" | "hq-interop" => Version::default(),
                 "h3-29" | "hq-29" => Version::Draft29,

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -332,9 +332,8 @@ impl QuicParameters {
             };
             params.versions(first.0, all.iter().map(|&x| x.0).collect())
         } else {
-            #[allow(clippy::match_same_arms)]
             let version = match alpn {
-                "h3" | "hq-interop" => Version::default(),
+                "h3" | "hq-interop" => Version::Version1,
                 "h3-29" | "hq-29" => Version::Draft29,
                 "h3-30" | "hq-30" => Version::Draft30,
                 "h3-31" | "hq-31" => Version::Draft31,

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -736,11 +736,9 @@ fn run_test<'t>(peer: &Peer, test: &'t Test) -> (&'t Test, String) {
             return (test, String::from("OK"));
         }
         Test::H9 => test_h9(&nctx, &mut client),
-        Test::H3 => test_h3(&nctx, peer, client, test),
+        Test::H3 | Test::D => test_h3(&nctx, peer, client, test),
         Test::VN => unimplemented!(),
-        Test::R => test_h3_rz(&nctx, peer, client, test),
-        Test::Z => test_h3_rz(&nctx, peer, client, test),
-        Test::D => test_h3(&nctx, peer, client, test),
+        Test::R | Test::Z => test_h3_rz(&nctx, peer, client, test),
     };
 
     if let Err(e) = res {

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1019,7 +1019,7 @@ impl Connection {
                 let res = self.client_start(now);
                 self.absorb_error(now, res);
             }
-            (State::Init, Role::Server) | (State::WaitInitial, Role::Server) => {
+            (State::Init | State::WaitInitial, Role::Server) => {
                 return Output::None;
             }
             _ => {
@@ -1292,8 +1292,7 @@ impl Connection {
                 self.handle_retry(packet, now);
                 return Ok(PreprocessResult::Next);
             }
-            (PacketType::Handshake, State::WaitInitial, Role::Client)
-            | (PacketType::Short, State::WaitInitial, Role::Client) => {
+            (PacketType::Handshake | PacketType::Short, State::WaitInitial, Role::Client) => {
                 // This packet can't be processed now, but it could be a sign
                 // that Initial packets were lost.
                 // Resend Initial CRYPTO frames immediately a few times just
@@ -1306,9 +1305,7 @@ impl Connection {
                     self.crypto.resend_unacked(PacketNumberSpace::Initial);
                 }
             }
-            (PacketType::VersionNegotiation, ..)
-            | (PacketType::Retry, ..)
-            | (PacketType::OtherVersion, ..) => {
+            (PacketType::VersionNegotiation | PacketType::Retry | PacketType::OtherVersion, ..) => {
                 self.stats
                     .borrow_mut()
                     .pkt_dropped(format!("{:?}", packet.packet_type()));

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -113,8 +113,7 @@ pub fn connection_state_updated(qlog: &mut NeqoQlog, new: &State) {
         let ev_data = EventData::ConnectionStateUpdated(ConnectionStateUpdated {
             old: None,
             new: match new {
-                State::Init => ConnectionState::Attempted,
-                State::WaitInitial => ConnectionState::Attempted,
+                State::Init | State::WaitInitial => ConnectionState::Attempted,
                 State::WaitVersion | State::Handshaking => ConnectionState::HandshakeStarted,
                 State::Connected => ConnectionState::HandshakeCompleted,
                 State::Confirmed => ConnectionState::HandshakeConfirmed,


### PR DESCRIPTION
Addresses clippy lint match-same-arms and unnested-or-patterns.

https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms

https://rust-lang.github.io/rust-clippy/master/index.html#unnested_or_patterns

Meta issue: https://github.com/mozilla/neqo/issues/553