### PR TITLE
fix(qns): fallback if server is not sending NEW_TOKEN

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -71,6 +71,6 @@ jobs:
           name: 'neqo-latest'
           image: ${{ steps.docker_build_and_push.outputs.imageID }}
           url: https://github.com/mozilla/neqo
-          test: handshake,ecn,keyupdate
+          test: handshake,ecn,keyupdate,resumption
           client: neqo-latest,quic-go,ngtcp2,neqo,msquic
           server: neqo-latest,quic-go,ngtcp2,neqo,msquic

--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -95,16 +95,10 @@ impl<'a> super::Handler for Handler<'a> {
         Ok(false)
     }
 
-    fn take_token(&mut self) -> Option<ResumptionToken> {
-        self.token.take()
-    }
-
-    fn has_token(&mut self, client: &mut Self::Client) -> bool {
-        if self.token.is_some() {
-            return true;
-        }
-        self.token = client.take_resumption_token(Instant::now());
-        self.token.is_some()
+    fn take_token(&mut self, client: &mut Self::Client) -> Option<ResumptionToken> {
+        self.token
+            .take()
+            .or_else(|| client.take_resumption_token(Instant::now()))
     }
 }
 

--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -95,10 +95,16 @@ impl<'a> super::Handler for Handler<'a> {
         Ok(false)
     }
 
-    fn take_token(&mut self, client: &mut Self::Client) -> Option<ResumptionToken> {
-        self.token
-            .take()
-            .or_else(|| client.take_resumption_token(Instant::now()))
+    fn take_token(&mut self) -> Option<ResumptionToken> {
+        self.token.take()
+    }
+
+    fn has_token(&mut self, client: &mut Self::Client) -> bool {
+        if self.token.is_some() {
+            return true;
+        }
+        self.token = client.take_resumption_token(Instant::now());
+        self.token.is_some()
     }
 }
 

--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -87,18 +87,22 @@ impl<'a> super::Handler for Handler<'a> {
             }
         }
 
-        if self.streams.is_empty() && self.url_queue.is_empty() {
-            // Handler is done.
-            return Ok(true);
+        if !self.streams.is_empty() || !self.url_queue.is_empty() {
+            return Ok(false);
         }
 
-        Ok(false)
+        if self.args.resume && self.token.is_none() {
+            let Some(token) = client.take_resumption_token(Instant::now()) else {
+                return Ok(false);
+            };
+            self.token = Some(token);
+        }
+
+        Ok(true)
     }
 
-    fn take_token(&mut self, client: &mut Self::Client) -> Option<ResumptionToken> {
-        self.token
-            .take()
-            .or_else(|| client.take_resumption_token(Instant::now()))
+    fn take_token(&mut self) -> Option<ResumptionToken> {
+        self.token.take()
     }
 }
 
@@ -159,11 +163,15 @@ impl super::Client for Connection {
         }
     }
 
-    fn is_closed(&self) -> Option<ConnectionError> {
-        if let State::Closed(err) = self.state() {
-            return Some(err.clone());
+    fn is_closed(&self) -> Result<bool, ConnectionError> {
+        match self.state() {
+            State::Closed(
+                ConnectionError::Transport(neqo_transport::Error::NoError)
+                | ConnectionError::Application(0),
+            ) => Ok(true),
+            State::Closed(err) => Err(err.clone()),
+            _ => Ok(false),
         }
-        None
     }
 
     fn stats(&self) -> neqo_transport::Stats {

--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -95,12 +95,10 @@ impl<'a> super::Handler for Handler<'a> {
         Ok(false)
     }
 
-    fn take_token(&mut self) -> Option<ResumptionToken> {
-        self.token.take()
-    }
-
-    fn has_token(&self) -> bool {
-        self.token.is_some()
+    fn take_token(&mut self, client: &mut Self::Client) -> Option<ResumptionToken> {
+        self.token
+            .take()
+            .or_else(|| client.take_resumption_token(Instant::now()))
     }
 }
 

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -223,12 +223,10 @@ impl<'a> super::Handler for Handler<'a> {
         Ok(self.url_handler.done())
     }
 
-    fn take_token(&mut self) -> Option<ResumptionToken> {
-        self.token.take()
-    }
-
-    fn has_token(&self) -> bool {
-        self.token.is_some()
+    fn take_token(&mut self, client: &mut Self::Client) -> Option<ResumptionToken> {
+        self.token
+            .take()
+            .or_else(|| client.take_resumption_token(Instant::now()))
     }
 }
 

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -223,10 +223,16 @@ impl<'a> super::Handler for Handler<'a> {
         Ok(self.url_handler.done())
     }
 
-    fn take_token(&mut self, client: &mut Self::Client) -> Option<ResumptionToken> {
-        self.token
-            .take()
-            .or_else(|| client.take_resumption_token(Instant::now()))
+    fn take_token(&mut self) -> Option<ResumptionToken> {
+        self.token.take()
+    }
+
+    fn has_token(&mut self, client: &mut Self::Client) -> bool {
+        if self.token.is_some() {
+            return true;
+        }
+        self.token = client.take_resumption_token(Instant::now());
+        self.token.is_some()
     }
 }
 

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -223,16 +223,10 @@ impl<'a> super::Handler for Handler<'a> {
         Ok(self.url_handler.done())
     }
 
-    fn take_token(&mut self) -> Option<ResumptionToken> {
-        self.token.take()
-    }
-
-    fn has_token(&mut self, client: &mut Self::Client) -> bool {
-        if self.token.is_some() {
-            return true;
-        }
-        self.token = client.take_resumption_token(Instant::now());
-        self.token.is_some()
+    fn take_token(&mut self, client: &mut Self::Client) -> Option<ResumptionToken> {
+        self.token
+            .take()
+            .or_else(|| client.take_resumption_token(Instant::now()))
     }
 }
 

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -106,11 +106,15 @@ pub(crate) fn create_client(
 }
 
 impl super::Client for Http3Client {
-    fn is_closed(&self) -> Option<ConnectionError> {
-        if let Http3State::Closed(err) = self.state() {
-            return Some(err);
+    fn is_closed(&self) -> Result<bool, ConnectionError> {
+        match self.state() {
+            Http3State::Closed(
+                ConnectionError::Transport(neqo_transport::Error::NoError)
+                | ConnectionError::Application(0),
+            ) => Ok(true),
+            Http3State::Closed(err) => Err(err.clone()),
+            _ => Ok(false),
         }
-        None
     }
 
     fn process_output(&mut self, now: Instant) -> Output {
@@ -223,10 +227,8 @@ impl<'a> super::Handler for Handler<'a> {
         Ok(self.url_handler.done())
     }
 
-    fn take_token(&mut self, client: &mut Self::Client) -> Option<ResumptionToken> {
-        self.token
-            .take()
-            .or_else(|| client.take_resumption_token(Instant::now()))
+    fn take_token(&mut self) -> Option<ResumptionToken> {
+        self.token.take()
     }
 }
 

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -341,8 +341,7 @@ trait Handler {
     type Client: Client;
 
     fn handle(&mut self, client: &mut Self::Client) -> Res<bool>;
-    fn take_token(&mut self) -> Option<ResumptionToken>;
-    fn has_token(&mut self, client: &mut Self::Client) -> bool;
+    fn take_token(&mut self, client: &mut Self::Client) -> Option<ResumptionToken>;
 }
 
 /// Network client, e.g. [`neqo_transport::Connection`] or [`neqo_http3::Http3Client`].
@@ -374,35 +373,20 @@ struct Runner<'a, H: Handler> {
 
 impl<'a, H: Handler> Runner<'a, H> {
     async fn run(mut self) -> Res<Option<ResumptionToken>> {
-        loop {
+        let close_reason = loop {
             let handler_done = self.handler.handle(&mut self.client)?;
-
-            match (handler_done, self.args.resume, self.handler.has_token(&mut self.client)) {
-                // Handler isn't done. Continue.
-                (false, _, _) => {},
-                // Handler done. Resumption token needed but not present. Continue.
-                (true, true, false) => {
-                    qdebug!("Handler done. Waiting for resumption token.");
-                }
-                // Handler is done, no resumption token needed. Close.
-                (true, false, _) |
-                // Handler is done, resumption token needed and present. Close.
-                (true, true, true) => {
-                    self.client.close(Instant::now(), 0, "kthxbye!");
-                }
-            }
-
             self.process_output().await?;
 
-            if let Some(reason) = self.client.is_closed() {
-                if self.args.stats {
-                    qinfo!("{:?}", self.client.stats());
+            match (handler_done, self.client.is_closed()) {
+                // more work
+                (false, _) => {}
+                // no more work, closing connection
+                (true, None) => {
+                    self.client.close(Instant::now(), 0, "kthxbye!");
+                    continue;
                 }
-                return match reason {
-                    ConnectionError::Transport(TransportError::NoError)
-                    | ConnectionError::Application(0) => Ok(self.handler.take_token()),
-                    _ => Err(reason.into()),
-                };
+                // no more work, connection closed, terminating
+                (true, Some(reason)) => break reason,
             }
 
             if self.client.has_events() {
@@ -415,6 +399,16 @@ impl<'a, H: Handler> Runner<'a, H> {
                     self.timeout = None;
                 }
             }
+        };
+
+        if self.args.stats {
+            qinfo!("{:?}", self.client.stats());
+        }
+
+        match close_reason {
+            ConnectionError::Transport(TransportError::NoError)
+            | ConnectionError::Application(0) => Ok(self.handler.take_token(&mut self.client)),
+            _ => Err(close_reason.into()),
         }
     }
 

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -341,8 +341,7 @@ trait Handler {
     type Client: Client;
 
     fn handle(&mut self, client: &mut Self::Client) -> Res<bool>;
-    fn take_token(&mut self) -> Option<ResumptionToken>;
-    fn has_token(&self) -> bool;
+    fn take_token(&mut self, client: &mut Self::Client) -> Option<ResumptionToken>;
 }
 
 /// Network client, e.g. [`neqo_transport::Connection`] or [`neqo_http3::Http3Client`].
@@ -374,35 +373,20 @@ struct Runner<'a, H: Handler> {
 
 impl<'a, H: Handler> Runner<'a, H> {
     async fn run(mut self) -> Res<Option<ResumptionToken>> {
-        loop {
+        let close_reason = loop {
             let handler_done = self.handler.handle(&mut self.client)?;
-
-            match (handler_done, self.args.resume, self.handler.has_token()) {
-                // Handler isn't done. Continue.
-                (false, _, _) => {},
-                // Handler done. Resumption token needed but not present. Continue.
-                (true, true, false) => {
-                    qdebug!("Handler done. Waiting for resumption token.");
-                }
-                // Handler is done, no resumption token needed. Close.
-                (true, false, _) |
-                // Handler is done, resumption token needed and present. Close.
-                (true, true, true) => {
-                    self.client.close(Instant::now(), 0, "kthxbye!");
-                }
-            }
-
             self.process_output().await?;
 
-            if let Some(reason) = self.client.is_closed() {
-                if self.args.stats {
-                    qinfo!("{:?}", self.client.stats());
+            match (handler_done, self.client.is_closed()) {
+                // more work
+                (false, _) => {}
+                // no more work, closing connection
+                (true, None) => {
+                    self.client.close(Instant::now(), 0, "kthxbye!");
+                    continue;
                 }
-                return match reason {
-                    ConnectionError::Transport(TransportError::NoError)
-                    | ConnectionError::Application(0) => Ok(self.handler.take_token()),
-                    _ => Err(reason.into()),
-                };
+                // no more work, connection closed, terminating
+                (true, Some(reason)) => break reason,
             }
 
             if self.client.has_events() {
@@ -415,6 +399,16 @@ impl<'a, H: Handler> Runner<'a, H> {
                     self.timeout = None;
                 }
             }
+        };
+
+        if self.args.stats {
+            qinfo!("{:?}", self.client.stats());
+        }
+
+        match close_reason {
+            ConnectionError::Transport(TransportError::NoError)
+            | ConnectionError::Application(0) => Ok(self.handler.take_token(&mut self.client)),
+            _ => Err(close_reason.into()),
         }
     }
 


### PR DESCRIPTION
https://github.com/mozilla/neqo/pull/1676 ensured for the client to wait for a resumption token from the server if one is needed, that is when running the `resumption` QUIC Interop testcase. #1676 accidentally removed the fallback using a session ticked if no resumption token was available.

https://github.com/mozilla/neqo/pull/1676/files#diff-64d071700a607884926de1b2caaf1588558fceda6d3a0e899cfb3c3b7e5ae41fL1353-L1359

This commit re-introduces the fallback and enables the `resumption` QUIC Interop testcase on CI.

Along the way, it simplifies `Runner::run` and reserves the `resume` command line argument for the QUIC Interop testcases only. Let me know if this adds too much noise to the actual fix. Happy to extract it into a separate pull request.

---

Test failure reported in https://github.com/mozilla/neqo/pull/1786#issuecomment-2060058643.