### PR TITLE
chore: Remove some outdated files

### DIFF
--- a/neqo-crypto/.gitignore
+++ b/neqo-crypto/.gitignore
@@ -1,6 +1,0 @@
-Cargo.lock
-/target
-**/*.rs.bk
-/nss
-/nspr
-/dist

--- a/neqo-crypto/TODO
+++ b/neqo-crypto/TODO
@@ -1,4 +1,0 @@
-early data - API in place for inspection, but depends on resumption
-handle panics more gracefully for extension handlers
-client certificates
-read/write - probably never

--- a/neqo-transport/.gitignore
+++ b/neqo-transport/.gitignore
@@ -1,3 +1,0 @@
-Cargo.lock
-/target
-**/*.rs.bk

--- a/neqo-transport/TODO
+++ b/neqo-transport/TODO
@@ -1,9 +1,0 @@
-Use stream events in h3 // grover or dragana?
-harmonize our rust usage:
- - use foo::* or use foo::{bar, baz} and ordering/grouping
- - remove extern crate
- - sort #[derive()] args
-cleanup public API
-write docs for public API
-write docs for everything else
-CI


### PR DESCRIPTION
The .gitignore files serve no purpose, and if there is anything in the TODO files left to be done, those things should become GitHub issues.