### PR TITLE
Range tracker benchmark

### DIFF
--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -34,3 +34,8 @@ required-features = ["bench"]
 name = "rx_stream_orderer"
 harness = false
 required-features = ["bench"]
+
+[[bench]]
+name = "range_tracker"
+harness = false
+required-features = ["bench"]

--- a/neqo-transport/benches/range_tracker.rs
+++ b/neqo-transport/benches/range_tracker.rs
@@ -1,0 +1,44 @@
+use criterion::{criterion_group, criterion_main, Criterion}; // black_box
+use neqo_transport::send_stream::{RangeState, RangeTracker};
+
+const CHUNK: u64 = 1000;
+const END: u64 = 100_000;
+fn build_coalesce(len: u64) -> RangeTracker {
+    let mut used = RangeTracker::default();
+    used.mark_range(0, CHUNK as usize, RangeState::Acked);
+    used.mark_range(CHUNK, END as usize, RangeState::Sent);
+    // leave a gap or it will coalesce here
+    for i in 2..=len {
+        // These do not get immediately coalesced when marking since they're not at the end or start
+        used.mark_range(i * CHUNK, CHUNK as usize, RangeState::Acked);
+    }
+    used
+}
+
+fn coalesce(c: &mut Criterion, count: u64) {
+    c.bench_function(
+        &format!("coalesce_acked_from_zero {count}+1 entries"),
+        |b| {
+            b.iter_batched_ref(
+                || build_coalesce(count),
+                |used| {
+                    used.mark_range(CHUNK, CHUNK as usize, RangeState::Acked);
+                    let tail = (count + 1) * CHUNK;
+                    used.mark_range(tail, CHUNK as usize, RangeState::Sent);
+                    used.mark_range(tail, CHUNK as usize, RangeState::Acked);
+                },
+                criterion::BatchSize::SmallInput,
+            )
+        },
+    );
+}
+
+fn benchmark_coalesce(c: &mut Criterion) {
+    coalesce(c, 1);
+    coalesce(c, 3);
+    coalesce(c, 10);
+    coalesce(c, 1000);
+}
+
+criterion_group!(benches, benchmark_coalesce);
+criterion_main!(benches);

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -30,6 +30,9 @@ pub mod recv_stream;
 #[cfg(not(feature = "bench"))]
 mod recv_stream;
 mod rtt;
+#[cfg(feature = "bench")]
+pub mod send_stream;
+#[cfg(not(feature = "bench"))]
 mod send_stream;
 mod sender;
 pub mod server;

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -135,8 +135,8 @@ impl Default for RetransmissionPriority {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
-enum RangeState {
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum RangeState {
     Sent,
     Acked,
 }
@@ -144,7 +144,7 @@ enum RangeState {
 /// Track ranges in the stream as sent or acked. Acked implies sent. Not in a
 /// range implies needing-to-be-sent, either initially or as a retransmission.
 #[derive(Debug, Default, PartialEq)]
-struct RangeTracker {
+pub struct RangeTracker {
     /// offset, (len, RangeState). Use u64 for len because ranges can exceed 32bits.
     used: BTreeMap<u64, (u64, RangeState)>,
     /// this is a cache for first_unmarked_range(), which we check a log
@@ -325,7 +325,7 @@ impl RangeTracker {
         }
     }
 
-    fn mark_range(&mut self, off: u64, len: usize, state: RangeState) {
+    pub fn mark_range(&mut self, off: u64, len: usize, state: RangeState) {
         if len == 0 {
             qinfo!("mark 0-length range at {}", off);
             return;


### PR DESCRIPTION
This is a version of #1592 that I think is better than alternatives.  It creates a single gap in the range tracker, then fills it.

I'm splitting this off #1594 so we can get a good baseline.

<details><summary>Preview of #1594 against main</summary>

There is some amount of variability, but this generally seems good to me.


```
coalesce_acked_from_zero 1+1 entries
                        time:   [74.649 ns 75.089 ns 75.792 ns]
                        change: [-51.264% -51.008% -50.698%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  5 (5.00%) high severe

coalesce_acked_from_zero 3+1 entries
                        time:   [103.37 ns 103.61 ns 103.88 ns]
                        change: [-47.846% -47.326% -46.435%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

coalesce_acked_from_zero 10+1 entries
                        time:   [103.04 ns 103.26 ns 103.50 ns]
                        change: [-73.240% -73.159% -73.073%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

coalesce_acked_from_zero 1000+1 entries
                        time:   [97.270 ns 98.279 ns 99.448 ns]
                        change: [-96.672% -96.646% -96.612%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) high mild
  6 (6.00%) high severe
```

</details>

Closes #1592.