### PR TITLE
Don't crash when timeBeginPeriod/timeEndPeriod returns an error

### DIFF
--- a/neqo-common/src/hrtime.rs
+++ b/neqo-common/src/hrtime.rs
@@ -301,7 +301,7 @@ impl Time {
         #[cfg(windows)]
         {
             if let Some(p) = self.active {
-                assert_eq!(0, unsafe { timeBeginPeriod(p.as_uint()) });
+                unsafe { timeBeginPeriod(p.as_uint()); };
             }
         }
     }
@@ -311,7 +311,7 @@ impl Time {
         #[cfg(windows)]
         {
             if let Some(p) = self.active {
-                assert_eq!(0, unsafe { timeEndPeriod(p.as_uint()) });
+                unsafe { timeEndPeriod(p.as_uint()); };
             }
         }
     }

--- a/neqo-common/src/hrtime.rs
+++ b/neqo-common/src/hrtime.rs
@@ -301,7 +301,9 @@ impl Time {
         #[cfg(windows)]
         {
             if let Some(p) = self.active {
-                unsafe { timeBeginPeriod(p.as_uint()); };
+                unsafe {
+                    timeBeginPeriod(p.as_uint());
+                };
             }
         }
     }
@@ -311,7 +313,9 @@ impl Time {
         #[cfg(windows)]
         {
             if let Some(p) = self.active {
-                unsafe { timeEndPeriod(p.as_uint()); };
+                unsafe {
+                    timeEndPeriod(p.as_uint());
+                };
             }
         }
     }

--- a/neqo-common/src/hrtime.rs
+++ b/neqo-common/src/hrtime.rs
@@ -301,9 +301,7 @@ impl Time {
         #[cfg(windows)]
         {
             if let Some(p) = self.active {
-                unsafe {
-                    timeBeginPeriod(p.as_uint());
-                };
+                _ = unsafe { timeBeginPeriod(p.as_uint()) };
             }
         }
     }
@@ -313,9 +311,7 @@ impl Time {
         #[cfg(windows)]
         {
             if let Some(p) = self.active {
-                unsafe {
-                    timeEndPeriod(p.as_uint());
-                };
+                _ = unsafe { timeEndPeriod(p.as_uint()) };
             }
         }
     }


### PR DESCRIPTION
See the crash in this [bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=1874581).
The crash reason `assertion failed: (left == right) left: 0, right: 97` means that `timeEndPeriod` returns the error `TIMERR_NOCANDO`.
It's unclear to me why we got this error, but I think we should not crash in this case.