### PR TITLE
ci: Use the git mirrors for NSS and NSPR

### DIFF
--- a/.github/actions/nss/action.yml
+++ b/.github/actions/nss/action.yml
@@ -1,21 +1,19 @@
-name: Checkout NSS and NSPR
+name: Fetch and build NSS
 
 runs:
   using: composite
   steps:
-    - name: Fetch NSS and NSPR
+    - name: Fetch and build NSS
       shell: bash
       run: |
-        for i in {1..$RETRIES}; do
-          hg clone https://hg.mozilla.org/projects/nspr "$NSPR_DIR" && break || sleep $DELAY && false
-        done
-        for i in {1..$RETRIES}; do
-          hg clone https://hg.mozilla.org/projects/nss "$NSS_DIR" && break || sleep $DELAY && false
-        done
+        git clone --depth=1 https://github.com/nss-dev/nspr "$NSPR_DIR"
+        git clone --depth=1 https://github.com/nss-dev/nss "$NSS_DIR"
+        $NSS_DIR/build.sh -g -Ddisable_tests=1 -o
         echo "NSS_DIR=$NSS_DIR" >> "$GITHUB_ENV"
         echo "NSPR_DIR=$NSPR_DIR" >> "$GITHUB_ENV"
+        echo "LD_LIBRARY_PATH=$NSS_DIR/../dist/Release/lib" >> "$GITHUB_ENV"
+        echo "DYLD_FALLBACK_LIBRARY_PATH=$NSS_DIR/../dist/Release/lib" >> "$GITHUB_ENV"
+        echo "$NSS_DIR/../dist/Release/lib" >> "$GITHUB_PATH"
       env:
         NSS_DIR: ${{ github.workspace }}/nss
         NSPR_DIR: ${{ github.workspace }}/nspr
-        RETRIES: 10
-        DELAY: 10

--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -38,4 +38,4 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         cache-all-crates: "true"
-        cache-directories: "dist"
+        cache-directories: "$NSS_DIR/../dist"

--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -38,3 +38,4 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         cache-all-crates: "true"
+        cache-directories: "dist"

--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -38,4 +38,4 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         cache-all-crates: "true"
-        cache-directories: "$NSS_DIR/../dist"
+        cache-directories: "${{ github.workspace }}/dist"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,8 +18,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      LD_LIBRARY_PATH: ${{ github.workspace }}/dist/Release/lib
 
     steps:
       - name: Checkout
@@ -34,12 +32,11 @@ jobs:
           version: $TOOLCHAIN
           components: rustfmt
 
-      - name: Fetch NSS and NSPR
+      - name: Fetch and build NSS and NSPR
         uses: ./.github/actions/nss
 
       - name: Build
         run: |
-          $NSS_DIR/build.sh -g -Ddisable_tests=1 -o
           cargo +$TOOLCHAIN bench --features bench --no-run
           cargo +$TOOLCHAIN build --release --bin neqo-client --bin neqo-server
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get install -y --no-install-recommends gyp mercurial ninja-build lld
+          sudo apt-get install -y --no-install-recommends gyp ninja-build lld
           echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld" >> "$GITHUB_ENV"
 
       # In addition to installing dependencies, first make sure System Integrity Protection (SIP)
@@ -64,7 +64,7 @@ jobs:
         if: runner.os == 'MacOS'
         run: |
           csrutil status | grep disabled
-          brew install ninja mercurial llvm
+          brew install ninja llvm
           echo "/opt/homebrew/opt/llvm/bin" >> "$GITHUB_PATH"
           ln -s /opt/homebrew/bin/python3 /opt/homebrew/bin/python
           # python3 -m pip install gyp-next
@@ -89,14 +89,6 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
 
-      # This step might be removed if the distro included a recent enough
-      # version of NSS.  Ubuntu 20.04 only has 3.49, which is far too old.
-      # (neqo-crypto/build.rs would also need to query pkg-config to get the
-      # right build flags rather than building NSS.)
-      # Clone from the main hg repo, because the GitHub mirror can be out of date.
-      - name: Fetch NSS and NSPR
-        uses: ./.github/actions/nss
-
       - name: Set up NSS/NSPR build environment (Windows)
         if: runner.os == 'Windows'
         run: |
@@ -106,14 +98,15 @@ jobs:
           # See https://github.com/ilammy/msvc-dev-cmd#name-conflicts-with-shell-bash
           rm /usr/bin/link.exe
 
+      # This step might be removed if the distro included a recent enough
+      # version of NSS.  Ubuntu 20.04 only has 3.49, which is far too old.
+      # (neqo-crypto/build.rs would also need to query pkg-config to get the
+      # right build flags rather than building NSS.)
+      - name: Fetch and build NSS and NSPR
+        uses: ./.github/actions/nss
+
       - name: Build
-        run: |
-          cargo +${{ matrix.rust-toolchain }} build $BUILD_TYPE --all-targets --features ci,bench
-          echo "LD_LIBRARY_PATH=${{ github.workspace }}/dist/$LIB_DIR/lib" >> "$GITHUB_ENV"
-          echo "DYLD_FALLBACK_LIBRARY_PATH=${{ github.workspace }}/dist/$LIB_DIR/lib" >> "$GITHUB_ENV"
-          echo "${{ github.workspace }}/dist/$LIB_DIR/lib" >> "$GITHUB_PATH"
-        env:
-          LIB_DIR: ${{ matrix.type == 'release' && 'Release' || 'Debug' }}
+        run: cargo +${{ matrix.rust-toolchain }} build $BUILD_TYPE --all-targets --features ci,bench
 
       - name: Run tests and determine coverage
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -106,7 +106,7 @@ jobs:
         uses: ./.github/actions/nss
 
       - name: Build
-        run: cargo +${{ matrix.rust-toolchain }} build $BUILD_TYPE --all-targets --features ci,bench
+        run: cargo +${{ matrix.rust-toolchain }} build $BUILD_TYPE --all-targets --features ci
 
       - name: Run tests and determine coverage
         run: |

--- a/qns/Dockerfile
+++ b/qns/Dockerfile
@@ -4,8 +4,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl git mercurial \
     build-essential libclang-dev lld \
     gyp ninja-build zlib1g-dev python \
- && apt-get autoremove -y && apt-get clean -y \
- && rm -rf /var/lib/apt/lists/*
+    && apt-get autoremove -y && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 
 ARG RUST_VERSION=stable
 
@@ -21,8 +21,8 @@ ENV NSS_DIR=/nss \
     LD_LIBRARY_PATH=/dist/Release/lib
 
 RUN set -eux; \
-    hg clone https://hg.mozilla.org/projects/nss "$NSS_DIR"; \
-    hg clone https://hg.mozilla.org/projects/nspr "$NSPR_DIR"
+    git clone --depth=1 https://github.com/nss-dev/nspr "$NSPR_DIR"; \
+    git clone --depth=1 https://github.com/nss-dev/nss "$NSS_DIR"
 
 RUN "$NSS_DIR"/build.sh --static -Ddisable_tests=1 -o
 
@@ -31,7 +31,7 @@ ADD . /neqo
 RUN set -eux; \
     cd /neqo; \
     RUSTFLAGS="-g -C link-arg=-fuse-ld=lld" cargo build --release \
-      --bin neqo-client --bin neqo-server
+    --bin neqo-client --bin neqo-server
 
 # Copy only binaries to the final image to keep it small.
 


### PR DESCRIPTION
Since the mercurial ones are often flaky.

Also build NSS as part of the `nss` action, to reduce replication.