### PR TITLE
refactor(.github): rename comment workflow

### DIFF
--- a/.github/workflows/qns-comment.yml
+++ b/.github/workflows/qns-comment.yml
@@ -4,7 +4,7 @@
 # tests itself might run off of a fork, i.e. an untrusted environment and should
 # thus not be granted write permissions.
 
-name: Comment on the pull request
+name: QUIC Network Simulator Comment
 
 on:
   workflow_run:


### PR DESCRIPTION
Rename `Comment on the pull request` to `QUIC Network Simulator Comment`.

Might be a bit more intuitive, when seeing it next to the other workflows:

![image](https://github.com/mozilla/neqo/assets/7047859/70810e4f-d1e4-4ab9-a6e2-7c548484755d)
