### PR TITLE
feat(bin): use quinn-udp crates.io release instead of git ref

### DIFF
--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -35,7 +35,7 @@ neqo-http3 = { path = "./../neqo-http3" }
 neqo-qpack = { path = "./../neqo-qpack" }
 neqo-transport = { path = "./../neqo-transport" }
 qlog = { workspace = true }
-quinn-udp = { git = "https://github.com/quinn-rs/quinn/", rev = "a947962131aba8a6521253d03cc948b20098a2d6" }
+quinn-udp = { version = "0.5.0", default-features = false }
 regex = { version = "1.9", default-features = false, features = ["unicode-perl"] }
 tokio = { version = "1", default-features = false, features = ["net", "time", "macros", "rt", "rt-multi-thread"] }
 url = { version = "2.5", default-features = false }

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -418,7 +418,7 @@ impl<'a, H: Handler> Runner<'a, H> {
             match self.client.process_output(Instant::now()) {
                 Output::Datagram(dgram) => {
                     self.socket.writable().await?;
-                    self.socket.send(dgram)?;
+                    self.socket.send(&dgram)?;
                 }
                 Output::Callback(new_timeout) => {
                     qdebug!("Setting timeout of {:?}", new_timeout);

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -232,7 +232,7 @@ impl ServerRunner {
                 Output::Datagram(dgram) => {
                     let socket = self.find_socket(dgram.source());
                     socket.writable().await?;
-                    socket.send(dgram)?;
+                    socket.send(&dgram)?;
                 }
                 Output::Callback(new_timeout) => {
                     qdebug!("Setting timeout of {:?}", new_timeout);


### PR DESCRIPTION
`neqo-bin` has been importing `quinn-udp` as a git reference, in order to include https://github.com/quinn-rs/quinn/pull/1765. The quinn project has since released `quinn-udp` `v0.5.0`.

This commit upgrades `neqo-bin` to use `quinn-udp` `v0.5.0`.

`quinn-udp` now takes a data reference (`&[u8]`) instead of owned data (`bytes::Bytes`) on its send path, thus no longer requiring `neqo-bin` to convert, but simply pass a reference. See
https://github.com/quinn-rs/quinn/pull/1729#discussion_r1570214659 for details.

`quinn-udp` has dropped `sendmmsg` support in the `v0.5.0` release (https://github.com/quinn-rs/quinn/commit/ee0882657a16a8ffd7ff5844f355caca519e63ce). `neqo-bin` does not (yet) use `sendmmsg`. This might change in the future (https://github.com/mozilla/neqo/issues/1693).