### PR TITLE
rollback qlog to 0.9.0

### DIFF
--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -15,7 +15,7 @@ neqo-crypto = { path = "./../neqo-crypto" }
 neqo-http3 = { path = "./../neqo-http3" }
 neqo-qpack = { path = "./../neqo-qpack" }
 neqo-transport = { path = "./../neqo-transport" }
-qlog = "0.11.0"
+qlog = "0.9.0"
 structopt = "0.3"
 url = "~2.5.0"
 

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -12,7 +12,7 @@ enum-map = "2.7"
 env_logger = { version = "0.10", default-features = false }
 lazy_static = "1.4"
 log = { version = "0.4", default-features = false }
-qlog = "0.11.0"
+qlog = "0.9.0"
 time = {version = "0.3.23", features = ["formatting"]}
 
 [dev-dependencies]

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -14,7 +14,7 @@ neqo-common = { path = "./../neqo-common" }
 neqo-crypto = { path = "./../neqo-crypto" }
 neqo-qpack = { path = "./../neqo-qpack" }
 neqo-transport = { path = "./../neqo-transport" }
-qlog = "0.11.0"
+qlog = "0.9.0"
 sfv = "0.9.3"
 smallvec = "1.11.1"
 url = "2.5"

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -12,7 +12,7 @@ log = {version = "~0.4.17", default-features = false}
 neqo-common = { path = "./../neqo-common" }
 neqo-crypto = { path = "./../neqo-crypto" }
 neqo-transport = { path = "./../neqo-transport" }
-qlog = "0.11.0"
+qlog = "0.9.0"
 static_assertions = "~1.1.0"
 
 [dev-dependencies]

--- a/neqo-server/Cargo.toml
+++ b/neqo-server/Cargo.toml
@@ -14,7 +14,7 @@ neqo-crypto = { path = "./../neqo-crypto" }
 neqo-http3 = { path = "./../neqo-http3" }
 neqo-qpack = { path = "./../neqo-qpack" }
 neqo-transport = { path = "./../neqo-transport" }
-qlog = "0.11.0"
+qlog = "0.9.0"
 regex = "1.9"
 structopt = "0.3"
 tokio = { version = "1", features = ["net", "time", "macros", "rt", "rt-multi-thread"] }

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -12,7 +12,7 @@ lazy_static = "1.4"
 log = { version = "0.4.17", default-features = false }
 neqo-common = { path = "../neqo-common" }
 neqo-crypto = { path = "../neqo-crypto" }
-qlog = "0.11.0"
+qlog = "0.9.0"
 smallvec = "1.11.1"
 
 [dev-dependencies]

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1216,12 +1216,13 @@ impl Connection {
                 .get_versions_mut()
                 .set_initial(self.conn_params.get_versions().initial());
             mem::swap(self, &mut c);
-            qlog::client_version_information_negotiated(
+            // TODO: Uncomment this when we move qlog to 0.11.0
+            /*qlog::client_version_information_negotiated(
                 &mut self.qlog,
                 self.conn_params.get_versions().all(),
                 supported,
                 version,
-            );
+            );*/
             Ok(())
         } else {
             qinfo!([self], "Version negotiation: failed with {:?}", supported);
@@ -2328,7 +2329,8 @@ impl Connection {
         qinfo!([self], "client_start");
         debug_assert_eq!(self.role, Role::Client);
         qlog::client_connection_started(&mut self.qlog, &self.paths.primary());
-        qlog::client_version_information_initiated(&mut self.qlog, self.conn_params.get_versions());
+        // TODO: Uncomment this when we move qlog to 0.11.0
+        // qlog::client_version_information_initiated(&mut self.qlog, self.conn_params.get_versions());
 
         self.handshake(now, self.version, PacketNumberSpace::Initial, None)?;
         self.set_state(State::WaitInitial);

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -6,6 +6,9 @@
 
 // Functions that handle capturing QLOG traces.
 
+// TODO: Remove this when we move qlog to 0.11.0
+#![allow(dead_code)]
+
 use std::{
     convert::TryFrom,
     ops::{Deref, RangeInclusive},

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -196,7 +196,7 @@ pub fn packet_sent(
 ) {
     qlog.add_event_with_stream(|stream| {
         let mut d = Decoder::from(body);
-        let header = PacketHeader::with_type(to_qlog_pkt_type(pt), Some(pn), None, None, None);
+        let header = PacketHeader::with_type(to_qlog_pkt_type(pt), pn, None, None, None);
         let raw = RawInfo {
             length: Some(plen as u64),
             payload_length: None,
@@ -232,9 +232,10 @@ pub fn packet_sent(
 
 pub fn packet_dropped(qlog: &mut NeqoQlog, public_packet: &PublicPacket) {
     qlog.add_event_data(|| {
+        // TODO: packet number is optional in the spec but qlog crate doesn't support that, so use a placeholder value of 0
         let header = PacketHeader::with_type(
             to_qlog_pkt_type(public_packet.packet_type()),
-            None,
+            0,
             None,
             None,
             None,
@@ -261,7 +262,7 @@ pub fn packets_lost(qlog: &mut NeqoQlog, pkts: &[SentPacket]) {
     qlog.add_event_with_stream(|stream| {
         for pkt in pkts {
             let header =
-                PacketHeader::with_type(to_qlog_pkt_type(pkt.pt), Some(pkt.pn), None, None, None);
+                PacketHeader::with_type(to_qlog_pkt_type(pkt.pt), pkt.pn, None, None, None);
 
             let ev_data = EventData::PacketLost(PacketLost {
                 header: Some(header),
@@ -285,7 +286,7 @@ pub fn packet_received(
 
         let header = PacketHeader::with_type(
             to_qlog_pkt_type(public_packet.packet_type()),
-            Some(payload.pn()),
+            payload.pn(),
             None,
             None,
             None,

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -14,7 +14,7 @@ neqo-crypto = { path = "../neqo-crypto" }
 neqo-http3 = { path = "../neqo-http3" }
 neqo-qpack = { path = "../neqo-qpack" }
 neqo-transport = { path = "../neqo-transport" }
-qlog = "0.11.0"
+qlog = "0.9.0"
 
 [features]
 deny-warnings = []


### PR DESCRIPTION
Please see https://phabricator.services.mozilla.com/D200303#inline-1111249
I think we can use `qlog 0.9.0` temporarily  until this [PR](https://github.com/cloudflare/quiche/pull/1719) to be merged.