### PR TITLE
bench(bin): panic when server terminates

### DIFF
--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -75,7 +75,7 @@ fn spawn_server() -> tokio::sync::oneshot::Sender<()> {
             let mut server = Box::pin(server::server(server::Args::default()));
             tokio::select! {
                 _ = &mut done_receiver => {}
-                _ = &mut server  => {}
+                res = &mut server  => panic!("expect server not to terminate: {res:?}"),
             }
         });
     });


### PR DESCRIPTION
The `neqo-bin` benchmarks spin up a `neqo-server` and then run various different client scenarios against it. Once done, they send the `neqo-server` a signal to terminate.

In case the server terminates early (e.g. due to an error), surface it to the user.