### PR TITLE
Return an error if the path is not permanent

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1937,6 +1937,10 @@ impl Connection {
             };
 
             let path = close.path().borrow();
+            if path.is_temporary() {
+                debug_assert!(false, "Path is not permanent");
+                return Err(Error::InternalError);
+            }
             let (_, mut builder) = Self::build_packet_header(
                 &path,
                 cspace,

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1942,9 +1942,7 @@ impl Connection {
             // a packet on a new path, we avoid sending (and the privacy risk) rather
             // than reuse a connection ID.
             if path.is_temporary() {
-                if cfg!(test) {
-                    panic!("attempting to close with a temporary path");
-                }
+                assert!(!cfg!(test), "attempting to close with a temporary path");
                 return Err(Error::InternalError);
             }
             let (_, mut builder) = Self::build_packet_header(

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1942,8 +1942,9 @@ impl Connection {
             // a packet on a new path, we avoid sending (and the privacy risk) rather
             // than reuse a connection ID.
             if path.is_temporary() {
-                #[cfg(test)]
-                assert!(false, "path is temporary");
+                if cfg!(test) {
+                    panic!("attempting to close with a temporary path");
+                }
                 return Err(Error::InternalError);
             }
             let (_, mut builder) = Self::build_packet_header(

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1942,6 +1942,8 @@ impl Connection {
             // a packet on a new path, we avoid sending (and the privacy risk) rather
             // than reuse a connection ID.
             if path.is_temporary() {
+                #[cfg(test)]
+                assert!(false, "path is temporary");
                 return Err(Error::InternalError);
             }
             let (_, mut builder) = Self::build_packet_header(

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1937,8 +1937,11 @@ impl Connection {
             };
 
             let path = close.path().borrow();
+            // In some error cases, we will not be able to make a new, permanent path.
+            // For example, if we run out of connection IDs and the error results from
+            // a packet on a new path, we avoid sending (and the privacy risk) rather
+            // than reuse a connection ID.
             if path.is_temporary() {
-                debug_assert!(false, "Path is not permanent");
                 return Err(Error::InternalError);
             }
             let (_, mut builder) = Self::build_packet_header(

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -6,6 +6,7 @@
 
 use std::{
     cell::RefCell,
+    mem,
     net::{IpAddr, Ipv6Addr, SocketAddr},
     rc::Rc,
     time::{Duration, Instant},
@@ -949,4 +950,44 @@ fn retire_prior_to_migration_success() {
     assert_v4_path(&dgram, false);
     assert_ne!(get_cid(&dgram), original_cid);
     assert_ne!(get_cid(&dgram), probe_cid);
+}
+
+struct GarbageWriter {}
+
+impl crate::connection::test_internal::FrameWriter for GarbageWriter {
+    fn write_frames(&mut self, builder: &mut PacketBuilder) {
+        builder.encode_varint(u32::MAX);
+    }
+}
+
+/// Test the case that we run out of connection ID and receive an invalid frame
+/// from a new path.
+#[test]
+fn error_on_new_path_with_no_connection_id() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+
+    let dgram = send_something(&mut server, now());
+    let dgram = change_path(&dgram, DEFAULT_ADDR_V4);
+    client.process_input(&dgram, now());
+
+    let cid_gen: Rc<RefCell<dyn ConnectionIdGenerator>> =
+        Rc::new(RefCell::new(CountingConnectionIdGenerator::default()));
+    server.test_frame_writer = Some(Box::new(RetireAll { cid_gen }));
+    let retire_all = send_something(&mut server, now());
+    server.test_frame_writer = None;
+
+    client.process_input(&retire_all, now());
+
+    server.test_frame_writer = Some(Box::new(GarbageWriter {}));
+    let garbage = send_something(&mut server, now());
+    server.test_frame_writer = None;
+
+    let dgram = change_path(&garbage, DEFAULT_ADDR_V4);
+    client.process_input(&dgram, now());
+
+    // See issue #1697. We had a crash when the client had a temporary path and
+    // process_output is called.
+    mem::drop(client.process_output(now()));
 }

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -964,7 +964,7 @@ impl crate::connection::test_internal::FrameWriter for GarbageWriter {
 /// Test the case that we run out of connection ID and receive an invalid frame
 /// from a new path.
 #[test]
-#[should_panic(expected = "path is temporary")]
+#[should_panic(expected = "attempting to close with a temporary path")]
 fn error_on_new_path_with_no_connection_id() {
     let mut client = default_client();
     let mut server = default_server();


### PR DESCRIPTION
For issue #1697 
This is just a workaround for stop crashing.
The root cause of this crash is still not clear. Maybe necko does something wrong.

Note that the [crash signature](https://crash-stats.mozilla.org/report/index/42c84380-18ac-4d7a-b425-8947f0240224) seems wrong. The frame 9 is `neqo_transport::path::Path::local_cid()`, but the provided [link](https://hg.mozilla.org/releases/mozilla-beta/file/f52b92d785d0346848c447a502d5d50bebd2ea53/third_party/rust/neqo-transport/src/path.rs#l679) to the code indicates the function is `neqo_transport::path::Path::remote_cid()`. 
