### PR TITLE
fix(client): only take single url on (args.resume && first)

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -1086,12 +1086,15 @@ fn main() -> Res<()> {
 
         let hostname = format!("{host}");
         let mut token: Option<ResumptionToken> = None;
+        let mut first = true;
         while !urls.is_empty() {
-            let to_request = if args.resume || args.download_in_series {
+            let to_request = if (args.resume && first) || args.download_in_series {
                 urls.pop_front().into_iter().collect()
             } else {
                 std::mem::take(&mut urls)
             };
+
+            first = false;
 
             token = if args.use_old_http {
                 old::old_client(


### PR DESCRIPTION
QUIC Interop Runner testcases `resumption` and `0-rtt` expect the client to download the first file, close the connection, and then download the remaining files on a second connection.

https://github.com/quic-interop/quic-interop-runner/tree/master#test-cases

Thus `neqo-client`, when `args.resume` is `true` must only take a single URL on the **first** loop iteration. On the second iteration it must take all remaining URLs.

Regression introduced in https://github.com/mozilla/neqo/pull/1569. My bad.

---

![image](https://github.com/mozilla/neqo/assets/7047859/e76eb604-def1-451d-8e37-3c06285fec1f)

With this patch all, but the `amplification` testcase, are green. Note that the `amplification` testcase failed with the previous qns image as well. See https://interop.seemann.io/. 

```
Received a 1337 byte Handshake packet from the server. Total: 5348
Server violated the amplification limit, but stayed within 3-4x amplification. Letting it slide.
Received a 1337 byte Handshake packet from the server. Total: 6685
Server violated the amplification limit.
```

Needed for https://github.com/quic-interop/quic-interop-runner/pull/344.
Related to https://github.com/mozilla/neqo/issues/1552.

