### PR TITLE
ci: Only show performance improvements and regressions details

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -205,6 +205,7 @@ jobs:
                    -e 's/^ +((<\/pre>|Found).*)/\1/gi' \
                    -e 's/^<details>(.*Performance has.*)/<details open>\1/gi' >> results.md
           {
+            echo
             echo "### Client/server transfer results"
             cat comparison.md
           } >> results.md

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -197,13 +197,13 @@ jobs:
               echo
             } >> results.md
           fi
-          grep -Ev 'ignored|running \d+ tests|%\)' results.txt |\
-            sed -E  -e 's/(Performance has regressed.)/:broken_heart: **\1**/gi' \
-                    -e 's/(Performance has improved.)/:green_heart: **\1**/gi' \
-                    -e 's/^ +/   /gi' \
-                    -e 's/^([a-z0-9].*)$/* **\1**/gi' \
-                    -e 's/(change:[^%]*% )([^%]*%)(.*)/\1**\2**\3/gi' \
-              >> results.md
+          sed -E -e 's/^                 //gi' \
+                 -e 's/((change|time|thrpt):[^%]*% )([^%]*%)(.*)/\1<b>\3<\/b>\4/gi' results.txt |\
+            perl -p -0777 -e 's/(.*?)\n(.*?)((No change|Change within|Performance has).*?)\n(.*?)\n\n/<details><summary>$1: $3<\/summary><pre>\n$2$5<\/pre><\/details>\n/gs' |\
+            sed -E -e 's/(Performance has regressed.)/:broken_heart: <b>\1<\/b>/gi' \
+                   -e 's/(Performance has improved.)/:green_heart: <b>\1<\/b>/gi' \
+                   -e 's/^ +((<\/pre>|Found).*)/\1/gi' \
+                   -e 's/^<details>(.*Performance has.*)/<details open>\1/gi' >> results.md
           {
             echo "### Client/server transfer results"
             cat comparison.md


### PR DESCRIPTION
By default. Makes the perf PR comment a bit more concise. [See below.](https://github.com/mozilla/neqo/pull/1906#issuecomment-2114951843)