### PR TITLE
Priority headers should be set by the application

### DIFF
--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -835,9 +835,6 @@ impl Http3Connection {
             final_headers.push(Header::new(":protocol", conn_type.string()));
         }
 
-        if let Some(priority_header) = request.priority.header() {
-            final_headers.push(priority_header);
-        }
         final_headers.extend_from_slice(request.headers);
         Ok(final_headers)
     }

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -68,7 +68,7 @@ fn priority_update() {
             Instant::now(),
             "GET",
             &("https", "something.com", "/"),
-            &[],
+            &[Header::new("priority", "u=4,i")],
             Priority::new(4, true),
         )
         .unwrap();
@@ -129,7 +129,7 @@ fn priority_update_dont_send_for_cancelled_stream() {
             Instant::now(),
             "GET",
             &("https", "something.com", "/"),
-            &[],
+            &[Header::new("priority", "u=5")],
             Priority::new(5, false),
         )
         .unwrap();


### PR DESCRIPTION
Instead of setting the priority headers in neqo, the headers should be provided by the application.

See related https://phabricator.services.mozilla.com/D201265
