### PR TITLE
fix: feature flag Datagram::into_data

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,7 +98,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install Rust tools
-        run: cargo +${{ matrix.rust-toolchain }} binstall --no-confirm cargo-llvm-cov cargo-nextest
+        run: cargo +${{ matrix.rust-toolchain }} binstall --no-confirm cargo-llvm-cov cargo-nextest cargo-hack
 
       # This step might be removed if the distro included a recent enough
       # version of NSS.  Ubuntu 20.04 only has 3.49, which is far too old.
@@ -158,7 +158,6 @@ jobs:
           # respective default features only. Can reveal warnings otherwise
           # hidden given that a plain cargo clippy combines all features of the
           # workspace. See e.g. https://github.com/mozilla/neqo/pull/1695.
-          cargo +${{ matrix.rust-toolchain }} install cargo-hack
           cargo +${{ matrix.rust-toolchain }} hack clippy --all-targets -- -D warnings || ${{ matrix.rust-toolchain == 'nightly' }}
         if: success() || failure()
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -153,7 +153,13 @@ jobs:
         if: success() || failure()
 
       - name: Clippy
-        run: cargo +${{ matrix.rust-toolchain }} clippy --all-targets -- -D warnings || ${{ matrix.rust-toolchain == 'nightly' }}
+        run: |
+          # Use cargo-hack to run clippy on each crate individually with its
+          # respective default features only. Can reveal warnings otherwise
+          # hidden given that a plain cargo clippy combines all features of the
+          # workspace. See e.g. https://github.com/mozilla/neqo/pull/1695.
+          cargo +${{ matrix.rust-toolchain }} install cargo-hack
+          cargo +${{ matrix.rust-toolchain }} hack clippy --all-targets -- -D warnings || ${{ matrix.rust-toolchain == 'nightly' }}
         if: success() || failure()
 
       - name: Check rustdoc links

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -54,6 +54,7 @@ impl Datagram {
         self.ttl
     }
 
+    #[cfg(feature = "udp")]
     #[must_use]
     pub(crate) fn into_data(self) -> Vec<u8> {
         self.d


### PR DESCRIPTION
`Datagram::into_data` is used in `neqo_common::udp` only. `neqo_common::udp` is behind the `udp` feature. The feature is not part of the crate's default features. Thus a plain `cargo check` rightly complains with:

```
warning: method `into_data` is never used
  --> neqo-common/src/datagram.rs:58:19
   |
20 | impl Datagram {
   | ------------- method in this implementation
...
58 |     pub(crate) fn into_data(self) -> Vec<u8> {
   |                   ^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```

This commit hides `into_data` behind the `udp` feature as well.

Introduced in https://github.com/mozilla/neqo/pull/1604. My bad.