### PR TITLE
fix(bin): benchmark HPS without zero RTT

### DIFF
--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -13,8 +13,6 @@ use tokio::runtime::Runtime;
 struct Benchmark {
     name: String,
     requests: Vec<u64>,
-    /// Download resources in series using separate connections.
-    download_in_series: bool,
     sample_size: Option<usize>,
 }
 
@@ -27,25 +25,21 @@ fn transfer(c: &mut Criterion) {
     for Benchmark {
         name,
         requests,
-        download_in_series,
         sample_size,
     } in [
         Benchmark {
             name: "1-conn/1-100mb-resp (aka. Download)".to_string(),
             requests: vec![100 * 1024 * 1024],
-            download_in_series: false,
             sample_size: Some(10),
         },
         Benchmark {
             name: "1-conn/10_000-1b-seq-resp (aka. RPS)".to_string(),
             requests: vec![1; 10_000],
-            download_in_series: false,
             sample_size: None,
         },
         Benchmark {
-            name: "100-seq-conn/1-1b-resp (aka. HPS)".to_string(),
-            requests: vec![1; 100],
-            download_in_series: true,
+            name: "1-conn/1-1b-resp (aka. HPS)".to_string(),
+            requests: vec![1; 1],
             sample_size: None,
         },
     ] {
@@ -61,7 +55,7 @@ fn transfer(c: &mut Criterion) {
         }
         group.bench_function("client", |b| {
             b.to_async(Runtime::new().unwrap()).iter_batched(
-                || client::client(client::Args::new(&requests, download_in_series)),
+                || client::client(client::Args::new(&requests)),
                 |client| async move {
                     client.await.unwrap();
                 },

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -200,7 +200,7 @@ impl Args {
     #[must_use]
     #[cfg(feature = "bench")]
     #[allow(clippy::missing_panics_doc)]
-    pub fn new(requests: &[u64], download_in_series: bool) -> Self {
+    pub fn new(requests: &[u64]) -> Self {
         use std::str::FromStr;
         Self {
             verbose: clap_verbosity_flag::Verbosity::<clap_verbosity_flag::InfoLevel>::default(),
@@ -212,7 +212,7 @@ impl Args {
             method: "GET".into(),
             header: vec![],
             max_concurrent_push_streams: 10,
-            download_in_series,
+            download_in_series: false,
             concurrency: 100,
             output_read_data: false,
             output_dir: Some("/dev/null".into()),


### PR DESCRIPTION
The "100-seq-conn/1-1b-resp (aka. HPS)" benchmark supposedly measures the time for 100 uniform handshakes. Though `neqo-client` by default uses a resumption token for zero RTT if available. Thus the first is a normal and all following 99 handshakes are a zero RTT handshake.

To simplify the benchmark and to measure the same handshake type, establish a single connection within the benchmark function and have criterion do all the iterating.

---

Benchmark introduced in https://github.com/mozilla/neqo/pull/1758.