### PR TITLE
feat(bin/client): use BufWriter when writing to file

### DIFF
--- a/neqo-bin/src/bin/client/http3.rs
+++ b/neqo-bin/src/bin/client/http3.rs
@@ -26,7 +26,7 @@ use neqo_transport::{
 };
 use url::Url;
 
-use crate::{get_output_file, qlog_new, Args, KeyUpdateState, Res};
+use crate::{get_output_file, qlog_new, Args, KeyUpdateState, Res, BUFWRITER_BUFFER_SIZE};
 
 pub(crate) struct Handler<'a> {
     #[allow(
@@ -255,7 +255,8 @@ impl StreamHandlerType {
         match handler_type {
             Self::Download => {
                 let out_file = get_output_file(url, &args.output_dir, all_paths);
-                let buf_writer = out_file.map(|file| BufWriter::with_capacity(64 * 1024, file));
+                let buf_writer =
+                    out_file.map(|file| BufWriter::with_capacity(BUFWRITER_BUFFER_SIZE, file));
                 client.stream_close_send(client_stream_id).unwrap();
                 Box::new(DownloadStreamHandler { buf_writer })
             }

--- a/neqo-bin/src/bin/client/http3.rs
+++ b/neqo-bin/src/bin/client/http3.rs
@@ -301,8 +301,12 @@ impl StreamHandler for DownloadStreamHandler {
             println!("READ[{}]: 0x{}", stream_id, hex(&data));
         }
 
-        if fin && self.buf_writer.is_none() {
-            println!("<FIN[{stream_id}]>");
+        if fin {
+            if self.buf_writer.is_none() {
+                println!("<FIN[{stream_id}]>");
+            } else {
+                self.buf_writer.take().unwrap().flush()?;
+            }
         }
 
         Ok(true)

--- a/neqo-bin/src/bin/client/http3.rs
+++ b/neqo-bin/src/bin/client/http3.rs
@@ -302,7 +302,7 @@ impl StreamHandler for DownloadStreamHandler {
         }
 
         if fin {
-            if let Some(buf_writer) = self.buf_writer.take() {
+            if let Some(mut buf_writer) = self.buf_writer.take() {
                 buf_writer.flush()?;
             } else {
                 println!("<FIN[{stream_id}]>");

--- a/neqo-bin/src/bin/client/http3.rs
+++ b/neqo-bin/src/bin/client/http3.rs
@@ -302,10 +302,10 @@ impl StreamHandler for DownloadStreamHandler {
         }
 
         if fin {
-            if self.buf_writer.is_none() {
-                println!("<FIN[{stream_id}]>");
+            if let Some(buf_writer) = self.buf_writer.take() {
+                buf_writer.flush()?;
             } else {
-                self.buf_writer.take().unwrap().flush()?;
+                println!("<FIN[{stream_id}]>");
             }
         }
 

--- a/neqo-bin/src/bin/client/main.rs
+++ b/neqo-bin/src/bin/client/main.rs
@@ -36,6 +36,8 @@ use url::{Origin, Url};
 mod http09;
 mod http3;
 
+const BUFWRITER_BUFFER_SIZE: usize = 64 * 1024;
+
 #[derive(Debug)]
 pub enum ClientError {
     ArgumentError(&'static str),

--- a/neqo-bin/src/bin/client/main.rs
+++ b/neqo-bin/src/bin/client/main.rs
@@ -8,7 +8,7 @@ use std::{
     collections::{HashMap, VecDeque},
     fmt::{self, Display},
     fs::{create_dir_all, File, OpenOptions},
-    io,
+    io::{self, BufWriter},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs},
     path::PathBuf,
     pin::Pin,
@@ -254,7 +254,7 @@ fn get_output_file(
     url: &Url,
     output_dir: &Option<PathBuf>,
     all_paths: &mut Vec<PathBuf>,
-) -> Option<File> {
+) -> Option<BufWriter<File>> {
     if let Some(ref dir) = output_dir {
         let mut out_path = dir.clone();
 
@@ -286,7 +286,7 @@ fn get_output_file(
             .ok()?;
 
         all_paths.push(out_path);
-        Some(f)
+        Some(BufWriter::with_capacity(BUFWRITER_BUFFER_SIZE, f))
     } else {
         None
     }


### PR DESCRIPTION
`neqo-client` has the option to write a response to file.

With this commit, `File` is wrapped in a `64KB` `BufWriter` to increase I/O batch size and thus improve performance.

Replaces https://github.com/mozilla/neqo/pull/1752 (see https://github.com/mozilla/neqo/pull/1752#issuecomment-2002599047).