### PR TITLE
fix(transport/bench): increase transfer bench noise threshold

### DIFF
--- a/neqo-transport/benches/transfer.rs
+++ b/neqo-transport/benches/transfer.rs
@@ -23,6 +23,7 @@ const TRANSFER_AMOUNT: usize = 1 << 22; // 4Mbyte
 fn benchmark_transfer(c: &mut Criterion, label: &str, seed: Option<impl AsRef<str>>) {
     let mut group = c.benchmark_group("transfer");
     group.throughput(Throughput::Bytes(u64::try_from(TRANSFER_AMOUNT).unwrap()));
+    group.noise_threshold(0.03);
     group.bench_function(label, |b| {
         b.iter_batched(
             || {


### PR DESCRIPTION
The default Criterion noise threshold is 0.01, i.e.

``` rust
    /// Changes the noise threshold for benchmarks in this group. The noise threshold
    /// is used to filter out small changes in performance from one run to the next, even if they
    /// are statistically significant. Sometimes benchmarking the same code twice will result in
    /// small but statistically significant differences solely because of noise. This provides a way
    /// to filter out some of these false positives at the cost of making it harder to detect small
    /// changes to the true performance of the benchmark.
    ///
    /// The default is 0.01, meaning that changes smaller than 1% will be ignored.
    ///
    /// # Panics
    ///
    /// Panics if the threshold is set to a negative value
    pub fn noise_threshold(&mut self, threshold: f64) -> &mut Self {
```

https://bheisler.github.io/criterion.rs/criterion/struct.BenchmarkGroup.html#method.noise_threshold

Multiple runs of the `neqo-transport` `transfer/*` benchmarks showed between 2% and 3% performance regression on unrelated changes.

- https://github.com/mozilla/neqo/actions/runs/8402727182/job/23012699901
- https://github.com/mozilla/neqo/actions/runs/8408164062/job/23024217712

To improve the signal-to-noise ratio of the benchmarks, set the noise threshold to 3%.