### PR TITLE
refactor(udp): remove useless Socket::send return value

### DIFF
--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -56,7 +56,7 @@ impl Socket {
     }
 
     /// Send the UDP datagram on the specified socket.
-    pub fn send(&self, d: Datagram) -> io::Result<usize> {
+    pub fn send(&self, d: Datagram) -> io::Result<()> {
         let transmit = Transmit {
             destination: d.destination(),
             ecn: EcnCodepoint::from_bits(Into::<u8>::into(d.tos())),
@@ -72,7 +72,7 @@ impl Socket {
 
         assert_eq!(n, 1, "only passed one slice");
 
-        Ok(n)
+        Ok(())
     }
 
     /// Receive a UDP datagram on the specified socket.


### PR DESCRIPTION
`Socket::send` returns the number of `Datagram`s sent. Given that it only accepts a single `Datagram` to be send, this return value is at best useless and in the worst case confusing. It is ignored at all call sites.

---

Introduced in https://github.com/mozilla/neqo/pull/1604/. My bad. Sorry for the noise.