### PR TITLE
fix(server): enable `regex` crate `unicode-perl` feature

### DIFF
--- a/neqo-server/Cargo.toml
+++ b/neqo-server/Cargo.toml
@@ -23,5 +23,5 @@ neqo-http3 = { path = "./../neqo-http3" }
 neqo-qpack = { path = "./../neqo-qpack" }
 neqo-transport = { path = "./../neqo-transport" }
 qlog = { version = "0.12", default-features = false }
-regex = { version = "1.9", default-features = false }
+regex = { version = "1.9", default-features = false, features = ["unicode-perl"] }
 tokio = { version = "1", default-features = false, features = ["net", "time", "macros", "rt", "rt-multi-thread"] }


### PR DESCRIPTION
Enable the `unicode-perl` feature flag on `regex` crate dependency in `neqo-server` crate.

The following regex makes use of the feature:

``` rust
Regex::new(r"GET +/(\S+)(?:\r)?\n").unwrap()
```

Without the feature, the QUIC Interop tests panic with:

```
server  | thread 'main' panicked at neqo-server/src/old_https.rs:140:49:
server  | called `Result::unwrap()` on an `Err` value: Syntax(
server  | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
server  | regex parse error:
server  |     GET +/(\S+)(?:\r)?\n
server  |            ^^
server  | error: Unicode-aware Perl class not found (make sure the unicode-perl feature is enabled)
server  | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
server  | )
```

---

I will prioritize https://github.com/mozilla/neqo/pull/1682 more to make sure we catch these regressions before merge.