### PR TITLE
fix: Disable generation of criterion HTML graphs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -141,11 +141,3 @@ jobs:
               > results.md
           echo '' >> results.md
           echo '[:arrow_down: Download full results](${{ steps.export.outputs.artifact-url }})' >> results.md
-
-      - name: "Post results to PR"
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          filePath: results.md
-          pr_number: ${{ github.event.pull_request.number }}
-          comment_tag: bench-results
-

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run cargo bench
         run: |
           taskset -c 0 nice -n -20 \
-            cargo +$TOOLCHAIN bench --features bench | tee results.txt
+            cargo +$TOOLCHAIN bench --features bench -- --noplot | tee results.txt
 
       # Pin the transfer benchmark to core 0 and run it at elevated priority inside perf.
       # Work around https://github.com/flamegraph-rs/flamegraph/issues/248 by passing explicit perf arguments.
@@ -70,7 +70,7 @@ jobs:
           mv target/criterion-transfer-profile target/criterion || true
           taskset -c 0 nice -n -20 \
             cargo +$TOOLCHAIN flamegraph -v -c "$PERF_CMD" --features bench --bench transfer -- \
-              --bench --exact "Run multiple transfers with varying seeds"
+              --bench --exact "Run multiple transfers with varying seeds" --noplot
           # And now restore the directories.
           mv target/criterion target/criterion-transfer-profile
           mv target/criterion-bench target/criterion

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -151,3 +151,10 @@ jobs:
                     -e 's/(change:[^%]*%)([^%]*%)(.*)/\1**\2**\3/gi' \
               > results.md
           echo '' >> results.md
+
+      - name: Export PR comment data
+        uses: ./.github/actions/pr-comment-data-export
+        with:
+          name: bench
+          contents: results.md
+          log-url: ${{ steps.export.outputs.artifact-url }}

--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -12,10 +12,12 @@ license.workspace = true
 [[bin]]
 name = "neqo-client"
 path = "src/bin/client.rs"
+bench = false
 
 [[bin]]
 name = "neqo-server"
 path = "src/bin/server/main.rs"
+bench = false
 
 [lints]
 workspace = true
@@ -35,3 +37,7 @@ qlog = { version = "0.12", default-features = false }
 regex = { version = "1.9", default-features = false, features = ["unicode-perl"] }
 tokio = { version = "1", default-features = false, features = ["net", "time", "macros", "rt", "rt-multi-thread"] }
 url = { version = "2.5", default-features = false }
+
+[lib]
+# See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -32,3 +32,7 @@ udp = ["dep:quinn-udp", "dep:tokio"]
 [target."cfg(windows)".dependencies.winapi]
 version = "0.3"
 features = ["timeapi"]
+
+[lib]
+# See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false

--- a/neqo-crypto/Cargo.toml
+++ b/neqo-crypto/Cargo.toml
@@ -31,3 +31,7 @@ test-fixture = { path = "../test-fixture" }
 [features]
 gecko = ["mozbuild"]
 fuzzing = []
+
+[lib]
+# See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -29,3 +29,7 @@ test-fixture = { path = "../test-fixture" }
 
 [features]
 fuzzing = ["neqo-transport/fuzzing", "neqo-crypto/fuzzing"]
+
+[lib]
+# See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -22,3 +22,7 @@ static_assertions = { version = "1.1", default-features = false }
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }
+
+[lib]
+# See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -21,7 +21,7 @@ qlog = { version = "0.12", default-features = false }
 smallvec = { version = "1.11", default-features = false }
 
 [dev-dependencies]
-criterion = { version = "0.5", default-features = false, features = ["html_reports"] }
+criterion = { version = "0.5", default-features = false }
 enum-map = { version = "2.7", default-features = false }
 test-fixture = { path = "../test-fixture" }
 

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -21,13 +21,17 @@ qlog = { version = "0.12", default-features = false }
 smallvec = { version = "1.11", default-features = false }
 
 [dev-dependencies]
-criterion = { version = "0.5", default-features = false }
+criterion = { version = "0.5", default-features = false, features = ["html_reports"] }
 enum-map = { version = "2.7", default-features = false }
 test-fixture = { path = "../test-fixture" }
 
 [features]
 bench = []
 fuzzing = ["neqo-crypto/fuzzing"]
+
+[lib]
+# See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
 
 [[bench]]
 name = "transfer"

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -23,3 +23,7 @@ qlog = { version = "0.12", default-features = false }
 
 [features]
 bench = []
+
+[lib]
+# See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false


### PR DESCRIPTION
Because we pin the benchmark runs to single cores, and criterion hence runs the report generation also on those cores, and based on `top` output it appears as this is parallelized and hence may interfere with the benchmark runs.