### PR TITLE
ci: Benchmark without a qlog

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -81,13 +81,12 @@ jobs:
             nice -n -20 taskset -c 0 \
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
               --bin neqo-server -- --db ../test-fixture/db $HOST:4433 || true; } &
-          PID=$!
           mkdir client; \
             cd client; \
             time nice -n -20 taskset -c 1 \
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
               --bin neqo-client -- --output-dir . https://$HOST:4433/$SIZE
-          kill -INT $PID
+          killall -INT neqo-server
           cd ${{ github.workspace }}
           [ "$(wc -c < client/"$SIZE")" -eq "$SIZE" ] || exit 1
         env:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -61,29 +61,29 @@ jobs:
           echo "PERF_CMD=record -o perf.data -F997 --call-graph dwarf,16384 -g" >> "$GITHUB_ENV"
 
       # Pin the benchmark run to core 0 and run all benchmarks at elevated priority.
-      # - name: Benchmark
-      #   run: |
-      #     nice -n -20 taskset -c 0 \
-      #       cargo +$TOOLCHAIN bench --features bench | tee output.txt
+      - name: Benchmark
+        run: |
+          taskset -c 0 nice -n -20 \
+            cargo +$TOOLCHAIN bench --features bench | tee output.txt
 
       # Pin the transfer benchmark to core 0 and run it at elevated priority inside perf.
       # Work around https://github.com/flamegraph-rs/flamegraph/issues/248 by passing explicit perf arguments.
-      # - name: Perf transfer benchmark
-      #   run: |
-      #     nice -n -20 taskset -c 0 \
-      #       cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" --features bench --bench transfer -- \
-      #         --bench --exact "Run multiple transfers with varying seeds"
+      - name: Perf transfer benchmark
+        run: |
+          taskset -c 0 nice -n -20 \
+            cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" --features bench --bench transfer -- \
+              --bench --exact "Run multiple transfers with varying seeds"
 
       - name: Benchmark a client/server transfer
         run: |
           { mkdir server; \
             cd server; \
-            nice -n -20 taskset -c 0 \
+            taskset -c 0 nice -n -20 \
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
               --bin neqo-server -- --db ../test-fixture/db $HOST:4433 || true; } &
           mkdir client; \
             cd client; \
-            time nice -n -20 taskset -c 1 \
+            time taskset -c 1 nice -n -20 \
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
               --bin neqo-client -- --output-dir . https://$HOST:4433/$SIZE
           killall -INT neqo-server
@@ -91,7 +91,7 @@ jobs:
           [ "$(wc -c < client/"$SIZE")" -eq "$SIZE" ] || exit 1
         env:
           HOST: localhost
-          SIZE: 256000000
+          SIZE: 536870912 # 512 MB
 
       # Re-enable turboboost, hyperthreading and use powersave governor.
       - name: Restore machine
@@ -119,11 +119,11 @@ jobs:
 
       - name: Convert for profiler.firefox.com
         run: |
-          # perf script -i perf.data -F +pid > transfer.perf &
+          perf script -i perf.data -F +pid > transfer.perf &
           perf script -i client/perf.data -F +pid > client.perf &
           perf script -i server/perf.data -F +pid > server.perf &
           wait
-          # mv flamegraph.svg transfer.svg
+          mv flamegraph.svg transfer.svg
           mv client/flamegraph.svg client.svg
           mv server/flamegraph.svg server.svg
           rm neqo.svg

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -82,17 +82,21 @@ jobs:
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
               --bin neqo-server -- --db ../test-fixture/db $HOST:4433 &
           PID=$!
+          ps -ef
+          echo $PID
           mkdir client && \
             cd client && \
             time nice -n -20 taskset -c 1 \
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
               --bin neqo-client -- --output-dir . https://$HOST:4433/$SIZE
+          ps -ef
           kill -INT $PID
+          ps -ef
           cd ${{ github.workspace }}
           [ "$(wc -c < client/"$SIZE")" -eq "$SIZE" ] || exit 1
         env:
           HOST: localhost
-          SIZE: 87654321
+          SIZE: 256000000
 
       # Re-enable turboboost, hyperthreading and use powersave governor.
       - name: Restore machine

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,5 @@
 name: Bench
 on:
-  push:
-  pull_request:
   workflow_call:
 env:
   CARGO_PROFILE_BENCH_BUILD_OVERRIDE_DEBUG: true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -54,6 +54,18 @@ jobs:
           cargo +$TOOLCHAIN build --release --bin neqo-client --bin neqo-server
           echo "LD_LIBRARY_PATH=${{ github.workspace }}/dist/Debug/lib" >> "$GITHUB_ENV"
 
+      - name: Download criterion results
+        uses: actions/cache/restore@v4
+        with:
+          path: ./target/criterion
+          key: neqo-${{ runner.os }}-main-criterion
+
+      - name: Download github-action-benchmark results
+        uses: actions/cache/restore@v4
+        with:
+          path: ./cache
+          key: neqo-${{ runner.os }}-main-github-action-benchmark
+
       # Disable turboboost, hyperthreading and use performance governor.
       - name: Prepare machine
         run: |
@@ -98,12 +110,6 @@ jobs:
         run: sudo /root/bin/unprep.sh
         if: success() || failure() || cancelled()
 
-      - name: Download previous benchmark results
-        uses: actions/cache@v4
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
-
       # TODO: Wait for this action to be allowlisted. And then figure out how to only upload
       # benchmark data when the main branch is being updated (e.g., if: ${{ github.ref == "refs/heads/main" }})
       # - name: Store current benchmark results
@@ -127,6 +133,21 @@ jobs:
           mv client/flamegraph.svg client.svg
           mv server/flamegraph.svg server.svg
           rm neqo.svg
+
+      - name: Upload criterion results
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: ./target/criterion
+          key: neqo-${{ runner.os }}-main-criterion
+
+      - name: Upload github-action-benchmark results
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: ./cache
+          key: neqo-${{ runner.os }}-main-github-action-benchmark
+
 
       - name: Archive perf data
         uses: actions/upload-artifact@v4

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Build
         run: |
           cargo +$TOOLCHAIN bench --features bench --no-run
-          echo "LD_LIBRARY_PATH=${{ github.workspace }}/dist/Debug/lib" >> "$GITHUB_ENV"
+          cargo +$TOOLCHAIN build --release --bin neqo-client --bin neqo-server
+          echo "LD_LIBRARY_PATH=${{ github.workspace }}/dist/Release/lib" >> "$GITHUB_ENV"
 
       # Disable turboboost, hyperthreading and use performance governor.
       - name: Prepare machine
@@ -74,7 +75,6 @@ jobs:
 
       - name: Benchmark a client/server transfer
         run: |
-          cargo +$TOOLCHAIN build --profile bench --features bench --bin neqo-client --bin neqo-server
           mkdir server && \
             cd server && \
             nice -n -20 taskset -c 0 \
@@ -118,13 +118,13 @@ jobs:
 
       - name: Convert for profiler.firefox.com
         run: |
+          perf script -i perf.data -F +pid > transfer.perf &
+          perf script -i client/perf.data -F +pid > client.perf &
+          perf script -i server/perf.data -F +pid > server.perf &
+          wait
           mv flamegraph.svg transfer.svg
           mv client/flamegraph.svg client.svg
           mv server/flamegraph.svg server.svg
-          mv perf.data transfer.perf && perf script -i transfer.perf -F +pid > transfer.firefox.perf &
-          mv client/perf.data client.perf && perf script -i client.perf -F +pid > client.firefox.perf &
-          mv server/perf.data server.perf && perf script -i server.perf -F +pid > server.firefox.perf &
-          wait
           rm neqo.svg
 
       - name: Archive perf data

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,6 +5,7 @@ on:
   workflow_call:
 env:
   CARGO_PROFILE_BENCH_BUILD_OVERRIDE_DEBUG: true
+  CARGO_PROFILE_RELEASE_DEBUG: true
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   TOOLCHAIN: nightly
@@ -51,7 +52,7 @@ jobs:
         run: |
           cargo +$TOOLCHAIN bench --features bench --no-run
           cargo +$TOOLCHAIN build --release --bin neqo-client --bin neqo-server
-          echo "LD_LIBRARY_PATH=${{ github.workspace }}/dist/Release/lib" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=${{ github.workspace }}/dist/Debug/lib" >> "$GITHUB_ENV"
 
       # Disable turboboost, hyperthreading and use performance governor.
       - name: Prepare machine

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -76,11 +76,11 @@ jobs:
 
       - name: Benchmark a client/server transfer
         run: |
-          mkdir server && \
+          { mkdir server && \
             cd server && \
             nice -n -20 taskset -c 0 \
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
-              --bin neqo-server -- --db ../test-fixture/db $HOST:4433 &
+              --bin neqo-server -- --db ../test-fixture/db $HOST:4433 ; } &
           PID=$!
           ps -ef
           echo $PID
@@ -92,6 +92,7 @@ jobs:
           ps -ef
           kill -INT $PID
           ps -ef
+          fg $PID
           cd ${{ github.workspace }}
           [ "$(wc -c < client/"$SIZE")" -eq "$SIZE" ] || exit 1
         env:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,5 @@
 name: Bench
 on:
-  push:
-  pull_request:
   workflow_call:
 env:
   CARGO_PROFILE_BENCH_BUILD_OVERRIDE_DEBUG: true
@@ -73,20 +71,20 @@ jobs:
           echo "PERF_CMD=record -o perf.data -F997 --call-graph dwarf,16384 -g" >> "$GITHUB_ENV"
 
       # Pin the benchmark run to core 0 and run all benchmarks at elevated priority.
-      - name: Benchmark
+      - name: Run cargo bench
         run: |
           taskset -c 0 nice -n -20 \
             cargo +$TOOLCHAIN bench --features bench | tee output.txt
 
       # Pin the transfer benchmark to core 0 and run it at elevated priority inside perf.
       # Work around https://github.com/flamegraph-rs/flamegraph/issues/248 by passing explicit perf arguments.
-      - name: Perf transfer benchmark
+      - name: Profile cargo bench transfer
         run: |
           taskset -c 0 nice -n -20 \
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" --features bench --bench transfer -- \
               --bench --exact "Run multiple transfers with varying seeds"
 
-      - name: Benchmark a client/server transfer
+      - name: Profile client/server transfer
         run: |
           { mkdir server; \
             cd server; \
@@ -103,7 +101,7 @@ jobs:
           [ "$(wc -c < client/"$SIZE")" -eq "$SIZE" ] || exit 1
         env:
           HOST: localhost
-          SIZE: 536870912 # 512 MB
+          SIZE: 1073741824 # 1 GB
 
       # Re-enable turboboost, hyperthreading and use powersave governor.
       - name: Restore machine
@@ -147,7 +145,6 @@ jobs:
         with:
           path: ./cache
           key: neqo-${{ runner.os }}-main-github-action-benchmark
-
 
       - name: Archive perf data
         uses: actions/upload-artifact@v4

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,5 +1,7 @@
 name: Bench
 on:
+  push:
+  pull_request:
   workflow_call:
 env:
   CARGO_PROFILE_BENCH_BUILD_OVERRIDE_DEBUG: true
@@ -52,7 +54,9 @@ jobs:
 
       # Disable turboboost, hyperthreading and use performance governor.
       - name: Prepare machine
-        run: sudo /root/bin/prep.sh
+        run: |
+          sudo /root/bin/prep.sh
+          echo 'PERF_CMD="record -o perf.data -F997 --call-graph dwarf,16384 -g"' >> "$GITHUB_ENV"
 
       # Pin the benchmark run to core 0 and run all benchmarks at elevated priority.
       - name: Benchmark
@@ -65,8 +69,24 @@ jobs:
       - name: Perf transfer benchmark
         run: |
           nice -n -20 taskset -c 0 \
-            cargo +$TOOLCHAIN flamegraph -v -c "record -o perf.data -F997 --call-graph dwarf,16384 -g" --features bench --bench transfer -- \
+            cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" --features bench --bench transfer -- \
               --bench --exact "Run multiple transfers with varying seeds"
+
+      - name: Benchmark a client/server transfer
+        run: |
+          cargo +$TOOLCHAIN build --profile bench --features bench --bin neqo-client --bin neqo-server
+          mkdir server && \
+            cd server && \
+            cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" --bin neqo-server -- $HOST:4433 &
+          PID=$!
+          mkdir client && \
+            cd client && \
+            cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" --bin neqo-client -- --output-dir . https://$HOST:4433/$SIZE
+          kill $PID
+          [ "$(wc -c <"$SIZE")" -eq "$SIZE" ] || exit 1
+        env:
+          HOST: localhost
+          SIZE: 7654321
 
       # Re-enable turboboost, hyperthreading and use powersave governor.
       - name: Restore machine

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -80,7 +80,7 @@ jobs:
             cd server && \
             nice -n -20 taskset -c 0 \
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
-              --bin neqo-server -- $HOST:4433 &
+              --bin neqo-server -- --db ../test-fixture/db $HOST:4433 &
           PID=$!
           mkdir client && \
             cd client && \
@@ -96,7 +96,7 @@ jobs:
       # Re-enable turboboost, hyperthreading and use powersave governor.
       - name: Restore machine
         run: sudo /root/bin/unprep.sh
-        if: success() || failure()
+        if: success() || failure() || cancelled()
 
       - name: Download previous benchmark results
         uses: actions/cache@v4

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -61,18 +61,18 @@ jobs:
           echo "PERF_CMD=record -o perf.data -F997 --call-graph dwarf,16384 -g" >> "$GITHUB_ENV"
 
       # Pin the benchmark run to core 0 and run all benchmarks at elevated priority.
-      - name: Benchmark
-        run: |
-          nice -n -20 taskset -c 0 \
-            cargo +$TOOLCHAIN bench --features bench | tee output.txt
+      # - name: Benchmark
+      #   run: |
+      #     nice -n -20 taskset -c 0 \
+      #       cargo +$TOOLCHAIN bench --features bench | tee output.txt
 
       # Pin the transfer benchmark to core 0 and run it at elevated priority inside perf.
       # Work around https://github.com/flamegraph-rs/flamegraph/issues/248 by passing explicit perf arguments.
-      - name: Perf transfer benchmark
-        run: |
-          nice -n -20 taskset -c 0 \
-            cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" --features bench --bench transfer -- \
-              --bench --exact "Run multiple transfers with varying seeds"
+      # - name: Perf transfer benchmark
+      #   run: |
+      #     nice -n -20 taskset -c 0 \
+      #       cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" --features bench --bench transfer -- \
+      #         --bench --exact "Run multiple transfers with varying seeds"
 
       - name: Benchmark a client/server transfer
         run: |
@@ -88,6 +88,7 @@ jobs:
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
               --bin neqo-client -- --output-dir . https://$HOST:4433/$SIZE
           kill $PID
+          cd ${{ github.workspace }}
           [ "$(wc -c < client/"$SIZE")" -eq "$SIZE" ] || exit 1
         env:
           HOST: localhost

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -76,23 +76,18 @@ jobs:
 
       - name: Benchmark a client/server transfer
         run: |
-          { mkdir server && \
-            cd server && \
+          { mkdir server; \
+            cd server; \
             nice -n -20 taskset -c 0 \
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
-              --bin neqo-server -- --db ../test-fixture/db $HOST:4433 ; } &
+              --bin neqo-server -- --db ../test-fixture/db $HOST:4433 || true; } &
           PID=$!
-          ps -ef
-          echo $PID
-          mkdir client && \
-            cd client && \
+          mkdir client; \
+            cd client; \
             time nice -n -20 taskset -c 1 \
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
               --bin neqo-client -- --output-dir . https://$HOST:4433/$SIZE
-          ps -ef
           kill -INT $PID
-          ps -ef
-          fg $PID
           cd ${{ github.workspace }}
           [ "$(wc -c < client/"$SIZE")" -eq "$SIZE" ] || exit 1
         env:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -63,6 +63,7 @@ jobs:
             cargo +$TOOLCHAIN bench --features bench | tee output.txt
 
       # Pin the transfer benchmark to core 0 and run it at elevated priority inside perf.
+      # Work around https://github.com/flamegraph-rs/flamegraph/issues/248 by passing explicit perf arguments.
       - name: Perf transfer benchmark
         run: |
           nice -n -20 taskset -c 0 \
@@ -93,14 +94,16 @@ jobs:
       #     comment-on-alert: true
       #     summary-always: true
 
-      - name: Convert perf data
-        run: |
-          perf script -i perf.data -F +pid | zstd > perf.ff.data.zst
-          zstd perf.data
+      - name: Convert for profiler.firefox.com
+        run: perf script -i perf.data -F +pid > perf.firefox.data
 
       - name: Archive perf data
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.head_ref || github.ref_name }}-perf
-          path: "*.zst"
-          compression-level: 0
+          path: |
+            flamegraph.svg
+            perf*.data
+            output.txt
+            target/criterion
+          compression-level: 9

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Prepare machine
         run: |
           sudo /root/bin/prep.sh
-          echo 'PERF_CMD="record -o perf.data -F997 --call-graph dwarf,16384 -g"' >> "$GITHUB_ENV"
+          echo "PERF_CMD=record -o perf.data -F997 --call-graph dwarf,16384 -g" >> "$GITHUB_ENV"
 
       # Pin the benchmark run to core 0 and run all benchmarks at elevated priority.
       - name: Benchmark
@@ -77,13 +77,17 @@ jobs:
           cargo +$TOOLCHAIN build --profile bench --features bench --bin neqo-client --bin neqo-server
           mkdir server && \
             cd server && \
-            cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" --bin neqo-server -- $HOST:4433 &
+            nice -n -20 taskset -c 0 \
+            cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
+              --bin neqo-server -- $HOST:4433 &
           PID=$!
           mkdir client && \
             cd client && \
-            cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" --bin neqo-client -- --output-dir . https://$HOST:4433/$SIZE
+            nice -n -20 taskset -c 1 \
+            cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
+              --bin neqo-client -- --output-dir . https://$HOST:4433/$SIZE
           kill $PID
-          [ "$(wc -c <"$SIZE")" -eq "$SIZE" ] || exit 1
+          [ "$(wc -c < client/"$SIZE")" -eq "$SIZE" ] || exit 1
         env:
           HOST: localhost
           SIZE: 7654321
@@ -113,15 +117,23 @@ jobs:
       #     summary-always: true
 
       - name: Convert for profiler.firefox.com
-        run: perf script -i perf.data -F +pid > perf.firefox.data
+        run: |
+          mv flamegraph.svg transfer.svg
+          mv client/flamegraph.svg client.svg
+          mv server/flamegraph.svg server.svg
+          mv perf.data transfer.perf && perf script -i transfer.perf -F +pid > transfer.firefox.perf &
+          mv client/perf.data client.perf && perf script -i client.perf -F +pid > client.firefox.perf &
+          mv server/perf.data server.perf && perf script -i server.perf -F +pid > server.firefox.perf &
+          wait
+          rm neqo.svg
 
       - name: Archive perf data
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.head_ref || github.ref_name }}-perf
           path: |
-            flamegraph.svg
-            perf*.data
+            *.svg
+            *.perf
             output.txt
             target/criterion
           compression-level: 9

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Perf transfer benchmark
         run: |
           nice -n -20 taskset -c 0 \
-            cargo +$TOOLCHAIN flamegraph -v -F 997 --features bench --bench transfer -- \
+            cargo +$TOOLCHAIN flamegraph -v -c "record -o perf.data -F997 --call-graph dwarf,16384 -g" --features bench --bench transfer -- \
               --bench --exact "Run multiple transfers with varying seeds"
 
       # Re-enable turboboost, hyperthreading and use powersave governor.

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,5 +1,7 @@
 name: Bench
 on:
+  push:
+  pull_request:
   workflow_call:
 env:
   CARGO_PROFILE_BENCH_BUILD_OVERRIDE_DEBUG: true
@@ -22,19 +24,28 @@ jobs:
           toolchain: $TOOLCHAIN
           components: rustfmt
 
-      - name: Configure Rust
-        run: echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld -C link-arg=-Wl,--no-rosegment" >> "$GITHUB_ENV"
-
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.4
 
-      - name: Enable sccache
+      - name: Configure Rust
         run: |
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld -C link-arg=-Wl,--no-rosegment" >> "$GITHUB_ENV"
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          cargo install flamegraph
 
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Fetch NSS and NSPR
+        run: |
+          hg clone https://hg.mozilla.org/projects/nspr "$NSPR_DIR"
+          hg clone https://hg.mozilla.org/projects/nss "$NSS_DIR"
+          echo "NSS_DIR=$NSS_DIR" >> "$GITHUB_ENV"
+          echo "NSPR_DIR=$NSPR_DIR" >> "$GITHUB_ENV"
+        env:
+          NSS_DIR: ${{ github.workspace }}/nss
+          NSPR_DIR: ${{ github.workspace }}/nspr
 
       - name: Build
         run: cargo +$TOOLCHAIN bench --features bench --no-run
@@ -53,9 +64,8 @@ jobs:
       - name: Perf transfer benchmark
         run: |
           /usr/bin/nice -n -20 taskset -c 0 \
-            perf record -F997 --call-graph=lbr -o perf.data \
-            cargo +$TOOLCHAIN bench --features bench --bench transfer -- \
-              --exact "Run multiple transfers with varying seeds"
+            cargo +$TOOLCHAIN flamegraph -v -F 997 --features bench --bench transfer -- \
+              --bench --exact "Run multiple transfers with varying seeds"
 
       # Re-enable turboboost, hyperthreading and use powersave governor.
       - name: Restore machine

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build
-        run: cargo +$TOOLCHAIN bench --features ci,bench --no-run
+        run: cargo +$TOOLCHAIN bench --features bench --no-run
 
       # Disable turboboost, hyperthreading and use performance governor.
       - name: Prepare machine
@@ -46,15 +46,16 @@ jobs:
       # Pin the benchmark run to core 0 and run all benchmarks at elevated priority.
       - name: Benchmark
         run: |
-          nice -n -20 taskset -c 0 \
-            cargo +$TOOLCHAIN bench --features ci,bench | tee output.txt
+          /usr/bin/nice -n -20 taskset -c 0 \
+            cargo +$TOOLCHAIN bench --features bench | tee output.txt
 
       # Pin the transfer benchmark to core 0 and run it at elevated priority inside perf.
       - name: Perf transfer benchmark
         run: |
-          nice -n -20 taskset -c 0 \
+          /usr/bin/nice -n -20 taskset -c 0 \
             perf record -F997 --call-graph=lbr -o perf.data \
-            cargo +$TOOLCHAIN bench --features ci,bench --bench transfer
+            cargo +$TOOLCHAIN bench --features bench --bench transfer -- \
+              --exact "Run multiple transfers with varying seeds"
 
       # Re-enable turboboost, hyperthreading and use powersave governor.
       - name: Restore machine
@@ -68,7 +69,7 @@ jobs:
           key: ${{ runner.os }}-benchmark
 
       # TODO: Wait for this action to be allowlisted. And then figure out how to only upload
-      # benchmark data when the main branch is being updated.
+      # benchmark data when the main branch is being updated (e.g., if: ${{ github.ref == "refs/heads/main" }})
       # - name: Store current benchmark results
       #   uses: benchmark-action/github-action-benchmark@v1
       #   with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -84,15 +84,15 @@ jobs:
           PID=$!
           mkdir client && \
             cd client && \
-            nice -n -20 taskset -c 1 \
+            time nice -n -20 taskset -c 1 \
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" \
               --bin neqo-client -- --output-dir . https://$HOST:4433/$SIZE
-          kill $PID
+          kill -INT $PID
           cd ${{ github.workspace }}
           [ "$(wc -c < client/"$SIZE")" -eq "$SIZE" ] || exit 1
         env:
           HOST: localhost
-          SIZE: 7654321
+          SIZE: 87654321
 
       # Re-enable turboboost, hyperthreading and use powersave governor.
       - name: Restore machine
@@ -120,11 +120,11 @@ jobs:
 
       - name: Convert for profiler.firefox.com
         run: |
-          perf script -i perf.data -F +pid > transfer.perf &
+          # perf script -i perf.data -F +pid > transfer.perf &
           perf script -i client/perf.data -F +pid > client.perf &
           perf script -i server/perf.data -F +pid > server.perf &
           wait
-          mv flamegraph.svg transfer.svg
+          # mv flamegraph.svg transfer.svg
           mv client/flamegraph.svg client.svg
           mv server/flamegraph.svg server.svg
           rm neqo.svg

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,8 @@
 name: Bench
 on:
   workflow_call:
+  push:
+  pull_request:
 env:
   CARGO_PROFILE_BENCH_BUILD_OVERRIDE_DEBUG: true
   CARGO_TERM_COLOR: always
@@ -95,7 +97,7 @@ jobs:
       - name: Convert for profiler.firefox.com
         run: perf script -i perf.data -F +pid > perf.firefox.data
 
-      - name: Archive perf data
+      - name: Archive all benchmark results
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.head_ref || github.ref_name }}-perf
@@ -104,4 +106,11 @@ jobs:
             perf*.data
             output.txt
             target/criterion
+          compression-level: 9
+
+      - name: Archive for profiler.firefox.com
+        uses: actions/upload-artifact@v4
+        with:
+          name: profiler.firefox.com
+          path: perf.firefox.data
           compression-level: 9

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -48,7 +48,9 @@ jobs:
           NSPR_DIR: ${{ github.workspace }}/nspr
 
       - name: Build
-        run: cargo +$TOOLCHAIN bench --features bench --no-run
+        run: |
+          cargo +$TOOLCHAIN bench --features bench --no-run
+          echo "LD_LIBRARY_PATH=${{ github.workspace }}/dist/Debug/lib" >> "$GITHUB_ENV"
 
       # Disable turboboost, hyperthreading and use performance governor.
       - name: Prepare machine
@@ -57,13 +59,13 @@ jobs:
       # Pin the benchmark run to core 0 and run all benchmarks at elevated priority.
       - name: Benchmark
         run: |
-          /usr/bin/nice -n -20 taskset -c 0 \
+          nice -n -20 taskset -c 0 \
             cargo +$TOOLCHAIN bench --features bench | tee output.txt
 
       # Pin the transfer benchmark to core 0 and run it at elevated priority inside perf.
       - name: Perf transfer benchmark
         run: |
-          /usr/bin/nice -n -20 taskset -c 0 \
+          nice -n -20 taskset -c 0 \
             cargo +$TOOLCHAIN flamegraph -v -F 997 --features bench --bench transfer -- \
               --bench --exact "Run multiple transfers with varying seeds"
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,8 +1,6 @@
 name: Bench
 on:
   workflow_call:
-  push:
-  pull_request:
 env:
   CARGO_PROFILE_BENCH_BUILD_OVERRIDE_DEBUG: true
   CARGO_TERM_COLOR: always
@@ -97,7 +95,7 @@ jobs:
       - name: Convert for profiler.firefox.com
         run: perf script -i perf.data -F +pid > perf.firefox.data
 
-      - name: Archive all benchmark results
+      - name: Archive perf data
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.head_ref || github.ref_name }}-perf
@@ -106,11 +104,4 @@ jobs:
             perf*.data
             output.txt
             target/criterion
-          compression-level: 9
-
-      - name: Archive for profiler.firefox.com
-        uses: actions/upload-artifact@v4
-        with:
-          name: profiler.firefox.com
-          path: perf.firefox.data
           compression-level: 9

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -134,14 +134,16 @@ jobs:
           LIB_DIR: ${{ matrix.type == 'release' && 'Release' || 'Debug' }}
 
       - name: Run tests and determine coverage
-        run: cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --all-targets --features ci,bench --no-fail-fast --lcov --output-path lcov.info
+        run: |
+          cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --all-targets --features ci --no-fail-fast --lcov --output-path lcov.info
+          cargo +${{ matrix.rust-toolchain }} bench --features bench --no-run
 
       - name: Run client/server transfer
         run: |
-          cargo +${{ matrix.rust-toolchain }} build $BUILD_TYPE --features ci,bench --bin neqo-client --bin neqo-server
-          cargo +${{ matrix.rust-toolchain }} run $BUILD_TYPE  --features ci,bench --bin neqo-server -- $HOST:4433 &
+          cargo +${{ matrix.rust-toolchain }} build $BUILD_TYPE --bin neqo-client --bin neqo-server
+          cargo +${{ matrix.rust-toolchain }} run $BUILD_TYPE --bin neqo-server -- $HOST:4433 &
           PID=$!
-          cargo +${{ matrix.rust-toolchain }} run $BUILD_TYPE --features ci,bench --bin neqo-client -- --output-dir . https://$HOST:4433/$SIZE
+          cargo +${{ matrix.rust-toolchain }} run $BUILD_TYPE --bin neqo-client -- --output-dir . https://$HOST:4433/$SIZE
           kill $PID
           [ "$(wc -c <"$SIZE")" -eq "$SIZE" ] || exit 1
         env:

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -93,10 +93,6 @@ impl NeqoQlog {
         F: FnOnce(&mut QlogStreamer) -> Result<(), qlog::Error>,
     {
         if let Some(inner) = self.inner.borrow_mut().as_mut() {
-            // TODO: Hack.
-            if inner.qlog_path == Path::new("") {
-                return;
-            }
             if let Err(e) = f(&mut inner.streamer) {
                 crate::do_log!(
                     ::log::Level::Error,

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -93,6 +93,10 @@ impl NeqoQlog {
         F: FnOnce(&mut QlogStreamer) -> Result<(), qlog::Error>,
     {
         if let Some(inner) = self.inner.borrow_mut().as_mut() {
+            // TODO: Hack.
+            if inner.qlog_path == Path::new("") {
+                return;
+            }
             if let Err(e) = f(&mut inner.streamer) {
                 crate::do_log!(
                     ::log::Level::Error,

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -20,3 +20,4 @@ qlog = "0.12"
 
 [features]
 deny-warnings = []
+bench = []

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -392,12 +392,16 @@ impl ToString for SharedVec {
 /// Panics if the log cannot be created.
 #[must_use]
 pub fn new_neqo_qlog() -> (NeqoQlog, SharedVec) {
-    let mut trace = new_trace(Role::Client);
-    // Set reference time to 0.0 for testing.
-    trace.common_fields.as_mut().unwrap().reference_time = Some(0.0);
     let buf = SharedVec {
         buf: Arc::default(),
     };
+
+    #[cfg(feature = "bench")]
+    return (NeqoQlog::disabled(), buf);
+
+    let mut trace = new_trace(Role::Client);
+    // Set reference time to 0.0 for testing.
+    trace.common_fields.as_mut().unwrap().reference_time = Some(0.0);
     let contents = buf.clone();
     let streamer = QlogStreamer::new(
         qlog::QLOG_VERSION.to_string(),

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -396,8 +396,9 @@ pub fn new_neqo_qlog() -> (NeqoQlog, SharedVec) {
         buf: Arc::default(),
     };
 
-    #[cfg(feature = "bench")]
-    return (NeqoQlog::disabled(), buf);
+    if cfg!(feature = "bench") {
+        return (NeqoQlog::disabled(), buf);
+    }
 
     let mut trace = new_trace(Role::Client);
     // Set reference time to 0.0 for testing.


### PR DESCRIPTION
To remove those overheads from the profile.

This PR also rolls in some changes to the bencher, i.e., to make it generate flamegraphs and make them and the raw perf/criterion data available as build artifacts.