### PR TITLE
fix: Don't send superfluous PING-only Initial packets during handshake

### DIFF
--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -296,14 +296,18 @@ fn idle_caching() {
     client.process_input(&handshake.unwrap(), start);
 
     // Perform an exchange and keep the connection alive.
+    // Only allow a packet containing a PING to pass.
     let middle = start + AT_LEAST_PTO;
+    mem::drop(client.process_output(middle));
     let dgram = client.process_output(middle).dgram();
 
     // Get the server to send its first probe and throw that away.
     mem::drop(server.process_output(middle).dgram());
-    // Now let the server process the client packet.  This causes the server
+    // Now let the server process the client PING.  This causes the server
     // to send CRYPTO frames again, so manually extract and discard those.
+    let ping_before_s = server.stats().frame_rx.ping;
     server.process_input(&dgram.unwrap(), middle);
+    assert_eq!(server.stats().frame_rx.ping, ping_before_s + 1);
     let mut tokens = Vec::new();
     server
         .crypto
@@ -333,8 +337,10 @@ fn idle_caching() {
     // Now only allow the Initial packet from the server through;
     // it shouldn't contain a CRYPTO frame.
     let (initial, _) = split_datagram(&dgram.unwrap());
+    let ping_before_c = client.stats().frame_rx.ping;
     let ack_before = client.stats().frame_rx.ack;
     client.process_input(&initial, middle);
+    assert_eq!(client.stats().frame_rx.ping, ping_before_c + 1);
     assert_eq!(client.stats().frame_rx.ack, ack_before + 1);
 
     let end = start + default_timeout() + (AT_LEAST_PTO / 2);

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -13,7 +13,9 @@ use super::{
 use crate::{
     cc::CWND_MIN,
     path::PATH_MTU_V6,
-    recovery::{FAST_PTO_SCALE, MAX_OUTSTANDING_UNACK, MIN_OUTSTANDING_UNACK, MAX_PTO_PACKET_COUNT},
+    recovery::{
+        FAST_PTO_SCALE, MAX_OUTSTANDING_UNACK, MAX_PTO_PACKET_COUNT, MIN_OUTSTANDING_UNACK,
+    },
     rtt::GRANULARITY,
     stats::MAX_PTO_COUNTS,
     tparams::TransportParameter,
@@ -570,6 +572,8 @@ fn loss_time_past_largest_acked() {
     assert!(s_pto < RTT);
     let s_hs2 = server.process(None, now + s_pto).dgram();
     assert!(s_hs2.is_some());
+    let s_hs3 = server.process(None, now + s_pto).dgram();
+    assert!(s_hs3.is_some());
 
     // Get some Handshake packets from the client.
     // We need one to be left unacknowledged before one that is acknowledged.
@@ -589,10 +593,14 @@ fn loss_time_past_largest_acked() {
     let _p1 = send_something(&mut client, now + INCR);
     let c_hs3 = client.process(s_hs2.as_ref(), now + (INCR * 2)).dgram();
     assert!(c_hs3.is_some()); // This will be left outstanding.
+    let c_hs4 = client.process(s_hs3.as_ref(), now + (INCR * 3)).dgram();
+    assert!(c_hs4.is_some()); // This will be acknowledged.
 
-    // Process c_hs2, but skip c_hs3.
+    // Process c_hs2 and c_hs4, but skip c_hs3.
     // Then get an ACK for the client.
     now += RTT / 2;
+    // Deliver c_hs4 first, but don't generate a packet.
+    server.process_input(&c_hs4.unwrap(), now);
     let s_ack = server.process(c_hs2.as_ref(), now).dgram();
     assert!(s_ack.is_some());
     // This includes an ACK, but it also includes HANDSHAKE_DONE,

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -13,7 +13,7 @@ use super::{
 use crate::{
     cc::CWND_MIN,
     path::PATH_MTU_V6,
-    recovery::{FAST_PTO_SCALE, MAX_OUTSTANDING_UNACK, MIN_OUTSTANDING_UNACK, PTO_PACKET_COUNT},
+    recovery::{FAST_PTO_SCALE, MAX_OUTSTANDING_UNACK, MIN_OUTSTANDING_UNACK, MAX_PTO_PACKET_COUNT},
     rtt::GRANULARITY,
     stats::MAX_PTO_COUNTS,
     tparams::TransportParameter,
@@ -172,10 +172,6 @@ fn pto_initial() {
     let pkt2 = client.process(None, now).dgram();
     assert!(pkt2.is_some());
     assert_eq!(pkt2.unwrap().len(), PATH_MTU_V6);
-
-    let pkt3 = client.process(None, now).dgram();
-    assert!(pkt3.is_some());
-    assert_eq!(pkt3.unwrap().len(), PATH_MTU_V6);
 
     let delay = client.process(None, now).callback();
     // PTO has doubled.
@@ -468,7 +464,8 @@ fn ack_after_pto() {
 
     // Jump forward to the PTO and drain the PTO packets.
     now += AT_LEAST_PTO;
-    for _ in 0..PTO_PACKET_COUNT {
+    // We can use MAX_PTO_PACKET_COUNT, because we know the handshake is over.
+    for _ in 0..MAX_PTO_PACKET_COUNT {
         let dgram = client.process(None, now).dgram();
         assert!(dgram.is_some());
     }
@@ -573,8 +570,6 @@ fn loss_time_past_largest_acked() {
     assert!(s_pto < RTT);
     let s_hs2 = server.process(None, now + s_pto).dgram();
     assert!(s_hs2.is_some());
-    let s_hs3 = server.process(None, now + s_pto).dgram();
-    assert!(s_hs3.is_some());
 
     // Get some Handshake packets from the client.
     // We need one to be left unacknowledged before one that is acknowledged.
@@ -594,14 +589,10 @@ fn loss_time_past_largest_acked() {
     let _p1 = send_something(&mut client, now + INCR);
     let c_hs3 = client.process(s_hs2.as_ref(), now + (INCR * 2)).dgram();
     assert!(c_hs3.is_some()); // This will be left outstanding.
-    let c_hs4 = client.process(s_hs3.as_ref(), now + (INCR * 3)).dgram();
-    assert!(c_hs4.is_some()); // This will be acknowledged.
 
-    // Process c_hs2 and c_hs4, but skip c_hs3.
+    // Process c_hs2, but skip c_hs3.
     // Then get an ACK for the client.
     now += RTT / 2;
-    // Deliver c_hs4 first, but don't generate a packet.
-    server.process_input(&c_hs4.unwrap(), now);
     let s_ack = server.process(c_hs2.as_ref(), now).dgram();
     assert!(s_ack.is_some());
     // This includes an ACK, but it also includes HANDSHAKE_DONE,

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -326,10 +326,8 @@ fn retry_after_pto() {
 
     // Let PTO fire on the client and then let it exhaust its PTO packets.
     now += Duration::from_secs(1);
-    let pto1 = client.process(None, now).dgram();
-    assert!(pto1.unwrap().len() >= 1200);
-    let pto2 = client.process(None, now).dgram();
-    assert!(pto2.unwrap().len() >= 1200);
+    let pto = client.process(None, now).dgram();
+    assert!(pto.unwrap().len() >= 1200);
     let cb = client.process(None, now).callback();
     assert_ne!(cb, Duration::new(0, 0));
 


### PR DESCRIPTION
This limits the Initial packet number space to sending one packet when a PTO fires (other packet number spaces will continue to send two.) This stops PING-only Initial packets during handshake.

Some tests based in the assumption that those PINGs would be sent. Fix those, too. I'd appreciate if someone could esp. double-check the test modifications, esp. to the `idle_caching` test, which is gnarly.

Fixes #744