### PR TITLE
perf: Move acked-from-zero out of the tree and directly into RangeTracker

### DIFF
--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -14,6 +14,7 @@ log = {version = "0.4.0", default-features = false}
 smallvec = "1.0.0"
 qlog = "0.10.0"
 indexmap = "1.0"
+criterion = "0.5.1"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -18,7 +18,12 @@ criterion = "0.5.1"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }
+criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [features]
 deny-warnings = []
 fuzzing = ["neqo-crypto/fuzzing"]
+
+[[bench]]
+name = "range_tracker"
+harness = false

--- a/neqo-transport/benches/range_tracker.rs
+++ b/neqo-transport/benches/range_tracker.rs
@@ -1,0 +1,30 @@
+use criterion::{criterion_group, criterion_main, Criterion}; // black_box
+use neqo_transport::send_stream::{RangeState, RangeTracker};
+
+fn build_coalesce(len: u64) -> RangeTracker {
+    let mut used = RangeTracker::default();
+    used.mark_range(0, 1000, RangeState::Acked);
+    used.mark_range(1000, 100000, RangeState::Sent);
+    // leave a gap or it will coalesce here
+    for i in 1 .. len {
+	// These do not get immediately coalesced when marking since they're not at the end or start
+	used.mark_range((i+1) * 1000, 1000, RangeState::Acked); 
+    }
+    return used;
+}
+
+fn coalesce(used: &mut RangeTracker) {
+    used.mark_range(1000,1000, RangeState::Acked);
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut used = build_coalesce(1);
+    c.bench_function("coalesce_acked_from_zero 2 entries", |b| b.iter(|| coalesce(&mut used)));
+    used = build_coalesce(100);
+    c.bench_function("coalesce_acked_from_zero 100 entries", |b| b.iter(|| coalesce(&mut used)));
+    used = build_coalesce(1000);
+    c.bench_function("coalesce_acked_from_zero 1000 entries", |b| b.iter(|| coalesce(&mut used)));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -28,7 +28,7 @@ mod quic_datagrams;
 mod recovery;
 mod recv_stream;
 mod rtt;
-mod send_stream;
+pub mod send_stream;
 mod sender;
 pub mod server;
 mod stats;
@@ -184,7 +184,7 @@ impl From<std::num::TryFromIntError> for Error {
 }
 
 impl ::std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn::std::error::Error + 'static)> {
         match self {
             Self::CryptoError(e) => Some(e),
             _ => None,

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -137,7 +137,7 @@ impl Default for RetransmissionPriority {
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-enum RangeState {
+pub enum RangeState {
     Sent,
     Acked,
 }
@@ -145,7 +145,7 @@ enum RangeState {
 /// Track ranges in the stream as sent or acked. Acked implies sent. Not in a
 /// range implies needing-to-be-sent, either initially or as a retransmission.
 #[derive(Debug, Default, PartialEq)]
-struct RangeTracker {
+pub struct RangeTracker {
     // offset, (len, RangeState). Use u64 for len because ranges can exceed 32bits.
     used: BTreeMap<u64, (u64, RangeState)>,
 }
@@ -300,7 +300,7 @@ impl RangeTracker {
         }
     }
 
-    fn mark_range(&mut self, off: u64, len: usize, state: RangeState) {
+    pub fn mark_range(&mut self, off: u64, len: usize, state: RangeState) {
         if len == 0 {
             qinfo!("mark 0-length range at {}", off);
             return;

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -276,8 +276,6 @@ impl RangeTracker {
             .map(|(len, _)| *len);
 
         if let Some(len_from_zero) = acked_range_from_zero {
-            let mut to_remove = SmallVec::<[_; 8]>::new();
-
             let mut new_len_from_zero = len_from_zero;
 
             // See if there's another Acked range entry contiguous to this one
@@ -286,16 +284,13 @@ impl RangeTracker {
                 .get(&new_len_from_zero)
                 .filter(|(_, state)| *state == RangeState::Acked)
             {
-                to_remove.push(new_len_from_zero);
+                let to_remove = new_len_from_zero;
                 new_len_from_zero += *next_len;
+                self.used.remove(&to_remove);
             }
 
             if len_from_zero != new_len_from_zero {
                 self.used.get_mut(&0).expect("must be there").0 = new_len_from_zero;
-            }
-
-            for val in to_remove {
-                self.used.remove(&val);
             }
         }
     }


### PR DESCRIPTION
Simplifies coalesce, but complicates mark_range slightly because the code will try to make data as acked multiple times.

benchmarks improve (with the bench_coalesce PR) by ~65% for the common case (2 nodes), and 75% in the edge-cases