### PR TITLE
fix(udp): pre-allocate receive buffer

### DIFF
--- a/neqo-client/src/main.rs
+++ b/neqo-client/src/main.rs
@@ -763,7 +763,7 @@ fn to_headers(values: &[impl AsRef<str>]) -> Vec<Header> {
 
 struct ClientRunner<'a> {
     local_addr: SocketAddr,
-    socket: &'a udp::Socket,
+    socket: &'a mut udp::Socket,
     client: Http3Client,
     handler: Handler<'a>,
     timeout: Option<Pin<Box<Sleep>>>,
@@ -773,7 +773,7 @@ struct ClientRunner<'a> {
 impl<'a> ClientRunner<'a> {
     fn new(
         args: &'a mut Args,
-        socket: &'a udp::Socket,
+        socket: &'a mut udp::Socket,
         local_addr: SocketAddr,
         remote_addr: SocketAddr,
         hostname: &str,
@@ -998,7 +998,7 @@ async fn main() -> Res<()> {
             SocketAddr::V6(..) => SocketAddr::new(IpAddr::V6(Ipv6Addr::from([0; 16])), 0),
         };
 
-        let socket = udp::Socket::bind(local_addr)?;
+        let mut socket = udp::Socket::bind(local_addr)?;
         let real_local = socket.local_addr().unwrap();
         println!(
             "{} Client connecting: {:?} -> {:?}",
@@ -1022,7 +1022,7 @@ async fn main() -> Res<()> {
             token = if args.use_old_http {
                 old::ClientRunner::new(
                     &args,
-                    &socket,
+                    &mut socket,
                     real_local,
                     remote_addr,
                     &hostname,
@@ -1034,7 +1034,7 @@ async fn main() -> Res<()> {
             } else {
                 ClientRunner::new(
                     &mut args,
-                    &socket,
+                    &mut socket,
                     real_local,
                     remote_addr,
                     &hostname,
@@ -1249,7 +1249,7 @@ mod old {
 
     pub struct ClientRunner<'a> {
         local_addr: SocketAddr,
-        socket: &'a udp::Socket,
+        socket: &'a mut udp::Socket,
         client: Connection,
         handler: HandlerOld<'a>,
         timeout: Option<Pin<Box<Sleep>>>,
@@ -1259,7 +1259,7 @@ mod old {
     impl<'a> ClientRunner<'a> {
         pub fn new(
             args: &'a Args,
-            socket: &'a udp::Socket,
+            socket: &'a mut udp::Socket,
             local_addr: SocketAddr,
             remote_addr: SocketAddr,
             origin: &str,


### PR DESCRIPTION
Instead of allocating a new receive buffer on each call to `neqo_common::udp::Socket::recv`, preallocate a long-lived buffer in `Socket::bind` and reuse this buffer on each read.

See flamegraphs below. With the patch `neqo_common::udp::Socket::recv` simply delegates to `tokio::net::udp::UdpSocket::try_io` instead of spending significant time in `memset`.

Quick-fix while working on https://github.com/mozilla/neqo/issues/1693.

Addresses first performance issue in https://github.com/mozilla/neqo/issues/1690.


Before:

![flamegraph](https://github.com/mozilla/neqo/assets/7047859/fcf1234f-25cc-4386-98f7-926c95297e91)

After:

![patch](https://github.com/mozilla/neqo/assets/7047859/738e8f4b-e089-4b9f-b59a-4481cd06efe7)
