### PR TITLE
fix(udp): handle multiple datagrams on GRO

### DIFF
--- a/neqo-server/src/main.rs
+++ b/neqo-server/src/main.rs
@@ -688,11 +688,13 @@ impl ServersRunner {
             match self.ready().await? {
                 Ready::Socket(inx) => loop {
                     let (host, socket) = self.sockets.get_mut(inx).unwrap();
-                    let dgram = socket.recv(host)?;
-                    if dgram.is_none() {
+                    let dgrams = socket.recv(host)?;
+                    if dgrams.is_empty() {
                         break;
                     }
-                    self.process(dgram.as_ref()).await?;
+                    for dgram in dgrams {
+                        self.process(Some(&dgram)).await?;
+                    }
                 },
                 Ready::Timeout => {
                     self.timeout = None;


### PR DESCRIPTION
Previously `Socket::recv` would at most return a single `Datagram` (i.e. `-> Result<Option<Datagram>, io::Error>`). When supported by the OS, the underlying `quinn-udp` can use both recvMmsg and GRO, each with the ability to return one or more datagrams.

As of today, `neqo_common::udp` does not make use of recvmmsg effectively, i.e. it only provides a single `IoSliceMut` to write into. That said, that single `IoSliceMut` might contain multiple `Datagram`s through GRO. Previously this would have been provided as a single `Datagram` to the caller of `Socket::recv`.

This commit makes sure to handle the case where many `Datagram`s are retrieved via GRO. I.e. where `meta.stride < meta.len`, indicating that the `IoSliceMut` contains more than one datagram. In addition it updates `neqo_common::udp::Socket::recv` and `neqo-server` and `neqo-client` accordingly.

See also the `quinn-udp` implementation and its usage in `quinn`:
- https://github.com/quinn-rs/quinn/blob/9611c5ef6932781eb84bc775e7f008474531b20e/quinn-udp/src/lib.rs#L75-L84
- https://github.com/quinn-rs/quinn/blob/9611c5ef6932781eb84bc775e7f008474531b20e/quinn/src/endpoint.rs#L417-L418

---

This pull request has two commits:

1. [Test multi packet GRO read](https://github.com/mozilla/neqo/pull/1708/commits/bc1659a0d3a219907ea7935d495bfbf5ec6ca630)
    - Failing test using `quinn-udp` to send set of uniform datagrams via single GSO sendmmsg, to then be received via single GRO recvmmsg call.
    - See sample failure in https://github.com/mozilla/neqo/actions/runs/8130581760/job/22218948010?pr=1708
2. [fix(udp): handle multiple datagrams through gro](https://github.com/mozilla/neqo/pull/1708/commits/5db3ca8a753045f81de9ae47baa329e80a621710)
    - The actual fix, having `Socket::recv` return multiple `Datagram`s on GRO read.

Bug introduced in https://github.com/mozilla/neqo/pull/1604. Note however that since `neqo_common::udp::Socket::send` [would never do GSO](https://github.com/mozilla/neqo/blob/a2d525b3c37badbe890f4141f945164f357325c7/neqo-common/src/udp.rs#L60), this bug is unlikely to occur between `neqo-client` and `neqo-server`. It can however occur when connecting to other implementations.

Given that this is a bug fix only, diff is kept at a minimum. Proper GRO (and GSO) support coming with https://github.com/mozilla/neqo/issues/1693.