### PR TITLE
Add key exchange group configuration knobs

### DIFF
--- a/neqo-crypto/bindings/bindings.toml
+++ b/neqo-crypto/bindings/bindings.toml
@@ -49,6 +49,7 @@ functions = [
     "SSL_PeerSignedCertTimestamps",
     "SSL_PeerStapledOCSPResponses",
     "SSL_ResetHandshake",
+    "SSL_SendAdditionalKeyShares",
     "SSL_SetNextProtoNego",
     "SSL_SetURL",
     "SSL_VersionRangeSet",

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -461,6 +461,16 @@ impl SecretAgent {
         })
     }
 
+    /// Set the number of additional key shares that will be sent in the client hello
+    ///
+    /// # Errors
+    /// If the underlying API fails (which shouldn't happen).
+    pub fn send_additional_key_shares(&mut self, count: usize) -> Res<()> {
+        secstatus_to_res(unsafe {
+            ssl::SSL_SendAdditionalKeyShares(self.fd, c_uint::try_from(count)?)
+        })
+    }
+
     /// Set TLS options.
     ///
     /// # Errors

--- a/neqo-crypto/src/constants.rs
+++ b/neqo-crypto/src/constants.rs
@@ -62,6 +62,7 @@ remap_enum! {
         TLS_GRP_EC_SECP384R1 = ssl_grp_ec_secp384r1,
         TLS_GRP_EC_SECP521R1 = ssl_grp_ec_secp521r1,
         TLS_GRP_EC_X25519 = ssl_grp_ec_curve25519,
+        TLS_GRP_KEM_XYBER768D00 = ssl_grp_kem_xyber768d00,
     }
 }
 

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -74,7 +74,7 @@ use std::{
     ptr::null,
 };
 
-const MINIMUM_NSS_VERSION: &str = "3.74";
+const MINIMUM_NSS_VERSION: &str = "3.97";
 
 #[allow(non_upper_case_globals, clippy::redundant_static_lifetimes)]
 #[allow(clippy::upper_case_acronyms)]

--- a/neqo-crypto/tests/agent.rs
+++ b/neqo-crypto/tests/agent.rs
@@ -4,7 +4,7 @@
 use neqo_crypto::{
     generate_ech_keys, AuthenticationStatus, Client, Error, HandshakeState, SecretAgentPreInfo,
     Server, ZeroRttCheckResult, ZeroRttChecker, TLS_AES_128_GCM_SHA256,
-    TLS_CHACHA20_POLY1305_SHA256, TLS_GRP_EC_SECP256R1, TLS_VERSION_1_3,
+    TLS_CHACHA20_POLY1305_SHA256, TLS_GRP_EC_SECP256R1, TLS_GRP_EC_X25519, TLS_VERSION_1_3,
 };
 
 use std::boxed::Box;
@@ -156,6 +156,48 @@ fn chacha_client() {
 }
 
 #[test]
+fn server_prefers_first_client_share() {
+    fixture_init();
+    let mut client = Client::new("server.example", true).expect("should create client");
+    let mut server = Server::new(&["key"]).expect("should create server");
+    server
+        .set_groups(&[TLS_GRP_EC_X25519, TLS_GRP_EC_SECP256R1])
+        .expect("groups set");
+    client
+        .set_groups(&[TLS_GRP_EC_X25519, TLS_GRP_EC_SECP256R1])
+        .expect("groups set");
+    client
+        .send_additional_key_shares(1)
+        .expect("should set additional key share count");
+
+    connect(&mut client, &mut server);
+
+    assert_eq!(client.info().unwrap().key_exchange(), TLS_GRP_EC_X25519);
+    assert_eq!(server.info().unwrap().key_exchange(), TLS_GRP_EC_X25519);
+}
+
+#[test]
+fn server_prefers_second_client_share() {
+    fixture_init();
+    let mut client = Client::new("server.example", true).expect("should create client");
+    let mut server = Server::new(&["key"]).expect("should create server");
+    server
+        .set_groups(&[TLS_GRP_EC_SECP256R1, TLS_GRP_EC_X25519])
+        .expect("groups set");
+    client
+        .set_groups(&[TLS_GRP_EC_X25519, TLS_GRP_EC_SECP256R1])
+        .expect("groups set");
+    client
+        .send_additional_key_shares(1)
+        .expect("should set additional key share count");
+
+    connect(&mut client, &mut server);
+
+    assert_eq!(client.info().unwrap().key_exchange(), TLS_GRP_EC_SECP256R1);
+    assert_eq!(server.info().unwrap().key_exchange(), TLS_GRP_EC_SECP256R1);
+}
+
+#[test]
 fn p256_server() {
     fixture_init();
     let mut client = Client::new("server.example", true).expect("should create client");
@@ -163,6 +205,27 @@ fn p256_server() {
     server
         .set_groups(&[TLS_GRP_EC_SECP256R1])
         .expect("groups set");
+
+    connect(&mut client, &mut server);
+
+    assert_eq!(client.info().unwrap().key_exchange(), TLS_GRP_EC_SECP256R1);
+    assert_eq!(server.info().unwrap().key_exchange(), TLS_GRP_EC_SECP256R1);
+}
+
+#[test]
+fn p256_server_hrr() {
+    fixture_init();
+    let mut client = Client::new("server.example", true).expect("should create client");
+    let mut server = Server::new(&["key"]).expect("should create server");
+    server
+        .set_groups(&[TLS_GRP_EC_SECP256R1])
+        .expect("groups set");
+    client
+        .set_groups(&[TLS_GRP_EC_X25519, TLS_GRP_EC_SECP256R1])
+        .expect("groups set");
+    client
+        .send_additional_key_shares(0)
+        .expect("should set additional key share count");
 
     connect(&mut client, &mut server);
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -42,7 +42,7 @@ use neqo_common::{
     qlog::NeqoQlog, qtrace, qwarn, Datagram, Decoder, Encoder, Role,
 };
 use neqo_crypto::{
-    agent::CertificateInfo, random, Agent, AntiReplay, AuthenticationStatus, Cipher, Client,
+    agent::CertificateInfo, random, Agent, AntiReplay, AuthenticationStatus, Cipher, Client, Group,
     HandshakeState, PrivateKey, PublicKey, ResumptionToken, SecretAgentInfo, SecretAgentPreInfo,
     Server, ZeroRttChecker,
 };
@@ -542,6 +542,26 @@ impl Connection {
             return Err(Error::ConnectionState);
         }
         self.crypto.tls.set_ciphers(ciphers)?;
+        Ok(())
+    }
+
+    /// Enable a set of key exchange groups.
+    pub fn set_groups(&mut self, groups: &[Group]) -> Res<()> {
+        if self.state != State::Init {
+            qerror!([self], "Cannot enable groups in state {:?}", self.state);
+            return Err(Error::ConnectionState);
+        }
+        self.crypto.tls.set_groups(groups)?;
+        Ok(())
+    }
+
+    /// Set the number of additional key shares to send in the client hello.
+    pub fn send_additional_key_shares(&mut self, count: usize) -> Res<()> {
+        if self.state != State::Init {
+            qerror!([self], "Cannot enable groups in state {:?}", self.state);
+            return Err(Error::ConnectionState);
+        }
+        self.crypto.tls.send_additional_key_shares(count)?;
         Ok(())
     }
 

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -22,6 +22,7 @@ use neqo_crypto::{
     PrivateKey, PublicKey, Record, RecordList, ResumptionToken, SymKey, ZeroRttChecker,
     TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256, TLS_CT_HANDSHAKE,
     TLS_EPOCH_APPLICATION_DATA, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL, TLS_EPOCH_ZERO_RTT,
+    TLS_GRP_EC_SECP256R1, TLS_GRP_EC_SECP384R1, TLS_GRP_EC_SECP521R1, TLS_GRP_EC_X25519,
     TLS_VERSION_1_3,
 };
 
@@ -78,6 +79,13 @@ impl Crypto {
             TLS_AES_256_GCM_SHA384,
             TLS_CHACHA20_POLY1305_SHA256,
         ])?;
+        agent.set_groups(&[
+            TLS_GRP_EC_X25519,
+            TLS_GRP_EC_SECP256R1,
+            TLS_GRP_EC_SECP384R1,
+            TLS_GRP_EC_SECP521R1,
+        ])?;
+        agent.send_additional_key_shares(1)?;
         agent.set_alpn(&protocols)?;
         agent.disable_end_of_early_data()?;
         // Always enable 0-RTT on the client, but the server needs


### PR DESCRIPTION
Currently, neqo clients list all of the key exchange groups supported by NSS in their supported_groups extension, and this is not configurable. They also send only one key share entry.

The first patch in this PR makes it possible to configure both the supported_groups list and the number of key share entries that are sent. The second patch sets defaults for both. 

According to [telemetry](https://glam.telemetry.mozilla.org/firefox/probe/ssl_kea_ecdhe_curve_full/explore), about 82% of TLS 1.3 connections over TCP negotiate X25519 and 16% negotiate P-256. The remainder use P-384 or P-521. My guess is that QUIC is even more heavily skewed towards X25519 but that it still makes sense to send a P-256 share.

Some additional motivation for this change:

I've recently [added support](https://bugzilla.mozilla.org/show_bug.cgi?id=1871629) for [xyber768d00](https://www.ietf.org/archive/id/draft-tls-westerbaan-xyber768d00-02.html) to NSS, and I'm going to start an [experiment](https://bugzilla.mozilla.org/show_bug.cgi?id=1874959) with it in Firefox. I need the new knobs here to keep xyber768d00 out of supported_groups when it is disabled by pref. Currently I'm relying on an [NSS policy kludge](https://bugzilla.mozilla.org/show_bug.cgi?id=1875158) to do this.
