### PR TITLE
ci: Handle empty `log-url` when commenting on PRs

### DIFF
--- a/.github/actions/pr-comment-data-export/action.yml
+++ b/.github/actions/pr-comment-data-export/action.yml
@@ -26,9 +26,10 @@ runs:
         mkdir comment-data
         cp "${{ inputs.contents }}" comment-data/contents
         echo "${{ inputs.name }}" > comment-data/name
-        echo "${{ inputs.log-url }}" > comment-data/log-url
         echo "${{ github.event.number }}" > comment-data/pr-number
-
+        if [ -n "${{ inputs.log-url }}" ]; then
+          echo "${{ inputs.log-url }}" > comment-data/log-url
+        fi
     - if: github.event_name == 'pull_request'
       uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -27,7 +27,10 @@ runs:
 
     - shell: bash
       run: |
-        [ -s log-url ] && echo "" >> contents && echo "[:arrow_down: Download logs]($(cat log-url))" >> contents
+        if [ -s log-url ]; then
+          echo "" >> contents
+          echo "[:arrow_down: Download logs]($(cat log-url))" >> contents
+        fi
 
     - uses: thollander/actions-comment-pull-request@v2
       with:


### PR DESCRIPTION
Extracted from #1847