### PR TITLE
refactor(SendStream): remove borrow-checker work-around

### DIFF
--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1634,20 +1634,16 @@ impl SendStreams {
     }
 
     pub fn remove_terminal(&mut self) {
-        let map: &mut IndexMap<StreamId, SendStream> = &mut self.map;
-        let regular: &mut OrderGroup = &mut self.regular;
-        let sendordered: &mut BTreeMap<SendOrder, OrderGroup> = &mut self.sendordered;
-
-        // Take refs to all the items we need to modify instead of &mut
-        // self to keep the compiler happy (if we use self.map.retain it
-        // gets upset due to borrows)
-        map.retain(|stream_id, stream| {
+        self.map.retain(|stream_id, stream| {
             if stream.is_terminal() {
                 if stream.is_fair() {
                     match stream.sendorder() {
-                        None => regular.remove(*stream_id),
+                        None => self.regular.remove(*stream_id),
                         Some(sendorder) => {
-                            sendordered.get_mut(&sendorder).unwrap().remove(*stream_id);
+                            self.sendordered
+                                .get_mut(&sendorder)
+                                .unwrap()
+                                .remove(*stream_id);
                         }
                     };
                 }


### PR DESCRIPTION
With recent Rust versions, the Rust borrow-checker has become more capable, especially when it comes to borrowing subsets of `self`.

This commit removes the no longer necessary borrow-checker work-around.

---

Sorry for the many tiny pull requests today. Let me know if you don't think they are worth the noise.