### PR TITLE
refactor: remove dead fairness and sendorder fn on SendStream

### DIFF
--- a/neqo-http3/src/features/extended_connect/webtransport_session.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_session.rs
@@ -8,7 +8,7 @@ use std::{cell::RefCell, collections::BTreeSet, mem, rc::Rc};
 
 use neqo_common::{qtrace, Encoder, Header, MessageType, Role};
 use neqo_qpack::{QPackDecoder, QPackEncoder};
-use neqo_transport::{streams::SendOrder, Connection, DatagramTracking, StreamId};
+use neqo_transport::{Connection, DatagramTracking, StreamId};
 
 use super::{ExtendedConnectEvents, ExtendedConnectType, SessionCloseReason};
 use crate::{
@@ -484,16 +484,6 @@ impl SendStream for Rc<RefCell<WebTransportSession>> {
 
     fn has_data_to_send(&self) -> bool {
         self.borrow_mut().has_data_to_send()
-    }
-
-    fn set_sendorder(&mut self, _conn: &mut Connection, _sendorder: Option<SendOrder>) -> Res<()> {
-        // Not relevant on session
-        Ok(())
-    }
-
-    fn set_fairness(&mut self, _conn: &mut Connection, _fairness: bool) -> Res<()> {
-        // Not relevant on session
-        Ok(())
     }
 
     fn stream_writable(&self) {}

--- a/neqo-http3/src/features/extended_connect/webtransport_streams.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_streams.rs
@@ -215,16 +215,6 @@ impl SendStream for WebTransportSendStream {
         }
     }
 
-    fn set_sendorder(&mut self, conn: &mut Connection, sendorder: Option<i64>) -> Res<()> {
-        conn.stream_sendorder(self.stream_id, sendorder)
-            .map_err(|_| crate::Error::InvalidStreamId)
-    }
-
-    fn set_fairness(&mut self, conn: &mut Connection, fairness: bool) -> Res<()> {
-        conn.stream_fairness(self.stream_id, fairness)
-            .map_err(|_| crate::Error::InvalidStreamId)
-    }
-
     fn handle_stop_sending(&mut self, close_type: CloseType) {
         self.set_done(close_type);
     }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -570,10 +570,6 @@ trait SendStream: Stream {
     fn has_data_to_send(&self) -> bool;
     fn stream_writable(&self);
     fn done(&self) -> bool;
-    #[allow(dead_code)] // https://github.com/mozilla/neqo/issues/1651
-    fn set_sendorder(&mut self, conn: &mut Connection, sendorder: Option<SendOrder>) -> Res<()>;
-    #[allow(dead_code)] // https://github.com/mozilla/neqo/issues/1651
-    fn set_fairness(&mut self, conn: &mut Connection, fairness: bool) -> Res<()>;
 
     /// # Errors
     ///

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -8,7 +8,7 @@ use std::{cell::RefCell, cmp::min, fmt::Debug, rc::Rc};
 
 use neqo_common::{qdebug, qinfo, qtrace, Encoder, Header, MessageType};
 use neqo_qpack::encoder::QPackEncoder;
-use neqo_transport::{streams::SendOrder, Connection, StreamId};
+use neqo_transport::{Connection, StreamId};
 
 use crate::{
     frames::HFrame,
@@ -268,16 +268,6 @@ impl SendStream for SendMessage {
     // http client afterwards using `send_request_body` after receiving DataWritable event.
     fn has_data_to_send(&self) -> bool {
         self.stream.has_buffered_data()
-    }
-
-    fn set_sendorder(&mut self, _conn: &mut Connection, _sendorder: Option<SendOrder>) -> Res<()> {
-        // Not relevant for SendMessage
-        Ok(())
-    }
-
-    fn set_fairness(&mut self, _conn: &mut Connection, _fairness: bool) -> Res<()> {
-        // Not relevant for SendMessage
-        Ok(())
     }
 
     fn close(&mut self, conn: &mut Connection) -> Res<()> {


### PR DESCRIPTION
Removes `fn` `set_sendorder` and `set_fairness` on `SendStream` trait.

The `SendStream` trait is not publicly exposed. Neither `set_sendorder` nor `set_fairness` is called within `neqo-http3`.

Fixes https://github.com/mozilla/neqo/issues/1651.