### PR TITLE
log SendProfile when nothing to send

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2260,6 +2260,7 @@ impl Connection {
         }
 
         if encoder.is_empty() {
+            qinfo!("TX blocked, profile={:?} ", profile);
             Ok(SendOption::No(profile.paced()))
         } else {
             // Perform additional padding for Initial packets as necessary.


### PR DESCRIPTION
I think it should be useful to log the reason why TX is blocked.
As the first step, logging `SendProfile` might be enough.
