### PR TITLE
ci(qns): run all tests and remove msquic & quic-go

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -71,6 +71,5 @@ jobs:
           name: 'neqo-latest'
           image: ${{ steps.docker_build_and_push.outputs.imageID }}
           url: https://github.com/mozilla/neqo
-          test: handshake
-          client: neqo-latest,quic-go,ngtcp2,neqo,msquic
-          server: neqo-latest,quic-go,ngtcp2,neqo,msquic
+          client: neqo-latest,neqo,ngtcp2
+          server: neqo-latest,neqo,ngtcp2


### PR DESCRIPTION
Run all QUIC Interop Runner testcases.

For the sake of reducing runtime, this commit also removes msquic and quic-go, leaving only ngtcp2 and neqo itself. Reason being, that ngtcp2 is the only implementation that passes all testcases, especially the ECN testcase.

Long term we can consider parallelizing the test execution as suggested by Marten in https://github.com/quic-go/quic-go/pull/4339#issuecomment-1977606709.