### PR TITLE
ci: Improve QNS workflow

### DIFF
--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -103,4 +103,4 @@ runs:
         path: |
           result.json
           summary.txt
-          retention-days: 1
+        retention-days: 1

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -23,6 +23,7 @@ permissions:
 env:
   LATEST: neqo-latest
   DELIM: ' vs. '
+  TIMEOUT: 20
 
 jobs:
   docker-image:
@@ -148,6 +149,7 @@ jobs:
 
       # TODO: Replace once https://github.com/quic-interop/quic-interop-runner/pull/356 is merged.
       - uses: ./.github/actions/quic-interop-runner
+        timeout-minutes: ${{ fromJSON(env.TIMEOUT) }}
         with:
           client: ${{ steps.depair.outputs.client }}
           server: ${{ steps.depair.outputs.server }}
@@ -155,7 +157,7 @@ jobs:
 
   report:
     name: Report results
-    needs: run-qns
+    needs: [run-qns, implementations]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -166,10 +168,30 @@ jobs:
           path: results
 
       - run: |
-          for RUN in results/*; do
-            [ -e "$RUN/result.json" ] || continue
-            CLIENT=$(jq -r < "$RUN/result.json" '.clients[0]')
-            SERVER=$(jq -r < "$RUN/result.json" '.servers[0]')
+          mapfile -t LIST < <(echo '${{ needs.implementations.outputs.pairs }}' | jq '.[]' | sort)
+          for PREFIX in "${LIST[@]}"; do
+            PREFIX=$(echo "$PREFIX" | tr -d '"')
+            CLIENT=$(echo "$PREFIX" | cut -f1 -d " ")
+            SERVER=$(echo "$PREFIX" | cut -f3 -d " ")
+            RUN="results/${PREFIX} results"
+            {
+              [ "$CLIENT" == "$LATEST" ] || echo -n "<ins>"
+              echo -n "$CLIENT"
+              [ "$CLIENT" == "$LATEST" ] || echo -n "</ins>"
+              echo -n "$DELIM"
+              [ "$SERVER" == "$LATEST" ] || echo -n "<ins>"
+              echo -n "$SERVER"
+              [ "$SERVER" == "$LATEST" ] || echo -n "</ins>"
+            } > "pair.md"
+            if [ ! -e "$RUN/result.json" ]; then
+              {
+                echo -n "* "
+                cat "pair.md"
+                echo -n ": "
+                echo "run cancelled after $TIMEOUT min"
+              } >> "failed.md"
+              continue
+            fi
             jq < "$RUN/result.json" '
                 . as $data |
                 {
@@ -184,13 +206,7 @@ jobs:
               [ -n "$RESULT" ] || continue
               {
                 echo -n "* ["
-                [ "$CLIENT" == "$LATEST" ] || echo -n "<ins>"
-                echo -n "$CLIENT"
-                [ "$CLIENT" == "$LATEST" ] || echo -n "</ins>"
-                echo -n "$DELIM"
-                [ "$SERVER" == "$LATEST" ] || echo -n "<ins>"
-                echo -n "$SERVER"
-                [ "$SERVER" == "$LATEST" ] || echo -n "</ins>"
+                cat "pair.md"
                 echo -n "]($LOG): "
                 echo "**$RESULT**"
               } >> "$GROUP.md"

--- a/qns/Dockerfile
+++ b/qns/Dockerfile
@@ -1,7 +1,7 @@
 FROM martenseemann/quic-network-simulator-endpoint@sha256:91b21d42e23023e08c5ed63c1c08ec24d058c4b30edd52aa3bd74bee87096a5b AS buildimage
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libclang-dev libnss3-dev pkg-config lld \
+    git coreutils build-essential libclang-dev lld gyp ninja-build zlib1g-dev python \
     && apt-get autoremove -y && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
@@ -47,6 +47,19 @@ RUN set -eux; \
 
 # End of copy from https://github.com/rust-lang/docker-rust...
 
+# We unfortunately need to build NSS from source, because the Debian package is
+# not compiled with support for SSLKEYLOGFILE.
+# See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=842292
+ENV NSS_DIR=/nss \
+    NSPR_DIR=/nspr \
+    LD_LIBRARY_PATH=/dist/Release/lib
+
+RUN set -eux; \
+    git clone --depth=1 https://github.com/nss-dev/nspr "$NSPR_DIR"; \
+    git clone --depth=1 https://github.com/nss-dev/nss "$NSS_DIR"
+
+RUN "$NSS_DIR"/build.sh --static -Ddisable_tests=1 -o
+
 ADD . /neqo
 
 RUN set -eux; \
@@ -58,12 +71,10 @@ RUN set -eux; \
 
 FROM martenseemann/quic-network-simulator-endpoint@sha256:91b21d42e23023e08c5ed63c1c08ec24d058c4b30edd52aa3bd74bee87096a5b
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libnss3-tools libnss3-dev \
-    && apt-get autoremove -y && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
-
+ENV LD_LIBRARY_PATH=/neqo/lib
 COPY --from=buildimage /neqo/target/release/neqo-client /neqo/target/release/neqo-server /neqo/bin/
+COPY --from=buildimage /dist/Release/lib/*.so /neqo/lib/
+COPY --from=buildimage /dist/Release/bin/certutil /dist/Release/bin/pk12util /neqo/bin/
 
 COPY qns/interop.sh /neqo/
 RUN chmod +x /neqo/interop.sh

--- a/qns/interop.sh
+++ b/qns/interop.sh
@@ -12,6 +12,7 @@ export PATH="${PATH}:/neqo/bin"
 case "$ROLE" in
 client)
   /wait-for-it.sh sim:57832 -s -t 30
+  # shellcheck disable=SC2086
   RUST_LOG=debug RUST_BACKTRACE=1 neqo-client --cc cubic --qns-test "$TESTCASE" \
     --qlog-dir "$QLOGDIR" --output-dir /downloads $REQUESTS 2> >(tee -i -a "/logs/$ROLE.log" >&2)
   ;;
@@ -26,7 +27,7 @@ server)
     -name "$CERT" -passout pass: -out "$P12CERT"
   pk12util -d "sql:$DB" -i "$P12CERT" -W ''
   certutil -L -d "sql:$DB" -n "$CERT"
-  RUST_LOG=info RUST_BACKTRACE=1 neqo-server --cc cubic --qns-test "$TESTCASE" \
+  RUST_LOG=debug RUST_BACKTRACE=1 neqo-server --cc cubic --qns-test "$TESTCASE" \
     --qlog-dir "$QLOGDIR" -d "$DB" -k "$CERT" '[::]:443' 2> >(tee -i -a "/logs/$ROLE.log" >&2)
   ;;
 


### PR DESCRIPTION
* Cancel runs after 20 min, and report that that happened
* Build NSS from source, to make SSLKEYLOGFILE work
* Shorten retention for some artifacts
* Run interop server at `debug` log level

Factored out of #1875, which was a convenient test case.