### PR TITLE
chore(neqo-udp): drop tokio dependency

### DIFF
--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -36,8 +36,9 @@ neqo-common = { path = "./../neqo-common" }
 neqo-crypto = { path = "./../neqo-crypto" }
 neqo-http3 = { path = "./../neqo-http3" }
 neqo-transport = { path = "./../neqo-transport" }
-neqo-udp = { path = "./../neqo-udp", default-features = false, features = ["tokio"] }
+neqo-udp = { path = "./../neqo-udp" }
 qlog = { workspace = true }
+quinn-udp = { version = "0.5.0", default-features = false }
 regex = { version = "1.9", default-features = false, features = ["unicode-perl"] }
 tokio = { version = "1", default-features = false, features = ["net", "time", "macros", "rt", "rt-multi-thread"] }
 url = { version = "2.5", default-features = false }

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -328,7 +328,7 @@ enum Ready {
 
 // Wait for the socket to be readable or the timeout to fire.
 async fn ready(
-    socket: &neqo_udp::Socket<tokio::net::UdpSocket>,
+    socket: &crate::udp::Socket,
     mut timeout: Option<&mut Pin<Box<Sleep>>>,
 ) -> Result<Ready, io::Error> {
     let socket_ready = Box::pin(socket.readable()).map_ok(|()| Ready::Socket);
@@ -369,7 +369,7 @@ trait Client {
 
 struct Runner<'a, H: Handler> {
     local_addr: SocketAddr,
-    socket: &'a mut neqo_udp::Socket<tokio::net::UdpSocket>,
+    socket: &'a mut crate::udp::Socket,
     client: H::Client,
     handler: H,
     timeout: Option<Pin<Box<Sleep>>>,
@@ -533,7 +533,7 @@ pub async fn client(mut args: Args) -> Res<()> {
             SocketAddr::V6(..) => SocketAddr::new(IpAddr::V6(Ipv6Addr::from([0; 16])), 0),
         };
 
-        let mut socket = neqo_udp::Socket::bind(local_addr)?;
+        let mut socket = crate::udp::Socket::bind(local_addr)?;
         let real_local = socket.local_addr().unwrap();
         qinfo!(
             "{} Client connecting: {:?} -> {:?}",

--- a/neqo-bin/src/lib.rs
+++ b/neqo-bin/src/lib.rs
@@ -22,6 +22,7 @@ use neqo_transport::{
 
 pub mod client;
 pub mod server;
+pub mod udp;
 
 #[derive(Debug, Parser)]
 pub struct SharedArgs {

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -196,7 +196,7 @@ pub struct ServerRunner {
     now: Box<dyn Fn() -> Instant>,
     server: Box<dyn HttpServer>,
     timeout: Option<Pin<Box<Sleep>>>,
-    sockets: Vec<(SocketAddr, neqo_udp::Socket<tokio::net::UdpSocket>)>,
+    sockets: Vec<(SocketAddr, crate::udp::Socket)>,
 }
 
 impl ServerRunner {
@@ -204,7 +204,7 @@ impl ServerRunner {
     pub fn new(
         now: Box<dyn Fn() -> Instant>,
         server: Box<dyn HttpServer>,
-        sockets: Vec<(SocketAddr, neqo_udp::Socket<tokio::net::UdpSocket>)>,
+        sockets: Vec<(SocketAddr, crate::udp::Socket)>,
     ) -> Self {
         Self {
             now,
@@ -215,7 +215,7 @@ impl ServerRunner {
     }
 
     /// Tries to find a socket, but then just falls back to sending from the first.
-    fn find_socket(&mut self, addr: SocketAddr) -> &mut neqo_udp::Socket<tokio::net::UdpSocket> {
+    fn find_socket(&mut self, addr: SocketAddr) -> &mut crate::udp::Socket {
         let ((_host, first_socket), rest) = self.sockets.split_first_mut().unwrap();
         rest.iter_mut()
             .map(|(_host, socket)| socket)
@@ -365,7 +365,7 @@ pub async fn server(mut args: Args) -> Res<()> {
     let sockets = hosts
         .into_iter()
         .map(|host| {
-            let socket = neqo_udp::Socket::bind(host)?;
+            let socket = crate::udp::Socket::bind(host)?;
             let local_addr = socket.local_addr()?;
             qinfo!("Server waiting for connection on: {local_addr:?}");
 

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -13,7 +13,7 @@ use neqo_common::Datagram;
 /// audited as `safe-to-deploy`. `cargo vet` will require `safe-to-deploy` for
 /// [`tokio`] even when behind a feature flag.
 ///
-/// See https://github.com/mozilla/cargo-vet/issues/626.
+/// See <https://github.com/mozilla/cargo-vet/issues/626>.
 pub struct Socket {
     state: quinn_udp::UdpSocketState,
     inner: tokio::net::UdpSocket,

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -1,0 +1,70 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{io, net::SocketAddr};
+
+use neqo_common::Datagram;
+
+/// Ideally this would live in [`neqo-udp`]. [`neqo-udp`] is used in Firefox.
+/// Firefox uses `cargo vet`. [`tokio`] the dependency of [`neqo-udp`] is not
+/// audited as `safe-to-deploy`. `cargo vet` will require `safe-to-deploy` for
+/// [`tokio`] even when behind a feature flag.
+///
+/// See https://github.com/mozilla/cargo-vet/issues/626.
+pub struct Socket {
+    state: quinn_udp::UdpSocketState,
+    inner: tokio::net::UdpSocket,
+}
+
+impl Socket {
+    /// Create a new [`Socket`] bound to the provided address, not managed externally.
+    pub fn bind<A: std::net::ToSocketAddrs>(addr: A) -> Result<Self, io::Error> {
+        let socket = std::net::UdpSocket::bind(addr)?;
+
+        Ok(Self {
+            state: quinn_udp::UdpSocketState::new((&socket).into())?,
+            inner: tokio::net::UdpSocket::from_std(socket)?,
+        })
+    }
+
+    /// See [`tokio::net::UdpSocket::local_addr`].
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.inner.local_addr()
+    }
+
+    /// See [`tokio::net::UdpSocket::writable`].
+    pub async fn writable(&self) -> Result<(), io::Error> {
+        self.inner.writable().await
+    }
+
+    /// See [`tokio::net::UdpSocket::readable`].
+    pub async fn readable(&self) -> Result<(), io::Error> {
+        self.inner.readable().await
+    }
+
+    /// Send a [`Datagram`] on the given [`Socket`].
+    pub fn send(&self, d: &Datagram) -> io::Result<()> {
+        self.inner.try_io(tokio::io::Interest::WRITABLE, || {
+            neqo_udp::send_inner(&self.state, (&self.inner).into(), d)
+        })
+    }
+
+    /// Receive a batch of [`Datagram`]s on the given [`Socket`], each set with
+    /// the provided local address.
+    pub fn recv(&self, local_address: &SocketAddr) -> Result<Vec<Datagram>, io::Error> {
+        self.inner
+            .try_io(tokio::io::Interest::READABLE, || {
+                neqo_udp::recv_inner(local_address, &self.state, (&self.inner).into())
+            })
+            .or_else(|e| {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    Ok(vec![])
+                } else {
+                    Err(e)
+                }
+            })
+    }
+}

--- a/neqo-udp/Cargo.toml
+++ b/neqo-udp/Cargo.toml
@@ -19,10 +19,6 @@ workspace = true
 log = { workspace = true }
 neqo-common = { path = "./../neqo-common" }
 quinn-udp = { version = "0.5.0", default-features = false }
-tokio = { version = "1", default-features = false, features = ["net"], optional = true }
-
-[dev-dependencies]
-tokio = { version = "1", default-features = false, features = ["net", "time", "macros", "rt", "rt-multi-thread"] }
 
 [package.metadata.cargo-machete]
 ignored = ["log"]

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -104,7 +104,7 @@ pub struct Socket<S> {
 impl<#[cfg(unix)] S: std::os::fd::AsFd, #[cfg(windows)] S: std::os::windows::io::AsSocket>
     Socket<S>
 {
-    /// Create a new [`BorrowedSocket`] given a [`Borrowed`] socket managed externally.
+    /// Create a new [`Socket`] given a raw file descriptor managed externally.
     pub fn new(socket: S) -> Result<Self, io::Error> {
         Ok(Self {
             state: quinn_udp::UdpSocketState::new((&socket).into())?,
@@ -112,12 +112,12 @@ impl<#[cfg(unix)] S: std::os::fd::AsFd, #[cfg(windows)] S: std::os::windows::io:
         })
     }
 
-    /// Send a [`Datagram`] on the given [`BorrowedSocket`].
+    /// Send a [`Datagram`] on the given [`Socket`].
     pub fn send(&self, d: &Datagram) -> io::Result<()> {
         send_inner(&self.state, (&self.inner).into(), d)
     }
 
-    /// Receive a batch of [`Datagram`]s on the given [`BorrowedSocket`], each
+    /// Receive a batch of [`Datagram`]s on the given [`Socket`], each
     /// set with the provided local address.
     pub fn recv(&self, local_address: &SocketAddr) -> Result<Vec<Datagram>, io::Error> {
         recv_inner(local_address, &self.state, (&self.inner).into())


### PR DESCRIPTION
`neqo-udp` is used in Firefox. Firefox uses `cargo vet` to audit its dependencies. `tokio`, the dependency of `neqo-udp`, is not audited as `safe-to-deploy`. `cargo vet` will require `safe-to-deploy` for `tokio` even when behind a feature flag.

To work around this limitation in `cargo vet`, drop `tokio` dependency in `neqo-udp`, moving `tokio` specific logic into `neqo-bin`.

See details in:

- https://github.com/mozilla/cargo-vet/issues/626
- https://bugzilla.mozilla.org/show_bug.cgi?id=1907810
- https://phabricator.services.mozilla.com/D212959#inline-1194604