### PR TITLE
update .gitignore for nss and nspr folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ Cargo.lock
 *.qlog
 *.swp
 /qns/.last-update-*
+/nss
+/nspr
+/dist


### PR DESCRIPTION
At [here](https://github.com/mozilla/neqo#faster-builds-with-separate-nssnspr) we said that one can clone `nss` and `nspr` in the same directory, so I think we should update `gitignore` to ignore those folders.