### PR TITLE
ci: Switch to rust nightly for CI canary

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,3 @@
+enabled: true
+titleOnly: true
+targetUrl: "https://www.conventionalcommits.org/en/v1.0.0/#summary"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -134,9 +134,11 @@ jobs:
           RUST_LOG: warn
 
       - name: Check formatting
-        run: cargo +${{ matrix.rust-toolchain }} fmt --all -- --check $CONFIG_PATH
-        env:
-          CONFIG_PATH: ${{ matrix.rust-toolchain != 'nightly' && '--config-path=$(mktemp)' || '' }}
+        run: |
+          if [ "${{ matrix.rust-toolchain }}" != "nightly" ]; then
+            export CONFIG_PATH="--config-path=$(mktemp)"
+          fi
+          cargo +${{ matrix.rust-toolchain }} fmt --all -- --check $CONFIG_PATH
         if: success() || failure()
 
       - name: Clippy

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -135,8 +135,9 @@ jobs:
 
       - name: Check formatting
         run: |
-          cargo +${{ matrix.rust-toolchain }} fmt --all -- --check \
-            ${{ matrix.rust-toolchain != 'nightly' && '--config-path=/dev/null' }}
+          cargo +${{ matrix.rust-toolchain }} fmt --all -- --check "$CONFIG_PATH"
+        env:
+          CONFIG_PATH: ${{ matrix.rust-toolchain != 'nightly' && '--config-path=/dev/null' || '' }}
         if: success() || failure()
 
       - name: Clippy

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Check formatting
         run: cargo +${{ matrix.rust-toolchain }} fmt --all -- --check $CONFIG_PATH
         env:
-          CONFIG_PATH: ${{ matrix.rust-toolchain != 'nightly' && '--config-path=/none' || '' }}
+          CONFIG_PATH: ${{ matrix.rust-toolchain != 'nightly' && '--config-path=$(mktemp)' || '' }}
         if: success() || failure()
 
       - name: Clippy

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Build
         run: |
-          cargo +${{ matrix.rust-toolchain }} build -v --all-targets
+          cargo +${{ matrix.rust-toolchain }} build --all-targets
           echo "LD_LIBRARY_PATH=${{ github.workspace }}/dist/Debug/lib" >> "$GITHUB_ENV"
           echo "DYLD_FALLBACK_LIBRARY_PATH=${{ github.workspace }}/dist/Debug/lib" >> "$GITHUB_ENV"
           echo "${{ github.workspace }}/dist/Debug/lib" >> "$GITHUB_PATH"
@@ -142,12 +142,12 @@ jobs:
         if: success() || failure()
 
       - name: Clippy
-        run: cargo +${{ matrix.rust-toolchain }} clippy -v --tests -- -D warnings
+        run: cargo +${{ matrix.rust-toolchain }} clippy --tests -- -D warnings
         if: success() || failure()
         continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
 
       - name: Check rustdoc links
-        run: cargo +${{ matrix.rust-toolchain }} doc --verbose --workspace --no-deps --document-private-items
+        run: cargo +${{ matrix.rust-toolchain }} doc --workspace --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: "--deny rustdoc::broken_intra_doc_links --deny warnings"
         if: success() || failure()

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Check formatting
         run: |
           cargo +${{ matrix.rust-toolchain }} fmt --all -- --check \
-            ${{ matrix.rust-toolchain != 'nightly' && --config-path=/dev/null }}
+            ${{ matrix.rust-toolchain != 'nightly' && '--config-path=/dev/null' }}
         if: success() || failure()
 
       - name: Clippy

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
-        rust-toolchain: [1.70.0, stable, beta]
+        rust-toolchain: [1.70.0, stable, nightly]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -134,13 +134,15 @@ jobs:
           RUST_LOG: warn
 
       - name: Check formatting
-        run: cargo +${{ matrix.rust-toolchain }} fmt --all -- --check
+        run: |
+          cargo +${{ matrix.rust-toolchain }} fmt --all -- --check \
+            ${{ matrix.rust-toolchain != 'nightly' && --config-path=/dev/null }}
         if: success() || failure()
 
       - name: Clippy
         run: cargo +${{ matrix.rust-toolchain }} clippy -v --tests -- -D warnings
         if: success() || failure()
-        continue-on-error: ${{ matrix.rust-toolchain == 'beta' }}
+        continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
 
       - name: Check rustdoc links
         run: cargo +${{ matrix.rust-toolchain }} doc --verbose --workspace --no-deps --document-private-items

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -134,8 +134,7 @@ jobs:
           RUST_LOG: warn
 
       - name: Check formatting
-        run: |
-          cargo +${{ matrix.rust-toolchain }} fmt --all -- --check "$CONFIG_PATH"
+        run: cargo +${{ matrix.rust-toolchain }} fmt --all -- --check $CONFIG_PATH
         env:
           CONFIG_PATH: ${{ matrix.rust-toolchain != 'nightly' && '--config-path=/dev/null' || '' }}
         if: success() || failure()

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Check formatting
         run: cargo +${{ matrix.rust-toolchain }} fmt --all -- --check $CONFIG_PATH
         env:
-          CONFIG_PATH: ${{ matrix.rust-toolchain != 'nightly' && '--config-path=/dev/null' || '' }}
+          CONFIG_PATH: ${{ matrix.rust-toolchain != 'nightly' && '--config-path=/none' || '' }}
         if: success() || failure()
 
       - name: Clippy

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -32,12 +32,20 @@ if [[ ./neqo-crypto/bindings/bindings.toml -nt ./neqo-crypto/src/lib.rs ]]; then
     exit 1
 fi
 
+toolchain=nightly
+fmtconfig="$root/.rustfmt.toml"
+if cargo "+$toolchain" version >/dev/null; then
+    echo "warning: A rust $toolchain toolchain is recommended to check formatting."
+    toolchain=stable
+    fmtconfig=/dev/null
+fi
+
 # Check formatting.
 trap 'git stash pop -q' EXIT
 git stash push -k -u -q -m "pre-commit stash"
-if ! errors=($(cargo fmt -- --check -l)); then
+if ! errors=($(cargo "+$toolchain" fmt -- --check -l --config-path="$fmtconfig")); then
     echo "Formatting errors found."
-    echo "Run \`cargo fmt\` to fix the following files:"
+    echo "Run \`cargo fmt +$toolchain\` to fix the following files:"
     for err in "${errors[@]}"; do
         echo "  $err"
     done

--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -29,8 +29,6 @@ use futures::{
     future::{select, select_all, Either},
     FutureExt,
 };
-use tokio::{net::UdpSocket, time::Sleep};
-
 use neqo_common::{hex, qdebug, qinfo, qwarn, Datagram, Header, IpTos};
 use neqo_crypto::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256},
@@ -45,6 +43,7 @@ use neqo_transport::{
     Version,
 };
 use structopt::StructOpt;
+use tokio::{net::UdpSocket, time::Sleep};
 
 use crate::old_https::Http09Server;
 


### PR DESCRIPTION
And fix the pre-commit hook to check using nightly.

This is because we now rely on rust nightly for some rustfmt configuration options.  This will make our canary builds a little more forward-looking which comes with a little less stability, but I think that's better than adding a specific build just for formatting.