### PR TITLE
ci: Only use cargo-quickinstall

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - name: Install Rust tools
       shell: bash
-      run: cargo +${{ inputs.version }} quickinstall cargo-llvm-cov cargo-nextest flamegraph cargo-hack cargo-mutants hyperfine
+      run: cargo +${{ inputs.version }} quickinstall --no-binstall --no-fallback cargo-llvm-cov cargo-nextest flamegraph cargo-hack cargo-mutants hyperfine
 
     # sccache slows CI down, so we leave it disabled.
     # Leaving the steps below commented out, so we can re-evaluate enabling it later.


### PR DESCRIPTION
Since binstall is having issues on macOS it seems.