### PR TITLE
chore: Make the qns image multiarch & shrink the build context further

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,8 @@
 *
 # Except for the following:
 !**/*.toml
-!Cargo.lock
 !**/*.rs
 !**/*.h
 !**/*.hpp
 !qns
+!Cargo.lock

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,8 @@
-nss
-nspr
-target
+# Ignore everything:
+*
+# Except for the following:
+!**/*.toml
+!**/*.rs
+!**/*.h
+!**/*.hpp
+!qns

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 *
 # Except for the following:
 !**/*.toml
+!Cargo.lock
 !**/*.rs
 !**/*.h
 !**/*.hpp

--- a/qns/Dockerfile
+++ b/qns/Dockerfile
@@ -13,8 +13,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
-RUN \
-    curl https://sh.rustup.rs -sSf | \
+RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- -y -q --no-modify-path --profile minimal --default-toolchain $RUST_VERSION
 
 ENV NSS_DIR=/nss \

--- a/qns/Dockerfile
+++ b/qns/Dockerfile
@@ -14,19 +14,15 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH
 
 RUN set -eux; \
-    curl -sSLf "https://static.rust-lang.org/rustup/archive/1.26.0/x86_64-unknown-linux-gnu/rustup-init" -o rustup-init; \
-    echo '0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db *rustup-init' | sha256sum -c -; \
-    chmod +x rustup-init; \
-    ./rustup-init -y -q --no-modify-path --profile minimal --default-toolchain "$RUST_VERSION"; \
-    rm -f rustup-init; \
-    chmod -R a+w "$RUSTUP_HOME" "$CARGO_HOME"
+    curl https://sh.rustup.rs -sSf | \
+    sh -s -- -y -q --no-modify-path --profile minimal --component rustfmt --default-toolchain $RUST_VERSION
 
 ENV NSS_DIR=/nss \
     NSPR_DIR=/nspr \
     LD_LIBRARY_PATH=/dist/Release/lib
 
 RUN set -eux; \
-    hg clone https://hg.mozilla.org/projects/nss "$NSS_DIR"; \
+    git clone --depth=1 https://github.com/nss-dev/nss "$NSS_DIR"; \
     hg clone https://hg.mozilla.org/projects/nspr "$NSPR_DIR"
 
 RUN "$NSS_DIR"/build.sh --static -Ddisable_tests=1 -o

--- a/qns/Dockerfile
+++ b/qns/Dockerfile
@@ -13,7 +13,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
-RUN set -eux; \
+RUN \
     curl https://sh.rustup.rs -sSf | \
     sh -s -- -y -q --no-modify-path --profile minimal --default-toolchain $RUST_VERSION
 

--- a/qns/Dockerfile
+++ b/qns/Dockerfile
@@ -1,9 +1,9 @@
 FROM martenseemann/quic-network-simulator-endpoint:latest AS buildimage
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates coreutils curl git make mercurial ssh \
-    build-essential clang llvm libclang-dev lld \
-    gyp ninja-build pkg-config zlib1g-dev python \
+    curl git mercurial \
+    build-essential libclang-dev lld \
+    gyp ninja-build zlib1g-dev python \
  && apt-get autoremove -y && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/*
 
@@ -15,7 +15,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 RUN set -eux; \
     curl https://sh.rustup.rs -sSf | \
-    sh -s -- -y -q --no-modify-path --profile minimal --component rustfmt --default-toolchain $RUST_VERSION
+    sh -s -- -y -q --no-modify-path --profile minimal --default-toolchain $RUST_VERSION
 
 ENV NSS_DIR=/nss \
     NSPR_DIR=/nspr \


### PR DESCRIPTION
Also use `git` to get nss, which is a bit faster.

CC @mxinden 