### PR TITLE
ci: Delete QNS PR comment on successful run

### DIFF
--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -5,6 +5,9 @@ inputs:
   name:
     description: 'Artifact name to import comment data from.'
     required: true
+  mode:
+    description: 'Mode of operation (upsert/recreate/delete).'
+    required: true
   token:
     description: 'A Github PAT'
     required: true

--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -32,5 +32,6 @@ runs:
     - uses: thollander/actions-comment-pull-request@v2
       with:
         filePath: contents
+        mode: ${{ inputs.mode }}
         pr_number: ${{ steps.pr-number.outputs.number }}
         comment_tag: ${{ inputs.name }}-comment

--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -91,12 +91,9 @@ runs:
     - name: Format GitHub comment
       if: always()
       run: |
-        if [ -s quic-interop-runner/summary ]; then
-          exit 0
-        fi
         echo '[**QUIC Interop Runner**](https://github.com/quic-interop/quic-interop-runner)' >> comment
         echo '' >> comment
-        # Ignore all, but table, which starts with "|".
+        # Ignore all, but table, which starts with "|". Also reformat it to GitHub Markdown.
         grep -E '^\|' quic-interop-runner/summary |\
           awk '(!/^\| *:-/ || (d++ && d < 3))' |\
           sed -E -e 's/✓/:white_check_mark:/gi' -e 's/✕/:x:/gi' -e 's/\?/:grey_question:/gi' \
@@ -106,7 +103,7 @@ runs:
       shell: bash
 
     - name: Export PR comment data
-      if: env.EXPORT_COMMENT == '1'
+      if: always()
       uses: ./.github/actions/pr-comment-data-export
       with:
         name: qns

--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -25,4 +25,5 @@ jobs:
       - uses: ./.github/actions/pr-comment
         with:
           name: bench
+          mode: upsert
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -25,5 +25,4 @@ jobs:
       - uses: ./.github/actions/pr-comment
         with:
           name: bench
-          mode: upsert
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/qns-comment.yml
+++ b/.github/workflows/qns-comment.yml
@@ -18,8 +18,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     if: |
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'failure'
+      github.event.workflow_run.event == 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pr-comment

--- a/.github/workflows/qns-comment.yml
+++ b/.github/workflows/qns-comment.yml
@@ -24,4 +24,5 @@ jobs:
       - uses: ./.github/actions/pr-comment
         with:
           name: qns
+          mode: ${{ github.event.workflow_run.conclusion == 'success' && 'delete' || 'upsert' }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
~~Because we only add one when there is a failure, and when things then later get fixed we don't update it again (because we skip the update on success). So the outdated, failed state keeps being shown.~~

Because if we only update on failure, we keep showing the last-failed state after success.