### PR TITLE
build: Enable "fat" LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ rust-version = "1.74.0"
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 
+[profile.release]
+lto = "fat"
+
 [profile.bench]
 # Inherits from the "release" profile, so just provide overrides here:
 # https://doc.rust-lang.org/cargo/reference/profiles.html#release


### PR DESCRIPTION
Because that's what Firefox does:
https://searchfox.org/mozilla-central/source/config/makefiles/rust.mk#95