### PR TITLE
refactor: rename ConnectionError to CloseReason

### DIFF
--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -20,7 +20,7 @@ use std::{
 use neqo_common::{event::Provider, qdebug, qinfo, qwarn, Datagram};
 use neqo_crypto::{AuthenticationStatus, ResumptionToken};
 use neqo_transport::{
-    Connection, ConnectionError, ConnectionEvent, EmptyConnectionIdGenerator, Error, Output, State,
+    CloseReason, Connection, ConnectionEvent, EmptyConnectionIdGenerator, Error, Output, State,
     StreamId, StreamType,
 };
 use url::Url;
@@ -143,7 +143,7 @@ pub(crate) fn create_client(
 }
 
 impl TryFrom<&State> for CloseState {
-    type Error = ConnectionError;
+    type Error = CloseReason;
 
     fn try_from(value: &State) -> Result<Self, Self::Error> {
         let (state, error) = match value {
@@ -183,7 +183,7 @@ impl super::Client for Connection {
         }
     }
 
-    fn is_closed(&self) -> Result<CloseState, ConnectionError> {
+    fn is_closed(&self) -> Result<CloseState, CloseReason> {
         self.state().try_into()
     }
 

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -22,8 +22,8 @@ use neqo_common::{event::Provider, hex, qdebug, qinfo, qwarn, Datagram, Header};
 use neqo_crypto::{AuthenticationStatus, ResumptionToken};
 use neqo_http3::{Error, Http3Client, Http3ClientEvent, Http3Parameters, Http3State, Priority};
 use neqo_transport::{
-    AppError, Connection, ConnectionError, EmptyConnectionIdGenerator, Error as TransportError,
-    Output, StreamId,
+    AppError, CloseReason, Connection, EmptyConnectionIdGenerator, Error as TransportError, Output,
+    StreamId,
 };
 use url::Url;
 
@@ -106,7 +106,7 @@ pub(crate) fn create_client(
 }
 
 impl TryFrom<Http3State> for CloseState {
-    type Error = ConnectionError;
+    type Error = CloseReason;
 
     fn try_from(value: Http3State) -> Result<Self, Self::Error> {
         let (state, error) = match value {
@@ -124,7 +124,7 @@ impl TryFrom<Http3State> for CloseState {
 }
 
 impl super::Client for Http3Client {
-    fn is_closed(&self) -> Result<CloseState, ConnectionError> {
+    fn is_closed(&self) -> Result<CloseState, CloseReason> {
         self.state().try_into()
     }
 

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -27,7 +27,7 @@ use neqo_crypto::{
     init, Cipher, ResumptionToken,
 };
 use neqo_http3::Output;
-use neqo_transport::{AppError, ConnectionError, ConnectionId, Version};
+use neqo_transport::{AppError, CloseReason, ConnectionId, Version};
 use qlog::{events::EventImportance, streamer::QlogStreamer};
 use tokio::time::Sleep;
 use url::{Origin, Url};
@@ -80,11 +80,11 @@ impl From<neqo_transport::Error> for Error {
     }
 }
 
-impl From<neqo_transport::ConnectionError> for Error {
-    fn from(err: neqo_transport::ConnectionError) -> Self {
+impl From<neqo_transport::CloseReason> for Error {
+    fn from(err: neqo_transport::CloseReason) -> Self {
         match err {
-            ConnectionError::Transport(e) => Self::TransportError(e),
-            ConnectionError::Application(e) => Self::ApplicationError(e),
+            CloseReason::Transport(e) => Self::TransportError(e),
+            CloseReason::Application(e) => Self::ApplicationError(e),
         }
     }
 }
@@ -361,7 +361,7 @@ trait Client {
     fn close<S>(&mut self, now: Instant, app_error: AppError, msg: S)
     where
         S: AsRef<str> + Display;
-    fn is_closed(&self) -> Result<CloseState, ConnectionError>;
+    fn is_closed(&self) -> Result<CloseState, CloseReason>;
     fn stats(&self) -> neqo_transport::Stats;
 }
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -1291,8 +1291,8 @@ mod tests {
     use neqo_crypto::{AllowZeroRtt, AntiReplay, ResumptionToken};
     use neqo_qpack::{encoder::QPackEncoder, QpackSettings};
     use neqo_transport::{
-        ConnectionError, ConnectionEvent, ConnectionParameters, Output, State, StreamId,
-        StreamType, Version, RECV_BUFFER_SIZE, SEND_BUFFER_SIZE,
+        CloseReason, ConnectionEvent, ConnectionParameters, Output, State, StreamId, StreamType,
+        Version, RECV_BUFFER_SIZE, SEND_BUFFER_SIZE,
     };
     use test_fixture::{
         anti_replay, default_server_h3, fixture_init, new_server, now,
@@ -1314,7 +1314,7 @@ mod tests {
     fn assert_closed(client: &Http3Client, expected: &Error) {
         match client.state() {
             Http3State::Closing(err) | Http3State::Closed(err) => {
-                assert_eq!(err, ConnectionError::Application(expected.code()));
+                assert_eq!(err, CloseReason::Application(expected.code()));
             }
             _ => panic!("Wrong state {:?}", client.state()),
         };
@@ -4419,7 +4419,7 @@ mod tests {
                 HSetting::new(HSettingType::BlockedStreams, 100),
                 HSetting::new(HSettingType::MaxHeaderListSize, 10000),
             ],
-            &Http3State::Closing(ConnectionError::Application(265)),
+            &Http3State::Closing(CloseReason::Application(265)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }
@@ -4437,7 +4437,7 @@ mod tests {
                 HSetting::new(HSettingType::MaxTableCapacity, 100),
                 HSetting::new(HSettingType::MaxHeaderListSize, 10000),
             ],
-            &Http3State::Closing(ConnectionError::Application(265)),
+            &Http3State::Closing(CloseReason::Application(265)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }
@@ -4474,7 +4474,7 @@ mod tests {
                 HSetting::new(HSettingType::BlockedStreams, 100),
                 HSetting::new(HSettingType::MaxHeaderListSize, 10000),
             ],
-            &Http3State::Closing(ConnectionError::Application(514)),
+            &Http3State::Closing(CloseReason::Application(514)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }
@@ -4493,7 +4493,7 @@ mod tests {
                 HSetting::new(HSettingType::BlockedStreams, 100),
                 HSetting::new(HSettingType::MaxHeaderListSize, 10000),
             ],
-            &Http3State::Closing(ConnectionError::Application(265)),
+            &Http3State::Closing(CloseReason::Application(265)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }
@@ -4531,7 +4531,7 @@ mod tests {
                 HSetting::new(HSettingType::BlockedStreams, 50),
                 HSetting::new(HSettingType::MaxHeaderListSize, 10000),
             ],
-            &Http3State::Closing(ConnectionError::Application(265)),
+            &Http3State::Closing(CloseReason::Application(265)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }
@@ -4569,7 +4569,7 @@ mod tests {
                 HSetting::new(HSettingType::BlockedStreams, 100),
                 HSetting::new(HSettingType::MaxHeaderListSize, 5000),
             ],
-            &Http3State::Closing(ConnectionError::Application(265)),
+            &Http3State::Closing(CloseReason::Application(265)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }
@@ -4626,7 +4626,7 @@ mod tests {
                 HSetting::new(HSettingType::BlockedStreams, 100),
                 HSetting::new(HSettingType::MaxHeaderListSize, 10000),
             ],
-            &Http3State::Closing(ConnectionError::Application(265)),
+            &Http3State::Closing(CloseReason::Application(265)),
             ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
         );
     }

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/negotiation.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/negotiation.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use neqo_common::{event::Provider, Encoder};
 use neqo_crypto::AuthenticationStatus;
-use neqo_transport::{Connection, ConnectionError, StreamType};
+use neqo_transport::{CloseReason, Connection, StreamType};
 use test_fixture::{default_server_h3, now};
 
 use super::{connect, default_http3_client, default_http3_server, exchange_packets};
@@ -270,10 +270,7 @@ fn wrong_setting_value() {
     exchange_packets2(&mut client, &mut server);
     match client.state() {
         Http3State::Closing(err) | Http3State::Closed(err) => {
-            assert_eq!(
-                err,
-                ConnectionError::Application(Error::HttpSettings.code())
-            );
+            assert_eq!(err, CloseReason::Application(Error::HttpSettings.code()));
         }
         _ => panic!("Wrong state {:?}", client.state()),
     };

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -323,7 +323,7 @@ mod tests {
     use neqo_crypto::{AuthenticationStatus, ZeroRttCheckResult, ZeroRttChecker};
     use neqo_qpack::{encoder::QPackEncoder, QpackSettings};
     use neqo_transport::{
-        Connection, ConnectionError, ConnectionEvent, State, StreamId, StreamType, ZeroRttState,
+        CloseReason, Connection, ConnectionEvent, State, StreamId, StreamType, ZeroRttState,
     };
     use test_fixture::{
         anti_replay, default_client, fixture_init, now, CountingConnectionIdGenerator,
@@ -366,7 +366,7 @@ mod tests {
     }
 
     fn assert_closed(hconn: &mut Http3Server, expected: &Error) {
-        let err = ConnectionError::Application(expected.code());
+        let err = CloseReason::Application(expected.code());
         let closed = |e| matches!(e, Http3ServerEvent::StateChange{ state: Http3State::Closing(e) | Http3State::Closed(e), .. } if e == err);
         assert!(hconn.events().any(closed));
     }

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -17,7 +17,7 @@ use neqo_http3::{
     Header, Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3Parameters, Http3Server,
     Http3ServerEvent, Http3State, Priority,
 };
-use neqo_transport::{ConnectionError, ConnectionParameters, Error, Output, StreamType};
+use neqo_transport::{CloseReason, ConnectionParameters, Error, Output, StreamType};
 use test_fixture::*;
 
 const RESPONSE_DATA: &[u8] = &[0x61, 0x62, 0x63];
@@ -448,7 +448,7 @@ fn fetch_noresponse_will_idletimeout() {
             if let Http3ClientEvent::StateChange(state) = event {
                 match state {
                     Http3State::Closing(error_code) | Http3State::Closed(error_code) => {
-                        assert_eq!(error_code, ConnectionError::Transport(Error::IdleTimeout));
+                        assert_eq!(error_code, CloseReason::Transport(Error::IdleTimeout));
                         done = true;
                     }
                     _ => {}

--- a/neqo-transport/src/connection/state.rs
+++ b/neqo-transport/src/connection/state.rs
@@ -21,7 +21,7 @@ use crate::{
     packet::PacketBuilder,
     path::PathRef,
     recovery::RecoveryToken,
-    ConnectionError, Error,
+    CloseReason, Error,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -42,14 +42,14 @@ pub enum State {
     Connected,
     Confirmed,
     Closing {
-        error: ConnectionError,
+        error: CloseReason,
         timeout: Instant,
     },
     Draining {
-        error: ConnectionError,
+        error: CloseReason,
         timeout: Instant,
     },
-    Closed(ConnectionError),
+    Closed(CloseReason),
 }
 
 impl State {
@@ -67,7 +67,7 @@ impl State {
     }
 
     #[must_use]
-    pub fn error(&self) -> Option<&ConnectionError> {
+    pub fn error(&self) -> Option<&CloseReason> {
         if let Self::Closing { error, .. } | Self::Draining { error, .. } | Self::Closed(error) =
             self
         {
@@ -116,7 +116,7 @@ impl Ord for State {
 #[derive(Debug, Clone)]
 pub struct ClosingFrame {
     path: PathRef,
-    error: ConnectionError,
+    error: CloseReason,
     frame_type: FrameType,
     reason_phrase: Vec<u8>,
 }
@@ -124,7 +124,7 @@ pub struct ClosingFrame {
 impl ClosingFrame {
     fn new(
         path: PathRef,
-        error: ConnectionError,
+        error: CloseReason,
         frame_type: FrameType,
         message: impl AsRef<str>,
     ) -> Self {
@@ -142,12 +142,12 @@ impl ClosingFrame {
     }
 
     pub fn sanitize(&self) -> Option<Self> {
-        if let ConnectionError::Application(_) = self.error {
+        if let CloseReason::Application(_) = self.error {
             // The default CONNECTION_CLOSE frame that is sent when an application
             // error code needs to be sent in an Initial or Handshake packet.
             Some(Self {
                 path: Rc::clone(&self.path),
-                error: ConnectionError::Transport(Error::ApplicationError),
+                error: CloseReason::Transport(Error::ApplicationError),
                 frame_type: 0,
                 reason_phrase: Vec::new(),
             })
@@ -166,12 +166,12 @@ impl ClosingFrame {
             return;
         }
         match &self.error {
-            ConnectionError::Transport(e) => {
+            CloseReason::Transport(e) => {
                 builder.encode_varint(FRAME_TYPE_CONNECTION_CLOSE_TRANSPORT);
                 builder.encode_varint(e.code());
                 builder.encode_varint(self.frame_type);
             }
-            ConnectionError::Application(code) => {
+            CloseReason::Application(code) => {
                 builder.encode_varint(FRAME_TYPE_CONNECTION_CLOSE_APPLICATION);
                 builder.encode_varint(*code);
             }
@@ -234,7 +234,7 @@ impl StateSignaling {
     pub fn close(
         &mut self,
         path: PathRef,
-        error: ConnectionError,
+        error: CloseReason,
         frame_type: FrameType,
         message: impl AsRef<str>,
     ) {
@@ -246,7 +246,7 @@ impl StateSignaling {
     pub fn drain(
         &mut self,
         path: PathRef,
-        error: ConnectionError,
+        error: CloseReason,
         frame_type: FrameType,
         message: impl AsRef<str>,
     ) {

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -19,7 +19,7 @@ use crate::{
     packet::PacketBuilder,
     quic_datagrams::MAX_QUIC_DATAGRAM,
     send_stream::{RetransmissionPriority, TransmissionPriority},
-    Connection, ConnectionError, ConnectionParameters, Error, StreamType,
+    CloseReason, Connection, ConnectionParameters, Error, StreamType,
 };
 
 const DATAGRAM_LEN_MTU: u64 = 1310;
@@ -362,10 +362,7 @@ fn dgram_no_allowed() {
 
     client.process_input(&out, now());
 
-    assert_error(
-        &client,
-        &ConnectionError::Transport(Error::ProtocolViolation),
-    );
+    assert_error(&client, &CloseReason::Transport(Error::ProtocolViolation));
 }
 
 #[test]
@@ -383,10 +380,7 @@ fn dgram_too_big() {
 
     client.process_input(&out, now());
 
-    assert_error(
-        &client,
-        &ConnectionError::Transport(Error::ProtocolViolation),
-    );
+    assert_error(&client, &CloseReason::Transport(Error::ProtocolViolation));
 }
 
 #[test]

--- a/neqo-transport/src/connection/tests/keys.rs
+++ b/neqo-transport/src/connection/tests/keys.rs
@@ -11,7 +11,7 @@ use test_fixture::now;
 
 use super::{
     super::{
-        super::{ConnectionError, ERROR_AEAD_LIMIT_REACHED},
+        super::{CloseReason, ERROR_AEAD_LIMIT_REACHED},
         Connection, ConnectionParameters, Error, Output, State, StreamType,
     },
     connect, connect_force_idle, default_client, default_server, maybe_authenticate,
@@ -269,7 +269,7 @@ fn exhaust_write_keys() {
     assert!(dgram.is_none());
     assert!(matches!(
         client.state(),
-        State::Closed(ConnectionError::Transport(Error::KeysExhausted))
+        State::Closed(CloseReason::Transport(Error::KeysExhausted))
     ));
 }
 
@@ -285,14 +285,14 @@ fn exhaust_read_keys() {
     let dgram = server.process(Some(&dgram), now()).dgram();
     assert!(matches!(
         server.state(),
-        State::Closed(ConnectionError::Transport(Error::KeysExhausted))
+        State::Closed(CloseReason::Transport(Error::KeysExhausted))
     ));
 
     client.process_input(&dgram.unwrap(), now());
     assert!(matches!(
         client.state(),
         State::Draining {
-            error: ConnectionError::Transport(Error::PeerError(ERROR_AEAD_LIMIT_REACHED)),
+            error: CloseReason::Transport(Error::PeerError(ERROR_AEAD_LIMIT_REACHED)),
             ..
         }
     ));
@@ -341,6 +341,6 @@ fn automatic_update_write_keys_blocked() {
     assert!(dgram.is_none());
     assert!(matches!(
         client.state(),
-        State::Closed(ConnectionError::Transport(Error::KeysExhausted))
+        State::Closed(CloseReason::Transport(Error::KeysExhausted))
     ));
 }

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -30,7 +30,7 @@ use crate::{
     packet::PacketBuilder,
     path::{PATH_MTU_V4, PATH_MTU_V6},
     tparams::{self, PreferredAddress, TransportParameter},
-    ConnectionError, ConnectionId, ConnectionIdDecoder, ConnectionIdGenerator, ConnectionIdRef,
+    CloseReason, ConnectionId, ConnectionIdDecoder, ConnectionIdGenerator, ConnectionIdRef,
     ConnectionParameters, EmptyConnectionIdGenerator, Error,
 };
 
@@ -357,7 +357,7 @@ fn migrate_same_fail() {
     assert!(matches!(res, Output::None));
     assert!(matches!(
         client.state(),
-        State::Closed(ConnectionError::Transport(Error::NoAvailablePath))
+        State::Closed(CloseReason::Transport(Error::NoAvailablePath))
     ));
 }
 
@@ -894,7 +894,7 @@ fn retire_prior_to_migration_failure() {
     assert!(matches!(
         client.state(),
         State::Closing {
-            error: ConnectionError::Transport(Error::InvalidMigration),
+            error: CloseReason::Transport(Error::InvalidMigration),
             ..
         }
     ));

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -17,7 +17,7 @@ use neqo_common::{event::Provider, qdebug, qtrace, Datagram, Decoder, Role};
 use neqo_crypto::{random, AllowZeroRtt, AuthenticationStatus, ResumptionToken};
 use test_fixture::{fixture_init, new_neqo_qlog, now, DEFAULT_ADDR};
 
-use super::{Connection, ConnectionError, ConnectionId, Output, State};
+use super::{CloseReason, Connection, ConnectionId, Output, State};
 use crate::{
     addr_valid::{AddressValidation, ValidateAddress},
     cc::{CWND_INITIAL_PKTS, CWND_MIN},
@@ -245,8 +245,8 @@ fn connect_fail(
     server_error: Error,
 ) {
     handshake(client, server, now(), Duration::new(0, 0));
-    assert_error(client, &ConnectionError::Transport(client_error));
-    assert_error(server, &ConnectionError::Transport(server_error));
+    assert_error(client, &CloseReason::Transport(client_error));
+    assert_error(server, &CloseReason::Transport(server_error));
 }
 
 fn connect_with_rtt_and_modifier(
@@ -284,7 +284,7 @@ fn connect(client: &mut Connection, server: &mut Connection) {
     connect_with_rtt(client, server, now(), Duration::new(0, 0));
 }
 
-fn assert_error(c: &Connection, expected: &ConnectionError) {
+fn assert_error(c: &Connection, expected: &CloseReason) {
     match c.state() {
         State::Closing { error, .. } | State::Draining { error, .. } | State::Closed(error) => {
             assert_eq!(*error, *expected, "{c} error mismatch");

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -19,9 +19,9 @@ use crate::{
     send_stream::{OrderGroup, SendStreamState, SEND_BUFFER_SIZE},
     streams::{SendOrder, StreamOrder},
     tparams::{self, TransportParameter},
+    CloseReason,
     // tracking::DEFAULT_ACK_PACKET_TOLERANCE,
     Connection,
-    ConnectionError,
     ConnectionParameters,
     Error,
     StreamId,
@@ -494,12 +494,9 @@ fn exceed_max_data() {
 
     assert_error(
         &client,
-        &ConnectionError::Transport(Error::PeerError(Error::FlowControlError.code())),
+        &CloseReason::Transport(Error::PeerError(Error::FlowControlError.code())),
     );
-    assert_error(
-        &server,
-        &ConnectionError::Transport(Error::FlowControlError),
-    );
+    assert_error(&server, &CloseReason::Transport(Error::FlowControlError));
 }
 
 #[test]

--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -10,7 +10,7 @@ use neqo_common::{event::Provider, Decoder, Encoder};
 use test_fixture::{assertions, datagram, now};
 
 use super::{
-    super::{ConnectionError, ConnectionEvent, Output, State, ZeroRttState},
+    super::{CloseReason, ConnectionEvent, Output, State, ZeroRttState},
     connect, connect_fail, default_client, default_server, exchange_ticket, new_client, new_server,
     send_something,
 };
@@ -124,7 +124,7 @@ fn version_negotiation_only_reserved() {
     assert_eq!(client.process(Some(&dgram), now()), Output::None);
     match client.state() {
         State::Closed(err) => {
-            assert_eq!(*err, ConnectionError::Transport(Error::VersionNegotiation));
+            assert_eq!(*err, CloseReason::Transport(Error::VersionNegotiation));
         }
         _ => panic!("Invalid client state"),
     }
@@ -183,7 +183,7 @@ fn version_negotiation_not_supported() {
     assert_eq!(client.process(Some(&dgram), now()), Output::None);
     match client.state() {
         State::Closed(err) => {
-            assert_eq!(*err, ConnectionError::Transport(Error::VersionNegotiation));
+            assert_eq!(*err, CloseReason::Transport(Error::VersionNegotiation));
         }
         _ => panic!("Invalid client state"),
     }
@@ -338,7 +338,7 @@ fn invalid_server_version() {
     // The server effectively hasn't reacted here.
     match server.state() {
         State::Closed(err) => {
-            assert_eq!(*err, ConnectionError::Transport(Error::CryptoAlert(47)));
+            assert_eq!(*err, CloseReason::Transport(Error::CryptoAlert(47)));
         }
         _ => panic!("invalid server state"),
     }

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -256,7 +256,7 @@ impl EventProvider for ConnectionEvents {
 mod tests {
     use neqo_common::event::Provider;
 
-    use crate::{ConnectionError, ConnectionEvent, ConnectionEvents, Error, State, StreamId};
+    use crate::{CloseReason, ConnectionEvent, ConnectionEvents, Error, State, StreamId};
 
     #[test]
     fn event_culling() {
@@ -314,7 +314,7 @@ mod tests {
 
         evts.send_stream_writable(9.into());
         evts.send_stream_stop_sending(10.into(), 55);
-        evts.connection_state_change(State::Closed(ConnectionError::Transport(
+        evts.connection_state_change(State::Closed(CloseReason::Transport(
             Error::StreamStateError,
         )));
         assert_eq!(evts.events().count(), 1);

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -15,7 +15,7 @@ use crate::{
     ecn::EcnCount,
     packet::PacketType,
     stream_id::{StreamId, StreamType},
-    AppError, ConnectionError, Error, Res, TransportError,
+    AppError, CloseReason, Error, Res, TransportError,
 };
 
 #[allow(clippy::module_name_repetitions)]
@@ -87,11 +87,11 @@ impl CloseError {
     }
 }
 
-impl From<ConnectionError> for CloseError {
-    fn from(err: ConnectionError) -> Self {
+impl From<CloseReason> for CloseError {
+    fn from(err: CloseReason) -> Self {
         match err {
-            ConnectionError::Transport(c) => Self::Transport(c.code()),
-            ConnectionError::Application(c) => Self::Application(c),
+            CloseReason::Transport(c) => Self::Transport(c.code()),
+            CloseReason::Application(c) => Self::Application(c),
         }
     }
 }

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -209,13 +209,17 @@ impl ::std::fmt::Display for Error {
 
 pub type AppError = u64;
 
+#[deprecated(note = "use `CloseReason` instead")]
+pub type ConnectionError = CloseReason;
+
+/// Reason why a connection closed.
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
-pub enum ConnectionError {
+pub enum CloseReason {
     Transport(Error),
     Application(AppError),
 }
 
-impl ConnectionError {
+impl CloseReason {
     #[must_use]
     pub fn app_code(&self) -> Option<AppError> {
         match self {
@@ -225,17 +229,17 @@ impl ConnectionError {
     }
 
     /// Checks enclosed error for [`Error::NoError`] and
-    /// [`ConnectionError::Application(0)`].
+    /// [`CloseReason::Application(0)`].
     #[must_use]
     pub fn is_error(&self) -> bool {
         !matches!(
             self,
-            ConnectionError::Transport(Error::NoError) | ConnectionError::Application(0),
+            CloseReason::Transport(Error::NoError) | CloseReason::Application(0),
         )
     }
 }
 
-impl From<CloseError> for ConnectionError {
+impl From<CloseError> for CloseReason {
     fn from(err: CloseError) -> Self {
         match err {
             CloseError::Transport(c) => Self::Transport(Error::PeerError(c)),

--- a/neqo-transport/tests/connection.rs
+++ b/neqo-transport/tests/connection.rs
@@ -7,7 +7,7 @@
 mod common;
 
 use neqo_common::{Datagram, Decoder, Encoder, Role};
-use neqo_transport::{ConnectionError, ConnectionParameters, Error, State, Version};
+use neqo_transport::{CloseReason, ConnectionParameters, Error, State, Version};
 use test_fixture::{
     default_client, default_server,
     header_protection::{
@@ -180,7 +180,7 @@ fn packet_without_frames() {
     client.process_input(&modified, now());
     assert_eq!(
         client.state(),
-        &State::Closed(ConnectionError::Transport(Error::ProtocolViolation))
+        &State::Closed(CloseReason::Transport(Error::ProtocolViolation))
     );
 }
 
@@ -266,10 +266,7 @@ fn overflow_crypto() {
         client.process_input(&dgram, now());
         if let State::Closing { error, .. } = client.state() {
             assert!(
-                matches!(
-                    error,
-                    ConnectionError::Transport(Error::CryptoBufferExceeded),
-                ),
+                matches!(error, CloseReason::Transport(Error::CryptoBufferExceeded),),
                 "the connection need to abort on crypto buffer"
             );
             assert!(pn > 64, "at least 64000 bytes of data is buffered");

--- a/neqo-transport/tests/network.rs
+++ b/neqo-transport/tests/network.rs
@@ -6,7 +6,7 @@
 
 use std::{ops::Range, time::Duration};
 
-use neqo_transport::{ConnectionError, ConnectionParameters, Error, State};
+use neqo_transport::{CloseReason, ConnectionParameters, Error, State};
 use test_fixture::{
     boxed,
     sim::{
@@ -48,10 +48,10 @@ simulate!(
     idle_timeout,
     [
         ConnectionNode::default_client(boxed![ReachState::new(State::Closed(
-            ConnectionError::Transport(Error::IdleTimeout)
+            CloseReason::Transport(Error::IdleTimeout)
         ))]),
         ConnectionNode::default_server(boxed![ReachState::new(State::Closed(
-            ConnectionError::Transport(Error::IdleTimeout)
+            CloseReason::Transport(Error::IdleTimeout)
         ))]),
     ]
 );
@@ -62,7 +62,7 @@ simulate!(
         ConnectionNode::new_client(
             ConnectionParameters::default().idle_timeout(weeks(1000)),
             boxed![ReachState::new(State::Confirmed),],
-            boxed![ReachState::new(State::Closed(ConnectionError::Transport(
+            boxed![ReachState::new(State::Closed(CloseReason::Transport(
                 Error::IdleTimeout
             )))]
         ),
@@ -71,7 +71,7 @@ simulate!(
         ConnectionNode::new_server(
             ConnectionParameters::default().idle_timeout(weeks(1000)),
             boxed![ReachState::new(State::Confirmed),],
-            boxed![ReachState::new(State::Closed(ConnectionError::Transport(
+            boxed![ReachState::new(State::Closed(CloseReason::Transport(
                 Error::IdleTimeout
             )))]
         ),

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -17,7 +17,7 @@ use std::{
 use common::{connected_server, default_server, generate_ticket};
 use neqo_common::{hex_with_len, qdebug, qtrace, Datagram, Encoder, Role};
 use neqo_crypto::AuthenticationStatus;
-use neqo_transport::{server::ValidateAddress, ConnectionError, Error, State, StreamType};
+use neqo_transport::{server::ValidateAddress, CloseReason, Error, State, StreamType};
 use test_fixture::{
     assertions, datagram, default_client,
     header_protection::{
@@ -469,7 +469,7 @@ fn mitm_retry() {
     assert!(matches!(
         *client.state(),
         State::Closing {
-            error: ConnectionError::Transport(Error::ProtocolViolation),
+            error: CloseReason::Transport(Error::ProtocolViolation),
             ..
         }
     ));

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -15,7 +15,7 @@ use neqo_crypto::{
 };
 use neqo_transport::{
     server::{ActiveConnectionRef, Server, ValidateAddress},
-    Connection, ConnectionError, ConnectionParameters, Error, Output, State, StreamType, Version,
+    CloseReason, Connection, ConnectionParameters, Error, Output, State, StreamType, Version,
 };
 use test_fixture::{
     assertions, datagram, default_client,
@@ -463,13 +463,13 @@ fn bad_client_initial() {
     assert_ne!(delay, Duration::from_secs(0));
     assert!(matches!(
         *client.state(),
-        State::Draining { error: ConnectionError::Transport(Error::PeerError(code)), .. } if code == Error::ProtocolViolation.code()
+        State::Draining { error: CloseReason::Transport(Error::PeerError(code)), .. } if code == Error::ProtocolViolation.code()
     ));
 
     for server in server.active_connections() {
         assert_eq!(
             *server.borrow().state(),
-            State::Closed(ConnectionError::Transport(Error::ProtocolViolation))
+            State::Closed(CloseReason::Transport(Error::ProtocolViolation))
         );
     }
 


### PR DESCRIPTION
The `neqo_transport::ConnectionError` enum contains the two non-error variants `Error::NoError` and `CloseReason::Application(0)`. In other words, `ConnectionError` contains variants that are not errors.

This commit renames `ConnectionError` to the more descriptive name `CloseReason`.

See suggestion in https://github.com/mozilla/neqo/pull/1866#issuecomment-2091654649.

To ease the upgrade for downstream users, this commit adds a deprecated `ConnectionError`, guiding users to rename to `CloseReason` via a deprecation warning.

``` rust
#[deprecated(note = "use `CloseReason` instead")]
pub type ConnectionError = CloseReason;
```