### PR TITLE
refactor: address clippy::unreadable-literal

### DIFF
--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -440,7 +440,7 @@ impl TransportParameters {
         let rbuf = random(4);
         let mut other = Vec::with_capacity(versions.all().len() + 1);
         let mut dec = Decoder::new(&rbuf);
-        let grease = (dec.decode_uint(4).unwrap() as u32) & 0xf0f0_f0f0 | 0x0a0a0a0a;
+        let grease = (dec.decode_uint(4).unwrap() as u32) & 0xf0f0_f0f0 | 0x0a0a_0a0a;
         other.push(grease);
         for &v in versions.all() {
             if role == Role::Client && !versions.initial().is_compatible(v) {

--- a/neqo-transport/src/version.rs
+++ b/neqo-transport/src/version.rs
@@ -23,7 +23,7 @@ pub enum Version {
 impl Version {
     pub const fn wire_version(self) -> WireVersion {
         match self {
-            Self::Version2 => 0x6b3343cf,
+            Self::Version2 => 0x6b33_43cf,
             Self::Version1 => 1,
             Self::Draft29 => 0xff00_0000 + 29,
             Self::Draft30 => 0xff00_0000 + 30,
@@ -131,7 +131,7 @@ impl TryFrom<WireVersion> for Version {
     fn try_from(wire: WireVersion) -> Res<Self> {
         if wire == 1 {
             Ok(Self::Version1)
-        } else if wire == 0x6b3343cf {
+        } else if wire == 0x6b33_43cf {
             Ok(Self::Version2)
         } else if wire == 0xff00_0000 + 29 {
             Ok(Self::Draft29)


### PR DESCRIPTION
Fixes clippy lint `unreadable-literal`.

https://rust-lang.github.io/rust-clippy/master/#/unreadable_literal

Meta issue: https://github.com/mozilla/neqo/issues/553