### PR TITLE
fix(bin): consider env when no verbosity flag is set

### DIFF
--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -105,9 +105,6 @@ type Res<T> = Result<T, Error>;
 #[allow(clippy::struct_excessive_bools)] // Not a good use of that lint.
 pub struct Args {
     #[command(flatten)]
-    verbose: Option<clap_verbosity_flag::Verbosity>,
-
-    #[command(flatten)]
     shared: SharedArgs,
 
     urls: Vec<Url>,
@@ -180,7 +177,6 @@ impl Args {
     pub fn new(requests: &[u64]) -> Self {
         use std::str::FromStr;
         Self {
-            verbose: None,
             shared: crate::SharedArgs::default(),
             urls: requests
                 .iter()
@@ -486,7 +482,8 @@ fn qlog_new(args: &Args, hostname: &str, cid: &ConnectionId) -> Res<NeqoQlog> {
 
 pub async fn client(mut args: Args) -> Res<()> {
     neqo_common::log::init(
-        args.verbose
+        args.shared
+            .verbose
             .as_ref()
             .map(clap_verbosity_flag::Verbosity::log_level_filter),
     );

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -485,7 +485,11 @@ fn qlog_new(args: &Args, hostname: &str, cid: &ConnectionId) -> Res<NeqoQlog> {
 }
 
 pub async fn client(mut args: Args) -> Res<()> {
-    neqo_common::log::init(args.verbose.as_ref().map(|v| v.log_level_filter()));
+    neqo_common::log::init(
+        args.verbose
+            .as_ref()
+            .map(clap_verbosity_flag::Verbosity::log_level_filter),
+    );
     init()?;
 
     args.update_for_tests();

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -105,7 +105,7 @@ type Res<T> = Result<T, Error>;
 #[allow(clippy::struct_excessive_bools)] // Not a good use of that lint.
 pub struct Args {
     #[command(flatten)]
-    verbose: clap_verbosity_flag::Verbosity<clap_verbosity_flag::InfoLevel>,
+    verbose: Option<clap_verbosity_flag::Verbosity>,
 
     #[command(flatten)]
     shared: SharedArgs,
@@ -180,7 +180,7 @@ impl Args {
     pub fn new(requests: &[u64]) -> Self {
         use std::str::FromStr;
         Self {
-            verbose: clap_verbosity_flag::Verbosity::<clap_verbosity_flag::InfoLevel>::default(),
+            verbose: None,
             shared: crate::SharedArgs::default(),
             urls: requests
                 .iter()
@@ -485,7 +485,7 @@ fn qlog_new(args: &Args, hostname: &str, cid: &ConnectionId) -> Res<NeqoQlog> {
 }
 
 pub async fn client(mut args: Args) -> Res<()> {
-    neqo_common::log::init(Some(args.verbose.log_level_filter()));
+    neqo_common::log::init(args.verbose.as_ref().map(|v| v.log_level_filter()));
     init()?;
 
     args.update_for_tests();

--- a/neqo-bin/src/lib.rs
+++ b/neqo-bin/src/lib.rs
@@ -26,6 +26,9 @@ mod udp;
 
 #[derive(Debug, Parser)]
 pub struct SharedArgs {
+    #[command(flatten)]
+    verbose: Option<clap_verbosity_flag::Verbosity>,
+
     #[arg(short = 'a', long, default_value = "h3")]
     /// ALPN labels to negotiate.
     ///
@@ -66,6 +69,7 @@ pub struct SharedArgs {
 impl Default for SharedArgs {
     fn default() -> Self {
         Self {
+            verbose: None,
             alpn: "h3".into(),
             qlog_dir: None,
             max_table_size_encoder: 16384,

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -587,7 +587,11 @@ enum Ready {
 pub async fn server(mut args: Args) -> Res<()> {
     const HQ_INTEROP: &str = "hq-interop";
 
-    neqo_common::log::init(args.verbose.as_ref().map(|v| v.log_level_filter()));
+    neqo_common::log::init(
+        args.verbose
+            .as_ref()
+            .map(clap_verbosity_flag::Verbosity::log_level_filter),
+    );
     assert!(!args.key.is_empty(), "Need at least one key");
 
     init_db(args.db.clone())?;

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -99,9 +99,6 @@ type Res<T> = Result<T, Error>;
 #[command(author, version, about, long_about = None)]
 pub struct Args {
     #[command(flatten)]
-    verbose: Option<clap_verbosity_flag::Verbosity>,
-
-    #[command(flatten)]
     shared: SharedArgs,
 
     /// List of IP:port to listen on
@@ -132,7 +129,6 @@ impl Default for Args {
     fn default() -> Self {
         use std::str::FromStr;
         Self {
-            verbose: None,
             shared: crate::SharedArgs::default(),
             hosts: vec!["[::]:12345".to_string()],
             db: PathBuf::from_str("../test-fixture/db").unwrap(),
@@ -588,7 +584,8 @@ pub async fn server(mut args: Args) -> Res<()> {
     const HQ_INTEROP: &str = "hq-interop";
 
     neqo_common::log::init(
-        args.verbose
+        args.shared
+            .verbose
             .as_ref()
             .map(clap_verbosity_flag::Verbosity::log_level_filter),
     );

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -99,7 +99,7 @@ type Res<T> = Result<T, Error>;
 #[command(author, version, about, long_about = None)]
 pub struct Args {
     #[command(flatten)]
-    verbose: clap_verbosity_flag::Verbosity<clap_verbosity_flag::InfoLevel>,
+    verbose: Option<clap_verbosity_flag::Verbosity>,
 
     #[command(flatten)]
     shared: SharedArgs,
@@ -132,7 +132,7 @@ impl Default for Args {
     fn default() -> Self {
         use std::str::FromStr;
         Self {
-            verbose: clap_verbosity_flag::Verbosity::<clap_verbosity_flag::InfoLevel>::default(),
+            verbose: None,
             shared: crate::SharedArgs::default(),
             hosts: vec!["[::]:12345".to_string()],
             db: PathBuf::from_str("../test-fixture/db").unwrap(),
@@ -587,7 +587,7 @@ enum Ready {
 pub async fn server(mut args: Args) -> Res<()> {
     const HQ_INTEROP: &str = "hq-interop";
 
-    neqo_common::log::init(Some(args.verbose.log_level_filter()));
+    neqo_common::log::init(args.verbose.as_ref().map(|v| v.log_level_filter()));
     assert!(!args.key.is_empty(), "Need at least one key");
 
     init_db(args.db.clone())?;


### PR DESCRIPTION
There are two ways to specify the maximum log level of `neqo-server` and `neqo-client`. Via the `RUST_LOG` environment variable and since https://github.com/mozilla/neqo/pull/1692 via the verbosity flags (e.g. `-v`).

Previously, if no verbosity flag was provided, `INFO` was set as the maximum log level, the `RUST_LOG` environment variable was simply ignored.

With this commit, if no flag is set, the `RUST_LOG` environment variable is considered, and only then the `env_logger` crate default value (`ERROR`) is used.

In other words, the precedence order now is:

1. command line flags (e.g. `-v`)
2. `RUST_LOG` environment variable
3. default `ERROR` level

---

Among other places, ensures the `RUST_LOG=debug` in the QUIC Interop tests isn't ignored.

https://github.com/mozilla/neqo/blob/4fc4d16744ede5b099dd5bb4bfd5922d07deb046/qns/interop.sh#L15