### PR TITLE
ci: Reduce bench transfer size to 32MB

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -88,7 +88,7 @@ jobs:
         env:
           HOST: 127.0.0.1
           PORT: 4433
-          SIZE: 134217728 # 128 MB
+          SIZE: 33554432 # 32 MB
         run: |
           TMP=$(mktemp -d)
           # Make a cert and key for msquic.


### PR DESCRIPTION
Because I've also limited the loopback MTU to 1500 as part of the machine config.