### PR TITLE
ci: Only upload coverage from stable debug builds to Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+# neqo has no test coverage for its example client, server and interop test
+ignore:
+  - "neqo-client"
+  - "neqo-interop"
+  - "neqo-server"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -164,3 +164,4 @@ jobs:
           file: lcov.info
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+        if: matrix.type == 'debug' && matrix.rust-toolchain == 'stable'


### PR DESCRIPTION
Eliminates some redundancy