### PR TITLE
fix(transport): only emit SendStreamWritable on ack if prev. blocked

### DIFF
--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -2514,7 +2514,7 @@ mod tests {
         conn_events.events().next().unwrap();
 
         // Fill the tx buffer.
-        let res = s.send(&[4; SEND_BUFFER_SIZE]).unwrap();
+        let res = s.send(&vec![4; SEND_BUFFER_SIZE]).unwrap();
         assert_eq!(res, SEND_BUFFER_SIZE);
         assert!(conn_events.events().next().is_none());
         // The stream is now constrained by the tx buffer.


### PR DESCRIPTION
`neqo_transport::SendStream` emits `ConnectionEvent::SendStreamWritable` to inform a user that they can write more data into a stream.

It emits this event in 3 cases:

- on `SendStream::new`
- on `SendStream::set_max_data`
- on `SendStream::mark_as_acked`

Emitting a `SendStreamWritable` event, even though writing wasn't previously blocked, is useless. That is why `SendStream::set_max_data` only emits the event if sending was previously blocked on stream flow control.

https://github.com/mozilla/neqo/blob/c004359a817ffdea33394e94944d2f882e7e78af/neqo-transport/src/send_stream.rs#L1206-L1216

This commit adds the corresponding check to `SendStream::mark_as_acked` as well. I.e. it checks whether sending was previously blocked on the tx buffer size, before emitting a `SendStreamWritable` event.

This is especially relevant for `SendStream::mark_as_acked`, as each received ack would otherwise result in a `SendStreamWritable` event. The event in itself isn't expensive. The logic it triggers is.

---

As an example, I was seeing > 200 `SendStreamWritable` events queued at once in the [`Download` benchmark](https://github.com/mozilla/neqo/blob/c004359a817ffdea33394e94944d2f882e7e78af/neqo-bin/benches/main.rs#L30-L34).

I suggest prioritizing the related https://github.com/mozilla/neqo/issues/1819 (bug) before this pull request (optimization).