### PR TITLE
ci: Run a daily baseline benchmark of `main` for the cache

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,6 +2,9 @@ name: Bench
 on:
   workflow_call:
   workflow_dispatch:
+  schedule:
+    # Run at 1 AM each day, so there is a `main`-branch baseline in the cache.
+    - cron: '0 1 * * *'
 env:
   CARGO_PROFILE_BENCH_BUILD_OVERRIDE_DEBUG: true
   CARGO_PROFILE_RELEASE_DEBUG: true


### PR DESCRIPTION
The docker and python caches put quite a bit of stress on the GHA cache, causing it - for example - to time out the benchmark results too soon. See https://github.com/mozilla/neqo/actions/caches

This makes sure we should have a fresh baseline benchmark in the cache for comparison.

Simpler than #1769