### PR TITLE
chore: Drop patch versions from deps

### DIFF
--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -10,18 +10,19 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-clap = { version = "4.4.18", features = ["derive"] }
+# neqo-client is not used in Firefox, so we can be liberal with dependency versions
+clap = { version = "4.4", features = ["derive"] }
 futures = "0.3"
-hex = "0.4.3"
-log = { version = "0.4.17", default-features = false }
+hex = "0.4"
+log = { version = "0.4", default-features = false }
 neqo-common = { path = "./../neqo-common" }
 neqo-crypto = { path = "./../neqo-crypto" }
 neqo-http3 = { path = "./../neqo-http3" }
 neqo-qpack = { path = "./../neqo-qpack" }
 neqo-transport = { path = "./../neqo-transport" }
-qlog = "0.12.0"
+qlog = "0.12"
 tokio = { version = "1", features = ["net", "time", "macros", "rt", "rt-multi-thread"] }
-url = "~2.5.0"
+url = "2.5"
 
 [features]
 deny-warnings = []

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -10,12 +10,13 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
 enum-map = "2.7"
 env_logger = { version = "0.10", default-features = false }
 lazy_static = "1.4"
 log = { version = "0.4", default-features = false }
-qlog = "0.12.0"
-time = { version = "0.3.23", features = ["formatting"] }
+qlog = "0.12"
+time = { version = "0.3", features = ["formatting"] }
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-crypto/Cargo.toml
+++ b/neqo-crypto/Cargo.toml
@@ -10,15 +10,17 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-log = { version = "~0.4.17", default-features = false }
+# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
+log = { version = "0.4", default-features = false }
 neqo-common = { path = "../neqo-common" }
 
 [build-dependencies]
-bindgen = { version = "0.69.1", default-features = false, features = ["runtime"] }
+# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
+bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
 mozbuild = { version = "0.1", optional = true }
-serde = "1.0.195"
-serde_derive = "1.0.195"
-toml = "0.5.11"
+serde = "1.0"
+serde_derive = "1.0"
+toml = "0.5"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -9,16 +9,17 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-enumset = "1.1.2"
+# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
+enumset = "1.1"
 lazy_static = "1.4"
-log = { version = "0.4.17", default-features = false }
+log = { version = "0.4", default-features = false }
 neqo-common = { path = "./../neqo-common" }
 neqo-crypto = { path = "./../neqo-crypto" }
 neqo-qpack = { path = "./../neqo-qpack" }
 neqo-transport = { path = "./../neqo-transport" }
-qlog = "0.12.0"
-sfv = "0.9.3"
-smallvec = "1.11.1"
+qlog = "0.12"
+sfv = "0.9"
+smallvec = "1.11"
 url = "2.5"
 
 [dev-dependencies]

--- a/neqo-interop/Cargo.toml
+++ b/neqo-interop/Cargo.toml
@@ -10,7 +10,8 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-clap = { version = "4.4.18", features = ["derive"] }
+# neqo-interop is not used in Firefox, so we can be liberal with dependency versions
+clap = { version = "4.4", features = ["derive"] }
 lazy_static = "1.4"
 neqo-common = { path = "./../neqo-common" }
 neqo-crypto = { path = "./../neqo-crypto" }

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -9,13 +9,14 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-lazy_static = "~1.4.0"
-log = { version = "~0.4.17", default-features = false }
+# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
+lazy_static = "1.4"
+log = { version = "0.4", default-features = false }
 neqo-common = { path = "./../neqo-common" }
 neqo-crypto = { path = "./../neqo-crypto" }
 neqo-transport = { path = "./../neqo-transport" }
-qlog = "0.12.0"
-static_assertions = "~1.1.0"
+qlog = "0.12"
+static_assertions = "1.1"
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-server/Cargo.toml
+++ b/neqo-server/Cargo.toml
@@ -10,15 +10,16 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-clap = { version = "4.4.18", features = ["derive"] }
+# neqo-server is not used in Firefox, so we can be liberal with dependency versions
+clap = { version = "4.4", features = ["derive"] }
 futures = "0.3"
-log = { version = "0.4.17", default-features = false }
+log = { version = "0.4", default-features = false }
 neqo-common = { path = "./../neqo-common" }
 neqo-crypto = { path = "./../neqo-crypto" }
 neqo-http3 = { path = "./../neqo-http3" }
 neqo-qpack = { path = "./../neqo-qpack" }
 neqo-transport = { path = "./../neqo-transport" }
-qlog = "0.12.0"
+qlog = "0.12"
 regex = "1.9"
 tokio = { version = "1", features = ["net", "time", "macros", "rt", "rt-multi-thread"] }
 

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -9,16 +9,17 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-indexmap = "1.9.3"
+# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
+indexmap = "1.9"
 lazy_static = "1.4"
-log = { version = "0.4.17", default-features = false }
+log = { version = "0.4", default-features = false }
 neqo-common = { path = "../neqo-common" }
 neqo-crypto = { path = "../neqo-crypto" }
-qlog = "0.12.0"
-smallvec = "1.11.1"
+qlog = "0.12"
+smallvec = "1.11"
 
 [dev-dependencies]
-criterion = { version = "0.5.1", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 enum-map = "2.7"
 test-fixture = { path = "../test-fixture" }
 

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -9,14 +9,15 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
 lazy_static = "1.4"
-log = { version = "0.4.17", default-features = false }
+log = { version = "0.4", default-features = false }
 neqo-common = { path = "../neqo-common" }
 neqo-crypto = { path = "../neqo-crypto" }
 neqo-http3 = { path = "../neqo-http3" }
 neqo-qpack = { path = "../neqo-qpack" }
 neqo-transport = { path = "../neqo-transport" }
-qlog = "0.12.0"
+qlog = "0.12"
 
 [features]
 deny-warnings = []


### PR DESCRIPTION
And more clearly mark those needing to be in sync with Firefox.