### PR TITLE
fix(tests/cc): compare cwnd before and after congestion

### DIFF
--- a/neqo-transport/src/connection/tests/cc.rs
+++ b/neqo-transport/src/connection/tests/cc.rs
@@ -71,6 +71,7 @@ fn cc_slow_start_to_cong_avoidance_recovery_period() {
         client.stats().frame_rx.largest_acknowledged,
         flight1_largest
     );
+    let cwnd_before_cong = cwnd(&client);
 
     // Client: send more
     let (mut c_tx_dgrams, mut now) = fill_cwnd(&mut client, stream_id, now);
@@ -93,6 +94,7 @@ fn cc_slow_start_to_cong_avoidance_recovery_period() {
         client.stats().frame_rx.largest_acknowledged,
         flight2_largest
     );
+    assert!(cwnd(&client) < cwnd_before_cong);
 }
 
 #[test]


### PR DESCRIPTION
The `cc_slow_start_to_cong_avoidance_recovery_period` test sends two flights of data from client to server. In the second flight the first packet is dropped, which is thus not included in the second ACK of the server to the client.

Due to the dropped packet, the client is expected to move into recovery state. But the test only checks the largest acknowledged packet. It does not assert the state change. Making `ClassicCongestionControl::on_congestion_event` a no-op does not fail the test.

With this commit, the test asserts that the congestion window decreases, thus presuming a state change.

---

Hope I am not missing something.

Is comparing `cwnd`s the best way to witness a state change?