### PR TITLE
perf(timer): check subset of self.items

### DIFF
--- a/neqo-common/benches/timer.rs
+++ b/neqo-common/benches/timer.rs
@@ -11,40 +11,39 @@ use neqo_common::timer::Timer;
 use test_fixture::now;
 
 fn benchmark_timer(c: &mut Criterion) {
-    c.bench_function("drain a small timer quickly", |b| {
-        b.iter_batched(make_small_timer, drain, criterion::BatchSize::SmallInput);
-    });
-    c.bench_function("drain a large mostly empty timer quickly", |b| {
+    c.bench_function("drain a timer quickly", |b| {
         b.iter_batched(
-            make_large_mostly_empty_timer,
-            drain,
+            || {
+                const TIMES: &[u64] = &[1, 2, 3, 5, 8, 13, 21, 34];
+                let now = now();
+                let mut timer = Timer::new(now, Duration::from_millis(777), 100);
+                for &t in TIMES {
+                    timer.add(now + Duration::from_secs(t), ());
+                }
+                timer
+            },
+            |mut timer| {
+                while let Some(t) = timer.next_time() {
+                    assert!(timer.take_next(t).is_some());
+                }
+            },
             criterion::BatchSize::SmallInput,
         );
     });
-}
-
-fn make_small_timer() -> Timer<()> {
-    const TIMES: &[u64] = &[1, 2, 3, 5, 8, 13, 21, 34];
-
-    let now = now();
-    let mut timer = Timer::new(now, Duration::from_millis(777), 100);
-    for &t in TIMES {
-        timer.add(now + Duration::from_secs(t), ());
-    }
-    timer
-}
-
-fn make_large_mostly_empty_timer() -> Timer<()> {
-    let now = now();
-    let mut timer = Timer::new(now, Duration::from_millis(4), 16384);
-    timer.add(now + Duration::from_millis(400), ());
-    timer
-}
-
-fn drain(mut timer: Timer<()>) {
-    while let Some(t) = timer.next_time() {
-        assert!(timer.take_next(t).is_some());
-    }
+    c.bench_function("drain an empty timer", |b| {
+        b.iter_batched(
+            || {
+                let now = now();
+                let timer = Timer::<()>::new(now, Duration::from_millis(4), 16384);
+                let lookup_time = now + Duration::from_millis(400);
+                (timer, lookup_time)
+            },
+            |(mut timer, lookup_time)| {
+                assert_eq!(None, timer.take_next(lookup_time));
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
 }
 
 criterion_group!(benches, benchmark_timer);

--- a/neqo-common/benches/timer.rs
+++ b/neqo-common/benches/timer.rs
@@ -4,27 +4,26 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_common::timer::Timer;
 use test_fixture::now;
 
 fn benchmark_timer(c: &mut Criterion) {
-    c.bench_function("drain a timer quickly", |b| {
-        b.iter_batched_ref(
-            make_timer,
-            |(_now, timer)| {
-                while let Some(t) = timer.next_time() {
-                    assert!(timer.take_next(t).is_some());
-                }
-            },
+    c.bench_function("drain a small timer quickly", |b| {
+        b.iter_batched(make_small_timer, drain, criterion::BatchSize::SmallInput)
+    });
+    c.bench_function("drain a large mostly empty timer quickly", |b| {
+        b.iter_batched(
+            make_large_mostly_empty_timer,
+            drain,
             criterion::BatchSize::SmallInput,
-        );
+        )
     });
 }
 
-fn make_timer() -> (Instant, Timer<()>) {
+fn make_small_timer() -> Timer<()> {
     const TIMES: &[u64] = &[1, 2, 3, 5, 8, 13, 21, 34];
 
     let now = now();
@@ -32,7 +31,20 @@ fn make_timer() -> (Instant, Timer<()>) {
     for &t in TIMES {
         timer.add(now + Duration::from_secs(t), ());
     }
-    (now, timer)
+    timer
+}
+
+fn make_large_mostly_empty_timer() -> Timer<()> {
+    let now = now();
+    let mut timer = Timer::new(now, Duration::from_millis(4), 16384);
+    timer.add(now + Duration::from_millis(400), ());
+    timer
+}
+
+fn drain(mut timer: Timer<()>) {
+    while let Some(t) = timer.next_time() {
+        assert!(timer.take_next(t).is_some());
+    }
 }
 
 criterion_group!(benches, benchmark_timer);

--- a/neqo-common/benches/timer.rs
+++ b/neqo-common/benches/timer.rs
@@ -12,14 +12,14 @@ use test_fixture::now;
 
 fn benchmark_timer(c: &mut Criterion) {
     c.bench_function("drain a small timer quickly", |b| {
-        b.iter_batched(make_small_timer, drain, criterion::BatchSize::SmallInput)
+        b.iter_batched(make_small_timer, drain, criterion::BatchSize::SmallInput);
     });
     c.bench_function("drain a large mostly empty timer quickly", |b| {
         b.iter_batched(
             make_large_mostly_empty_timer,
             drain,
             criterion::BatchSize::SmallInput,
-        )
+        );
     });
 }
 

--- a/neqo-common/benches/timer.rs
+++ b/neqo-common/benches/timer.rs
@@ -12,7 +12,7 @@ use test_fixture::now;
 
 fn benchmark_timer(c: &mut Criterion) {
     c.bench_function("drain a timer quickly", |b| {
-        b.iter_batched(
+        b.iter_batched_ref(
             || {
                 const TIMES: &[u64] = &[1, 2, 3, 5, 8, 13, 21, 34];
                 let now = now();
@@ -22,7 +22,7 @@ fn benchmark_timer(c: &mut Criterion) {
                 }
                 timer
             },
-            |mut timer| {
+            |timer| {
                 while let Some(t) = timer.next_time() {
                     assert!(timer.take_next(t).is_some());
                 }
@@ -31,15 +31,15 @@ fn benchmark_timer(c: &mut Criterion) {
         );
     });
     c.bench_function("drain an empty timer", |b| {
-        b.iter_batched(
+        b.iter_batched_ref(
             || {
                 let now = now();
                 let timer = Timer::<()>::new(now, Duration::from_millis(4), 16384);
                 let lookup_time = now + Duration::from_millis(400);
                 (timer, lookup_time)
             },
-            |(mut timer, lookup_time)| {
-                assert_eq!(None, timer.take_next(lookup_time));
+            |(timer, lookup_time)| {
+                assert_eq!(None, timer.take_next(*lookup_time));
             },
             criterion::BatchSize::SmallInput,
         );

--- a/neqo-common/src/timer.rs
+++ b/neqo-common/src/timer.rs
@@ -202,15 +202,9 @@ impl<T> Timer<T> {
             }
         }
 
-        let idx = self.bucket(0);
-        for i in idx..self.items.len() {
-            let res = maybe_take(&mut self.items[i], until);
-            if res.is_some() {
-                return res;
-            }
-        }
-        for i in 0..idx {
-            let res = maybe_take(&mut self.items[i], until);
+        for i in self.cursor..(self.cursor + self.delta(until)) {
+            let i = i % self.items.len();
+            let res = maybe_take(&mut self.items[i], until)?;
             if res.is_some() {
                 return res;
             }

--- a/neqo-common/src/timer.rs
+++ b/neqo-common/src/timer.rs
@@ -204,7 +204,7 @@ impl<T> Timer<T> {
 
         for i in self.cursor..(self.cursor + self.delta(until)) {
             let i = i % self.items.len();
-            let res = maybe_take(&mut self.items[i], until)?;
+            let res = maybe_take(&mut self.items[i], until);
             if res.is_some() {
                 return res;
             }

--- a/neqo-common/src/timer.rs
+++ b/neqo-common/src/timer.rs
@@ -198,13 +198,13 @@ impl<T> Timer<T> {
     ///
     /// Impossible, I think.
     pub fn take_next(&mut self, until: Instant) -> Option<T> {
-        let delta = self.delta(until);
-        let range = if self.cursor < delta {
+        let last_bucket = (self.cursor + self.delta(until)) % self.items.len();
+        let range = if self.cursor < last_bucket {
             #[allow(clippy::range_plus_one)] // non-inclusive range to match with type below
-            (self.cursor..(self.cursor + delta + 1)).chain(0..0) // additional empty range to match
-                                                                 // with type below
+            (self.cursor..(last_bucket + 1)).chain(0..0) // additional empty range to match with
+                                                         // type below
         } else {
-            (self.cursor..self.items.len()).chain(0..delta)
+            (self.cursor..self.items.len()).chain(0..last_bucket)
         };
 
         for i in range {

--- a/neqo-common/src/timer.rs
+++ b/neqo-common/src/timer.rs
@@ -198,12 +198,16 @@ impl<T> Timer<T> {
     ///
     /// Impossible, I think.
     pub fn take_next(&mut self, until: Instant) -> Option<T> {
-        let last_bucket = (self.cursor + self.delta(until)) % self.items.len();
-        let range = if self.cursor < last_bucket {
+        let last_bucket = self.cursor + self.delta(until);
+
+        let range = if last_bucket <= self.items.len() {
+            // Simple case, no wrap around.
             #[allow(clippy::range_plus_one)] // non-inclusive range to match with type below
             (self.cursor..(last_bucket + 1)).chain(0..0) // additional empty range to match with
                                                          // type below
         } else {
+            // Complex case, with wrap around.
+            let last_bucket = last_bucket - self.items.len();
             (self.cursor..self.items.len()).chain(0..last_bucket)
         };
 

--- a/neqo-common/src/timer.rs
+++ b/neqo-common/src/timer.rs
@@ -200,7 +200,7 @@ impl<T> Timer<T> {
     pub fn take_next(&mut self, until: Instant) -> Option<T> {
         let last_bucket = self.cursor + self.delta(until);
 
-        let range = if last_bucket <= self.items.len() {
+        let range = if last_bucket < self.items.len() {
             // Simple case, no wrap around.
             #[allow(clippy::range_plus_one)] // non-inclusive range to match with type below
             (self.cursor..(last_bucket + 1)).chain(0..0) // additional empty range to match with


### PR DESCRIPTION
`Timer::take_next` iterates each `VecDeque` in the `Vec` `self.items`. It then checks the first item in those `VecDeque`s.

**Under the assumption that all items in `self.items[t]` are smaller than all items in `self.items[t+1]` (ignoring wrap around), only a subset of `self.items` needs to be iterated, namely only from `self.cursor` to `self.delta(until)`.**

**Is this assumption correct?**

This commit changes `take_nextl` to only check this subset.

---

Why is `Timer::take_next`'s performance relevant?

Whenever `Server::process_next_output` has no more other work to do, it checks for expired timers.

https://github.com/mozilla/neqo/blob/3151adc53e71273eed1319114380119c70e169a2/neqo-transport/src/server.rs#L650

A `Server` has at most one item per connection in `Timer`. Thus, a `Server` with a single connection has a single item in `Timer` total.

The `Timer` timer wheel has 16_384 slots.

https://github.com/mozilla/neqo/blob/3151adc53e71273eed1319114380119c70e169a2/neqo-transport/src/server.rs#L55

Thus whenever `Server::process_next_output` has no more other work to do, it iterates a `Vec` of length `16_384`, only to find at most one timer, which might or might not be expired.

This shows up in CPU profiles with up to 33%. See e.g. https://github.com/mozilla/neqo/actions/runs/8452074231/artifacts/1363138571. On my local machine, a call to `Timer::take_next` takes between 5-10 micro seconds.

Note that the profiles do not always show `take_next` as it is oftentimes inlined. Add `#[inline(never)]` to make sure it isn't.

``` diff
modified   neqo-common/src/timer.rs
@@ -193,6 +193,7 @@ impl<T> Timer<T> {

     /// Take the next item, unless there are no items with
     /// a timeout in the past relative to `until`.
+    #[inline(never)]
     pub fn take_next(&mut self, until: Instant) -> Option<T> {
```

With this patch `Timer::take_next` takes significantly less CPU time on my machine (~2.8%).

Arguably a 16_384 slot timer wheel is overkill for a single timer. Maybe, to cover the use-case of a `Server` with a small amount of connections, a hierarchical timer wheel is helpful?