### PR TITLE
fix: Use correct ECN mark when sending datagram

### DIFF
--- a/neqo-transport/src/ecn.rs
+++ b/neqo-transport/src/ecn.rs
@@ -207,7 +207,7 @@ impl EcnInfo {
         } else if ecn_diff[IpTosEcn::Ect1] > 0 {
             qwarn!("ECN validation failed, ACK counted ECT(1) marks that were never sent");
             self.state = EcnValidationState::Failed;
-        } else {
+        } else if self.state != EcnValidationState::Capable {
             qinfo!("ECN validation succeeded, path is capable");
             self.state = EcnValidationState::Capable;
         }

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -706,8 +706,12 @@ impl Path {
 
     /// Make a datagram.
     pub fn datagram<V: Into<Vec<u8>>>(&mut self, payload: V) -> Datagram {
+        // Make sure to use the TOS value from before calling EcnInfo::on_packet_sent, which may
+        // update the ECN state and can hence change it - this packet should still be sent
+        // with the current value.
+        let tos = self.tos();
         self.ecn_info.on_packet_sent();
-        Datagram::new(self.local, self.remote, self.tos(), Some(self.ttl), payload)
+        Datagram::new(self.local, self.remote, tos, Some(self.ttl), payload)
     }
 
     /// Get local address as `SocketAddr`


### PR DESCRIPTION
`EcnInfo::on_packet_sent` may update the ECN state and can hence change it.

Also throw in some unrelated fixes to make the ECN log output more quiet, and to test/test.sh.