### PR TITLE
ci: Disable some caching

### DIFF
--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -52,8 +52,9 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.8
-        cache: 'pip'
-        cache-dependency-path: 'quic-interop-runner/requirements.txt'
+        # This puts too much stress on our cache, causing other things to be flushed too early:
+        # cache: 'pip'
+        # cache-dependency-path: 'quic-interop-runner/requirements.txt'
 
     - name: Install Python packages
       run: |

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -23,6 +23,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          # Leaving `cache-binary` at `true` puts too much stress on our cache,
+          # causing other things to be flushed too early.
+          cache-binary: false
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -55,7 +59,9 @@ jobs:
           build-args: |
             RUST_VERSION=stable
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Setting `mode` to `max` puts too much stress on our cache,
+          # causing other things to be flushed too early.
+          cache-to: type=gha,mode=min
           # On pull requests only build amd64 for the sake of CI time.
           platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64, linux/arm64' }}
           load: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -23,10 +23,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          # Leaving `cache-binary` at `true` puts too much stress on our cache,
-          # causing other things to be flushed too early.
-          cache-binary: false
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
The docker and python caches put quite a bit of stress on the GHA cache, causing it - for example - to time out the benchmark results too soon. See https://github.com/mozilla/neqo/actions/caches

(Need to check how much slower this makes the build though, hence draft PR.)