### PR TITLE
fix(bin/client): don't close closing connection

### DIFF
--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -383,6 +383,7 @@ impl<'a, H: Handler> Runner<'a, H> {
                 continue;
             }
 
+            #[allow(clippy::match_same_arms)]
             match (handler_done, self.client.is_closed()?) {
                 // more work
                 (false, _) => {}

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -223,6 +223,16 @@ impl ConnectionError {
             Self::Transport(_) => None,
         }
     }
+
+    /// Checks enclosed error for [`Error::NoError`] and
+    /// [`ConnectionError::Application(0)`].
+    #[must_use]
+    pub fn is_error(&self) -> bool {
+        !matches!(
+            self,
+            ConnectionError::Transport(Error::NoError) | ConnectionError::Application(0),
+        )
+    }
 }
 
 impl From<CloseError> for ConnectionError {


### PR DESCRIPTION
The `bin/src/client/mod.rs` `Runner::run` function continuously checks whether there is more work. In case there is none, it initiates closing of the connection (`self.client.close`) and then `continue`s to the top of the loop in order to send out a closing frame.

https://github.com/mozilla/neqo/blob/14cafbaa7fa88434def2c1d19e932c08e00173f8/neqo-bin/src/client/mod.rs#L376-L409

There is a potential busy loop when closing an already closing connection. `Runner::run` will call `self.client.close` and then continously `continue` to the top of the loop.

This commit differentiates a connection state in `NotClosing`, `Closing` and `Closed`. It only attempts to close a `NotClosing` connection and only then `continue`s to the top of the loop.

---

Fixes https://github.com/mozilla/neqo/issues/1864.

