### PR TITLE
ci: Clone NSS from hg and not the GitHub mirror

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -87,10 +87,11 @@ jobs:
       # version of NSS.  Ubuntu 20.04 only has 3.49, which is far too old.
       # (neqo-crypto/build.rs would also need to query pkg-config to get the
       # right build flags rather than building NSS.)
+      # Clone from the main hg repo, because the GitHub mirror can be out of date.
       - name: Fetch NSS and NSPR
         run: |
           hg clone https://hg.mozilla.org/projects/nspr "$NSPR_DIR"
-          git clone --depth=1 https://github.com/nss-dev/nss "$NSS_DIR"
+          hg clone https://hg.mozilla.org/projects/nss "$NSS_DIR"
           echo "NSS_DIR=$NSS_DIR" >> "$GITHUB_ENV"
           echo "NSPR_DIR=$NSPR_DIR" >> "$GITHUB_ENV"
         env:

--- a/qns/Dockerfile
+++ b/qns/Dockerfile
@@ -21,7 +21,7 @@ ENV NSS_DIR=/nss \
     LD_LIBRARY_PATH=/dist/Release/lib
 
 RUN set -eux; \
-    git clone --depth=1 https://github.com/nss-dev/nss "$NSS_DIR"; \
+    hg clone https://hg.mozilla.org/projects/nss "$NSS_DIR"; \
     hg clone https://hg.mozilla.org/projects/nspr "$NSPR_DIR"
 
 RUN "$NSS_DIR"/build.sh --static -Ddisable_tests=1 -o


### PR DESCRIPTION
Because the latter can be outdated. This is why #1081 is failing CI.