### PR TITLE
Cap the PTO count when working out the period

### DIFF
--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -848,11 +848,7 @@ impl LossRecovery {
         // where F = fast_pto / FAST_PTO_SCALE (== 1 by default)
         let pto_count = pto_state.map_or(0, |p| u32::try_from(p.count).unwrap_or(0));
         rtt.pto(pn_space)
-            .checked_mul(
-                u32::from(fast_pto)
-                    .checked_shl(pto_count)
-                    .unwrap_or(u32::MAX),
-            )
+            .checked_mul(u32::from(fast_pto) << min(pto_count, u32::BITS - u8::BITS))
             .map_or(Duration::from_secs(3600), |p| p / u32::from(FAST_PTO_SCALE))
     }
 


### PR DESCRIPTION
The previous code would overflow and produce a 0ns timeout when the PTO count got large (well over 24).  This is because the `fast_pto` value tends to have trailing zero bits and shift values between 32-(number of zeros) and 31 (inclusive) would still shift left.

This code instead stops increasing the PTO once it hits 24.  That should be enough for most cases.

Closes #1602.