### PR TITLE
refactor(SendStream): remove duplicate buf.is_empty check

### DIFF
--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1269,7 +1269,7 @@ impl SendStream {
             return Err(Error::FinalSizeError);
         }
 
-        let buf = if buf.is_empty() || (self.avail() == 0) {
+        let buf = if self.avail() == 0 {
             return Ok(0);
         } else if self.avail() < buf.len() {
             if atomic {


### PR DESCRIPTION
`SendStream::send_internal` starts off with a check to `buf.is_empty`.

https://github.com/mozilla/neqo/blob/cf0009842dade14a52416180f94a2dc507cd867a/neqo-transport/src/send_stream.rs#L1252-L1256

Thus the following `buf.is_empty` check isn't necessary.

https://github.com/mozilla/neqo/blob/cf0009842dade14a52416180f94a2dc507cd867a/neqo-transport/src/send_stream.rs#L1272