### PR TITLE
chore: Add a `.rustfmt.toml` and reformat

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,5 @@
+comment_width=100
+wrap_comments=true
+
+imports_granularity="Crate"
+group_imports="StdExternalCrate"

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -3,3 +3,5 @@ wrap_comments=true
 
 imports_granularity="Crate"
 group_imports="StdExternalCrate"
+
+format_code_in_doc_comments=true

--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -7,25 +7,6 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::use_self)]
 
-use common::IpTos;
-use qlog::{events::EventImportance, streamer::QlogStreamer};
-
-use mio::{net::UdpSocket, Events, Poll, PollOpt, Ready, Token};
-
-use neqo_common::{self as common, event::Provider, hex, qlog::NeqoQlog, Datagram, Role};
-use neqo_crypto::{
-    constants::{TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256},
-    init, AuthenticationStatus, Cipher, ResumptionToken,
-};
-use neqo_http3::{
-    self, Error, Header, Http3Client, Http3ClientEvent, Http3Parameters, Http3State, Output,
-    Priority,
-};
-use neqo_transport::{
-    CongestionControlAlgorithm, Connection, ConnectionId, ConnectionParameters,
-    EmptyConnectionIdGenerator, Error as TransportError, StreamId, StreamType, Version,
-};
-
 use std::{
     cell::RefCell,
     collections::{HashMap, VecDeque},
@@ -41,6 +22,22 @@ use std::{
     time::{Duration, Instant},
 };
 
+use common::IpTos;
+use mio::{net::UdpSocket, Events, Poll, PollOpt, Ready, Token};
+use neqo_common::{self as common, event::Provider, hex, qlog::NeqoQlog, Datagram, Role};
+use neqo_crypto::{
+    constants::{TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256},
+    init, AuthenticationStatus, Cipher, ResumptionToken,
+};
+use neqo_http3::{
+    self, Error, Header, Http3Client, Http3ClientEvent, Http3Parameters, Http3State, Output,
+    Priority,
+};
+use neqo_transport::{
+    CongestionControlAlgorithm, Connection, ConnectionId, ConnectionParameters,
+    EmptyConnectionIdGenerator, Error as TransportError, StreamId, StreamType, Version,
+};
+use qlog::{events::EventImportance, streamer::QlogStreamer};
 use structopt::StructOpt;
 use url::{Origin, Url};
 
@@ -1140,9 +1137,6 @@ mod old {
         time::{Duration, Instant},
     };
 
-    use url::Url;
-
-    use super::{qlog_new, KeyUpdateState, Res};
     use mio::{Events, Poll};
     use neqo_common::{event::Provider, Datagram, IpTos};
     use neqo_crypto::{AuthenticationStatus, ResumptionToken};
@@ -1150,8 +1144,9 @@ mod old {
         Connection, ConnectionEvent, EmptyConnectionIdGenerator, Error, Output, State, StreamId,
         StreamType,
     };
+    use url::Url;
 
-    use super::{emit_datagram, get_output_file, Args};
+    use super::{emit_datagram, get_output_file, qlog_new, Args, KeyUpdateState, Res};
 
     struct HandlerOld<'b> {
         streams: HashMap<StreamId, Option<File>>,

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -34,7 +34,9 @@ impl<'a> Decoder<'a> {
     }
 
     /// Skip n bytes.
+    ///
     /// # Panics
+    ///
     /// If the remaining quantity is less than `n`.
     pub fn skip(&mut self, n: usize) {
         assert!(self.remaining() >= n, "insufficient data");
@@ -90,7 +92,9 @@ impl<'a> Decoder<'a> {
     }
 
     /// Decodes an unsigned integer of length 1..=8.
+    ///
     /// # Panics
+    ///
     /// This panics if `n` is not in the range `1..=8`.
     pub fn decode_uint(&mut self, n: usize) -> Option<u64> {
         assert!(n > 0 && n <= 8);
@@ -198,7 +202,9 @@ pub struct Encoder {
 
 impl Encoder {
     /// Static helper function for previewing the results of encoding without doing it.
+    ///
     /// # Panics
+    ///
     /// When `v` is too large.
     #[must_use]
     pub const fn varint_len(v: u64) -> usize {
@@ -212,7 +218,9 @@ impl Encoder {
     }
 
     /// Static helper to determine how long a varint-prefixed array encodes to.
+    ///
     /// # Panics
+    ///
     /// When `len` doesn't fit in a `u64`.
     #[must_use]
     pub fn vvec_len(len: usize) -> usize {
@@ -261,7 +269,9 @@ impl Encoder {
     }
 
     /// Don't use this except in testing.
+    ///
     /// # Panics
+    ///
     /// When `s` contains non-hex values or an odd number of values.
     #[must_use]
     pub fn from_hex(s: impl AsRef<str>) -> Self {
@@ -291,7 +301,9 @@ impl Encoder {
     }
 
     /// Encode an integer of any size up to u64.
+    ///
     /// # Panics
+    ///
     /// When `n` is outside the range `1..=8`.
     #[allow(clippy::cast_possible_truncation)]
     pub fn encode_uint<T: Into<u64>>(&mut self, n: usize, v: T) -> &mut Self {
@@ -304,7 +316,9 @@ impl Encoder {
     }
 
     /// Encode a QUIC varint.
+    ///
     /// # Panics
+    ///
     /// When `v >= 1<<62`.
     pub fn encode_varint<T: Into<u64>>(&mut self, v: T) -> &mut Self {
         let v = v.into();
@@ -319,7 +333,9 @@ impl Encoder {
     }
 
     /// Encode a vector in TLS style.
+    ///
     /// # Panics
+    ///
     /// When `v` is longer than 2^64.
     pub fn encode_vec(&mut self, n: usize, v: &[u8]) -> &mut Self {
         self.encode_uint(n, u64::try_from(v.as_ref().len()).unwrap())
@@ -327,7 +343,9 @@ impl Encoder {
     }
 
     /// Encode a vector in TLS style using a closure for the contents.
+    ///
     /// # Panics
+    ///
     /// When `f()` returns a length larger than `2^8n`.
     #[allow(clippy::cast_possible_truncation)]
     pub fn encode_vec_with<F: FnOnce(&mut Self)>(&mut self, n: usize, f: F) -> &mut Self {
@@ -343,7 +361,9 @@ impl Encoder {
     }
 
     /// Encode a vector with a varint length.
+    ///
     /// # Panics
+    ///
     /// When `v` is longer than 2^64.
     pub fn encode_vvec(&mut self, v: &[u8]) -> &mut Self {
         self.encode_varint(u64::try_from(v.as_ref().len()).unwrap())
@@ -351,7 +371,9 @@ impl Encoder {
     }
 
     /// Encode a vector with a varint length using a closure.
+    ///
     /// # Panics
+    ///
     /// When `f()` writes more than 2^62 bytes.
     #[allow(clippy::cast_possible_truncation)]
     pub fn encode_vvec_with<F: FnOnce(&mut Self)>(&mut self, f: F) -> &mut Self {

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -4,8 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::net::SocketAddr;
-use std::ops::Deref;
+use std::{net::SocketAddr, ops::Deref};
 
 use crate::{hex_with_len, IpTos};
 

--- a/neqo-common/src/event.rs
+++ b/neqo-common/src/event.rs
@@ -4,8 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::iter::Iterator;
-use std::marker::PhantomData;
+use std::{iter::Iterator, marker::PhantomData};
 
 /// An event provider is able to generate a stream of events.
 pub trait Provider {

--- a/neqo-common/src/hrtime.rs
+++ b/neqo-common/src/hrtime.rs
@@ -379,11 +379,12 @@ impl Drop for Time {
     not(all(any(target_os = "macos", target_os = "windows"), feature = "ci"))
 ))]
 mod test {
-    use super::Time;
     use std::{
         thread::{sleep, spawn},
         time::{Duration, Instant},
     };
+
+    use super::Time;
 
     const ONE: Duration = Duration::from_millis(1);
     const ONE_AND_A_BIT: Duration = Duration::from_micros(1500);

--- a/neqo-common/src/incrdecoder.rs
+++ b/neqo-common/src/incrdecoder.rs
@@ -21,7 +21,9 @@ impl IncrementalDecoderUint {
     }
 
     /// Consume some data.
+    ///
     /// # Panics
+    ///
     /// Never, but this is not something the compiler can tell.
     pub fn consume(&mut self, dv: &mut Decoder) -> Option<u64> {
         if let Some(r) = &mut self.remaining {
@@ -87,7 +89,9 @@ impl IncrementalDecoderBuffer {
     }
 
     /// Consume some bytes from the decoder.
+    ///
     /// # Panics
+    ///
     /// Never; but rust doesn't know that.
     pub fn consume(&mut self, dv: &mut Decoder) -> Option<Vec<u8>> {
         let amount = min(self.remaining, dv.remaining());
@@ -109,7 +113,9 @@ pub struct IncrementalDecoderIgnore {
 
 impl IncrementalDecoderIgnore {
     /// Make a new ignoring decoder.
+    ///
     /// # Panics
+    ///
     /// If the amount to ignore is zero.
     #[must_use]
     pub fn new(n: usize) -> Self {

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -18,17 +18,17 @@ pub mod qlog;
 pub mod timer;
 pub mod tos;
 
-pub use self::codec::{Decoder, Encoder};
-pub use self::datagram::Datagram;
-pub use self::header::Header;
-pub use self::incrdecoder::{
-    IncrementalDecoderBuffer, IncrementalDecoderIgnore, IncrementalDecoderUint,
-};
-pub use self::tos::{IpTos, IpTosDscp, IpTosEcn};
-
 use std::fmt::Write;
 
 use enum_map::Enum;
+
+pub use self::{
+    codec::{Decoder, Encoder},
+    datagram::Datagram,
+    header::Header,
+    incrdecoder::{IncrementalDecoderBuffer, IncrementalDecoderIgnore, IncrementalDecoderUint},
+    tos::{IpTos, IpTosDscp, IpTosEcn},
+};
 
 #[must_use]
 pub fn hex(buf: impl AsRef<[u8]>) -> String {

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -6,11 +6,10 @@
 
 #![allow(clippy::module_name_repetitions)]
 
+use std::{io::Write, sync::Once, time::Instant};
+
 use env_logger::Builder;
 use lazy_static::lazy_static;
-use std::io::Write;
-use std::sync::Once;
-use std::time::Instant;
 
 #[macro_export]
 macro_rules! do_log {

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -31,6 +31,7 @@ pub struct NeqoQlogShared {
 
 impl NeqoQlog {
     /// Create an enabled `NeqoQlog` configuration.
+    ///
     /// # Errors
     ///
     /// Will return `qlog::Error` if cannot write to the new log.

--- a/neqo-common/src/timer.rs
+++ b/neqo-common/src/timer.rs
@@ -4,9 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::convert::TryFrom;
-use std::mem;
-use std::time::{Duration, Instant};
+use std::{
+    convert::TryFrom,
+    mem,
+    time::{Duration, Instant},
+};
 
 /// Internal structure for a timer item.
 struct TimerItem<T> {
@@ -21,10 +23,10 @@ impl<T> TimerItem<T> {
 }
 
 /// A timer queue.
-/// This uses a classic timer wheel arrangement, with some characteristics that might be considered peculiar.
-/// Each slot in the wheel is sorted (complexity O(N) insertions, but O(logN) to find cut points).
-/// Time is relative, the wheel has an origin time and it is unable to represent times that are more than
-/// `granularity * capacity` past that time.
+/// This uses a classic timer wheel arrangement, with some characteristics that might be considered
+/// peculiar. Each slot in the wheel is sorted (complexity O(N) insertions, but O(logN) to find cut
+/// points). Time is relative, the wheel has an origin time and it is unable to represent times that
+/// are more than `granularity * capacity` past that time.
 pub struct Timer<T> {
     items: Vec<Vec<TimerItem<T>>>,
     now: Instant,
@@ -241,8 +243,9 @@ impl<T> Timer<T> {
 
 #[cfg(test)]
 mod test {
-    use super::{Duration, Instant, Timer};
     use lazy_static::lazy_static;
+
+    use super::{Duration, Instant, Timer};
 
     lazy_static! {
         static ref NOW: Instant = Instant::now();

--- a/neqo-common/src/timer.rs
+++ b/neqo-common/src/timer.rs
@@ -36,7 +36,9 @@ pub struct Timer<T> {
 
 impl<T> Timer<T> {
     /// Construct a new wheel at the given granularity, starting at the given time.
+    ///
     /// # Panics
+    ///
     /// When `capacity` is too large to fit in `u32` or `granularity` is zero.
     pub fn new(now: Instant, granularity: Duration, capacity: usize) -> Self {
         assert!(u32::try_from(capacity).is_ok());
@@ -111,7 +113,9 @@ impl<T> Timer<T> {
     }
 
     /// Asserts if the time given is in the past or too far in the future.
+    ///
     /// # Panics
+    ///
     /// When `time` is in the past relative to previous calls.
     pub fn add(&mut self, time: Instant, item: T) {
         assert!(time >= self.now);

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -7,13 +7,15 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::pedantic)]
 
+use std::{
+    collections::HashMap,
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
 use bindgen::Builder;
 use serde_derive::Deserialize;
-use std::collections::HashMap;
-use std::env;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
 
 const BINDINGS_DIR: &str = "bindings";
 const BINDINGS_CONFIG: &str = "bindings.toml";

--- a/neqo-crypto/src/aead.rs
+++ b/neqo-crypto/src/aead.rs
@@ -62,6 +62,7 @@ impl RealAead {
     /// Create a new AEAD based on the indicated TLS version and cipher suite.
     ///
     /// # Errors
+    ///
     /// Returns `Error` when the supporting NSS functions fail.
     pub fn new(
         _fuzzing: bool,
@@ -107,6 +108,7 @@ impl RealAead {
     /// the value provided in `Aead::expansion`.
     ///
     /// # Errors
+    ///
     /// If the input can't be protected or any input is too large for NSS.
     pub fn encrypt<'a>(
         &self,
@@ -139,6 +141,7 @@ impl RealAead {
     /// the final result will be shorter.
     ///
     /// # Errors
+    ///
     /// If the input isn't authenticated or any input is too large for NSS.
     pub fn decrypt<'a>(
         &self,

--- a/neqo-crypto/src/aead.rs
+++ b/neqo-crypto/src/aead.rs
@@ -4,6 +4,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{
+    convert::{TryFrom, TryInto},
+    fmt,
+    ops::{Deref, DerefMut},
+    os::raw::{c_char, c_uint},
+    ptr::null_mut,
+};
+
 use crate::{
     constants::{Cipher, Version},
     err::Res,
@@ -11,14 +19,6 @@ use crate::{
     p11::{PK11SymKey, SymKey},
     scoped_ptr,
     ssl::{self, PRUint16, PRUint64, PRUint8, SSLAeadContext},
-};
-
-use std::{
-    convert::{TryFrom, TryInto},
-    fmt,
-    ops::{Deref, DerefMut},
-    os::raw::{c_char, c_uint},
-    ptr::null_mut,
 };
 
 experimental_api!(SSL_MakeAead(

--- a/neqo-crypto/src/aead_fuzzing.rs
+++ b/neqo-crypto/src/aead_fuzzing.rs
@@ -4,11 +4,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::constants::{Cipher, Version};
-use crate::err::{sec::SEC_ERROR_BAD_DATA, Error, Res};
-use crate::p11::SymKey;
-use crate::RealAead;
 use std::fmt;
+
+use crate::{
+    constants::{Cipher, Version},
+    err::{sec::SEC_ERROR_BAD_DATA, Error, Res},
+    p11::SymKey,
+    RealAead,
+};
 
 pub const FIXED_TAG_FUZZING: &[u8] = &[0x0a; 16];
 
@@ -76,8 +79,8 @@ impl FuzzingAead {
         let len_encrypted = input.len() - FIXED_TAG_FUZZING.len();
         // Check that:
         // 1) expansion is all zeros and
-        // 2) if the encrypted data is also supplied that at least some values
-        //    are no zero (otherwise padding will be interpreted as a valid packet)
+        // 2) if the encrypted data is also supplied that at least some values are no zero
+        //    (otherwise padding will be interpreted as a valid packet)
         if &input[len_encrypted..] == FIXED_TAG_FUZZING
             && (len_encrypted == 0 || input[..len_encrypted].iter().any(|x| *x != 0x0))
         {

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -159,6 +159,7 @@ impl SecretAgentPreInfo {
     }
 
     /// # Panics
+    ///
     /// If `usize` is less than 32 bits and the value is too large.
     #[must_use]
     pub fn max_early_data(&self) -> usize {
@@ -185,6 +186,7 @@ impl SecretAgentPreInfo {
     /// which contains a valid ECH configuration.
     ///
     /// # Errors
+    ///
     /// When the public name is not valid UTF-8.  (Note: names should be ASCII.)
     pub fn ech_public_name(&self) -> Res<Option<&str>> {
         if self.info.valuesSet & ssl::ssl_preinfo_ech == 0 || self.info.echPublicName.is_null() {
@@ -397,6 +399,7 @@ impl SecretAgent {
     /// Default configuration.
     ///
     /// # Errors
+    ///
     /// If `set_version_range` fails.
     fn configure(&mut self, grease: bool) -> Res<()> {
         self.set_version_range(TLS_VERSION_1_3, TLS_VERSION_1_3)?;
@@ -413,6 +416,7 @@ impl SecretAgent {
     /// Set the versions that are supported.
     ///
     /// # Errors
+    ///
     /// If the range of versions isn't supported.
     pub fn set_version_range(&mut self, min: Version, max: Version) -> Res<()> {
         let range = ssl::SSLVersionRange { min, max };
@@ -422,6 +426,7 @@ impl SecretAgent {
     /// Enable a set of ciphers.  Note that the order of these is not respected.
     ///
     /// # Errors
+    ///
     /// If NSS can't enable or disable ciphers.
     pub fn set_ciphers(&mut self, ciphers: &[Cipher]) -> Res<()> {
         if self.state != HandshakeState::New {
@@ -449,6 +454,7 @@ impl SecretAgent {
     /// Set key exchange groups.
     ///
     /// # Errors
+    ///
     /// If the underlying API fails (which shouldn't happen).
     pub fn set_groups(&mut self, groups: &[Group]) -> Res<()> {
         // SSLNamedGroup is a different size to Group, so copy one by one.
@@ -466,6 +472,7 @@ impl SecretAgent {
     /// Set the number of additional key shares that will be sent in the client hello
     ///
     /// # Errors
+    ///
     /// If the underlying API fails (which shouldn't happen).
     pub fn send_additional_key_shares(&mut self, count: usize) -> Res<()> {
         secstatus_to_res(unsafe {
@@ -476,6 +483,7 @@ impl SecretAgent {
     /// Set TLS options.
     ///
     /// # Errors
+    ///
     /// Returns an error if the option or option value is invalid; i.e., never.
     pub fn set_option(&mut self, opt: ssl::Opt, value: bool) -> Res<()> {
         opt.set(self.fd, value)
@@ -484,6 +492,7 @@ impl SecretAgent {
     /// Enable 0-RTT.
     ///
     /// # Errors
+    ///
     /// See `set_option`.
     pub fn enable_0rtt(&mut self) -> Res<()> {
         self.set_option(ssl::Opt::EarlyData, true)
@@ -492,6 +501,7 @@ impl SecretAgent {
     /// Disable the `EndOfEarlyData` message.
     ///
     /// # Errors
+    ///
     /// See `set_option`.
     pub fn disable_end_of_early_data(&mut self) -> Res<()> {
         self.set_option(ssl::Opt::SuppressEndOfEarlyData, true)
@@ -505,8 +515,11 @@ impl SecretAgent {
     /// 255 octets in length.
     ///
     /// # Errors
+    ///
     /// This should always panic rather than return an error.
+    ///
     /// # Panics
+    ///
     /// If any of the provided `protocols` are more than 255 bytes long.
     ///
     /// [RFC7301]: https://datatracker.ietf.org/doc/html/rfc7301
@@ -556,6 +569,7 @@ impl SecretAgent {
     /// and later access any state that it accumulates.
     ///
     /// # Errors
+    ///
     /// When the extension handler can't be successfully installed.
     pub fn extension_handler(
         &mut self,
@@ -599,6 +613,7 @@ impl SecretAgent {
     /// Calling this function collects all the relevant information.
     ///
     /// # Errors
+    ///
     /// When the underlying socket functions fail.
     pub fn preinfo(&self) -> Res<SecretAgentPreInfo> {
         SecretAgentPreInfo::new(self.fd)
@@ -617,7 +632,9 @@ impl SecretAgent {
     }
 
     /// Call this function to mark the peer as authenticated.
+    ///
     /// # Panics
+    ///
     /// If the handshake doesn't need to be authenticated.
     pub fn authenticated(&mut self, status: AuthenticationStatus) {
         assert!(self.state.authentication_needed());
@@ -666,6 +683,7 @@ impl SecretAgent {
     /// function if you want to proceed, because this will mark the certificate as OK.
     ///
     /// # Errors
+    ///
     /// When the handshake fails this returns an error.
     pub fn handshake(&mut self, now: Instant, input: &[u8]) -> Res<Vec<u8>> {
         self.now.set(now)?;
@@ -702,6 +720,7 @@ impl SecretAgent {
     /// If you send data from multiple epochs, you might end up being sad.
     ///
     /// # Errors
+    ///
     /// When the handshake fails this returns an error.
     pub fn handshake_raw(&mut self, now: Instant, input: Option<Record>) -> Res<RecordList> {
         self.now.set(now)?;
@@ -729,6 +748,7 @@ impl SecretAgent {
     }
 
     /// # Panics
+    ///
     /// If setup fails.
     #[allow(unknown_lints, clippy::branches_sharing_code)]
     pub fn close(&mut self) {
@@ -834,6 +854,7 @@ impl Client {
     /// Create a new client agent.
     ///
     /// # Errors
+    ///
     /// Errors returned if the socket can't be created or configured.
     pub fn new(server_name: impl Into<String>, grease: bool) -> Res<Self> {
         let server_name = server_name.into();
@@ -923,6 +944,7 @@ impl Client {
     /// Enable resumption, using a token previously provided.
     ///
     /// # Errors
+    ///
     /// Error returned when the resumption token is invalid or
     /// the socket is not able to use the value.
     pub fn enable_resumption(&mut self, token: impl AsRef<[u8]>) -> Res<()> {
@@ -946,6 +968,7 @@ impl Client {
     /// ECH greasing.  When that is done, there is no need to look for `EchRetry`
     ///
     /// # Errors
+    ///
     /// Error returned when the configuration is invalid.
     pub fn enable_ech(&mut self, ech_config_list: impl AsRef<[u8]>) -> Res<()> {
         let config = ech_config_list.as_ref();
@@ -1040,6 +1063,7 @@ impl Server {
     /// Create a new server agent.
     ///
     /// # Errors
+    ///
     /// Errors returned when NSS fails.
     pub fn new(certificates: &[impl AsRef<str>]) -> Res<Self> {
         let mut agent = SecretAgent::new()?;
@@ -1108,6 +1132,7 @@ impl Server {
     /// via the Deref implementation on Server.
     ///
     /// # Errors
+    ///
     /// Returns an error if the underlying NSS functions fail.
     pub fn enable_0rtt(
         &mut self,
@@ -1135,6 +1160,7 @@ impl Server {
     /// The records that are sent are captured and returned.
     ///
     /// # Errors
+    ///
     /// If NSS is unable to send a ticket, or if this agent is incorrectly configured.
     pub fn send_ticket(&mut self, now: Instant, extra: &[u8]) -> Res<RecordList> {
         self.agent.now.set(now)?;
@@ -1150,6 +1176,7 @@ impl Server {
     /// Enable encrypted client hello (ECH).
     ///
     /// # Errors
+    ///
     /// Fails when NSS cannot create a key pair.
     pub fn enable_ech(
         &mut self,

--- a/neqo-crypto/src/agentio.rs
+++ b/neqo-crypto/src/agentio.rs
@@ -4,21 +4,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::constants::{ContentType, Epoch};
-use crate::err::{nspr, Error, PR_SetError, Res};
-use crate::prio;
-use crate::ssl;
+use std::{
+    cmp::min,
+    convert::{TryFrom, TryInto},
+    fmt, mem,
+    ops::Deref,
+    os::raw::{c_uint, c_void},
+    pin::Pin,
+    ptr::{null, null_mut},
+    vec::Vec,
+};
 
 use neqo_common::{hex, hex_with_len, qtrace};
-use std::cmp::min;
-use std::convert::{TryFrom, TryInto};
-use std::fmt;
-use std::mem;
-use std::ops::Deref;
-use std::os::raw::{c_uint, c_void};
-use std::pin::Pin;
-use std::ptr::{null, null_mut};
-use std::vec::Vec;
+
+use crate::{
+    constants::{ContentType, Epoch},
+    err::{nspr, Error, PR_SetError, Res},
+    prio, ssl,
+};
 
 // Alias common types.
 type PrFd = *mut prio::PRFileDesc;

--- a/neqo-crypto/src/cert.rs
+++ b/neqo-crypto/src/cert.rs
@@ -4,18 +4,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::err::secstatus_to_res;
-use crate::p11::{CERTCertListNode, CERT_GetCertificateDer, CertList, Item, SECItem, SECItemArray};
-use crate::ssl::{
-    PRFileDesc, SSL_PeerCertificateChain, SSL_PeerSignedCertTimestamps,
-    SSL_PeerStapledOCSPResponses,
+use std::{
+    convert::TryFrom,
+    ptr::{addr_of, NonNull},
+    slice,
 };
+
 use neqo_common::qerror;
 
-use std::convert::TryFrom;
-use std::ptr::{addr_of, NonNull};
-
-use std::slice;
+use crate::{
+    err::secstatus_to_res,
+    p11::{CERTCertListNode, CERT_GetCertificateDer, CertList, Item, SECItem, SECItemArray},
+    ssl::{
+        PRFileDesc, SSL_PeerCertificateChain, SSL_PeerSignedCertTimestamps,
+        SSL_PeerStapledOCSPResponses,
+    },
+};
 
 pub struct CertificateInfo {
     certs: CertList,

--- a/neqo-crypto/src/ech.rs
+++ b/neqo-crypto/src/ech.rs
@@ -4,6 +4,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{
+    convert::TryFrom,
+    ffi::CString,
+    os::raw::{c_char, c_uint},
+    ptr::{addr_of_mut, null_mut},
+};
+
+use neqo_common::qtrace;
+
 use crate::{
     err::{ssl::SSL_ERROR_ECH_RETRY_WITH_ECH, Error, Res},
     experimental_api,
@@ -13,14 +22,6 @@ use crate::{
     },
     ssl::{PRBool, PRFileDesc},
 };
-use neqo_common::qtrace;
-use std::{
-    convert::TryFrom,
-    ffi::CString,
-    os::raw::{c_char, c_uint},
-    ptr::{addr_of_mut, null_mut},
-};
-
 pub use crate::{
     p11::{HpkeAeadId as AeadId, HpkeKdfId as KdfId, HpkeKemId as KemId},
     ssl::HpkeSymmetricSuite as SymmetricSuite,

--- a/neqo-crypto/src/ech.rs
+++ b/neqo-crypto/src/ech.rs
@@ -90,8 +90,11 @@ pub fn convert_ech_error(fd: *mut PRFileDesc, err: Error) -> Error {
 /// Generate a key pair for encrypted client hello (ECH).
 ///
 /// # Errors
+///
 /// When NSS fails to generate a key pair or when the KEM is not supported.
+///
 /// # Panics
+///
 /// When underlying types aren't large enough to hold keys.  So never.
 pub fn generate_keys() -> Res<(PrivateKey, PublicKey)> {
     let slot = Slot::internal()?;
@@ -154,6 +157,7 @@ pub fn generate_keys() -> Res<(PrivateKey, PublicKey)> {
 /// Encode a configuration for encrypted client hello (ECH).
 ///
 /// # Errors
+///
 /// When NSS fails to generate a valid configuration encoding (i.e., unlikely).
 pub fn encode_config(config: u8, public_name: &str, pk: &PublicKey) -> Res<Vec<u8>> {
     // A sensible fixed value for the maximum length of a name.

--- a/neqo-crypto/src/err.rs
+++ b/neqo-crypto/src/err.rs
@@ -7,8 +7,7 @@
 #![allow(dead_code)]
 #![allow(clippy::upper_case_acronyms)]
 
-use std::os::raw::c_char;
-use std::str::Utf8Error;
+use std::{os::raw::c_char, str::Utf8Error};
 
 use crate::ssl::{SECStatus, SECSuccess};
 
@@ -19,9 +18,7 @@ mod codes {
     include!(concat!(env!("OUT_DIR"), "/nss_sslerr.rs"));
     include!(concat!(env!("OUT_DIR"), "/mozpkix.rs"));
 }
-pub use codes::mozilla_pkix_ErrorCode as mozpkix;
-pub use codes::SECErrorCodes as sec;
-pub use codes::SSLErrorCodes as ssl;
+pub use codes::{mozilla_pkix_ErrorCode as mozpkix, SECErrorCodes as sec, SSLErrorCodes as ssl};
 pub mod nspr {
     include!(concat!(env!("OUT_DIR"), "/nspr_err.rs"));
 }
@@ -137,9 +134,12 @@ pub fn is_blocked(result: &Res<()>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::err::{self, is_blocked, secstatus_to_res, Error, PRErrorCode, PR_SetError};
-    use crate::ssl::{SECFailure, SECSuccess};
     use test_fixture::fixture_init;
+
+    use crate::{
+        err::{self, is_blocked, secstatus_to_res, Error, PRErrorCode, PR_SetError},
+        ssl::{SECFailure, SECSuccess},
+    };
 
     fn set_error_code(code: PRErrorCode) {
         // This code doesn't work without initializing NSS first.

--- a/neqo-crypto/src/ext.rs
+++ b/neqo-crypto/src/ext.rs
@@ -4,6 +4,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{
+    cell::RefCell,
+    convert::TryFrom,
+    os::raw::{c_uint, c_void},
+    pin::Pin,
+    rc::Rc,
+};
+
 use crate::{
     agentio::as_c_void,
     constants::{Extension, HandshakeMessage, TLS_HS_CLIENT_HELLO, TLS_HS_ENCRYPTED_EXTENSIONS},
@@ -12,13 +20,6 @@ use crate::{
         PRBool, PRFileDesc, SECFailure, SECStatus, SECSuccess, SSLAlertDescription,
         SSLExtensionHandler, SSLExtensionWriter, SSLHandshakeType,
     },
-};
-use std::{
-    cell::RefCell,
-    convert::TryFrom,
-    os::raw::{c_uint, c_void},
-    pin::Pin,
-    rc::Rc,
 };
 
 experimental_api!(SSL_InstallExtensionHooks(

--- a/neqo-crypto/src/ext.rs
+++ b/neqo-crypto/src/ext.rs
@@ -122,11 +122,13 @@ impl ExtensionTracker {
     /// Use the provided handler to manage an extension.  This is quite unsafe.
     ///
     /// # Safety
+    ///
     /// The holder of this `ExtensionTracker` needs to ensure that it lives at
     /// least as long as the file descriptor, as NSS provides no way to remove
     /// an extension handler once it is configured.
     ///
     /// # Errors
+    ///
     /// If the underlying NSS API fails to register a handler.
     pub unsafe fn new(
         fd: *mut PRFileDesc,

--- a/neqo-crypto/src/hkdf.rs
+++ b/neqo-crypto/src/hkdf.rs
@@ -54,6 +54,7 @@ fn key_size(version: Version, cipher: Cipher) -> Res<usize> {
 /// Generate a random key of the right size for the given suite.
 ///
 /// # Errors
+///
 /// Only if NSS fails.
 pub fn generate_key(version: Version, cipher: Cipher) -> Res<SymKey> {
     import_key(version, &random(key_size(version, cipher)?))
@@ -62,6 +63,7 @@ pub fn generate_key(version: Version, cipher: Cipher) -> Res<SymKey> {
 /// Import a symmetric key for use with HKDF.
 ///
 /// # Errors
+///
 /// Errors returned if the key buffer is an incompatible size or the NSS functions fail.
 pub fn import_key(version: Version, buf: &[u8]) -> Res<SymKey> {
     if version != TLS_VERSION_1_3 {
@@ -85,6 +87,7 @@ pub fn import_key(version: Version, buf: &[u8]) -> Res<SymKey> {
 /// Extract a PRK from the given salt and IKM using the algorithm defined in RFC 5869.
 ///
 /// # Errors
+///
 /// Errors returned if inputs are too large or the NSS functions fail.
 pub fn extract(
     version: Version,
@@ -104,6 +107,7 @@ pub fn extract(
 /// Expand a PRK using the HKDF-Expand-Label function defined in RFC 8446.
 ///
 /// # Errors
+///
 /// Errors returned if inputs are too large or the NSS functions fail.
 pub fn expand_label(
     version: Version,

--- a/neqo-crypto/src/hkdf.rs
+++ b/neqo-crypto/src/hkdf.rs
@@ -4,6 +4,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{
+    convert::TryFrom,
+    os::raw::{c_char, c_uint},
+    ptr::null_mut,
+};
+
 use crate::{
     constants::{
         Cipher, Version, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384,
@@ -14,12 +20,6 @@ use crate::{
         random, Item, PK11Origin, PK11SymKey, PK11_ImportDataKey, Slot, SymKey, CKA_DERIVE,
         CKM_HKDF_DERIVE, CK_ATTRIBUTE_TYPE, CK_MECHANISM_TYPE,
     },
-};
-
-use std::{
-    convert::TryFrom,
-    os::raw::{c_char, c_uint},
-    ptr::null_mut,
 };
 
 experimental_api!(SSL_HkdfExtract(

--- a/neqo-crypto/src/hp.rs
+++ b/neqo-crypto/src/hp.rs
@@ -63,8 +63,11 @@ impl HpKey {
     /// QUIC-specific API for extracting a header-protection key.
     ///
     /// # Errors
+    ///
     /// Errors if HKDF fails or if the label is too long to fit in a `c_uint`.
+    ///
     /// # Panics
+    ///
     /// When `cipher` is not known to this code.
     #[allow(clippy::cast_sign_loss)] // Cast for PK11_GetBlockSize is safe.
     pub fn extract(version: Version, cipher: Cipher, prk: &SymKey, label: &str) -> Res<Self> {
@@ -142,9 +145,12 @@ impl HpKey {
     /// Generate a header protection mask for QUIC.
     ///
     /// # Errors
+    ///
     /// An error is returned if the NSS functions fail; a sample of the
     /// wrong size is the obvious cause.
+    ///
     /// # Panics
+    ///
     /// When the mechanism for our key is not supported.
     pub fn mask(&self, sample: &[u8]) -> Res<Vec<u8>> {
         let mut output = vec![0_u8; self.block_size()];

--- a/neqo-crypto/src/hp.rs
+++ b/neqo-crypto/src/hp.rs
@@ -4,6 +4,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{
+    cell::RefCell,
+    convert::TryFrom,
+    fmt::{self, Debug},
+    os::raw::{c_char, c_int, c_uint},
+    ptr::{addr_of_mut, null, null_mut},
+    rc::Rc,
+};
+
 use crate::{
     constants::{
         Cipher, Version, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384,
@@ -15,14 +24,6 @@ use crate::{
         PK11_GetBlockSize, SymKey, CKA_ENCRYPT, CKM_AES_ECB, CKM_CHACHA20, CK_ATTRIBUTE_TYPE,
         CK_CHACHA20_PARAMS, CK_MECHANISM_TYPE,
     },
-};
-use std::{
-    cell::RefCell,
-    convert::TryFrom,
-    fmt::{self, Debug},
-    os::raw::{c_char, c_int, c_uint},
-    ptr::{addr_of_mut, null, null_mut},
-    rc::Rc,
 };
 
 experimental_api!(SSL_HkdfExpandLabelWithMech(

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -37,15 +37,19 @@ pub mod selfencrypt;
 mod ssl;
 mod time;
 
+use std::{
+    ffi::CString,
+    path::{Path, PathBuf},
+    ptr::null,
+};
+
 #[cfg(not(feature = "fuzzing"))]
 pub use self::aead::RealAead as Aead;
-
-#[cfg(feature = "fuzzing")]
-pub use self::aead_fuzzing::FuzzingAead as Aead;
-
 #[cfg(feature = "fuzzing")]
 pub use self::aead::RealAead;
-
+#[cfg(feature = "fuzzing")]
+pub use self::aead_fuzzing::FuzzingAead as Aead;
+use self::once::OnceResult;
 pub use self::{
     agent::{
         Agent, AllowZeroRtt, Client, HandshakeState, Record, RecordList, ResumptionToken,
@@ -64,14 +68,6 @@ pub use self::{
     replay::AntiReplay,
     secrets::SecretDirection,
     ssl::Opt,
-};
-
-use self::once::OnceResult;
-
-use std::{
-    ffi::CString,
-    path::{Path, PathBuf},
-    ptr::null,
 };
 
 const MINIMUM_NSS_VERSION: &str = "3.97";
@@ -119,8 +115,8 @@ fn version_check() {
     );
 }
 
-/// Initialize NSS.  This only executes the initialization routines once, so if there is any chance that
-/// # Panics
+/// Initialize NSS.  This only executes the initialization routines once, so if there is any chance
+/// that # Panics
 /// When NSS initialization fails.
 pub fn init() {
     // Set time zero.

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -116,7 +116,10 @@ fn version_check() {
 }
 
 /// Initialize NSS.  This only executes the initialization routines once, so if there is any chance
-/// that # Panics
+/// that
+///
+/// # Panics
+///
 /// When NSS initialization fails.
 pub fn init() {
     // Set time zero.
@@ -149,7 +152,9 @@ fn enable_ssl_trace() {
 }
 
 /// Initialize with a database.
+///
 /// # Panics
+///
 /// If NSS cannot be initialized.
 pub fn init_db<P: Into<PathBuf>>(dir: P) {
     time::init();
@@ -192,6 +197,7 @@ pub fn init_db<P: Into<PathBuf>>(dir: P) {
 }
 
 /// # Panics
+///
 /// If NSS isn't initialized.
 pub fn assert_initialized() {
     unsafe {

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -9,8 +9,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-use crate::err::{secstatus_to_res, Error, Res};
-use neqo_common::hex_with_len;
 use std::{
     convert::TryFrom,
     mem,
@@ -18,6 +16,10 @@ use std::{
     os::raw::{c_int, c_uint},
     ptr::null_mut,
 };
+
+use neqo_common::hex_with_len;
+
+use crate::err::{secstatus_to_res, Error, Res};
 
 #[allow(clippy::upper_case_acronyms)]
 #[allow(clippy::unreadable_literal)]
@@ -294,8 +296,9 @@ pub fn random(size: usize) -> Vec<u8> {
 
 #[cfg(test)]
 mod test {
-    use super::random;
     use test_fixture::fixture_init;
+
+    use super::random;
 
     #[test]
     fn randomness() {

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -41,6 +41,7 @@ macro_rules! scoped_ptr {
             /// Create a new instance of `$scoped` from a pointer.
             ///
             /// # Errors
+            ///
             /// When passed a null pointer generates an error.
             pub fn from_ptr(ptr: *mut $target) -> Result<Self, $crate::err::Error> {
                 if ptr.is_null() {
@@ -82,8 +83,11 @@ impl PublicKey {
     /// Get the HPKE serialization of the public key.
     ///
     /// # Errors
+    ///
     /// When the key cannot be exported, which can be because the type is not supported.
+    ///
     /// # Panics
+    ///
     /// When keys are too large to fit in `c_uint/usize`.  So only on programming error.
     pub fn key_data(&self) -> Res<Vec<u8>> {
         let mut buf = vec![0; 100];
@@ -126,9 +130,12 @@ impl PrivateKey {
     /// Get the bits of the private key.
     ///
     /// # Errors
+    ///
     /// When the key cannot be exported, which can be because the type is not supported
     /// or because the key data cannot be extracted from the PKCS#11 module.
+    ///
     /// # Panics
+    ///
     /// When the values are too large to fit.  So never.
     pub fn key_data(&self) -> Res<Vec<u8>> {
         let mut key_item = Item::make_empty();
@@ -190,6 +197,7 @@ impl SymKey {
     /// You really don't want to use this.
     ///
     /// # Errors
+    ///
     /// Internal errors in case of failures in NSS.
     pub fn as_bytes(&self) -> Res<&[u8]> {
         secstatus_to_res(unsafe { PK11_ExtractKeyValue(self.ptr) })?;
@@ -271,6 +279,7 @@ impl Item {
     /// content that is referenced there.
     ///
     /// # Safety
+    ///
     /// This dereferences two pointers.  It doesn't get much less safe.
     pub unsafe fn into_vec(self) -> Vec<u8> {
         let b = self.ptr.as_ref().unwrap();
@@ -282,7 +291,9 @@ impl Item {
 }
 
 /// Generate a randomized buffer.
+///
 /// # Panics
+///
 /// When `size` is too large or NSS fails.
 #[must_use]
 pub fn random(size: usize) -> Vec<u8> {

--- a/neqo-crypto/src/replay.rs
+++ b/neqo-crypto/src/replay.rs
@@ -4,17 +4,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{
-    err::Res,
-    ssl::PRFileDesc,
-    time::{Interval, PRTime, Time},
-};
 use std::{
     convert::{TryFrom, TryInto},
     ops::{Deref, DerefMut},
     os::raw::c_uint,
     ptr::null_mut,
     time::{Duration, Instant},
+};
+
+use crate::{
+    err::Res,
+    ssl::PRFileDesc,
+    time::{Interval, PRTime, Time},
 };
 
 // This is an opaque struct in NSS.

--- a/neqo-crypto/src/replay.rs
+++ b/neqo-crypto/src/replay.rs
@@ -56,6 +56,7 @@ impl AntiReplay {
     /// See the documentation in NSS for advice on how to set these values.
     ///
     /// # Errors
+    ///
     /// Returns an error if `now` is in the past relative to our baseline or
     /// NSS is unable to generate an anti-replay context.
     pub fn new(now: Instant, window: Duration, k: usize, bits: usize) -> Res<Self> {

--- a/neqo-crypto/src/secrets.rs
+++ b/neqo-crypto/src/secrets.rs
@@ -4,6 +4,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{os::raw::c_void, pin::Pin};
+
+use neqo_common::qdebug;
+
 use crate::{
     agentio::as_c_void,
     constants::Epoch,
@@ -11,8 +15,6 @@ use crate::{
     p11::{PK11SymKey, PK11_ReferenceSymKey, SymKey},
     ssl::{PRFileDesc, SSLSecretCallback, SSLSecretDirection},
 };
-use neqo_common::qdebug;
-use std::{os::raw::c_void, pin::Pin};
 
 experimental_api!(SSL_SecretCallback(
     fd: *mut PRFileDesc,

--- a/neqo-crypto/src/selfencrypt.rs
+++ b/neqo-crypto/src/selfencrypt.rs
@@ -30,6 +30,7 @@ impl SelfEncrypt {
     const SALT_LENGTH: usize = 16;
 
     /// # Errors
+    ///
     /// Failure to generate a new HKDF key using NSS results in an error.
     pub fn new(version: Version, cipher: Cipher) -> Res<Self> {
         let key = hkdf::generate_key(version, cipher)?;
@@ -53,6 +54,7 @@ impl SelfEncrypt {
     /// key.
     ///
     /// # Errors
+    ///
     /// Failure to generate a new HKDF key using NSS results in an error.
     pub fn rotate(&mut self) -> Res<()> {
         let new_key = hkdf::generate_key(self.version, self.cipher)?;
@@ -69,6 +71,7 @@ impl SelfEncrypt {
     /// caller is responsible for carrying the AAD as appropriate.
     ///
     /// # Errors
+    ///
     /// Failure to protect using NSS AEAD APIs produces an error.
     pub fn seal(&self, aad: &[u8], plaintext: &[u8]) -> Res<Vec<u8>> {
         // Format is:
@@ -121,6 +124,7 @@ impl SelfEncrypt {
     /// Open the protected `ciphertext`.
     ///
     /// # Errors
+    ///
     /// Returns an error when the self-encrypted object is invalid;
     /// when the keys have been rotated; or when NSS fails.
     #[allow(clippy::similar_names)] // aad is similar to aead

--- a/neqo-crypto/src/selfencrypt.rs
+++ b/neqo-crypto/src/selfencrypt.rs
@@ -4,14 +4,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::constants::{Cipher, Version};
-use crate::err::{Error, Res};
-use crate::p11::{random, SymKey};
-use crate::{hkdf, Aead};
+use std::mem;
 
 use neqo_common::{hex, qinfo, qtrace, Encoder};
 
-use std::mem;
+use crate::{
+    constants::{Cipher, Version},
+    err::{Error, Res},
+    hkdf,
+    p11::{random, SymKey},
+    Aead,
+};
 
 #[derive(Debug)]
 pub struct SelfEncrypt {
@@ -46,7 +49,8 @@ impl SelfEncrypt {
         Aead::new(false, self.version, self.cipher, &secret, "neqo self")
     }
 
-    /// Rotate keys.  This causes any previous key that is being held to be replaced by the current key.
+    /// Rotate keys.  This causes any previous key that is being held to be replaced by the current
+    /// key.
     ///
     /// # Errors
     /// Failure to generate a new HKDF key using NSS results in an error.

--- a/neqo-crypto/src/ssl.rs
+++ b/neqo-crypto/src/ssl.rs
@@ -15,10 +15,12 @@
     clippy::borrow_as_ptr
 )]
 
-use crate::constants::Epoch;
-use crate::err::{secstatus_to_res, Res};
-
 use std::os::raw::{c_uint, c_void};
+
+use crate::{
+    constants::Epoch,
+    err::{secstatus_to_res, Res},
+};
 
 include!(concat!(env!("OUT_DIR"), "/nss_ssl.rs"));
 mod SSLOption {

--- a/neqo-crypto/src/time.rs
+++ b/neqo-crypto/src/time.rs
@@ -6,13 +6,6 @@
 
 #![allow(clippy::upper_case_acronyms)]
 
-use crate::{
-    agentio::as_c_void,
-    err::{Error, Res},
-    once::OnceResult,
-    ssl::{PRFileDesc, SSLTimeFunc},
-};
-
 use std::{
     boxed::Box,
     convert::{TryFrom, TryInto},
@@ -20,6 +13,13 @@ use std::{
     os::raw::c_void,
     pin::Pin,
     time::{Duration, Instant},
+};
+
+use crate::{
+    agentio::as_c_void,
+    err::{Error, Res},
+    once::OnceResult,
+    ssl::{PRFileDesc, SSLTimeFunc},
 };
 
 include!(concat!(env!("OUT_DIR"), "/nspr_time.rs"));
@@ -207,12 +207,13 @@ impl Default for TimeHolder {
 
 #[cfg(test)]
 mod test {
-    use super::{get_base, init, Interval, PRTime, Time};
-    use crate::err::Res;
     use std::{
         convert::{TryFrom, TryInto},
         time::{Duration, Instant},
     };
+
+    use super::{get_base, init, Interval, PRTime, Time};
+    use crate::err::Res;
 
     #[test]
     fn convert_stable() {

--- a/neqo-crypto/tests/aead.rs
+++ b/neqo-crypto/tests/aead.rs
@@ -2,9 +2,10 @@
 #![warn(clippy::pedantic)]
 #![cfg(not(feature = "fuzzing"))]
 
-use neqo_crypto::constants::{Cipher, TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3};
-use neqo_crypto::hkdf;
-use neqo_crypto::Aead;
+use neqo_crypto::{
+    constants::{Cipher, TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
+    hkdf, Aead,
+};
 use test_fixture::fixture_init;
 
 const AAD: &[u8] = &[

--- a/neqo-crypto/tests/agent.rs
+++ b/neqo-crypto/tests/agent.rs
@@ -1,20 +1,21 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::pedantic)]
 
+use std::boxed::Box;
+
 use neqo_crypto::{
     generate_ech_keys, AuthenticationStatus, Client, Error, HandshakeState, SecretAgentPreInfo,
     Server, ZeroRttCheckResult, ZeroRttChecker, TLS_AES_128_GCM_SHA256,
     TLS_CHACHA20_POLY1305_SHA256, TLS_GRP_EC_SECP256R1, TLS_GRP_EC_X25519, TLS_VERSION_1_3,
 };
 
-use std::boxed::Box;
-
 mod handshake;
+use test_fixture::{fixture_init, now};
+
 use crate::handshake::{
     connect, connect_fail, forward_records, resumption_setup, PermissiveZeroRttChecker, Resumption,
     ZERO_RTT_TOKEN_DATA,
 };
-use test_fixture::{fixture_init, now};
 
 #[test]
 fn make_client() {

--- a/neqo-crypto/tests/ext.rs
+++ b/neqo-crypto/tests/ext.rs
@@ -1,11 +1,13 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::pedantic)]
 
-use neqo_crypto::constants::{HandshakeMessage, TLS_HS_CLIENT_HELLO, TLS_HS_ENCRYPTED_EXTENSIONS};
-use neqo_crypto::ext::{ExtensionHandler, ExtensionHandlerResult, ExtensionWriterResult};
-use neqo_crypto::{Client, Server};
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
+
+use neqo_crypto::{
+    constants::{HandshakeMessage, TLS_HS_CLIENT_HELLO, TLS_HS_ENCRYPTED_EXTENSIONS},
+    ext::{ExtensionHandler, ExtensionHandlerResult, ExtensionWriterResult},
+    Client, Server,
+};
 use test_fixture::fixture_init;
 
 mod handshake;

--- a/neqo-crypto/tests/handshake.rs
+++ b/neqo-crypto/tests/handshake.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code)]
 
+use std::{mem, time::Instant};
+
 use neqo_common::qinfo;
 use neqo_crypto::{
     AntiReplay, AuthenticationStatus, Client, HandshakeState, RecordList, Res, ResumptionToken,
     SecretAgent, Server, ZeroRttCheckResult, ZeroRttChecker,
 };
-use std::mem;
-use std::time::Instant;
 use test_fixture::{anti_replay, fixture_init, now};
 
 /// Consume records until the handshake state changes.

--- a/neqo-crypto/tests/hkdf.rs
+++ b/neqo-crypto/tests/hkdf.rs
@@ -1,11 +1,13 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::pedantic)]
 
-use neqo_crypto::constants::{
-    Cipher, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256,
-    TLS_VERSION_1_3,
+use neqo_crypto::{
+    constants::{
+        Cipher, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256,
+        TLS_VERSION_1_3,
+    },
+    hkdf, SymKey,
 };
-use neqo_crypto::{hkdf, SymKey};
 use test_fixture::fixture_init;
 
 const SALT: &[u8] = &[

--- a/neqo-crypto/tests/hp.rs
+++ b/neqo-crypto/tests/hp.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::pedantic)]
 
+use std::mem;
+
 use neqo_crypto::{
     constants::{
         Cipher, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256,
@@ -9,7 +11,6 @@ use neqo_crypto::{
     hkdf,
     hp::HpKey,
 };
-use std::mem;
 use test_fixture::fixture_init;
 
 fn make_hp(cipher: Cipher) -> HpKey {

--- a/neqo-crypto/tests/selfencrypt.rs
+++ b/neqo-crypto/tests/selfencrypt.rs
@@ -2,8 +2,12 @@
 #![warn(clippy::pedantic)]
 #![cfg(not(feature = "fuzzing"))]
 
-use neqo_crypto::constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3};
-use neqo_crypto::{init, selfencrypt::SelfEncrypt, Error};
+use neqo_crypto::{
+    constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
+    init,
+    selfencrypt::SelfEncrypt,
+    Error,
+};
 
 #[test]
 fn se_create() {

--- a/neqo-http3/src/buffered_send_stream.rs
+++ b/neqo-http3/src/buffered_send_stream.rs
@@ -4,9 +4,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::Res;
 use neqo_common::qtrace;
 use neqo_transport::{Connection, StreamId};
+
+use crate::Res;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum BufferedStream {

--- a/neqo-http3/src/buffered_send_stream.rs
+++ b/neqo-http3/src/buffered_send_stream.rs
@@ -37,6 +37,7 @@ impl BufferedStream {
     }
 
     /// # Panics
+    ///
     /// If the `BufferedStream` is initialized more than one it will panic.
     pub fn init(&mut self, stream_id: StreamId) {
         debug_assert!(&Self::Uninitialized == self);
@@ -47,6 +48,7 @@ impl BufferedStream {
     }
 
     /// # Panics
+    ///
     /// This functon cannot be called before the `BufferedStream` is initialized.
     pub fn buffer(&mut self, to_buf: &[u8]) {
         if let Self::Initialized { buf, .. } = self {
@@ -57,6 +59,7 @@ impl BufferedStream {
     }
 
     /// # Errors
+    ///
     /// Returns `neqo_transport` errors.
     pub fn send_buffer(&mut self, conn: &mut Connection) -> Res<usize> {
         let label = ::neqo_common::log_subject!(::log::Level::Debug, self);
@@ -77,6 +80,7 @@ impl BufferedStream {
     }
 
     /// # Errors
+    ///
     /// Returns `neqo_transport` errors.
     pub fn send_atomic(&mut self, conn: &mut Connection, to_send: &[u8]) -> Res<bool> {
         // First try to send anything that is in the buffer.

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -6,19 +6,18 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use crate::connection::Http3State;
-use crate::settings::HSettingType;
-use crate::{
-    features::extended_connect::{ExtendedConnectEvents, ExtendedConnectType, SessionCloseReason},
-    CloseType, Http3StreamInfo, HttpRecvStreamEvents, RecvStreamEvents, SendStreamEvents,
-};
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
+
 use neqo_common::{event::Provider as EventProvider, Header};
 use neqo_crypto::ResumptionToken;
 use neqo_transport::{AppError, StreamId, StreamType};
 
-use std::cell::RefCell;
-use std::collections::VecDeque;
-use std::rc::Rc;
+use crate::{
+    connection::Http3State,
+    features::extended_connect::{ExtendedConnectEvents, ExtendedConnectType, SessionCloseReason},
+    settings::HSettingType,
+    CloseType, Http3StreamInfo, HttpRecvStreamEvents, RecvStreamEvents, SendStreamEvents,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum WebTransportEvent {

--- a/neqo-http3/src/conn_params.rs
+++ b/neqo-http3/src/conn_params.rs
@@ -54,6 +54,7 @@ impl Http3Parameters {
     }
 
     /// # Panics
+    ///
     /// The table size must be smaller than 1 << 30 by the spec.
     #[must_use]
     pub fn max_table_size_encoder(mut self, mut max_table: u64) -> Self {
@@ -69,6 +70,7 @@ impl Http3Parameters {
     }
 
     /// # Panics
+    ///
     /// The table size must be smaller than 1 << 30 by the spec.
     #[must_use]
     pub fn max_table_size_decoder(mut self, mut max_table: u64) -> Self {

--- a/neqo-http3/src/conn_params.rs
+++ b/neqo-http3/src/conn_params.rs
@@ -4,9 +4,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::cmp::min;
+
 use neqo_qpack::QpackSettings;
 use neqo_transport::ConnectionParameters;
-use std::cmp::min;
 
 const QPACK_MAX_TABLE_SIZE_DEFAULT: u64 = 65536;
 const QPACK_TABLE_SIZE_LIMIT: u64 = (1 << 30) - 1;

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -944,7 +944,9 @@ impl Http3Connection {
 
     /// Stream data are read directly into a buffer supplied as a parameter of this function to
     /// avoid copying data.
+    ///
     /// # Errors
+    ///
     /// It returns an error if a stream does not exist or an error happens while reading a stream,
     /// e.g. early close, protocol error, etc.
     pub fn read_data(
@@ -1010,7 +1012,9 @@ impl Http3Connection {
     }
 
     /// Set the stream `SendOrder`.
+    ///
     /// # Errors
+    ///
     /// Returns `InvalidStreamId` if the stream id doesn't exist
     pub fn stream_set_sendorder(
         conn: &mut Connection,
@@ -1024,7 +1028,9 @@ impl Http3Connection {
     /// Set the stream Fairness.   Fair streams will share bandwidth with other
     /// streams of the same sendOrder group (or the unordered group).  Unfair streams
     /// will give bandwidth preferentially to the lowest streamId with data to send.
+    ///
     /// # Errors
+    ///
     /// Returns `InvalidStreamId` if the stream id doesn't exist
     pub fn stream_set_fairness(
         conn: &mut Connection,

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -6,41 +6,43 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use crate::control_stream_local::ControlStreamLocal;
-use crate::control_stream_remote::ControlStreamRemote;
-use crate::features::extended_connect::{
-    webtransport_session::WebTransportSession,
-    webtransport_streams::{WebTransportRecvStream, WebTransportSendStream},
-    ExtendedConnectEvents, ExtendedConnectFeature, ExtendedConnectType,
+use std::{
+    cell::RefCell,
+    collections::{BTreeSet, HashMap},
+    fmt::Debug,
+    mem,
+    rc::Rc,
 };
-use crate::frames::HFrame;
-use crate::push_controller::PushController;
-use crate::qpack_decoder_receiver::DecoderRecvStream;
-use crate::qpack_encoder_receiver::EncoderRecvStream;
-use crate::recv_message::{RecvMessage, RecvMessageInfo};
-use crate::request_target::{AsRequestTarget, RequestTarget};
-use crate::send_message::SendMessage;
-use crate::settings::{HSettingType, HSettings, HttpZeroRttChecker};
-use crate::stream_type_reader::NewStreamHeadReader;
-use crate::{
-    client_events::Http3ClientEvents, CloseType, Http3Parameters, Http3StreamType,
-    HttpRecvStreamEvents, NewStreamType, Priority, PriorityHandler, ReceiveOutput, RecvStream,
-    RecvStreamEvents, SendStream, SendStreamEvents,
-};
+
 use neqo_common::{qdebug, qerror, qinfo, qtrace, qwarn, Decoder, Header, MessageType, Role};
-use neqo_qpack::decoder::QPackDecoder;
-use neqo_qpack::encoder::QPackEncoder;
+use neqo_qpack::{decoder::QPackDecoder, encoder::QPackEncoder};
 use neqo_transport::{
     streams::SendOrder, AppError, Connection, ConnectionError, DatagramTracking, State, StreamId,
     StreamType, ZeroRttState,
 };
-use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap};
-use std::fmt::Debug;
-use std::mem;
-use std::rc::Rc;
 
-use crate::{Error, Res};
+use crate::{
+    client_events::Http3ClientEvents,
+    control_stream_local::ControlStreamLocal,
+    control_stream_remote::ControlStreamRemote,
+    features::extended_connect::{
+        webtransport_session::WebTransportSession,
+        webtransport_streams::{WebTransportRecvStream, WebTransportSendStream},
+        ExtendedConnectEvents, ExtendedConnectFeature, ExtendedConnectType,
+    },
+    frames::HFrame,
+    push_controller::PushController,
+    qpack_decoder_receiver::DecoderRecvStream,
+    qpack_encoder_receiver::EncoderRecvStream,
+    recv_message::{RecvMessage, RecvMessageInfo},
+    request_target::{AsRequestTarget, RequestTarget},
+    send_message::SendMessage,
+    settings::{HSettingType, HSettings, HttpZeroRttChecker},
+    stream_type_reader::NewStreamHeadReader,
+    CloseType, Error, Http3Parameters, Http3StreamType, HttpRecvStreamEvents, NewStreamType,
+    Priority, PriorityHandler, ReceiveOutput, RecvStream, RecvStreamEvents, Res, SendStream,
+    SendStreamEvents,
+};
 
 pub(crate) struct RequestDescription<'b, 't, T>
 where
@@ -79,8 +81,8 @@ enum Http3RemoteSettingsState {
 /// - `ZeroRtt`: 0-RTT has been enabled and is active
 /// - Connected
 /// - GoingAway(StreamId): The connection has received a `GOAWAY` frame
-/// - Closing(ConnectionError): The connection is closed. The closing has been initiated by this
-///   end of the connection, e.g., the `CONNECTION_CLOSE` frame has been sent. In this state, the
+/// - Closing(ConnectionError): The connection is closed. The closing has been initiated by this end
+///   of the connection, e.g., the `CONNECTION_CLOSE` frame has been sent. In this state, the
 ///   connection waits a certain amount of time to retransmit the `CONNECTION_CLOSE` frame if
 ///   needed.
 /// - Closed(ConnectionError): This is the final close state: closing has been initialized by the
@@ -384,7 +386,8 @@ impl Http3Connection {
         Ok(())
     }
 
-    /// Inform a `HttpConnection` that a stream has data to send and that `send` should be called for the stream.
+    /// Inform a `HttpConnection` that a stream has data to send and that `send` should be called
+    /// for the stream.
     pub fn stream_has_pending_data(&mut self, stream_id: StreamId) {
         self.streams_with_pending_data.insert(stream_id);
     }
@@ -502,8 +505,8 @@ impl Http3Connection {
     /// stream and unidi stream that are still do not have a type.
     /// The function cannot handle:
     /// 1) a `Push(_)`, `Htttp` or `WebTransportStream(_)` stream
-    /// 2) frames `MaxPushId`, `PriorityUpdateRequest`, `PriorityUpdateRequestPush` or `Goaway`
-    ///    must be handled by `Http3Client`/`Server`.
+    /// 2) frames `MaxPushId`, `PriorityUpdateRequest`, `PriorityUpdateRequestPush` or `Goaway` must
+    ///    be handled by `Http3Client`/`Server`.
     /// The function returns `ReceiveOutput`.
     pub fn handle_stream_readable(
         &mut self,
@@ -579,8 +582,8 @@ impl Http3Connection {
         Ok(())
     }
 
-    /// This is called when `neqo_transport::Connection` state has been change to take proper actions in
-    /// the HTTP3 layer.
+    /// This is called when `neqo_transport::Connection` state has been change to take proper
+    /// actions in the HTTP3 layer.
     pub fn handle_state_change(&mut self, conn: &mut Connection, state: &State) -> Res<bool> {
         qdebug!([self], "Handle state change {:?}", state);
         match state {
@@ -626,7 +629,8 @@ impl Http3Connection {
         }
     }
 
-    /// This is called when 0RTT has been reset to clear `send_streams`, `recv_streams` and settings.
+    /// This is called when 0RTT has been reset to clear `send_streams`, `recv_streams` and
+    /// settings.
     pub fn handle_zero_rtt_rejected(&mut self) -> Res<()> {
         if self.state == Http3State::ZeroRtt {
             self.state = Http3State::Initializing;
@@ -774,16 +778,16 @@ impl Http3Connection {
     /// This function will not handle the output of the function completely, but only
     /// handle the indication that a stream is closed. There are 2 cases:
     ///  - an error occurred or
-    ///  - the stream is done, i.e. the second value in `output` tuple is true if
-    ///    the stream is done and can be removed from the `recv_streams`
+    ///  - the stream is done, i.e. the second value in `output` tuple is true if the stream is done
+    ///    and can be removed from the `recv_streams`
     /// How it is handling `output`:
     ///  - if the stream is done, it removes the stream from `recv_streams`
     ///  - if the stream is not done and there is no error, return `output` and the caller will
     ///    handle it.
     ///  - in case of an error:
-    ///    - if it is only a stream error and the stream is not critical, send `STOP_SENDING`
-    ///      frame, remove the stream from `recv_streams` and inform the listener that the stream
-    ///      has been reset.
+    ///    - if it is only a stream error and the stream is not critical, send `STOP_SENDING` frame,
+    ///      remove the stream from `recv_streams` and inform the listener that the stream has been
+    ///      reset.
     ///    - otherwise this is a connection error. In this case, propagate the error to the caller
     ///      that will handle it properly.
     fn handle_stream_manipulation_output<U>(
@@ -861,7 +865,8 @@ impl Http3Connection {
     }
 
     fn create_bidi_transport_stream(&self, conn: &mut Connection) -> Res<StreamId> {
-        // Requests cannot be created when a connection is in states: Initializing, GoingAway, Closing and Closed.
+        // Requests cannot be created when a connection is in states: Initializing, GoingAway,
+        // Closing and Closed.
         match self.state() {
             Http3State::GoingAway(..) | Http3State::Closing(..) | Http3State::Closed(..) => {
                 return Err(Error::AlreadyClosed)
@@ -927,8 +932,9 @@ impl Http3Connection {
             )),
         );
 
-        // Call immediately send so that at least headers get sent. This will make Firefox faster, since
-        // it can send request body immediately in most cases and does not need to do a complete process loop.
+        // Call immediately send so that at least headers get sent. This will make Firefox faster,
+        // since it can send request body immediately in most cases and does not need to do
+        // a complete process loop.
         self.send_streams
             .get_mut(&stream_id)
             .ok_or(Error::InvalidStreamId)?
@@ -936,11 +942,11 @@ impl Http3Connection {
         Ok(())
     }
 
-    /// Stream data are read directly into a buffer supplied as a parameter of this function to avoid copying
-    /// data.
+    /// Stream data are read directly into a buffer supplied as a parameter of this function to
+    /// avoid copying data.
     /// # Errors
-    /// It returns an error if a stream does not exist or an error happens while reading a stream, e.g.
-    /// early close, protocol error, etc.
+    /// It returns an error if a stream does not exist or an error happens while reading a stream,
+    /// e.g. early close, protocol error, etc.
     pub fn read_data(
         &mut self,
         conn: &mut Connection,
@@ -1088,8 +1094,8 @@ impl Http3Connection {
             .send_streams
             .get_mut(&stream_id)
             .ok_or(Error::InvalidStreamId)?;
-        // The following function may return InvalidStreamId from the transport layer if the stream has been closed
-        // already. It is ok to ignore it here.
+        // The following function may return InvalidStreamId from the transport layer if the stream
+        // has been closed already. It is ok to ignore it here.
         mem::drop(send_stream.close(conn));
         if send_stream.done() {
             self.remove_send_stream(stream_id, conn);
@@ -1184,7 +1190,8 @@ impl Http3Connection {
                     .is_ok()
                 {
                     mem::drop(self.stream_close_send(conn, stream_id));
-                    // TODO issue 1294: add a timer to clean up the recv_stream if the peer does not do that in a short time.
+                    // TODO issue 1294: add a timer to clean up the recv_stream if the peer does not
+                    // do that in a short time.
                     self.streams_with_pending_data.insert(stream_id);
                 } else {
                     self.cancel_fetch(stream_id, Error::HttpRequestRejected.code(), conn)?;
@@ -1571,8 +1578,8 @@ impl Http3Connection {
 
         for id in recv {
             qtrace!("Remove the extended connect sub receiver stream {}", id);
-            // Use CloseType::ResetRemote so that an event will be sent. CloseType::LocalError would have
-            // the same effect.
+            // Use CloseType::ResetRemote so that an event will be sent. CloseType::LocalError would
+            // have the same effect.
             if let Some(mut s) = self.recv_streams.remove(&id) {
                 mem::drop(s.reset(CloseType::ResetRemote(Error::HttpRequestCancelled.code())));
             }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -785,7 +785,7 @@ impl Http3Client {
 
     /// Returns the current max size of a datagram that can fit into a packet.
     /// The value will change over time depending on the encoded size of the
-    ///  packet number, ack frames, etc.
+    /// packet number, ack frames, etc.
     ///
     /// # Errors
     ///
@@ -2845,7 +2845,7 @@ mod tests {
             out = client.process(out.as_dgram_ref(), now());
         }
 
-        //  check received frames and send a response.
+        // Check received frames and send a response.
         while let Some(e) = server.conn.next_event() {
             if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
                 if stream_id == request_stream_id {
@@ -5520,7 +5520,7 @@ mod tests {
         assert!(!client.events().any(push_event));
     }
 
-    //  Test that max_push_id is enforced when a push promise frame is received.
+    // Test that max_push_id is enforced when a push promise frame is received.
     #[test]
     fn exceed_max_push_id_promise() {
         // Connect and send a request

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -4,16 +4,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{
-    client_events::{Http3ClientEvent, Http3ClientEvents},
-    connection::{Http3Connection, Http3State, RequestDescription},
-    frames::HFrame,
-    push_controller::{PushController, RecvPushEvents},
-    recv_message::{RecvMessage, RecvMessageInfo},
-    request_target::AsRequestTarget,
-    settings::HSettings,
-    Http3Parameters, Http3StreamType, NewStreamType, Priority, PriorityHandler, ReceiveOutput,
+use std::{
+    cell::RefCell,
+    convert::TryFrom,
+    fmt::{Debug, Display},
+    mem,
+    net::SocketAddr,
+    rc::Rc,
+    time::Instant,
 };
+
 use neqo_common::{
     event::Provider as EventProvider, hex, hex_with_len, qdebug, qinfo, qlog::NeqoQlog, qtrace,
     Datagram, Decoder, Encoder, Header, MessageType, Role,
@@ -25,20 +25,21 @@ use neqo_transport::{
     DatagramTracking, Output, RecvStreamStats, SendStreamStats, Stats as TransportStats, StreamId,
     StreamType, Version, ZeroRttState,
 };
-use std::{
-    cell::RefCell,
-    convert::TryFrom,
-    fmt::{Debug, Display},
-    mem,
-    net::SocketAddr,
-    rc::Rc,
-    time::Instant,
+
+use crate::{
+    client_events::{Http3ClientEvent, Http3ClientEvents},
+    connection::{Http3Connection, Http3State, RequestDescription},
+    frames::HFrame,
+    push_controller::{PushController, RecvPushEvents},
+    recv_message::{RecvMessage, RecvMessageInfo},
+    request_target::AsRequestTarget,
+    settings::HSettings,
+    Error, Http3Parameters, Http3StreamType, NewStreamType, Priority, PriorityHandler,
+    ReceiveOutput, Res,
 };
 
-use crate::{Error, Res};
-
-// This is used for filtering send_streams and recv_Streams with a stream_ids greater than or equal a given id.
-// Only the same type (bidirectional or unidirectionsl) streams are filtered.
+// This is used for filtering send_streams and recv_Streams with a stream_ids greater than or equal
+// a given id. Only the same type (bidirectional or unidirectionsl) streams are filtered.
 fn id_gte<U>(base: StreamId) -> impl FnMut((&StreamId, &U)) -> Option<StreamId> + 'static
 where
     U: ?Sized,
@@ -161,7 +162,7 @@ fn alpn_from_quic_version(version: Version) -> &'static str {
 ///         }
 ///     }
 /// }
-///```
+/// ```
 ///
 /// ### Creating a `WebTransport` session
 ///
@@ -198,8 +199,7 @@ fn alpn_from_quic_version(version: Version) -> &'static str {
 ///         }
 ///     }
 /// }
-///
-///```
+/// ```
 ///
 /// ### `WebTransport`: create a stream, send and receive data on the stream
 ///
@@ -287,7 +287,6 @@ fn alpn_from_quic_version(version: Version) -> &'static str {
 ///     }
 /// }
 /// ```
-///
 pub struct Http3Client {
     conn: Connection,
     base_handler: Http3Connection,
@@ -303,8 +302,8 @@ impl Display for Http3Client {
 
 impl Http3Client {
     /// # Errors
-    /// Making a `neqo-transport::connection` may produce an error. This can only be a crypto error if
-    /// the crypto context can't be created or configured.
+    /// Making a `neqo-transport::connection` may produce an error. This can only be a crypto error
+    /// if the crypto context can't be created or configured.
     pub fn new(
         server_name: impl Into<String>,
         cid_manager: Rc<RefCell<dyn ConnectionIdGenerator>>,
@@ -433,7 +432,8 @@ impl Http3Client {
             .and_then(|t| self.encode_resumption_token(&t))
     }
 
-    /// This may be call if an application has a resumption token. This must be called before connection starts.
+    /// This may be call if an application has a resumption token. This must be called before
+    /// connection starts.
     ///
     /// The resumption token also contains encoded HTTP/3 settings. The settings will be decoded
     /// and used until the setting are received from the server.
@@ -600,9 +600,10 @@ impl Http3Client {
     /// # Errors
     /// `InvalidStreamId` if the stream does not exist,
     /// `AlreadyClosed` if the stream has already been closed.
-    /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if `process_output`
-    /// has not been called when needed, and HTTP3 layer has not picked up the info that the stream has been closed.)
-    /// `InvalidInput` if an empty buffer has been supplied.
+    /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if
+    /// `process_output` has not been called when needed, and HTTP3 layer has not picked up the
+    /// info that the stream has been closed.) `InvalidInput` if an empty buffer has been
+    /// supplied.
     pub fn send_data(&mut self, stream_id: StreamId, buf: &[u8]) -> Res<usize> {
         qinfo!(
             [self],
@@ -617,11 +618,11 @@ impl Http3Client {
             .send_data(&mut self.conn, buf)
     }
 
-    /// Response data are read directly into a buffer supplied as a parameter of this function to avoid copying
-    /// data.
+    /// Response data are read directly into a buffer supplied as a parameter of this function to
+    /// avoid copying data.
     /// # Errors
-    /// It returns an error if a stream does not exist or an error happen while reading a stream, e.g.
-    /// early close, protocol error, etc.
+    /// It returns an error if a stream does not exist or an error happen while reading a stream,
+    /// e.g. early close, protocol error, etc.
     pub fn read_data(
         &mut self,
         now: Instant,
@@ -652,8 +653,8 @@ impl Http3Client {
     /// Push response data are read directly into a buffer supplied as a parameter of this function
     /// to avoid copying data.
     /// # Errors
-    /// It returns an error if a stream does not exist(`InvalidStreamId`) or an error has happened while
-    /// reading a stream, e.g. early close, protocol error, etc.
+    /// It returns an error if a stream does not exist(`InvalidStreamId`) or an error has happened
+    /// while reading a stream, e.g. early close, protocol error, etc.
     pub fn push_read_data(
         &mut self,
         now: Instant,
@@ -701,9 +702,10 @@ impl Http3Client {
     /// Close `WebTransport` cleanly
     /// # Errors
     /// `InvalidStreamId` if the stream does not exist,
-    /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if `process_output`
-    /// has not been called when needed, and HTTP3 layer has not picked up the info that the stream has been closed.)
-    /// `InvalidInput` if an empty buffer has been supplied.
+    /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if
+    /// `process_output` has not been called when needed, and HTTP3 layer has not picked up the
+    /// info that the stream has been closed.) `InvalidInput` if an empty buffer has been
+    /// supplied.
     pub fn webtransport_close_session(
         &mut self,
         session_id: StreamId,
@@ -883,7 +885,8 @@ impl Http3Client {
     ///
     /// `process_output` can return:
     /// - a [`Output::Datagram(Datagram)`][1]: data that should be sent as a UDP payload,
-    /// - a [`Output::Callback(Duration)`][1]: the duration of a  timer. `process_output` should be called at least after the time expires,
+    /// - a [`Output::Callback(Duration)`][1]: the duration of a  timer. `process_output` should be
+    ///   called at least after the time expires,
     /// - [`Output::None`][1]: this is returned when `Nttp3Client` is done and can be destroyed.
     ///
     /// The application should call this function repeatedly until a timer value or None is
@@ -938,14 +941,14 @@ impl Http3Client {
         }
     }
 
-    /// This function checks [`ConnectionEvent`][2]s emitted by the QUIC layer, e.g. connection change
-    /// state events, new incoming stream data is available, a stream is was reset, etc. The HTTP/3
-    /// layer needs to handle these events. Most of the events are handled by
+    /// This function checks [`ConnectionEvent`][2]s emitted by the QUIC layer, e.g. connection
+    /// change state events, new incoming stream data is available, a stream is was reset, etc.
+    /// The HTTP/3 layer needs to handle these events. Most of the events are handled by
     /// [`Http3Connection`][1] by calling appropriate functions, e.g. `handle_state_change`,
     /// `handle_stream_reset`, etc. [`Http3Connection`][1] handle functionalities that are common
     /// for the client and server side. Some of the functionalities are specific to the client and
-    /// they are handled by `Http3Client`. For example, [`ConnectionEvent::RecvStreamReadable`][3] event
-    /// is handled by `Http3Client::handle_stream_readable`. The  function calls
+    /// they are handled by `Http3Client`. For example, [`ConnectionEvent::RecvStreamReadable`][3]
+    /// event is handled by `Http3Client::handle_stream_readable`. The  function calls
     /// `Http3Connection::handle_stream_readable` and then hands the return value as appropriate
     /// for the client-side.
     ///
@@ -958,11 +961,11 @@ impl Http3Client {
             qdebug!([self], "check_connection_events - event {:?}.", e);
             match e {
                 ConnectionEvent::NewStream { stream_id } => {
-                    // During this event we only add a new stream to the Http3Connection stream list,
-                    // with NewStreamHeadReader stream handler.
+                    // During this event we only add a new stream to the Http3Connection stream
+                    // list, with NewStreamHeadReader stream handler.
                     // This function will not read from the stream and try to decode the stream.
-                    // RecvStreamReadable  will be emitted after this event and reading, i.e. decoding
-                    // of a stream will happen during that event.
+                    // RecvStreamReadable  will be emitted after this event and reading, i.e.
+                    // decoding of a stream will happen during that event.
                     self.base_handler.add_new_stream(stream_id);
                 }
                 ConnectionEvent::SendStreamWritable { stream_id } => {
@@ -1036,12 +1039,12 @@ impl Http3Client {
     ///  - `ReceiveOutput::NewStream(NewStreamType::WebTransportStream(_))` - because
     ///    `Http3ClientEvents`is needed and events handler is specific to the client.
     ///  - `ReceiveOutput::ControlFrames(control_frames)` - some control frame handling differs
-    ///     between the  client and the server:
+    ///    between the  client and the server:
     ///     - `HFrame::CancelPush` - only the client-side may receive it,
     ///     - `HFrame::MaxPushId { .. }`, `HFrame::PriorityUpdateRequest { .. } ` and
-    ///        `HFrame::PriorityUpdatePush` can only be receive on the server side,
+    ///       `HFrame::PriorityUpdatePush` can only be receive on the server side,
     ///     - `HFrame::Goaway { stream_id }` needs specific handling by the client by the protocol
-    ///        specification.
+    ///       specification.
     ///
     /// [1]: https://github.com/mozilla/neqo/blob/main/neqo-http3/src/connection.rs
     fn handle_stream_readable(&mut self, stream_id: StreamId) -> Res<()> {
@@ -1241,6 +1244,20 @@ impl EventProvider for Http3Client {
 
 #[cfg(test)]
 mod tests {
+    use std::{convert::TryFrom, mem, time::Duration};
+
+    use neqo_common::{event::Provider, qtrace, Datagram, Decoder, Encoder};
+    use neqo_crypto::{AllowZeroRtt, AntiReplay, ResumptionToken};
+    use neqo_qpack::{encoder::QPackEncoder, QpackSettings};
+    use neqo_transport::{
+        ConnectionError, ConnectionEvent, ConnectionParameters, Output, State, StreamId,
+        StreamType, Version, RECV_BUFFER_SIZE, SEND_BUFFER_SIZE,
+    };
+    use test_fixture::{
+        addr, anti_replay, default_server_h3, fixture_init, new_server, now,
+        CountingConnectionIdGenerator, DEFAULT_ALPN_H3, DEFAULT_KEYS, DEFAULT_SERVER_NAME,
+    };
+
     use super::{
         AuthenticationStatus, Connection, Error, HSettings, Header, Http3Client, Http3ClientEvent,
         Http3Parameters, Http3State, Rc, RefCell,
@@ -1250,18 +1267,6 @@ mod tests {
         qpack_encoder_receiver::EncoderRecvStream,
         settings::{HSetting, HSettingType, H3_RESERVED_SETTINGS},
         Http3Server, Priority, RecvStream,
-    };
-    use neqo_common::{event::Provider, qtrace, Datagram, Decoder, Encoder};
-    use neqo_crypto::{AllowZeroRtt, AntiReplay, ResumptionToken};
-    use neqo_qpack::{encoder::QPackEncoder, QpackSettings};
-    use neqo_transport::{
-        ConnectionError, ConnectionEvent, ConnectionParameters, Output, State, StreamId,
-        StreamType, Version, RECV_BUFFER_SIZE, SEND_BUFFER_SIZE,
-    };
-    use std::{convert::TryFrom, mem, time::Duration};
-    use test_fixture::{
-        addr, anti_replay, default_server_h3, fixture_init, new_server, now,
-        CountingConnectionIdGenerator, DEFAULT_ALPN_H3, DEFAULT_KEYS, DEFAULT_SERVER_NAME,
     };
 
     fn assert_closed(client: &Http3Client, expected: &Error) {
@@ -1710,8 +1715,8 @@ mod tests {
         0x43, 0xd3, 0xc1,
     ];
 
-    // For fetch request fetch("GET", "https", "something.com", "/", &[(String::from("myheaders", "myvalue"))])
-    // the following request header frame will be sent:
+    // For fetch request fetch("GET", "https", "something.com", "/", &[(String::from("myheaders",
+    // "myvalue"))]) the following request header frame will be sent:
     const EXPECTED_REQUEST_HEADER_FRAME_VERSION2: &[u8] = &[
         0x01, 0x11, 0x02, 0x80, 0xd1, 0xd7, 0x50, 0x89, 0x41, 0xe9, 0x2a, 0x67, 0x35, 0x53, 0x2e,
         0x43, 0xd3, 0xc1, 0x10,
@@ -1719,8 +1724,8 @@ mod tests {
 
     const HTTP_HEADER_FRAME_0: &[u8] = &[0x01, 0x06, 0x00, 0x00, 0xd9, 0x54, 0x01, 0x30];
 
-    // The response header from HTTP_HEADER_FRAME (0x01, 0x06, 0x00, 0x00, 0xd9, 0x54, 0x01, 0x30) are
-    // decoded into:
+    // The response header from HTTP_HEADER_FRAME (0x01, 0x06, 0x00, 0x00, 0xd9, 0x54, 0x01, 0x30)
+    // are decoded into:
     fn check_response_header_0(header: &[Header]) {
         let expected_response_header_0 = &[
             Header::new(":status", "200"),
@@ -2487,7 +2492,8 @@ mod tests {
 
     #[test]
     fn fetch_basic() {
-        // Connect exchange headers and send a request. Also check if the correct header frame has been sent.
+        // Connect exchange headers and send a request. Also check if the correct header frame has
+        // been sent.
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
 
         // send response - 200  Content-Length: 7
@@ -2627,7 +2633,8 @@ mod tests {
     // Send a request with the request body.
     #[test]
     fn fetch_with_data() {
-        // Connect exchange headers and send a request. Also check if the correct header frame has been sent.
+        // Connect exchange headers and send a request. Also check if the correct header frame has
+        // been sent.
         let (mut client, mut server, request_stream_id) = connect_and_send_request(false);
 
         // Get DataWritable for the request stream so that we can write the request body.
@@ -2669,9 +2676,11 @@ mod tests {
         read_response(&mut client, &mut server.conn, request_stream_id);
     }
 
-    // send a request with request body containing request_body. We expect to receive expected_data_frame_header.
+    // send a request with request body containing request_body. We expect to receive
+    // expected_data_frame_header.
     fn fetch_with_data_length_xbytes(request_body: &[u8], expected_data_frame_header: &[u8]) {
-        // Connect exchange headers and send a request. Also check if the correct header frame has been sent.
+        // Connect exchange headers and send a request. Also check if the correct header frame has
+        // been sent.
         let (mut client, mut server, request_stream_id) = connect_and_send_request(false);
 
         // Get DataWritable for the request stream so that we can write the request body.
@@ -2757,7 +2766,8 @@ mod tests {
         expected_second_data_frame_header: &[u8],
         expected_second_data_frame: &[u8],
     ) {
-        // Connect exchange headers and send a request. Also check if the correct header frame has been sent.
+        // Connect exchange headers and send a request. Also check if the correct header frame has
+        // been sent.
         let (mut client, mut server, request_stream_id) = connect_and_send_request(false);
 
         // Get DataWritable for the request stream so that we can write the request body.
@@ -2872,7 +2882,8 @@ mod tests {
     }
 
     // Send 2 frames. For the second one we can only send 16383 bytes.
-    // After the first frame there is exactly 16383+4 bytes left in the send buffer, but we can only send 16383 bytes.
+    // After the first frame there is exactly 16383+4 bytes left in the send buffer, but we can only
+    // send 16383 bytes.
     #[test]
     fn fetch_two_data_frame_second_16383bytes_place_for_16387() {
         let (buf, hdr) = alloc_buffer(SEND_BUFFER_SIZE - 16410);
@@ -2880,7 +2891,8 @@ mod tests {
     }
 
     // Send 2 frames. For the second one we can only send 16383 bytes.
-    // After the first frame there is exactly 16383+5 bytes left in the send buffer, but we can only send 16383 bytes.
+    // After the first frame there is exactly 16383+5 bytes left in the send buffer, but we can only
+    // send 16383 bytes.
     #[test]
     fn fetch_two_data_frame_second_16383bytes_place_for_16388() {
         let (buf, hdr) = alloc_buffer(SEND_BUFFER_SIZE - 16411);
@@ -2888,7 +2900,8 @@ mod tests {
     }
 
     // Send 2 frames. For the second one we can send 16384 bytes.
-    // After the first frame there is exactly 16384+5 bytes left in the send buffer, but we can send 16384 bytes.
+    // After the first frame there is exactly 16384+5 bytes left in the send buffer, but we can send
+    // 16384 bytes.
     #[test]
     fn fetch_two_data_frame_second_16384bytes_place_for_16389() {
         let (buf, hdr) = alloc_buffer(SEND_BUFFER_SIZE - 16412);
@@ -2898,7 +2911,8 @@ mod tests {
     // Test receiving STOP_SENDING with the HttpNoError error code.
     #[test]
     fn test_stop_sending_early_response() {
-        // Connect exchange headers and send a request. Also check if the correct header frame has been sent.
+        // Connect exchange headers and send a request. Also check if the correct header frame has
+        // been sent.
         let (mut client, mut server, request_stream_id) = connect_and_send_request(false);
 
         // Stop sending with early_response.
@@ -2975,7 +2989,8 @@ mod tests {
     // Server sends stop sending and reset.
     #[test]
     fn test_stop_sending_other_error_with_reset() {
-        // Connect exchange headers and send a request. Also check if the correct header frame has been sent.
+        // Connect exchange headers and send a request. Also check if the correct header frame has
+        // been sent.
         let (mut client, mut server, request_stream_id) = connect_and_send_request(false);
 
         // Stop sending with RequestRejected.
@@ -3038,7 +3053,8 @@ mod tests {
     // Server sends stop sending with RequestRejected, but it does not send reset.
     #[test]
     fn test_stop_sending_other_error_wo_reset() {
-        // Connect exchange headers and send a request. Also check if the correct header frame has been sent.
+        // Connect exchange headers and send a request. Also check if the correct header frame has
+        // been sent.
         let (mut client, mut server, request_stream_id) = connect_and_send_request(false);
 
         // Stop sending with RequestRejected.
@@ -3085,7 +3101,8 @@ mod tests {
     // in client.events. The events will be removed.
     #[test]
     fn test_stop_sending_and_reset_other_error_with_events() {
-        // Connect exchange headers and send a request. Also check if the correct header frame has been sent.
+        // Connect exchange headers and send a request. Also check if the correct header frame has
+        // been sent.
         let (mut client, mut server, request_stream_id) = connect_and_send_request(false);
 
         // send response - 200  Content-Length: 3
@@ -3158,7 +3175,8 @@ mod tests {
     // The events will be removed.
     #[test]
     fn test_stop_sending_other_error_with_events() {
-        // Connect exchange headers and send a request. Also check if the correct header frame has been sent.
+        // Connect exchange headers and send a request. Also check if the correct header frame has
+        // been sent.
         let (mut client, mut server, request_stream_id) = connect_and_send_request(false);
 
         // send response - 200  Content-Length: 3
@@ -3221,7 +3239,8 @@ mod tests {
     // Server sends a reset. We will close sending side as well.
     #[test]
     fn test_reset_wo_stop_sending() {
-        // Connect exchange headers and send a request. Also check if the correct header frame has been sent.
+        // Connect exchange headers and send a request. Also check if the correct header frame has
+        // been sent.
         let (mut client, mut server, request_stream_id) = connect_and_send_request(false);
 
         // Send a reset.
@@ -3958,7 +3977,8 @@ mod tests {
             header_block: encoded_headers.to_vec(),
         };
 
-        // Send the encoder instructions, but delay them so that the stream is blocked on decoding headers.
+        // Send the encoder instructions, but delay them so that the stream is blocked on decoding
+        // headers.
         let encoder_inst_pkt = server.conn.process(None, now());
 
         // Send response
@@ -4026,7 +4046,8 @@ mod tests {
             header_block: encoded_headers.to_vec(),
         };
 
-        // Send the encoder instructions, but delay them so that the stream is blocked on decoding headers.
+        // Send the encoder instructions, but delay them so that the stream is blocked on decoding
+        // headers.
         let encoder_inst_pkt = server.conn.process(None, now());
 
         let mut d = Encoder::default();
@@ -4790,7 +4811,8 @@ mod tests {
 
     #[test]
     fn no_data_ready_events_after_fin() {
-        // Connect exchange headers and send a request. Also check if the correct header frame has been sent.
+        // Connect exchange headers and send a request. Also check if the correct header frame has
+        // been sent.
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
 
         // send response - 200  Content-Length: 7
@@ -5003,7 +5025,8 @@ mod tests {
 
         assert_eq!(client.state(), Http3State::Connected);
 
-        // Check that the push has been closed, e.g. calling cancel_push should return InvalidStreamId.
+        // Check that the push has been closed, e.g. calling cancel_push should return
+        // InvalidStreamId.
         assert_eq!(client.cancel_push(0), Err(Error::InvalidStreamId));
     }
 
@@ -5094,7 +5117,8 @@ mod tests {
 
         assert_eq!(client.state(), Http3State::Connected);
 
-        // Check that the push has been closed, e.g. calling cancel_push should return InvalidStreamId.
+        // Check that the push has been closed, e.g. calling cancel_push should return
+        // InvalidStreamId.
         assert_eq!(client.cancel_push(0), Err(Error::InvalidStreamId));
         assert_eq!(client.cancel_push(1), Err(Error::InvalidStreamId));
     }
@@ -5608,7 +5632,8 @@ mod tests {
         )));
     }
 
-    // Test CANCEL_PUSH frame: after cancel push any new PUSH_PROMISE or push stream will be ignored.
+    // Test CANCEL_PUSH frame: after cancel push any new PUSH_PROMISE or push stream will be
+    // ignored.
     #[test]
     fn cancel_push_ignore_promise() {
         // Connect and send a request
@@ -5624,7 +5649,8 @@ mod tests {
         // Assert that we do not have any push event.
         assert!(!check_push_events(&mut client));
 
-        // Check that the push has been closed, e.g. calling cancel_push should return InvalidStreamId.
+        // Check that the push has been closed, e.g. calling cancel_push should return
+        // InvalidStreamId.
         assert_eq!(client.cancel_push(0), Err(Error::InvalidStreamId));
 
         // Check that the push has been canceled by the client.
@@ -5653,7 +5679,8 @@ mod tests {
         // Assert that we do not have any push event.
         assert!(!check_push_events(&mut client));
 
-        // Check that the push has been closed, e.g. calling cancel_push should return InvalidStreamId.
+        // Check that the push has been closed, e.g. calling cancel_push should return
+        // InvalidStreamId.
         assert_eq!(client.cancel_push(0), Err(Error::InvalidStreamId));
 
         // Check that the push has been canceled by the client.
@@ -5681,7 +5708,8 @@ mod tests {
         // Assert that we do not have any push event.
         assert!(!check_push_events(&mut client));
 
-        // Check that the push has been closed, e.g. calling cancel_push should return InvalidStreamId.
+        // Check that the push has been closed, e.g. calling cancel_push should return
+        // InvalidStreamId.
         assert_eq!(client.cancel_push(0), Err(Error::InvalidStreamId));
 
         // Check that the push has been canceled by the client.
@@ -5694,7 +5722,8 @@ mod tests {
         assert_eq!(client.state(), Http3State::Connected);
     }
 
-    // Test a push stream reset after a new PUSH_PROMISE or/and push stream. The events will be ignored.
+    // Test a push stream reset after a new PUSH_PROMISE or/and push stream. The events will be
+    // ignored.
     #[test]
     fn cancel_push_stream_after_push_promise_and_push_stream() {
         // Connect and send a request
@@ -5715,7 +5744,8 @@ mod tests {
         // Assert that we do not have any push event.
         assert!(!check_push_events(&mut client));
 
-        // Check that the push has been closed, e.g. calling cancel_push should return InvalidStreamId.
+        // Check that the push has been closed, e.g. calling cancel_push should return
+        // InvalidStreamId.
         assert_eq!(client.cancel_push(0), Err(Error::InvalidStreamId));
 
         assert_eq!(client.state(), Http3State::Connected);
@@ -5743,7 +5773,8 @@ mod tests {
         // Assert that we do not have any push event.
         assert!(!check_push_events(&mut client));
 
-        // Check that the push has been closed, e.g. calling cancel_push should return InvalidStreamId.
+        // Check that the push has been closed, e.g. calling cancel_push should return
+        // InvalidStreamId.
         assert_eq!(client.cancel_push(0), Err(Error::InvalidStreamId));
 
         assert_eq!(client.state(), Http3State::Connected);
@@ -5762,13 +5793,15 @@ mod tests {
         // Assert that we do not have any push event.
         assert!(!check_push_events(&mut client));
 
-        // Check that the push has been closed, e.g. calling cancel_push should return InvalidStreamId.
+        // Check that the push has been closed, e.g. calling cancel_push should return
+        // InvalidStreamId.
         assert_eq!(client.cancel_push(0), Err(Error::InvalidStreamId));
 
         assert_eq!(client.state(), Http3State::Connected);
     }
 
-    // Test that push_promise and push data events will be removed after application calls cancel_push.
+    // Test that push_promise and push data events will be removed after application calls
+    // cancel_push.
     #[test]
     fn app_cancel_push_after_push_promise_and_push_stream() {
         // Connect and send a request
@@ -5785,7 +5818,8 @@ mod tests {
         // Assert that we do not have any push event.
         assert!(!check_push_events(&mut client));
 
-        // Check that the push has been closed, e.g. calling cancel_push should return InvalidStreamId.
+        // Check that the push has been closed, e.g. calling cancel_push should return
+        // InvalidStreamId.
         assert_eq!(client.cancel_push(0), Err(Error::InvalidStreamId));
 
         // Check that the push has been canceled by the client.
@@ -5817,7 +5851,8 @@ mod tests {
         // Assert that we do not have any push event.
         assert!(!check_push_events(&mut client));
 
-        // Check that the push has been closed, e.g. calling cancel_push should return InvalidStreamId.
+        // Check that the push has been closed, e.g. calling cancel_push should return
+        // InvalidStreamId.
         assert_eq!(client.cancel_push(0), Err(Error::InvalidStreamId));
 
         // Check that the push has been canceled by the client.
@@ -5899,7 +5934,8 @@ mod tests {
             header_block: encoded_headers.to_vec(),
         };
 
-        // Send the encoder instructions, but delay them so that the stream is blocked on decoding headers.
+        // Send the encoder instructions, but delay them so that the stream is blocked on decoding
+        // headers.
         let encoder_inst_pkt = server.conn.process(None, now()).dgram();
         assert!(encoder_inst_pkt.is_some());
 
@@ -7106,11 +7142,12 @@ mod tests {
         let out = server.conn.process(out.as_dgram_ref(), now());
 
         // the server increased the max_data during the second read if that isn't the case
-        // in the future and therefore this asserts fails, the request data on stream 0 could be read
-        // to cause a max_update frame
+        // in the future and therefore this asserts fails, the request data on stream 0 could be
+        // read to cause a max_update frame
         assert_eq!(md_before + 1, server.conn.stats().frame_tx.max_data);
 
-        // make sure that the server didn't receive a priority_update on client control stream (stream_id 2) yet
+        // make sure that the server didn't receive a priority_update on client control stream
+        // (stream_id 2) yet
         let mut buf = [0; 32];
         assert_eq!(
             server.conn.stream_recv(StreamId::new(2), &mut buf),
@@ -7149,7 +7186,8 @@ mod tests {
             header_block: encoded_headers.to_vec(),
         };
 
-        // Send the encoder instructions, but delay them so that the stream is blocked on decoding headers.
+        // Send the encoder instructions, but delay them so that the stream is blocked on decoding
+        // headers.
         let encoder_inst_pkt = server.conn.process(None, now());
 
         // Send response

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -302,6 +302,7 @@ impl Display for Http3Client {
 
 impl Http3Client {
     /// # Errors
+    ///
     /// Making a `neqo-transport::connection` may produce an error. This can only be a crypto error
     /// if the crypto context can't be created or configured.
     pub fn new(
@@ -390,6 +391,7 @@ impl Http3Client {
     /// Enable encrypted client hello (ECH).
     ///
     /// # Errors
+    ///
     /// Fails when the configuration provided is bad.
     pub fn enable_ech(&mut self, ech_config_list: impl AsRef<[u8]>) -> Res<()> {
         self.conn.client_enable_ech(ech_config_list)?;
@@ -398,7 +400,9 @@ impl Http3Client {
 
     /// Get the connection id, which is useful for disambiguating connections to
     /// the same origin.
+    ///
     /// # Panics
+    ///
     /// Never, because clients always have this field.
     #[must_use]
     pub fn connection_id(&self) -> &ConnectionId {
@@ -439,8 +443,11 @@ impl Http3Client {
     /// and used until the setting are received from the server.
     ///
     /// # Errors
+    ///
     /// An error is return if token cannot be decoded or a connection is is a wrong state.
+    ///
     /// # Panics
+    ///
     /// On closing if the base handler can't handle it (debug only).
     pub fn enable_resumption(&mut self, now: Instant, token: impl AsRef<[u8]>) -> Res<()> {
         if self.base_handler.state != Http3State::Initializing {
@@ -499,7 +506,9 @@ impl Http3Client {
     }
 
     /// Attempt to force a key update.
+    ///
     /// # Errors
+    ///
     /// If the connection isn't confirmed, or there is an outstanding key update, this
     /// returns `Err(Error::TransportError(neqo_transport::Error::KeyUpdateBlocked))`.
     pub fn initiate_key_update(&mut self) -> Res<()> {
@@ -512,9 +521,13 @@ impl Http3Client {
     /// The function fetches a resource using `method`, `target` and `headers`. A response body
     /// may be added by calling `send_data`. `stream_close_send` must be sent to finish the request
     /// even if request data are not sent.
+    ///
     /// # Errors
+    ///
     /// If a new stream cannot be created an error will be return.
+    ///
     /// # Panics
+    ///
     /// `SendMessage` implements `http_stream` so it will not panic.
     pub fn fetch<'x, 't: 'x, T>(
         &mut self,
@@ -550,7 +563,9 @@ impl Http3Client {
 
     /// Send an [`PRIORITY_UPDATE`-frame][1] on next `Http3Client::process_output()` call.
     /// Returns if the priority got changed.
+    ///
     /// # Errors
+    ///
     /// `InvalidStreamId` if the stream does not exist
     ///
     /// [1]: https://datatracker.ietf.org/doc/html/draft-kazuho-httpbis-priority-04#section-5.2
@@ -560,7 +575,9 @@ impl Http3Client {
 
     /// An application may cancel a stream(request).
     /// Both sides, the receiviing and sending side, sending and receiving side, will be closed.
+    ///
     /// # Errors
+    ///
     /// An error will be return if a stream does not exist.
     pub fn cancel_fetch(&mut self, stream_id: StreamId, error: AppError) -> Res<()> {
         qinfo!([self], "reset_stream {} error={}.", stream_id, error);
@@ -569,7 +586,9 @@ impl Http3Client {
     }
 
     /// This is call when application is done sending a request.
+    ///
     /// # Errors
+    ///
     /// An error will be return if stream does not exist.
     pub fn stream_close_send(&mut self, stream_id: StreamId) -> Res<()> {
         qinfo!([self], "Close sending side stream={}.", stream_id);
@@ -578,6 +597,7 @@ impl Http3Client {
     }
 
     /// # Errors
+    ///
     /// An error will be return if a stream does not exist.
     pub fn stream_reset_send(&mut self, stream_id: StreamId, error: AppError) -> Res<()> {
         qinfo!([self], "stream_reset_send {} error={}.", stream_id, error);
@@ -586,6 +606,7 @@ impl Http3Client {
     }
 
     /// # Errors
+    ///
     /// An error will be return if a stream does not exist.
     pub fn stream_stop_sending(&mut self, stream_id: StreamId, error: AppError) -> Res<()> {
         qinfo!([self], "stream_stop_sending {} error={}.", stream_id, error);
@@ -598,6 +619,7 @@ impl Http3Client {
     /// headers are supplied through the `fetch` function.
     ///
     /// # Errors
+    ///
     /// `InvalidStreamId` if the stream does not exist,
     /// `AlreadyClosed` if the stream has already been closed.
     /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if
@@ -620,7 +642,9 @@ impl Http3Client {
 
     /// Response data are read directly into a buffer supplied as a parameter of this function to
     /// avoid copying data.
+    ///
     /// # Errors
+    ///
     /// It returns an error if a stream does not exist or an error happen while reading a stream,
     /// e.g. early close, protocol error, etc.
     pub fn read_data(
@@ -642,7 +666,9 @@ impl Http3Client {
     // API: Push streams
 
     /// Cancel a push
+    ///
     /// # Errors
+    ///
     /// `InvalidStreamId` if the stream does not exist.
     pub fn cancel_push(&mut self, push_id: u64) -> Res<()> {
         self.push_handler
@@ -652,7 +678,9 @@ impl Http3Client {
 
     /// Push response data are read directly into a buffer supplied as a parameter of this function
     /// to avoid copying data.
+    ///
     /// # Errors
+    ///
     /// It returns an error if a stream does not exist(`InvalidStreamId`) or an error has happened
     /// while reading a stream, e.g. early close, protocol error, etc.
     pub fn push_read_data(
@@ -671,8 +699,9 @@ impl Http3Client {
     }
 
     // API WebTransport
-
+    //
     /// # Errors
+    ///
     /// If `WebTransport` cannot be created, e.g. the `WebTransport` support is
     /// not negotiated or the HTTP/3 connection is closed.
     pub fn webtransport_create_session<'x, 't: 'x, T>(
@@ -700,7 +729,9 @@ impl Http3Client {
     }
 
     /// Close `WebTransport` cleanly
+    ///
     /// # Errors
+    ///
     /// `InvalidStreamId` if the stream does not exist,
     /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if
     /// `process_output` has not been called when needed, and HTTP3 layer has not picked up the
@@ -717,6 +748,7 @@ impl Http3Client {
     }
 
     /// # Errors
+    ///
     /// This may return an error if the particular session does not exist
     /// or the connection is not in the active state.
     pub fn webtransport_create_stream(
@@ -734,7 +766,9 @@ impl Http3Client {
     }
 
     /// Send `WebTransport` datagram.
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     /// The function returns `TooMuchData` if the supply buffer is bigger than
     /// the allowed remote datagram size.
@@ -752,9 +786,13 @@ impl Http3Client {
     /// Returns the current max size of a datagram that can fit into a packet.
     /// The value will change over time depending on the encoded size of the
     ///  packet number, ack frames, etc.
+    ///
     /// # Errors
+    ///
     /// The function returns `NotAvailable` if datagrams are not enabled.
+    ///
     /// # Panics
+    ///
     /// This cannot panic. The max varint length is 8.
     pub fn webtransport_max_datagram_size(&self, session_id: StreamId) -> Res<u64> {
         Ok(self.conn.max_datagram_size()?
@@ -762,9 +800,13 @@ impl Http3Client {
     }
 
     /// Sets the `SendOrder` for a given stream
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    ///
     /// # Panics
+    ///
     /// This cannot panic.
     pub fn webtransport_set_sendorder(
         &mut self,
@@ -775,16 +817,22 @@ impl Http3Client {
     }
 
     /// Sets the `Fairness` for a given stream
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    ///
     /// # Panics
+    ///
     /// This cannot panic.
     pub fn webtransport_set_fairness(&mut self, stream_id: StreamId, fairness: bool) -> Res<()> {
         Http3Connection::stream_set_fairness(&mut self.conn, stream_id, fairness)
     }
 
     /// Returns the current `SendStreamStats` of a `WebTransportSendStream`.
+    ///
     /// # Errors
+    ///
     /// `InvalidStreamId` if the stream does not exist.
     pub fn webtransport_send_stream_stats(&mut self, stream_id: StreamId) -> Res<SendStreamStats> {
         self.base_handler
@@ -795,7 +843,9 @@ impl Http3Client {
     }
 
     /// Returns the current `RecvStreamStats` of a `WebTransportRecvStream`.
+    ///
     /// # Errors
+    ///
     /// `InvalidStreamId` if the stream does not exist.
     pub fn webtransport_recv_stream_stats(&mut self, stream_id: StreamId) -> Res<RecvStreamStats> {
         self.base_handler
@@ -1197,7 +1247,9 @@ impl Http3Client {
     }
 
     /// Increases `max_stream_data` for a `stream_id`.
+    ///
     /// # Errors
+    ///
     /// Returns `InvalidStreamId` if a stream does not exist or the receiving
     /// side is closed.
     pub fn set_stream_max_data(&mut self, stream_id: StreamId, max_data: u64) -> Res<()> {

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -4,21 +4,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::connection::{Http3Connection, Http3State, WebTransportSessionAcceptAction};
-use crate::frames::HFrame;
-use crate::recv_message::{RecvMessage, RecvMessageInfo};
-use crate::send_message::SendMessage;
-use crate::server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents};
-use crate::{
-    Error, Http3Parameters, Http3StreamType, NewStreamType, Priority, PriorityHandler,
-    ReceiveOutput, Res,
-};
+use std::{rc::Rc, time::Instant};
+
 use neqo_common::{event::Provider, qdebug, qinfo, qtrace, Header, MessageType, Role};
 use neqo_transport::{
     AppError, Connection, ConnectionEvent, DatagramTracking, StreamId, StreamType,
 };
-use std::rc::Rc;
-use std::time::Instant;
+
+use crate::{
+    connection::{Http3Connection, Http3State, WebTransportSessionAcceptAction},
+    frames::HFrame,
+    recv_message::{RecvMessage, RecvMessageInfo},
+    send_message::SendMessage,
+    server_connection_events::{Http3ServerConnEvent, Http3ServerConnEvents},
+    Error, Http3Parameters, Http3StreamType, NewStreamType, Priority, PriorityHandler,
+    ReceiveOutput, Res,
+};
 
 #[derive(Debug)]
 pub struct Http3ServerHandler {
@@ -51,9 +52,10 @@ impl Http3ServerHandler {
     /// # Errors
     /// `InvalidStreamId` if the stream does not exist,
     /// `AlreadyClosed` if the stream has already been closed.
-    /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if `process_output`
-    /// has not been called when needed, and HTTP3 layer has not picked up the info that the stream has been closed.)
-    /// `InvalidInput` if an empty buffer has been supplied.
+    /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if
+    /// `process_output` has not been called when needed, and HTTP3 layer has not picked up the
+    /// info that the stream has been closed.) `InvalidInput` if an empty buffer has been
+    /// supplied.
     pub(crate) fn send_data(
         &mut self,
         stream_id: StreamId,
@@ -156,9 +158,10 @@ impl Http3ServerHandler {
     /// Close `WebTransport` cleanly
     /// # Errors
     /// `InvalidStreamId` if the stream does not exist,
-    /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if `process_output`
-    /// has not been called when needed, and HTTP3 layer has not picked up the info that the stream has been closed.)
-    /// `InvalidInput` if an empty buffer has been supplied.
+    /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if
+    /// `process_output` has not been called when needed, and HTTP3 layer has not picked up the
+    /// info that the stream has been closed.) `InvalidInput` if an empty buffer has been
+    /// supplied.
     pub fn webtransport_close_session(
         &mut self,
         conn: &mut Connection,
@@ -383,11 +386,11 @@ impl Http3ServerHandler {
         }
     }
 
-    /// Response data are read directly into a buffer supplied as a parameter of this function to avoid copying
-    /// data.
+    /// Response data are read directly into a buffer supplied as a parameter of this function to
+    /// avoid copying data.
     /// # Errors
-    /// It returns an error if a stream does not exist or an error happen while reading a stream, e.g.
-    /// early close, protocol error, etc.
+    /// It returns an error if a stream does not exist or an error happen while reading a stream,
+    /// e.g. early close, protocol error, etc.
     pub fn read_data(
         &mut self,
         conn: &mut Connection,

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -49,7 +49,9 @@ impl Http3ServerHandler {
     }
 
     /// Supply a response for a request.
+    ///
     /// # Errors
+    ///
     /// `InvalidStreamId` if the stream does not exist,
     /// `AlreadyClosed` if the stream has already been closed.
     /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if
@@ -91,7 +93,9 @@ impl Http3ServerHandler {
     }
 
     /// This is called when application is done sending a request.
+    ///
     /// # Errors
+    ///
     /// An error will be returned if stream does not exist.
     pub fn stream_close_send(&mut self, stream_id: StreamId, conn: &mut Connection) -> Res<()> {
         qinfo!([self], "Close sending side stream={}.", stream_id);
@@ -103,7 +107,9 @@ impl Http3ServerHandler {
 
     /// An application may reset a stream(request).
     /// Both sides, sending and receiving side, will be closed.
+    ///
     /// # Errors
+    ///
     /// An error will be return if a stream does not exist.
     pub fn cancel_fetch(
         &mut self,
@@ -156,7 +162,9 @@ impl Http3ServerHandler {
     }
 
     /// Close `WebTransport` cleanly
+    ///
     /// # Errors
+    ///
     /// `InvalidStreamId` if the stream does not exist,
     /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if
     /// `process_output` has not been called when needed, and HTTP3 layer has not picked up the
@@ -388,7 +396,9 @@ impl Http3ServerHandler {
 
     /// Response data are read directly into a buffer supplied as a parameter of this function to
     /// avoid copying data.
+    ///
     /// # Errors
+    ///
     /// It returns an error if a stream does not exist or an error happen while reading a stream,
     /// e.g. early close, protocol error, etc.
     pub fn read_data(

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -365,7 +365,7 @@ impl Http3ServerHandler {
                         }
                         HFrame::PriorityUpdatePush { element_id, priority } => {
                             // TODO: check if the element_id references a promised push stream or
-                            //       is greater than the maximum Push ID.
+                            // is greater than the maximum Push ID.
                             self.events.priority_update(StreamId::from(element_id), priority);
                             Ok(())
                         }

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -4,12 +4,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::frames::HFrame;
-use crate::{BufferedStream, Http3StreamType, RecvStream, Res};
+use std::{
+    collections::{HashMap, VecDeque},
+    convert::TryFrom,
+};
+
 use neqo_common::{qtrace, Encoder};
 use neqo_transport::{Connection, StreamId, StreamType};
-use std::collections::{HashMap, VecDeque};
-use std::convert::TryFrom;
+
+use crate::{frames::HFrame, BufferedStream, Http3StreamType, RecvStream, Res};
 
 pub const HTTP3_UNI_STREAM_TYPE_CONTROL: u64 = 0x0;
 

--- a/neqo-http3/src/control_stream_remote.rs
+++ b/neqo-http3/src/control_stream_remote.rs
@@ -4,12 +4,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::frames::{FrameReader, HFrame, StreamReaderConnectionWrapper};
-use crate::{CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream};
 use neqo_common::qdebug;
 use neqo_transport::{Connection, StreamId};
 
-/// The remote control stream is responsible only for reading frames. The frames are handled by `Http3Connection`.
+use crate::{
+    frames::{FrameReader, HFrame, StreamReaderConnectionWrapper},
+    CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream,
+};
+
+/// The remote control stream is responsible only for reading frames. The frames are handled by
+/// `Http3Connection`.
 #[derive(Debug)]
 pub(crate) struct ControlStreamRemote {
     stream_id: StreamId,

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -9,14 +9,18 @@
 pub(crate) mod webtransport_session;
 pub(crate) mod webtransport_streams;
 
-use crate::client_events::Http3ClientEvents;
-use crate::features::NegotiationState;
-use crate::settings::{HSettingType, HSettings};
-use crate::{CloseType, Http3StreamInfo, Http3StreamType};
+use std::fmt::Debug;
+
 use neqo_common::Header;
 use neqo_transport::{AppError, StreamId};
-use std::fmt::Debug;
 pub(crate) use webtransport_session::WebTransportSession;
+
+use crate::{
+    client_events::Http3ClientEvents,
+    features::NegotiationState,
+    settings::{HSettingType, HSettings},
+    CloseType, Http3StreamInfo, Http3StreamType,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SessionCloseReason {

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -4,13 +4,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::features::extended_connect::tests::webtransport::{
-    wt_default_parameters, WtTest, DATAGRAM_SIZE,
-};
-use crate::{Error, Http3Parameters, WebTransportRequest};
+use std::convert::TryFrom;
+
 use neqo_common::Encoder;
 use neqo_transport::Error as TransportError;
-use std::convert::TryFrom;
+
+use crate::{
+    features::extended_connect::tests::webtransport::{
+        wt_default_parameters, WtTest, DATAGRAM_SIZE,
+    },
+    Error, Http3Parameters, WebTransportRequest,
+};
 
 const DGRAM: &[u8] = &[0, 100];
 

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -8,23 +8,21 @@ mod datagrams;
 mod negotiation;
 mod sessions;
 mod streams;
+use std::{cell::RefCell, rc::Rc, time::Duration};
+
 use neqo_common::event::Provider;
+use neqo_crypto::AuthenticationStatus;
+use neqo_transport::{ConnectionParameters, StreamId, StreamType};
+use test_fixture::{
+    addr, anti_replay, fixture_init, now, CountingConnectionIdGenerator, DEFAULT_ALPN_H3,
+    DEFAULT_KEYS, DEFAULT_SERVER_NAME,
+};
 
 use crate::{
     features::extended_connect::SessionCloseReason, Error, Header, Http3Client, Http3ClientEvent,
     Http3OrWebTransportStream, Http3Parameters, Http3Server, Http3ServerEvent, Http3State,
     RecvStreamStats, SendStreamStats, WebTransportEvent, WebTransportRequest,
     WebTransportServerEvent, WebTransportSessionAcceptAction,
-};
-use neqo_crypto::AuthenticationStatus;
-use neqo_transport::{ConnectionParameters, StreamId, StreamType};
-use std::cell::RefCell;
-use std::rc::Rc;
-use std::time::Duration;
-
-use test_fixture::{
-    addr, anti_replay, fixture_init, now, CountingConnectionIdGenerator, DEFAULT_ALPN_H3,
-    DEFAULT_KEYS, DEFAULT_SERVER_NAME,
 };
 
 const DATAGRAM_SIZE: u64 = 1200;

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/negotiation.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/negotiation.rs
@@ -4,17 +4,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::time::Duration;
+
+use neqo_common::{event::Provider, Encoder};
+use neqo_crypto::AuthenticationStatus;
+use neqo_transport::{Connection, ConnectionError, StreamType};
+use test_fixture::{default_server_h3, now};
+
 use super::{connect, default_http3_client, default_http3_server, exchange_packets};
 use crate::{
     settings::{HSetting, HSettingType, HSettings},
     Error, HFrame, Http3Client, Http3ClientEvent, Http3Parameters, Http3Server, Http3State,
     WebTransportEvent,
 };
-use neqo_common::{event::Provider, Encoder};
-use neqo_crypto::AuthenticationStatus;
-use neqo_transport::{Connection, ConnectionError, StreamType};
-use std::time::Duration;
-use test_fixture::{default_server_h3, now};
 
 fn check_wt_event(client: &mut Http3Client, wt_enable_client: bool, wt_enable_server: bool) {
     let wt_event = client.events().find_map(|e| {

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -4,18 +4,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::features::extended_connect::tests::webtransport::{
-    default_http3_client, default_http3_server, wt_default_parameters, WtTest,
-};
-use crate::{
-    features::extended_connect::SessionCloseReason, frames::WebTransportFrame, Error, Header,
-    Http3ClientEvent, Http3OrWebTransportStream, Http3Server, Http3ServerEvent, Http3State,
-    Priority, WebTransportEvent, WebTransportServerEvent, WebTransportSessionAcceptAction,
-};
+use std::mem;
+
 use neqo_common::{event::Provider, Encoder};
 use neqo_transport::StreamType;
-use std::mem;
 use test_fixture::now;
+
+use crate::{
+    features::extended_connect::{
+        tests::webtransport::{
+            default_http3_client, default_http3_server, wt_default_parameters, WtTest,
+        },
+        SessionCloseReason,
+    },
+    frames::WebTransportFrame,
+    Error, Header, Http3ClientEvent, Http3OrWebTransportStream, Http3Server, Http3ServerEvent,
+    Http3State, Priority, WebTransportEvent, WebTransportServerEvent,
+    WebTransportSessionAcceptAction,
+};
 
 #[test]
 fn wt_session() {

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
@@ -4,10 +4,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::features::extended_connect::tests::webtransport::WtTest;
-use crate::{features::extended_connect::SessionCloseReason, Error};
-use neqo_transport::StreamType;
 use std::mem;
+
+use neqo_transport::StreamType;
+
+use crate::{
+    features::extended_connect::{tests::webtransport::WtTest, SessionCloseReason},
+    Error,
+};
 
 #[test]
 fn wt_client_stream_uni() {
@@ -287,13 +291,17 @@ fn wt_server_stream_bidi_stop_sending() {
 //  1) Both sides of a bidirectional client stream are opened.
 //  2) A client unidirectional stream is opened.
 //  3) A client unidirectional stream has been closed and both sides consumed the closing info.
-//  4) A client unidirectional stream has been closed, but only the server has consumed the closing info.
-//  5) A client unidirectional stream has been closed, but only the client has consum the closing info.
+//  4) A client unidirectional stream has been closed, but only the server has consumed the closing
+//     info.
+//  5) A client unidirectional stream has been closed, but only the client has consum the closing
+//     info.
 //  6) Both sides of a bidirectional server stream are opened.
 //  7) A server unidirectional stream is opened.
 //  8) A server unidirectional stream has been closed and both sides consumed the closing info.
-//  9) A server unidirectional stream has been closed, but only the server has consumed the closing info.
-//  10) A server unidirectional stream has been closed, but only the client has consumed the closing info.
+//  9) A server unidirectional stream has been closed, but only the server has consumed the closing
+//     info.
+//  10) A server unidirectional stream has been closed, but only the client has consumed the closing
+//      info.
 //  11) Both sides of a bidirectional stream have been closed and consumed by both sides.
 //  12) Both sides of a bidirectional stream have been closed, but not consumed by both sides.
 //  13) Multiples open streams

--- a/neqo-http3/src/features/extended_connect/webtransport_session.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_session.rs
@@ -6,6 +6,12 @@
 
 #![allow(clippy::module_name_repetitions)]
 
+use std::{any::Any, cell::RefCell, collections::BTreeSet, mem, rc::Rc};
+
+use neqo_common::{qtrace, Encoder, Header, MessageType, Role};
+use neqo_qpack::{QPackDecoder, QPackEncoder};
+use neqo_transport::{streams::SendOrder, Connection, DatagramTracking, StreamId};
+
 use super::{ExtendedConnectEvents, ExtendedConnectType, SessionCloseReason};
 use crate::{
     frames::{FrameReader, StreamReaderRecvStreamWrapper, WebTransportFrame},
@@ -15,14 +21,6 @@ use crate::{
     HttpRecvStreamEvents, Priority, PriorityHandler, ReceiveOutput, RecvStream, RecvStreamEvents,
     Res, SendStream, SendStreamEvents, Stream,
 };
-use neqo_common::{qtrace, Encoder, Header, MessageType, Role};
-use neqo_qpack::{QPackDecoder, QPackEncoder};
-use neqo_transport::{streams::SendOrder, Connection, DatagramTracking, StreamId};
-use std::any::Any;
-use std::cell::RefCell;
-use std::collections::BTreeSet;
-use std::mem;
-use std::rc::Rc;
 
 #[derive(Debug, PartialEq)]
 enum SessionState {
@@ -373,8 +371,8 @@ impl WebTransportSession {
     }
 
     /// # Errors
-    /// Return an error if the stream was closed on the transport layer, but that information is not yet
-    /// consumed on the http/3 layer.
+    /// Return an error if the stream was closed on the transport layer, but that information is not
+    /// yet consumed on the http/3 layer.
     pub fn close_session(&mut self, conn: &mut Connection, error: u32, message: &str) -> Res<()> {
         self.state = SessionState::Done;
         let close_frame = WebTransportFrame::CloseSession {

--- a/neqo-http3/src/features/extended_connect/webtransport_session.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_session.rs
@@ -98,6 +98,7 @@ impl WebTransportSession {
     }
 
     /// # Panics
+    ///
     /// This function is only called with `RecvStream` and `SendStream` that also implement
     /// the http specific functions and `http_stream()` will never return `None`.
     #[must_use]
@@ -132,8 +133,11 @@ impl WebTransportSession {
     }
 
     /// # Errors
+    ///
     /// The function can only fail if supplied headers are not valid http headers.
+    ///
     /// # Panics
+    ///
     /// `control_stream_send` implements the  http specific functions and `http_stream()`
     /// will never return `None`.
     pub fn send_request(&mut self, headers: &[Header], conn: &mut Connection) -> Res<()> {
@@ -218,6 +222,7 @@ impl WebTransportSession {
     }
 
     /// # Panics
+    ///
     /// This cannot panic because headers are checked before this function called.
     pub fn maybe_check_headers(&mut self) {
         if SessionState::Negotiating != self.state {
@@ -333,6 +338,7 @@ impl WebTransportSession {
     }
 
     /// # Errors
+    ///
     /// It may return an error if the frame is not correctly decoded.
     pub fn read_control_stream(&mut self, conn: &mut Connection) -> Res<()> {
         let (f, fin) = self
@@ -371,6 +377,7 @@ impl WebTransportSession {
     }
 
     /// # Errors
+    ///
     /// Return an error if the stream was closed on the transport layer, but that information is not
     /// yet consumed on the http/3 layer.
     pub fn close_session(&mut self, conn: &mut Connection, error: u32, message: &str) -> Res<()> {
@@ -397,6 +404,7 @@ impl WebTransportSession {
     }
 
     /// # Errors
+    ///
     /// Returns an error if the datagram exceeds the remote datagram size limit.
     pub fn send_datagram(
         &self,

--- a/neqo-http3/src/features/extended_connect/webtransport_streams.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_streams.rs
@@ -4,15 +4,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{cell::RefCell, rc::Rc};
+
+use neqo_common::Encoder;
+use neqo_transport::{Connection, RecvStreamStats, SendStreamStats, StreamId};
+
 use super::WebTransportSession;
 use crate::{
     CloseType, Http3StreamInfo, Http3StreamType, ReceiveOutput, RecvStream, RecvStreamEvents, Res,
     SendStream, SendStreamEvents, Stream,
 };
-use neqo_common::Encoder;
-use neqo_transport::{Connection, RecvStreamStats, SendStreamStats, StreamId};
-use std::cell::RefCell;
-use std::rc::Rc;
 
 pub const WEBTRANSPORT_UNI_STREAM: u64 = 0x54;
 pub const WEBTRANSPORT_STREAM: u64 = 0x41;

--- a/neqo-http3/src/features/mod.rs
+++ b/neqo-http3/src/features/mod.rs
@@ -4,23 +4,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{fmt::Debug, mem};
+
+use neqo_common::qtrace;
+
 use crate::{
     client_events::Http3ClientEvents,
     settings::{HSettingType, HSettings},
 };
-use neqo_common::qtrace;
-use std::fmt::Debug;
-use std::mem;
 
 pub mod extended_connect;
 
 /// States:
 /// - `Disable` - it is not turned on for this connection.
-/// - `Negotiating` - the feature is enabled locally, but settings from the peer
-///                  have not been received yet.
+/// - `Negotiating` - the feature is enabled locally, but settings from the peer have not been
+///   received yet.
 /// - `Negotiated` - the settings have been received and both sides support the feature.
-/// - `NegotiationFailed` - the settings have been received and the peer does not
-///                         support the feature.
+/// - `NegotiationFailed` - the settings have been received and the peer does not support the
+///   feature.
 #[derive(Debug)]
 pub enum NegotiationState {
     Disabled,

--- a/neqo-http3/src/frames/hframe.rs
+++ b/neqo-http3/src/frames/hframe.rs
@@ -4,12 +4,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{frames::reader::FrameDecoder, settings::HSettings, Error, Priority, Res};
+use std::{fmt::Debug, io::Write};
+
 use neqo_common::{Decoder, Encoder};
 use neqo_crypto::random;
 use neqo_transport::StreamId;
-use std::fmt::Debug;
-use std::io::Write;
+
+use crate::{frames::reader::FrameDecoder, settings::HSettings, Error, Priority, Res};
 
 pub(crate) type HFrameType = u64;
 

--- a/neqo-http3/src/frames/reader.rs
+++ b/neqo-http3/src/frames/reader.rs
@@ -6,14 +6,15 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use crate::{Error, RecvStream, Res};
+use std::{convert::TryFrom, fmt::Debug};
+
 use neqo_common::{
     hex_with_len, qtrace, Decoder, IncrementalDecoderBuffer, IncrementalDecoderIgnore,
     IncrementalDecoderUint,
 };
 use neqo_transport::{Connection, StreamId};
-use std::convert::TryFrom;
-use std::fmt::Debug;
+
+use crate::{Error, RecvStream, Res};
 
 const MAX_READ_SIZE: usize = 4096;
 
@@ -32,8 +33,8 @@ pub(crate) trait FrameDecoder<T> {
 pub(crate) trait StreamReader {
     /// # Errors
     /// An error may happen while reading a stream, e.g. early close, protocol error, etc.
-    /// Return an error if the stream was closed on the transport layer, but that information is not yet
-    /// consumed on the  http/3 layer.
+    /// Return an error if the stream was closed on the transport layer, but that information is not
+    /// yet consumed on the  http/3 layer.
     fn read_data(&mut self, buf: &mut [u8]) -> Res<(usize, bool)>;
 }
 

--- a/neqo-http3/src/frames/reader.rs
+++ b/neqo-http3/src/frames/reader.rs
@@ -21,17 +21,21 @@ const MAX_READ_SIZE: usize = 4096;
 pub(crate) trait FrameDecoder<T> {
     fn is_known_type(frame_type: u64) -> bool;
     /// # Errors
+    ///
     /// Returns `HttpFrameUnexpected` if frames is not alowed, i.e. is a `H3_RESERVED_FRAME_TYPES`.
     fn frame_type_allowed(_frame_type: u64) -> Res<()> {
         Ok(())
     }
+
     /// # Errors
+    ///
     /// If a frame cannot be properly decoded.
     fn decode(frame_type: u64, frame_len: u64, data: Option<&[u8]>) -> Res<Option<T>>;
 }
 
 pub(crate) trait StreamReader {
     /// # Errors
+    ///
     /// An error may happen while reading a stream, e.g. early close, protocol error, etc.
     /// Return an error if the stream was closed on the transport layer, but that information is not
     /// yet consumed on the  http/3 layer.
@@ -51,6 +55,7 @@ impl<'a> StreamReaderConnectionWrapper<'a> {
 
 impl<'a> StreamReader for StreamReaderConnectionWrapper<'a> {
     /// # Errors
+    ///
     /// An error may happen while reading a stream, e.g. early close, protocol error, etc.
     fn read_data(&mut self, buf: &mut [u8]) -> Res<(usize, bool)> {
         let res = self.conn.stream_recv(self.stream_id, buf)?;
@@ -71,6 +76,7 @@ impl<'a> StreamReaderRecvStreamWrapper<'a> {
 
 impl<'a> StreamReader for StreamReaderRecvStreamWrapper<'a> {
     /// # Errors
+    ///
     /// An error may happen while reading a stream, e.g. early close, protocol error, etc.
     fn read_data(&mut self, buf: &mut [u8]) -> Res<(usize, bool)> {
         self.recv_stream.read_data(self.conn, buf)
@@ -147,7 +153,9 @@ impl FrameReader {
     }
 
     /// returns true if quic stream was closed.
+    ///
     /// # Errors
+    ///
     /// May return `HttpFrame` if a frame cannot be decoded.
     /// and `TransportStreamDoesNotExist` if `stream_recv` fails.
     pub fn receive<T: FrameDecoder<T>>(
@@ -187,6 +195,7 @@ impl FrameReader {
     }
 
     /// # Errors
+    ///
     /// May return `HttpFrame` if a frame cannot be decoded.
     fn consume<T: FrameDecoder<T>>(&mut self, mut input: Decoder) -> Res<Option<T>> {
         match &mut self.state {

--- a/neqo-http3/src/frames/tests/hframe.rs
+++ b/neqo-http3/src/frames/tests/hframe.rs
@@ -4,15 +4,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use neqo_common::{Decoder, Encoder};
+use neqo_transport::StreamId;
+use test_fixture::fixture_init;
+
 use super::enc_dec_hframe;
 use crate::{
     frames::HFrame,
     settings::{HSetting, HSettingType, HSettings},
     Priority,
 };
-use neqo_common::{Decoder, Encoder};
-use neqo_transport::StreamId;
-use test_fixture::fixture_init;
 
 #[test]
 fn test_data_frame() {

--- a/neqo-http3/src/frames/tests/mod.rs
+++ b/neqo-http3/src/frames/tests/mod.rs
@@ -4,14 +4,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::frames::{
-    reader::FrameDecoder, FrameReader, HFrame, StreamReaderConnectionWrapper, WebTransportFrame,
-};
+use std::mem;
+
 use neqo_common::Encoder;
 use neqo_crypto::AuthenticationStatus;
 use neqo_transport::StreamType;
-use std::mem;
 use test_fixture::{default_client, default_server, now};
+
+use crate::frames::{
+    reader::FrameDecoder, FrameReader, HFrame, StreamReaderConnectionWrapper, WebTransportFrame,
+};
 
 #[allow(clippy::many_single_char_names)]
 pub(crate) fn enc_dec<T: FrameDecoder<T>>(d: &Encoder, st: &str, remaining: usize) -> T {

--- a/neqo-http3/src/frames/tests/reader.rs
+++ b/neqo-http3/src/frames/tests/reader.rs
@@ -4,6 +4,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{fmt::Debug, mem};
+
+use neqo_common::Encoder;
+use neqo_transport::{Connection, StreamId, StreamType};
+use test_fixture::{connect, now};
+
 use crate::{
     frames::{
         reader::FrameDecoder, FrameReader, HFrame, StreamReaderConnectionWrapper, WebTransportFrame,
@@ -11,11 +17,6 @@ use crate::{
     settings::{HSetting, HSettingType, HSettings},
     Error,
 };
-use neqo_common::Encoder;
-use neqo_transport::{Connection, StreamId, StreamType};
-use std::fmt::Debug;
-use std::mem;
-use test_fixture::{connect, now};
 
 struct FrameReaderTest {
     pub fr: FrameReader,

--- a/neqo-http3/src/frames/wtframe.rs
+++ b/neqo-http3/src/frames/wtframe.rs
@@ -4,9 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{frames::reader::FrameDecoder, Error, Res};
-use neqo_common::{Decoder, Encoder};
 use std::convert::TryFrom;
+
+use neqo_common::{Decoder, Encoder};
+
+use crate::{frames::reader::FrameDecoder, Error, Res};
 
 pub(crate) type WebTransportFrameType = u64;
 

--- a/neqo-http3/src/headers_checks.rs
+++ b/neqo-http3/src/headers_checks.rs
@@ -47,7 +47,9 @@ impl TryFrom<(MessageType, &str)> for PseudoHeaderState {
 }
 
 /// Check whether the response is informational(1xx).
+///
 /// # Errors
+///
 /// Returns an error if response headers do not contain
 /// a status header or if the value of the header is 101 or cannot be parsed.
 pub fn is_interim(headers: &[Header]) -> Res<bool> {
@@ -91,7 +93,9 @@ fn track_pseudo(
 
 /// Checks if request/response headers are well formed, i.e. contain
 /// allowed pseudo headers and in a right order, etc.
+///
 /// # Errors
+///
 /// Returns an error if headers are not well formed.
 pub fn headers_valid(headers: &[Header], message_type: MessageType) -> Res<()> {
     let mut method_value: Option<&str> = None;
@@ -157,7 +161,9 @@ pub fn headers_valid(headers: &[Header], message_type: MessageType) -> Res<()> {
 
 /// Checks if trailers are well formed, i.e. pseudo headers are not
 /// allowed in trailers.
+///
 /// # Errors
+///
 /// Returns an error if trailers are not well formed.
 pub fn trailers_valid(headers: &[Header]) -> Res<()> {
     for header in headers {

--- a/neqo-http3/src/headers_checks.rs
+++ b/neqo-http3/src/headers_checks.rs
@@ -6,10 +6,12 @@
 
 #![allow(clippy::unused_unit)] // see https://github.com/Lymia/enumset/issues/44
 
-use crate::{Error, MessageType, Res};
+use std::convert::TryFrom;
+
 use enumset::{enum_set, EnumSet, EnumSetType};
 use neqo_common::Header;
-use std::convert::TryFrom;
+
+use crate::{Error, MessageType, Res};
 
 #[derive(EnumSetType, Debug)]
 enum PseudoHeaderState {
@@ -168,9 +170,10 @@ pub fn trailers_valid(headers: &[Header]) -> Res<()> {
 
 #[cfg(test)]
 mod tests {
+    use neqo_common::Header;
+
     use super::headers_valid;
     use crate::MessageType;
-    use neqo_common::Header;
 
     fn create_connect_headers() -> Vec<Header> {
         vec![

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -287,6 +287,7 @@ impl Error {
     }
 
     /// # Panics
+    ///
     /// On unexpected errors, in debug mode.
     #[must_use]
     pub fn map_stream_send_errors(err: &Error) -> Self {
@@ -303,6 +304,7 @@ impl Error {
     }
 
     /// # Panics
+    ///
     /// On unexpected errors, in debug mode.
     #[must_use]
     pub fn map_stream_create_errors(err: &TransportError) -> Self {
@@ -317,6 +319,7 @@ impl Error {
     }
 
     /// # Panics
+    ///
     /// On unexpected errors, in debug mode.
     #[must_use]
     pub fn map_stream_recv_errors(err: &Error) -> Self {
@@ -344,8 +347,11 @@ impl Error {
     }
 
     /// # Errors
+    ///
     ///   Any error is mapped to the indicated type.
+    ///
     /// # Panics
+    ///
     /// On internal errors, in debug mode.
     fn map_error<R>(r: Result<R, impl Into<Self>>, err: Self) -> Result<R, Self> {
         r.map_err(|e| {
@@ -449,16 +455,23 @@ trait RecvStream: Stream {
     /// The stream reads data from the corresponding quic stream and returns `ReceiveOutput`.
     /// The function also returns true as the second parameter if the stream is done and
     /// could be forgotten, i.e. removed from all records.
+    ///
     /// # Errors
+    ///
     /// An error may happen while reading a stream, e.g. early close, protocol error, etc.
     fn receive(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)>;
+
     /// # Errors
+    ///
     /// An error may happen while reading a stream, e.g. early close, etc.
     fn reset(&mut self, close_type: CloseType) -> Res<()>;
+
     /// The function allows an app to read directly from the quic stream. The function
     /// returns the number of bytes written into `buf` and true/false if the stream is
     /// completely done and can be forgotten, i.e. removed from all records.
+    ///
     /// # Errors
+    ///
     /// An error may happen while reading a stream, e.g. early close, protocol error, etc.
     fn read_data(&mut self, _conn: &mut Connection, _buf: &mut [u8]) -> Res<(usize, bool)> {
         Err(Error::InvalidStreamId)
@@ -482,7 +495,9 @@ trait HttpRecvStream: RecvStream {
     /// This function is similar to the receive function and has the same output, i.e.
     /// a `ReceiveOutput` enum and bool. The bool is true if the stream is completely done
     /// and can be forgotten, i.e. removed from all records.
+    ///
     /// # Errors
+    ///
     /// An error may happen while reading a stream, e.g. early close, protocol error, etc.
     fn header_unblocked(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)>;
 
@@ -551,6 +566,7 @@ trait HttpRecvStreamEvents: RecvStreamEvents {
 
 trait SendStream: Stream {
     /// # Errors
+    ///
     /// Error my occur during sending data, e.g. protocol error, etc.
     fn send(&mut self, conn: &mut Connection) -> Res<()>;
     fn has_data_to_send(&self) -> bool;
@@ -558,14 +574,19 @@ trait SendStream: Stream {
     fn done(&self) -> bool;
     fn set_sendorder(&mut self, conn: &mut Connection, sendorder: Option<SendOrder>) -> Res<()>;
     fn set_fairness(&mut self, conn: &mut Connection, fairness: bool) -> Res<()>;
+
     /// # Errors
+    ///
     /// Error my occur during sending data, e.g. protocol error, etc.
     fn send_data(&mut self, _conn: &mut Connection, _buf: &[u8]) -> Res<usize>;
 
     /// # Errors
+    ///
     /// It may happen that the transport stream is already close. This is unlikely.
     fn close(&mut self, conn: &mut Connection) -> Res<()>;
+
     /// # Errors
+    ///
     /// It may happen that the transport stream is already close. This is unlikely.
     fn close_with_message(
         &mut self,
@@ -575,6 +596,7 @@ trait SendStream: Stream {
     ) -> Res<()> {
         Err(Error::InvalidStreamId)
     }
+
     /// This function is called when sending side is closed abruptly by the peer or
     /// the application.
     fn handle_stop_sending(&mut self, close_type: CloseType);
@@ -583,6 +605,7 @@ trait SendStream: Stream {
     }
 
     /// # Errors
+    ///
     /// It may happen that the transport stream is already close. This is unlikely.
     fn send_data_atomic(&mut self, _conn: &mut Connection, _buf: &[u8]) -> Res<()> {
         Err(Error::InvalidStreamId)
@@ -598,7 +621,9 @@ trait HttpSendStream: SendStream {
     /// This function is used to supply headers to a http message. The
     /// function is used for request headers, response headers, 1xx response and
     /// trailers.
+    ///
     /// # Errors
+    ///
     /// This can also return an error if the underlying stream is closed.
     fn send_headers(&mut self, headers: &[Header], conn: &mut Connection) -> Res<()>;
     fn set_new_listener(&mut self, _conn_events: Box<dyn SendStreamEvents>) {}

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -160,14 +160,8 @@ mod server_events;
 mod settings;
 mod stream_type_reader;
 
-use neqo_qpack::Error as QpackError;
-pub use neqo_transport::{streams::SendOrder, Output, StreamId};
-use neqo_transport::{
-    AppError, Connection, Error as TransportError, RecvStreamStats, SendStreamStats,
-};
-use std::fmt::Debug;
+use std::{any::Any, cell::RefCell, fmt::Debug, rc::Rc};
 
-use crate::priority::PriorityHandler;
 use buffered_send_stream::BufferedStream;
 pub use client_events::{Http3ClientEvent, WebTransportEvent};
 pub use conn_params::Http3Parameters;
@@ -177,15 +171,19 @@ use features::extended_connect::WebTransportSession;
 use frames::HFrame;
 pub use neqo_common::Header;
 use neqo_common::MessageType;
+use neqo_qpack::Error as QpackError;
+pub use neqo_transport::{streams::SendOrder, Output, StreamId};
+use neqo_transport::{
+    AppError, Connection, Error as TransportError, RecvStreamStats, SendStreamStats,
+};
 pub use priority::Priority;
 pub use server::Http3Server;
 pub use server_events::{
     Http3OrWebTransportStream, Http3ServerEvent, WebTransportRequest, WebTransportServerEvent,
 };
-use std::any::Any;
-use std::cell::RefCell;
-use std::rc::Rc;
 use stream_type_reader::NewStreamType;
+
+use crate::priority::PriorityHandler;
 
 type Res<T> = Result<T, Error>;
 
@@ -193,7 +191,8 @@ type Res<T> = Result<T, Error>;
 pub enum Error {
     HttpNoError,
     HttpGeneralProtocol,
-    HttpGeneralProtocolStream, //this is the same as the above but it should only close a stream not a connection.
+    HttpGeneralProtocolStream, /* this is the same as the above but it should only close a
+                                * stream not a connection. */
     // When using this error, you need to provide a value that is unique, which
     // will allow the specific error to be identified.  This will be validated in CI.
     HttpInternal(u16),

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -348,7 +348,7 @@ impl Error {
 
     /// # Errors
     ///
-    ///   Any error is mapped to the indicated type.
+    /// Any error is mapped to the indicated type.
     ///
     /// # Panics
     ///

--- a/neqo-http3/src/priority.rs
+++ b/neqo-http3/src/priority.rs
@@ -22,6 +22,7 @@ impl Default for Priority {
 
 impl Priority {
     /// # Panics
+    ///
     /// If an invalid urgency (>7 is given)
     #[must_use]
     pub fn new(urgency: u8, incremental: bool) -> Priority {
@@ -45,9 +46,13 @@ impl Priority {
     }
 
     /// Constructs a priority from raw bytes (either a field value of frame content).
+    ///
     /// # Errors
+    ///
     /// When the contained syntax is invalid.
+    ///
     /// # Panics
+    ///
     /// Never, but the compiler is not smart enough to work that out.
     pub fn from_bytes(bytes: &[u8]) -> Res<Priority> {
         let dict = Parser::parse_dictionary(bytes).map_err(|_| Error::HttpFrame)?;

--- a/neqo-http3/src/priority.rs
+++ b/neqo-http3/src/priority.rs
@@ -1,8 +1,9 @@
-use crate::{frames::HFrame, Error, Header, Res};
+use std::{convert::TryFrom, fmt};
+
 use neqo_transport::StreamId;
 use sfv::{BareItem, Item, ListEntry, Parser};
-use std::convert::TryFrom;
-use std::fmt;
+
+use crate::{frames::HFrame, Error, Header, Res};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Priority {
@@ -149,9 +150,9 @@ impl PriorityHandler {
 
 #[cfg(test)]
 mod test {
-    use crate::priority::PriorityHandler;
-    use crate::{HFrame, Priority};
     use neqo_transport::StreamId;
+
+    use crate::{priority::PriorityHandler, HFrame, Priority};
 
     #[test]
     fn priority_updates_ignore_same() {
@@ -183,7 +184,8 @@ mod test {
         let mut p = PriorityHandler::new(false, Priority::new(5, false));
         assert!(p.maybe_update_priority(Priority::new(6, false)));
         assert!(p.maybe_update_priority(Priority::new(7, false)));
-        // updating two times with a different priority -> the last priority update should be in the next frame
+        // updating two times with a different priority -> the last priority update should be in the
+        // next frame
         let expected = HFrame::PriorityUpdateRequest {
             element_id: 4,
             priority: Priority::new(7, false),

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -3,28 +3,33 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::client_events::{Http3ClientEvent, Http3ClientEvents};
-use crate::connection::Http3Connection;
-use crate::frames::HFrame;
-use crate::{CloseType, Error, Http3StreamInfo, HttpRecvStreamEvents, RecvStreamEvents, Res};
+use std::{
+    cell::RefCell,
+    collections::VecDeque,
+    convert::TryFrom,
+    fmt::{Debug, Display},
+    mem,
+    rc::Rc,
+    slice::SliceIndex,
+};
+
 use neqo_common::{qerror, qinfo, qtrace, Header};
 use neqo_transport::{Connection, StreamId};
-use std::cell::RefCell;
-use std::collections::VecDeque;
-use std::convert::TryFrom;
-use std::fmt::Debug;
-use std::fmt::Display;
-use std::mem;
-use std::rc::Rc;
-use std::slice::SliceIndex;
+
+use crate::{
+    client_events::{Http3ClientEvent, Http3ClientEvents},
+    connection::Http3Connection,
+    frames::HFrame,
+    CloseType, Error, Http3StreamInfo, HttpRecvStreamEvents, RecvStreamEvents, Res,
+};
 
 /// `PushStates`:
-///   `Init`: there is no push stream nor a push promise. This state is only used to keep track of opened and closed
-///           push streams.
+///   `Init`: there is no push stream nor a push promise. This state is only used to keep track of
+/// opened and closed           push streams.
 ///   `PushPromise`: the push has only ever receive a pushpromise frame
-///   `OnlyPushStream`: there is only a push stream. All push stream events, i.e. `PushHeaderReady` and
-///                     `PushDataReadable` will be delayed until a push promise is received (they are kept in
-///                     `events`).
+///   `OnlyPushStream`: there is only a push stream. All push stream events, i.e. `PushHeaderReady`
+/// and                     `PushDataReadable` will be delayed until a push promise is received
+/// (they are kept in                     `events`).
 ///   `Active`: there is a push steam and at least one push promise frame.
 ///   `Close`: the push stream has been closed or reset already.
 #[derive(Debug, PartialEq, Clone)]
@@ -122,21 +127,22 @@ impl ActivePushStreams {
 
 /// `PushController` keeps information about push stream states.
 ///
-/// A `PushStream` calls `add_new_push_stream` that may change the push state from Init to `OnlyPushStream` or from
-/// `PushPromise` to `Active`. If a stream has already been closed `add_new_push_stream` returns false (the `PushStream`
-/// will close the transport stream).
+/// A `PushStream` calls `add_new_push_stream` that may change the push state from Init to
+/// `OnlyPushStream` or from `PushPromise` to `Active`. If a stream has already been closed
+/// `add_new_push_stream` returns false (the `PushStream` will close the transport stream).
 /// A `PushStream` calls `push_stream_reset` if the transport stream has been canceled.
 /// When a push stream is done it calls `close`.
 ///
 /// The `PushController` handles:
-///  `PUSH_PROMISE` frame: frames may change the push state from Init to `PushPromise` and from `OnlyPushStream` to
-///                        `Active`. Frames for a closed steams are ignored.
-///  `CANCEL_PUSH` frame: (`handle_cancel_push` will be called). If a push is in state `PushPromise` or `Active`, any
-///                       posted events will be removed and a `PushCanceled` event will be posted. If a push is in
-///                       state `OnlyPushStream` or `Active` the transport stream and the `PushStream` will be closed.
-///                       The frame will be ignored for already closed pushes.
-///  Application calling cancel: the actions are similar to the `CANCEL_PUSH` frame. The difference is that
-///                              `PushCanceled` will not be posted and a `CANCEL_PUSH` frame may be sent.
+///  `PUSH_PROMISE` frame: frames may change the push state from Init to `PushPromise` and from
+/// `OnlyPushStream` to                        `Active`. Frames for a closed steams are ignored.
+///  `CANCEL_PUSH` frame: (`handle_cancel_push` will be called). If a push is in state `PushPromise`
+/// or `Active`, any                       posted events will be removed and a `PushCanceled` event
+/// will be posted. If a push is in                       state `OnlyPushStream` or `Active` the
+/// transport stream and the `PushStream` will be closed.                       The frame will be
+/// ignored for already closed pushes.  Application calling cancel: the actions are similar to the
+/// `CANCEL_PUSH` frame. The difference is that                              `PushCanceled` will not
+/// be posted and a `CANCEL_PUSH` frame may be sent.
 #[derive(Debug)]
 pub(crate) struct PushController {
     max_concurent_push: u64,
@@ -145,8 +151,8 @@ pub(crate) struct PushController {
     // We keep a stream until the stream has been closed.
     push_streams: ActivePushStreams,
     // The keeps the next consecutive push_id that should be open.
-    // All push_id < next_push_id_to_open are in the push_stream lists. If they are not in the list they have
-    // been already closed.
+    // All push_id < next_push_id_to_open are in the push_stream lists. If they are not in the list
+    // they have been already closed.
     conn_events: Http3ClientEvents,
 }
 
@@ -338,8 +344,9 @@ impl PushController {
         match self.push_streams.get(push_id) {
             None => {
                 qtrace!("Push has already been closed.");
-                // If we have some events for the push_id in the event queue, the caller still does not
-                // not know that the push has been closed. Otherwise return InvalidStreamId.
+                // If we have some events for the push_id in the event queue, the caller still does
+                // not not know that the push has been closed. Otherwise return
+                // InvalidStreamId.
                 if self.conn_events.has_push(push_id) {
                     self.conn_events.remove_events_for_push_id(push_id);
                     Ok(())

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -175,7 +175,9 @@ impl Display for PushController {
 
 impl PushController {
     /// A new `push_promise` has been received.
+    ///
     /// # Errors
+    ///
     /// `HttpId` if `push_id` greater than it is allowed has been received.
     pub fn new_push_promise(
         &mut self,

--- a/neqo-http3/src/qlog.rs
+++ b/neqo-http3/src/qlog.rs
@@ -8,13 +8,12 @@
 
 use std::convert::TryFrom;
 
+use neqo_common::qlog::NeqoQlog;
+use neqo_transport::StreamId;
 use qlog::{
     self,
     events::{DataRecipient, EventData},
 };
-
-use neqo_common::qlog::NeqoQlog;
-use neqo_transport::StreamId;
 
 pub fn h3_data_moved_up(qlog: &mut NeqoQlog, stream_id: StreamId, amount: usize) {
     qlog.add_event_data(|| {

--- a/neqo-http3/src/qpack_decoder_receiver.rs
+++ b/neqo-http3/src/qpack_decoder_receiver.rs
@@ -4,11 +4,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream};
+use std::{cell::RefCell, rc::Rc};
+
 use neqo_qpack::QPackDecoder;
 use neqo_transport::{Connection, StreamId};
-use std::cell::RefCell;
-use std::rc::Rc;
+
+use crate::{CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream};
 
 #[derive(Debug)]
 pub(crate) struct DecoderRecvStream {

--- a/neqo-http3/src/qpack_encoder_receiver.rs
+++ b/neqo-http3/src/qpack_encoder_receiver.rs
@@ -4,11 +4,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream};
+use std::{cell::RefCell, rc::Rc};
+
 use neqo_qpack::QPackEncoder;
 use neqo_transport::{Connection, StreamId};
-use std::cell::RefCell;
-use std::rc::Rc;
+
+use crate::{CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream};
 
 #[derive(Debug)]
 pub(crate) struct EncoderRecvStream {

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -4,24 +4,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::frames::{FrameReader, HFrame, StreamReaderConnectionWrapper, H3_FRAME_TYPE_HEADERS};
-use crate::push_controller::PushController;
-use crate::{
-    headers_checks::{headers_valid, is_interim},
-    priority::PriorityHandler,
-    qlog, CloseType, Error, Http3StreamInfo, Http3StreamType, HttpRecvStream, HttpRecvStreamEvents,
-    MessageType, Priority, ReceiveOutput, RecvStream, Res, Stream,
+use std::{
+    any::Any, cell::RefCell, cmp::min, collections::VecDeque, convert::TryFrom, fmt::Debug, rc::Rc,
 };
+
 use neqo_common::{qdebug, qinfo, qtrace, Header};
 use neqo_qpack::decoder::QPackDecoder;
 use neqo_transport::{Connection, StreamId};
-use std::any::Any;
-use std::cell::RefCell;
-use std::cmp::min;
-use std::collections::VecDeque;
-use std::convert::TryFrom;
-use std::fmt::Debug;
-use std::rc::Rc;
+
+use crate::{
+    frames::{FrameReader, HFrame, StreamReaderConnectionWrapper, H3_FRAME_TYPE_HEADERS},
+    headers_checks::{headers_valid, is_interim},
+    priority::PriorityHandler,
+    push_controller::PushController,
+    qlog, CloseType, Error, Http3StreamInfo, Http3StreamType, HttpRecvStream, HttpRecvStreamEvents,
+    MessageType, Priority, ReceiveOutput, RecvStream, Res, Stream,
+};
 
 #[allow(clippy::module_name_repetitions)]
 pub(crate) struct RecvMessageInfo {
@@ -348,7 +346,8 @@ impl RecvMessage {
                     panic!("Stream readable after being closed!");
                 }
                 RecvMessageState::ExtendedConnect => {
-                    // Ignore read event, this request is waiting to be picked up by a new WebTransportSession
+                    // Ignore read event, this request is waiting to be picked up by a new
+                    // WebTransportSession
                     break Ok(());
                 }
             };

--- a/neqo-http3/src/request_target.rs
+++ b/neqo-http3/src/request_target.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 use std::fmt::{Debug, Formatter};
+
 use url::{ParseError, Url};
 
 pub trait RequestTarget: Debug {

--- a/neqo-http3/src/request_target.rs
+++ b/neqo-http3/src/request_target.rs
@@ -59,7 +59,9 @@ pub trait AsRequestTarget<'x> {
     type Target: RequestTarget;
     type Error;
     /// Produce a `RequestTarget` that refers to `self`.
+    ///
     /// # Errors
+    ///
     /// This method can generate an error of type `Self::Error`
     /// if the conversion is unsuccessful.
     fn as_request_target(&'x self) -> Result<Self::Target, Self::Error>;

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -131,6 +131,7 @@ impl SendMessage {
     }
 
     /// # Errors
+    ///
     /// `ClosedCriticalStream` if the encoder stream is closed.
     /// `InternalError` if an unexpected error occurred.
     fn encode(
@@ -233,6 +234,7 @@ impl SendStream for SendMessage {
     }
 
     /// # Errors
+    ///
     /// `InternalError` if an unexpected error occurred.
     /// `InvalidStreamId` if the stream does not exist,
     /// `AlreadyClosed` if the stream has already been closed.

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -4,21 +4,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::frames::HFrame;
-use crate::{
-    headers_checks::{headers_valid, is_interim, trailers_valid},
-    qlog, BufferedStream, CloseType, Error, Http3StreamInfo, Http3StreamType, HttpSendStream, Res,
-    SendStream, SendStreamEvents, Stream,
-};
+use std::{any::Any, cell::RefCell, cmp::min, fmt::Debug, rc::Rc};
 
 use neqo_common::{qdebug, qinfo, qtrace, Encoder, Header, MessageType};
 use neqo_qpack::encoder::QPackEncoder;
 use neqo_transport::{streams::SendOrder, Connection, StreamId};
-use std::any::Any;
-use std::cell::RefCell;
-use std::cmp::min;
-use std::fmt::Debug;
-use std::rc::Rc;
+
+use crate::{
+    frames::HFrame,
+    headers_checks::{headers_valid, is_interim, trailers_valid},
+    qlog, BufferedStream, CloseType, Error, Http3StreamInfo, Http3StreamType, HttpSendStream, Res,
+    SendStream, SendStreamEvents, Stream,
+};
 
 const MAX_DATA_HEADER_SIZE_2: usize = (1 << 6) - 1; // Maximal amount of data with DATA frame header size 2
 const MAX_DATA_HEADER_SIZE_2_LIMIT: usize = MAX_DATA_HEADER_SIZE_2 + 3; // 63 + 3 (size of the next buffer data frame header)
@@ -239,8 +236,9 @@ impl SendStream for SendMessage {
     /// `InternalError` if an unexpected error occurred.
     /// `InvalidStreamId` if the stream does not exist,
     /// `AlreadyClosed` if the stream has already been closed.
-    /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if `process_output`
-    /// has not been called when needed, and HTTP3 layer has not picked up the info that the stream has been closed.)
+    /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if
+    /// `process_output` has not been called when needed, and HTTP3 layer has not picked up the
+    /// info that the stream has been closed.)
     fn send(&mut self, conn: &mut Connection) -> Res<()> {
         let sent = Error::map_error(self.stream.send_buffer(conn), Error::HttpInternal(5))?;
         qlog::h3_data_moved_down(conn.qlog_mut(), self.stream_id(), sent);

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -51,6 +51,7 @@ impl ::std::fmt::Display for Http3Server {
 
 impl Http3Server {
     /// # Errors
+    ///
     /// Making a `neqo_transport::Server` may produce an error. This can only be a crypto error if
     /// the socket can't be created or configured.
     pub fn new(
@@ -94,6 +95,7 @@ impl Http3Server {
     /// Enable encrypted client hello (ECH).
     ///
     /// # Errors
+    ///
     /// Only when NSS can't serialize a configuration.
     pub fn enable_ech(
         &mut self,

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -4,17 +4,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::connection::Http3State;
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
+
+use neqo_common::Header;
+use neqo_transport::{AppError, StreamId};
+
 use crate::{
+    connection::Http3State,
     features::extended_connect::{ExtendedConnectEvents, ExtendedConnectType, SessionCloseReason},
     CloseType, Http3StreamInfo, HttpRecvStreamEvents, Priority, RecvStreamEvents, SendStreamEvents,
 };
-use neqo_common::Header;
-use neqo_transport::AppError;
-use neqo_transport::StreamId;
-use std::cell::RefCell;
-use std::collections::VecDeque;
-use std::rc::Rc;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub(crate) enum Http3ServerConnEvent {

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -6,20 +6,25 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use crate::connection::{Http3State, WebTransportSessionAcceptAction};
-use crate::connection_server::Http3ServerHandler;
-use crate::{
-    features::extended_connect::SessionCloseReason, Http3StreamInfo, Http3StreamType, Priority, Res,
+use std::{
+    cell::RefCell,
+    collections::VecDeque,
+    convert::TryFrom,
+    ops::{Deref, DerefMut},
+    rc::Rc,
 };
-use neqo_common::{qdebug, qinfo, Encoder, Header};
-use neqo_transport::server::ActiveConnectionRef;
-use neqo_transport::{AppError, Connection, DatagramTracking, StreamId, StreamType};
 
-use std::cell::RefCell;
-use std::collections::VecDeque;
-use std::convert::TryFrom;
-use std::ops::{Deref, DerefMut};
-use std::rc::Rc;
+use neqo_common::{qdebug, qinfo, Encoder, Header};
+use neqo_transport::{
+    server::ActiveConnectionRef, AppError, Connection, DatagramTracking, StreamId, StreamType,
+};
+
+use crate::{
+    connection::{Http3State, WebTransportSessionAcceptAction},
+    connection_server::Http3ServerHandler,
+    features::extended_connect::SessionCloseReason,
+    Http3StreamInfo, Http3StreamType, Priority, Res,
+};
 
 #[derive(Debug, Clone)]
 pub struct StreamHandler {

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -62,7 +62,9 @@ impl StreamHandler {
     }
 
     /// Supply a response header to a request.
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn send_headers(&mut self, headers: &[Header]) -> Res<()> {
         self.handler.borrow_mut().send_headers(
@@ -73,7 +75,9 @@ impl StreamHandler {
     }
 
     /// Supply response data to a request.
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn send_data(&mut self, buf: &[u8]) -> Res<usize> {
         self.handler
@@ -82,7 +86,9 @@ impl StreamHandler {
     }
 
     /// Close sending side.
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn stream_close_send(&mut self) -> Res<()> {
         self.handler
@@ -91,7 +97,9 @@ impl StreamHandler {
     }
 
     /// Request a peer to stop sending a stream.
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn stream_stop_sending(&mut self, app_error: AppError) -> Res<()> {
         qdebug!(
@@ -108,7 +116,9 @@ impl StreamHandler {
     }
 
     /// Reset sending side of a stream.
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn stream_reset_send(&mut self, app_error: AppError) -> Res<()> {
         qdebug!(
@@ -125,7 +135,9 @@ impl StreamHandler {
     }
 
     /// Reset a stream/request.
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore
     pub fn cancel_fetch(&mut self, app_error: AppError) -> Res<()> {
         qdebug!([self], "reset error:{}.", app_error);
@@ -164,14 +176,18 @@ impl Http3OrWebTransportStream {
     }
 
     /// Supply a response header to a request.
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn send_headers(&mut self, headers: &[Header]) -> Res<()> {
         self.stream_handler.send_headers(headers)
     }
 
     /// Supply response data to a request.
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn send_data(&mut self, data: &[u8]) -> Res<usize> {
         qinfo!([self], "Set new response.");
@@ -179,7 +195,9 @@ impl Http3OrWebTransportStream {
     }
 
     /// Close sending side.
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn stream_close_send(&mut self) -> Res<()> {
         qinfo!([self], "Set new response.");
@@ -248,7 +266,9 @@ impl WebTransportRequest {
     }
 
     /// Respond to a `WebTransport` session request.
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn response(&mut self, accept: &WebTransportSessionAcceptAction) -> Res<()> {
         qinfo!([self], "Set a response for a WebTransport session.");
@@ -263,6 +283,7 @@ impl WebTransportRequest {
     }
 
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     /// Also return an error if the stream was closed on the transport layer,
     /// but that information is not yet consumed on the  http/3 layer.
@@ -284,7 +305,9 @@ impl WebTransportRequest {
     }
 
     /// Close sending side.
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn create_stream(&mut self, stream_type: StreamType) -> Res<Http3OrWebTransportStream> {
         let session_id = self.stream_handler.stream_id();
@@ -306,7 +329,9 @@ impl WebTransportRequest {
     }
 
     /// Send `WebTransport` datagram.
+    ///
     /// # Errors
+    ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     /// The function returns `TooMuchData` if the supply buffer is bigger than
     /// the allowed remote datagram size.
@@ -331,9 +356,13 @@ impl WebTransportRequest {
     /// Returns the current max size of a datagram that can fit into a packet.
     /// The value will change over time depending on the encoded size of the
     /// packet number, ack frames, etc.
+    ///
     /// # Errors
+    ///
     /// The function returns `NotAvailable` if datagrams are not enabled.
+    ///
     /// # Panics
+    ///
     /// This cannot panic. The max varint length is 8.
     pub fn max_datagram_size(&self) -> Res<u64> {
         let max_size = self.stream_handler.conn.borrow().max_datagram_size()?;

--- a/neqo-http3/src/settings.rs
+++ b/neqo-http3/src/settings.rs
@@ -6,10 +6,12 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use crate::{Error, Http3Parameters, Res};
+use std::ops::Deref;
+
 use neqo_common::{Decoder, Encoder};
 use neqo_crypto::{ZeroRttCheckResult, ZeroRttChecker};
-use std::ops::Deref;
+
+use crate::{Error, Http3Parameters, Res};
 
 type SettingsType = u64;
 

--- a/neqo-http3/src/settings.rs
+++ b/neqo-http3/src/settings.rs
@@ -122,6 +122,7 @@ impl HSettings {
     }
 
     /// # Errors
+    ///
     /// Returns an error if settings types are reserved of settings value are not permitted.
     pub fn decode_frame_contents(&mut self, dec: &mut Decoder) -> Res<()> {
         while dec.remaining() > 0 {

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -6,13 +6,14 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use crate::control_stream_local::HTTP3_UNI_STREAM_TYPE_CONTROL;
-use crate::frames::H3_FRAME_TYPE_HEADERS;
-use crate::{CloseType, Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream};
 use neqo_common::{qtrace, Decoder, IncrementalDecoderUint, Role};
-use neqo_qpack::decoder::QPACK_UNI_STREAM_TYPE_DECODER;
-use neqo_qpack::encoder::QPACK_UNI_STREAM_TYPE_ENCODER;
+use neqo_qpack::{decoder::QPACK_UNI_STREAM_TYPE_DECODER, encoder::QPACK_UNI_STREAM_TYPE_ENCODER};
 use neqo_transport::{Connection, StreamId, StreamType};
+
+use crate::{
+    control_stream_local::HTTP3_UNI_STREAM_TYPE_CONTROL, frames::H3_FRAME_TYPE_HEADERS, CloseType,
+    Error, Http3StreamType, ReceiveOutput, RecvStream, Res, Stream,
+};
 
 pub(crate) const HTTP3_UNI_STREAM_TYPE_PUSH: u64 = 0x1;
 pub(crate) const WEBTRANSPORT_UNI_STREAM: u64 = 0x54;
@@ -67,12 +68,11 @@ impl NewStreamType {
 
 /// `NewStreamHeadReader` reads the head of an unidirectional stream to identify the stream.
 /// There are 2 type of streams:
-///  - streams identified by the single type (varint encoded). Most streams belong to
-///    this category. The `NewStreamHeadReader` will switch from `ReadType`to `Done` state.
-///  - streams identified by the type and the ID (both varint encoded). For example, a
-///    push stream is identified by the type and `PushId`. After reading the type in
-///    the `ReadType` state, `NewStreamHeadReader` changes to `ReadId` state and from there
-///    to `Done` state
+///  - streams identified by the single type (varint encoded). Most streams belong to this category.
+///    The `NewStreamHeadReader` will switch from `ReadType`to `Done` state.
+///  - streams identified by the type and the ID (both varint encoded). For example, a push stream
+///    is identified by the type and `PushId`. After reading the type in the `ReadType` state,
+///    `NewStreamHeadReader` changes to `ReadId` state and from there to `Done` state
 #[derive(Debug)]
 pub(crate) enum NewStreamHeadReader {
     ReadType {
@@ -140,12 +140,12 @@ impl NewStreamHeadReader {
                     role, stream_id, ..
                 } => {
                     // final_stream_type may return:
-                    //  - an error if a stream type is not allowed for the role, e.g. Push
-                    //    stream received at the server.
+                    //  - an error if a stream type is not allowed for the role, e.g. Push stream
+                    //    received at the server.
                     //  - a final type if a stream is only identify by the type
                     //  - None - if a stream is not identified by the type only, but it needs
-                    //    additional data from the header to produce the final type, e.g.
-                    //    a push stream needs pushId as well.
+                    //    additional data from the header to produce the final type, e.g. a push
+                    //    stream needs pushId as well.
                     let final_type =
                         NewStreamType::final_stream_type(output, stream_id.stream_type(), *role);
                     match (&final_type, fin) {
@@ -234,20 +234,23 @@ impl RecvStream for NewStreamHeadReader {
 
 #[cfg(test)]
 mod tests {
+    use std::mem;
+
+    use neqo_common::{Encoder, Role};
+    use neqo_qpack::{
+        decoder::QPACK_UNI_STREAM_TYPE_DECODER, encoder::QPACK_UNI_STREAM_TYPE_ENCODER,
+    };
+    use neqo_transport::{Connection, StreamId, StreamType};
+    use test_fixture::{connect, now};
+
     use super::{
         NewStreamHeadReader, HTTP3_UNI_STREAM_TYPE_PUSH, WEBTRANSPORT_STREAM,
         WEBTRANSPORT_UNI_STREAM,
     };
-    use neqo_transport::{Connection, StreamId, StreamType};
-    use std::mem;
-    use test_fixture::{connect, now};
-
-    use crate::control_stream_local::HTTP3_UNI_STREAM_TYPE_CONTROL;
-    use crate::frames::H3_FRAME_TYPE_HEADERS;
-    use crate::{CloseType, Error, NewStreamType, ReceiveOutput, RecvStream, Res};
-    use neqo_common::{Encoder, Role};
-    use neqo_qpack::decoder::QPACK_UNI_STREAM_TYPE_DECODER;
-    use neqo_qpack::encoder::QPACK_UNI_STREAM_TYPE_ENCODER;
+    use crate::{
+        control_stream_local::HTTP3_UNI_STREAM_TYPE_CONTROL, frames::H3_FRAME_TYPE_HEADERS,
+        CloseType, Error, NewStreamType, ReceiveOutput, RecvStream, Res,
+    };
 
     struct Test {
         conn_c: Connection,
@@ -397,7 +400,8 @@ mod tests {
 
         let mut t = Test::new(StreamType::UniDi, Role::Server);
         t.decode(
-            &[H3_FRAME_TYPE_HEADERS], // this is the same as a HTTP3_UNI_STREAM_TYPE_PUSH which is not aallowed on the server side.
+            &[H3_FRAME_TYPE_HEADERS], /* this is the same as a HTTP3_UNI_STREAM_TYPE_PUSH which
+                                       * is not aallowed on the server side. */
             false,
             &Err(Error::HttpStreamCreation),
             true,
@@ -413,7 +417,8 @@ mod tests {
 
         let mut t = Test::new(StreamType::UniDi, Role::Client);
         t.decode(
-            &[H3_FRAME_TYPE_HEADERS, 0xaaaa_aaaa], // this is the same as a HTTP3_UNI_STREAM_TYPE_PUSH
+            &[H3_FRAME_TYPE_HEADERS, 0xaaaa_aaaa], /* this is the same as a
+                                                    * HTTP3_UNI_STREAM_TYPE_PUSH */
             false,
             &Ok((
                 ReceiveOutput::NewStream(NewStreamType::Push(0xaaaa_aaaa)),

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -34,7 +34,9 @@ impl NewStreamType {
     /// Get the final `NewStreamType` from a stream type. All streams, except Push stream,
     /// are identified by the type only. This function will return None for the Push stream
     /// because it needs the ID besides the type.
-    /// # Error
+    ///
+    /// # Errors
+    ///
     /// Push streams received by the server are not allowed and this function will return
     /// `HttpStreamCreation` error.
     fn final_stream_type(

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -99,7 +99,7 @@ fn connect_peers(hconn_c: &mut Http3Client, hconn_s: &mut Http3Server) -> Option
     let out = hconn_c.process(None, now()); // Initial
     let out = hconn_s.process(out.as_dgram_ref(), now()); // Initial + Handshake
     let out = hconn_c.process(out.as_dgram_ref(), now()); // ACK
-    mem::drop(hconn_s.process(out.as_dgram_ref(), now())); //consume ACK
+    mem::drop(hconn_s.process(out.as_dgram_ref(), now())); // consume ACK
     let authentication_needed = |e| matches!(e, Http3ClientEvent::AuthenticationNeeded);
     assert!(hconn_c.events().any(authentication_needed));
     hconn_c.authenticated(AuthenticationStatus::Ok, now());
@@ -129,7 +129,7 @@ fn connect_peers_with_network_propagation_delay(
     now += net_delay;
     let out = hconn_c.process(out.as_dgram_ref(), now); // ACK
     now += net_delay;
-    let out = hconn_s.process(out.as_dgram_ref(), now); //consume ACK
+    let out = hconn_s.process(out.as_dgram_ref(), now); // consume ACK
     assert!(out.dgram().is_none());
     let authentication_needed = |e| matches!(e, Http3ClientEvent::AuthenticationNeeded);
     assert!(hconn_c.events().any(authentication_needed));

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -6,6 +6,11 @@
 
 #![allow(unused_assignments)]
 
+use std::{
+    mem,
+    time::{Duration, Instant},
+};
+
 use neqo_common::{event::Provider, qtrace, Datagram};
 use neqo_crypto::{AuthenticationStatus, ResumptionToken};
 use neqo_http3::{
@@ -13,8 +18,6 @@ use neqo_http3::{
     Http3ServerEvent, Http3State, Priority,
 };
 use neqo_transport::{ConnectionError, ConnectionParameters, Error, Output, StreamType};
-use std::mem;
-use std::time::{Duration, Instant};
 use test_fixture::*;
 
 const RESPONSE_DATA: &[u8] = &[0x61, 0x62, 0x63];

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -4,14 +4,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::event::Provider;
+use std::time::Instant;
 
+use neqo_common::event::Provider;
 use neqo_crypto::AuthenticationStatus;
 use neqo_http3::{
     Header, Http3Client, Http3ClientEvent, Http3Server, Http3ServerEvent, Http3State, Priority,
 };
-
-use std::time::Instant;
 use test_fixture::*;
 
 fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {

--- a/neqo-http3/tests/webtransport.rs
+++ b/neqo-http3/tests/webtransport.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{cell::RefCell, rc::Rc};
+
 use neqo_common::{event::Provider, Header};
 use neqo_crypto::AuthenticationStatus;
 use neqo_http3::{
@@ -12,8 +14,6 @@ use neqo_http3::{
     WebTransportSessionAcceptAction,
 };
 use neqo_transport::{StreamId, StreamType};
-use std::cell::RefCell;
-use std::rc::Rc;
 use test_fixture::{
     addr, anti_replay, fixture_init, now, CountingConnectionIdGenerator, DEFAULT_ALPN_H3,
     DEFAULT_KEYS, DEFAULT_SERVER_NAME,

--- a/neqo-interop/src/main.rs
+++ b/neqo-interop/src/main.rs
@@ -7,14 +7,6 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::use_self)]
 
-use neqo_common::{event::Provider, hex, Datagram, IpTos};
-use neqo_crypto::{init, AuthenticationStatus, ResumptionToken};
-use neqo_http3::{Header, Http3Client, Http3ClientEvent, Http3Parameters, Http3State, Priority};
-use neqo_transport::{
-    Connection, ConnectionError, ConnectionEvent, ConnectionParameters, EmptyConnectionIdGenerator,
-    Error, Output, State, StreamId, StreamType,
-};
-
 use std::{
     cell::RefCell,
     cmp::min,
@@ -30,6 +22,14 @@ use std::{
     sync::Mutex,
     thread,
     time::{Duration, Instant},
+};
+
+use neqo_common::{event::Provider, hex, Datagram, IpTos};
+use neqo_crypto::{init, AuthenticationStatus, ResumptionToken};
+use neqo_http3::{Header, Http3Client, Http3ClientEvent, Http3Parameters, Http3State, Priority};
+use neqo_transport::{
+    Connection, ConnectionError, ConnectionEvent, ConnectionParameters, EmptyConnectionIdGenerator,
+    Error, Output, State, StreamId, StreamType,
 };
 use structopt::StructOpt;
 
@@ -560,7 +560,8 @@ fn test_h3(nctx: &NetworkCtx, peer: &Peer, client: Connection, test: &Test) -> R
     }
 
     if *test == Test::D {
-        // Send another request, when the first one was send we probably did not have the peer's qpack parameter.
+        // Send another request, when the first one was send we probably did not have the peer's
+        // qpack parameter.
         let client_stream_id = hc
             .h3
             .fetch(

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -4,6 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::convert::TryFrom;
+
+use neqo_common::{qdebug, Header};
+use neqo_transport::{Connection, StreamId};
+
 use crate::{
     decoder_instructions::DecoderInstruction,
     encoder_instructions::{DecodedEncoderInstruction, EncoderInstructionReader},
@@ -14,9 +19,6 @@ use crate::{
     table::HeaderTable,
     Error, QpackSettings, Res,
 };
-use neqo_common::{qdebug, Header};
-use neqo_transport::{Connection, StreamId};
-use std::convert::TryFrom;
 
 pub const QPACK_UNI_STREAM_TYPE_DECODER: u64 = 0x3;
 
@@ -272,12 +274,14 @@ fn map_error(err: &Error) -> Error {
 
 #[cfg(test)]
 mod tests {
-    use super::{Connection, Error, QPackDecoder, Res};
-    use crate::QpackSettings;
+    use std::{convert::TryFrom, mem};
+
     use neqo_common::Header;
     use neqo_transport::{StreamId, StreamType};
-    use std::{convert::TryFrom, mem};
     use test_fixture::now;
+
+    use super::{Connection, Error, QPackDecoder, Res};
+    use crate::QpackSettings;
 
     const STREAM_0: StreamId = StreamId::new(0);
 
@@ -434,7 +438,8 @@ mod tests {
         );
     }
 
-    // this test tests header decoding, the header acks command and the insert count increment command.
+    // this test tests header decoding, the header acks command and the insert count increment
+    // command.
     #[test]
     fn test_duplicate() {
         let mut decoder = connect();
@@ -467,8 +472,8 @@ mod tests {
     fn test_encode_incr_encode_header_ack_some() {
         // 1. Decoder receives an instruction (header and value both as literal)
         // 2. Decoder process the instruction and sends an increment instruction.
-        // 3. Decoder receives another two instruction (header and value both as literal) and
-        //    a header block.
+        // 3. Decoder receives another two instruction (header and value both as literal) and a
+        //    header block.
         // 4. Now it sends only a header ack and an increment instruction with increment==1.
         let headers = vec![
             Header::new("my-headera", "my-valuea"),
@@ -504,8 +509,8 @@ mod tests {
     fn test_encode_incr_encode_header_ack_all() {
         // 1. Decoder receives an instruction (header and value both as literal)
         // 2. Decoder process the instruction and sends an increment instruction.
-        // 3. Decoder receives another instruction (header and value both as literal) and
-        //    a header block.
+        // 3. Decoder receives another instruction (header and value both as literal) and a header
+        //    block.
         // 4. Now it sends only a header ack.
         let headers = vec![
             Header::new("my-headera", "my-valuea"),
@@ -604,7 +609,8 @@ mod tests {
                 ],
                 encoder_inst: &[],
             },
-            // test adding a new header and encode_post_base_index, also test fix_header_block_prefix
+            // test adding a new header and encode_post_base_index, also test
+            // fix_header_block_prefix
             TestElement {
                 headers: vec![Header::new("my-header", "my-value")],
                 header_block: &[0x02, 0x80, 0x10],
@@ -683,7 +689,8 @@ mod tests {
                 ],
                 encoder_inst: &[],
             },
-            // test adding a new header and encode_post_base_index, also test fix_header_block_prefix
+            // test adding a new header and encode_post_base_index, also test
+            // fix_header_block_prefix
             TestElement {
                 headers: vec![Header::new("my-header", "my-value")],
                 header_block: &[0x02, 0x80, 0x10],

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -32,12 +32,13 @@ pub struct QPackDecoder {
     local_stream_id: Option<StreamId>,
     max_table_size: u64,
     max_blocked_streams: usize,
-    blocked_streams: Vec<(StreamId, u64)>, //stream_id and requested inserts count.
+    blocked_streams: Vec<(StreamId, u64)>, // stream_id and requested inserts count.
     stats: Stats,
 }
 
 impl QPackDecoder {
     /// # Panics
+    ///
     /// If settings include invalid values.
     #[must_use]
     pub fn new(qpack_settings: &QpackSettings) -> Self {
@@ -69,6 +70,7 @@ impl QPackDecoder {
     }
 
     /// # Panics
+    ///
     /// If the number of blocked streams is too large.
     #[must_use]
     pub fn get_blocked_streams(&self) -> u16 {
@@ -76,7 +78,9 @@ impl QPackDecoder {
     }
 
     /// returns a list of unblocked streams
+    ///
     /// # Errors
+    ///
     /// May return: `ClosedCriticalStream` if stream has been closed or `EncoderStream`
     /// in case of any other transport error.
     pub fn receive(&mut self, conn: &mut Connection, stream_id: StreamId) -> Res<Vec<StreamId>> {
@@ -166,8 +170,11 @@ impl QPackDecoder {
     }
 
     /// # Errors
+    ///
     /// May return an error in case of any transport error. TODO: define transport errors.
+    ///
     /// # Panics
+    ///
     /// Never, but rust doesn't know that.
     #[allow(clippy::map_err_ignore)]
     pub fn send(&mut self, conn: &mut Connection) -> Res<()> {
@@ -188,6 +195,7 @@ impl QPackDecoder {
     }
 
     /// # Errors
+    ///
     /// May return `DecompressionFailed` if header block is incorrect or incomplete.
     pub fn refers_dynamic_table(&self, buf: &[u8]) -> Res<bool> {
         HeaderDecoder::new(buf).refers_dynamic_table(self.max_entries, self.table.base())
@@ -195,9 +203,13 @@ impl QPackDecoder {
 
     /// This function returns None if the stream is blocked waiting for table insertions.
     /// 'buf' must contain the complete header block.
+    ///
     /// # Errors
+    ///
     /// May return `DecompressionFailed` if header block is incorrect or incomplete.
+    ///
     /// # Panics
+    ///
     /// When there is a programming error.
     pub fn decode_header_block(
         &mut self,
@@ -238,6 +250,7 @@ impl QPackDecoder {
     }
 
     /// # Panics
+    ///
     /// When a stream has already been added.
     pub fn add_send_stream(&mut self, stream_id: StreamId) {
         assert!(

--- a/neqo-qpack/src/decoder_instructions.rs
+++ b/neqo-qpack/src/decoder_instructions.rs
@@ -83,7 +83,8 @@ impl DecoderInstructionReader {
         }
     }
 
-    /// ### Errors
+    /// # Errors
+    ///
     ///  1) `NeedMoreData` if the reader needs more data
     ///  2) `ClosedCriticalStream`
     ///  3) other errors will be translated to `DecoderStream` by the caller of this function.

--- a/neqo-qpack/src/decoder_instructions.rs
+++ b/neqo-qpack/src/decoder_instructions.rs
@@ -4,15 +4,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::prefix::{
-    DECODER_HEADER_ACK, DECODER_INSERT_COUNT_INCREMENT, DECODER_STREAM_CANCELLATION,
-};
-use crate::qpack_send_buf::QpackData;
-use crate::reader::{IntReader, ReadByte};
-use crate::Res;
+use std::mem;
+
 use neqo_common::{qdebug, qtrace};
 use neqo_transport::StreamId;
-use std::mem;
+
+use crate::{
+    prefix::{DECODER_HEADER_ACK, DECODER_INSERT_COUNT_INCREMENT, DECODER_STREAM_CANCELLATION},
+    qpack_send_buf::QpackData,
+    reader::{IntReader, ReadByte},
+    Res,
+};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum DecoderInstruction {
@@ -137,10 +139,10 @@ impl DecoderInstructionReader {
 #[cfg(test)]
 mod test {
 
-    use super::{DecoderInstruction, DecoderInstructionReader, QpackData};
-    use crate::reader::test_receiver::TestReceiver;
-    use crate::Error;
     use neqo_transport::StreamId;
+
+    use super::{DecoderInstruction, DecoderInstructionReader, QpackData};
+    use crate::{reader::test_receiver::TestReceiver, Error};
 
     fn test_encoding_decoding(instruction: DecoderInstruction) {
         let mut buf = QpackData::default();

--- a/neqo-qpack/src/decoder_instructions.rs
+++ b/neqo-qpack/src/decoder_instructions.rs
@@ -85,9 +85,9 @@ impl DecoderInstructionReader {
 
     /// # Errors
     ///
-    ///  1) `NeedMoreData` if the reader needs more data
-    ///  2) `ClosedCriticalStream`
-    ///  3) other errors will be translated to `DecoderStream` by the caller of this function.
+    /// 1) `NeedMoreData` if the reader needs more data
+    /// 2) `ClosedCriticalStream`
+    /// 3) other errors will be translated to `DecoderStream` by the caller of this function.
     pub fn read_instructions<R: ReadByte>(&mut self, recv: &mut R) -> Res<DecoderInstruction> {
         qdebug!([self], "read a new instraction");
         loop {

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -4,19 +4,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::decoder_instructions::{DecoderInstruction, DecoderInstructionReader};
-use crate::encoder_instructions::EncoderInstruction;
-use crate::header_block::HeaderEncoder;
-use crate::qlog;
-use crate::qpack_send_buf::QpackData;
-use crate::reader::ReceiverConnWrapper;
-use crate::stats::Stats;
-use crate::table::{HeaderTable, LookupResult, ADDITIONAL_TABLE_ENTRY_SIZE};
-use crate::{Error, QpackSettings, Res};
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    convert::TryFrom,
+};
+
 use neqo_common::{qdebug, qerror, qlog::NeqoQlog, qtrace, Header};
 use neqo_transport::{Connection, Error as TransportError, StreamId};
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::convert::TryFrom;
+
+use crate::{
+    decoder_instructions::{DecoderInstruction, DecoderInstructionReader},
+    encoder_instructions::EncoderInstruction,
+    header_block::HeaderEncoder,
+    qlog,
+    qpack_send_buf::QpackData,
+    reader::ReceiverConnWrapper,
+    stats::Stats,
+    table::{HeaderTable, LookupResult, ADDITIONAL_TABLE_ENTRY_SIZE},
+    Error, QpackSettings, Res,
+};
 
 pub const QPACK_UNI_STREAM_TYPE_ENCODER: u64 = 0x2;
 
@@ -45,9 +51,9 @@ pub struct QPackEncoder {
     local_stream: LocalStreamState,
     max_blocked_streams: u16,
     // Remember header blocks that are referring to dynamic table.
-    // There can be multiple header blocks in one stream, headers, trailer, push stream request, etc.
-    // This HashMap maps a stream ID to a list of header blocks. Each header block is a list of
-    // referenced dynamic table entries.
+    // There can be multiple header blocks in one stream, headers, trailer, push stream request,
+    // etc. This HashMap maps a stream ID to a list of header blocks. Each header block is a
+    // list of referenced dynamic table entries.
     unacked_header_blocks: HashMap<StreamId, VecDeque<HashSet<u64>>>,
     blocked_stream_cnt: u16,
     use_huffman: bool,
@@ -221,14 +227,14 @@ impl QPackEncoder {
         }
     }
 
-    /// Inserts a new entry into a table and sends the corresponding instruction to a peer. An entry is added only
-    /// if it is possible to send the corresponding instruction immediately, i.e. the encoder stream is not
-    /// blocked by the flow control (or stream internal buffer(this is very unlikely)).
-    /// ### Errors
+    /// Inserts a new entry into a table and sends the corresponding instruction to a peer. An entry
+    /// is added only if it is possible to send the corresponding instruction immediately, i.e.
+    /// the encoder stream is not blocked by the flow control (or stream internal buffer(this is
+    /// very unlikely)). ### Errors
     /// `EncoderStreamBlocked` if the encoder stream is blocked by the flow control.
     /// `DynamicTableFull` if the dynamic table does not have enough space for the entry.
-    /// The function can return transport errors: `InvalidStreamId`, `InvalidInput` and `FinalSizeError`.
-    /// # Panics
+    /// The function can return transport errors: `InvalidStreamId`, `InvalidInput` and
+    /// `FinalSizeError`. # Panics
     /// When the insertion fails (it should not).
     pub fn send_and_insert(
         &mut self,
@@ -279,7 +285,8 @@ impl QPackEncoder {
         stream_id: StreamId,
     ) -> Res<()> {
         if let Some(cap) = self.next_capacity {
-            // Check if it is possible to reduce the capacity, e.g. if enough space can be make free for the reduction.
+            // Check if it is possible to reduce the capacity, e.g. if enough space can be make free
+            // for the reduction.
             if cap < self.table.capacity() && !self.table.can_evict_to(cap) {
                 return Err(Error::DynamicTableFull);
             }
@@ -358,11 +365,9 @@ impl QPackEncoder {
             // to write to the encoder stream AND if it can't uses
             // literal instructions.
             // The errors can be:
-            //   1) `EncoderStreamBlocked` - this is an error that
-            //      can occur.
+            //   1) `EncoderStreamBlocked` - this is an error that can occur.
             //   2) `InternalError` - this is unexpected error.
-            //   3) `ClosedCriticalStream` - this is error that should
-            //      close the HTTP/3 session.
+            //   3) `ClosedCriticalStream` - this is error that should close the HTTP/3 session.
             // The last 2 errors are ignored here and will be picked up
             // by the main loop.
             encoder_blocked = true;
@@ -406,8 +411,9 @@ impl QPackEncoder {
                     self.table.add_ref(index);
                 }
             } else if can_block && !encoder_blocked {
-                // Insert using an InsertWithNameLiteral instruction. This entry name does not match any name in the
-                // tables therefore we cannot use any other instruction.
+                // Insert using an InsertWithNameLiteral instruction. This entry name does not match
+                // any name in the tables therefore we cannot use any other
+                // instruction.
                 if let Ok(index) = self.send_and_insert(conn, &name, &value) {
                     encoded_h.encode_indexed_dynamic(index);
                     ref_entries.insert(index);
@@ -417,16 +423,15 @@ impl QPackEncoder {
                     // to write to the encoder stream AND if it can't uses
                     // literal instructions.
                     // The errors can be:
-                    //   1) `EncoderStreamBlocked` - this is an error that
-                    //      can occur.
-                    //   2) `DynamicTableFull` - this is an error that
-                    //      can occur.
+                    //   1) `EncoderStreamBlocked` - this is an error that can occur.
+                    //   2) `DynamicTableFull` - this is an error that can occur.
                     //   3) `InternalError` - this is unexpected error.
-                    //   4) `ClosedCriticalStream` - this is error that should
-                    //      close the HTTP/3 session.
+                    //   4) `ClosedCriticalStream` - this is error that should close the HTTP/3
+                    //      session.
                     // The last 2 errors are ignored here and will be picked up
                     // by the main loop.
-                    // As soon as one of the instructions cannot be written or the table is full, do not try again.
+                    // As soon as one of the instructions cannot be written or the table is full, do
+                    // not try again.
                     encoder_blocked = true;
                     encoded_h.encode_literal_with_name_literal(&name, &value);
                 }
@@ -512,11 +517,13 @@ fn map_stream_send_atomic_error(err: &TransportError) -> Error {
 
 #[cfg(test)]
 mod tests {
+    use std::mem;
+
+    use neqo_transport::{ConnectionParameters, StreamId, StreamType};
+    use test_fixture::{default_client, default_server, handshake, new_server, now, DEFAULT_ALPN};
+
     use super::{Connection, Error, Header, QPackEncoder, Res};
     use crate::QpackSettings;
-    use neqo_transport::{ConnectionParameters, StreamId, StreamType};
-    use std::mem;
-    use test_fixture::{default_client, default_server, handshake, new_server, now, DEFAULT_ALPN};
 
     struct TestEncoder {
         encoder: QPackEncoder,
@@ -529,7 +536,8 @@ mod tests {
     impl TestEncoder {
         pub fn change_capacity(&mut self, capacity: u64) -> Res<()> {
             self.encoder.set_max_capacity(capacity).unwrap();
-            // We will try to really change the table only when we send the change capacity instruction.
+            // We will try to really change the table only when we send the change capacity
+            // instruction.
             self.encoder.send_encoder_updates(&mut self.conn)
         }
 
@@ -722,7 +730,8 @@ mod tests {
                 ],
                 encoder_inst: &[],
             },
-            // test adding a new header and encode_post_base_index, also test fix_header_block_prefix
+            // test adding a new header and encode_post_base_index, also test
+            // fix_header_block_prefix
             TestElement {
                 headers: vec![Header::new("my-header", "my-value")],
                 header_block: &[0x02, 0x80, 0x10],
@@ -796,7 +805,8 @@ mod tests {
                 ],
                 encoder_inst: &[],
             },
-            // test adding a new header and encode_post_base_index, also test fix_header_block_prefix
+            // test adding a new header and encode_post_base_index, also test
+            // fix_header_block_prefix
             TestElement {
                 headers: vec![Header::new("my-header", "my-value")],
                 header_block: &[0x02, 0x80, 0x10],
@@ -870,7 +880,8 @@ mod tests {
         assert!(res.is_ok());
         encoder.send_instructions(HEADER_CONTENT_LENGTH_VALUE_1_NAME_LITERAL);
 
-        // insert "content-length: 12345 which will fail because the ntry in the table cannot be evicted.
+        // insert "content-length: 12345 which will fail because the ntry in the table cannot be
+        // evicted.
         let res =
             encoder
                 .encoder
@@ -921,7 +932,8 @@ mod tests {
         assert_eq!(&buf[..], ENCODE_INDEXED_REF_DYNAMIC);
         encoder.send_instructions(&[]);
 
-        // insert "content-length: 12345 which will fail because the entry in the table cannot be evicted
+        // insert "content-length: 12345 which will fail because the entry in the table cannot be
+        // evicted
         let res =
             encoder
                 .encoder
@@ -1004,8 +1016,8 @@ mod tests {
 
         encoder.send_instructions(&[]);
 
-        // The next one will not use the dynamic entry because it is exceeding the max_blocked_streams
-        // limit.
+        // The next one will not use the dynamic entry because it is exceeding the
+        // max_blocked_streams limit.
         let buf = encoder.encoder.encode_header_block(
             &mut encoder.conn,
             &[Header::new("content-length", "1234")],
@@ -1099,7 +1111,8 @@ mod tests {
 
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 1);
 
-        // The next one will not create a new entry because the encoder is on max_blocked_streams limit.
+        // The next one will not create a new entry because the encoder is on max_blocked_streams
+        // limit.
         let buf = encoder.encoder.encode_header_block(
             &mut encoder.conn,
             &[Header::new("name2", "value2")],
@@ -1274,8 +1287,8 @@ mod tests {
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 2);
 
         // receive a stream cancel for the first stream.
-        // This will remove the first stream as blocking but it will not mark the instruction as acked.
-        // and the second steam will still be blocking.
+        // This will remove the first stream as blocking but it will not mark the instruction as
+        // acked. and the second steam will still be blocking.
         recv_instruction(&mut encoder, STREAM_CANCELED_ID_1);
 
         // The stream is not blocking anymore because header ack also acks the instruction.
@@ -1507,9 +1520,10 @@ mod tests {
         assert!(encoder.encoder.set_max_capacity(1000).is_ok());
         encoder.send_instructions(CAP_INSTRUCTION_1000);
 
-        // Encode a header block with 2 headers. The first header will be added to the dynamic table.
-        // The second will not be added to the dynamic table, because the corresponding instruction
-        // cannot be written immediately due to the flow control limit.
+        // Encode a header block with 2 headers. The first header will be added to the dynamic
+        // table. The second will not be added to the dynamic table, because the
+        // corresponding instruction cannot be written immediately due to the flow control
+        // limit.
         let buf1 = encoder.encoder.encode_header_block(
             &mut encoder.conn,
             &[
@@ -1524,7 +1538,8 @@ mod tests {
         // Assert that the second header is encoded as a literal with a name literal
         assert_eq!(buf1[3] & 0xf0, 0x20);
 
-        // Try to encode another header block. Here both headers will be encoded as a literal with a name literal
+        // Try to encode another header block. Here both headers will be encoded as a literal with a
+        // name literal
         let buf2 = encoder.encoder.encode_header_block(
             &mut encoder.conn,
             &[
@@ -1542,8 +1557,8 @@ mod tests {
         let out = encoder.peer_conn.process(None, now());
         mem::drop(encoder.conn.process(out.as_dgram_ref(), now()));
 
-        // Try writing a new header block. Now, headers will be added to the dynamic table again, because
-        // instructions can be sent.
+        // Try writing a new header block. Now, headers will be added to the dynamic table again,
+        // because instructions can be sent.
         let buf3 = encoder.encoder.encode_header_block(
             &mut encoder.conn,
             &[

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -81,7 +81,9 @@ impl QPackEncoder {
 
     /// This function is use for setting encoders table max capacity. The value is received as
     /// a `SETTINGS_QPACK_MAX_TABLE_CAPACITY` setting parameter.
+    ///
     /// # Errors
+    ///
     /// `EncoderStream` if value is too big.
     /// `ChangeCapacity` if table capacity cannot be reduced.
     pub fn set_max_capacity(&mut self, cap: u64) -> Res<()> {
@@ -109,7 +111,9 @@ impl QPackEncoder {
 
     /// This function is use for setting encoders max blocked streams. The value is received as
     /// a `SETTINGS_QPACK_BLOCKED_STREAMS` setting parameter.
+    ///
     /// # Errors
+    ///
     /// `EncoderStream` if value is too big.
     pub fn set_max_blocked_streams(&mut self, blocked_streams: u64) -> Res<()> {
         self.max_blocked_streams = u16::try_from(blocked_streams).or(Err(Error::EncoderStream))?;
@@ -117,7 +121,9 @@ impl QPackEncoder {
     }
 
     /// Reads decoder instructions.
+    ///
     /// # Errors
+    ///
     /// May return: `ClosedCriticalStream` if stream has been closed or `DecoderStream`
     /// in case of any other transport error.
     pub fn receive(&mut self, conn: &mut Connection, stream_id: StreamId) -> Res<()> {
@@ -230,11 +236,17 @@ impl QPackEncoder {
     /// Inserts a new entry into a table and sends the corresponding instruction to a peer. An entry
     /// is added only if it is possible to send the corresponding instruction immediately, i.e.
     /// the encoder stream is not blocked by the flow control (or stream internal buffer(this is
-    /// very unlikely)). ### Errors
+    /// very unlikely)).
+    ///
+    /// # Errors
+    ///
     /// `EncoderStreamBlocked` if the encoder stream is blocked by the flow control.
     /// `DynamicTableFull` if the dynamic table does not have enough space for the entry.
     /// The function can return transport errors: `InvalidStreamId`, `InvalidInput` and
-    /// `FinalSizeError`. # Panics
+    /// `FinalSizeError`.
+    ///
+    /// # Panics
+    ///
     /// When the insertion fails (it should not).
     pub fn send_and_insert(
         &mut self,
@@ -309,7 +321,9 @@ impl QPackEncoder {
     }
 
     /// Sends any qpack encoder instructions.
+    ///
     /// # Errors
+    ///
     ///   returns `EncoderStream` in case of an error.
     pub fn send_encoder_updates(&mut self, conn: &mut Connection) -> Res<()> {
         match self.local_stream {
@@ -345,10 +359,14 @@ impl QPackEncoder {
     }
 
     /// Encodes headers
+    ///
     /// # Errors
+    ///
     /// `ClosedCriticalStream` if the encoder stream is closed.
     /// `InternalError` if an unexpected error occurred.
+    ///
     /// # Panics
+    ///
     /// If there is a programming error.
     pub fn encode_header_block(
         &mut self,
@@ -463,7 +481,9 @@ impl QPackEncoder {
     }
 
     /// Encoder stream has been created. Add the stream id.
+    ///
     /// # Panics
+    ///
     /// If a stream has already been added.
     pub fn add_send_stream(&mut self, stream_id: StreamId) {
         if self.local_stream == LocalStreamState::NoStream {

--- a/neqo-qpack/src/encoder_instructions.rs
+++ b/neqo-qpack/src/encoder_instructions.rs
@@ -4,15 +4,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::prefix::{
-    ENCODER_CAPACITY, ENCODER_DUPLICATE, ENCODER_INSERT_WITH_NAME_LITERAL,
-    ENCODER_INSERT_WITH_NAME_REF_DYNAMIC, ENCODER_INSERT_WITH_NAME_REF_STATIC, NO_PREFIX,
-};
-use crate::qpack_send_buf::QpackData;
-use crate::reader::{IntReader, LiteralReader, ReadByte, Reader};
-use crate::Res;
-use neqo_common::{qdebug, qtrace};
 use std::mem;
+
+use neqo_common::{qdebug, qtrace};
+
+use crate::{
+    prefix::{
+        ENCODER_CAPACITY, ENCODER_DUPLICATE, ENCODER_INSERT_WITH_NAME_LITERAL,
+        ENCODER_INSERT_WITH_NAME_REF_DYNAMIC, ENCODER_INSERT_WITH_NAME_REF_STATIC, NO_PREFIX,
+    },
+    qpack_send_buf::QpackData,
+    reader::{IntReader, LiteralReader, ReadByte, Reader},
+    Res,
+};
 
 // The encoder only uses InsertWithNameLiteral, therefore clippy is complaining about dead_code.
 // We may decide to use othe instruction in the future.
@@ -265,8 +269,7 @@ impl EncoderInstructionReader {
 mod test {
 
     use super::{EncoderInstruction, EncoderInstructionReader, QpackData};
-    use crate::reader::test_receiver::TestReceiver;
-    use crate::Error;
+    use crate::{reader::test_receiver::TestReceiver, Error};
 
     fn test_encoding_decoding(instruction: &EncoderInstruction, use_huffman: bool) {
         let mut buf = QpackData::default();

--- a/neqo-qpack/src/encoder_instructions.rs
+++ b/neqo-qpack/src/encoder_instructions.rs
@@ -187,7 +187,8 @@ impl EncoderInstructionReader {
         Ok(())
     }
 
-    /// ### Errors
+    /// # Errors
+    ///
     ///  1) `NeedMoreData` if the reader needs more data
     ///  2) `ClosedCriticalStream`
     ///  3) other errors will be translated to `EncoderStream` by the caller of this function.

--- a/neqo-qpack/src/encoder_instructions.rs
+++ b/neqo-qpack/src/encoder_instructions.rs
@@ -189,9 +189,9 @@ impl EncoderInstructionReader {
 
     /// # Errors
     ///
-    ///  1) `NeedMoreData` if the reader needs more data
-    ///  2) `ClosedCriticalStream`
-    ///  3) other errors will be translated to `EncoderStream` by the caller of this function.
+    /// 1) `NeedMoreData` if the reader needs more data
+    /// 2) `ClosedCriticalStream`
+    /// 3) other errors will be translated to `EncoderStream` by the caller of this function.
     pub fn read_instructions<T: ReadByte + Reader>(
         &mut self,
         recv: &mut T,

--- a/neqo-qpack/src/header_block.rs
+++ b/neqo-qpack/src/header_block.rs
@@ -4,6 +4,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{
+    mem,
+    ops::{Deref, Div},
+};
+
+use neqo_common::{qtrace, Header};
+
 use crate::{
     prefix::{
         BASE_PREFIX_NEGATIVE, BASE_PREFIX_POSITIVE, HEADER_FIELD_INDEX_DYNAMIC,
@@ -16,11 +23,6 @@ use crate::{
     reader::{parse_utf8, ReceiverBufferWrapper},
     table::HeaderTable,
     Error, Res,
-};
-use neqo_common::{qtrace, Header};
-use std::{
-    mem,
-    ops::{Deref, Div},
 };
 
 #[derive(Default, Debug, PartialEq)]

--- a/neqo-qpack/src/huffman.rs
+++ b/neqo-qpack/src/huffman.rs
@@ -68,9 +68,14 @@ impl<'a> BitReader<'a> {
 }
 
 /// Decodes huffman encoded input.
+///
 /// # Errors
+///
 /// This function may return `HuffmanDecompressionFailed` if `input` is not a correct
-/// huffman-encoded array of bits. # Panics
+/// huffman-encoded array of bits.
+///
+/// # Panics
+///
 /// Never, but rust can't know that.
 pub fn decode_huffman(input: &[u8]) -> Res<Vec<u8>> {
     let mut reader = BitReader::new(input);
@@ -112,6 +117,7 @@ fn decode_character(reader: &mut BitReader) -> Res<Option<u16>> {
 }
 
 /// # Panics
+///
 /// Never, but rust doesn't know that.
 #[must_use]
 pub fn encode_huffman(input: &[u8]) -> Vec<u8> {

--- a/neqo-qpack/src/huffman.rs
+++ b/neqo-qpack/src/huffman.rs
@@ -4,10 +4,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::huffman_decode_helper::{HuffmanDecoderNode, HUFFMAN_DECODE_ROOT};
-use crate::huffman_table::HUFFMAN_TABLE;
-use crate::{Error, Res};
 use std::convert::TryFrom;
+
+use crate::{
+    huffman_decode_helper::{HuffmanDecoderNode, HUFFMAN_DECODE_ROOT},
+    huffman_table::HUFFMAN_TABLE,
+    Error, Res,
+};
 
 struct BitReader<'a> {
     input: &'a [u8],
@@ -66,8 +69,8 @@ impl<'a> BitReader<'a> {
 
 /// Decodes huffman encoded input.
 /// # Errors
-/// This function may return `HuffmanDecompressionFailed` if `input` is not a correct huffman-encoded array of bits.
-/// # Panics
+/// This function may return `HuffmanDecompressionFailed` if `input` is not a correct
+/// huffman-encoded array of bits. # Panics
 /// Never, but rust can't know that.
 pub fn decode_huffman(input: &[u8]) -> Res<Vec<u8>> {
     let mut reader = BitReader::new(input);

--- a/neqo-qpack/src/huffman_decode_helper.rs
+++ b/neqo-qpack/src/huffman_decode_helper.rs
@@ -4,9 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::huffman_table::HUFFMAN_TABLE;
-use lazy_static::lazy_static;
 use std::convert::TryFrom;
+
+use lazy_static::lazy_static;
+
+use crate::huffman_table::HUFFMAN_TABLE;
 
 pub struct HuffmanDecoderNode {
     pub next: [Option<Box<HuffmanDecoderNode>>; 2],

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -6,7 +6,8 @@
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::pedantic)]
-// This is because of Encoder and Decoder structs. TODO: think about a better namings for crate and structs.
+// This is because of Encoder and Decoder structs. TODO: think about a better namings for crate and
+// structs.
 #![allow(clippy::module_name_repetitions)]
 
 pub mod decoder;
@@ -47,7 +48,8 @@ pub enum Error {
     InternalError(u16),
 
     // These are internal errors, they will be transformed into one of the above.
-    NeedMoreData, // Return when an input stream does not have more data that a decoder needs.(It does not mean that a stream is closed.)
+    NeedMoreData, /* Return when an input stream does not have more data that a decoder
+                   * needs.(It does not mean that a stream is closed.) */
     HeaderLookup,
     HuffmanDecompressionFailed,
     BadUtf8,

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -81,7 +81,7 @@ impl Error {
 
     /// # Errors
     ///
-    ///   Any error is mapped to the indicated type.
+    /// Any error is mapped to the indicated type.
     fn map_error<R>(r: Result<R, Self>, err: Self) -> Result<R, Self> {
         r.map_err(|e| {
             if matches!(e, Self::ClosedCriticalStream) {

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -80,6 +80,7 @@ impl Error {
     }
 
     /// # Errors
+    ///
     ///   Any error is mapped to the indicated type.
     fn map_error<R>(r: Result<R, Self>, err: Self) -> Result<R, Self> {
         r.map_err(|e| {

--- a/neqo-qpack/src/prefix.rs
+++ b/neqo-qpack/src/prefix.rs
@@ -111,7 +111,7 @@ create_prefix!(ENCODER_INSERT_WITH_NAME_LITERAL, 0x40, 2);
 create_prefix!(ENCODER_DUPLICATE, 0x00, 3);
 
 //=====================================================================
-//Header block encoding prefixes
+// Header block encoding prefixes
 //=====================================================================
 
 create_prefix!(BASE_PREFIX_POSITIVE, 0x00, 1);

--- a/neqo-qpack/src/prefix.rs
+++ b/neqo-qpack/src/prefix.rs
@@ -16,9 +16,10 @@ pub struct Prefix {
 impl Prefix {
     pub fn new(prefix: u8, len: u8) -> Self {
         // len should never be larger than 7.
-        // Most of Prefixes are instantiated as consts bellow. The only place where this construcrtor is used
-        // is in tests and when literals are encoded and the Huffman bit is added to one of the consts bellow.
-        // create_prefix guaranty that all const have len < 7 so we can safely assert that len is <=7.
+        // Most of Prefixes are instantiated as consts bellow. The only place where this
+        // construcrtor is used is in tests and when literals are encoded and the Huffman
+        // bit is added to one of the consts bellow. create_prefix guaranty that all const
+        // have len < 7 so we can safely assert that len is <=7.
         assert!(len <= 7);
         assert!((len == 0) || (prefix & ((1 << (8 - len)) - 1) == 0));
         Self {
@@ -137,5 +138,6 @@ create_prefix!(HEADER_FIELD_LITERAL_NAME_REF_DYNAMIC, 0x40, 4, 0xD0);
 create_prefix!(HEADER_FIELD_LITERAL_NAME_REF_DYNAMIC_POST, 0x00, 5, 0xF0);
 
 // | 0 | 0 | 1 | N | H |  Index(3+) |
-// N is ignored and H is not relevant for decoding this prefix, therefore the mask is 1110 0000 = 0xE0
+// N is ignored and H is not relevant for decoding this prefix, therefore the mask is 1110 0000 =
+// 0xE0
 create_prefix!(HEADER_FIELD_LITERAL_NAME_LITERAL, 0x20, 4, 0xE0);

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -6,11 +6,9 @@
 
 // Functions that handle capturing QLOG traces.
 
-use neqo_common::hex;
-use neqo_common::qlog::NeqoQlog;
+use neqo_common::{hex, qlog::NeqoQlog};
 use qlog::events::{
-    qpack::QpackInstructionTypeName,
-    qpack::{QPackInstruction, QpackInstructionParsed},
+    qpack::{QPackInstruction, QpackInstructionParsed, QpackInstructionTypeName},
     EventData, RawInfo,
 };
 

--- a/neqo-qpack/src/qpack_send_buf.rs
+++ b/neqo-qpack/src/qpack_send_buf.rs
@@ -4,11 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::huffman::encode_huffman;
-use crate::prefix::Prefix;
+use std::{convert::TryFrom, ops::Deref};
+
 use neqo_common::Encoder;
-use std::convert::TryFrom;
-use std::ops::Deref;
+
+use crate::{huffman::encode_huffman, prefix::Prefix};
 
 #[derive(Default, Debug, PartialEq)]
 pub(crate) struct QpackData {

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -4,10 +4,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{huffman::decode_huffman, prefix::Prefix, Error, Res};
+use std::{convert::TryInto, mem, str};
+
 use neqo_common::{qdebug, qerror};
 use neqo_transport::{Connection, StreamId};
-use std::{convert::TryInto, mem, str};
+
+use crate::{huffman::decode_huffman, prefix::Prefix, Error, Res};
 
 pub trait ReadByte {
     /// # Errors
@@ -318,8 +320,9 @@ pub fn parse_utf8(v: &[u8]) -> Res<&str> {
 #[cfg(test)]
 pub(crate) mod test_receiver {
 
-    use super::{Error, ReadByte, Reader, Res};
     use std::collections::VecDeque;
+
+    use super::{Error, ReadByte, Reader, Res};
 
     #[derive(Default)]
     pub struct TestReceiver {
@@ -358,11 +361,12 @@ pub(crate) mod test_receiver {
 #[cfg(test)]
 mod tests {
 
+    use test_receiver::TestReceiver;
+
     use super::{
         parse_utf8, str, test_receiver, Error, IntReader, LiteralReader, ReadByte,
         ReceiverBufferWrapper, Res,
     };
-    use test_receiver::TestReceiver;
 
     const TEST_CASES_NUMBERS: [(&[u8], u8, u64); 7] = [
         (&[0xEA], 3, 10),

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -13,6 +13,7 @@ use crate::{huffman::decode_huffman, prefix::Prefix, Error, Res};
 
 pub trait ReadByte {
     /// # Errors
+    ///
     ///    Return error occurred while reading a byte.
     ///    The exact error depends on trait implementation.
     fn read_byte(&mut self) -> Res<u8>;
@@ -20,6 +21,7 @@ pub trait ReadByte {
 
 pub trait Reader {
     /// # Errors
+    ///
     ///    Return error occurred while reading date into a buffer.
     ///    The exact error depends on trait implementation.
     fn read(&mut self, buf: &mut [u8]) -> Res<usize>;
@@ -156,7 +158,9 @@ pub struct IntReader {
 impl IntReader {
     /// `IntReader` is created by suppling the first byte anf prefix length.
     /// A varint may take only one byte, In that case already the first by has set state to done.
+    ///
     /// # Panics
+    ///
     /// When `prefix_len` is 8 or larger.
     #[must_use]
     pub fn new(first_byte: u8, prefix_len: u8) -> Self {
@@ -176,6 +180,7 @@ impl IntReader {
     }
 
     /// # Panics
+    ///
     /// Never, but rust doesn't know that.
     #[must_use]
     pub fn make(first_byte: u8, prefixes: &[Prefix]) -> Self {
@@ -189,7 +194,9 @@ impl IntReader {
 
     /// This function reads bytes until the varint is decoded or until stream/buffer does not
     /// have any more date.
+    ///
     /// # Errors
+    ///
     /// Possible errors are:
     ///  1) `NeedMoreData` if the reader needs more data,
     ///  2) `IntegerOverflow`,
@@ -247,7 +254,9 @@ impl LiteralReader {
     /// Creates `LiteralReader` with the first byte. This constructor is always used
     /// when a litreral has a prefix.
     /// For literals without a prefix please use the default constructor.
+    ///
     /// # Panics
+    ///
     /// If `prefix_len` is 8 or more.
     #[must_use]
     pub fn new_with_first_byte(first_byte: u8, prefix_len: u8) -> Self {
@@ -263,13 +272,17 @@ impl LiteralReader {
 
     /// This function reads bytes until the literal is decoded or until stream/buffer does not
     /// have any more date ready.
+    ///
     /// # Errors
+    ///
     /// Possible errors are:
     ///  1) `NeedMoreData` if the reader needs more data,
     ///  2) `IntegerOverflow`
     ///  3) Any `ReadByte`'s error
     /// It returns value if reading the literal is done or None if it needs more data.
+    ///
     /// # Panics
+    ///
     /// When this object is complete.
     pub fn read<T: ReadByte + Reader>(&mut self, s: &mut T) -> Res<Vec<u8>> {
         loop {
@@ -311,7 +324,9 @@ impl LiteralReader {
 
 /// This is a helper function used only by `ReceiverBufferWrapper`, therefore it returns
 /// `DecompressionFailed` if any error happens.
+///
 /// # Errors
+///
 /// If an parsing error occurred, the function returns `BadUtf8`.
 pub fn parse_utf8(v: &[u8]) -> Res<&str> {
     str::from_utf8(v).map_err(|_| Error::BadUtf8)

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -14,16 +14,16 @@ use crate::{huffman::decode_huffman, prefix::Prefix, Error, Res};
 pub trait ReadByte {
     /// # Errors
     ///
-    ///    Return error occurred while reading a byte.
-    ///    The exact error depends on trait implementation.
+    /// Return error occurred while reading a byte.
+    /// The exact error depends on trait implementation.
     fn read_byte(&mut self) -> Res<u8>;
 }
 
 pub trait Reader {
     /// # Errors
     ///
-    ///    Return error occurred while reading date into a buffer.
-    ///    The exact error depends on trait implementation.
+    /// Return error occurred while reading date into a buffer.
+    /// The exact error depends on trait implementation.
     fn read(&mut self, buf: &mut [u8]) -> Res<usize>;
 }
 

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -4,11 +4,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::static_table::{StaticTableEntry, HEADER_STATIC_TABLE};
-use crate::{Error, Res};
+use std::{collections::VecDeque, convert::TryFrom};
+
 use neqo_common::qtrace;
-use std::collections::VecDeque;
-use std::convert::TryFrom;
+
+use crate::{
+    static_table::{StaticTableEntry, HEADER_STATIC_TABLE},
+    Error, Res,
+};
 
 pub const ADDITIONAL_TABLE_ENTRY_SIZE: usize = 32;
 
@@ -108,7 +111,8 @@ impl HeaderTable {
     /// Change the dynamic table capacity.
     /// ### Errors
     /// `ChangeCapacity` if table capacity cannot be reduced.
-    /// The table cannot be reduce if there are entries that are referred at the moment or their inserts are unacked.
+    /// The table cannot be reduce if there are entries that are referred at the moment or their
+    /// inserts are unacked.
     pub fn set_capacity(&mut self, cap: u64) -> Res<()> {
         qtrace!([self], "set capacity to {}", cap);
         if !self.evict_to(cap) {
@@ -186,8 +190,8 @@ impl HeaderTable {
     }
 
     /// Look for a header pair.
-    /// The function returns `LookupResult`: `index`, `static_table` (if it is a static table entry) and `value_matches`
-    /// (if the header value matches as well not only header name)
+    /// The function returns `LookupResult`: `index`, `static_table` (if it is a static table entry)
+    /// and `value_matches` (if the header value matches as well not only header name)
     pub fn lookup(&mut self, name: &[u8], value: &[u8], can_block: bool) -> Option<LookupResult> {
         qtrace!(
             [self],
@@ -281,8 +285,8 @@ impl HeaderTable {
 
     /// Insert a new entry.
     /// ### Errors
-    /// `DynamicTableFull` if an entry cannot be added to the table because there is not enough space and/or
-    /// other entry cannot be evicted.
+    /// `DynamicTableFull` if an entry cannot be added to the table because there is not enough
+    /// space and/or other entry cannot be evicted.
     pub fn insert(&mut self, name: &[u8], value: &[u8]) -> Res<u64> {
         qtrace!([self], "insert name={:?} value={:?}", name, value);
         let entry = DynamicTableEntry {
@@ -305,8 +309,8 @@ impl HeaderTable {
 
     /// Insert a new entry with the name refer to by a index to static or dynamic table.
     /// ### Errors
-    /// `DynamicTableFull` if an entry cannot be added to the table because there is not enough space and/or
-    /// other entry cannot be evicted.
+    /// `DynamicTableFull` if an entry cannot be added to the table because there is not enough
+    /// space and/or other entry cannot be evicted.
     /// `HeaderLookup` if the index dos not exits in the static/dynamic table.
     pub fn insert_with_name_ref(
         &mut self,
@@ -337,8 +341,8 @@ impl HeaderTable {
 
     /// Duplicate an entry.
     /// ### Errors
-    /// `DynamicTableFull` if an entry cannot be added to the table because there is not enough space and/or
-    /// other entry cannot be evicted.
+    /// `DynamicTableFull` if an entry cannot be added to the table because there is not enough
+    /// space and/or other entry cannot be evicted.
     /// `HeaderLookup` if the index dos not exits in the static/dynamic table.
     pub fn duplicate(&mut self, index: u64) -> Res<u64> {
         qtrace!([self], "duplicate entry={}", index);

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -109,7 +109,9 @@ impl HeaderTable {
     }
 
     /// Change the dynamic table capacity.
-    /// ### Errors
+    ///
+    /// # Errors
+    ///
     /// `ChangeCapacity` if table capacity cannot be reduced.
     /// The table cannot be reduce if there are entries that are referred at the moment or their
     /// inserts are unacked.
@@ -123,7 +125,9 @@ impl HeaderTable {
     }
 
     /// Get a static entry with `index`.
-    /// ### Errors
+    ///
+    /// # Errors
+    ///
     /// `HeaderLookup` if the index does not exist in the static table.
     pub fn get_static(index: u64) -> Res<&'static StaticTableEntry> {
         let inx = usize::try_from(index).or(Err(Error::HeaderLookup))?;
@@ -155,7 +159,9 @@ impl HeaderTable {
     }
 
     /// Get a entry in the  dynamic table.
-    /// ### Errors
+    ///
+    /// # Errors
+    ///
     /// `HeaderLookup` if entry does not exist.
     pub fn get_dynamic(&self, index: u64, base: u64, post: bool) -> Res<&DynamicTableEntry> {
         let inx = if post {
@@ -284,7 +290,9 @@ impl HeaderTable {
     }
 
     /// Insert a new entry.
-    /// ### Errors
+    ///
+    /// # Errors
+    ///
     /// `DynamicTableFull` if an entry cannot be added to the table because there is not enough
     /// space and/or other entry cannot be evicted.
     pub fn insert(&mut self, name: &[u8], value: &[u8]) -> Res<u64> {
@@ -308,7 +316,9 @@ impl HeaderTable {
     }
 
     /// Insert a new entry with the name refer to by a index to static or dynamic table.
-    /// ### Errors
+    ///
+    /// # Errors
+    ///
     /// `DynamicTableFull` if an entry cannot be added to the table because there is not enough
     /// space and/or other entry cannot be evicted.
     /// `HeaderLookup` if the index dos not exits in the static/dynamic table.
@@ -340,7 +350,9 @@ impl HeaderTable {
     }
 
     /// Duplicate an entry.
-    /// ### Errors
+    ///
+    /// # Errors
+    ///
     /// `DynamicTableFull` if an entry cannot be added to the table because there is not enough
     /// space and/or other entry cannot be evicted.
     /// `HeaderLookup` if the index dos not exits in the static/dynamic table.
@@ -359,7 +371,9 @@ impl HeaderTable {
     }
 
     /// Increment number of acknowledge entries.
-    /// ### Errors
+    ///
+    /// # Errors
+    ///
     /// `IncrementAck` if ack is greater than actual number of inserts.
     pub fn increment_acked(&mut self, increment: u64) -> Res<()> {
         qtrace!([self], "increment acked by {}", increment);

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -27,9 +27,6 @@ use std::{
 
 use mio::{net::UdpSocket, Events, Poll, PollOpt, Ready, Token};
 use mio_extras::timer::{Builder, Timeout, Timer};
-use neqo_transport::ConnectionIdGenerator;
-use structopt::StructOpt;
-
 use neqo_common::{hex, qdebug, qinfo, qwarn, Datagram, Header, IpTos};
 use neqo_crypto::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256},
@@ -40,8 +37,10 @@ use neqo_http3::{
 };
 use neqo_transport::{
     server::ValidateAddress, tparams::PreferredAddress, CongestionControlAlgorithm,
-    ConnectionParameters, Output, RandomConnectionIdGenerator, StreamType, Version,
+    ConnectionIdGenerator, ConnectionParameters, Output, RandomConnectionIdGenerator, StreamType,
+    Version,
 };
+use structopt::StructOpt;
 
 use crate::old_https::Http09Server;
 

--- a/neqo-server/src/old_https.rs
+++ b/neqo-server/src/old_https.rs
@@ -7,14 +7,9 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::use_self)]
 
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::fmt::Display;
-use std::path::PathBuf;
-use std::rc::Rc;
-use std::time::Instant;
-
-use regex::Regex;
+use std::{
+    cell::RefCell, collections::HashMap, fmt::Display, path::PathBuf, rc::Rc, time::Instant,
+};
 
 use neqo_common::{event::Provider, hex, qdebug, Datagram};
 use neqo_crypto::{generate_ech_keys, random, AllowZeroRtt, AntiReplay, Cipher};
@@ -23,6 +18,7 @@ use neqo_transport::{
     server::{ActiveConnectionRef, Server, ValidateAddress},
     ConnectionEvent, ConnectionIdGenerator, ConnectionParameters, Output, State, StreamId,
 };
+use regex::Regex;
 
 use super::{qns_read_response, Args, HttpServer};
 

--- a/neqo-transport/src/ackrate.rs
+++ b/neqo-transport/src/ackrate.rs
@@ -7,16 +7,14 @@
 // Management of the peer's ack rate.
 #![deny(clippy::pedantic)]
 
-use crate::connection::params::ACK_RATIO_SCALE;
-use crate::frame::FRAME_TYPE_ACK_FREQUENCY;
-use crate::packet::PacketBuilder;
-use crate::recovery::RecoveryToken;
-use crate::stats::FrameStats;
+use std::{cmp::max, convert::TryFrom, time::Duration};
 
 use neqo_common::qtrace;
-use std::cmp::max;
-use std::convert::TryFrom;
-use std::time::Duration;
+
+use crate::{
+    connection::params::ACK_RATIO_SCALE, frame::FRAME_TYPE_ACK_FREQUENCY, packet::PacketBuilder,
+    recovery::RecoveryToken, stats::FrameStats,
+};
 
 #[derive(Debug, Clone)]
 pub struct AckRate {

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -6,22 +6,23 @@
 
 // This file implements functions necessary for address validation.
 
+use std::{
+    convert::TryFrom,
+    net::{IpAddr, SocketAddr},
+    time::{Duration, Instant},
+};
+
 use neqo_common::{qinfo, qtrace, Decoder, Encoder, Role};
 use neqo_crypto::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
     selfencrypt::SelfEncrypt,
 };
-
-use crate::cid::ConnectionId;
-use crate::packet::PacketBuilder;
-use crate::recovery::RecoveryToken;
-use crate::stats::FrameStats;
-use crate::{Error, Res};
-
 use smallvec::SmallVec;
-use std::convert::TryFrom;
-use std::net::{IpAddr, SocketAddr};
-use std::time::{Duration, Instant};
+
+use crate::{
+    cid::ConnectionId, packet::PacketBuilder, recovery::RecoveryToken, stats::FrameStats, Error,
+    Res,
+};
 
 /// A prefix we add to Retry tokens to distinguish them from NEW_TOKEN tokens.
 const TOKEN_IDENTIFIER_RETRY: &[u8] = &[0x52, 0x65, 0x74, 0x72, 0x79];
@@ -460,8 +461,9 @@ impl NewTokenSender {
 
 #[cfg(test)]
 mod tests {
-    use super::NewTokenState;
     use neqo_common::Role;
+
+    use super::NewTokenState;
 
     const ONE: &[u8] = &[1, 2, 3];
     const TWO: &[u8] = &[4, 5];

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -14,7 +14,6 @@ use std::{
 };
 
 use super::CongestionControl;
-
 use crate::{
     cc::MAX_DATAGRAM_SIZE,
     packet::PacketNumber,
@@ -537,6 +536,14 @@ impl<T: WindowAdjustment> ClassicCongestionControl<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        convert::TryFrom,
+        time::{Duration, Instant},
+    };
+
+    use neqo_common::qinfo;
+    use test_fixture::now;
+
     use super::{
         ClassicCongestionControl, WindowAdjustment, CWND_INITIAL, CWND_MIN, PERSISTENT_CONG_THRESH,
     };
@@ -551,12 +558,6 @@ mod tests {
         rtt::RttEstimate,
         tracking::SentPacket,
     };
-    use neqo_common::qinfo;
-    use std::{
-        convert::TryFrom,
-        time::{Duration, Instant},
-    };
-    use test_fixture::now;
 
     const PTO: Duration = Duration::from_millis(100);
     const RTT: Duration = Duration::from_millis(98);

--- a/neqo-transport/src/cc/cubic.rs
+++ b/neqo-transport/src/cc/cubic.rs
@@ -6,12 +6,15 @@
 
 #![deny(clippy::pedantic)]
 
-use std::fmt::{self, Display};
-use std::time::{Duration, Instant};
+use std::{
+    convert::TryFrom,
+    fmt::{self, Display},
+    time::{Duration, Instant},
+};
+
+use neqo_common::qtrace;
 
 use crate::cc::{classic_cc::WindowAdjustment, MAX_DATAGRAM_SIZE_F64};
-use neqo_common::qtrace;
-use std::convert::TryFrom;
 
 // CUBIC congestion control
 
@@ -163,8 +166,8 @@ impl WindowAdjustment for Cubic {
         // of `MAX_DATAGRAM_SIZE` to match the increase of `target - cwnd / cwnd` as defined
         // in the specification (Sections 4.4 and 4.5).
         // The amount of data required therefore reduces asymptotically as the target increases.
-        // If the target is not significantly higher than the congestion window, require a very large
-        // amount of acknowledged data (effectively block increases).
+        // If the target is not significantly higher than the congestion window, require a very
+        // large amount of acknowledged data (effectively block increases).
         let mut acked_to_increase =
             MAX_DATAGRAM_SIZE_F64 * curr_cwnd_f64 / (target_cwnd - curr_cwnd_f64).max(1.0);
 
@@ -178,9 +181,10 @@ impl WindowAdjustment for Cubic {
     fn reduce_cwnd(&mut self, curr_cwnd: usize, acked_bytes: usize) -> (usize, usize) {
         let curr_cwnd_f64 = convert_to_f64(curr_cwnd);
         // Fast Convergence
-        // If congestion event occurs before the maximum congestion window before the last congestion event,
-        // we reduce the the maximum congestion window and thereby W_max.
-        // check cwnd + MAX_DATAGRAM_SIZE instead of cwnd because with cwnd in bytes, cwnd may be slightly off.
+        // If congestion event occurs before the maximum congestion window before the last
+        // congestion event, we reduce the the maximum congestion window and thereby W_max.
+        // check cwnd + MAX_DATAGRAM_SIZE instead of cwnd because with cwnd in bytes, cwnd may be
+        // slightly off.
         self.last_max_cwnd = if curr_cwnd_f64 + MAX_DATAGRAM_SIZE_F64 < self.last_max_cwnd {
             curr_cwnd_f64 * CUBIC_FAST_CONVERGENCE
         } else {

--- a/neqo-transport/src/cc/mod.rs
+++ b/neqo-transport/src/cc/mod.rs
@@ -7,14 +7,15 @@
 // Congestion control
 #![deny(clippy::pedantic)]
 
-use crate::{path::PATH_MTU_V6, rtt::RttEstimate, tracking::SentPacket, Error};
-use neqo_common::qlog::NeqoQlog;
-
 use std::{
     fmt::{Debug, Display},
     str::FromStr,
     time::{Duration, Instant},
 };
+
+use neqo_common::qlog::NeqoQlog;
+
+use crate::{path::PATH_MTU_V6, rtt::RttEstimate, tracking::SentPacket, Error};
 
 mod classic_cc;
 mod cubic;

--- a/neqo-transport/src/cc/new_reno.rs
+++ b/neqo-transport/src/cc/new_reno.rs
@@ -7,10 +7,12 @@
 // Congestion control
 #![deny(clippy::pedantic)]
 
-use std::fmt::{self, Display};
+use std::{
+    fmt::{self, Display},
+    time::{Duration, Instant},
+};
 
 use crate::cc::classic_cc::WindowAdjustment;
-use std::time::{Duration, Instant};
 
 #[derive(Debug, Default)]
 pub struct NewReno {}

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -7,6 +7,14 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_sign_loss)]
 
+use std::{
+    convert::TryFrom,
+    ops::Sub,
+    time::{Duration, Instant},
+};
+
+use test_fixture::now;
+
 use crate::{
     cc::{
         classic_cc::{ClassicCongestionControl, CWND_INITIAL},
@@ -20,12 +28,6 @@ use crate::{
     rtt::RttEstimate,
     tracking::SentPacket,
 };
-use std::{
-    convert::TryFrom,
-    ops::Sub,
-    time::{Duration, Instant},
-};
-use test_fixture::now;
 
 const RTT: Duration = Duration::from_millis(100);
 const RTT_ESTIMATE: RttEstimate = RttEstimate::from_duration(Duration::from_millis(100));
@@ -145,9 +147,10 @@ fn tcp_phase() {
     let expected_ack_tcp_increase = expected_tcp_acks(cwnd_rtt_start);
     assert!(num_acks < expected_ack_tcp_increase);
 
-    // This first increase after a TCP phase may be shorter than what it would take by a regular cubic phase,
-    // because of the proper byte counting and the credit it already had before entering this phase. Therefore
-    // We will perform another round and compare it to expected increase using the cubic equation.
+    // This first increase after a TCP phase may be shorter than what it would take by a regular
+    // cubic phase, because of the proper byte counting and the credit it already had before
+    // entering this phase. Therefore We will perform another round and compare it to expected
+    // increase using the cubic equation.
 
     let cwnd_rtt_start_after_tcp = cubic.cwnd();
     let elapsed_time = now - start_time;
@@ -167,12 +170,12 @@ fn tcp_phase() {
     let expected_ack_tcp_increase2 = expected_tcp_acks(cwnd_rtt_start_after_tcp);
     assert!(num_acks2 < expected_ack_tcp_increase2);
 
-    // The time needed to increase cwnd by MAX_DATAGRAM_SIZE using the cubic equation will be calculates from:
-    // W_cubic(elapsed_time + t_to_increase) - W_cubis(elapsed_time) = MAX_DATAGRAM_SIZE =>
-    // CUBIC_C * (elapsed_time + t_to_increase)^3 * MAX_DATAGRAM_SIZE + CWND_INITIAL -
-    //     CUBIC_C * elapsed_time^3 * MAX_DATAGRAM_SIZE + CWND_INITIAL = MAX_DATAGRAM_SIZE =>
-    // t_to_increase = cbrt((1 + CUBIC_C * elapsed_time^3) / CUBIC_C) - elapsed_time
-    // (t_to_increase is in seconds)
+    // The time needed to increase cwnd by MAX_DATAGRAM_SIZE using the cubic equation will be
+    // calculates from: W_cubic(elapsed_time + t_to_increase) - W_cubis(elapsed_time) =
+    // MAX_DATAGRAM_SIZE => CUBIC_C * (elapsed_time + t_to_increase)^3 * MAX_DATAGRAM_SIZE +
+    // CWND_INITIAL -     CUBIC_C * elapsed_time^3 * MAX_DATAGRAM_SIZE + CWND_INITIAL =
+    // MAX_DATAGRAM_SIZE => t_to_increase = cbrt((1 + CUBIC_C * elapsed_time^3) / CUBIC_C) -
+    // elapsed_time (t_to_increase is in seconds)
     // number of ack needed is t_to_increase / time_increase.
     let expected_ack_cubic_increase =
         ((((1.0 + CUBIC_C * (elapsed_time).as_secs_f64().powi(3)) / CUBIC_C).cbrt()
@@ -180,15 +183,16 @@ fn tcp_phase() {
             / time_increase.as_secs_f64())
         .ceil() as u64;
     // num_acks is very close to the calculated value. The exact value is hard to calculate
-    // because the proportional increase(i.e. curr_cwnd_f64 / (target - curr_cwnd_f64) * MAX_DATAGRAM_SIZE_F64)
-    // and the byte counting.
+    // because the proportional increase(i.e. curr_cwnd_f64 / (target - curr_cwnd_f64) *
+    // MAX_DATAGRAM_SIZE_F64) and the byte counting.
     assert_eq!(num_acks2, expected_ack_cubic_increase + 2);
 }
 
 #[test]
 fn cubic_phase() {
     let mut cubic = ClassicCongestionControl::new(Cubic::default());
-    // Set last_max_cwnd to a higher number make sure that cc is the cubic phase (cwnd is calculated by the cubic equation).
+    // Set last_max_cwnd to a higher number make sure that cc is the cubic phase (cwnd is calculated
+    // by the cubic equation).
     cubic.set_last_max_cwnd(CWND_INITIAL_10_F64);
     // Set ssthresh to something small to make sure that cc is in the congection avoidance phase.
     cubic.set_ssthresh(1);
@@ -264,7 +268,8 @@ fn congestion_event_congestion_avoidance() {
     // Set ssthresh to something small to make sure that cc is in the congection avoidance phase.
     cubic.set_ssthresh(1);
 
-    // Set last_max_cwnd to something smaller than cwnd so that the fast convergence is not triggered.
+    // Set last_max_cwnd to something smaller than cwnd so that the fast convergence is not
+    // triggered.
     cubic.set_last_max_cwnd(3.0 * MAX_DATAGRAM_SIZE_F64);
 
     _ = fill_cwnd(&mut cubic, 0, now());

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -111,7 +111,7 @@ fn tcp_phase() {
 
     for _ in 0..num_tcp_increases {
         let cwnd_rtt_start = cubic.cwnd();
-        //Expected acks during a period of RTT / CUBIC_ALPHA.
+        // Expected acks during a period of RTT / CUBIC_ALPHA.
         let acks = expected_tcp_acks(cwnd_rtt_start);
         // The time between acks if they are ideally paced over a RTT.
         let time_increase = RTT / u32::try_from(cwnd_rtt_start / MAX_DATAGRAM_SIZE).unwrap();
@@ -209,7 +209,7 @@ fn cubic_phase() {
     let num_rtts_w_max = (k / RTT.as_secs_f64()).round() as u64;
     for _ in 0..num_rtts_w_max {
         let cwnd_rtt_start = cubic.cwnd();
-        //Expected acks
+        // Expected acks
         let acks = cwnd_rtt_start / MAX_DATAGRAM_SIZE;
         let time_increase = RTT / u32::try_from(acks).unwrap();
         for _ in 0..acks {

--- a/neqo-transport/src/cc/tests/new_reno.rs
+++ b/neqo-transport/src/cc/tests/new_reno.rs
@@ -7,6 +7,10 @@
 // Congestion control
 #![deny(clippy::pedantic)]
 
+use std::time::Duration;
+
+use test_fixture::now;
+
 use crate::{
     cc::{
         new_reno::NewReno, ClassicCongestionControl, CongestionControl, CWND_INITIAL,
@@ -16,9 +20,6 @@ use crate::{
     rtt::RttEstimate,
     tracking::SentPacket,
 };
-
-use std::time::Duration;
-use test_fixture::now;
 
 const PTO: Duration = Duration::from_millis(100);
 const RTT: Duration = Duration::from_millis(98);
@@ -169,8 +170,8 @@ fn issue_1465() {
     cwnd_is_default(&cc);
     assert_eq!(cc.bytes_in_flight(), 3 * MAX_DATAGRAM_SIZE);
 
-    // advance one rtt to detect lost packet there this simplifies the timers, because on_packet_loss
-    // would only be called after RTO, but that is not relevant to the problem
+    // advance one rtt to detect lost packet there this simplifies the timers, because
+    // on_packet_loss would only be called after RTO, but that is not relevant to the problem
     now += RTT;
     cc.on_packets_lost(Some(now), None, PTO, &[p1]);
 

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -6,15 +6,6 @@
 
 // Representation and management of connection IDs.
 
-use crate::{
-    frame::FRAME_TYPE_NEW_CONNECTION_ID, packet::PacketBuilder, recovery::RecoveryToken,
-    stats::FrameStats, Error, Res,
-};
-
-use neqo_common::{hex, hex_with_len, qinfo, Decoder, Encoder};
-use neqo_crypto::random;
-
-use smallvec::SmallVec;
 use std::{
     borrow::Borrow,
     cell::{Ref, RefCell},
@@ -22,6 +13,15 @@ use std::{
     convert::{AsRef, TryFrom},
     ops::Deref,
     rc::Rc,
+};
+
+use neqo_common::{hex, hex_with_len, qinfo, Decoder, Encoder};
+use neqo_crypto::random;
+use smallvec::SmallVec;
+
+use crate::{
+    frame::FRAME_TYPE_NEW_CONNECTION_ID, packet::PacketBuilder, recovery::RecoveryToken,
+    stats::FrameStats, Error, Res,
 };
 
 pub const MAX_CONNECTION_ID_LEN: usize = 20;
@@ -421,8 +421,9 @@ pub struct ConnectionIdManager {
     /// The `ConnectionIdGenerator` instance that is used to create connection IDs.
     generator: Rc<RefCell<dyn ConnectionIdGenerator>>,
     /// The connection IDs that we will accept.
-    /// This includes any we advertise in `NEW_CONNECTION_ID` that haven't been bound to a path yet.
-    /// During the handshake at the server, it also includes the randomized DCID pick by the client.
+    /// This includes any we advertise in `NEW_CONNECTION_ID` that haven't been bound to a path
+    /// yet. During the handshake at the server, it also includes the randomized DCID pick by
+    /// the client.
     connection_ids: ConnectionIdStore<()>,
     /// The maximum number of connection IDs this will accept.  This is at least 2 and won't
     /// be more than `LOCAL_ACTIVE_CID_LIMIT`.
@@ -595,8 +596,9 @@ impl ConnectionIdManager {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use test_fixture::fixture_init;
+
+    use super::*;
 
     #[test]
     fn generate_initial_cid() {

--- a/neqo-transport/src/connection/idle.rs
+++ b/neqo-transport/src/connection/idle.rs
@@ -4,12 +4,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::recovery::RecoveryToken;
-use neqo_common::qtrace;
 use std::{
     cmp::{max, min},
     time::{Duration, Instant},
 };
+
+use neqo_common::qtrace;
+
+use crate::recovery::RecoveryToken;
 
 #[derive(Debug, Clone)]
 /// There's a little bit of different behavior for resetting idle timeout. See

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -498,9 +498,9 @@ impl Connection {
     }
 
     /// `odcid` is their original choice for our CID, which we get from the Retry token.
-    /// `remote_cid` is the value from the Source Connection ID field of
-    ///   an incoming packet: what the peer wants us to use now.
-    /// `retry_cid` is what we asked them to use when we sent the Retry.
+    /// `remote_cid` is the value from the Source Connection ID field of an incoming packet: what
+    /// the peer wants us to use now. `retry_cid` is what we asked them to use when we sent the
+    /// Retry.
     pub(crate) fn set_retry_cids(
         &mut self,
         odcid: ConnectionId,

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -478,7 +478,9 @@ impl Connection {
     /// Set a local transport parameter, possibly overriding a default value.
     /// This only sets transport parameters without dealing with other aspects of
     /// setting the value.
+    ///
     /// # Panics
+    ///
     /// This panics if the transport parameter is known to this crate.
     pub fn set_local_tparam(&self, tp: TransportParameterId, value: TransportParameter) -> Res<()> {
         #[cfg(not(test))]
@@ -644,7 +646,9 @@ impl Connection {
     /// problem for short-lived connections, where the connection is closed before any events are
     /// released. This function retrieves the token, without waiting for a `NEW_TOKEN` frame to
     /// arrive.
+    ///
     /// # Panics
+    ///
     /// If this is called on a server.
     pub fn take_resumption_token(&mut self, now: Instant) -> Option<ResumptionToken> {
         assert_eq!(self.role, Role::Client);
@@ -1674,6 +1678,7 @@ impl Connection {
     /// Either way, the path is probed and will be abandoned if the probe fails.
     ///
     /// # Errors
+    ///
     /// Fails if this is not a client, not confirmed, or there are not enough connection
     /// IDs available to use.
     pub fn migrate(
@@ -2964,7 +2969,9 @@ impl Connection {
 
     /// Create a stream.
     /// Returns new stream id
+    ///
     /// # Errors
+    ///
     /// `ConnectionState` if the connecton stat does not allow to create streams.
     /// `StreamLimitError` if we are limiied by server's stream concurence.
     pub fn stream_create(&mut self, st: StreamType) -> Res<StreamId> {
@@ -2986,7 +2993,9 @@ impl Connection {
     }
 
     /// Set the priority of a stream.
+    ///
     /// # Errors
+    ///
     /// `InvalidStreamId` the stream does not exist.
     pub fn stream_priority(
         &mut self,
@@ -3001,7 +3010,9 @@ impl Connection {
     }
 
     /// Set the SendOrder of a stream.  Re-enqueues to keep the ordering correct
+    ///
     /// # Errors
+    ///
     /// Returns InvalidStreamId if the stream id doesn't exist
     pub fn stream_sendorder(
         &mut self,
@@ -3012,7 +3023,9 @@ impl Connection {
     }
 
     /// Set the Fairness of a stream
+    ///
     /// # Errors
+    ///
     /// Returns InvalidStreamId if the stream id doesn't exist
     pub fn stream_fairness(&mut self, stream_id: StreamId, fairness: bool) -> Res<()> {
         self.streams.set_fairness(stream_id, fairness)
@@ -3031,7 +3044,9 @@ impl Connection {
     /// Send data on a stream.
     /// Returns how many bytes were successfully sent. Could be less
     /// than total, based on receiver credit space available, etc.
+    ///
     /// # Errors
+    ///
     /// `InvalidStreamId` the stream does not exist,
     /// `InvalidInput` if length of `data` is zero,
     /// `FinalSizeError` if the stream has already been closed.
@@ -3042,7 +3057,9 @@ impl Connection {
     /// Send all data or nothing on a stream. May cause DATA_BLOCKED or
     /// STREAM_DATA_BLOCKED frames to be sent.
     /// Returns true if data was successfully sent, otherwise false.
+    ///
     /// # Errors
+    ///
     /// `InvalidStreamId` the stream does not exist,
     /// `InvalidInput` if length of `data` is zero,
     /// `FinalSizeError` if the stream has already been closed.
@@ -3083,7 +3100,9 @@ impl Connection {
 
     /// Read buffered data from stream. bool says whether read bytes includes
     /// the final data on stream.
+    ///
     /// # Errors
+    ///
     /// `InvalidStreamId` if the stream does not exist.
     /// `NoMoreData` if data and fin bit were previously read by the application.
     pub fn stream_recv(&mut self, stream_id: StreamId, data: &mut [u8]) -> Res<(usize, bool)> {
@@ -3102,7 +3121,9 @@ impl Connection {
     }
 
     /// Increases `max_stream_data` for a `stream_id`.
+    ///
     /// # Errors
+    ///
     /// Returns `InvalidStreamId` if a stream does not exist or the receiving
     /// side is closed.
     pub fn set_stream_max_data(&mut self, stream_id: StreamId, max_data: u64) -> Res<()> {
@@ -3116,7 +3137,9 @@ impl Connection {
     /// (if `keep` is `true`) or no longer important (if `keep` is `false`).  If any
     /// stream is marked this way, PING frames will be used to keep the connection
     /// alive, even when there is no activity.
+    ///
     /// # Errors
+    ///
     /// Returns `InvalidStreamId` if a stream does not exist or the receiving
     /// side is closed.
     pub fn stream_keep_alive(&mut self, stream_id: StreamId, keep: bool) -> Res<()> {
@@ -3130,7 +3153,9 @@ impl Connection {
     /// Returns the current max size of a datagram that can fit into a packet.
     /// The value will change over time depending on the encoded size of the
     /// packet number, ack frames, etc.
+    ///
     /// # Error
+    ///
     /// The function returns `NotAvailable` if datagrams are not enabled.
     pub fn max_datagram_size(&self) -> Res<u64> {
         let max_dgram_size = self.quic_datagrams.remote_datagram_size();
@@ -3171,7 +3196,9 @@ impl Connection {
     }
 
     /// Queue a datagram for sending.
+    ///
     /// # Error
+    ///
     /// The function returns `TooMuchData` if the supply buffer is bigger than
     /// the allowed remote datagram size. The funcion does not check if the
     /// datagram can fit into a packet (i.e. MTU limit). This is checked during

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -151,6 +151,7 @@ impl ConnectionParameters {
     }
 
     /// # Panics
+    ///
     /// If v > 2^60 (the maximum allowed by the protocol).
     pub fn max_streams(mut self, stream_type: StreamType, v: u64) -> Self {
         assert!(v <= (1 << 60), "max_streams is too large");
@@ -166,7 +167,9 @@ impl ConnectionParameters {
     }
 
     /// Get the maximum stream data that we will accept on different types of streams.
+    ///
     /// # Panics
+    ///
     /// If `StreamType::UniDi` and `false` are passed as that is not a valid combination.
     pub fn get_max_stream_data(&self, stream_type: StreamType, remote: bool) -> u64 {
         match (stream_type, remote) {
@@ -180,7 +183,9 @@ impl ConnectionParameters {
     }
 
     /// Set the maximum stream data that we will accept on different types of streams.
+    ///
     /// # Panics
+    ///
     /// If `StreamType::UniDi` and `false` are passed as that is not a valid combination
     /// or if v >= 62 (the maximum allowed by the protocol).
     pub fn max_stream_data(mut self, stream_type: StreamType, remote: bool, v: u64) -> Self {
@@ -228,6 +233,7 @@ impl ConnectionParameters {
     }
 
     /// # Panics
+    ///
     /// If `timeout` is 2^62 milliseconds or more.
     pub fn idle_timeout(mut self, timeout: Duration) -> Self {
         assert!(timeout.as_millis() < (1 << 62), "idle timeout is too long");
@@ -285,6 +291,7 @@ impl ConnectionParameters {
     /// congestion.
     ///
     /// # Panics
+    ///
     /// A value of 0 is invalid and will cause a panic.
     pub fn fast_pto(mut self, scale: u8) -> Self {
         assert_ne!(scale, 0);

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -4,18 +4,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::connection::{ConnectionIdManager, Role, LOCAL_ACTIVE_CID_LIMIT};
+use std::{cmp::max, convert::TryFrom, time::Duration};
+
 pub use crate::recovery::FAST_PTO_SCALE;
-use crate::recv_stream::RECV_BUFFER_SIZE;
-use crate::rtt::GRANULARITY;
-use crate::stream_id::StreamType;
-use crate::tparams::{self, PreferredAddress, TransportParameter, TransportParametersHandler};
-use crate::tracking::DEFAULT_ACK_DELAY;
-use crate::version::{Version, VersionConfig};
-use crate::{CongestionControlAlgorithm, Res};
-use std::cmp::max;
-use std::convert::TryFrom;
-use std::time::Duration;
+use crate::{
+    connection::{ConnectionIdManager, Role, LOCAL_ACTIVE_CID_LIMIT},
+    recv_stream::RECV_BUFFER_SIZE,
+    rtt::GRANULARITY,
+    stream_id::StreamType,
+    tparams::{self, PreferredAddress, TransportParameter, TransportParametersHandler},
+    tracking::DEFAULT_ACK_DELAY,
+    version::{Version, VersionConfig},
+    CongestionControlAlgorithm, Res,
+};
 
 const LOCAL_MAX_DATA: u64 = 0x3FFF_FFFF_FFFF_FFFF; // 2^62-1
 const LOCAL_STREAM_LIMIT_BIDI: u64 = 16;
@@ -49,11 +50,14 @@ pub struct ConnectionParameters {
     cc_algorithm: CongestionControlAlgorithm,
     /// Initial connection-level flow control limit.
     max_data: u64,
-    /// Initial flow control limit for receiving data on bidirectional streams that the peer creates.
+    /// Initial flow control limit for receiving data on bidirectional streams that the peer
+    /// creates.
     max_stream_data_bidi_remote: u64,
-    /// Initial flow control limit for receiving data on bidirectional streams that this endpoint creates.
+    /// Initial flow control limit for receiving data on bidirectional streams that this endpoint
+    /// creates.
     max_stream_data_bidi_local: u64,
-    /// Initial flow control limit for receiving data on unidirectional streams that the peer creates.
+    /// Initial flow control limit for receiving data on unidirectional streams that the peer
+    /// creates.
     max_stream_data_uni: u64,
     /// Initial limit on bidirectional streams that the peer creates.
     max_streams_bidi: u64,

--- a/neqo-transport/src/connection/saved.rs
+++ b/neqo-transport/src/connection/saved.rs
@@ -4,11 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::mem;
-use std::time::Instant;
+use std::{mem, time::Instant};
+
+use neqo_common::{qdebug, qinfo, Datagram};
 
 use crate::crypto::CryptoSpace;
-use neqo_common::{qdebug, qinfo, Datagram};
 
 /// The number of datagrams that are saved during the handshake when
 /// keys to decrypt them are not yet available.

--- a/neqo-transport/src/connection/state.rs
+++ b/neqo-transport/src/connection/state.rs
@@ -4,20 +4,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::Encoder;
-use std::cmp::{min, Ordering};
-use std::mem;
-use std::rc::Rc;
-use std::time::Instant;
-
-use crate::frame::{
-    FrameType, FRAME_TYPE_CONNECTION_CLOSE_APPLICATION, FRAME_TYPE_CONNECTION_CLOSE_TRANSPORT,
-    FRAME_TYPE_HANDSHAKE_DONE,
+use std::{
+    cmp::{min, Ordering},
+    mem,
+    rc::Rc,
+    time::Instant,
 };
-use crate::packet::PacketBuilder;
-use crate::path::PathRef;
-use crate::recovery::RecoveryToken;
-use crate::{ConnectionError, Error, Res};
+
+use neqo_common::Encoder;
+
+use crate::{
+    frame::{
+        FrameType, FRAME_TYPE_CONNECTION_CLOSE_APPLICATION, FRAME_TYPE_CONNECTION_CLOSE_TRANSPORT,
+        FRAME_TYPE_HANDSHAKE_DONE,
+    },
+    packet::PacketBuilder,
+    path::PathRef,
+    recovery::RecoveryToken,
+    ConnectionError, Error, Res,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// The state of the Connection.

--- a/neqo-transport/src/connection/tests/ackrate.rs
+++ b/neqo-transport/src/connection/tests/ackrate.rs
@@ -4,15 +4,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{mem, time::Duration};
+
+use test_fixture::{addr_v4, assertions};
+
 use super::{
     super::{ConnectionParameters, ACK_RATIO_SCALE},
     ack_bytes, connect_rtt_idle, default_client, default_server, fill_cwnd, increase_cwnd,
     induce_persistent_congestion, new_client, new_server, send_something, DEFAULT_RTT,
 };
 use crate::stream_id::StreamType;
-
-use std::{mem, time::Duration};
-use test_fixture::{addr_v4, assertions};
 
 /// With the default RTT here (100ms) and default ratio (4), endpoints won't send
 /// `ACK_FREQUENCY` as the ACK delay isn't different enough from the default.

--- a/neqo-transport/src/connection/tests/cc.rs
+++ b/neqo-transport/src/connection/tests/cc.rs
@@ -4,23 +4,23 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::super::Output;
-use super::{
-    ack_bytes, assert_full_cwnd, connect_rtt_idle, cwnd, cwnd_avail, cwnd_packets, default_client,
-    default_server, fill_cwnd, induce_persistent_congestion, send_something,
-    CLIENT_HANDSHAKE_1RTT_PACKETS, DEFAULT_RTT, POST_HANDSHAKE_CWND,
-};
-use crate::cc::MAX_DATAGRAM_SIZE;
-use crate::packet::PacketNumber;
-use crate::recovery::{ACK_ONLY_SIZE_LIMIT, PACKET_THRESHOLD};
-use crate::sender::PACING_BURST_SIZE;
-use crate::stream_id::StreamType;
-use crate::tracking::DEFAULT_ACK_PACKET_TOLERANCE;
+use std::{convert::TryFrom, mem, time::Duration};
 
 use neqo_common::{qdebug, qinfo, Datagram};
-use std::convert::TryFrom;
-use std::mem;
-use std::time::Duration;
+
+use super::{
+    super::Output, ack_bytes, assert_full_cwnd, connect_rtt_idle, cwnd, cwnd_avail, cwnd_packets,
+    default_client, default_server, fill_cwnd, induce_persistent_congestion, send_something,
+    CLIENT_HANDSHAKE_1RTT_PACKETS, DEFAULT_RTT, POST_HANDSHAKE_CWND,
+};
+use crate::{
+    cc::MAX_DATAGRAM_SIZE,
+    packet::PacketNumber,
+    recovery::{ACK_ONLY_SIZE_LIMIT, PACKET_THRESHOLD},
+    sender::PACING_BURST_SIZE,
+    stream_id::StreamType,
+    tracking::DEFAULT_ACK_PACKET_TOLERANCE,
+};
 
 #[test]
 /// Verify initial CWND is honored.

--- a/neqo-transport/src/connection/tests/close.rs
+++ b/neqo-transport/src/connection/tests/close.rs
@@ -4,13 +4,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::super::{Connection, Output, State};
-use super::{connect, connect_force_idle, default_client, default_server, send_something};
-use crate::tparams::{self, TransportParameter};
-use crate::{AppError, ConnectionError, Error, ERROR_APPLICATION_CLOSE};
-
 use std::time::Duration;
+
 use test_fixture::{self, datagram, now};
+
+use super::{
+    super::{Connection, Output, State},
+    connect, connect_force_idle, default_client, default_server, send_something,
+};
+use crate::{
+    tparams::{self, TransportParameter},
+    AppError, ConnectionError, Error, ERROR_APPLICATION_CLOSE,
+};
 
 fn assert_draining(c: &Connection, expected: &Error) {
     assert!(c.state().closed());

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -325,7 +325,7 @@ fn datagram_lost() {
     let pings_sent = client.stats().frame_tx.ping;
     let dgram_lost = client.stats().datagram_tx.lost;
     let out = client.process_output(now).dgram();
-    assert!(out.is_some()); //PING probing
+    assert!(out.is_some()); // PING probing
                             // Datagram is not sent again.
     assert_eq!(client.stats().frame_tx.ping, pings_sent + 1);
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent2);

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -4,21 +4,23 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{cell::RefCell, convert::TryFrom, rc::Rc};
+
+use neqo_common::event::Provider;
+use test_fixture::now;
+
 use super::{
     assert_error, connect_force_idle, default_client, default_server, new_client, new_server,
     AT_LEAST_PTO,
 };
-use crate::events::{ConnectionEvent, OutgoingDatagramOutcome};
-use crate::frame::FRAME_TYPE_DATAGRAM;
-use crate::packet::PacketBuilder;
-use crate::quic_datagrams::MAX_QUIC_DATAGRAM;
 use crate::{
+    events::{ConnectionEvent, OutgoingDatagramOutcome},
+    frame::FRAME_TYPE_DATAGRAM,
+    packet::PacketBuilder,
+    quic_datagrams::MAX_QUIC_DATAGRAM,
     send_stream::{RetransmissionPriority, TransmissionPriority},
     Connection, ConnectionError, ConnectionParameters, Error, StreamType,
 };
-use neqo_common::event::Provider;
-use std::{cell::RefCell, convert::TryFrom, rc::Rc};
-use test_fixture::now;
 
 const DATAGRAM_LEN_MTU: u64 = 1310;
 const DATA_MTU: &[u8] = &[1; 1310];

--- a/neqo-transport/src/connection/tests/fuzzing.rs
+++ b/neqo-transport/src/connection/tests/fuzzing.rs
@@ -8,10 +8,11 @@
 #![warn(clippy::pedantic)]
 #![cfg(feature = "fuzzing")]
 
-use super::{connect_force_idle, default_client, default_server};
-use crate::StreamType;
 use neqo_crypto::FIXED_TAG_FUZZING;
 use test_fixture::now;
+
+use super::{connect_force_idle, default_client, default_server};
+use crate::StreamType;
 
 #[test]
 fn no_encryption() {

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -4,34 +4,39 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::super::{Connection, Output, State};
-use super::{
-    assert_error, connect, connect_force_idle, connect_with_rtt, default_client, default_server,
-    get_tokens, handshake, maybe_authenticate, resumed_server, send_something,
-    CountingConnectionIdGenerator, AT_LEAST_PTO, DEFAULT_RTT, DEFAULT_STREAM_DATA,
-};
-use crate::connection::AddressValidation;
-use crate::events::ConnectionEvent;
-use crate::path::PATH_MTU_V6;
-use crate::server::ValidateAddress;
-use crate::tparams::{TransportParameter, MIN_ACK_DELAY};
-use crate::tracking::DEFAULT_ACK_DELAY;
-use crate::{
-    ConnectionError, ConnectionParameters, EmptyConnectionIdGenerator, Error, StreamType, Version,
+use std::{
+    cell::RefCell,
+    convert::TryFrom,
+    mem,
+    net::{IpAddr, Ipv6Addr, SocketAddr},
+    rc::Rc,
+    time::Duration,
 };
 
 use neqo_common::{event::Provider, qdebug, Datagram};
 use neqo_crypto::{
     constants::TLS_CHACHA20_POLY1305_SHA256, generate_ech_keys, AuthenticationStatus,
 };
-use std::cell::RefCell;
-use std::convert::TryFrom;
-use std::mem;
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
-use std::rc::Rc;
-use std::time::Duration;
-use test_fixture::assertions::assert_coalesced_0rtt;
-use test_fixture::{self, addr, assertions, datagram, fixture_init, now, split_datagram};
+use test_fixture::{
+    self, addr, assertions, assertions::assert_coalesced_0rtt, datagram, fixture_init, now,
+    split_datagram,
+};
+
+use super::{
+    super::{Connection, Output, State},
+    assert_error, connect, connect_force_idle, connect_with_rtt, default_client, default_server,
+    get_tokens, handshake, maybe_authenticate, resumed_server, send_something,
+    CountingConnectionIdGenerator, AT_LEAST_PTO, DEFAULT_RTT, DEFAULT_STREAM_DATA,
+};
+use crate::{
+    connection::AddressValidation,
+    events::ConnectionEvent,
+    path::PATH_MTU_V6,
+    server::ValidateAddress,
+    tparams::{TransportParameter, MIN_ACK_DELAY},
+    tracking::DEFAULT_ACK_DELAY,
+    ConnectionError, ConnectionParameters, EmptyConnectionIdGenerator, Error, StreamType, Version,
+};
 
 const ECH_CONFIG_ID: u8 = 7;
 const ECH_PUBLIC_NAME: &str = "public.example";

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -133,7 +133,7 @@ fn no_alpn() {
     handshake(&mut client, &mut server, now(), Duration::new(0, 0));
     // TODO (mt): errors are immediate, which means that we never send CONNECTION_CLOSE
     // and the client never sees the server's rejection of its handshake.
-    //assert_error(&client, ConnectionError::Transport(Error::CryptoAlert(120)));
+    // assert_error(&client, ConnectionError::Transport(Error::CryptoAlert(120)));
     assert_error(
         &server,
         &ConnectionError::Transport(Error::CryptoAlert(120)),

--- a/neqo-transport/src/connection/tests/keys.rs
+++ b/neqo-transport/src/connection/tests/keys.rs
@@ -4,19 +4,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::super::super::{ConnectionError, ERROR_AEAD_LIMIT_REACHED};
-use super::super::{Connection, ConnectionParameters, Error, Output, State, StreamType};
+use std::mem;
+
+use neqo_common::{qdebug, Datagram};
+use test_fixture::{self, now};
+
 use super::{
+    super::{
+        super::{ConnectionError, ERROR_AEAD_LIMIT_REACHED},
+        Connection, ConnectionParameters, Error, Output, State, StreamType,
+    },
     connect, connect_force_idle, default_client, default_server, maybe_authenticate,
     send_and_receive, send_something, AT_LEAST_PTO,
 };
-use crate::crypto::{OVERWRITE_INVOCATIONS, UPDATE_WRITE_KEYS_AT};
-use crate::packet::PacketNumber;
-use crate::path::PATH_MTU_V6;
-
-use neqo_common::{qdebug, Datagram};
-use std::mem;
-use test_fixture::{self, now};
+use crate::{
+    crypto::{OVERWRITE_INVOCATIONS, UPDATE_WRITE_KEYS_AT},
+    packet::PacketNumber,
+    path::PATH_MTU_V6,
+};
 
 fn check_discarded(
     peer: &mut Connection,

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -4,6 +4,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{
+    cell::RefCell,
+    net::{IpAddr, Ipv6Addr, SocketAddr},
+    rc::Rc,
+    time::{Duration, Instant},
+};
+
+use neqo_common::{Datagram, Decoder};
+use test_fixture::{
+    self, addr, addr_v4,
+    assertions::{assert_v4_path, assert_v6_path},
+    fixture_init, new_neqo_qlog, now,
+};
+
 use super::{
     super::{Connection, Output, State, StreamType},
     connect_fail, connect_force_idle, connect_rtt_idle, default_client, default_server,
@@ -18,19 +32,6 @@ use crate::{
     tparams::{self, PreferredAddress, TransportParameter},
     ConnectionError, ConnectionId, ConnectionIdDecoder, ConnectionIdGenerator, ConnectionIdRef,
     ConnectionParameters, EmptyConnectionIdGenerator, Error,
-};
-
-use neqo_common::{Datagram, Decoder};
-use std::{
-    cell::RefCell,
-    net::{IpAddr, Ipv6Addr, SocketAddr},
-    rc::Rc,
-    time::{Duration, Instant},
-};
-use test_fixture::{
-    self, addr, addr_v4,
-    assertions::{assert_v4_path, assert_v6_path},
-    fixture_init, new_neqo_qlog, now,
 };
 
 /// This should be a valid-seeming transport parameter.

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -6,6 +6,20 @@
 
 #![deny(clippy::pedantic)]
 
+use std::{
+    cell::RefCell,
+    cmp::min,
+    convert::TryFrom,
+    mem,
+    rc::Rc,
+    time::{Duration, Instant},
+};
+
+use enum_map::enum_map;
+use neqo_common::{event::Provider, qdebug, qtrace, Datagram, Decoder, Role};
+use neqo_crypto::{random, AllowZeroRtt, AuthenticationStatus, ResumptionToken};
+use test_fixture::{self, addr, fixture_init, new_neqo_qlog, now};
+
 use super::{Connection, ConnectionError, ConnectionId, Output, State};
 use crate::{
     addr_valid::{AddressValidation, ValidateAddress},
@@ -20,21 +34,6 @@ use crate::{
     ConnectionIdDecoder, ConnectionIdGenerator, ConnectionParameters, Error, StreamId, StreamType,
     Version,
 };
-
-use std::{
-    cell::RefCell,
-    cmp::min,
-    convert::TryFrom,
-    mem,
-    rc::Rc,
-    time::{Duration, Instant},
-};
-
-use neqo_common::{event::Provider, qdebug, qtrace, Datagram, Decoder, Role};
-use neqo_crypto::{random, AllowZeroRtt, AuthenticationStatus, ResumptionToken};
-use test_fixture::{self, addr, fixture_init, new_neqo_qlog, now};
-
-use enum_map::enum_map;
 
 // All the tests.
 mod ackrate;

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -404,7 +404,9 @@ fn increase_cwnd(
 }
 
 /// Receive multiple packets and generate an ack-only packet.
+///
 /// # Panics
+///
 /// The caller is responsible for ensuring that `dest` has received
 /// enough data that it wants to generate an ACK.  This panics if
 /// no ACK frame is generated.

--- a/neqo-transport/src/connection/tests/priority.rs
+++ b/neqo-transport/src/connection/tests/priority.rs
@@ -4,6 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{cell::RefCell, mem, rc::Rc};
+
+use neqo_common::event::Provider;
+use test_fixture::{self, now};
+
 use super::{
     super::{Connection, Error, Output},
     connect, default_client, default_server, fill_cwnd, maybe_authenticate,
@@ -13,10 +18,6 @@ use crate::{
     send_stream::{RetransmissionPriority, TransmissionPriority},
     ConnectionEvent, StreamId, StreamType,
 };
-
-use neqo_common::event::Provider;
-use std::{cell::RefCell, mem, rc::Rc};
-use test_fixture::{self, now};
 
 const BLOCK_SIZE: usize = 4_096;
 

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -4,6 +4,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{
+    mem,
+    time::{Duration, Instant},
+};
+
+use neqo_common::qdebug;
+use neqo_crypto::AuthenticationStatus;
+use test_fixture::{
+    assertions::{assert_handshake, assert_initial},
+    now, split_datagram,
+};
+
 use super::{
     super::{Connection, ConnectionParameters, Output, State},
     assert_full_cwnd, connect, connect_force_idle, connect_rtt_idle, connect_with_rtt, cwnd,
@@ -21,17 +33,6 @@ use crate::{
     tparams::TransportParameter,
     tracking::DEFAULT_ACK_DELAY,
     StreamType,
-};
-
-use neqo_common::qdebug;
-use neqo_crypto::AuthenticationStatus;
-use std::{
-    mem,
-    time::{Duration, Instant},
-};
-use test_fixture::{
-    assertions::{assert_handshake, assert_initial},
-    now, split_datagram,
 };
 
 #[test]

--- a/neqo-transport/src/connection/tests/resumption.rs
+++ b/neqo-transport/src/connection/tests/resumption.rs
@@ -4,18 +4,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{cell::RefCell, mem, rc::Rc, time::Duration};
+
+use test_fixture::{self, assertions, now};
+
 use super::{
     connect, connect_with_rtt, default_client, default_server, exchange_ticket, get_tokens,
     new_client, resumed_server, send_something, AT_LEAST_PTO,
 };
-use crate::addr_valid::{AddressValidation, ValidateAddress};
-use crate::{ConnectionParameters, Error, Version};
-
-use std::cell::RefCell;
-use std::mem;
-use std::rc::Rc;
-use std::time::Duration;
-use test_fixture::{self, assertions, now};
+use crate::{
+    addr_valid::{AddressValidation, ValidateAddress},
+    ConnectionParameters, Error, Version,
+};
 
 #[test]
 fn resume() {

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -4,6 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{cmp::max, collections::HashMap, convert::TryFrom, mem};
+
+use neqo_common::{event::Provider, qdebug};
+use test_fixture::now;
+
 use super::{
     super::State, assert_error, connect, connect_force_idle, default_client, default_server,
     maybe_authenticate, new_client, new_server, send_something, DEFAULT_STREAM_DATA,
@@ -22,11 +27,6 @@ use crate::{
     StreamId,
     StreamType,
 };
-use std::collections::HashMap;
-
-use neqo_common::{event::Provider, qdebug};
-use std::{cmp::max, convert::TryFrom, mem};
-use test_fixture::now;
 
 #[test]
 fn stream_create() {

--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -4,19 +4,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::super::{ConnectionError, ConnectionEvent, Output, State, ZeroRttState};
+use std::{mem, time::Duration};
+
+use neqo_common::{event::Provider, Decoder, Encoder};
+use test_fixture::{self, assertions, datagram, now};
+
 use super::{
+    super::{ConnectionError, ConnectionEvent, Output, State, ZeroRttState},
     connect, connect_fail, default_client, default_server, exchange_ticket, new_client, new_server,
     send_something,
 };
-use crate::packet::PACKET_BIT_LONG;
-use crate::tparams::{self, TransportParameter};
-use crate::{ConnectionParameters, Error, Version};
-
-use neqo_common::{event::Provider, Decoder, Encoder};
-use std::mem;
-use std::time::Duration;
-use test_fixture::{self, assertions, datagram, now};
+use crate::{
+    packet::PACKET_BIT_LONG,
+    tparams::{self, TransportParameter},
+    ConnectionParameters, Error, Version,
+};
 
 // The expected PTO duration after the first Initial is sent.
 const INITIAL_PTO: Duration = Duration::from_millis(300);
@@ -217,8 +219,8 @@ fn compatible_upgrade() {
     assert_eq!(server.version(), Version::Version2);
 }
 
-/// When the first packet from the client is gigantic, the server might generate acknowledgment packets in
-/// version 1.  Both client and server need to handle that gracefully.
+/// When the first packet from the client is gigantic, the server might generate acknowledgment
+/// packets in version 1.  Both client and server need to handle that gracefully.
 #[test]
 fn compatible_upgrade_large_initial() {
     let params = ConnectionParameters::default().versions(

--- a/neqo-transport/src/connection/tests/zerortt.rs
+++ b/neqo-transport/src/connection/tests/zerortt.rs
@@ -4,19 +4,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::super::Connection;
-use super::{
-    connect, default_client, default_server, exchange_ticket, new_server, resumed_server,
-    CountingConnectionIdGenerator,
-};
-use crate::events::ConnectionEvent;
-use crate::{ConnectionParameters, Error, StreamType, Version};
+use std::{cell::RefCell, rc::Rc};
 
 use neqo_common::event::Provider;
 use neqo_crypto::{AllowZeroRtt, AntiReplay};
-use std::cell::RefCell;
-use std::rc::Rc;
 use test_fixture::{self, assertions, now};
+
+use super::{
+    super::Connection, connect, default_client, default_server, exchange_ticket, new_server,
+    resumed_server, CountingConnectionIdGenerator,
+};
+use crate::{events::ConnectionEvent, ConnectionParameters, Error, StreamType, Version};
 
 #[test]
 fn zero_rtt_negotiate() {

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -16,7 +16,6 @@ use std::{
 };
 
 use neqo_common::{hex, hex_snip_middle, qdebug, qinfo, qtrace, Encoder, Role};
-
 use neqo_crypto::{
     hkdf, hp::HpKey, Aead, Agent, AntiReplay, Cipher, Epoch, Error as CryptoError, HandshakeState,
     PrivateKey, PublicKey, Record, RecordList, ResumptionToken, SymKey, ZeroRttChecker,
@@ -1542,8 +1541,8 @@ impl CryptoStreams {
             }
             // Calculate length of data based on the minimum of:
             // - available data
-            // - remaining space, less the header, which counts only one byte
-            //   for the length at first to avoid underestimating length
+            // - remaining space, less the header, which counts only one byte for the length at
+            //   first to avoid underestimating length
             let length = min(data.len(), builder.remaining() - header_len);
             header_len += Encoder::varint_len(u64::try_from(length).unwrap()) - 1;
             let length = min(data.len(), builder.remaining() - header_len);

--- a/neqo-transport/src/dump.rs
+++ b/neqo-transport/src/dump.rs
@@ -7,13 +7,16 @@
 // Enable just this file for logging to just see packets.
 // e.g. "RUST_LOG=neqo_transport::dump neqo-client ..."
 
-use crate::connection::Connection;
-use crate::frame::Frame;
-use crate::packet::{PacketNumber, PacketType};
-use crate::path::PathRef;
+use std::fmt::Write;
+
 use neqo_common::{qdebug, Decoder};
 
-use std::fmt::Write;
+use crate::{
+    connection::Connection,
+    frame::Frame,
+    packet::{PacketNumber, PacketType},
+    path::PathRef,
+};
 
 #[allow(clippy::module_name_repetitions)]
 pub fn dump_packet(

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -6,16 +6,17 @@
 
 // Collecting a list of events relevant to whoever is using the Connection.
 
-use std::cell::RefCell;
-use std::collections::VecDeque;
-use std::rc::Rc;
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
-use crate::connection::State;
-use crate::quic_datagrams::DatagramTracking;
-use crate::stream_id::{StreamId, StreamType};
-use crate::{AppError, Stats};
 use neqo_common::event::Provider as EventProvider;
 use neqo_crypto::ResumptionToken;
+
+use crate::{
+    connection::State,
+    quic_datagrams::DatagramTracking,
+    stream_id::{StreamId, StreamType},
+    AppError, Stats,
+};
 
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub enum OutgoingDatagramOutcome {

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -7,6 +7,14 @@
 // Tracks possibly-redundant flow control signals from other code and converts
 // into flow control frames needing to be sent to the remote.
 
+use std::{
+    convert::TryFrom,
+    fmt::Debug,
+    ops::{Deref, DerefMut, Index, IndexMut},
+};
+
+use neqo_common::{qtrace, Role};
+
 use crate::{
     frame::{
         FRAME_TYPE_DATA_BLOCKED, FRAME_TYPE_MAX_DATA, FRAME_TYPE_MAX_STREAMS_BIDI,
@@ -18,13 +26,6 @@ use crate::{
     stats::FrameStats,
     stream_id::{StreamId, StreamType},
     Error, Res,
-};
-use neqo_common::{qtrace, Role};
-
-use std::{
-    convert::TryFrom,
-    fmt::Debug,
-    ops::{Deref, DerefMut, Index, IndexMut},
 };
 
 #[derive(Debug)]
@@ -575,6 +576,8 @@ impl IndexMut<StreamType> for LocalStreamLimits {
 
 #[cfg(test)]
 mod test {
+    use neqo_common::{Encoder, Role};
+
     use super::{LocalStreamLimits, ReceiverFlowControl, RemoteStreamLimits, SenderFlowControl};
     use crate::{
         packet::PacketBuilder,
@@ -582,7 +585,6 @@ mod test {
         stream_id::{StreamId, StreamType},
         Error,
     };
-    use neqo_common::{Encoder, Role};
 
     #[test]
     fn blocked_at_zero() {

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -6,15 +6,16 @@
 
 // Directly relating to QUIC frames.
 
+use std::{convert::TryFrom, ops::RangeInclusive};
+
 use neqo_common::{qtrace, Decoder};
 
-use crate::cid::MAX_CONNECTION_ID_LEN;
-use crate::packet::PacketType;
-use crate::stream_id::{StreamId, StreamType};
-use crate::{AppError, ConnectionError, Error, Res, TransportError};
-
-use std::convert::TryFrom;
-use std::ops::RangeInclusive;
+use crate::{
+    cid::MAX_CONNECTION_ID_LEN,
+    packet::PacketType,
+    stream_id::{StreamId, StreamType},
+    AppError, ConnectionError, Error, Res, TransportError,
+};
 
 #[allow(clippy::module_name_repetitions)]
 pub type FrameType = u64;
@@ -612,8 +613,9 @@ impl<'a> Frame<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use neqo_common::{Decoder, Encoder};
+
+    use super::*;
 
     fn just_dec(f: &Frame, s: &str) {
         let encoded = Encoder::from_hex(s);

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -51,14 +51,11 @@ pub use self::{
     events::{ConnectionEvent, ConnectionEvents},
     frame::CloseError,
     quic_datagrams::DatagramTracking,
+    recv_stream::{RecvStreamStats, RECV_BUFFER_SIZE},
+    send_stream::{SendStreamStats, SEND_BUFFER_SIZE},
     stats::Stats,
     stream_id::{StreamId, StreamType},
     version::Version,
-};
-
-pub use self::{
-    recv_stream::{RecvStreamStats, RECV_BUFFER_SIZE},
-    send_stream::{SendStreamStats, SEND_BUFFER_SIZE},
 };
 
 pub type TransportError = u64;

--- a/neqo-transport/src/pace.rs
+++ b/neqo-transport/src/pace.rs
@@ -7,12 +7,14 @@
 // Pacer
 #![deny(clippy::pedantic)]
 
-use neqo_common::qtrace;
+use std::{
+    cmp::min,
+    convert::TryFrom,
+    fmt::{Debug, Display},
+    time::{Duration, Instant},
+};
 
-use std::cmp::min;
-use std::convert::TryFrom;
-use std::fmt::{Debug, Display};
-use std::time::{Duration, Instant};
+use neqo_common::qtrace;
 
 /// This value determines how much faster the pacer operates than the
 /// congestion window.
@@ -123,9 +125,11 @@ impl Debug for Pacer {
 
 #[cfg(test)]
 mod tests {
-    use super::Pacer;
     use std::time::Duration;
+
     use test_fixture::now;
+
+    use super::Pacer;
 
     const RTT: Duration = Duration::from_millis(1000);
     const PACKET: usize = 1000;

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -5,16 +5,6 @@
 // except according to those terms.
 
 // Encoding and decoding packets off the wire.
-use crate::{
-    cid::{ConnectionId, ConnectionIdDecoder, ConnectionIdRef, MAX_CONNECTION_ID_LEN},
-    crypto::{CryptoDxState, CryptoSpace, CryptoStates},
-    version::{Version, WireVersion},
-    Error, Res,
-};
-
-use neqo_common::{hex, hex_with_len, qtrace, qwarn, Decoder, Encoder};
-use neqo_crypto::random;
-
 use std::{
     cmp::min,
     convert::TryFrom,
@@ -22,6 +12,16 @@ use std::{
     iter::ExactSizeIterator,
     ops::{Deref, DerefMut, Range},
     time::Instant,
+};
+
+use neqo_common::{hex, hex_with_len, qtrace, qwarn, Decoder, Encoder};
+use neqo_crypto::random;
+
+use crate::{
+    cid::{ConnectionId, ConnectionIdDecoder, ConnectionIdRef, MAX_CONNECTION_ID_LEN},
+    crypto::{CryptoDxState, CryptoSpace, CryptoStates},
+    version::{Version, WireVersion},
+    Error, Res,
 };
 
 pub const PACKET_BIT_LONG: u8 = 0x80;
@@ -501,8 +501,8 @@ pub struct PublicPacket<'a> {
     dcid: ConnectionIdRef<'a>,
     /// The source connection ID, if this is a long header packet.
     scid: Option<ConnectionIdRef<'a>>,
-    /// Any token that is included in the packet (Retry always has a token; Initial sometimes does).
-    /// This is empty when there is no token.
+    /// Any token that is included in the packet (Retry always has a token; Initial sometimes
+    /// does). This is empty when there is no token.
     token: &'a [u8],
     /// The size of the header, not including the packet number.
     header_len: usize,
@@ -865,13 +865,14 @@ impl Deref for DecryptedPacket {
 
 #[cfg(all(test, not(feature = "fuzzing")))]
 mod tests {
+    use neqo_common::Encoder;
+    use test_fixture::{fixture_init, now};
+
     use super::*;
     use crate::{
         crypto::{CryptoDxState, CryptoStates},
         EmptyConnectionIdGenerator, RandomConnectionIdGenerator, Version,
     };
-    use neqo_common::Encoder;
-    use test_fixture::{fixture_init, now};
 
     const CLIENT_CID: &[u8] = &[0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08];
     const SERVER_CID: &[u8] = &[0xf0, 0x67, 0xa5, 0x50, 0x2a, 0x42, 0x62, 0xb5];
@@ -1023,7 +1024,8 @@ mod tests {
         assert_eq!(&decrypted[..], SAMPLE_SHORT_PAYLOAD);
     }
 
-    /// By telling the decoder that the connection ID is shorter than it really is, we get a decryption error.
+    /// By telling the decoder that the connection ID is shorter than it really is, we get a
+    /// decryption error.
     #[test]
     fn decode_short_bad_cid() {
         fixture_init();

--- a/neqo-transport/src/packet/retry.rs
+++ b/neqo-transport/src/packet/retry.rs
@@ -6,13 +6,12 @@
 
 #![deny(clippy::pedantic)]
 
-use crate::version::Version;
-use crate::{Error, Res};
+use std::cell::RefCell;
 
 use neqo_common::qerror;
 use neqo_crypto::{hkdf, Aead, TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3};
 
-use std::cell::RefCell;
+use crate::{version::Version, Error, Res};
 
 /// The AEAD used for Retry is fixed, so use thread local storage.
 fn make_aead(version: Version) -> Aead {

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -498,7 +498,7 @@ enum ProbeState {
 }
 
 impl ProbeState {
-    ///  Determine whether the current state requires probing.
+    /// Determine whether the current state requires probing.
     fn probe_needed(&self) -> bool {
         matches!(self, Self::ProbeNeeded { .. })
     }

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -17,6 +17,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+use neqo_common::{hex, qdebug, qinfo, qlog::NeqoQlog, qtrace, Datagram, Encoder, IpTos};
+use neqo_crypto::random;
+
 use crate::{
     ackrate::{AckRate, PeerAckDelay},
     cc::CongestionControlAlgorithm,
@@ -30,9 +33,6 @@ use crate::{
     tracking::{PacketNumberSpace, SentPacket},
     Error, Res, Stats,
 };
-
-use neqo_common::{hex, qdebug, qinfo, qlog::NeqoQlog, qtrace, Datagram, Encoder, IpTos};
-use neqo_crypto::random;
 
 /// This is the MTU that we assume when using IPv6.
 /// We use this size for Initial packets, so we don't need to worry about probing for support.
@@ -1008,7 +1008,8 @@ impl Path {
                 .map_or(usize::MAX, |limit| {
                     let budget = if limit == 0 {
                         // If we have received absolutely nothing thus far, then this endpoint
-                        // is the one initiating communication on this path.  Allow enough space for probing.
+                        // is the one initiating communication on this path.  Allow enough space for
+                        // probing.
                         self.mtu() * 5
                     } else {
                         limit

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -13,6 +13,7 @@ use std::{
     time::Duration,
 };
 
+use neqo_common::{hex, qinfo, qlog::NeqoQlog, Decoder};
 use qlog::events::{
     connectivity::{ConnectionStarted, ConnectionState, ConnectionStateUpdated},
     quic::{
@@ -21,8 +22,6 @@ use qlog::events::{
     },
     EventData, RawInfo,
 };
-
-use neqo_common::{hex, qinfo, qlog::NeqoQlog, Decoder};
 use smallvec::SmallVec;
 
 use crate::{

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -6,14 +6,17 @@
 
 // https://datatracker.ietf.org/doc/html/draft-ietf-quic-datagram
 
-use crate::frame::{FRAME_TYPE_DATAGRAM, FRAME_TYPE_DATAGRAM_WITH_LEN};
-use crate::packet::PacketBuilder;
-use crate::recovery::RecoveryToken;
-use crate::{events::OutgoingDatagramOutcome, ConnectionEvents, Error, Res, Stats};
+use std::{cmp::min, collections::VecDeque, convert::TryFrom};
+
 use neqo_common::Encoder;
-use std::cmp::min;
-use std::collections::VecDeque;
-use std::convert::TryFrom;
+
+use crate::{
+    events::OutgoingDatagramOutcome,
+    frame::{FRAME_TYPE_DATAGRAM, FRAME_TYPE_DATAGRAM_WITH_LEN},
+    packet::PacketBuilder,
+    recovery::RecoveryToken,
+    ConnectionEvents, Error, Res, Stats,
+};
 
 pub const MAX_QUIC_DATAGRAM: u64 = 65535;
 

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -143,7 +143,9 @@ impl QuicDatagrams {
     }
 
     /// Returns true if there was an unsent datagram that has been dismissed.
+    ///
     /// # Error
+    ///
     /// The function returns `TooMuchData` if the supply buffer is bigger than
     /// the allowed remote datagram size. The funcion does not check if the
     /// datagram can fit into a packet (i.e. MTU limit). This is checked during

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -17,9 +17,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use smallvec::{smallvec, SmallVec};
-
 use neqo_common::{qdebug, qinfo, qlog::NeqoQlog, qtrace, qwarn};
+use smallvec::{smallvec, SmallVec};
 
 use crate::{
     ackrate::AckRate,
@@ -526,9 +525,9 @@ impl PtoState {
     /// And the number to declare lost when the PTO timer is hit.
     fn pto_packet_count(space: PacketNumberSpace, rx_count: usize) -> usize {
         if space == PacketNumberSpace::Initial && rx_count == 0 {
-            // For the Initial space, we only send one packet on PTO if we have not received any packets
-            // from the peer yet. This avoids sending useless PING-only packets when the Client Initial
-            // is deemed lost.
+            // For the Initial space, we only send one packet on PTO if we have not received any
+            // packets from the peer yet. This avoids sending useless PING-only packets
+            // when the Client Initial is deemed lost.
             1
         } else {
             MAX_PTO_PACKET_COUNT
@@ -1017,6 +1016,17 @@ impl ::std::fmt::Display for LossRecovery {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        cell::RefCell,
+        convert::TryInto,
+        ops::{Deref, DerefMut, RangeInclusive},
+        rc::Rc,
+        time::{Duration, Instant},
+    };
+
+    use neqo_common::qlog::NeqoQlog;
+    use test_fixture::{addr, now};
+
     use super::{
         LossRecovery, LossRecoverySpace, PacketNumberSpace, SendProfile, SentPacket, FAST_PTO_SCALE,
     };
@@ -1028,15 +1038,6 @@ mod tests {
         rtt::RttEstimate,
         stats::{Stats, StatsCell},
     };
-    use neqo_common::qlog::NeqoQlog;
-    use std::{
-        cell::RefCell,
-        convert::TryInto,
-        ops::{Deref, DerefMut, RangeInclusive},
-        rc::Rc,
-        time::{Duration, Instant},
-    };
-    use test_fixture::{addr, now};
 
     // Shorthand for a time in milliseconds.
     const fn ms(t: u64) -> Duration {

--- a/neqo-transport/src/recovery.rs
+++ b/neqo-transport/src/recovery.rs
@@ -463,7 +463,9 @@ impl LossRecoverySpaces {
 
     /// Drop a packet number space and return all the packets that were
     /// outstanding, so that those can be marked as lost.
+    ///
     /// # Panics
+    ///
     /// If the space has already been removed.
     pub fn drop_space(&mut self, space: PacketNumberSpace) -> impl IntoIterator<Item = SentPacket> {
         let sp = match space {

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -8,6 +8,7 @@
 // incoming STREAM frames.
 
 use std::{
+    cell::RefCell,
     cmp::max,
     collections::BTreeMap,
     convert::TryFrom,
@@ -15,6 +16,7 @@ use std::{
     rc::{Rc, Weak},
 };
 
+use neqo_common::{qtrace, Role};
 use smallvec::SmallVec;
 
 use crate::{
@@ -28,8 +30,6 @@ use crate::{
     stream_id::StreamId,
     AppError, Error, Res,
 };
-use neqo_common::{qtrace, Role};
-use std::cell::RefCell;
 
 const RX_STREAM_DATA_WINDOW: u64 = 0x10_0000; // 1MiB
 
@@ -965,9 +965,11 @@ impl RecvStream {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use neqo_common::Encoder;
     use std::ops::Range;
+
+    use neqo_common::Encoder;
+
+    use super::*;
 
     const SESSION_WINDOW: usize = 1024;
 

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -768,6 +768,7 @@ impl RecvStream {
     }
 
     /// # Errors
+    ///
     /// `NoMoreData` if data and fin bit were previously read by the application.
     pub fn read(&mut self, buf: &mut [u8]) -> Res<(usize, bool)> {
         let data_recvd_state = matches!(self.state, RecvStreamState::DataRecvd { .. });

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -8,17 +8,21 @@
 
 #![deny(clippy::pedantic)]
 
-use std::cmp::{max, min};
-use std::time::{Duration, Instant};
+use std::{
+    cmp::{max, min},
+    time::{Duration, Instant},
+};
 
 use neqo_common::{qlog::NeqoQlog, qtrace};
 
-use crate::ackrate::{AckRate, PeerAckDelay};
-use crate::packet::PacketBuilder;
-use crate::qlog::{self, QlogMetric};
-use crate::recovery::RecoveryToken;
-use crate::stats::FrameStats;
-use crate::tracking::PacketNumberSpace;
+use crate::{
+    ackrate::{AckRate, PeerAckDelay},
+    packet::PacketBuilder,
+    qlog::{self, QlogMetric},
+    recovery::RecoveryToken,
+    stats::FrameStats,
+    tracking::PacketNumberSpace,
+};
 
 /// The smallest time that the system timer (via `sleep()`, `nanosleep()`,
 /// `select()`, or similar) can reliably deliver; see `neqo_common::hrtime`.

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1321,8 +1321,10 @@ impl OrderGroup {
 
     pub fn insert(&mut self, stream_id: StreamId) {
         match self.vec.binary_search(&stream_id) {
-            Ok(_) => panic!("Duplicate stream_id {}", stream_id), /* element already in vector @
-                                                                    * `pos` */
+            Ok(_) => {
+                // element already in vector @ `pos`
+                panic!("Duplicate stream_id {}", stream_id)
+            }
             Err(pos) => self.vec.insert(pos, stream_id),
         }
     }
@@ -1332,8 +1334,10 @@ impl OrderGroup {
             Ok(pos) => {
                 self.vec.remove(pos);
             }
-            Err(_) => panic!("Missing stream_id {}", stream_id), /* element already in vector @
-                                                                  * `pos` */
+            Err(_) => {
+                // element already in vector @ `pos`
+                panic!("Missing stream_id {}", stream_id)
+            }
         }
     }
 }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -11,16 +11,15 @@ use std::{
     cmp::{max, min, Ordering},
     collections::{BTreeMap, VecDeque},
     convert::TryFrom,
+    hash::{Hash, Hasher},
     mem,
     ops::Add,
     rc::Rc,
 };
 
 use indexmap::IndexMap;
-use smallvec::SmallVec;
-use std::hash::{Hash, Hasher};
-
 use neqo_common::{qdebug, qerror, qinfo, qtrace, Encoder, Role};
+use smallvec::SmallVec;
 
 use crate::{
     events::ConnectionEvents,
@@ -1280,7 +1279,8 @@ pub struct OrderGroupIter<'a> {
     // We store the next position in the OrderGroup.
     // Otherwise we'd need an explicit "done iterating" call to be made, or implement Drop to
     // copy the value back.
-    // This is where next was when we iterated for the first time; when we get back to that we stop.
+    // This is where next was when we iterated for the first time; when we get back to that we
+    // stop.
     started_at: Option<usize>,
 }
 
@@ -1321,7 +1321,8 @@ impl OrderGroup {
 
     pub fn insert(&mut self, stream_id: StreamId) {
         match self.vec.binary_search(&stream_id) {
-            Ok(_) => panic!("Duplicate stream_id {}", stream_id), // element already in vector @ `pos`
+            Ok(_) => panic!("Duplicate stream_id {}", stream_id), /* element already in vector @
+                                                                    * `pos` */
             Err(pos) => self.vec.insert(pos, stream_id),
         }
     }
@@ -1331,7 +1332,8 @@ impl OrderGroup {
             Ok(pos) => {
                 self.vec.remove(pos);
             }
-            Err(_) => panic!("Missing stream_id {}", stream_id), // element already in vector @ `pos`
+            Err(_) => panic!("Missing stream_id {}", stream_id), /* element already in vector @
+                                                                  * `pos` */
         }
     }
 }
@@ -1634,10 +1636,10 @@ pub struct SendStreamRecoveryToken {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use crate::events::ConnectionEvent;
     use neqo_common::{event::Provider, hex_with_len, qtrace};
+
+    use super::*;
+    use crate::events::ConnectionEvent;
 
     fn connection_fc(limit: u64) -> Rc<RefCell<SenderFlowControl<()>>> {
         Rc::new(RefCell::new(SenderFlowControl::new((), limit)))

--- a/neqo-transport/src/sender.rs
+++ b/neqo-transport/src/sender.rs
@@ -8,16 +8,19 @@
 #![deny(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
-use crate::cc::{
-    ClassicCongestionControl, CongestionControl, CongestionControlAlgorithm, Cubic, NewReno,
+use std::{
+    fmt::{self, Debug, Display},
+    time::{Duration, Instant},
 };
-use crate::pace::Pacer;
-use crate::rtt::RttEstimate;
-use crate::tracking::SentPacket;
+
 use neqo_common::qlog::NeqoQlog;
 
-use std::fmt::{self, Debug, Display};
-use std::time::{Duration, Instant};
+use crate::{
+    cc::{ClassicCongestionControl, CongestionControl, CongestionControlAlgorithm, Cubic, NewReno},
+    pace::Pacer,
+    rtt::RttEstimate,
+    tracking::SentPacket,
+};
 
 /// The number of packets we allow to burst from the pacer.
 pub const PACING_BURST_SIZE: usize = 2;

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -6,6 +6,18 @@
 
 // This file implements a server that can handle multiple connections.
 
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet, VecDeque},
+    fs::OpenOptions,
+    mem,
+    net::SocketAddr,
+    ops::{Deref, DerefMut},
+    path::PathBuf,
+    rc::{Rc, Weak},
+    time::{Duration, Instant},
+};
+
 use neqo_common::{
     self as common, event::Provider, hex, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn,
     timer::Timer, Datagram, Decoder, Role,
@@ -23,18 +35,6 @@ use crate::{
     connection::{Connection, Output, State},
     packet::{PacketBuilder, PacketType, PublicPacket},
     ConnectionParameters, Res, Version,
-};
-
-use std::{
-    cell::RefCell,
-    collections::{HashMap, HashSet, VecDeque},
-    fs::OpenOptions,
-    mem,
-    net::SocketAddr,
-    ops::{Deref, DerefMut},
-    path::PathBuf,
-    rc::{Rc, Weak},
-    time::{Duration, Instant},
 };
 
 pub enum InitialResult {
@@ -190,11 +190,11 @@ impl Server {
     /// * `certs` is a list of the certificates that should be configured.
     /// * `protocols` is the preference list of ALPN values.
     /// * `anti_replay` is an anti-replay context.
-    /// * `zero_rtt_checker` determines whether 0-RTT should be accepted. This
-    ///   will be passed the value of the `extra` argument that was passed to
-    ///   `Connection::send_ticket` to see if it is OK.
-    /// * `cid_generator` is responsible for generating connection IDs and parsing them;
-    ///   connection IDs produced by the manager cannot be zero-length.
+    /// * `zero_rtt_checker` determines whether 0-RTT should be accepted. This will be passed the
+    ///   value of the `extra` argument that was passed to `Connection::send_ticket` to see if it is
+    ///   OK.
+    /// * `cid_generator` is responsible for generating connection IDs and parsing them; connection
+    ///   IDs produced by the manager cannot be zero-length.
     pub fn new(
         now: Instant,
         certs: &[impl AsRef<str>],
@@ -615,7 +615,8 @@ impl Server {
                     qdebug!([self], "Drop initial: too short");
                     return None;
                 }
-                // Copy values from `packet` because they are currently still borrowing from `dgram`.
+                // Copy values from `packet` because they are currently still borrowing from
+                // `dgram`.
                 let initial = InitialDetails::new(&packet);
                 self.handle_initial(initial, dgram, now)
             }

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -7,8 +7,6 @@
 // Tracking of some useful statistics.
 #![deny(clippy::pedantic)]
 
-use crate::packet::PacketNumber;
-use neqo_common::qinfo;
 use std::{
     cell::RefCell,
     fmt::{self, Debug},
@@ -16,6 +14,10 @@ use std::{
     rc::Rc,
     time::Duration,
 };
+
+use neqo_common::qinfo;
+
+use crate::packet::PacketNumber;
 
 pub(crate) const MAX_PTO_COUNTS: usize = 16;
 

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -178,6 +178,7 @@ impl Stats {
     }
 
     /// # Panics
+    ///
     /// When preconditions are violated.
     pub fn add_pto_count(&mut self, count: usize) {
         debug_assert!(count > 0);

--- a/neqo-transport/src/stream_id.rs
+++ b/neqo-transport/src/stream_id.rs
@@ -133,8 +133,9 @@ impl ::std::fmt::Display for StreamId {
 
 #[cfg(test)]
 mod test {
-    use super::StreamId;
     use neqo_common::Role;
+
+    use super::StreamId;
 
     #[test]
     fn bidi_stream_properties() {

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -5,6 +5,10 @@
 // except according to those terms.
 
 // Stream management for a connection.
+use std::{cell::RefCell, cmp::Ordering, rc::Rc};
+
+use neqo_common::{qtrace, qwarn, Role};
+
 use crate::{
     fc::{LocalStreamLimits, ReceiverFlowControl, RemoteStreamLimits, SenderFlowControl},
     frame::Frame,
@@ -17,9 +21,6 @@ use crate::{
     tparams::{self, TransportParametersHandler},
     ConnectionEvents, Error, Res,
 };
-use neqo_common::{qtrace, qwarn, Role};
-use std::cmp::Ordering;
-use std::{cell::RefCell, rc::Rc};
 
 pub type SendOrder = i64;
 
@@ -438,9 +439,10 @@ impl Streams {
 
                 if st == StreamType::BiDi {
                     // From the local perspective, this is a local- originated BiDi stream. From the
-                    // remote perspective, this is a remote-originated BiDi stream. Therefore, look at
-                    // the local transport parameters for the INITIAL_MAX_STREAM_DATA_BIDI_LOCAL value
-                    // to decide how much this endpoint will allow its peer to send.
+                    // remote perspective, this is a remote-originated BiDi stream. Therefore, look
+                    // at the local transport parameters for the
+                    // INITIAL_MAX_STREAM_DATA_BIDI_LOCAL value to decide how
+                    // much this endpoint will allow its peer to send.
                     let recv_initial_max_stream_data = self
                         .tps
                         .borrow()

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -6,10 +6,12 @@
 
 // Transport parameters. See -transport section 7.3.
 
-use crate::{
-    cid::{ConnectionId, ConnectionIdEntry, CONNECTION_ID_SEQNO_PREFERRED, MAX_CONNECTION_ID_LEN},
-    version::{Version, VersionConfig, WireVersion},
-    Error, Res,
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    convert::TryFrom,
+    net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
+    rc::Rc,
 };
 
 use neqo_common::{hex, qdebug, qinfo, qtrace, Decoder, Encoder, Role};
@@ -19,12 +21,10 @@ use neqo_crypto::{
     random, HandshakeMessage, ZeroRttCheckResult, ZeroRttChecker,
 };
 
-use std::{
-    cell::RefCell,
-    collections::HashMap,
-    convert::TryFrom,
-    net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
-    rc::Rc,
+use crate::{
+    cid::{ConnectionId, ConnectionIdEntry, CONNECTION_ID_SEQNO_PREFERRED, MAX_CONNECTION_ID_LEN},
+    version::{Version, VersionConfig, WireVersion},
+    Error, Res,
 };
 
 pub type TransportParameterId = u64;
@@ -1023,7 +1023,8 @@ mod tests {
     fn active_connection_id_limit_min_2() {
         let mut tps = TransportParameters::default();
 
-        // Intentionally set an invalid value for the ACTIVE_CONNECTION_ID_LIMIT transport parameter.
+        // Intentionally set an invalid value for the ACTIVE_CONNECTION_ID_LIMIT transport
+        // parameter.
         tps.params
             .insert(ACTIVE_CONNECTION_ID_LIMIT, TransportParameter::Integer(1));
 

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -71,6 +71,7 @@ impl PreferredAddress {
     /// Make a new preferred address configuration.
     ///
     /// # Panics
+    ///
     /// If neither address is provided, or if either address is of the wrong type.
     #[must_use]
     pub fn new(v4: Option<SocketAddrV4>, v6: Option<SocketAddrV6>) -> Self {

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -18,6 +18,7 @@ use std::{
 
 use neqo_common::{qdebug, qinfo, qtrace, qwarn};
 use neqo_crypto::{Epoch, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL};
+use smallvec::{smallvec, SmallVec};
 
 use crate::{
     packet::{PacketBuilder, PacketNumber, PacketType},
@@ -25,8 +26,6 @@ use crate::{
     stats::FrameStats,
     Error, Res,
 };
-
-use smallvec::{smallvec, SmallVec};
 
 // TODO(mt) look at enabling EnumMap for this: https://stackoverflow.com/a/44905797/1375574
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
@@ -750,6 +749,11 @@ impl Default for AckTracker {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
+    use lazy_static::lazy_static;
+    use neqo_common::Encoder;
+
     use super::{
         AckTracker, Duration, Instant, PacketNumberSpace, PacketNumberSpaceSet, RecoveryToken,
         RecvdPackets, MAX_TRACKED_RANGES,
@@ -759,9 +763,6 @@ mod tests {
         packet::{PacketBuilder, PacketNumber},
         stats::FrameStats,
     };
-    use lazy_static::lazy_static;
-    use neqo_common::Encoder;
-    use std::collections::HashSet;
 
     const RTT: Duration = Duration::from_millis(100);
     lazy_static! {

--- a/neqo-transport/src/version.rs
+++ b/neqo-transport/src/version.rs
@@ -4,9 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{Error, Res};
-use neqo_common::qdebug;
 use std::convert::TryFrom;
+
+use neqo_common::qdebug;
+
+use crate::{Error, Res};
 
 pub type WireVersion = u32;
 

--- a/neqo-transport/tests/common/mod.rs
+++ b/neqo-transport/tests/common/mod.rs
@@ -8,6 +8,8 @@
 #![warn(clippy::pedantic)]
 #![allow(unused)]
 
+use std::{cell::RefCell, convert::TryFrom, mem, ops::Range, rc::Rc};
+
 use neqo_common::{event::Provider, hex_with_len, qtrace, Datagram, Decoder, Role};
 use neqo_crypto::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
@@ -20,12 +22,6 @@ use neqo_transport::{
     Connection, ConnectionEvent, ConnectionParameters, State,
 };
 use test_fixture::{self, default_client, now, CountingConnectionIdGenerator};
-
-use std::cell::RefCell;
-use std::convert::TryFrom;
-use std::mem;
-use std::ops::Range;
-use std::rc::Rc;
 
 /// Create a server.  This is different than the one in the fixture, which is a single connection.
 pub fn new_server(params: ConnectionParameters) -> Server {

--- a/neqo-transport/tests/conn_vectors.rs
+++ b/neqo-transport/tests/conn_vectors.rs
@@ -8,13 +8,12 @@
 #![deny(clippy::pedantic)]
 #![cfg(not(feature = "fuzzing"))]
 
+use std::{cell::RefCell, rc::Rc};
+
 use neqo_transport::{
     Connection, ConnectionParameters, RandomConnectionIdGenerator, State, Version,
 };
 use test_fixture::{self, datagram, now};
-
-use std::cell::RefCell;
-use std::rc::Rc;
 
 const INITIAL_PACKET_V2: &[u8] = &[
     0xd7, 0x6b, 0x33, 0x43, 0xcf, 0x08, 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08, 0x00, 0x00,

--- a/neqo-transport/tests/connection.rs
+++ b/neqo-transport/tests/connection.rs
@@ -9,12 +9,13 @@
 
 mod common;
 
+use std::convert::TryFrom;
+
 use common::{
     apply_header_protection, decode_initial_header, initial_aead_and_hp, remove_header_protection,
 };
 use neqo_common::{Datagram, Decoder, Encoder, Role};
 use neqo_transport::{ConnectionError, ConnectionParameters, Error, State, Version};
-use std::convert::TryFrom;
 use test_fixture::{self, default_client, default_server, new_client, now, split_datagram};
 
 #[test]

--- a/neqo-transport/tests/network.rs
+++ b/neqo-transport/tests/network.rs
@@ -9,14 +9,14 @@
 
 mod sim;
 
+use std::{ops::Range, time::Duration};
+
 use neqo_transport::{ConnectionError, ConnectionParameters, Error, State};
 use sim::{
     connection::{ConnectionNode, ReachState, ReceiveData, SendData},
     network::{Delay, Drop, TailDrop},
     Simulator,
 };
-use std::ops::Range;
-use std::time::Duration;
 
 /// The amount of transfer.  Much more than this takes a surprising amount of time.
 const TRANSFER_AMOUNT: usize = 1 << 20; // 1M

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -10,6 +10,13 @@
 
 mod common;
 
+use std::{
+    convert::TryFrom,
+    mem,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    time::Duration,
+};
+
 use common::{
     apply_header_protection, connected_server, decode_initial_header, default_server,
     generate_ticket, initial_aead_and_hp, remove_header_protection,
@@ -17,10 +24,6 @@ use common::{
 use neqo_common::{hex_with_len, qdebug, qtrace, Datagram, Encoder, Role};
 use neqo_crypto::AuthenticationStatus;
 use neqo_transport::{server::ValidateAddress, ConnectionError, Error, State, StreamType};
-use std::convert::TryFrom;
-use std::mem;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::time::Duration;
 use test_fixture::{self, assertions, datagram, default_client, now, split_datagram};
 
 #[test]

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -9,11 +9,12 @@
 
 mod common;
 
+use std::{cell::RefCell, convert::TryFrom, mem, net::SocketAddr, rc::Rc, time::Duration};
+
 use common::{
     apply_header_protection, connect, connected_server, decode_initial_header, default_server,
     find_ticket, generate_ticket, initial_aead_and_hp, new_server, remove_header_protection,
 };
-
 use neqo_common::{qtrace, Datagram, Decoder, Encoder, Role};
 use neqo_crypto::{
     generate_ech_keys, AllowZeroRtt, AuthenticationStatus, ZeroRttCheckResult, ZeroRttChecker,
@@ -26,8 +27,6 @@ use test_fixture::{
     self, assertions, datagram, default_client, new_client, now, split_datagram,
     CountingConnectionIdGenerator,
 };
-
-use std::{cell::RefCell, convert::TryFrom, mem, net::SocketAddr, rc::Rc, time::Duration};
 
 /// Take a pair of connections in any state and complete the handshake.
 /// The `datagram` argument is a packet that was received from the server.

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -31,7 +31,9 @@ use test_fixture::{
 /// Take a pair of connections in any state and complete the handshake.
 /// The `datagram` argument is a packet that was received from the server.
 /// See `connect` for what this returns.
+///
 /// # Panics
+///
 /// Only when the connection fails.
 pub fn complete_connection(
     client: &mut Connection,

--- a/neqo-transport/tests/sim/connection.rs
+++ b/neqo-transport/tests/sim/connection.rs
@@ -6,17 +6,19 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use super::{Node, Rng};
-use neqo_common::{event::Provider, qdebug, qtrace, Datagram};
-use neqo_crypto::AuthenticationStatus;
-use neqo_transport::{
-    Connection, ConnectionEvent, ConnectionParameters, Output, State, StreamId, StreamType,
-};
 use std::{
     cmp::min,
     fmt::{self, Debug},
     time::Instant,
 };
+
+use neqo_common::{event::Provider, qdebug, qtrace, Datagram};
+use neqo_crypto::AuthenticationStatus;
+use neqo_transport::{
+    Connection, ConnectionEvent, ConnectionParameters, Output, State, StreamId, StreamType,
+};
+
+use super::{Node, Rng};
 
 /// The status of the processing of an event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/neqo-transport/tests/sim/delay.rs
+++ b/neqo-transport/tests/sim/delay.rs
@@ -6,14 +6,18 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use super::{Node, Rng};
+use std::{
+    collections::BTreeMap,
+    convert::TryFrom,
+    fmt::{self, Debug},
+    ops::Range,
+    time::{Duration, Instant},
+};
+
 use neqo_common::Datagram;
 use neqo_transport::Output;
-use std::collections::BTreeMap;
-use std::convert::TryFrom;
-use std::fmt::{self, Debug};
-use std::ops::Range;
-use std::time::{Duration, Instant};
+
+use super::{Node, Rng};
 
 /// An iterator that shares a `Random` instance and produces uniformly
 /// random `Duration`s within a specified range.

--- a/neqo-transport/tests/sim/drop.rs
+++ b/neqo-transport/tests/sim/drop.rs
@@ -6,11 +6,15 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use super::{Node, Rng};
+use std::{
+    fmt::{self, Debug},
+    time::Instant,
+};
+
 use neqo_common::{qtrace, Datagram};
 use neqo_transport::Output;
-use std::fmt::{self, Debug};
-use std::time::Instant;
+
+use super::{Node, Rng};
 
 /// A random dropper.
 pub struct Drop {

--- a/neqo-transport/tests/sim/mod.rs
+++ b/neqo-transport/tests/sim/mod.rs
@@ -14,23 +14,23 @@ mod drop;
 pub mod rng;
 mod taildrop;
 
+use std::{
+    cell::RefCell,
+    cmp::min,
+    convert::TryFrom,
+    fmt::Debug,
+    rc::Rc,
+    time::{Duration, Instant},
+};
+
 use neqo_common::{qdebug, qinfo, qtrace, Datagram, Encoder};
 use neqo_transport::Output;
 use rng::Random;
-use std::cell::RefCell;
-use std::cmp::min;
-use std::convert::TryFrom;
-use std::fmt::Debug;
-use std::rc::Rc;
-use std::time::{Duration, Instant};
 use test_fixture::{self, now};
-
 use NodeState::{Active, Idle, Waiting};
 
 pub mod network {
-    pub use super::delay::Delay;
-    pub use super::drop::Drop;
-    pub use super::taildrop::TailDrop;
+    pub use super::{delay::Delay, drop::Drop, taildrop::TailDrop};
 }
 
 type Rng = Rc<RefCell<Random>>;

--- a/neqo-transport/tests/sim/rng.rs
+++ b/neqo-transport/tests/sim/rng.rs
@@ -4,9 +4,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{convert::TryFrom, ops::Range};
+
 use neqo_common::Decoder;
-use std::convert::TryFrom;
-use std::ops::Range;
 
 /// An implementation of a xoshiro256** pseudorandom generator.
 pub struct Random {

--- a/neqo-transport/tests/sim/taildrop.rs
+++ b/neqo-transport/tests/sim/taildrop.rs
@@ -6,14 +6,18 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use super::Node;
+use std::{
+    cmp::max,
+    collections::VecDeque,
+    convert::TryFrom,
+    fmt::{self, Debug},
+    time::{Duration, Instant},
+};
+
 use neqo_common::{qtrace, Datagram};
 use neqo_transport::Output;
-use std::cmp::max;
-use std::collections::VecDeque;
-use std::convert::TryFrom;
-use std::fmt::{self, Debug};
-use std::time::{Duration, Instant};
+
+use super::Node;
 
 /// One second in nanoseconds.
 const ONE_SECOND_NS: u128 = 1_000_000_000;

--- a/test-fixture/src/assertions.rs
+++ b/test-fixture/src/assertions.rs
@@ -35,7 +35,9 @@ fn assert_long_packet_type(b: u8, v1_expected: u8, version: Version) {
 }
 
 /// Simple checks for the version being correct.
+///
 /// # Panics
+///
 /// If this is not a long header packet with the given version.
 pub fn assert_version(payload: &[u8], v: u32) {
     let mut dec = Decoder::from(payload);
@@ -44,7 +46,9 @@ pub fn assert_version(payload: &[u8], v: u32) {
 }
 
 /// Simple checks for a Version Negotiation packet.
+///
 /// # Panics
+///
 /// If this is clearly not a Version Negotiation packet.
 pub fn assert_vn(payload: &[u8]) {
     let mut dec = Decoder::from(payload);
@@ -56,7 +60,9 @@ pub fn assert_vn(payload: &[u8]) {
 }
 
 /// Do a simple decode of the datagram to verify that it is coalesced.
+///
 /// # Panics
+///
 /// If the tests fail.
 pub fn assert_coalesced_0rtt(payload: &[u8]) {
     assert!(payload.len() >= 1200);
@@ -74,6 +80,7 @@ pub fn assert_coalesced_0rtt(payload: &[u8]) {
 }
 
 /// # Panics
+///
 /// If the tests fail.
 pub fn assert_retry(payload: &[u8]) {
     let mut dec = Decoder::from(payload);
@@ -83,7 +90,9 @@ pub fn assert_retry(payload: &[u8]) {
 }
 
 /// Assert that this is an Initial packet with (or without) a token.
+///
 /// # Panics
+///
 /// If the tests fail.
 pub fn assert_initial(payload: &[u8], expect_token: bool) {
     let mut dec = Decoder::from(payload);
@@ -97,7 +106,9 @@ pub fn assert_initial(payload: &[u8], expect_token: bool) {
 }
 
 /// Assert that this is a Handshake packet.
+///
 /// # Panics
+///
 /// If the tests fail.
 pub fn assert_handshake(payload: &[u8]) {
     let mut dec = Decoder::from(payload);
@@ -107,6 +118,7 @@ pub fn assert_handshake(payload: &[u8]) {
 }
 
 /// # Panics
+///
 /// If the tests fail.
 pub fn assert_no_1rtt(payload: &[u8]) {
     let mut dec = Decoder::from(payload);
@@ -138,6 +150,7 @@ pub fn assert_no_1rtt(payload: &[u8]) {
 }
 
 /// # Panics
+///
 /// When the path doesn't use the given socket address at both ends.
 pub fn assert_path(dgram: &Datagram, path_addr: SocketAddr) {
     assert_eq!(dgram.source(), path_addr);
@@ -145,6 +158,7 @@ pub fn assert_path(dgram: &Datagram, path_addr: SocketAddr) {
 }
 
 /// # Panics
+///
 /// When the path doesn't use the default v4 socket address at both ends.
 pub fn assert_v4_path(dgram: &Datagram, padded: bool) {
     assert_path(dgram, addr_v4());
@@ -154,6 +168,7 @@ pub fn assert_v4_path(dgram: &Datagram, padded: bool) {
 }
 
 /// # Panics
+///
 /// When the path doesn't use the default v6 socket address at both ends.
 pub fn assert_v6_path(dgram: &Datagram, padded: bool) {
     assert_path(dgram, addr());

--- a/test-fixture/src/assertions.rs
+++ b/test-fixture/src/assertions.rs
@@ -4,12 +4,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{addr, addr_v4};
+use std::{
+    convert::{TryFrom, TryInto},
+    net::SocketAddr,
+};
+
 use neqo_common::{Datagram, Decoder};
-use neqo_transport::version::WireVersion;
-use neqo_transport::Version;
-use std::convert::{TryFrom, TryInto};
-use std::net::SocketAddr;
+use neqo_transport::{version::WireVersion, Version};
+
+use crate::{addr, addr_v4};
 
 const PACKET_TYPE_MASK: u8 = 0b1011_0000;
 

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -7,22 +7,6 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(clippy::pedantic)]
 
-use neqo_common::{
-    event::Provider,
-    hex,
-    qlog::{new_trace, NeqoQlog},
-    qtrace, Datagram, Decoder, IpTos, Role,
-};
-
-use neqo_crypto::{init_db, random, AllowZeroRtt, AntiReplay, AuthenticationStatus};
-use neqo_http3::{Http3Client, Http3Parameters, Http3Server};
-use neqo_transport::{
-    version::WireVersion, Connection, ConnectionEvent, ConnectionId, ConnectionIdDecoder,
-    ConnectionIdGenerator, ConnectionIdRef, ConnectionParameters, State, Version,
-};
-
-use qlog::{events::EventImportance, streamer::QlogStreamer};
-
 use std::{
     cell::RefCell,
     cmp::max,
@@ -36,6 +20,19 @@ use std::{
 };
 
 use lazy_static::lazy_static;
+use neqo_common::{
+    event::Provider,
+    hex,
+    qlog::{new_trace, NeqoQlog},
+    qtrace, Datagram, Decoder, IpTos, Role,
+};
+use neqo_crypto::{init_db, random, AllowZeroRtt, AntiReplay, AuthenticationStatus};
+use neqo_http3::{Http3Client, Http3Parameters, Http3Server};
+use neqo_transport::{
+    version::WireVersion, Connection, ConnectionEvent, ConnectionId, ConnectionIdDecoder,
+    ConnectionIdGenerator, ConnectionIdRef, ConnectionParameters, State, Version,
+};
+use qlog::{events::EventImportance, streamer::QlogStreamer};
 
 pub mod assertions;
 

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -61,15 +61,19 @@ fn earlier() -> Instant {
 
 /// The current time for the test.  Which is in the future,
 /// because 0-RTT tests need to run at least `ANTI_REPLAY_WINDOW` in the past.
+///
 /// # Panics
+///
 /// When the setup fails.
 #[must_use]
 pub fn now() -> Instant {
     earlier().checked_add(ANTI_REPLAY_WINDOW).unwrap()
 }
 
-// Create a default anti-replay context.
+/// Create a default anti-replay context.
+///
 /// # Panics
+///
 /// When the setup fails.
 #[must_use]
 pub fn anti_replay() -> AntiReplay {
@@ -137,7 +141,9 @@ impl ConnectionIdGenerator for CountingConnectionIdGenerator {
 }
 
 /// Create a new client.
+///
 /// # Panics
+///
 /// If this doesn't work.
 #[must_use]
 pub fn new_client(params: ConnectionParameters) -> Connection {
@@ -176,7 +182,9 @@ pub fn default_server_h3() -> Connection {
 }
 
 /// Create a transport server with a configuration.
+///
 /// # Panics
+///
 /// If this doesn't work.
 #[must_use]
 pub fn new_server(alpn: &[impl AsRef<str>], params: ConnectionParameters) -> Connection {
@@ -226,6 +234,7 @@ pub fn handshake(client: &mut Connection, server: &mut Connection) {
 }
 
 /// # Panics
+///
 /// When the connection fails.
 #[must_use]
 pub fn connect() -> (Connection, Connection) {
@@ -238,7 +247,9 @@ pub fn connect() -> (Connection, Connection) {
 }
 
 /// Create a http3 client with default configuration.
+///
 /// # Panics
+///
 /// When the client can't be created.
 #[must_use]
 pub fn default_http3_client() -> Http3Client {
@@ -259,7 +270,9 @@ pub fn default_http3_client() -> Http3Client {
 }
 
 /// Create a http3 client.
+///
 /// # Panics
+///
 /// When the client can't be created.
 #[must_use]
 pub fn http3_client_with_params(params: Http3Parameters) -> Http3Client {
@@ -276,7 +289,9 @@ pub fn http3_client_with_params(params: Http3Parameters) -> Http3Client {
 }
 
 /// Create a http3 server with default configuration.
+///
 /// # Panics
+///
 /// When the server can't be created.
 #[must_use]
 pub fn default_http3_server() -> Http3Server {
@@ -363,7 +378,9 @@ impl ToString for SharedVec {
 /// Returns a pair of new enabled `NeqoQlog` that is backed by a [`Vec<u8>`]
 /// together with a [`Cursor<Vec<u8>>`] that can be used to read the contents of
 /// the log.
+///
 /// # Panics
+///
 /// Panics if the log cannot be created.
 #[must_use]
 pub fn new_neqo_qlog() -> (NeqoQlog, SharedVec) {


### PR DESCRIPTION
Some of the settings in `.rustfmt.toml` require the nightly toolchain, i.e, you need to `cargo +nightly fmt` to have them be used.

For VS Code, you can make is use the nightly `rustfmt` by default by adding
```
        "rust-analyzer.rustfmt.extraArgs": [
                "+nightly"
        ],
```
to your `settings.json` file.

Fixes #1417