### PR TITLE
ci: Set `RUST_LOG` during coverage tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -152,7 +152,7 @@ jobs:
         if: success() || failure()
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@5ecb98a3c6b747ed38dc09f787459979aebb39be # v4.3.1
+        uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c # v4.4.1
         with:
           file: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -152,7 +152,7 @@ jobs:
         if: success() || failure()
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@6d798873df2b1b8e5846dba6fb86631229fbcb17 # v4.4.0
+        uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c # v4.4.1
         with:
           file: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Run tests and determine coverage
         run: |
           # shellcheck disable=SC2086
-          cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --features ci --no-fail-fast --lcov --output-path lcov.info
+          RUST_LOG=trace cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --features ci --no-fail-fast --lcov --output-path lcov.info
           cargo +${{ matrix.rust-toolchain }} bench --features bench --no-run
 
       - name: Run client/server transfer

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -152,7 +152,7 @@ jobs:
         if: success() || failure()
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@6d798873df2b1b8e5846dba6fb86631229fbcb17 # v4.4.0
+        uses: codecov/codecov-action@5ecb98a3c6b747ed38dc09f787459979aebb39be # v4.3.1
         with:
           file: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -152,7 +152,7 @@ jobs:
         if: success() || failure()
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c # v4.4.1
+        uses: codecov/codecov-action@6d798873df2b1b8e5846dba6fb86631229fbcb17 # v4.4.0
         with:
           file: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -157,6 +157,7 @@ jobs:
           file: lcov.info
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
         if: matrix.type == 'debug' && matrix.rust-toolchain == 'stable'
 
   bench:


### PR DESCRIPTION
So that logging-related code is being included in the coverage check.