### PR TITLE
fix(qns): always use Version1 on server

### DIFF
--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -836,14 +836,14 @@ fn main() -> Result<(), io::Error> {
     init_db(args.db.clone());
 
     if let Some(testcase) = args.qns_test.as_ref() {
-        assert!(
-            args.quic_parameters.quic_version.is_empty(),
-            "-V and --qns-test are mutually exclusive. Each qns testcase itself dictates the supported versions.",
-        );
-        // Quic Interop Runner expects the server to support `Version1` only.
-        // Exceptions are testcases `versionnegotiation` and `v2`. Neither are
-        // supported by Neqo. Thus always set `Version1`.
-        args.quic_parameters.quic_version = vec![VersionArg(Version::Version1)];
+        if args.quic_parameters.quic_version.is_empty() {
+            // Quic Interop Runner expects the server to support `Version1` only.
+            // Exceptions are testcases `versionnegotiation` and `v2`. Neither are
+            // supported by Neqo. Thus always set `Version1`.
+            args.quic_parameters.quic_version = vec![VersionArg(Version::Version1)];
+        } else {
+            qwarn!("Both -V and --qns-test were set. Ignoring testcase specific versions.");
+        }
 
         match testcase.as_str() {
             "http3" => (),

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -836,6 +836,15 @@ fn main() -> Result<(), io::Error> {
     init_db(args.db.clone());
 
     if let Some(testcase) = args.qns_test.as_ref() {
+        assert!(
+            args.quic_parameters.quic_version.is_empty(),
+            "-V and --qns-test are mutually exclusive. Each qns testcase itself dictates the supported versions.",
+        );
+        // Quic Interop Runner expects the server to support `Version1` only.
+        // Exceptions are testcases `versionnegotiation` and `v2`. Neither are
+        // supported by Neqo. Thus always set `Version1`.
+        args.quic_parameters.quic_version = vec![VersionArg(Version::Version1)];
+
         match testcase.as_str() {
             "http3" => (),
             "zerortt" => {


### PR DESCRIPTION
The Quic Interop Runner expects the server to use `Version::Version1` in all testcases but `versionnegotiation` and `v2`.

See discussion in [Quic Interop Runner issue](https://github.com/quic-interop/quic-interop-runner/pull/344#issuecomment-1895771528) and corresponding code in the [Quic Interop Runner](https://github.com/quic-interop/quic-interop-runner/blob/ca27dcb5272a82d994337ae3d14533c318d81b76/testcases.py#L188-L195).

While Neqo's default `Version` is `Version1`, the default `VersionConfig` includes all versions (`Version::all()`) and thus the server will currently upgrade the connection to the compatible `Version::Version2`.

With this commit, the server will always choose `Version1` when running a qns testcase. Given that Neqo's qns implementation does not support the `versionnegotiation` and `v2` testcases, this fix is applicable for all supported testcases.

@larseggert I opted for a fix in `neqo-server/src/main.rs` instead of, as you suggested, in `qns/interop.sh`. I find it much easier to maintain this logic in Rust rather than a shell script. I don't feel strongly about it. Let me know whether you prefer the `-V 1` fix in `interop.sh`.

---

While this does not fix all interop test failures, it does get us much closer.

Before:

![image](https://github.com/mozilla/neqo/assets/7047859/a746df4e-25f8-45e1-aa42-96d2fbc86f78)

After:

![image](https://github.com/mozilla/neqo/assets/7047859/bd2d8420-1d41-4279-91a8-79ab0349f6b7)

I will take a look at the remaining failures next.
