### PR TITLE
feat(.github): enable merge queue

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
     paths-ignore: ["*.md", "*.png", "*.svg", "LICENSE-*"]
+  merge_group:
+    branches: ["main"]
+    paths-ignore: ["*.md", "*.png", "*.svg", "LICENSE-*"]
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -9,6 +9,11 @@ on:
     paths:
       - 'qns/**'
       - '.github/workflows/qns.yml'
+  merge_group:
+    branches: ["main"]
+    paths:
+      - 'qns/**'
+      - '.github/workflows/qns.yml'
 jobs:
   docker-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
If I understand the documentation correctly, using GitHub's Merge Queue requires two steps:

1. Adding the `merge_group` trigger to each workflow. Done via this pull request.
2. Enabling Merge Queue in the settings.
    1. Settings/Branches/Branch Protection Rules/main/edit
    2. Enable "Require Merge queue"
      
![image](https://github.com/mozilla/neqo/assets/7047859/337bb434-5a7c-4ff7-b735-74614bbed2c5)

See [GitHub documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions).

Fixes https://github.com/mozilla/neqo/issues/1673.

