### PR TITLE
fix(.github/qns): print to stdout instead of undefined $GROUP.md

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -196,7 +196,7 @@ jobs:
           done
           {
             echo "### Failed Interop Tests"
-            echo "[QUIC Interop Runner](https://github.com/quic-interop/quic-interop-runner), *client* vs. *server*" >> "$GROUP.md"
+            echo "[QUIC Interop Runner](https://github.com/quic-interop/quic-interop-runner), *client* vs. *server*"
             cat failed.md
             echo "<details><summary>Succeeded and unsupported tests</summary>"
             for GROUP in succeeded unsupported; do


### PR DESCRIPTION
The qns.yml workflow adds a heading to the GitHub comment linking to the quic-interop-runner repository. The heading is redirected to `$GROUP.md`. Though `$GROUP` is not defined in this scope.

This commit changes the `echo` command to print to `stdout` directly.