### PR TITLE
test(transport): maximum throughput on unlimited bandwidth and 50ms

### DIFF
--- a/test-fixture/src/sim/mod.rs
+++ b/test-fixture/src/sim/mod.rs
@@ -279,7 +279,7 @@ pub struct ReadySimulator {
 }
 
 impl ReadySimulator {
-    pub fn run(mut self) {
+    pub fn run_sim_time(mut self) -> Duration {
         let real_start = Instant::now();
         let end = self.sim.process_loop(self.start, self.now);
         let sim_time = end - self.now;
@@ -289,5 +289,10 @@ impl ReadySimulator {
             wall = real_start.elapsed(),
         );
         self.sim.print_summary();
+        sim_time
+    }
+
+    pub fn run(self) {
+        self.run_sim_time();
     }
 }


### PR DESCRIPTION
This commit adds a basic smoke test using the `test-fixture` simulator, asserting that on a connection with unlimited bandwidth and 50ms round-trip-time Neqo can eventually achieve > 1 Gbit/s throughput.

Showcases the potential that a future stream flow-control auto-tuning algorithm can have.

See https://github.com/mozilla/neqo/issues/733.

---

Draft for now. Not familiar enough with the simulator yet. Will be helpful for an implementation of https://github.com/mozilla/neqo/issues/733.

As expected, test is currently failing. I can not quite yet explain the value of `106 Mbit/s`. I would expect a value closer to `160 Mbit/s` given the `1 MiB` send and receive stream buffer. (See calculation in https://github.com/mozilla/neqo/issues/1820.)

```
thread 'unlimited_bandwidth_50ms_delay_connection' panicked at neqo-transport/tests/network.rs:227:5:
expect transfer on 50ms connection with unlimited bandwidth to eventually surpass 1 Gbit/s but got 106.41665660578931 Mbit/s.
```