### PR TITLE
feat(bin/client): add --stats flag printing connection statistics

### DIFF
--- a/neqo-bin/src/bin/client/http09.rs
+++ b/neqo-bin/src/bin/client/http09.rs
@@ -153,6 +153,10 @@ impl super::Client for Connection {
     fn is_closed(&self) -> bool {
         matches!(self.state(), State::Closed(..))
     }
+
+    fn stats(&self) -> neqo_transport::Stats {
+        self.stats()
+    }
 }
 
 impl<'b> Handler<'b> {

--- a/neqo-bin/src/bin/client/http3.rs
+++ b/neqo-bin/src/bin/client/http3.rs
@@ -125,6 +125,10 @@ impl super::Client for Http3Client {
     {
         self.close(now, app_error, msg);
     }
+
+    fn stats(&self) -> neqo_transport::Stats {
+        self.transport_stats()
+    }
 }
 
 impl<'a> super::Handler for Handler<'a> {

--- a/neqo-bin/src/bin/client/main.rs
+++ b/neqo-bin/src/bin/client/main.rs
@@ -179,6 +179,10 @@ pub struct Args {
     /// The request size that will be used for upload test.
     #[arg(name = "upload-size", long, default_value = "100")]
     upload_size: usize,
+
+    /// Print connection stats after close.
+    #[arg(name = "stats", long)]
+    stats: bool,
 }
 
 impl Args {
@@ -327,6 +331,7 @@ trait Client {
     where
         S: AsRef<str> + Display;
     fn is_closed(&self) -> bool;
+    fn stats(&self) -> neqo_transport::Stats;
 }
 
 struct Runner<'a, H: Handler> {
@@ -361,6 +366,9 @@ impl<'a, H: Handler> Runner<'a, H> {
             self.process(None).await?;
 
             if self.client.is_closed() {
+                if self.args.stats {
+                    qinfo!("{:?}", self.client.stats());
+                }
                 return Ok(self.handler.take_token());
             }
 

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -206,7 +206,7 @@ impl Debug for Stats {
             "  tx: {} lost {} lateack {} ptoack {}",
             self.packets_tx, self.lost, self.late_ack, self.pto_ack
         )?;
-        writeln!(f, "  resumed: {} ", self.resumed)?;
+        writeln!(f, "  resumed: {}", self.resumed)?;
         writeln!(f, "  frames rx:")?;
         self.frame_rx.fmt(f)?;
         writeln!(f, "  frames tx:")?;


### PR DESCRIPTION
This commit introduces the `--stats` flag to `neqo-client`. It will print the `neqo_transport::Stats` of the `Connection` after close.

```
$ cargo run --bin neqo-client -- --stats http://127.0.0.1:12345/10000000

stats for Client ...
  rx: 7728 drop 1 dup 0 saved 1
  tx: 819 lost 12 lateack 0 ptoack 4
  resumed: false
  frames rx:
    crypto 3 done 1 token 1 close 0
    ack 40 (max 805) ping 0 padding 0
    stream 7704 reset 0 stop 0
    max: stream 0 data 0 stream_data 0
    blocked: stream 0 data 0 stream_data 19
    datagram 0
    ncid 7 rcid 0 pchallenge 0 presponse 0
    ack_frequency 4
  frames tx:
    crypto 2 done 0 token 0 close 0
    ack 783 (max 7769) ping 5 padding 0
    stream 5 reset 0 stop 0
    max: stream 0 data 0 stream_data 30
    blocked: stream 0 data 0 stream_data 0
    datagram 0
    ncid 0 rcid 0 pchallenge 0 presponse 0
    ack_frequency 2
```

---

Just an idea. Helpful to e.g. debug packet loss. What do folks think?

(I stumbled across `neqo_transport/src/stats.rs` only today. I see that Firefox consumes them. How are they surfaced to the user?)

https://searchfox.org/mozilla-central/source/netwerk/socket/neqo_glue/src/lib.rs#1287-1289