### PR TITLE
feat(qns): implement v2 testcase

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -1018,7 +1018,9 @@ fn main() -> Res<()> {
                 args.use_old_http = true;
                 args.key_update = true;
             }
-            "v2" => {}
+            "v2" => {
+                args.use_old_http = true;
+            }
             _ => exit(127),
         }
     }

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -1018,6 +1018,7 @@ fn main() -> Res<()> {
                 args.use_old_http = true;
                 args.key_update = true;
             }
+            "v2" => {}
             _ => exit(127),
         }
     }

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -837,10 +837,12 @@ fn main() -> Result<(), io::Error> {
 
     if let Some(testcase) = args.qns_test.as_ref() {
         if args.quic_parameters.quic_version.is_empty() {
-            // Quic Interop Runner expects the server to support `Version1` only.
-            // Exceptions are testcases `versionnegotiation` and `v2`. Neither are
-            // supported by Neqo. Thus always set `Version1`.
-            args.quic_parameters.quic_version = vec![VersionArg(Version::Version1)];
+            // Quic Interop Runner expects the server to support `Version1`
+            // only. Exceptions are testcases `versionnegotiation` (not yet
+            // implemented) and `v2`.
+            if testcase != "v2" {
+                args.quic_parameters.quic_version = vec![VersionArg(Version::Version1)];
+            }
         } else {
             qwarn!("Both -V and --qns-test were set. Ignoring testcase specific versions.");
         }
@@ -868,6 +870,7 @@ fn main() -> Result<(), io::Error> {
                 args.alpn = String::from(HQ_INTEROP);
                 args.retry = true;
             }
+            "v2" => (),
             _ => exit(127),
         }
     }

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -870,7 +870,10 @@ fn main() -> Result<(), io::Error> {
                 args.alpn = String::from(HQ_INTEROP);
                 args.retry = true;
             }
-            "v2" => (),
+            "v2" => {
+                args.use_old_http = true;
+                args.alpn = String::from(HQ_INTEROP);
+            }
             _ => exit(127),
         }
     }


### PR DESCRIPTION
Add support for Quic Network Simulator `v2` testcase.

In `v2` testcase, don't restrict the server to `Version::Version1`, thus allowing the server to upgrade incoming `Version::Version1` connection to compatible `Version::Version2` connection.

See also [Quic Network Simulator `v2` testcase implementation]( https://github.com/quic-interop/quic-interop-runner/blob/ca27dcb5272a82d994337ae3d14533c318d81b76/testcases.py#L1460-L1545).

---

//CC @marten-seemann

Follow-up to https://github.com/mozilla/neqo/pull/1563.
Related to https://github.com/quic-interop/quic-interop-runner/pull/344 and https://github.com/mozilla/neqo/issues/1552.