### PR TITLE
ci(interop/action): always upload comment data

### DIFF
--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -89,6 +89,7 @@ runs:
         path: quic-interop-runner/logs
 
     - name: Format GitHub comment
+      if: always()
       run: |
         echo '[**QUIC Interop Runner**](https://github.com/quic-interop/quic-interop-runner)' >> comment
         echo '' >> comment
@@ -98,6 +99,7 @@ runs:
       shell: bash
 
     - name: Export PR comment data
+      if: always()
       uses: ./.github/actions/pr-comment-data-export
       with:
         name: qns


### PR DESCRIPTION
In https://github.com/mozilla/neqo/pull/1785 the QUIC Network Simulator workflow failed.

https://github.com/mozilla/neqo/actions/runs/8523273988/job/23345192160?pr=1785

This triggers the QUIC Network Simulator Comment workflow.

https://github.com/mozilla/neqo/actions/runs/8524906268

Though currently, the former does not upload the _comment_ artifact on failure, which is to be consumed by the latter.

This commit makes the former always upload the comment data, such that the latter can consume it on failure.