### PR TITLE
ci: Only build Fx for PRs

### DIFF
--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -1,5 +1,6 @@
 name: Firefox
 on:
+  workflow_dispatch:
   pull_request:
     branches: ["main"]
     paths-ignore: ["*.md", "*.png", "*.svg", "LICENSE-*"]

--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -1,12 +1,8 @@
 name: Firefox
 on:
-  push:
-    branches: ["main"]
-    paths-ignore: ["*.md", "*.png", "*.svg", "LICENSE-*"]
   pull_request:
     branches: ["main"]
     paths-ignore: ["*.md", "*.png", "*.svg", "LICENSE-*"]
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}


### PR DESCRIPTION
And not when landing a PR in `main`. Can manually make it build for main via `workflow_dispatch`.