### PR TITLE
fix: Rust intra doc links

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -121,6 +121,9 @@ jobs:
         if: success() || failure()
         continue-on-error: ${{ matrix.rust-toolchain == 'beta' }}
 
+      - name: Check rustdoc links
+        run: RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links --deny warnings" cargo doc --verbose --workspace --no-deps --document-private-items
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -71,43 +71,43 @@ fn alpn_from_quic_version(version: Version) -> &'static str {
 
 /// The API is used for:
 /// - create and close an endpoint:
-///   - [`new`](struct.Http3Client.html#method.new)
-///   - [`new_with_conn`](struct.Http3Client.html#method.new_with_conn)
-///   - [`close`](struct.Http3Client.html#method.close)
+///   - [`Http3Client::new`]
+///   - [`Http3Client::new_with_conn`]
+///   - [`Http3Client::close`]
 /// - configuring an endpoint:
-///   - [`authenticated`](struct.Http3Client.html#method.authenticated)
-///   - [`enable_ech`](struct.Http3Client.html#method.enable_ech)
-///   - [`enable_resumption`](struct.Http3Client.html#method.enable_resumption)
-///   - [`initiate_key_update`](struct.Http3Client.html#method.initiate_key_update)
-///   - [`set_qlog`](struct.Http3Client.html#method.set_qlog)
+///   - [`Http3Client::authenticated`]
+///   - [`Http3Client::enable_ech`]
+///   - [`Http3Client::enable_resumption`]
+///   - [`Http3Client::initiate_key_update`]
+///   - [`Http3Client::set_qlog`]
 /// - retrieving information about a connection:
-/// - [`peer_certificate`](struct.Http3Client.html#method.peer_certificate)
-///   - [`qpack_decoder_stats`](struct.Http3Client.html#method.qpack_decoder_stats)
-///   - [`qpack_encoder_stats`](struct.Http3Client.html#method.qpack_encoder_stats)
-///   - [`transport_stats`](struct.Http3Client.html#method.transport_stats)
-///   - [`state`](struct.Http3Client.html#method.state)
-///   - [`take_resumption_token`](struct.Http3Client.html#method.take_resumption_token)
-///   - [`tls_inf`](struct.Http3Client.html#method.tls_info)
+/// - [`Http3Client::peer_certificate`]
+///   - [`Http3Client::qpack_decoder_stats`]
+///   - [`Http3Client::qpack_encoder_stats`]
+///   - [`Http3Client::transport_stats`]
+///   - [`Http3Client::state`]
+///   - [`Http3Client::take_resumption_token`]
+///   - [`Http3Client::tls_info`]
 /// - driving HTTP/3 session:
-///   - [`process_output`](struct.Http3Client.html#method.process_output)
-///   - [`process_input`](struct.Http3Client.html#method.process_input)
-///   - [`process`](struct.Http3Client.html#method.process)
+///   - [`Http3Client::process_output`]
+///   - [`Http3Client::process_input`]
+///   - [`Http3Client::process`]
 /// - create requests, send/receive data, and cancel requests:
-///   - [`fetch`](struct.Http3Client.html#method.fetch)
-///   - [`send_data`](struct.Http3Client.html#method.send_data)
-///   - [`read_dara`](struct.Http3Client.html#method.read_data)
-///   - [`stream_close_send`](struct.Http3Client.html#method.stream_close_send)
-///   - [`cancel_fetch`](struct.Http3Client.html#method.cancel_fetch)
-///   - [`stream_reset_send`](struct.Http3Client.html#method.stream_reset_send)
-///   - [`stream_stop_sending`](struct.Http3Client.html#method.stream_stop_sending)
-///   - [`set_stream_max_data`](struct.Http3Client.html#method.set_stream_max_data)
+///   - [`Http3Client::fetch`]
+///   - [`Http3Client::send_data`]
+///   - [`Http3Client::read_data`]
+///   - [`Http3Client::stream_close_send`]
+///   - [`Http3Client::cancel_fetch`]
+///   - [`Http3Client::stream_reset_send`]
+///   - [`Http3Client::stream_stop_sending`]
+///   - [`Http3Client::set_stream_max_data`]
 /// - priority feature:
-///   - [`priority_update`](struct.Http3Client.html#method.priority_update)
+///   - [`Http3Client::priority_update`]
 /// - `WebTransport` feature:
-///   - [`webtransport_create_session`](struct.Http3Client.html#method.webtransport_create_session)
-///   - [`webtransport_close_session`](struct.Http3Client.html#method.webtransport_close_session)
-///   - [`webtransport_create_stream`](struct.Http3Client.html#method.webtransport_create_sstream)
-///   - [`webtransport_enabled`](struct.Http3Client.html#method.webtransport_enabled)
+///   - [`Http3Client::webtransport_create_session`]
+///   - [`Http3Client::webtransport_close_session`]
+///   - [`Http3Client::webtransport_create_stream`]
+///   - [`Http3Client::webtransport_enabled`]
 ///
 /// ## Examples
 ///

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -35,7 +35,7 @@ supported and can be enabled using [`Http3Parameters`](struct.Http3Parameters.ht
 
 The crate does not create an OS level UDP socket, it produces, i.e. encodes, data that should be
 sent as a payload in a UDP packet and consumes data received on the UDP socket. For example,
-[`std::net::UdpSocket`](std::net::UdpSocket) or [`mio::net::UdpSocket`](https://crates.io/crates/mio)
+[`std::net::UdpSocket`] or [`mio::net::UdpSocket`](https://crates.io/crates/mio)
 could be used for creating UDP sockets.
 
 The application is responsible for creating a socket, polling the socket, and sending and receiving

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -409,7 +409,7 @@ impl PacketBuilder {
     /// Make a retry packet.
     /// As this is a simple packet, this is just an associated function.
     /// As Retry is odd (it has to be constructed with leading bytes),
-    /// this returns a Vec<u8> rather than building on an encoder.
+    /// this returns a [`Vec<u8>`] rather than building on an encoder.
     pub fn retry(
         version: Version,
         dcid: &[u8],

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -357,8 +357,9 @@ impl ToString for SharedVec {
     }
 }
 
-/// Returns a pair of new enabled `NeqoQlog` that is backed by a Vec<u8> together with a
-/// `Cursor<Vec<u8>>` that can be used to read the contents of the log.
+/// Returns a pair of new enabled `NeqoQlog` that is backed by a [`Vec<u8>`]
+/// together with a [`Cursor<Vec<u8>>`] that can be used to read the contents of
+/// the log.
 /// # Panics
 /// Panics if the log cannot be created.
 #[must_use]


### PR DESCRIPTION
- Fix minor typos in Rust intra doc links.
- Add CI check.

---

I find Rust intra doc links helpful, not so much for the links themselves, but for the static check flagging outdated documentation.