### PR TITLE
ci: Run `clippy` for all features except `gecko`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -148,7 +148,7 @@ jobs:
           # respective default features only. Can reveal warnings otherwise
           # hidden given that a plain cargo clippy combines all features of the
           # workspace. See e.g. https://github.com/mozilla/neqo/pull/1695.
-          cargo +${{ matrix.rust-toolchain }} hack clippy --all-targets --each-feature --exclude-features gecko -- -D warnings || ${{ matrix.rust-toolchain == 'nightly' }}
+          cargo +${{ matrix.rust-toolchain }} hack clippy --all-targets --feature-powerset --exclude-features gecko -- -D warnings || ${{ matrix.rust-toolchain == 'nightly' }}
         if: success() || failure()
 
       - name: Check rustdoc links

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -148,7 +148,7 @@ jobs:
           # respective default features only. Can reveal warnings otherwise
           # hidden given that a plain cargo clippy combines all features of the
           # workspace. See e.g. https://github.com/mozilla/neqo/pull/1695.
-          cargo +${{ matrix.rust-toolchain }} hack clippy --all-targets -- -D warnings || ${{ matrix.rust-toolchain == 'nightly' }}
+          cargo +${{ matrix.rust-toolchain }} hack clippy --all-targets --each-feature --exclude-features gecko -- -D warnings || ${{ matrix.rust-toolchain == 'nightly' }}
         if: success() || failure()
 
       - name: Check rustdoc links

--- a/neqo-crypto/src/aead_fuzzing.rs
+++ b/neqo-crypto/src/aead_fuzzing.rs
@@ -20,6 +20,7 @@ pub struct FuzzingAead {
 }
 
 impl FuzzingAead {
+    #[allow(clippy::missing_errors_doc)]
     pub fn new(
         fuzzing: bool,
         version: Version,
@@ -44,6 +45,7 @@ impl FuzzingAead {
         }
     }
 
+    #[allow(clippy::missing_errors_doc)]
     pub fn encrypt<'a>(
         &self,
         count: u64,
@@ -61,6 +63,7 @@ impl FuzzingAead {
         Ok(&output[..l + 16])
     }
 
+    #[allow(clippy::missing_errors_doc)]
     pub fn decrypt<'a>(
         &self,
         count: u64,

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -9,7 +9,7 @@
 
 mod aead;
 #[cfg(feature = "fuzzing")]
-mod aead_fuzzing;
+pub mod aead_fuzzing;
 pub mod agent;
 mod agentio;
 mod auth;

--- a/neqo-transport/benches/range_tracker.rs
+++ b/neqo-transport/benches/range_tracker.rs
@@ -11,30 +11,32 @@ const CHUNK: u64 = 1000;
 const END: u64 = 100_000;
 fn build_coalesce(len: u64) -> RangeTracker {
     let mut used = RangeTracker::default();
-    used.mark_acked(0, CHUNK as usize);
-    used.mark_sent(CHUNK, END as usize);
+    let chunk = usize::try_from(CHUNK).expect("should fit");
+    used.mark_acked(0, chunk);
+    used.mark_sent(CHUNK, usize::try_from(END).expect("should fit"));
     // leave a gap or it will coalesce here
     for i in 2..=len {
         // These do not get immediately coalesced when marking since they're not at the end or start
-        used.mark_acked(i * CHUNK, CHUNK as usize);
+        used.mark_acked(i * CHUNK, chunk);
     }
     used
 }
 
 fn coalesce(c: &mut Criterion, count: u64) {
+    let chunk = usize::try_from(CHUNK).expect("should fit");
     c.bench_function(
         &format!("coalesce_acked_from_zero {count}+1 entries"),
         |b| {
             b.iter_batched_ref(
                 || build_coalesce(count),
                 |used| {
-                    used.mark_acked(CHUNK, CHUNK as usize);
+                    used.mark_acked(CHUNK, chunk);
                     let tail = (count + 1) * CHUNK;
-                    used.mark_sent(tail, CHUNK as usize);
-                    used.mark_acked(tail, CHUNK as usize);
+                    used.mark_sent(tail, chunk);
+                    used.mark_acked(tail, chunk);
                 },
                 criterion::BatchSize::SmallInput,
-            )
+            );
         },
     );
 }

--- a/neqo-transport/benches/rx_stream_orderer.rs
+++ b/neqo-transport/benches/rx_stream_orderer.rs
@@ -11,14 +11,14 @@ fn rx_stream_orderer() {
     let mut rx = RxStreamOrderer::new();
     let data: &[u8] = &[0; 1337];
 
-    for i in 0..100000 {
+    for i in 0..100_000 {
         rx.inbound_frame(i * 1337, data);
     }
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("RxStreamOrderer::inbound_frame()", |b| {
-        b.iter(rx_stream_orderer)
+        b.iter(rx_stream_orderer);
     });
 }
 

--- a/neqo-transport/benches/transfer.rs
+++ b/neqo-transport/benches/transfer.rs
@@ -20,7 +20,7 @@ const ZERO: Duration = Duration::from_millis(0);
 const JITTER: Duration = Duration::from_millis(10);
 const TRANSFER_AMOUNT: usize = 1 << 22; // 4Mbyte
 
-fn benchmark_transfer(c: &mut Criterion, label: &str, seed: Option<impl AsRef<str>>) {
+fn benchmark_transfer(c: &mut Criterion, label: &str, seed: &Option<impl AsRef<str>>) {
     let mut group = c.benchmark_group("transfer");
     group.throughput(Throughput::Bytes(u64::try_from(TRANSFER_AMOUNT).unwrap()));
     group.bench_function(label, |b| {
@@ -44,7 +44,7 @@ fn benchmark_transfer(c: &mut Criterion, label: &str, seed: Option<impl AsRef<st
                 sim.run();
             },
             SmallInput,
-        )
+        );
     });
     group.finish();
 }
@@ -53,7 +53,7 @@ fn benchmark_transfer_variable(c: &mut Criterion) {
     benchmark_transfer(
         c,
         "Run multiple transfers with varying seeds",
-        std::env::var("SIMULATION_SEED").ok(),
+        &std::env::var("SIMULATION_SEED").ok(),
     );
 }
 
@@ -61,7 +61,7 @@ fn benchmark_transfer_fixed(c: &mut Criterion) {
     benchmark_transfer(
         c,
         "Run multiple transfers with the same seed",
-        Some("62df6933ba1f543cece01db8f27fb2025529b27f93df39e19f006e1db3b8c843"),
+        &Some("62df6933ba1f543cece01db8f27fb2025529b27f93df39e19f006e1db3b8c843"),
     );
 }
 

--- a/neqo-transport/src/connection/tests/fuzzing.rs
+++ b/neqo-transport/src/connection/tests/fuzzing.rs
@@ -6,7 +6,7 @@
 
 #![cfg(feature = "fuzzing")]
 
-use neqo_crypto::FIXED_TAG_FUZZING;
+use neqo_crypto::aead_fuzzing::FIXED_TAG_FUZZING;
 use test_fixture::now;
 
 use super::{connect_force_idle, default_client, default_server};

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -16,9 +16,10 @@ use neqo_common::{event::Provider, qdebug, Datagram};
 use neqo_crypto::{
     constants::TLS_CHACHA20_POLY1305_SHA256, generate_ech_keys, AuthenticationStatus,
 };
+#[cfg(not(feature = "fuzzing"))]
+use test_fixture::datagram;
 use test_fixture::{
-    assertions, assertions::assert_coalesced_0rtt, datagram, fixture_init, now, split_datagram,
-    DEFAULT_ADDR,
+    assertions, assertions::assert_coalesced_0rtt, fixture_init, now, split_datagram, DEFAULT_ADDR,
 };
 
 use super::{


### PR DESCRIPTION
Because it didn't get to have opinions about benches and various other code before that was hidden behind features. Avoids bitrot, too.