### PR TITLE
feat(client,server): rework logging

### DIFF
--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -25,6 +25,7 @@ workspace = true
 [dependencies]
 # neqo-bin is not used in Firefox, so we can be liberal with dependency versions
 clap = { version = "4.4", default-features = false, features = ["std", "color", "help", "usage", "error-context", "suggestions", "derive"] }
+clap-verbosity-flag = { version = "2.2", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 hex = { version = "0.4", default-features = false, features = ["std"] }
 log = { version = "0.4", default-features = false }

--- a/neqo-bin/src/bin/client/http09.rs
+++ b/neqo-bin/src/bin/client/http09.rs
@@ -17,7 +17,7 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{event::Provider, Datagram};
+use neqo_common::{event::Provider, qdebug, qinfo, qwarn, Datagram};
 use neqo_crypto::{AuthenticationStatus, ResumptionToken};
 use neqo_transport::{
     Connection, ConnectionEvent, EmptyConnectionIdGenerator, Error, Output, State, StreamId,
@@ -50,13 +50,13 @@ impl<'a> super::Handler for Handler<'a> {
                     self.read(client, stream_id)?;
                 }
                 ConnectionEvent::SendStreamWritable { stream_id } => {
-                    println!("stream {stream_id} writable");
+                    qdebug!("stream {stream_id} writable");
                 }
                 ConnectionEvent::SendStreamComplete { stream_id } => {
-                    println!("stream {stream_id} complete");
+                    qdebug!("stream {stream_id} complete");
                 }
                 ConnectionEvent::SendStreamCreatable { stream_type } => {
-                    println!("stream {stream_type:?} creatable");
+                    qdebug!("stream {stream_type:?} creatable");
                     if stream_type == StreamType::BiDi {
                         self.download_urls(client);
                     }
@@ -64,7 +64,7 @@ impl<'a> super::Handler for Handler<'a> {
                 ConnectionEvent::StateChange(
                     State::WaitInitial | State::Handshaking | State::Connected,
                 ) => {
-                    println!("{event:?}");
+                    qdebug!("{event:?}");
                     self.download_urls(client);
                 }
                 ConnectionEvent::StateChange(State::Confirmed) => {
@@ -74,7 +74,7 @@ impl<'a> super::Handler for Handler<'a> {
                     self.token = Some(token);
                 }
                 _ => {
-                    println!("Unhandled event {event:?}");
+                    qwarn!("Unhandled event {event:?}");
                 }
             }
         }
@@ -183,7 +183,7 @@ impl<'b> Handler<'b> {
 
     fn download_next(&mut self, client: &mut Connection) -> bool {
         if self.key_update.needed() {
-            println!("Deferring requests until after first key update");
+            qdebug!("Deferring requests until after first key update");
             return false;
         }
         let url = self
@@ -192,7 +192,7 @@ impl<'b> Handler<'b> {
             .expect("download_next called with empty queue");
         match client.stream_create(StreamType::BiDi) {
             Ok(client_stream_id) => {
-                println!("Created stream {client_stream_id} for {url}");
+                qinfo!("Created stream {client_stream_id} for {url}");
                 let req = format!("GET {}\r\n", url.path());
                 _ = client
                     .stream_send(client_stream_id, req.as_bytes())
@@ -203,7 +203,7 @@ impl<'b> Handler<'b> {
                 true
             }
             Err(e @ (Error::StreamLimitError | Error::ConnectionState)) => {
-                println!("Cannot create stream {e:?}");
+                qwarn!("Cannot create stream {e:?}");
                 self.url_queue.push_front(url);
                 false
             }
@@ -231,9 +231,9 @@ impl<'b> Handler<'b> {
             if let Some(out_file) = maybe_out_file {
                 out_file.write_all(&data[..sz])?;
             } else if !output_read_data {
-                println!("READ[{stream_id}]: {sz} bytes");
+                qdebug!("READ[{stream_id}]: {sz} bytes");
             } else {
-                println!(
+                qdebug!(
                     "READ[{}]: {}",
                     stream_id,
                     String::from_utf8(data.clone()).unwrap()
@@ -248,7 +248,7 @@ impl<'b> Handler<'b> {
     fn read(&mut self, client: &mut Connection, stream_id: StreamId) -> Res<()> {
         match self.streams.get_mut(&stream_id) {
             None => {
-                println!("Data on unexpected stream: {stream_id}");
+                qwarn!("Data on unexpected stream: {stream_id}");
                 return Ok(());
             }
             Some(maybe_out_file) => {
@@ -263,7 +263,7 @@ impl<'b> Handler<'b> {
                     if let Some(mut out_file) = maybe_out_file.take() {
                         out_file.flush()?;
                     } else {
-                        println!("<FIN[{stream_id}]>");
+                        qinfo!("<FIN[{stream_id}]>");
                     }
                     self.streams.remove(&stream_id);
                     self.download_urls(client);

--- a/neqo-bin/src/bin/client/http3.rs
+++ b/neqo-bin/src/bin/client/http3.rs
@@ -18,7 +18,7 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{event::Provider, hex, Datagram, Header};
+use neqo_common::{event::Provider, hex, qdebug, qinfo, qwarn, Datagram, Header};
 use neqo_crypto::{AuthenticationStatus, ResumptionToken};
 use neqo_http3::{Error, Http3Client, Http3ClientEvent, Http3Parameters, Http3State, Priority};
 use neqo_transport::{
@@ -145,7 +145,7 @@ impl<'a> super::Handler for Handler<'a> {
                     if let Some(handler) = self.url_handler.stream_handler(stream_id) {
                         handler.process_header_ready(stream_id, fin, headers);
                     } else {
-                        println!("Data on unexpected stream: {stream_id}");
+                        qwarn!("Data on unexpected stream: {stream_id}");
                     }
                     if fin {
                         self.url_handler.on_stream_fin(client, stream_id);
@@ -155,7 +155,7 @@ impl<'a> super::Handler for Handler<'a> {
                     let mut stream_done = false;
                     match self.url_handler.stream_handler(stream_id) {
                         None => {
-                            println!("Data on unexpected stream: {stream_id}");
+                            qwarn!("Data on unexpected stream: {stream_id}");
                         }
                         Some(handler) => loop {
                             let mut data = vec![0; 4096];
@@ -189,7 +189,7 @@ impl<'a> super::Handler for Handler<'a> {
                 Http3ClientEvent::DataWritable { stream_id } => {
                     match self.url_handler.stream_handler(stream_id) {
                         None => {
-                            println!("Data on unexpected stream: {stream_id}");
+                            qwarn!("Data on unexpected stream: {stream_id}");
                         }
                         Some(handler) => {
                             handler.process_data_writable(client, stream_id);
@@ -202,7 +202,7 @@ impl<'a> super::Handler for Handler<'a> {
                 }
                 Http3ClientEvent::ResumptionToken(t) => self.token = Some(t),
                 _ => {
-                    println!("Unhandled event {event:?}");
+                    qwarn!("Unhandled event {event:?}");
                 }
             }
         }
@@ -275,7 +275,7 @@ struct DownloadStreamHandler {
 impl StreamHandler for DownloadStreamHandler {
     fn process_header_ready(&mut self, stream_id: StreamId, fin: bool, headers: Vec<Header>) {
         if self.out_file.is_none() {
-            println!("READ HEADERS[{stream_id}]: fin={fin} {headers:?}");
+            qdebug!("READ HEADERS[{stream_id}]: fin={fin} {headers:?}");
         }
     }
 
@@ -293,18 +293,18 @@ impl StreamHandler for DownloadStreamHandler {
             }
             return Ok(true);
         } else if !output_read_data {
-            println!("READ[{stream_id}]: {sz} bytes");
+            qdebug!("READ[{stream_id}]: {sz} bytes");
         } else if let Ok(txt) = String::from_utf8(data.clone()) {
-            println!("READ[{stream_id}]: {txt}");
+            qdebug!("READ[{stream_id}]: {txt}");
         } else {
-            println!("READ[{}]: 0x{}", stream_id, hex(&data));
+            qdebug!("READ[{}]: 0x{}", stream_id, hex(&data));
         }
 
         if fin {
             if let Some(mut out_file) = self.out_file.take() {
                 out_file.flush()?;
             } else {
-                println!("<FIN[{stream_id}]>");
+                qdebug!("<FIN[{stream_id}]>");
             }
         }
 
@@ -323,7 +323,7 @@ struct UploadStreamHandler {
 
 impl StreamHandler for UploadStreamHandler {
     fn process_header_ready(&mut self, stream_id: StreamId, fin: bool, headers: Vec<Header>) {
-        println!("READ HEADERS[{stream_id}]: fin={fin} {headers:?}");
+        qdebug!("READ HEADERS[{stream_id}]: fin={fin} {headers:?}");
     }
 
     fn process_data_readable(
@@ -339,7 +339,7 @@ impl StreamHandler for UploadStreamHandler {
             let parsed: usize = trimmed_txt.parse().unwrap();
             if parsed == self.data.len() {
                 let upload_time = Instant::now().duration_since(self.start);
-                println!("Stream ID: {stream_id:?}, Upload time: {upload_time:?}");
+                qinfo!("Stream ID: {stream_id:?}, Upload time: {upload_time:?}");
             }
         } else {
             panic!("Unexpected data [{}]: 0x{}", stream_id, hex(&data));
@@ -407,7 +407,7 @@ impl<'a> UrlHandler<'a> {
             Priority::default(),
         ) {
             Ok(client_stream_id) => {
-                println!("Successfully created stream id {client_stream_id} for {url}");
+                qdebug!("Successfully created stream id {client_stream_id} for {url}");
 
                 let handler: Box<dyn StreamHandler> = StreamHandlerType::make_handler(
                     &self.handler_type,

--- a/neqo-bin/src/bin/client/main.rs
+++ b/neqo-bin/src/bin/client/main.rs
@@ -22,7 +22,7 @@ use futures::{
     FutureExt, TryFutureExt,
 };
 use neqo_bin::udp;
-use neqo_common::{self as common, qdebug, qinfo, qlog::NeqoQlog, Datagram, Role};
+use neqo_common::{self as common, qdebug, qerror, qinfo, qlog::NeqoQlog, qwarn, Datagram, Role};
 use neqo_crypto::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256},
     init, Cipher, ResumptionToken,
@@ -103,7 +103,7 @@ impl KeyUpdateState {
                     _ => return Err(e),
                 }
             } else {
-                println!("Keys updated");
+                qerror!("Keys updated");
                 self.0 = false;
             }
         }
@@ -119,6 +119,9 @@ impl KeyUpdateState {
 #[command(author, version, about, long_about = None)]
 #[allow(clippy::struct_excessive_bools)] // Not a good use of that lint.
 pub struct Args {
+    #[command(flatten)]
+    verbose: clap_verbosity_flag::Verbosity<clap_verbosity_flag::InfoLevel>,
+
     #[command(flatten)]
     shared: neqo_bin::SharedArgs,
 
@@ -207,7 +210,7 @@ impl Args {
             "http3" => {
                 if let Some(testcase) = &self.test {
                     if testcase.as_str() != "upload" {
-                        eprintln!("Unsupported test case: {testcase}");
+                        qerror!("Unsupported test case: {testcase}");
                         exit(127)
                     }
 
@@ -219,7 +222,7 @@ impl Args {
             }
             "zerortt" | "resumption" => {
                 if self.urls.len() < 2 {
-                    eprintln!("Warning: resumption tests won't work without >1 URL");
+                    qerror!("Warning: resumption tests won't work without >1 URL");
                     exit(127);
                 }
                 self.shared.use_old_http = true;
@@ -268,11 +271,11 @@ fn get_output_file(
         out_path.push(url_path);
 
         if all_paths.contains(&out_path) {
-            eprintln!("duplicate path {}", out_path.display());
+            qerror!("duplicate path {}", out_path.display());
             return None;
         }
 
-        eprintln!("Saving {url} to {out_path:?}");
+        qinfo!("Saving {url} to {out_path:?}");
 
         if let Some(parent) = out_path.parent() {
             create_dir_all(parent).ok()?;
@@ -390,7 +393,7 @@ impl<'a, H: Handler> Runner<'a, H> {
                     self.socket.send(dgram)?;
                 }
                 Output::Callback(new_timeout) => {
-                    qinfo!("Setting timeout of {:?}", new_timeout);
+                    qdebug!("Setting timeout of {:?}", new_timeout);
                     self.timeout = Some(Box::pin(tokio::time::sleep(new_timeout)));
                     break;
                 }
@@ -436,10 +439,11 @@ fn qlog_new(args: &Args, hostname: &str, cid: &ConnectionId) -> Res<NeqoQlog> {
 
 #[tokio::main]
 async fn main() -> Res<()> {
-    init();
-
     let mut args = Args::parse();
+    neqo_common::log::init(Some(args.verbose.log_level_filter()));
     args.update_for_tests();
+
+    init();
 
     let urls_by_origin = args
         .urls
@@ -453,14 +457,14 @@ async fn main() -> Res<()> {
         .filter_map(|(origin, urls)| match origin {
             Origin::Tuple(_scheme, h, p) => Some(((h, p), urls)),
             Origin::Opaque(x) => {
-                eprintln!("Opaque origin {x:?}");
+                qwarn!("Opaque origin {x:?}");
                 None
             }
         });
 
     for ((host, port), mut urls) in urls_by_origin {
         if args.resume && urls.len() < 2 {
-            eprintln!("Resumption to {host} cannot work without at least 2 URLs.");
+            qerror!("Resumption to {host} cannot work without at least 2 URLs.");
             exit(127);
         }
 
@@ -471,7 +475,7 @@ async fn main() -> Res<()> {
             )
         });
         let Some(remote_addr) = remote_addr else {
-            eprintln!("No compatible address found for: {host}");
+            qerror!("No compatible address found for: {host}");
             exit(1);
         };
 
@@ -482,7 +486,7 @@ async fn main() -> Res<()> {
 
         let mut socket = udp::Socket::bind(local_addr)?;
         let real_local = socket.local_addr().unwrap();
-        println!(
+        qinfo!(
             "{} Client connecting: {:?} -> {:?}",
             if args.shared.use_old_http { "H9" } else { "H3" },
             real_local,

--- a/neqo-bin/src/bin/server/main.rs
+++ b/neqo-bin/src/bin/server/main.rs
@@ -25,7 +25,7 @@ use futures::{
     FutureExt,
 };
 use neqo_bin::udp;
-use neqo_common::{hex, qerror, qinfo, qwarn, Datagram, Header};
+use neqo_common::{hex, qdebug, qerror, qinfo, qwarn, Datagram, Header};
 use neqo_crypto::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256},
     generate_ech_keys, init_db, random, AntiReplay, Cipher,
@@ -315,7 +315,7 @@ impl HttpServer for SimpleServer {
                     headers,
                     fin,
                 } => {
-                    qinfo!("Headers (request={stream} fin={fin}): {headers:?}");
+                    qdebug!("Headers (request={stream} fin={fin}): {headers:?}");
 
                     let post = if let Some(method) = headers.iter().find(|&h| h.name() == ":method")
                     {
@@ -510,7 +510,7 @@ impl ServersRunner {
                     socket.send(dgram)?;
                 }
                 Output::Callback(new_timeout) => {
-                    qinfo!("Setting timeout of {:?}", new_timeout);
+                    qdebug!("Setting timeout of {:?}", new_timeout);
                     self.timeout = Some(Box::pin(tokio::time::sleep(new_timeout)));
                     break;
                 }

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -50,7 +50,7 @@ fn since_start() -> Duration {
     START_TIME.get_or_init(Instant::now).elapsed()
 }
 
-pub fn init() {
+pub fn init(level_filter: Option<log::LevelFilter>) {
     static INIT_ONCE: Once = Once::new();
 
     if ::log::STATIC_MAX_LEVEL == ::log::LevelFilter::Off {
@@ -59,6 +59,9 @@ pub fn init() {
 
     INIT_ONCE.call_once(|| {
         let mut builder = Builder::from_env("RUST_LOG");
+        if let Some(filter) = level_filter {
+            builder.filter_level(filter);
+        }
         builder.format(|buf, record| {
             let elapsed = since_start();
             writeln!(
@@ -71,9 +74,9 @@ pub fn init() {
             )
         });
         if let Err(e) = builder.try_init() {
-            do_log!(::log::Level::Info, "Logging initialization error {:?}", e);
+            do_log!(::log::Level::Warn, "Logging initialization error {:?}", e);
         } else {
-            do_log!(::log::Level::Info, "Logging initialized");
+            do_log!(::log::Level::Debug, "Logging initialized");
         }
     });
 }
@@ -81,32 +84,32 @@ pub fn init() {
 #[macro_export]
 macro_rules! log_invoke {
     ($lvl:expr, $ctx:expr, $($arg:tt)*) => ( {
-        ::neqo_common::log::init();
+        ::neqo_common::log::init(None);
         ::neqo_common::do_log!($lvl, "[{}] {}", $ctx, format!($($arg)*));
     } )
 }
 #[macro_export]
 macro_rules! qerror {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Error, $ctx, $($arg)*););
-    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::neqo_common::do_log!(::log::Level::Error, $($arg)*); } );
+    ($($arg:tt)*) => ( { ::neqo_common::log::init(None); ::neqo_common::do_log!(::log::Level::Error, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qwarn {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Warn, $ctx, $($arg)*););
-    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::neqo_common::do_log!(::log::Level::Warn, $($arg)*); } );
+    ($($arg:tt)*) => ( { ::neqo_common::log::init(None); ::neqo_common::do_log!(::log::Level::Warn, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qinfo {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Info, $ctx, $($arg)*););
-    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::neqo_common::do_log!(::log::Level::Info, $($arg)*); } );
+    ($($arg:tt)*) => ( { ::neqo_common::log::init(None); ::neqo_common::do_log!(::log::Level::Info, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qdebug {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Debug, $ctx, $($arg)*););
-    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::neqo_common::do_log!(::log::Level::Debug, $($arg)*); } );
+    ($($arg:tt)*) => ( { ::neqo_common::log::init(None); ::neqo_common::do_log!(::log::Level::Debug, $($arg)*); } );
 }
 #[macro_export]
 macro_rules! qtrace {
     ([$ctx:expr], $($arg:tt)*) => (::neqo_common::log_invoke!(::log::Level::Trace, $ctx, $($arg)*););
-    ($($arg:tt)*) => ( { ::neqo_common::log::init(); ::neqo_common::do_log!(::log::Level::Trace, $($arg)*); } );
+    ($($arg:tt)*) => ( { ::neqo_common::log::init(None); ::neqo_common::do_log!(::log::Level::Trace, $($arg)*); } );
 }

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -670,7 +670,7 @@ impl SecretAgent {
             let info = self.capture_error(SecretAgentInfo::new(self.fd))?;
             HandshakeState::Complete(info)
         };
-        qinfo!([self], "state -> {:?}", self.state);
+        qdebug!([self], "state -> {:?}", self.state);
         Ok(())
     }
 
@@ -898,7 +898,7 @@ impl Client {
         let len = usize::try_from(len).unwrap();
         let mut v = Vec::with_capacity(len);
         v.extend_from_slice(null_safe_slice(token, len));
-        qinfo!(
+        qdebug!(
             [format!("{fd:p}")],
             "Got resumption token {}",
             hex_snip_middle(&v)

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -354,7 +354,7 @@ impl Http3Connection {
     /// This function creates and initializes, i.e. send stream type, the control and qpack
     /// streams.
     fn initialize_http3_connection(&mut self, conn: &mut Connection) -> Res<()> {
-        qinfo!([self], "Initialize the http3 connection.");
+        qdebug!([self], "Initialize the http3 connection.");
         self.control_stream_local.create(conn)?;
 
         self.send_settings();
@@ -704,7 +704,7 @@ impl Http3Connection {
                 );
             }
             NewStreamType::Decoder => {
-                qinfo!([self], "A new remote qpack encoder stream {}", stream_id);
+                qdebug!([self], "A new remote qpack encoder stream {}", stream_id);
                 self.check_stream_exists(Http3StreamType::Decoder)?;
                 self.recv_streams.insert(
                     stream_id,
@@ -715,7 +715,7 @@ impl Http3Connection {
                 );
             }
             NewStreamType::Encoder => {
-                qinfo!([self], "A new remote qpack decoder stream {}", stream_id);
+                qdebug!([self], "A new remote qpack decoder stream {}", stream_id);
                 self.check_stream_exists(Http3StreamType::Encoder)?;
                 self.recv_streams.insert(
                     stream_id,
@@ -766,7 +766,7 @@ impl Http3Connection {
 
     /// This is called when an application closes the connection.
     pub fn close(&mut self, error: AppError) {
-        qinfo!([self], "Close connection error {:?}.", error);
+        qdebug!([self], "Close connection error {:?}.", error);
         self.state = Http3State::Closing(ConnectionError::Application(error));
         if (!self.send_streams.is_empty() || !self.recv_streams.is_empty()) && (error == 0) {
             qwarn!("close(0) called when streams still active");
@@ -952,7 +952,7 @@ impl Http3Connection {
         stream_id: StreamId,
         buf: &mut [u8],
     ) -> Res<(usize, bool)> {
-        qinfo!([self], "read_data from stream {}.", stream_id);
+        qdebug!([self], "read_data from stream {}.", stream_id);
         let res = self
             .recv_streams
             .get_mut(&stream_id)
@@ -1091,7 +1091,7 @@ impl Http3Connection {
 
     /// This is called when an application wants to close the sending side of a stream.
     pub fn stream_close_send(&mut self, conn: &mut Connection, stream_id: StreamId) -> Res<()> {
-        qinfo!([self], "Close the sending side for stream {}.", stream_id);
+        qdebug!([self], "Close the sending side for stream {}.", stream_id);
         debug_assert!(self.state.active());
         let send_stream = self
             .send_streams
@@ -1402,7 +1402,7 @@ impl Http3Connection {
     /// `PriorityUpdateRequestPush` which handling is specific to the client and server, we must
     /// give them to the specific client/server handler.
     fn handle_control_frame(&mut self, f: HFrame) -> Res<Option<HFrame>> {
-        qinfo!([self], "Handle a control frame {:?}", f);
+        qdebug!([self], "Handle a control frame {:?}", f);
         if !matches!(f, HFrame::Settings { .. })
             && !matches!(
                 self.settings_state,
@@ -1433,7 +1433,7 @@ impl Http3Connection {
     }
 
     fn handle_settings(&mut self, new_settings: HSettings) -> Res<()> {
-        qinfo!([self], "Handle SETTINGS frame.");
+        qdebug!([self], "Handle SETTINGS frame.");
         match &self.settings_state {
             Http3RemoteSettingsState::NotReceived => {
                 self.set_qpack_settings(&new_settings)?;

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -590,7 +590,7 @@ impl Http3Client {
     ///
     /// An error will be return if stream does not exist.
     pub fn stream_close_send(&mut self, stream_id: StreamId) -> Res<()> {
-        qinfo!([self], "Close sending side stream={}.", stream_id);
+        qdebug!([self], "Close sending side stream={}.", stream_id);
         self.base_handler
             .stream_close_send(&mut self.conn, stream_id)
     }
@@ -652,7 +652,7 @@ impl Http3Client {
         stream_id: StreamId,
         buf: &mut [u8],
     ) -> Res<(usize, bool)> {
-        qinfo!([self], "read_data from stream {}.", stream_id);
+        qdebug!([self], "read_data from stream {}.", stream_id);
         let res = self.base_handler.read_data(&mut self.conn, stream_id, buf);
         if let Err(e) = &res {
             if e.connection_error() {

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -98,7 +98,7 @@ impl Http3ServerHandler {
     ///
     /// An error will be returned if stream does not exist.
     pub fn stream_close_send(&mut self, stream_id: StreamId, conn: &mut Connection) -> Res<()> {
-        qinfo!([self], "Close sending side stream={}.", stream_id);
+        qdebug!([self], "Close sending side stream={}.", stream_id);
         self.base_handler.stream_close_send(conn, stream_id)?;
         self.base_handler.stream_has_pending_data(stream_id);
         self.needs_processing = true;
@@ -408,7 +408,7 @@ impl Http3ServerHandler {
         stream_id: StreamId,
         buf: &mut [u8],
     ) -> Res<(usize, bool)> {
-        qinfo!([self], "read_data from stream {}.", stream_id);
+        qdebug!([self], "read_data from stream {}.", stream_id);
         let res = self.base_handler.read_data(conn, stream_id, buf);
         if let Err(e) = &res {
             if e.connection_error() {

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -271,7 +271,7 @@ impl RecvMessage {
                         }
                         (None, false) => break Ok(()),
                         (Some(frame), fin) => {
-                            qinfo!(
+                            qdebug!(
                                 [self],
                                 "A new frame has been received: {:?}; state={:?} fin={}",
                                 frame,

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -119,7 +119,7 @@ impl SendMessage {
         encoder: Rc<RefCell<QPackEncoder>>,
         conn_events: Box<dyn SendStreamEvents>,
     ) -> Self {
-        qinfo!("Create a request stream_id={}", stream_id);
+        qdebug!("Create a request stream_id={}", stream_id);
         Self {
             state: MessageState::WaitingForHeaders,
             message_type,

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -6,7 +6,7 @@
 
 use std::{cell::RefCell, cmp::min, fmt::Debug, rc::Rc};
 
-use neqo_common::{qdebug, qinfo, qtrace, Encoder, Header, MessageType};
+use neqo_common::{qdebug, qtrace, Encoder, Header, MessageType};
 use neqo_qpack::encoder::QPackEncoder;
 use neqo_transport::{Connection, StreamId};
 
@@ -193,7 +193,7 @@ impl SendStream for SendMessage {
             min(buf.len(), available - 9)
         };
 
-        qinfo!(
+        qdebug!(
             [self],
             "send_request_body: available={} to_send={}.",
             available,

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -13,7 +13,7 @@ use std::{
     rc::Rc,
 };
 
-use neqo_common::{qdebug, qinfo, Encoder, Header};
+use neqo_common::{qdebug, Encoder, Header};
 use neqo_transport::{
     server::ActiveConnectionRef, AppError, Connection, DatagramTracking, StreamId, StreamType,
 };
@@ -189,7 +189,7 @@ impl Http3OrWebTransportStream {
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn send_data(&mut self, data: &[u8]) -> Res<usize> {
-        qinfo!([self], "Set new response.");
+        qdebug!([self], "Set new response.");
         self.stream_handler.send_data(data)
     }
 
@@ -199,7 +199,7 @@ impl Http3OrWebTransportStream {
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn stream_close_send(&mut self) -> Res<()> {
-        qinfo!([self], "Set new response.");
+        qdebug!([self], "Set new response.");
         self.stream_handler.stream_close_send()
     }
 }
@@ -270,7 +270,7 @@ impl WebTransportRequest {
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     pub fn response(&mut self, accept: &WebTransportSessionAcceptAction) -> Res<()> {
-        qinfo!([self], "Set a response for a WebTransport session.");
+        qdebug!([self], "Set a response for a WebTransport session.");
         self.stream_handler
             .handler
             .borrow_mut()

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -164,7 +164,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
         let mut is_app_limited = true;
         let mut new_acked = 0;
         for pkt in acked_pkts {
-            qinfo!(
+            qdebug!(
                 "packet_acked this={:p}, pn={}, ps={}, ignored={}, lost={}, rtt_est={:?}",
                 self,
                 pkt.pn,
@@ -198,7 +198,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
 
         if is_app_limited {
             self.cc_algorithm.on_app_limited();
-            qinfo!("on_packets_acked this={:p}, limited=1, bytes_in_flight={}, cwnd={}, state={:?}, new_acked={}", self, self.bytes_in_flight, self.congestion_window, self.state, new_acked);
+            qdebug!("on_packets_acked this={:p}, limited=1, bytes_in_flight={}, cwnd={}, state={:?}, new_acked={}", self, self.bytes_in_flight, self.congestion_window, self.state, new_acked);
             return;
         }
 
@@ -249,7 +249,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
                 QlogMetric::BytesInFlight(self.bytes_in_flight),
             ],
         );
-        qinfo!([self], "on_packets_acked this={:p}, limited=0, bytes_in_flight={}, cwnd={}, state={:?}, new_acked={}", self, self.bytes_in_flight, self.congestion_window, self.state, new_acked);
+        qdebug!([self], "on_packets_acked this={:p}, limited=0, bytes_in_flight={}, cwnd={}, state={:?}, new_acked={}", self, self.bytes_in_flight, self.congestion_window, self.state, new_acked);
     }
 
     /// Update congestion controller state based on lost packets.
@@ -265,7 +265,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
         }
 
         for pkt in lost_packets.iter().filter(|pkt| pkt.cc_in_flight()) {
-            qinfo!(
+            qdebug!(
                 "packet_lost this={:p}, pn={}, ps={}",
                 self,
                 pkt.pn,
@@ -286,7 +286,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
             pto,
             lost_packets,
         );
-        qinfo!(
+        qdebug!(
             "on_packets_lost this={:p}, bytes_in_flight={}, cwnd={}, state={:?}",
             self,
             self.bytes_in_flight,
@@ -335,7 +335,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
         }
 
         self.bytes_in_flight += pkt.size;
-        qinfo!(
+        qdebug!(
             "packet_sent this={:p}, pn={}, ps={}",
             self,
             pkt.pn,
@@ -498,7 +498,7 @@ impl<T: WindowAdjustment> ClassicCongestionControl<T> {
         self.congestion_window = max(cwnd, CWND_MIN);
         self.acked_bytes = acked_bytes;
         self.ssthresh = self.congestion_window;
-        qinfo!(
+        qdebug!(
             [self],
             "Cong event -> recovery; cwnd {}, ssthresh {}",
             self.congestion_window,

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -208,7 +208,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
             let increase = min(self.ssthresh - self.congestion_window, self.acked_bytes);
             self.congestion_window += increase;
             self.acked_bytes -= increase;
-            qinfo!([self], "slow start += {}", increase);
+            qdebug!([self], "slow start += {}", increase);
             if self.congestion_window == self.ssthresh {
                 // This doesn't look like it is necessary, but it can happen
                 // after persistent congestion.

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -778,7 +778,7 @@ impl Connection {
             });
             enc.encode(extra);
             let records = s.send_ticket(now, enc.as_ref())?;
-            qinfo!([self], "send session ticket {}", hex(&enc));
+            qdebug!([self], "send session ticket {}", hex(&enc));
             self.crypto.buffer_records(records)?;
         } else {
             unreachable!();

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -824,7 +824,7 @@ impl Connection {
     /// the connection to fail.  However, if no packets have been
     /// exchanged, it's not OK.
     pub fn authenticated(&mut self, status: AuthenticationStatus, now: Instant) {
-        qinfo!([self], "Authenticated {:?}", status);
+        qdebug!([self], "Authenticated {:?}", status);
         self.crypto.tls.authenticated(status);
         let res = self.handshake(now, self.version, PacketNumberSpace::Handshake, None);
         self.absorb_error(now, res);
@@ -1154,7 +1154,7 @@ impl Connection {
 
     fn discard_keys(&mut self, space: PacketNumberSpace, now: Instant) {
         if self.crypto.discard(space) {
-            qinfo!([self], "Drop packet number space {}", space);
+            qdebug!([self], "Drop packet number space {}", space);
             let primary = self.paths.primary();
             self.loss_recovery.discard(&primary, space, now);
             self.acks.drop_space(space);
@@ -2323,7 +2323,7 @@ impl Connection {
         }
 
         if encoder.is_empty() {
-            qinfo!("TX blocked, profile={:?} ", profile);
+            qdebug!("TX blocked, profile={:?} ", profile);
             Ok(SendOption::No(profile.paced()))
         } else {
             // Perform additional padding for Initial packets as necessary.
@@ -2367,7 +2367,7 @@ impl Connection {
     }
 
     fn client_start(&mut self, now: Instant) -> Res<()> {
-        qinfo!([self], "client_start");
+        qdebug!([self], "client_start");
         debug_assert_eq!(self.role, Role::Client);
         qlog::client_connection_started(&mut self.qlog, &self.paths.primary());
         qlog::client_version_information_initiated(&mut self.qlog, self.conn_params.get_versions());
@@ -2599,7 +2599,7 @@ impl Connection {
 
     fn confirm_version(&mut self, v: Version) {
         if self.version != v {
-            qinfo!([self], "Compatible upgrade {:?} ==> {:?}", self.version, v);
+            qdebug!([self], "Compatible upgrade {:?} ==> {:?}", self.version, v);
         }
         self.crypto.confirm_version(v);
         self.version = v;
@@ -2899,7 +2899,7 @@ impl Connection {
         R: IntoIterator<Item = RangeInclusive<u64>> + Debug,
         R::IntoIter: ExactSizeIterator,
     {
-        qinfo!([self], "Rx ACK space={}, ranges={:?}", space, ack_ranges);
+        qdebug!([self], "Rx ACK space={}, ranges={:?}", space, ack_ranges);
 
         let (acked_packets, lost_packets) = self.loss_recovery.on_ack_received(
             &self.paths.primary(),
@@ -2953,7 +2953,7 @@ impl Connection {
     }
 
     fn set_connected(&mut self, now: Instant) -> Res<()> {
-        qinfo!([self], "TLS connection complete");
+        qdebug!([self], "TLS connection complete");
         if self.crypto.tls.info().map(SecretAgentInfo::alpn).is_none() {
             qwarn!([self], "No ALPN. Closing connection.");
             // 120 = no_application_protocol
@@ -2996,7 +2996,7 @@ impl Connection {
 
     fn set_state(&mut self, state: State) {
         if state > self.state {
-            qinfo!([self], "State change from {:?} -> {:?}", self.state, state);
+            qdebug!([self], "State change from {:?} -> {:?}", self.state, state);
             self.state = state.clone();
             if self.state.closed() {
                 self.streams.clear_streams();

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -317,7 +317,7 @@ impl Crypto {
     }
 
     pub fn acked(&mut self, token: &CryptoRecoveryToken) {
-        qinfo!(
+        qdebug!(
             "Acked crypto frame space={} offset={} length={}",
             token.space,
             token.offset,
@@ -367,7 +367,7 @@ impl Crypto {
                 });
                 enc.encode_vvec(new_token.unwrap_or(&[]));
                 enc.encode(t.as_ref());
-                qinfo!("resumption token {}", hex_snip_middle(enc.as_ref()));
+                qdebug!("resumption token {}", hex_snip_middle(enc.as_ref()));
                 Some(ResumptionToken::new(enc.into(), t.expiration_time()))
             } else {
                 None
@@ -433,7 +433,7 @@ impl CryptoDxState {
         cipher: Cipher,
         fuzzing: bool,
     ) -> Self {
-        qinfo!(
+        qdebug!(
             "Making {:?} {} CryptoDxState, v={:?} cipher={}",
             direction,
             epoch,
@@ -980,7 +980,7 @@ impl CryptoStates {
         };
 
         for v in versions {
-            qinfo!(
+            qdebug!(
                 [self],
                 "Creating initial cipher state v={:?}, role={:?} dcid={}",
                 v,

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![allow(clippy::module_name_repetitions)] // This lint doesn't work here.
 
-use neqo_common::qinfo;
+use neqo_common::qwarn;
 use neqo_crypto::Error as CryptoError;
 
 mod ackrate;
@@ -165,7 +165,7 @@ impl Error {
 
 impl From<CryptoError> for Error {
     fn from(err: CryptoError) -> Self {
-        qinfo!("Crypto operation failed {:?}", err);
+        qwarn!("Crypto operation failed {:?}", err);
         match err {
             CryptoError::EchRetry(config) => Self::EchRetry(config),
             _ => Self::CryptoError(err),

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -216,7 +216,7 @@ impl Paths {
     /// to a migration from a peer, in which case the old path needs to be probed.
     #[must_use]
     fn select_primary(&mut self, path: &PathRef) -> Option<PathRef> {
-        qinfo!([path.borrow()], "set as primary path");
+        qdebug!([path.borrow()], "set as primary path");
         let old_path = self.primary.replace(Rc::clone(path)).map(|old| {
             old.borrow_mut().set_primary(false);
             old

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -14,7 +14,7 @@ use std::{
     time::Duration,
 };
 
-use neqo_common::qinfo;
+use neqo_common::qwarn;
 
 use crate::packet::PacketNumber;
 
@@ -168,7 +168,7 @@ impl Stats {
 
     pub fn pkt_dropped(&mut self, reason: impl AsRef<str>) {
         self.dropped_rx += 1;
-        qinfo!(
+        qwarn!(
             [self.info],
             "Dropped received packet: {}; Total: {}",
             reason.as_ref(),

--- a/test/upload_test.sh
+++ b/test/upload_test.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export RUST_LOG=neqo_transport::cc=debug
+
 server_address=127.0.0.1
 server_port=4433
 upload_size=8388608


### PR DESCRIPTION
- In `neqo-client` and `neqo-server` use `neqo_common::log` instead of `println!`   and `eprintln!`.
- Add `-q`, `-v`, `-vv`, `-vvv`, `-vvvv` log level flags via   `clap_verbosity_flag`.
- Set default log level to INFO. Demote many `qinfo!` to `qdebug!`.

---

Fixes https://github.com/mozilla/neqo/issues/685.