### PR TITLE
fix(client,server): re-enable clap default features

### DIFF
--- a/neqo-client/Cargo.toml
+++ b/neqo-client/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 # neqo-client is not used in Firefox, so we can be liberal with dependency versions
-clap = { version = "4.4", default-features = false, features = ["std", "derive"] }
+clap = { version = "4.4", default-features = false, features = ["std", "color", "help", "usage", "error-context", "suggestions", "derive"] }
 futures = { version = "0.3", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["std"] }
 log = { version = "0.4", default-features = false }

--- a/neqo-server/Cargo.toml
+++ b/neqo-server/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 # neqo-server is not used in Firefox, so we can be liberal with dependency versions
-clap = { version = "4.4", default-features = false, features = ["std", "derive"] }
+clap = { version = "4.4", default-features = false, features = ["std", "color", "help", "usage", "error-context", "suggestions", "derive"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4", default-features = false }
 neqo-common = { path = "./../neqo-common", features = ["udp"] }


### PR DESCRIPTION
When default features are disabled, clap does not e.g. generate logic for `--help` or `--version` handling. Instead it errors with the opaque error on anything other than correct command line flags.

```
$ neqo-client --version

error: unexpected argument found
```

Instead of removing `default-features = false`, enable them individually.

See https://docs.rs/clap/latest/clap/_features/index.html for details.