### PR TITLE
Drop the logging level for STREAM frame writing

### DIFF
--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1620,16 +1620,16 @@ impl SendStreams {
 
         // Iterate the map, but only those without fairness, then iterate
         // OrderGroups, then iterate each group
-        qdebug!("processing streams...  unfair:");
+        qtrace!("processing streams...  unfair:");
         for stream in self.map.values_mut() {
             if !stream.is_fair() {
-                qdebug!("   {}", stream);
+                qtrace!("   {}", stream);
                 if !stream.write_frames_with_early_return(priority, builder, tokens, stats) {
                     break;
                 }
             }
         }
-        qdebug!("fair streams:");
+        qtrace!("fair streams:");
         let stream_ids = self.regular.iter().chain(
             self.sendordered
                 .values_mut()
@@ -1639,9 +1639,9 @@ impl SendStreams {
         for stream_id in stream_ids {
             let stream = self.map.get_mut(&stream_id).unwrap();
             if let Some(order) = stream.sendorder() {
-                qdebug!("   {} ({})", stream_id, order)
+                qtrace!("   {} ({})", stream_id, order)
             } else {
-                qdebug!("   None")
+                qtrace!("   None")
             }
             if !stream.write_frames_with_early_return(priority, builder, tokens, stats) {
                 break;


### PR DESCRIPTION
This is very verbose and it pollutes things like interop runner traces too much.