### PR TITLE
fix(.rustfmt.toml): specify Rust edition 2021

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,5 @@
+edition = "2021"
+
 comment_width=100
 wrap_comments=true
 

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,8 @@
+# Keep in sync with `Cargo.toml` `edition`.
+#
+# `rustfmt` envoked not through `cargo fmt` but directly does not pick up Rust
+# edition in `Cargo.toml`. Thus duplicate here. See
+# https://github.com/mozilla/neqo/pull/1722 for details.
 edition = "2021"
 
 comment_width=100

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ homepage = "https://github.com/mozilla/neqo/"
 repository = "https://github.com/mozilla/neqo/"
 authors = ["The Neqo Authors <necko@mozilla.com>"]
 version = "0.7.1"
+# Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"
 # Don't increase beyond what Firefox is currently using:


### PR DESCRIPTION
Emacs' most popular Rust plugin [Rustic](https://github.com/brotzeit/rustic) uses `rustfmt` to format code. `rustfmt` only picks up the Rust edition from `Cargo.toml` when executed through `cargo fmt` (see [1] and [2]).

This commit duplicates the Rust edition in the `.rustfmt.toml` file. Thus all users of `rustfmt` (whether through `cargo fmt` or plain `rustfmt`) will get formatting according to their Rust edition, e.g. helpful when interacting with `async` code.

[1]: https://github.com/brotzeit/rustic?tab=readme-ov-file#edition-2018
[2]: https://github.com/rust-lang/rustfmt?tab=readme-ov-file#rusts-editions

There might be other editors using `rustfmt` directly.

---

Feel free to close in case you think this is too editor specific.

@jesup this might safe you some debugging time as a fellow emacs user.