### PR TITLE
chore: address nightly clippy lints

### DIFF
--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -211,10 +211,10 @@ impl Paths {
     #[must_use]
     fn select_primary(&mut self, path: &PathRef) -> Option<PathRef> {
         qdebug!([path.borrow()], "set as primary path");
-        let old_path = self.primary.replace(Rc::clone(path)).map(|old| {
-            old.borrow_mut().set_primary(false);
-            old
-        });
+        let old_path = self
+            .primary
+            .replace(Rc::clone(path))
+            .inspect(|old| old.borrow_mut().set_primary(false));
 
         // Swap the primary path into slot 0, so that it is protected from eviction.
         let idx = self

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -600,6 +600,9 @@ impl Server {
 
     /// This lists the connections that have received new events
     /// as a result of calling `process()`.
+    //
+    // `ActiveConnectionRef` `Hash` implementation doesn’t access any of the interior mutable types.
+    #[allow(clippy::mutable_key_type)]
     pub fn active_connections(&mut self) -> HashSet<ActiveConnectionRef> {
         self.connections
             .borrow()


### PR DESCRIPTION
See corresponding lints:

- https://rust-lang.github.io/rust-clippy/master/index.html#/mutable_key_type
- https://rust-lang.github.io/rust-clippy/master/index.html#/manual_inspect

See recent CI failure:

https://github.com/mozilla/neqo/actions/runs/9759065486/job/26934981259

```
  error:
     --> neqo-transport/src/path.rs:214:62
      |
  214 |         let old_path = self.primary.replace(Rc::clone(path)).map(|old| {
      |                                                              ^^^
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_inspect
      = note: `-D clippy::manual-inspect` implied by `-D warnings`
      = help: to override `-D warnings` add `#[allow(clippy::manual_inspect)]`
  help: try
      |
  214 ~         let old_path = self.primary.replace(Rc::clone(path)).inspect(|old| {
  215 ~             old.borrow_mut().set_primary(false);
      |

  error: mutable key type
     --> neqo-transport/src/server.rs:603:45
      |
  603 |     pub fn active_connections(&mut self) -> HashSet<ActiveConnectionRef> {
      |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type
      = note: `-D clippy::mutable-key-type` implied by `-D warnings`
      = help: to override `-D warnings` add `#[allow(clippy::mutable_key_type)]`

  error: could not compile `neqo-transport` (lib) due to 2 previous errors
error: process didn't exit successfully: `/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo clippy --all-targets --manifest-path fuzz/Cargo.toml -- -D warnings` (exit status: 101)
```