### PR TITLE
fix: Remove the "init NSS twice" tests

### DIFF
--- a/neqo-crypto/tests/init.rs
+++ b/neqo-crypto/tests/init.rs
@@ -30,17 +30,6 @@ fn init_nodb() {
     }
 }
 
-#[cfg(nss_nodb)]
-#[test]
-fn init_twice_nodb() {
-    unsafe {
-        nss::NSS_NoDB_Init(std::ptr::null());
-        assert_ne!(nss::NSS_IsInitialized(), 0);
-    }
-    // Now do it again
-    init_nodb();
-}
-
 #[cfg(not(nss_nodb))]
 #[test]
 fn init_withdb() {
@@ -49,28 +38,4 @@ fn init_withdb() {
     unsafe {
         assert_ne!(nss::NSS_IsInitialized(), 0);
     }
-}
-
-#[cfg(not(nss_nodb))]
-#[test]
-fn init_twice_withdb() {
-    use std::{ffi::CString, path::PathBuf};
-
-    let empty = CString::new("").unwrap();
-    let path: PathBuf = ::test_fixture::NSS_DB_PATH.into();
-    assert!(path.is_dir());
-    let pathstr = path.to_str().unwrap();
-    let dircstr = CString::new(pathstr).unwrap();
-    unsafe {
-        nss::NSS_Initialize(
-            dircstr.as_ptr(),
-            empty.as_ptr(),
-            empty.as_ptr(),
-            nss::SECMOD_DB.as_ptr().cast(),
-            nss::NSS_INIT_READONLY,
-        );
-        assert_ne!(nss::NSS_IsInitialized(), 0);
-    }
-    // Now do it again
-    init_withdb();
 }


### PR DESCRIPTION
They seem to have a race condition that makes them crash.

Fixes #1839.

I wasn't able to figure out why they crash, this seems to happen inside NSS:
```
Process 47677 stopped
* thread #2, name = 'init_twice_withdb', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x000000019b4994f8 libsystem_pthread.dylib`pthread_mutex_lock + 12
libsystem_pthread.dylib`pthread_mutex_lock:
->  0x19b4994f8 <+12>: ldr    x8, [x0]
    0x19b4994fc <+16>: mov    w9, #0x545a ; =21594
    0x19b499500 <+20>: movk   w9, #0x4d55, lsl #16
    0x19b499504 <+24>: cmp    x8, x9
(lldb) up
frame #1: 0x0000000100802f58 libnspr4.dylib`PR_Lock + 20
libnspr4.dylib`PR_Lock:
->  0x100802f58 <+20>: bl     0x10080c0c0    ; symbol stub for: pthread_self
    0x100802f5c <+24>: str    x0, [x19, #0xb8]
    0x100802f60 <+28>: mov    w8, #0x1 ; =1
    0x100802f64 <+32>: str    w8, [x19, #0xb0]
(lldb) up
frame #2: 0x00000001007fc188 libnspr4.dylib`PR_CallOnce + 56
libnspr4.dylib`PR_CallOnce:
->  0x1007fc188 <+56>: ldr    w23, [x19]
    0x1007fc18c <+60>: ldr    w20, [x19, #0x8]
    0x1007fc190 <+64>: ldr    x0, [x22, #0x430]
    0x1007fc194 <+68>: bl     0x100802f74    ; PR_Unlock
(lldb) up
frame #3: 0x000000010066f634 libnss3.dylib`nss_Init + 112
libnss3.dylib`nss_Init:
->  0x10066f634 <+112>: cbz    w0, 0x10066f640 ; <+124>
    0x10066f638 <+116>: mov    w19, #-0x1 ; =-1
    0x10066f63c <+120>: b      0x10066f968    ; <+932>
    0x10066f640 <+124>: stp    x21, x22, [x29, #-0x80]
(lldb) up
frame #4: 0x000000010066ff44 libnss3.dylib`NSS_Initialize + 100
libnss3.dylib`NSS_Initialize:
->  0x10066ff44 <+100>: ldp    x29, x30, [sp, #0x40]
    0x10066ff48 <+104>: add    sp, sp, #0x50
    0x10066ff4c <+108>: ret

libnss3.dylib`NSS_InitContext:
    0x10066ff50 <+0>:   sub    sp, sp, #0x60
(lldb) up
frame #5: 0x00000001000035fc init-d4e9f02b33e50e46`init::init_twice_withdb::h34013f715e9b4f6e at init.rs:65:9
   62  	    let pathstr = path.to_str().unwrap();
   63  	    let dircstr = CString::new(pathstr).unwrap();
   64  	    unsafe {
-> 65  	        nss::NSS_Initialize(
   66  	            dircstr.as_ptr(),
   67  	            empty.as_ptr(),
   68  	            empty.as_ptr(),
```