### PR TITLE
ci: Add `concurrency` to top-level workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -8,6 +8,10 @@ on:
     paths: [".github/**"]
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -8,6 +8,10 @@ on:
     branches: ["main"]
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   quic-network-simulator:
     runs-on: ubuntu-latest


### PR DESCRIPTION
So that a failure stops all CI for a PR.