### PR TITLE
refactor(server): remove ServerConnectionIdGenerator

### DIFF
--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -17,7 +17,7 @@ use std::{
 use neqo_common::{qtrace, Datagram};
 use neqo_crypto::{AntiReplay, Cipher, PrivateKey, PublicKey, ZeroRttChecker};
 use neqo_transport::{
-    server::{ActiveConnectionRef, Server, ValidateAddress},
+    server::{ConnectionRef, Server, ValidateAddress},
     ConnectionIdGenerator, Output,
 };
 
@@ -39,7 +39,7 @@ const MAX_EVENT_DATA_SIZE: usize = 1024;
 pub struct Http3Server {
     server: Server,
     http3_parameters: Http3Parameters,
-    http3_handlers: HashMap<ActiveConnectionRef, HandlerRef>,
+    http3_handlers: HashMap<ConnectionRef, HandlerRef>,
     events: Http3ServerEvents,
 }
 
@@ -147,7 +147,7 @@ impl Http3Server {
         }
     }
 
-    fn process_events(&mut self, conn: &ActiveConnectionRef, now: Instant) {
+    fn process_events(&mut self, conn: &ConnectionRef, now: Instant) {
         let mut remove = false;
         let http3_parameters = &self.http3_parameters;
         {
@@ -270,7 +270,7 @@ impl Http3Server {
 fn prepare_data(
     stream_info: Http3StreamInfo,
     handler_borrowed: &mut RefMut<Http3ServerHandler>,
-    conn: &ActiveConnectionRef,
+    conn: &ConnectionRef,
     handler: &HandlerRef,
     now: Instant,
     events: &Http3ServerEvents,

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -15,7 +15,7 @@ use std::{
 
 use neqo_common::{qdebug, Encoder, Header};
 use neqo_transport::{
-    server::ActiveConnectionRef, AppError, Connection, DatagramTracking, StreamId, StreamType,
+    server::ConnectionRef, AppError, Connection, DatagramTracking, StreamId, StreamType,
 };
 
 use crate::{
@@ -27,7 +27,7 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct StreamHandler {
-    pub conn: ActiveConnectionRef,
+    pub conn: ConnectionRef,
     pub handler: Rc<RefCell<Http3ServerHandler>>,
     pub stream_info: Http3StreamInfo,
 }
@@ -174,7 +174,7 @@ impl ::std::fmt::Display for Http3OrWebTransportStream {
 
 impl Http3OrWebTransportStream {
     pub(crate) const fn new(
-        conn: ActiveConnectionRef,
+        conn: ConnectionRef,
         handler: Rc<RefCell<Http3ServerHandler>>,
         stream_info: Http3StreamInfo,
     ) -> Self {
@@ -259,7 +259,7 @@ impl ::std::fmt::Display for WebTransportRequest {
 
 impl WebTransportRequest {
     pub(crate) const fn new(
-        conn: ActiveConnectionRef,
+        conn: ConnectionRef,
         handler: Rc<RefCell<Http3ServerHandler>>,
         stream_id: StreamId,
     ) -> Self {
@@ -460,7 +460,7 @@ pub enum Http3ServerEvent {
     },
     /// When individual connection change state. It is only used for tests.
     StateChange {
-        conn: ActiveConnectionRef,
+        conn: ConnectionRef,
         state: Http3State,
     },
     PriorityUpdate {
@@ -510,14 +510,14 @@ impl Http3ServerEvents {
     }
 
     /// Insert a `StateChange` event.
-    pub(crate) fn connection_state_change(&self, conn: ActiveConnectionRef, state: Http3State) {
+    pub(crate) fn connection_state_change(&self, conn: ConnectionRef, state: Http3State) {
         self.insert(Http3ServerEvent::StateChange { conn, state });
     }
 
     /// Insert a `Data` event.
     pub(crate) fn data(
         &self,
-        conn: ActiveConnectionRef,
+        conn: ConnectionRef,
         handler: Rc<RefCell<Http3ServerHandler>>,
         stream_info: Http3StreamInfo,
         data: Vec<u8>,
@@ -532,7 +532,7 @@ impl Http3ServerEvents {
 
     pub(crate) fn data_writable(
         &self,
-        conn: ActiveConnectionRef,
+        conn: ConnectionRef,
         handler: Rc<RefCell<Http3ServerHandler>>,
         stream_info: Http3StreamInfo,
     ) {
@@ -543,7 +543,7 @@ impl Http3ServerEvents {
 
     pub(crate) fn stream_reset(
         &self,
-        conn: ActiveConnectionRef,
+        conn: ConnectionRef,
         handler: Rc<RefCell<Http3ServerHandler>>,
         stream_info: Http3StreamInfo,
         error: AppError,
@@ -556,7 +556,7 @@ impl Http3ServerEvents {
 
     pub(crate) fn stream_stop_sending(
         &self,
-        conn: ActiveConnectionRef,
+        conn: ConnectionRef,
         handler: Rc<RefCell<Http3ServerHandler>>,
         stream_info: Http3StreamInfo,
         error: AppError,

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -987,6 +987,12 @@ impl Connection {
         }
     }
 
+    /// Whether the given [`ConnectionIdRef`] is a valid local [`ConnectionId`].
+    #[must_use]
+    pub fn is_valid_local_cid(&self, cid: ConnectionIdRef) -> bool {
+        self.cid_manager.is_valid(cid)
+    }
+
     /// Process new input datagrams on the connection.
     pub fn process_input(&mut self, d: &Datagram, now: Instant) {
         self.process_multiple_input(iter::once(d), now);

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -9,18 +9,18 @@
 use std::{
     cell::RefCell,
     cmp::min,
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     fs::OpenOptions,
     net::SocketAddr,
     ops::{Deref, DerefMut},
     path::PathBuf,
-    rc::{Rc, Weak},
+    rc::Rc,
     time::Instant,
 };
 
 use neqo_common::{
     self as common, event::Provider, hex, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn,
-    Datagram, Decoder, Role,
+    Datagram, Role,
 };
 use neqo_crypto::{
     encode_ech_config, AntiReplay, Cipher, PrivateKey, PublicKey, ZeroRttCheckResult,
@@ -31,7 +31,7 @@ use qlog::streamer::QlogStreamer;
 pub use crate::addr_valid::ValidateAddress;
 use crate::{
     addr_valid::{AddressValidation, AddressValidationResult},
-    cid::{ConnectionId, ConnectionIdDecoder, ConnectionIdGenerator, ConnectionIdRef},
+    cid::{ConnectionId, ConnectionIdGenerator, ConnectionIdRef},
     connection::{Connection, Output, State},
     packet::{PacketBuilder, PacketType, PublicPacket, MIN_INITIAL_PACKET_SIZE},
     ConnectionParameters, Res, Version,
@@ -43,39 +43,33 @@ pub enum InitialResult {
     Retry(Vec<u8>),
 }
 
-type StateRef = Rc<RefCell<ServerConnectionState>>;
-type ConnectionTableRef = Rc<RefCell<HashMap<ConnectionId, StateRef>>>;
-
 #[derive(Debug)]
 pub struct ServerConnectionState {
-    c: Connection,
+    c: Rc<RefCell<Connection>>,
     active_attempt: Option<AttemptKey>,
 }
 
 impl ServerConnectionState {
     fn process(&mut self, dgram: Option<&Datagram>, now: Instant) -> Output {
         qtrace!("Process connection {:?}", self.c);
-        let out = self.c.process(dgram, now);
+        let out = self.c.borrow_mut().process(dgram, now);
 
-        if *self.c.state() > State::Handshaking {
+        if *self.c.borrow().state() > State::Handshaking {
             // Remove any active connection attempt now that this is no longer handshaking.
             self.active_attempt.take();
         }
 
         out
     }
-}
 
-impl Deref for ServerConnectionState {
-    type Target = Connection;
-    fn deref(&self) -> &Self::Target {
-        &self.c
+    #[must_use]
+    pub fn borrow(&self) -> impl Deref<Target = Connection> + '_ {
+        self.c.borrow()
     }
-}
 
-impl DerefMut for ServerConnectionState {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.c
+    #[must_use]
+    pub fn borrow_mut(&self) -> impl DerefMut<Target = Connection> + '_ {
+        self.c.borrow_mut()
     }
 }
 
@@ -166,8 +160,8 @@ pub struct Server {
     cid_generator: Rc<RefCell<dyn ConnectionIdGenerator>>,
     /// Connection parameters.
     conn_params: ConnectionParameters,
-    /// All connections, keyed by `ConnectionId`.
-    connections: ConnectionTableRef,
+    /// All connections.
+    connections: Vec<ServerConnectionState>,
     /// Address validation logic, which determines whether we send a Retry.
     address_validation: Rc<RefCell<AddressValidation>>,
     /// Directory to create qlog traces in
@@ -207,7 +201,7 @@ impl Server {
             zero_rtt_checker: ServerZeroRttChecker::new(zero_rtt_checker),
             cid_generator,
             conn_params,
-            connections: Rc::default(),
+            connections: Vec::new(),
             address_validation: Rc::new(RefCell::new(validation)),
             qlog_dir: None,
             ech_config: None,
@@ -248,11 +242,12 @@ impl Server {
         self.ech_config.as_ref().map_or(&[], |cfg| &cfg.encoded)
     }
 
-    fn connection(&self, cid: ConnectionIdRef) -> Option<StateRef> {
-        self.connections.borrow().get(&cid[..]).cloned()
-    }
-
-    fn handle_initial(&self, initial: InitialDetails, dgram: &Datagram, now: Instant) -> Output {
+    fn handle_initial(
+        &mut self,
+        initial: InitialDetails,
+        dgram: &Datagram,
+        now: Instant,
+    ) -> Output {
         qdebug!([self], "Handle initial");
         let res = self
             .address_validation
@@ -307,7 +302,7 @@ impl Server {
     }
 
     fn connection_attempt(
-        &self,
+        &mut self,
         initial: InitialDetails,
         dgram: &Datagram,
         orig_dcid: Option<ConnectionId>,
@@ -317,20 +312,20 @@ impl Server {
             remote_address: dgram.source(),
             odcid: orig_dcid.as_ref().unwrap_or(&initial.dst_cid).clone(),
         };
-        let connection = self.connections.borrow().values().find_map(|c| {
-            (c.borrow().active_attempt.as_ref() == Some(&attempt_key)).then(|| Rc::clone(c))
-        });
-        connection.map_or_else(
-            || self.accept_connection(&attempt_key, initial, dgram, orig_dcid, now),
-            |c| {
-                qdebug!(
-                    [self],
-                    "Handle Initial for existing connection attempt {:?}",
-                    attempt_key
-                );
-                c.borrow_mut().process(Some(dgram), now)
-            },
-        )
+
+        let Some(connection) = self
+            .connections
+            .iter_mut()
+            .find(|c| c.active_attempt.as_ref() == Some(&attempt_key))
+        else {
+            return self.accept_connection(&attempt_key, initial, dgram, orig_dcid, now);
+        };
+
+        qdebug!(
+            "Handle Initial for existing connection attempt {:?}",
+            attempt_key
+        );
+        connection.process(Some(dgram), now)
     }
 
     fn create_qlog_trace(&self, odcid: ConnectionIdRef<'_>) -> NeqoQlog {
@@ -410,7 +405,7 @@ impl Server {
     }
 
     fn accept_connection(
-        &self,
+        &mut self,
         attempt_key: &AttemptKey,
         initial: InitialDetails,
         dgram: &Datagram,
@@ -421,31 +416,25 @@ impl Server {
         // The internal connection ID manager that we use is not used directly.
         // Instead, wrap it so that we can save connection IDs.
 
-        let cid_mgr = Rc::new(RefCell::new(ServerConnectionIdGenerator {
-            c: Weak::new(),
-            cid_generator: Rc::clone(&self.cid_generator),
-            connections: Rc::clone(&self.connections),
-            saved_cids: Vec::new(),
-        }));
-
         let mut params = self.conn_params.clone();
         params.get_versions_mut().set_initial(initial.version);
         let sconn = Connection::new_server(
             &self.certs,
             &self.protocols,
-            Rc::clone(&cid_mgr) as _,
+            Rc::clone(&self.cid_generator),
             params,
         );
 
         match sconn {
             Ok(mut c) => {
                 self.setup_connection(&mut c, attempt_key, initial, orig_dcid);
-                let c = Rc::new(RefCell::new(ServerConnectionState {
-                    c,
+                let mut c = ServerConnectionState {
+                    c: Rc::new(RefCell::new(c)),
                     active_attempt: Some(attempt_key.clone()),
-                }));
-                cid_mgr.borrow_mut().set_connection(&c);
-                return c.borrow_mut().process(Some(dgram), now);
+                };
+                let out = c.process(Some(dgram), now);
+                self.connections.push(c);
+                out
             }
             Err(e) => {
                 qwarn!([self], "Unable to create connection");
@@ -464,31 +453,31 @@ impl Server {
     /// Handle 0-RTT packets that were sent with the client's choice of connection ID.
     /// Most 0-RTT will arrive this way.  A client can usually send 1-RTT after it
     /// receives a connection ID from the server.
-    fn handle_0rtt(&self, dgram: &Datagram, dcid: ConnectionId, now: Instant) -> Output {
+    fn handle_0rtt(&mut self, dgram: &Datagram, dcid: ConnectionId, now: Instant) -> Output {
         let attempt_key = AttemptKey {
             remote_address: dgram.source(),
             odcid: dcid,
         };
-        let connection = self.connections.borrow().values().find_map(|c| {
-            (c.borrow().active_attempt.as_ref() == Some(&attempt_key)).then(|| Rc::clone(c))
-        });
-        connection.map_or_else(
-            || {
-                qdebug!([self], "Dropping 0-RTT for unknown connection");
-                Output::None
-            },
-            |c| {
-                qdebug!(
-                    [self],
-                    "Handle 0-RTT for existing connection attempt {:?}",
-                    attempt_key
-                );
-                c.borrow_mut().process(Some(dgram), now)
-            },
-        )
+
+        self.connections
+            .iter_mut()
+            .find(|c| c.active_attempt.as_ref() == Some(&attempt_key))
+            .map_or_else(
+                || {
+                    qdebug!("Dropping 0-RTT for unknown connection");
+                    Output::None
+                },
+                |c| {
+                    qdebug!(
+                        "Handle 0-RTT for existing connection attempt {:?}",
+                        attempt_key
+                    );
+                    c.process(Some(dgram), now)
+                },
+            )
     }
 
-    fn process_input(&self, dgram: &Datagram, now: Instant) -> Output {
+    fn process_input(&mut self, dgram: &Datagram, now: Instant) -> Output {
         qtrace!("Process datagram: {}", hex(&dgram[..]));
 
         // This is only looking at the first packet header in the datagram.
@@ -500,8 +489,12 @@ impl Server {
         };
 
         // Finding an existing connection. Should be the most common case.
-        if let Some(c) = self.connection(packet.dcid()) {
-            return c.borrow_mut().process(Some(dgram), now);
+        if let Some(c) = self
+            .connections
+            .iter_mut()
+            .find(|c| c.borrow().is_valid_local_cid(packet.dcid()))
+        {
+            return c.process(Some(dgram), now);
         }
 
         if packet.packet_type() == PacketType::Short {
@@ -570,11 +563,11 @@ impl Server {
 
     /// Iterate through the pending connections looking for any that might want
     /// to send a datagram.  Stop at the first one that does.
-    fn process_next_output(&self, now: Instant) -> Output {
+    fn process_next_output(&mut self, now: Instant) -> Output {
         let mut callback = None;
 
-        for connection in self.connections.borrow().values() {
-            match connection.borrow_mut().process(None, now) {
+        for connection in &mut self.connections {
+            match connection.process(None, now) {
                 Output::None => {}
                 d @ Output::Datagram(_) => return d,
                 Output::Callback(next) => match callback {
@@ -588,15 +581,14 @@ impl Server {
     }
 
     #[must_use]
-    pub fn process(&self, dgram: Option<&Datagram>, now: Instant) -> Output {
+    pub fn process(&mut self, dgram: Option<&Datagram>, now: Instant) -> Output {
         let out = dgram
             .map_or(Output::None, |d| self.process_input(d, now))
             .or_else(|| self.process_next_output(now));
 
         // Clean-up closed connections.
         self.connections
-            .borrow_mut()
-            .retain(|_, c| !matches!(c.borrow().state(), State::Closed(_)));
+            .retain(|c| !matches!(c.borrow().state(), State::Closed(_)));
 
         out
     }
@@ -606,12 +598,11 @@ impl Server {
     // `ActiveConnectionRef` `Hash` implementation doesn’t access any of the interior mutable types.
     #[allow(clippy::mutable_key_type)]
     #[must_use]
-    pub fn active_connections(&self) -> HashSet<ActiveConnectionRef> {
+    pub fn active_connections(&self) -> HashSet<ConnectionRef> {
         self.connections
-            .borrow()
-            .values()
+            .iter()
             .filter(|c| c.borrow().has_events())
-            .map(|c| ActiveConnectionRef { c: Rc::clone(c) })
+            .map(|c| ConnectionRef { c: Rc::clone(&c.c) })
             .collect()
     }
 
@@ -619,101 +610,46 @@ impl Server {
     /// `process()`.
     #[must_use]
     pub fn has_active_connections(&self) -> bool {
-        self.connections
-            .borrow()
-            .values()
-            .any(|c| c.borrow().has_events())
+        self.connections.iter().any(|c| c.borrow().has_events())
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct ActiveConnectionRef {
-    c: StateRef,
+pub struct ConnectionRef {
+    c: Rc<RefCell<Connection>>,
 }
 
-impl ActiveConnectionRef {
+impl ConnectionRef {
     #[must_use]
     pub fn borrow(&self) -> impl Deref<Target = Connection> + '_ {
-        std::cell::Ref::map(self.c.borrow(), |c| &c.c)
+        self.c.borrow()
     }
 
     #[must_use]
     pub fn borrow_mut(&self) -> impl DerefMut<Target = Connection> + '_ {
-        std::cell::RefMut::map(self.c.borrow_mut(), |c| &mut c.c)
+        self.c.borrow_mut()
     }
 
     #[must_use]
-    pub fn connection(&self) -> StateRef {
+    pub fn connection(&self) -> Rc<RefCell<Connection>> {
         Rc::clone(&self.c)
     }
 }
 
-impl std::hash::Hash for ActiveConnectionRef {
+impl std::hash::Hash for ConnectionRef {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let ptr: *const _ = self.c.as_ref();
         ptr.hash(state);
     }
 }
 
-impl PartialEq for ActiveConnectionRef {
+impl PartialEq for ConnectionRef {
     fn eq(&self, other: &Self) -> bool {
         Rc::ptr_eq(&self.c, &other.c)
     }
 }
 
-impl Eq for ActiveConnectionRef {}
-
-struct ServerConnectionIdGenerator {
-    c: Weak<RefCell<ServerConnectionState>>,
-    connections: ConnectionTableRef,
-    cid_generator: Rc<RefCell<dyn ConnectionIdGenerator>>,
-    saved_cids: Vec<ConnectionId>,
-}
-
-impl ServerConnectionIdGenerator {
-    pub fn set_connection(&mut self, c: &StateRef) {
-        let saved = std::mem::replace(&mut self.saved_cids, Vec::with_capacity(0));
-        for cid in saved {
-            qtrace!("ServerConnectionIdGenerator inserting saved cid {}", cid);
-            self.insert_cid(cid, Rc::clone(c));
-        }
-        self.c = Rc::downgrade(c);
-    }
-
-    fn insert_cid(&self, cid: ConnectionId, rc: StateRef) {
-        debug_assert!(!cid.is_empty());
-        self.connections.borrow_mut().insert(cid, rc);
-    }
-}
-
-impl ConnectionIdDecoder for ServerConnectionIdGenerator {
-    fn decode_cid<'a>(&self, dec: &mut Decoder<'a>) -> Option<ConnectionIdRef<'a>> {
-        self.cid_generator.borrow_mut().decode_cid(dec)
-    }
-}
-
-impl ConnectionIdGenerator for ServerConnectionIdGenerator {
-    fn generate_cid(&mut self) -> Option<ConnectionId> {
-        let maybe_cid = self.cid_generator.borrow_mut().generate_cid();
-        if let Some(cid) = maybe_cid {
-            if let Some(rc) = self.c.upgrade() {
-                self.insert_cid(cid.clone(), rc);
-            } else {
-                // This function can be called before the connection is set.
-                // So save any connection IDs until that hookup happens.
-                qtrace!("ServerConnectionIdGenerator saving cid {}", cid);
-                self.saved_cids.push(cid.clone());
-            }
-            Some(cid)
-        } else {
-            None
-        }
-    }
-
-    fn as_decoder(&self) -> &dyn ConnectionIdDecoder {
-        self
-    }
-}
+impl Eq for ConnectionRef {}
 
 impl ::std::fmt::Display for Server {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -31,7 +31,7 @@ use test_fixture::{
 
 #[test]
 fn retry_basic() {
-    let server = default_server();
+    let mut server = default_server();
     server.set_validation(ValidateAddress::Always);
     let mut client = default_client();
 
@@ -61,7 +61,7 @@ fn retry_basic() {
 #[test]
 fn implicit_rtt_retry() {
     const RTT: Duration = Duration::from_secs(2);
-    let server = default_server();
+    let mut server = default_server();
     server.set_validation(ValidateAddress::Always);
     let mut client = default_client();
     let mut now = now();
@@ -78,7 +78,7 @@ fn implicit_rtt_retry() {
 
 #[test]
 fn retry_expired() {
-    let server = default_server();
+    let mut server = default_server();
     server.set_validation(ValidateAddress::Always);
     let mut client = default_client();
     let mut now = now();
@@ -101,8 +101,8 @@ fn retry_expired() {
 // Attempt a retry with 0-RTT, and have 0-RTT packets sent with the second ClientHello.
 #[test]
 fn retry_0rtt() {
-    let server = default_server();
-    let token = generate_ticket(&server);
+    let mut server = default_server();
+    let token = generate_ticket(&mut server);
     server.set_validation(ValidateAddress::Always);
 
     let mut client = default_client();
@@ -138,7 +138,7 @@ fn retry_0rtt() {
 
 #[test]
 fn retry_different_ip() {
-    let server = default_server();
+    let mut server = default_server();
     server.set_validation(ValidateAddress::Always);
     let mut client = default_client();
 
@@ -163,8 +163,8 @@ fn retry_different_ip() {
 
 #[test]
 fn new_token_different_ip() {
-    let server = default_server();
-    let token = generate_ticket(&server);
+    let mut server = default_server();
+    let token = generate_ticket(&mut server);
     server.set_validation(ValidateAddress::NoToken);
 
     let mut client = default_client();
@@ -185,8 +185,8 @@ fn new_token_different_ip() {
 
 #[test]
 fn new_token_expired() {
-    let server = default_server();
-    let token = generate_ticket(&server);
+    let mut server = default_server();
+    let token = generate_ticket(&mut server);
     server.set_validation(ValidateAddress::NoToken);
 
     let mut client = default_client();
@@ -210,8 +210,8 @@ fn new_token_expired() {
 
 #[test]
 fn retry_after_initial() {
-    let server = default_server();
-    let retry_server = default_server();
+    let mut server = default_server();
+    let mut retry_server = default_server();
     retry_server.set_validation(ValidateAddress::Always);
     let mut client = default_client();
 
@@ -249,7 +249,7 @@ fn retry_after_initial() {
 
 #[test]
 fn retry_bad_integrity() {
-    let server = default_server();
+    let mut server = default_server();
     server.set_validation(ValidateAddress::Always);
     let mut client = default_client();
 
@@ -273,9 +273,9 @@ fn retry_bad_integrity() {
 #[test]
 fn retry_bad_token() {
     let mut client = default_client();
-    let retry_server = default_server();
+    let mut retry_server = default_server();
     retry_server.set_validation(ValidateAddress::Always);
-    let server = default_server();
+    let mut server = default_server();
 
     // Send a retry to one server, then replay it to the other.
     let client_initial1 = client.process(None, now()).dgram();
@@ -299,7 +299,7 @@ fn retry_bad_token() {
 #[test]
 fn retry_after_pto() {
     let mut client = default_client();
-    let server = default_server();
+    let mut server = default_server();
     server.set_validation(ValidateAddress::Always);
     let mut now = now();
 
@@ -322,7 +322,7 @@ fn retry_after_pto() {
 
 #[test]
 fn vn_after_retry() {
-    let server = default_server();
+    let mut server = default_server();
     server.set_validation(ValidateAddress::Always);
     let mut client = default_client();
 
@@ -364,9 +364,9 @@ fn vn_after_retry() {
 #[allow(clippy::shadow_unrelated)]
 fn mitm_retry() {
     let mut client = default_client();
-    let retry_server = default_server();
+    let mut retry_server = default_server();
     retry_server.set_validation(ValidateAddress::Always);
-    let server = default_server();
+    let mut server = default_server();
 
     // Trigger initial and a second client Initial.
     let client_initial1 = client.process(None, now()).dgram();

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -161,14 +161,14 @@ fn duplicate_initial_new_path() {
         &initial[..],
     );
 
-    // The server should respond to both as these came from different addresses.
-    let dgram = server.process(Some(&other), now()).dgram();
-    assert!(dgram.is_some());
-
     let server_initial = server.process(Some(&initial), now()).dgram();
     assert!(server_initial.is_some());
 
-    assert_eq!(server.active_connections().len(), 2);
+    // The server should ignore a packet with the same destination connection ID.
+    let dgram = server.process(Some(&other), now()).dgram();
+    assert!(dgram.is_none());
+
+    assert_eq!(server.active_connections().len(), 1);
     complete_connection(&mut client, &mut server, server_initial);
 }
 

--- a/test-fixture/src/header_protection.rs
+++ b/test-fixture/src/header_protection.rs
@@ -16,7 +16,7 @@ use neqo_crypto::{
     Aead, AllowZeroRtt, AuthenticationStatus, ResumptionToken,
 };
 use neqo_transport::{
-    server::{ActiveConnectionRef, Server, ValidateAddress},
+    server::{ConnectionRef, Server, ValidateAddress},
     Connection, ConnectionEvent, ConnectionParameters, State,
 };
 


### PR DESCRIPTION
A `neqo_transport::Server` manages multiple `neqo_transport::Connection`s. A `Server` keeps a `HashMap` of all `Connection`s, indexed by `ConnectionId`.

Indexing by `ConnectionId` is difficult as:

- The `ConnectionId` is not known before constructing the connection.
- The `ConnectionId` might change throughout the lifetime of a connection.

Previously the index was kept up-to-date through a wrapper around the `ConnectionIdGenerator` provided to a `Connection` by a `Server`. This wrapper would be provided a shared reference to the `Server`s `HashMap` of `Connection`s. Whenever the `Server` would `process` a `Connection` and that `Connection` would generate a new `ConnectionId` via `ConnectionIdGenerator::generate_cid`, the wrapped `ConnectionIdGenerator` would also insert the `Connection` keyed by the new `ConnectionId` into the `Server`'s `HashMap` of `Connection`s.

This has two problems:

- Complexity through indirection where a `Connection` owned by a `Server` can indirectly mutate the `Server` through the provided wrapped `ConnectionIdGenerator` having access to the `Server`'s set of `Connection`s.

- Double `RefCell` borrow e.g. when a `Server` would iterate its `Connection`s, process each, where one of them might generate a new `ConnectionId` via the provided `ConnectionIdGenerator`, which in turn would insert the `Connection` into the currently iterated set of `Connection`s of the `Server`.

This commit replaces the `HashMap<ConnectionId, Rc<RefCell<Connection>>>` of the `Server` with a simple `Vec<Connection>`. Given the removal of the index, the `ConnectionIdGenerator` wrapper (i.e. `ServerConnectionIdGenerator`) is no longer needed and removed and thus the shared reference to the `Server`s `Connection` `HashMap` is no longer needed and thus the above mentioned double borrow is made impossible.

Downside to the removal of the index by `ConnectionId` is a potential performance hit. When the `Server` manages a large set of `Connection`s, finding the `Connection` corresponding to a `ConnectionId` (e.g. from an incoming `Datagram`) is `O(n)` (`n` equal the number of connections).

---

Fixes https://github.com/mozilla/neqo/issues/1975.

Simplifies `neqo_transport::Server` once more.
![image](https://github.com/user-attachments/assets/fe3fe2c6-05f1-437a-8b8c-47be62c01e61)


Draft for now to test for performance regressions first.