### PR TITLE
feat(.github/interop): use markdown table

### DIFF
--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -68,7 +68,7 @@ runs:
         cd quic-interop-runner
         jq --arg key "${{ inputs.name }}" --argjson newEntry '{"image": "${{ inputs.image }}", "url": "${{ inputs.url }}", "role": "${{ inputs.role }}"}' '.[$key] = $newEntry' implementations.json > temp.$$ && mv temp.$$ implementations.json
         cat implementations.json
-        ARGS="--log-dir logs --must-include ${{ inputs.name }}"
+        ARGS="--log-dir logs --markdown --must-include ${{ inputs.name }}"
         if [ -n "${{ inputs.client }}" ]; then
           ARGS="$ARGS --client ${{ inputs.client }}"
         fi
@@ -92,9 +92,8 @@ runs:
       run: |
         echo '[**QUIC Interop Runner**](https://github.com/quic-interop/quic-interop-runner)' >> comment
         echo '' >> comment
-        echo '```' >> comment
-        cat quic-interop-runner/summary >> comment
-        echo '```' >> comment
+        # Ignore all, but table, which starts with "|:--".
+        cat quic-interop-runner/summary | awk '/^\|:--/{flag=1} flag' >> comment
         echo '' >> comment
       shell: bash
 


### PR DESCRIPTION
1. Provide `--markdown` flag to QUIC Interop Runner to get markdown formatted table.
2. Ignore all log output, but table.

---

Previous work: https://github.com/quic-interop/quic-interop-runner/pull/372