### PR TITLE
perf(bin/server): increase msg size and don't allocate msg per resp

### DIFF
--- a/neqo-bin/src/bin/server/main.rs
+++ b/neqo-bin/src/bin/server/main.rs
@@ -212,7 +212,7 @@ impl From<Vec<u8>> for ResponseData {
     fn from(data: Vec<u8>) -> Self {
         let remaining = data.len();
         Self {
-            data: Cow::Owned(data.into()),
+            data: Cow::Owned(data),
             offset: 0,
             remaining,
         }

--- a/neqo-bin/src/bin/server/main.rs
+++ b/neqo-bin/src/bin/server/main.rs
@@ -5,6 +5,7 @@
 // except according to those terms.
 
 use std::{
+    borrow::Cow,
     cell::RefCell,
     cmp::min,
     collections::HashMap,
@@ -196,7 +197,7 @@ trait HttpServer: Display {
 }
 
 struct ResponseData {
-    data: Vec<u8>,
+    data: Cow<'static, [u8]>,
     offset: usize,
     remaining: usize,
 }
@@ -211,7 +212,7 @@ impl From<Vec<u8>> for ResponseData {
     fn from(data: Vec<u8>) -> Self {
         let remaining = data.len();
         Self {
-            data,
+            data: Cow::Owned(data.into()),
             offset: 0,
             remaining,
         }
@@ -219,9 +220,9 @@ impl From<Vec<u8>> for ResponseData {
 }
 
 impl ResponseData {
-    fn repeat(buf: &[u8], total: usize) -> Self {
+    fn repeat(buf: &'static [u8], total: usize) -> Self {
         Self {
-            data: buf.to_owned(),
+            data: Cow::Borrowed(buf),
             offset: 0,
             remaining: total,
         }
@@ -260,14 +261,7 @@ struct SimpleServer {
 }
 
 impl SimpleServer {
-    const MESSAGE: &'static [u8] = b"I am the very model of a modern Major-General,\n\
-        I've information vegetable, animal, and mineral,\n\
-        I know the kings of England, and I quote the fights historical\n\
-        From Marathon to Waterloo, in order categorical;\n\
-        I'm very well acquainted, too, with matters mathematical,\n\
-        I understand equations, both the simple and quadratical,\n\
-        About binomial theorem, I'm teeming with a lot o' news,\n\
-        With many cheerful facts about the square of the hypotenuse.\n";
+    const MESSAGE: &'static [u8] = &[0; 4096];
 
     pub fn new(
         args: &Args,


### PR DESCRIPTION
Previously `neqo-server` would respond to a request by repeatedly sending a static 440 byte message (Major-General's Song). Instead of sending 440 bytes, increase the batch size to 4096 bytes. This also matches the `neqo-client` receive buffer size.

https://github.com/mozilla/neqo/blob/76630a5ebb6c6b94de6a40cf3f439b9a846f6ab7/neqo-bin/src/bin/client/http3.rs#L165

Previously `ResponseData::repeat` would convert the provided `buf: &[u8]` to ` Vec<u8>`, i.e. re-allocate the buf. Instead keep a reference to the original buf, thus removing the allocation.

---

Preliminary benchmark comparison:

`main`:

```
1-conn/1-100mb-resp (aka. Download)/client
                        time:   [768.10 ms 1.0894 s 1.5517 s]
                        thrpt:  [64.443 MiB/s 91.794 MiB/s 130.19 MiB/s]
```

this pull request:

```
1-conn/1-100mb-resp (aka. Download)/client
                        time:   [674.30 ms 837.63 ms 1.0564 s]
                        thrpt:  [94.661 MiB/s 119.38 MiB/s 148.30 MiB/s]
```

Also visible in qviz where client reads MANY small (440 bytes) chunks from server:

![image](https://github.com/mozilla/neqo/assets/7047859/2650be19-13ad-4d76-87a6-675a33cc3e8d)

I suggest merging https://github.com/mozilla/neqo/pull/1758 first. We can then validate this pull request using the CI benchmark server.

I will take a look whether a long lived receive buffer on the client side has any impact next.

https://github.com/mozilla/neqo/blob/76630a5ebb6c6b94de6a40cf3f439b9a846f6ab7/neqo-bin/src/bin/client/http3.rs#L165
