### PR TITLE
Make ConnectionIdRef Copy

### DIFF
--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -6,24 +6,23 @@
 
 // Representation and management of connection IDs.
 
-use crate::frame::FRAME_TYPE_NEW_CONNECTION_ID;
-use crate::packet::PacketBuilder;
-use crate::recovery::RecoveryToken;
-use crate::stats::FrameStats;
-use crate::{Error, Res};
+use crate::{
+    frame::FRAME_TYPE_NEW_CONNECTION_ID, packet::PacketBuilder, recovery::RecoveryToken,
+    stats::FrameStats, Error, Res,
+};
 
 use neqo_common::{hex, hex_with_len, qinfo, Decoder, Encoder};
 use neqo_crypto::random;
 
 use smallvec::SmallVec;
-use std::borrow::Borrow;
-use std::cell::{Ref, RefCell};
-use std::cmp::max;
-use std::cmp::min;
-use std::convert::AsRef;
-use std::convert::TryFrom;
-use std::ops::Deref;
-use std::rc::Rc;
+use std::{
+    borrow::Borrow,
+    cell::{Ref, RefCell},
+    cmp::{max, min},
+    convert::{AsRef, TryFrom},
+    ops::Deref,
+    rc::Rc,
+};
 
 pub const MAX_CONNECTION_ID_LEN: usize = 20;
 pub const LOCAL_ACTIVE_CID_LIMIT: usize = 8;
@@ -88,8 +87,8 @@ impl<T: AsRef<[u8]> + ?Sized> From<&T> for ConnectionId {
     }
 }
 
-impl<'a> From<&ConnectionIdRef<'a>> for ConnectionId {
-    fn from(cidref: &ConnectionIdRef<'a>) -> Self {
+impl<'a> From<ConnectionIdRef<'a>> for ConnectionId {
+    fn from(cidref: ConnectionIdRef<'a>) -> Self {
         Self::from(SmallVec::from(cidref.cid))
     }
 }
@@ -120,7 +119,7 @@ impl<'a> PartialEq<ConnectionIdRef<'a>> for ConnectionId {
     }
 }
 
-#[derive(Hash, Eq, PartialEq)]
+#[derive(Hash, Eq, PartialEq, Clone, Copy)]
 pub struct ConnectionIdRef<'a> {
     cid: &'a [u8],
 }
@@ -340,8 +339,8 @@ impl<SRT: Clone + PartialEq> ConnectionIdStore<SRT> {
         self.cids.retain(|c| c.seqno != seqno);
     }
 
-    pub fn contains(&self, cid: &ConnectionIdRef) -> bool {
-        self.cids.iter().any(|c| &c.cid == cid)
+    pub fn contains(&self, cid: ConnectionIdRef) -> bool {
+        self.cids.iter().any(|c| c.cid == cid)
     }
 
     pub fn next(&mut self) -> Option<ConnectionIdEntry<SRT>> {
@@ -479,7 +478,7 @@ impl ConnectionIdManager {
         }
     }
 
-    pub fn is_valid(&self, cid: &ConnectionIdRef) -> bool {
+    pub fn is_valid(&self, cid: ConnectionIdRef) -> bool {
         self.connection_ids.contains(cid)
     }
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1210,7 +1210,7 @@ impl Connection {
         dcid: Option<&ConnectionId>,
         now: Instant,
     ) -> Res<PreprocessResult> {
-        if dcid.map_or(false, |d| d != packet.dcid()) {
+        if dcid.map_or(false, |d| d != &packet.dcid()) {
             self.stats
                 .borrow_mut()
                 .pkt_dropped("Coalesced packet has different DCID");
@@ -1266,7 +1266,7 @@ impl Connection {
                         if versions.is_empty()
                             || versions.contains(&self.version().wire_version())
                             || versions.contains(&0)
-                            || packet.scid() != self.odcid().unwrap()
+                            || &packet.scid() != self.odcid().unwrap()
                             || matches!(
                                 self.address_validation,
                                 AddressValidationInfo::Retry { .. }
@@ -1373,7 +1373,7 @@ impl Connection {
             self.handle_migration(path, d, migrate, now);
         } else if self.role != Role::Client
             && (packet.packet_type() == PacketType::Handshake
-                || (packet.dcid().len() >= 8 && packet.dcid() == &self.local_initial_source_cid))
+                || (packet.dcid().len() >= 8 && packet.dcid() == self.local_initial_source_cid))
         {
             // We only allow one path during setup, so apply handshake
             // path validation to this path.

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -374,7 +374,7 @@ fn migration(mut client: Connection) {
     let probe = client.process_output(now).dgram().unwrap();
     assert_v4_path(&probe, true); // Contains PATH_CHALLENGE.
     assert_eq!(client.stats().frame_tx.path_challenge, 1);
-    let probe_cid = ConnectionId::from(&get_cid(&probe));
+    let probe_cid = ConnectionId::from(get_cid(&probe));
 
     let resp = server.process(Some(&probe), now).dgram().unwrap();
     assert_v4_path(&resp, true);
@@ -814,7 +814,7 @@ fn retire_all() {
     .unwrap();
     connect_force_idle(&mut client, &mut server);
 
-    let original_cid = ConnectionId::from(&get_cid(&send_something(&mut client, now())));
+    let original_cid = ConnectionId::from(get_cid(&send_something(&mut client, now())));
 
     server.test_frame_writer = Some(Box::new(RetireAll { cid_gen }));
     let ncid = send_something(&mut server, now());
@@ -852,7 +852,7 @@ fn retire_prior_to_migration_failure() {
     .unwrap();
     connect_force_idle(&mut client, &mut server);
 
-    let original_cid = ConnectionId::from(&get_cid(&send_something(&mut client, now())));
+    let original_cid = ConnectionId::from(get_cid(&send_something(&mut client, now())));
 
     client
         .migrate(Some(addr_v4()), Some(addr_v4()), false, now())
@@ -862,7 +862,7 @@ fn retire_prior_to_migration_failure() {
     let probe = client.process_output(now()).dgram().unwrap();
     assert_v4_path(&probe, true);
     assert_eq!(client.stats().frame_tx.path_challenge, 1);
-    let probe_cid = ConnectionId::from(&get_cid(&probe));
+    let probe_cid = ConnectionId::from(get_cid(&probe));
     assert_ne!(original_cid, probe_cid);
 
     // Have the server receive the probe, but separately have it decide to
@@ -907,7 +907,7 @@ fn retire_prior_to_migration_success() {
     .unwrap();
     connect_force_idle(&mut client, &mut server);
 
-    let original_cid = ConnectionId::from(&get_cid(&send_something(&mut client, now())));
+    let original_cid = ConnectionId::from(get_cid(&send_something(&mut client, now())));
 
     client
         .migrate(Some(addr_v4()), Some(addr_v4()), false, now())
@@ -917,7 +917,7 @@ fn retire_prior_to_migration_success() {
     let probe = client.process_output(now()).dgram().unwrap();
     assert_v4_path(&probe, true);
     assert_eq!(client.stats().frame_tx.path_challenge, 1);
-    let probe_cid = ConnectionId::from(&get_cid(&probe));
+    let probe_cid = ConnectionId::from(get_cid(&probe));
     assert_ne!(original_cid, probe_cid);
 
     // Have the server receive the probe, but separately have it decide to

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -673,13 +673,12 @@ impl<'a> PublicPacket<'a> {
         self.packet_type
     }
 
-    pub fn dcid(&self) -> &ConnectionIdRef<'a> {
-        &self.dcid
+    pub fn dcid(&self) -> ConnectionIdRef<'a> {
+        self.dcid
     }
 
-    pub fn scid(&self) -> &ConnectionIdRef<'a> {
+    pub fn scid(&self) -> ConnectionIdRef<'a> {
         self.scid
-            .as_ref()
             .expect("should only be called for long header packets")
     }
 

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -7,27 +7,29 @@
 #![deny(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
-use std::cell::RefCell;
-use std::convert::TryFrom;
-use std::fmt::{self, Display};
-use std::mem;
-use std::net::{IpAddr, SocketAddr};
-use std::rc::Rc;
-use std::time::{Duration, Instant};
-
-use crate::ackrate::{AckRate, PeerAckDelay};
-use crate::cc::CongestionControlAlgorithm;
-use crate::cid::{ConnectionId, ConnectionIdRef, ConnectionIdStore, RemoteConnectionIdEntry};
-use crate::frame::{
-    FRAME_TYPE_PATH_CHALLENGE, FRAME_TYPE_PATH_RESPONSE, FRAME_TYPE_RETIRE_CONNECTION_ID,
+use std::{
+    cell::RefCell,
+    convert::TryFrom,
+    fmt::{self, Display},
+    mem,
+    net::{IpAddr, SocketAddr},
+    rc::Rc,
+    time::{Duration, Instant},
 };
-use crate::packet::PacketBuilder;
-use crate::recovery::RecoveryToken;
-use crate::rtt::RttEstimate;
-use crate::sender::PacketSender;
-use crate::stats::FrameStats;
-use crate::tracking::{PacketNumberSpace, SentPacket};
-use crate::{Error, Res};
+
+use crate::{
+    ackrate::{AckRate, PeerAckDelay},
+    cc::CongestionControlAlgorithm,
+    cid::{ConnectionId, ConnectionIdRef, ConnectionIdStore, RemoteConnectionIdEntry},
+    frame::{FRAME_TYPE_PATH_CHALLENGE, FRAME_TYPE_PATH_RESPONSE, FRAME_TYPE_RETIRE_CONNECTION_ID},
+    packet::PacketBuilder,
+    recovery::RecoveryToken,
+    rtt::RttEstimate,
+    sender::PacketSender,
+    stats::FrameStats,
+    tracking::{PacketNumberSpace, SentPacket},
+    Error, Res,
+};
 
 use neqo_common::{hex, qdebug, qinfo, qlog::NeqoQlog, qtrace, Datagram, Encoder};
 use neqo_crypto::random;
@@ -664,7 +666,7 @@ impl Path {
 
     /// Set the remote connection ID based on the peer's choice.
     /// This is only valid during the handshake.
-    pub fn set_remote_cid(&mut self, cid: &ConnectionIdRef) {
+    pub fn set_remote_cid(&mut self, cid: ConnectionIdRef) {
         self.remote_cid
             .as_mut()
             .unwrap()


### PR DESCRIPTION
This is just a reference, so Copy is cheap.
This reduces the number of unnecessary references that are taken.