### PR TITLE
ci(check.yml): re-add sleep

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -122,6 +122,8 @@ jobs:
           cargo +${{ matrix.rust-toolchain }} build $BUILD_TYPE --bin neqo-client --bin neqo-server
           "target/$BUILD_DIR/neqo-server" "$HOST:4433" &
           PID=$!
+          # Give the server time to start.
+          sleep 1
           "target/$BUILD_DIR/neqo-client" --output-dir . "https://$HOST:4433/$SIZE"
           kill $PID
           [ "$(wc -c <"$SIZE")" -eq "$SIZE" ] || exit 1


### PR DESCRIPTION
Windows CI oftentimes fails with:

```
 0s  0ms INFO H3 Client connecting: [::]:65093 -> [::1]:4433
Error: IoError(Os { code: 10054, kind: ConnectionReset, message: "An existing connection was forcibly closed by the remote host." })
0s  0ms INFO Server waiting for connection on: [::1]:4433
0s  0ms INFO Server waiting for connection on: 127.0.0.1:4433
```

https://github.com/mozilla/neqo/actions/runs/8374577016/job/22930136500?pr=1692

This suggests that the client connects to the server before the server is ready to accept connections.

This commit adds a sleep, thus giving the server time to start up.

---

Tracked in https://github.com/mozilla/neqo/issues/1759.

Sleep was previously introduced in https://github.com/mozilla/neqo/pull/1713 but later removed in https://github.com/mozilla/neqo/pull/1717. What was the reason to remove the sleep?