### PR TITLE
fix(github): qns comment on failure only and update existing

### DIFF
--- a/.github/workflows/qns-comment.yml
+++ b/.github/workflows/qns-comment.yml
@@ -18,7 +18,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     if: >
-      github.event.workflow_run.event == 'pull_request'
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: Download comment-data
         uses: actions/download-artifact@v4
@@ -52,3 +53,4 @@ jobs:
         with:
           filePath: comment
           pr_number: ${{ steps.pr-number.outputs.number }}
+          comment_tag: quic-network-simulator-comment


### PR DESCRIPTION
Once the QUIC Network Simulator workflow finished, the QUIC Network Simulator Comment workflow adds the test results as a comment to the corresponding pull request.

This commit makes two changes:

- Only add a comment on test failure.
- In case a comment already exists, update it in place.

---

Parts of https://github.com/mozilla/neqo/issues/1716.

Note I have not been able to test this yet. Happy to port this over to my test-setup https://github.com/mxinden/quic-interop-runner-action/ though that will take me a bit more time. Your call.