### PR TITLE
fix(bin/bench): rename 1-conn/10_000-1b-seq-resp to parallel

### DIFF
--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -37,7 +37,7 @@ fn transfer(c: &mut Criterion) {
             sample_size: Some(10),
         },
         Benchmark {
-            name: "1-conn/10_000-1b-seq-resp (aka. RPS)".to_string(),
+            name: "1-conn/10_000-parallel-1b-resp (aka. RPS)".to_string(),
             requests: vec![1; 10_000],
             download_in_series: false,
             sample_size: None,


### PR DESCRIPTION
The benchmark is using the default concurrency factor. By default `neqo-client` runs up to `100` requests in parallel.

https://github.com/mozilla/neqo/blob/5dfe106669ccb695187511305c21b8e8a8775e91/neqo-bin/src/client/mod.rs#L151-L153

Thus the benchmark name is wrong, i.e. the requests are run in parallel and not sequentially.

---

Sorry for the all noise for such a minor change.
