### PR TITLE
fix: Disable pylint pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
   hooks:
   - id: end-of-file-fixer
   - id: trailing-whitespace
-- repo: https://github.com/pylint-dev/pylint
-  rev: v2.17.2
-  hooks:
-  - id: pylint
+# - repo: https://github.com/pylint-dev/pylint
+#   rev: v2.17.2
+#   hooks:
+#   - id: pylint


### PR DESCRIPTION
Not needed, and install fails on macOS for me.