### PR TITLE
chore: Set workspace resolver to version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "neqo-transport",
   "test-fixture",
 ]
+resolver = "2"
 
 [workspace.package]
 homepage = "https://github.com/mozilla/neqo/"


### PR DESCRIPTION
Avoids this warning during build:
```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```