### PR TITLE
refactor: print current `StateSignaling` variant in `debug_assert`

### DIFF
--- a/neqo-transport/src/connection/state.rs
+++ b/neqo-transport/src/connection/state.rs
@@ -211,8 +211,7 @@ impl StateSignaling {
         if !matches!(self, Self::Idle) {
             debug_assert!(
                 false,
-                "StateSignaling must be in Idle state but is in {:?} state.",
-                self
+                "StateSignaling must be in Idle state but is in {self:?} state.",
             );
             return;
         }

--- a/neqo-transport/src/connection/state.rs
+++ b/neqo-transport/src/connection/state.rs
@@ -209,7 +209,11 @@ pub enum StateSignaling {
 impl StateSignaling {
     pub fn handshake_done(&mut self) {
         if !matches!(self, Self::Idle) {
-            debug_assert!(false, "StateSignaling must be in Idle state.");
+            debug_assert!(
+                false,
+                "StateSignaling must be in Idle state but is in {:?} state.",
+                self
+            );
             return;
         }
         *self = Self::HandshakeDone;


### PR DESCRIPTION
CI paniced in `StateSignaling::handshake_done` called from `Connection::handle_lost_packets`. Unable to reproduce locally. To ease debugging future CI failures, print the current state on panic.

```
thread 'idle_timeout_crazy_rtt' panicked at neqo-transport\src\connection\state.rs:212:13:
StateSignaling must be in Idle state.
stack backtrace:
   0: std::panicking::begin_panic_handler
             at /rustc/8df7e723ea729a7f917501cc2d91d640b7021373/library\std\src\panicking.rs:646
   1: core::panicking::panic_fmt
             at /rustc/8df7e723ea729a7f917501cc2d91d640b7021373/library\core\src\panicking.rs:72
   2: enum2$<neqo_transport::connection::state::StateSignaling>::handshake_done
             at .\src\connection\state.rs:212
   3: neqo_transport::connection::Connection::handle_lost_packets
             at .\src\connection\mod.rs:2847
   4: neqo_transport::connection::Connection::process_timer
             at .\src\connection\mod.rs:966
   5: neqo_transport::connection::Connection::process_output
             at .\src\connection\mod.rs:1085
   6: neqo_transport::connection::Connection::process
             at .\src\connection\mod.rs:1108
   7: test_fixture::sim::connection::impl$1::process
             at D:\a\neqo\neqo\test-fixture\src\sim\connection.rs:146
   8: test_fixture::sim::Simulator::process_loop
             at D:\a\neqo\neqo\test-fixture\src\sim\mod.rs:193
   9: test_fixture::sim::ReadySimulator::run
             at D:\a\neqo\neqo\test-fixture\src\sim\mod.rs:284
  10: test_fixture::sim::Simulator::run
             at D:\a\neqo\neqo\test-fixture\src\sim\mod.rs:265
  11: network::idle_timeout_crazy_rtt
             at D:\a\neqo\neqo\test-fixture\src\sim\mod.rs:69
  12: network::idle_timeout_crazy_rtt::closure$0
             at D:\a\neqo\neqo\test-fixture\src\sim\mod.rs:58
  13: core::ops::function::FnOnce::call_once<network::idle_timeout_crazy_rtt::closure_env$0,tuple$<> >
             at /rustc/8df7e723ea729a7f917501cc2d91d640b7021373\library\core\src\ops\function.rs:250
  14: core::ops::function::FnOnce::call_once
             at /rustc/8df7e723ea729a7f917501cc2d91d640b7021373/library\core\src\ops\function.rs:250
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

https://github.com/mozilla/neqo/actions/runs/8496770595/job/23274538553

---

Might be related to https://github.com/mozilla/neqo/issues/974.