### PR TITLE
chore: Fix new clippy lints in cargo 1.80.0-nightly

### DIFF
--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -1,0 +1,9 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(fuzzing)");
+}

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "neqo-common"
-build = "build.rs"
 authors.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/neqo-crypto/Cargo.toml
+++ b/neqo-crypto/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "neqo-crypto"
-build = "build.rs"
 authors.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -421,6 +421,7 @@ fn setup_for_gecko() -> Vec<String> {
 }
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(nss_nodb)");
     let flags = if cfg!(feature = "gecko") {
         setup_for_gecko()
     } else if let Ok(nss_dir) = env::var("NSS_DIR") {

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -1267,16 +1267,15 @@ mod tests {
         let out = peer_conn.process(None, now());
         hconn.process(out.as_dgram_ref(), now());
 
-        #[allow(clippy::mutable_key_type)]
         let mut requests = HashMap::new();
         while let Some(event) = hconn.next_event() {
             match event {
                 Http3ServerEvent::Headers { stream, .. } => {
-                    assert!(!requests.contains_key(&stream));
-                    requests.insert(stream, 0);
+                    assert!(!requests.contains_key(&stream.stream_id()));
+                    requests.insert(stream.stream_id(), 0);
                 }
                 Http3ServerEvent::Data { stream, .. } => {
-                    assert!(requests.contains_key(&stream));
+                    assert!(requests.contains_key(&stream.stream_id()));
                 }
                 Http3ServerEvent::DataWritable { .. }
                 | Http3ServerEvent::StreamReset { .. }

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -1267,6 +1267,7 @@ mod tests {
         let out = peer_conn.process(None, now());
         hconn.process(out.as_dgram_ref(), now());
 
+        #[allow(clippy::mutable_key_type)]
         let mut requests = HashMap::new();
         while let Some(event) = hconn.next_event() {
             match event {

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -445,14 +445,12 @@ fn fetch_noresponse_will_idletimeout() {
     let mut done = false;
     while !done {
         while let Some(event) = hconn_c.next_event() {
-            if let Http3ClientEvent::StateChange(state) = event {
-                match state {
-                    Http3State::Closing(error_code) | Http3State::Closed(error_code) => {
-                        assert_eq!(error_code, CloseReason::Transport(Error::IdleTimeout));
-                        done = true;
-                    }
-                    _ => {}
-                }
+            if let Http3ClientEvent::StateChange(
+                Http3State::Closing(error_code) | Http3State::Closed(error_code),
+            ) = event
+            {
+                assert_eq!(error_code, CloseReason::Transport(Error::IdleTimeout));
+                done = true;
             }
         }
 

--- a/neqo-transport/build.rs
+++ b/neqo-transport/build.rs
@@ -1,0 +1,9 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(fuzzing)");
+}


### PR DESCRIPTION
This should fix the CI errors that have started to appear as of today.