### PR TITLE
fix(transport/dump): check module not max log level and move to conn

### DIFF
--- a/neqo-transport/src/connection/dump.rs
+++ b/neqo-transport/src/connection/dump.rs
@@ -27,7 +27,7 @@ pub fn dump_packet(
     pn: PacketNumber,
     payload: &[u8],
 ) {
-    if ::log::Level::Debug > ::log::max_level() {
+    if !log::log_enabled!(log::Level::Debug) {
         return;
     }
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -36,7 +36,6 @@ use crate::{
         ConnectionIdRef, ConnectionIdStore, LOCAL_ACTIVE_CID_LIMIT,
     },
     crypto::{Crypto, CryptoDxState, CryptoSpace},
-    dump::*,
     events::{ConnectionEvent, ConnectionEvents, OutgoingDatagramOutcome},
     frame::{
         CloseError, Frame, FrameType, FRAME_TYPE_CONNECTION_CLOSE_APPLICATION,
@@ -60,14 +59,14 @@ use crate::{
     version::{Version, WireVersion},
     AppError, ConnectionError, Error, Res, StreamId,
 };
-
+mod dump;
 mod idle;
 pub mod params;
 mod saved;
 mod state;
 #[cfg(test)]
 pub mod test_internal;
-
+use dump::dump_packet;
 use idle::IdleTimeout;
 pub use params::ConnectionParameters;
 use params::PreferredAddressConfig;

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -16,7 +16,6 @@ mod cc;
 mod cid;
 mod connection;
 mod crypto;
-mod dump;
 mod events;
 mod fc;
 mod frame;


### PR DESCRIPTION
This commit contains two changes:

The first change. To avoid expensive packet decoding and string encoding, the `neqo-transport` `dump_packet` function first checks the current log level:

``` rust
if ::log::Level::Debug > ::log::max_level() {
    return;
}
```

This is problematic when e.g. setting `RUST_LOG=info,neqo_crypto=debug`. While `::log::max_level` will return `::log::Level::Debug`, given the `neqo_crypto=debug`, the log level of the `neqo_transport` crate and `dump` module will be `info`. Thus the packet will be de-/encoded, but never logged, given that the `qdebug!` call calls `log::debug!`, which will check the module log level and not use the maximum log level.

Instead, with this commit, `dump_packet` checks the module log level.

``` rust
if !log::log_enabled!(log::Level::Debug) {
    return;
}
```

The second change. `dump_packet` is in `neqo_transport::dump`, but only called in `neqo_transport::connection`.
`RUST_LOG=info,neqo_transport::connection=debug` will thus not dump the packet as `dump_packet` checks its own module's log level, not the log level of its call side. To remove this small footgun, move `dump_packet` to `neqo_transport::connection::dump` and thus enable logging on e.g. `RUST_LOG=info,neqo_transport::connection=debug`.

Note that the `dump` module was never exposed beyond `neqo_transport` and thus this is not a breaking change to other crates.

An alternative, arguably more complex, approach would be to write `dump_packet` as a proc macro.

//CC @jesup @larseggert 

Closes https://github.com/mozilla/neqo/issues/1548.