### PR TITLE
chore(udp): disable bench

### DIFF
--- a/neqo-udp/Cargo.toml
+++ b/neqo-udp/Cargo.toml
@@ -19,3 +19,7 @@ tokio = { version = "1", default-features = false, features = ["net"], optional 
 
 [dev-dependencies]
 tokio = { version = "1", default-features = false, features = ["net", "time", "macros", "rt", "rt-multi-thread"] }
+
+[lib]
+# See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false


### PR DESCRIPTION
Set `bench = false`. By default cargo will use `libtest` for benchmarking. Executing a `cargo bench` with criterion specific command line flags at the workspace level will thus trigger an error when executing the `neqo-udp` benchmarks.

Follow-up to https://github.com/mozilla/neqo/pull/1920.