### PR TITLE
ci: Further lower the RTT for the `idle_timeout_crazy_rtt` test

### DIFF
--- a/neqo-transport/tests/network.rs
+++ b/neqo-transport/tests/network.rs
@@ -67,7 +67,7 @@ simulate!(
                 )))
             ]
         ),
-        Delay::new(weeks(15)..weeks(15)),
+        Delay::new(weeks(6)..weeks(6)),
         Drop::percentage(10),
         ConnectionNode::new_server(
             ConnectionParameters::default().idle_timeout(weeks(1000)),
@@ -78,7 +78,7 @@ simulate!(
                 )))
             ]
         ),
-        Delay::new(weeks(10)..weeks(10)),
+        Delay::new(weeks(8)..weeks(8)),
         Drop::percentage(10),
     ],
 );


### PR DESCRIPTION
Since what we had before was still larger than our max. PTO, making deadlock more likely with 10% loss.