### PR TITLE
chore: Fix clippy `usage of a legacy numeric method`

### DIFF
--- a/neqo-crypto/src/time.rs
+++ b/neqo-crypto/src/time.rs
@@ -258,11 +258,11 @@ mod test {
 
     #[test]
     // We allow replace_consts here because
-    // std::u64::max_value() isn't available
+    // std::u64::MAX isn't available
     // in all of our targets
     fn overflow_interval() {
         init();
-        let interval = Interval::from(Duration::from_micros(u64::max_value()));
+        let interval = Interval::from(Duration::from_micros(u64::MAX));
         let res: Res<PRTime> = interval.try_into();
         assert!(res.is_err());
     }

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -94,7 +94,7 @@ impl HeaderTable {
             capacity: 0,
             used: 0,
             base: 0,
-            acked_inserts_cnt: if encoder { 0 } else { u64::max_value() },
+            acked_inserts_cnt: if encoder { 0 } else { u64::MAX },
         }
     }
 

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -758,7 +758,7 @@ impl CryptoDxAppData {
     }
 
     pub fn next(&self) -> Res<Self> {
-        if self.dx.epoch == usize::max_value() {
+        if self.dx.epoch == usize::MAX {
             // Guard against too many key updates.
             return Err(Error::KeysExhausted);
         }

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -158,7 +158,7 @@ impl PacketBuilder {
         }
         Self {
             encoder,
-            pn: u64::max_value(),
+            pn: u64::MAX,
             header: header_start..header_start,
             offsets: PacketBuilderOffsets {
                 first_byte_mask: PACKET_HP_MASK_SHORT,
@@ -201,7 +201,7 @@ impl PacketBuilder {
 
         Self {
             encoder,
-            pn: u64::max_value(),
+            pn: u64::MAX,
             header: header_start..header_start,
             offsets: PacketBuilderOffsets {
                 first_byte_mask: PACKET_HP_MASK_LONG,


### PR DESCRIPTION
`u64::max_value()` -> `u64::MAX`