### PR TITLE
chore: FF now using Rust 1.74.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
-        rust-toolchain: [1.70.0, stable, nightly]
+        # Don't increase beyond what Firefox is currently using:
+        # https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html#schedule
+        rust-toolchain: [1.74.0, stable, nightly]
         type: [debug]
         include:
           - os: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,7 @@ repository = "https://github.com/mozilla/neqo/"
 authors = ["The Neqo Authors <necko@mozilla.com>"]
 version = "0.7.0"
 edition = "2018"
-rust-version = "1.70.0"
 license = "MIT OR Apache-2.0"
+# Don't increase beyond what Firefox is currently using:
+# https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html#schedule
+rust-version = "1.74.0"

--- a/neqo-crypto/src/ech.rs
+++ b/neqo-crypto/src/ech.rs
@@ -113,7 +113,6 @@ pub fn generate_keys() -> Res<(PrivateKey, PublicKey)> {
 
     // If we have tracing on, try to ensure that key data can be read.
     let insensitive_secret_ptr = if log::log_enabled!(log::Level::Trace) {
-        #[allow(clippy::useless_conversion)] // TODO: Remove when we bump the MSRV to 1.74.0.
         unsafe {
             p11::PK11_GenerateKeyPairWithOpFlags(
                 *slot,
@@ -131,7 +130,6 @@ pub fn generate_keys() -> Res<(PrivateKey, PublicKey)> {
     };
     assert_eq!(insensitive_secret_ptr.is_null(), public_ptr.is_null());
     let secret_ptr = if insensitive_secret_ptr.is_null() {
-        #[allow(clippy::useless_conversion)] // TODO: Remove when we bump the MSRV to 1.74.0.
         unsafe {
             p11::PK11_GenerateKeyPairWithOpFlags(
                 *slot,

--- a/neqo-crypto/src/hkdf.rs
+++ b/neqo-crypto/src/hkdf.rs
@@ -70,7 +70,6 @@ pub fn import_key(version: Version, buf: &[u8]) -> Res<SymKey> {
         return Err(Error::UnsupportedVersion);
     }
     let slot = Slot::internal()?;
-    #[allow(clippy::useless_conversion)] // TODO: Remove when we bump the MSRV to 1.74.0.
     let key_ptr = unsafe {
         PK11_ImportDataKey(
             *slot,

--- a/neqo-crypto/src/hp.rs
+++ b/neqo-crypto/src/hp.rs
@@ -76,7 +76,6 @@ impl HpKey {
         let l = label.as_bytes();
         let mut secret: *mut PK11SymKey = null_mut();
 
-        #[allow(clippy::useless_conversion)] // TODO: Remove when we bump the MSRV to 1.74.0.
         let (mech, key_size) = match cipher {
             TLS_AES_128_GCM_SHA256 => (CK_MECHANISM_TYPE::from(CKM_AES_ECB), 16),
             TLS_AES_256_GCM_SHA384 => (CK_MECHANISM_TYPE::from(CKM_AES_ECB), 32),
@@ -104,8 +103,6 @@ impl HpKey {
 
         let res = match cipher {
             TLS_AES_128_GCM_SHA256 | TLS_AES_256_GCM_SHA384 => {
-                // TODO: Remove when we bump the MSRV to 1.74.0.
-                #[allow(clippy::useless_conversion)]
                 let context_ptr = unsafe {
                     PK11_CreateContextBySymKey(
                         mech,
@@ -181,8 +178,6 @@ impl HpKey {
                 };
                 let mut output_len: c_uint = 0;
                 let mut param_item = Item::wrap_struct(&params);
-                // TODO: Remove when we bump the MSRV to 1.74.0.
-                #[allow(clippy::useless_conversion)]
                 secstatus_to_res(unsafe {
                     PK11_Encrypt(
                         **key,

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -139,7 +139,6 @@ impl PrivateKey {
     /// When the values are too large to fit.  So never.
     pub fn key_data(&self) -> Res<Vec<u8>> {
         let mut key_item = Item::make_empty();
-        #[allow(clippy::useless_conversion)] // TODO: Remove when we bump the MSRV to 1.74.0.
         secstatus_to_res(unsafe {
             PK11_ReadRawAttribute(
                 PK11ObjectType::PK11_TypePrivKey,

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1578,7 +1578,6 @@ impl Connection {
     /// During connection setup, the first path needs to be setup.
     /// This uses the connection IDs that were provided during the handshake
     /// to setup that path.
-    #[allow(clippy::or_fun_call)] // Remove when MSRV >= 1.59
     fn setup_handshake_path(&mut self, path: &PathRef, now: Instant) {
         self.paths.make_permanent(
             path,


### PR DESCRIPTION
This should address the CI build errors with `clap`. Also remove some clippy allows.