### PR TITLE
fix(SendMessage): use SendStream::set_writable_event_low_watermark

### DIFF
--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -181,7 +181,7 @@ impl SendStream for SendMessage {
         if available < MIN_DATA_FRAME_SIZE {
             conn.stream_set_writable_event_low_watermark(
                 self.stream_id(),
-                NonZeroUsize::new(MIN_DATA_FRAME_SIZE).expect("MIN_DATA_FRAME_SIZE greater than 0"),
+                NonZeroUsize::new(MIN_DATA_FRAME_SIZE).unwrap(),
             )?;
             return Ok(0);
         }

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -17,7 +17,7 @@ use crate::{
     SendStream, SendStreamEvents, Stream,
 };
 
-const MIN_DATA_FRAME_SIZE: usize = 3; // Minimal DATA frame size: 2 (header) + 1 (goodput)
+const MIN_DATA_FRAME_SIZE: usize = 3; // Minimal DATA frame size: 2 (header) + 1 (payload)
 const MAX_DATA_HEADER_SIZE_2: usize = (1 << 6) - 1; // Maximal amount of data with DATA frame header size 2
 const MAX_DATA_HEADER_SIZE_2_LIMIT: usize = MAX_DATA_HEADER_SIZE_2 + 3; // 63 + 3 (size of the next buffer data frame header)
 const MAX_DATA_HEADER_SIZE_3: usize = (1 << 14) - 1; // Maximal amount of data with DATA frame header size 3

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -179,6 +179,9 @@ impl SendStream for SendMessage {
             .stream_avail_send_space(self.stream_id())
             .map_err(|e| Error::map_stream_send_errors(&e.into()))?;
         if available < MIN_DATA_FRAME_SIZE {
+            // Setting this once, instead of every time the available send space
+            // is exhausted, would suffice. That said, function call should be
+            // cheap, thus not worth optimizing.
             conn.stream_set_writable_event_low_watermark(
                 self.stream_id(),
                 NonZeroUsize::new(MIN_DATA_FRAME_SIZE).unwrap(),

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -84,6 +84,19 @@ impl StreamHandler {
             .send_data(self.stream_id(), buf, &mut self.conn.borrow_mut())
     }
 
+    /// Bytes sendable on stream at the QUIC layer.
+    ///
+    /// Note that this does not yet account for HTTP3 frame headers.
+    ///
+    /// # Errors
+    ///
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn available(&mut self) -> Res<usize> {
+        let stream_id = self.stream_id();
+        let n = self.conn.borrow_mut().stream_avail_send_space(stream_id)?;
+        Ok(n)
+    }
+
     /// Close sending side.
     ///
     /// # Errors

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -302,8 +302,7 @@ fn test_data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::E
     assert!(hconn_s.events().any(data_writable));
 
     // Sending more fails, given that each data frame needs to be preceeded by a
-    // header, i.e. needs more than 1 byte of send space to send 1 byte of
-    // goodput.
+    // header, i.e. needs more than 1 byte of send space to send 1 byte payload.
     assert_eq!(request.available()?, 1);
     assert_eq!(request.send_data(&buf)?, 0);
 

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -276,8 +276,8 @@ fn test_data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::E
     let mut request = receive_request(&mut hconn_s).unwrap();
     request.send_headers(&[Header::new(":status", "200")])?;
 
-    // Actually sending these headers clears the serve's send stream buffer and
-    // thus emits a DataWritable event.
+    // Sending these headers clears the serve's send stream buffer and thus
+    // emits a DataWritable event.
     exchange_packets(&mut hconn_c, &mut hconn_s, None);
     let data_writable = |e| {
         matches!(
@@ -296,8 +296,8 @@ fn test_data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::E
     assert_eq!(sent, all_but_one);
     assert_eq!(request.available()?, 1);
 
-    // Actually sending the buffered data clears the send stream buffer and thus
-    // emits a DataWritable event.
+    // Sending the buffered data clears the send stream buffer and thus emits a
+    // DataWritable event.
     exchange_packets(&mut hconn_c, &mut hconn_s, None);
     assert!(hconn_s.events().any(data_writable));
 

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -276,7 +276,7 @@ fn test_data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::E
     let mut request = receive_request(&mut hconn_s).unwrap();
     request.send_headers(&[Header::new(":status", "200")])?;
 
-    // Sending these headers clears the serve's send stream buffer and thus
+    // Sending these headers clears the server's send stream buffer and thus
     // emits a DataWritable event.
     exchange_packets(&mut hconn_c, &mut hconn_s, None);
     let data_writable = |e| {

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -246,6 +246,84 @@ fn test_103_response() {
     process_client_events(&mut hconn_c);
 }
 
+/// Test [`neqo_http3::SendMessage::send_data`] to set
+/// [`neqo_transport::SendStream::set_writable_event_low_watermark`].
+#[allow(clippy::cast_possible_truncation)]
+#[test]
+fn test_data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::Error>> {
+    const STREAM_LIMIT: u64 = 5000;
+    const DATA_FRAME_HEADER_SIZE: usize = 3;
+
+    // Create a client and a server.
+    let mut hconn_c = http3_client_with_params(Http3Parameters::default().connection_parameters(
+        ConnectionParameters::default().max_stream_data(StreamType::BiDi, false, STREAM_LIMIT),
+    ));
+    let mut hconn_s = default_http3_server();
+    mem::drop(connect_peers(&mut hconn_c, &mut hconn_s));
+
+    // Client sends GET to server.
+    let stream_id = hconn_c.fetch(
+        now(),
+        "GET",
+        &("https", "something.com", "/"),
+        &[],
+        Priority::default(),
+    )?;
+    hconn_c.stream_close_send(stream_id)?;
+    exchange_packets(&mut hconn_c, &mut hconn_s, None);
+
+    // Server receives GET and responds with headers.
+    let mut request = receive_request(&mut hconn_s).unwrap();
+    request.send_headers(&[Header::new(":status", "200")])?;
+
+    // Actually sending these headers clears the serve's send stream buffer and
+    // thus emits a DataWritable event.
+    exchange_packets(&mut hconn_c, &mut hconn_s, None);
+    let data_writable = |e| {
+        matches!(
+            e,
+            Http3ServerEvent::DataWritable {
+                stream
+            } if stream.stream_id() == stream_id
+        )
+    };
+    assert!(hconn_s.events().any(data_writable));
+
+    // Have server fill entire send buffer minus 1 byte.
+    let all_but_one = request.available()? - DATA_FRAME_HEADER_SIZE - 1;
+    let buf = vec![1; all_but_one];
+    let sent = request.send_data(&buf)?;
+    assert_eq!(sent, all_but_one);
+    assert_eq!(request.available()?, 1);
+
+    // Actually sending the buffered data clears the send stream buffer and thus
+    // emits a DataWritable event.
+    exchange_packets(&mut hconn_c, &mut hconn_s, None);
+    assert!(hconn_s.events().any(data_writable));
+
+    // Sending more fails, given that each data frame needs to be preceeded by a
+    // header, i.e. needs more than 1 byte of send space to send 1 byte of
+    // goodput.
+    assert_eq!(request.available()?, 1);
+    assert_eq!(request.send_data(&buf)?, 0);
+
+    // Have the client read all the pending data.
+    let mut recv_buf = vec![0_u8; all_but_one];
+    let (recvd, _) = hconn_c.read_data(now(), stream_id, &mut recv_buf)?;
+    assert_eq!(sent, recvd);
+    exchange_packets(&mut hconn_c, &mut hconn_s, None);
+
+    // Expect the server's available send space to be back to the stream limit.
+    assert_eq!(request.available()?, STREAM_LIMIT as usize);
+
+    // Expect the server to emit a DataWritable event, even though it always had
+    // at least 1 byte available to send, i.e. it never exhausted the entire
+    // available send space.
+    assert!(hconn_s.events().any(data_writable));
+
+    Ok(())
+}
+
 #[test]
 fn test_data_writable_events() {
     const STREAM_LIMIT: u64 = 5000;

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -3142,15 +3142,21 @@ impl Connection {
         Ok(self.streams.get_send_stream(stream_id)?.avail())
     }
 
+    /// Set low watermark for [`ConnectionEvent::SendStreamWritable`] event.
+    ///
+    /// See [`SendStream::set_writable_event_low_watermark`].
+    ///
+    /// # Errors
+    /// When the stream ID is invalid.
     pub fn stream_set_writable_event_low_watermark(
         &mut self,
         stream_id: StreamId,
         watermark: NonZeroUsize,
     ) -> Res<()> {
-        Ok(self
-            .streams
+        self.streams
             .get_send_stream_mut(stream_id)?
-            .set_writable_event_low_watermark(watermark))
+            .set_writable_event_low_watermark(watermark);
+        Ok(())
     }
 
     /// Close the stream. Enqueued data will be sent.

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -3166,7 +3166,18 @@ impl Connection {
 
     /// Set low watermark for [`ConnectionEvent::SendStreamWritable`] event.
     ///
-    /// See [`SendStream::set_writable_event_low_watermark`].
+    /// Stream emits a [`crate::ConnectionEvent::SendStreamWritable`] event
+    /// when:
+    /// - the available sendable bytes increased to or above the watermark
+    /// - and was previously below the watermark.
+    ///
+    /// Default value is `1`. In other words
+    /// [`crate::ConnectionEvent::SendStreamWritable`] is emitted whenever the
+    /// available sendable bytes was previously at `0` and now increased to `1`
+    /// or more.
+    ///
+    /// Use this when your protocol needs at least `watermark` amount of available
+    /// sendable bytes to make progress.
     ///
     /// # Errors
     /// When the stream ID is invalid.

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -12,6 +12,7 @@ use std::{
     fmt::{self, Debug},
     iter, mem,
     net::{IpAddr, SocketAddr},
+    num::NonZeroUsize,
     ops::RangeInclusive,
     rc::{Rc, Weak},
     time::{Duration, Instant},
@@ -3139,6 +3140,17 @@ impl Connection {
     /// When the stream ID is invalid.
     pub fn stream_avail_send_space(&self, stream_id: StreamId) -> Res<usize> {
         Ok(self.streams.get_send_stream(stream_id)?.avail())
+    }
+
+    pub fn stream_set_writable_event_low_watermark(
+        &mut self,
+        stream_id: StreamId,
+        watermark: NonZeroUsize,
+    ) -> Res<()> {
+        Ok(self
+            .streams
+            .get_send_stream_mut(stream_id)?
+            .set_writable_event_low_watermark(watermark))
     }
 
     /// Close the stream. Enqueued data will be sent.

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -64,15 +64,16 @@ where
         }
     }
 
-    /// Update the maximum.  Returns `true` if the change was an increase.
-    pub fn update(&mut self, limit: u64) -> bool {
+    /// Update the maximum. Returns `Some` with the updated available flow
+    /// control if the change was an increase and `None` otherwise.
+    pub fn update(&mut self, limit: u64) -> Option<usize> {
         debug_assert!(limit < u64::MAX);
         if limit > self.limit {
             self.limit = limit;
             self.blocked_frame = false;
-            true
+            Some(self.available())
         } else {
-            false
+            None
         }
     }
 

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1207,19 +1207,10 @@ impl SendStream {
         }
     }
 
-    /// Set low watermark for [`ConnectionEvent::SendStreamWritable`] event.
+    /// Set low watermark for [`crate::ConnectionEvent::SendStreamWritable`]
+    /// event.
     ///
-    /// [`SendStream`] emits a [`ConnectionEvent::SendStreamWritable`] event when:
-    /// - the available sendable bytes increased to or above the watermark
-    /// - and was previously below the watermark.
-    ///
-    /// Default value is `1`. In other words
-    /// [`ConnectionEvent::SendStreamWritable`] is emitted whenever the
-    /// available sendable bytes was previously at `0` and now increased to `1`
-    /// or more.
-    ///
-    /// Use this when your protocol needs at least `watermark` amount of available
-    /// sendable bytes to make progress.
+    /// See [`crate::Connection::stream_set_writable_event_low_watermark`].
     pub fn set_writable_event_low_watermark(&mut self, watermark: NonZeroUsize) {
         self.writable_event_low_watermark = watermark;
     }
@@ -2537,8 +2528,9 @@ mod tests {
         assert_eq!(s.avail(), 0);
         assert_eq!(conn_events.events().count(), 0);
 
-        // Increasing the connection limit further (conn:11, stream:0, watermark: 3) will not generate
-        // event or allow sending anything. Stream wasn't constrained by connection limit before.
+        // Increasing the connection limit further (conn:11, stream:0, watermark: 3) will not
+        // generate event or allow sending anything. Stream wasn't constrained by connection
+        // limit before.
         assert!(conn_fc.borrow_mut().update(11));
         assert_eq!(s.avail(), 0);
         assert_eq!(conn_events.events().count(), 0);

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1388,18 +1388,14 @@ impl SendStream {
     ) {
         let low_watermark = self.writable_event_low_watermark.get();
 
-        if low_watermark < previous_limit {
-            // Stream was not constrained by limit before.
-            return;
-        }
-
-        if current_limit < low_watermark {
-            // Stream is still constrained by limit.
-            return;
-        }
-
-        if self.avail() < low_watermark {
-            // Stream is constrained by different limit.
+        // Skip if:
+        // - stream was not constrained by limit before,
+        // - or stream is still constrained by limit,
+        // - or stream is constrained by different limit.
+        if low_watermark < previous_limit
+            || current_limit < low_watermark
+            || self.avail() < low_watermark
+        {
             return;
         }
 

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1135,7 +1135,7 @@ impl SendStream {
                 let previous_limit = send_buf.avail();
                 send_buf.mark_as_acked(offset, len);
                 let current_limit = send_buf.avail();
-                self.emit_writable_event(previous_limit, current_limit);
+                self.maybe_emit_writable_event(previous_limit, current_limit);
             }
             SendStreamState::DataSent {
                 ref mut send_buf,
@@ -1222,7 +1222,7 @@ impl SendStream {
             let previous_limit = fc.available();
             fc.update(limit);
             let current_limit = fc.available();
-            self.emit_writable_event(previous_limit, current_limit);
+            self.maybe_emit_writable_event(previous_limit, current_limit);
         }
     }
 
@@ -1381,7 +1381,11 @@ impl SendStream {
         &mut self.state
     }
 
-    pub(crate) fn emit_writable_event(&mut self, previous_limit: usize, current_limit: usize) {
+    pub(crate) fn maybe_emit_writable_event(
+        &mut self,
+        previous_limit: usize,
+        current_limit: usize,
+    ) {
         let low_watermark = self.writable_event_low_watermark.into();
 
         if low_watermark < previous_limit {

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -728,6 +728,7 @@ impl PartialEq for SendStream {
 impl Eq for SendStream {}
 
 impl SendStream {
+    #[allow(clippy::missing_panics_doc)] // not possible
     pub fn new(
         stream_id: StreamId,
         max_stream_data: u64,
@@ -1206,6 +1207,19 @@ impl SendStream {
         }
     }
 
+    /// Set low watermark for [`ConnectionEvent::SendStreamWritable`] event.
+    ///
+    /// [`SendStream`] emits a [`ConnectionEvent::SendStreamWritable`] event when:
+    /// - the available sendable bytes increased to or above the watermark
+    /// - and was previously below the watermark.
+    ///
+    /// Default value is `1`. In other words
+    /// [`ConnectionEvent::SendStreamWritable`] is emitted whenever the
+    /// available sendable bytes was previously at `0` and now increased to `1`
+    /// or more.
+    ///
+    /// Use this when your protocol needs at least `watermark` amount of available
+    /// sendable bytes to make progress.
     pub fn set_writable_event_low_watermark(&mut self, watermark: NonZeroUsize) {
         self.writable_event_low_watermark = watermark;
     }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1386,7 +1386,7 @@ impl SendStream {
         previous_limit: usize,
         current_limit: usize,
     ) {
-        let low_watermark = self.writable_event_low_watermark.into();
+        let low_watermark = self.writable_event_low_watermark.get();
 
         if low_watermark < previous_limit {
             // Stream was not constrained by limit before.

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -748,7 +748,7 @@ impl SendStream {
             sendorder: None,
             bytes_sent: 0,
             fair: false,
-            writable_event_low_watermark: 1.try_into().expect("1 greater 0"),
+            writable_event_low_watermark: 1.try_into().unwrap(),
         };
         if ss.avail() > 0 {
             ss.conn_events.send_stream_writable(stream_id);

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -482,7 +482,7 @@ impl Streams {
 
         if conn_credit_increased {
             for (_id, ss) in &mut self.send {
-                ss.emit_writable_event(previous_limit, current_limit);
+                ss.maybe_emit_writable_event(previous_limit, current_limit);
             }
         }
     }

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -477,10 +477,12 @@ impl Streams {
 
     pub fn handle_max_data(&mut self, maximum_data: u64) {
         let previous_limit = self.sender_fc.borrow().available();
-        if let Some(current_limit) = self.sender_fc.borrow_mut().update(maximum_data) {
-            for (_id, ss) in &mut self.send {
-                ss.maybe_emit_writable_event(previous_limit, current_limit);
-            }
+        let Some(current_limit) = self.sender_fc.borrow_mut().update(maximum_data) else {
+            return;
+        };
+
+        for (_id, ss) in &mut self.send {
+            ss.maybe_emit_writable_event(previous_limit, current_limit);
         }
     }
 


### PR DESCRIPTION
Previously `SendMessage::send_data` could stall, if less than the minimum message size is available to be sent. See
https://github.com/mozilla/neqo/issues/1819 for details.

This commit implements solution (3) proposed in
https://github.com/mozilla/neqo/issues/1819.

This commit introduces `SendStream::set_writable_event_low_watermark` which is then used in `SendMessage::send_data` to signal to `SendStream` the minimum required send space (low watermark) for the next send. Once reached, `SendStream` emits a `SendStreamWritable` event, eventually triggering another `SendMessage::send_data`.

Alternative to https://github.com/mozilla/neqo/pull/1835. Compared to https://github.com/mozilla/neqo/pull/1835, this fix does not utilize the `SendMessage` buffer, thus does not introduce an indirection to the send path. In addition, under the assumption that available send space is increased in larger batches, this fix does not send tiny data frames (2 byte header, 1 byte goodput). Downside, compared to https://github.com/mozilla/neqo/pull/1835, is that it requires both changes in `neqo-transport` and `neqo-http3`.

Fixes https://github.com/mozilla/neqo/issues/1819.

Secondarily, this fixes https://github.com/mozilla/neqo/pull/1821 as well.

---

Thank you Martin and Lars for the input on #1819 out-of-band.