### PR TITLE
chore: Remove superfluous clippy allows

### DIFF
--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -30,11 +30,7 @@ use url::Url;
 use super::{get_output_file, qlog_new, Args, CloseState, Res};
 
 pub struct Handler<'a> {
-    #[allow(
-        unknown_lints,
-        clippy::struct_field_names,
-        clippy::redundant_field_names
-    )]
+    #[allow(clippy::struct_field_names)]
     url_handler: UrlHandler<'a>,
     token: Option<ResumptionToken>,
     output_read_data: bool,

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -304,7 +304,6 @@ impl Encoder {
     /// # Panics
     ///
     /// When `n` is outside the range `1..=8`.
-    #[allow(clippy::cast_possible_truncation)]
     pub fn encode_uint<T: Into<u64>>(&mut self, n: usize, v: T) -> &mut Self {
         let v = v.into();
         assert!(n > 0 && n <= 8);
@@ -374,7 +373,6 @@ impl Encoder {
     /// # Panics
     ///
     /// When `f()` writes more than 2^62 bytes.
-    #[allow(clippy::cast_possible_truncation)]
     pub fn encode_vvec_with<F: FnOnce(&mut Self)>(&mut self, f: F) -> &mut Self {
         let start = self.buf.len();
         // Optimize for short buffers, reserve a single byte for the length.

--- a/neqo-common/src/hrtime.rs
+++ b/neqo-common/src/hrtime.rs
@@ -287,36 +287,36 @@ impl Time {
         }
     }
 
-    #[allow(clippy::unused_self)] // Only on some platforms is it unused.
-    #[allow(clippy::missing_const_for_fn)] // Only const on some platforms where the function is empty.
+    #[cfg(target_os = "macos")]
     fn start(&self) {
-        #[cfg(target_os = "macos")]
-        {
-            if let Some(p) = self.active {
-                mac::set_realtime(p.scaled(self.scale));
-            } else {
-                mac::set_thread_policy(self.deflt);
-            }
-        }
-
-        #[cfg(windows)]
-        {
-            if let Some(p) = self.active {
-                _ = unsafe { timeBeginPeriod(p.as_uint()) };
-            }
+        if let Some(p) = self.active {
+            mac::set_realtime(p.scaled(self.scale));
+        } else {
+            mac::set_thread_policy(self.deflt);
         }
     }
 
-    #[allow(clippy::unused_self)] // Only on some platforms is it unused.
-    #[allow(clippy::missing_const_for_fn)] // Only const on some platforms where the function is empty.
+    #[cfg(target_os = "windows")]
+    fn start(&self) {
+        if let Some(p) = self.active {
+            _ = unsafe { timeBeginPeriod(p.as_uint()) };
+        }
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    #[allow(clippy::unused_self)]
+    const fn start(&self) {}
+
+    #[cfg(windows)]
     fn stop(&self) {
-        #[cfg(windows)]
-        {
-            if let Some(p) = self.active {
-                _ = unsafe { timeEndPeriod(p.as_uint()) };
-            }
+        if let Some(p) = self.active {
+            _ = unsafe { timeEndPeriod(p.as_uint()) };
         }
     }
+
+    #[cfg(not(target_os = "windows"))]
+    #[allow(clippy::unused_self)]
+    const fn stop(&self) {}
 
     fn update(&mut self) {
         let next = self.periods.min();

--- a/neqo-crypto/src/aead.rs
+++ b/neqo-crypto/src/aead.rs
@@ -69,7 +69,6 @@ impl RealAead {
     }
 
     #[must_use]
-    #[allow(clippy::unused_self)]
     pub const fn expansion(&self) -> usize {
         16
     }

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -748,7 +748,7 @@ impl SecretAgent {
     /// # Panics
     ///
     /// If setup fails.
-    #[allow(unknown_lints, clippy::branches_sharing_code)]
+    #[allow(clippy::branches_sharing_code)]
     pub fn close(&mut self) {
         // It should be safe to close multiple times.
         if self.fd.is_null() {
@@ -833,12 +833,7 @@ impl ResumptionToken {
 
 /// A TLS Client.
 #[derive(Debug)]
-#[allow(
-    renamed_and_removed_lints,
-    clippy::box_vec,
-    unknown_lints,
-    clippy::box_collection
-)] // We need the Box.
+#[allow(clippy::box_collection)] // We need the Box.
 pub struct Client {
     agent: SecretAgent,
 

--- a/neqo-crypto/src/agentio.rs
+++ b/neqo-crypto/src/agentio.rs
@@ -87,7 +87,6 @@ impl RecordList {
         self.records.push(Record::new(epoch, ct, data));
     }
 
-    #[allow(clippy::unused_self)]
     unsafe extern "C" fn ingest(
         _fd: *mut ssl::PRFileDesc,
         epoch: ssl::PRUint16,
@@ -220,7 +219,6 @@ impl AgentIo {
     }
 
     unsafe fn borrow(fd: &mut PrFd) -> &mut Self {
-        #[allow(clippy::cast_ptr_alignment)]
         (**fd).secret.cast::<Self>().as_mut().unwrap()
     }
 

--- a/neqo-crypto/src/err.rs
+++ b/neqo-crypto/src/err.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 #![allow(dead_code)]
-#![allow(clippy::upper_case_acronyms)]
 
 use std::{os::raw::c_char, str::Utf8Error};
 

--- a/neqo-crypto/src/ext.rs
+++ b/neqo-crypto/src/ext.rs
@@ -75,7 +75,7 @@ impl ExtensionTracker {
         f(&mut *rc.borrow_mut())
     }
 
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    #[allow(clippy::cast_possible_truncation)]
     unsafe extern "C" fn extension_writer(
         _fd: *mut PRFileDesc,
         message: SSLHandshakeType::Type,
@@ -106,7 +106,7 @@ impl ExtensionTracker {
         arg: *mut c_void,
     ) -> SECStatus {
         let d = null_safe_slice(data, len);
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        #[allow(clippy::cast_possible_truncation)]
         Self::wrap_handler_call(arg, |handler| {
             // Cast is safe here because the message type is always part of the enum
             match handler.handle(message as HandshakeMessage, d) {

--- a/neqo-crypto/src/ext.rs
+++ b/neqo-crypto/src/ext.rs
@@ -75,7 +75,7 @@ impl ExtensionTracker {
         f(&mut *rc.borrow_mut())
     }
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     unsafe extern "C" fn extension_writer(
         _fd: *mut PRFileDesc,
         message: SSLHandshakeType::Type,
@@ -106,7 +106,7 @@ impl ExtensionTracker {
         arg: *mut c_void,
     ) -> SECStatus {
         let d = null_safe_slice(data, len);
-        #[allow(clippy::cast_possible_truncation)]
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         Self::wrap_handler_call(arg, |handler| {
             // Cast is safe here because the message type is always part of the enum
             match handler.handle(message as HandshakeMessage, d) {

--- a/neqo-crypto/src/hp.rs
+++ b/neqo-crypto/src/hp.rs
@@ -68,7 +68,6 @@ impl HpKey {
     /// # Panics
     ///
     /// When `cipher` is not known to this code.
-    #[allow(clippy::cast_sign_loss)] // Cast for PK11_GetBlockSize is safe.
     pub fn extract(version: Version, cipher: Cipher, prk: &SymKey, label: &str) -> Res<Self> {
         const ZERO: &[u8] = &[0; 12];
 

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -62,9 +62,7 @@ pub use self::{
 mod min_version;
 use min_version::MINIMUM_NSS_VERSION;
 
-#[allow(non_upper_case_globals, clippy::redundant_static_lifetimes)]
-#[allow(clippy::upper_case_acronyms)]
-#[allow(unknown_lints, clippy::borrow_as_ptr)]
+#[allow(non_upper_case_globals)]
 mod nss {
     include!(concat!(env!("OUT_DIR"), "/nss_init.rs"));
 }

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -24,9 +24,7 @@ use crate::{
     null_safe_slice,
 };
 
-#[allow(clippy::upper_case_acronyms)]
 #[allow(clippy::unreadable_literal)]
-#[allow(unknown_lints, clippy::borrow_as_ptr)]
 mod nss_p11 {
     include!(concat!(env!("OUT_DIR"), "/nss_p11.rs"));
 }
@@ -70,9 +68,8 @@ macro_rules! scoped_ptr {
         }
 
         impl Drop for $scoped {
-            #[allow(unused_must_use)]
             fn drop(&mut self) {
-                unsafe { $dtor(self.ptr) };
+                unsafe { _ = $dtor(self.ptr) };
             }
         }
     };

--- a/neqo-crypto/src/prio.rs
+++ b/neqo-crypto/src/prio.rs
@@ -4,16 +4,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(clippy::upper_case_acronyms)]
 #![allow(
     dead_code,
     non_upper_case_globals,
     non_snake_case,
     clippy::cognitive_complexity,
-    clippy::empty_enum,
-    clippy::too_many_lines,
-    unknown_lints,
-    clippy::borrow_as_ptr
+    clippy::too_many_lines
 )]
 
 include!(concat!(env!("OUT_DIR"), "/nspr_io.rs"));

--- a/neqo-crypto/src/replay.rs
+++ b/neqo-crypto/src/replay.rs
@@ -18,8 +18,6 @@ use crate::{
 };
 
 // This is an opaque struct in NSS.
-#[allow(clippy::upper_case_acronyms)]
-#[allow(clippy::empty_enum)]
 pub enum SSLAntiReplayContext {}
 
 experimental_api!(SSL_CreateAntiReplayContext(

--- a/neqo-crypto/src/secrets.rs
+++ b/neqo-crypto/src/secrets.rs
@@ -70,7 +70,6 @@ pub struct Secrets {
 }
 
 impl Secrets {
-    #[allow(clippy::unused_self)]
     unsafe extern "C" fn secret_available(
         _fd: *mut PRFileDesc,
         epoch: u16,

--- a/neqo-crypto/src/ssl.rs
+++ b/neqo-crypto/src/ssl.rs
@@ -8,11 +8,8 @@
     dead_code,
     non_upper_case_globals,
     non_snake_case,
-    clippy::cognitive_complexity,
     clippy::too_many_lines,
-    clippy::upper_case_acronyms,
-    unknown_lints,
-    clippy::borrow_as_ptr
+    clippy::cognitive_complexity
 )]
 
 use std::os::raw::{c_uint, c_void};
@@ -28,9 +25,7 @@ mod SSLOption {
 }
 
 // I clearly don't understand how bindgen operates.
-#[allow(clippy::empty_enum)]
 pub enum PLArenaPool {}
-#[allow(clippy::empty_enum)]
 pub enum PRFileDesc {}
 
 // Remap some constants.

--- a/neqo-crypto/src/time.rs
+++ b/neqo-crypto/src/time.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(clippy::upper_case_acronyms)]
-
 use std::{
     ops::Deref,
     os::raw::c_void,

--- a/neqo-crypto/tests/handshake.rs
+++ b/neqo-crypto/tests/handshake.rs
@@ -5,8 +5,6 @@
 // except according to those terms.
 
 #![allow(dead_code)]
-#![allow(clippy::missing_panics_doc)]
-#![allow(clippy::missing_errors_doc)]
 
 use std::{mem, time::Instant};
 
@@ -18,6 +16,8 @@ use neqo_crypto::{
 use test_fixture::{anti_replay, fixture_init, now};
 
 /// Consume records until the handshake state changes.
+#[allow(clippy::missing_panics_doc)]
+#[allow(clippy::missing_errors_doc)]
 pub fn forward_records(
     now: Instant,
     agent: &mut SecretAgent,
@@ -65,6 +65,7 @@ fn handshake(now: Instant, client: &mut SecretAgent, server: &mut SecretAgent) {
     }
 }
 
+#[allow(clippy::missing_panics_doc)]
 pub fn connect_at(now: Instant, client: &mut SecretAgent, server: &mut SecretAgent) {
     handshake(now, client, server);
     qinfo!("client: {:?}", client.state());
@@ -77,6 +78,7 @@ pub fn connect(client: &mut SecretAgent, server: &mut SecretAgent) {
     connect_at(now(), client, server);
 }
 
+#[allow(clippy::missing_panics_doc)]
 pub fn connect_fail(client: &mut SecretAgent, server: &mut SecretAgent) {
     handshake(now(), client, server);
     assert!(!client.state().is_connected());
@@ -131,6 +133,7 @@ fn zero_rtt_setup(mode: Resumption, client: &Client, server: &mut Server) -> Opt
     }
 }
 
+#[allow(clippy::missing_panics_doc)]
 #[must_use]
 pub fn resumption_setup(mode: Resumption) -> (Option<AntiReplay>, ResumptionToken) {
     fixture_init();

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -467,7 +467,6 @@ impl Http3Connection {
 
     /// The function calls `receive` for a stream. It also deals with the outcome of a read by
     /// calling `handle_stream_manipulation_output`.
-    #[allow(clippy::option_if_let_else)] // False positive as borrow scope isn't lexical here.
     fn stream_receive(&mut self, conn: &mut Connection, stream_id: StreamId) -> Res<ReceiveOutput> {
         qtrace!([self], "Readable stream {}.", stream_id);
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -2801,7 +2801,6 @@ mod tests {
 
     // Send 2 data frames so that the second one cannot fit into the send_buf and it is only
     // partialy sent. We check that the sent data is correct.
-    #[allow(clippy::useless_vec)]
     fn fetch_with_two_data_frames(
         first_frame: &[u8],
         expected_first_data_frame_header: &[u8],

--- a/neqo-http3/src/control_stream_remote.rs
+++ b/neqo-http3/src/control_stream_remote.rs
@@ -63,7 +63,6 @@ impl RecvStream for ControlStreamRemote {
         Err(Error::HttpClosedCriticalStream)
     }
 
-    #[allow(clippy::vec_init_then_push)] // Clippy fail.
     fn receive(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)> {
         let mut control_frames = Vec::new();
 

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(clippy::module_name_repetitions)]
-
 pub(crate) mod webtransport_session;
 pub(crate) mod webtransport_streams;
 

--- a/neqo-http3/src/frames/tests/mod.rs
+++ b/neqo-http3/src/frames/tests/mod.rs
@@ -15,7 +15,6 @@ use crate::frames::{
     reader::FrameDecoder, FrameReader, HFrame, StreamReaderConnectionWrapper, WebTransportFrame,
 };
 
-#[allow(clippy::many_single_char_names)]
 pub fn enc_dec<T: FrameDecoder<T>>(d: &Encoder, st: &str, remaining: usize) -> T {
     // For data, headers and push_promise we do not read all bytes from the buffer
     let d2 = Encoder::from_hex(st);

--- a/neqo-http3/src/headers_checks.rs
+++ b/neqo-http3/src/headers_checks.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(clippy::unused_unit)] // see https://github.com/Lymia/enumset/issues/44
-
 use enumset::{enum_set, EnumSet, EnumSetType};
 use neqo_common::Header;
 

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(clippy::module_name_repetitions)] // This lint doesn't work here.
-
 /*!
 
 # The HTTP/3 protocol

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(clippy::module_name_repetitions)]
-
 use neqo_common::{qtrace, Decoder, IncrementalDecoderUint, Role};
 use neqo_qpack::{decoder::QPACK_UNI_STREAM_TYPE_DECODER, encoder::QPACK_UNI_STREAM_TYPE_ENCODER};
 use neqo_transport::{Connection, StreamId, StreamType};

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(unused_assignments)]
-
 use std::{
     mem,
     time::{Duration, Instant},

--- a/neqo-qpack/src/prefix.rs
+++ b/neqo-qpack/src/prefix.rs
@@ -6,7 +6,6 @@
 
 #[derive(Copy, Clone, Debug)]
 pub struct Prefix {
-    #[allow(unknown_lints)] // available with Rust v1.75
     #[allow(clippy::struct_field_names)]
     prefix: u8,
     len: u8,

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -267,7 +267,7 @@ impl AddressValidation {
 
 // Note: these lint override can be removed in later versions where the lints
 // either don't trip a false positive or don't apply.  rustc 1.46 is fine.
-#[allow(dead_code, clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant)]
 pub enum NewTokenState {
     Client {
         /// Tokens that haven't been taken yet.

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -21,7 +21,7 @@ use crate::{
     sender::PACING_BURST_SIZE,
     Pmtud,
 };
-#[rustfmt::skip] // to keep `::` and thus prevent conflict with `crate::qlog`
+#[rustfmt::skip]// to keep `::` and thus prevent conflict with `crate::qlog`
 use ::qlog::events::{quic::CongestionStateUpdated, EventData};
 use neqo_common::{const_max, const_min, qdebug, qinfo, qlog::NeqoQlog, qtrace};
 

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -21,7 +21,7 @@ use crate::{
     sender::PACING_BURST_SIZE,
     Pmtud,
 };
-#[rustfmt::skip]// to keep `::` and thus prevent conflict with `crate::qlog`
+#[rustfmt::skip] // to keep `::` and thus prevent conflict with `crate::qlog`
 use ::qlog::events::{quic::CongestionStateUpdated, EventData};
 use neqo_common::{const_max, const_min, qdebug, qinfo, qlog::NeqoQlog, qtrace};
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1118,6 +1118,7 @@ impl Connection {
             self.input(d, now, now);
             self.process_saved(now);
         }
+        #[allow(clippy::let_and_return)]
         let output = self.process_output(now);
         #[cfg(all(feature = "build-fuzzing-corpus", test))]
         if self.test_frame_writer.is_none() {

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1118,7 +1118,6 @@ impl Connection {
             self.input(d, now, now);
             self.process_saved(now);
         }
-        #[allow(clippy::let_and_return)]
         let output = self.process_output(now);
         #[cfg(all(feature = "build-fuzzing-corpus", test))]
         if self.test_frame_writer.is_none() {

--- a/neqo-transport/src/connection/state.rs
+++ b/neqo-transport/src/connection/state.rs
@@ -90,7 +90,6 @@ impl Ord for State {
         if mem::discriminant(self) == mem::discriminant(other) {
             return Ordering::Equal;
         }
-        #[allow(clippy::match_same_arms)] // Lint bug: rust-lang/rust-clippy#860
         match (self, other) {
             (Self::Init, _) => Ordering::Less,
             (_, Self::Init) => Ordering::Greater,

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -382,7 +382,6 @@ fn dgram_no_allowed() {
 }
 
 #[test]
-#[allow(clippy::assertions_on_constants)] // this is a static assert, thanks
 fn dgram_too_big() {
     let mut client =
         new_client(ConnectionParameters::default().datagram_size(DATAGRAM_LEN_SMALLER_THAN_MTU));

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -437,7 +437,6 @@ pub struct CryptoDxState {
 const INITIAL_LARGEST_PACKET_LEN: usize = 1 << 11; // 2048
 
 impl CryptoDxState {
-    #[allow(clippy::reversed_empty_ranges)] // To initialize an empty range.
     pub fn new(
         version: Version,
         direction: CryptoDxDirection,
@@ -1335,7 +1334,6 @@ pub struct CryptoStream {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)] // Suppress false positive: https://github.com/rust-lang/rust/issues/68408
 pub enum CryptoStreams {
     Initial {
         initial: CryptoStream,

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -149,7 +149,6 @@ impl PacketBuilder {
     ///
     /// If, after calling this method, `remaining()` returns 0, then call `abort()` to get
     /// the encoder back.
-    #[allow(clippy::reversed_empty_ranges)]
     pub fn short(mut encoder: Encoder, key_phase: bool, dcid: impl AsRef<[u8]>) -> Self {
         let mut limit = Self::infer_limit(&encoder);
         let header_start = encoder.len();
@@ -181,8 +180,6 @@ impl PacketBuilder {
     /// even if the token is empty.
     ///
     /// See `short()` for more on how to handle this in cases where there is no space.
-    #[allow(clippy::reversed_empty_ranges)] // For initializing an empty range.
-    #[allow(clippy::similar_names)] // For dcid and scid, which are fine here.
     pub fn long(
         mut encoder: Encoder,
         pt: PacketType,
@@ -454,7 +451,6 @@ impl PacketBuilder {
     /// # Errors
     ///
     /// This will return an error if AEAD encrypt fails.
-    #[allow(clippy::similar_names)] // scid and dcid are fine here.
     pub fn retry(
         version: Version,
         dcid: &[u8],
@@ -486,7 +482,6 @@ impl PacketBuilder {
     }
 
     /// Make a Version Negotiation packet.
-    #[allow(clippy::similar_names)] // scid and dcid are fine here.
     #[must_use]
     pub fn version_negotiation(
         dcid: &[u8],
@@ -602,7 +597,6 @@ impl<'a> PublicPacket<'a> {
     /// # Errors
     ///
     /// This will return an error if the packet could not be decoded.
-    #[allow(clippy::similar_names)] // For dcid and scid, which are fine.
     pub fn decode(data: &'a [u8], dcid_decoder: &dyn ConnectionIdDecoder) -> Res<(Self, &'a [u8])> {
         let mut decoder = Decoder::new(data);
         let first = Self::opt(decoder.decode_byte())?;
@@ -760,7 +754,6 @@ impl<'a> PublicPacket<'a> {
     }
 
     #[must_use]
-    #[allow(clippy::len_without_is_empty)] // is_empty() would always return false in this case
     pub const fn len(&self) -> usize {
         self.data.len()
     }

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -180,6 +180,7 @@ impl PacketBuilder {
     /// even if the token is empty.
     ///
     /// See `short()` for more on how to handle this in cases where there is no space.
+    #[allow(clippy::similar_names)]
     pub fn long(
         mut encoder: Encoder,
         pt: PacketType,
@@ -451,6 +452,7 @@ impl PacketBuilder {
     /// # Errors
     ///
     /// This will return an error if AEAD encrypt fails.
+    #[allow(clippy::similar_names)]
     pub fn retry(
         version: Version,
         dcid: &[u8],
@@ -483,6 +485,7 @@ impl PacketBuilder {
 
     /// Make a Version Negotiation packet.
     #[must_use]
+    #[allow(clippy::similar_names)]
     pub fn version_negotiation(
         dcid: &[u8],
         scid: &[u8],
@@ -597,6 +600,7 @@ impl<'a> PublicPacket<'a> {
     /// # Errors
     ///
     /// This will return an error if the packet could not be decoded.
+    #[allow(clippy::similar_names)]
     pub fn decode(data: &'a [u8], dcid_decoder: &dyn ConnectionIdDecoder) -> Res<(Self, &'a [u8])> {
         let mut decoder = Decoder::new(data);
         let first = Self::opt(decoder.decode_byte())?;

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -50,7 +50,6 @@ pub type PathRef = Rc<RefCell<Path>>;
 #[derive(Debug, Default)]
 pub struct Paths {
     /// All of the paths.  All of these paths will be permanent.
-    #[allow(unknown_lints)] // available with Rust v1.75
     #[allow(clippy::struct_field_names)]
     paths: Vec<PathRef>,
     /// This is the primary path.  This will only be `None` initially, so

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -33,7 +33,7 @@ use crate::{
 const RX_STREAM_DATA_WINDOW: u64 = 0x10_0000; // 1MiB
 
 // Export as usize for consistency with SEND_BUFFER_SIZE
-#[allow(clippy::cast_possible_truncation)] // Yeah, nope.
+#[allow(clippy::cast_possible_truncation)]// Yeah, nope.
 pub const RECV_BUFFER_SIZE: usize = RX_STREAM_DATA_WINDOW as usize;
 
 #[derive(Debug, Default)]
@@ -813,7 +813,7 @@ impl RecvStream {
 
     /// # Errors
     /// `NoMoreData` if data and fin bit were previously read by the application.
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)]// with a >16 exabyte packet on a 128-bit machine, maybe
     pub fn read(&mut self, buf: &mut [u8]) -> Res<(usize, bool)> {
         let data_recvd_state = matches!(self.state, RecvStreamState::DataRecvd { .. });
         match &mut self.state {

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -65,6 +65,7 @@ impl RecvStreams {
     pub fn get_mut(&mut self, id: StreamId) -> Res<&mut RecvStream> {
         self.streams.get_mut(&id).ok_or(Error::InvalidStreamId)
     }
+
     #[allow(clippy::missing_errors_doc)]
     pub fn keep_alive(&mut self, id: StreamId, k: bool) -> Res<()> {
         let self_ka = &mut self.keep_alive;
@@ -386,7 +387,6 @@ impl RxStreamOrderer {
 
 /// QUIC receiving states, based on -transport 3.2.
 #[derive(Debug)]
-#[allow(dead_code)]
 // Because a dead_code warning is easier than clippy::unused_self, see https://github.com/rust-lang/rust/issues/68408
 enum RecvStreamState {
     Recv {
@@ -813,7 +813,7 @@ impl RecvStream {
 
     /// # Errors
     /// `NoMoreData` if data and fin bit were previously read by the application.
-    #[allow(clippy::missing_panics_doc)] // with a >16 exabyte packet on a 128-bit machine, maybe
+    #[allow(clippy::missing_panics_doc)]
     pub fn read(&mut self, buf: &mut [u8]) -> Res<(usize, bool)> {
         let data_recvd_state = matches!(self.state, RecvStreamState::DataRecvd { .. });
         match &mut self.state {
@@ -1051,7 +1051,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(unknown_lints, clippy::single_range_in_vec_init)] // Because that lint makes no sense here.
+    #[allow(clippy::single_range_in_vec_init)] // Because that lint makes no sense here.
     fn recv_noncontiguous() {
         // Non-contiguous with the start, no data available.
         recv_ranges(&[10..20], 0);

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -33,7 +33,7 @@ use crate::{
 const RX_STREAM_DATA_WINDOW: u64 = 0x10_0000; // 1MiB
 
 // Export as usize for consistency with SEND_BUFFER_SIZE
-#[allow(clippy::cast_possible_truncation)]// Yeah, nope.
+#[allow(clippy::cast_possible_truncation)] // Yeah, nope.
 pub const RECV_BUFFER_SIZE: usize = RX_STREAM_DATA_WINDOW as usize;
 
 #[derive(Debug, Default)]
@@ -813,7 +813,7 @@ impl RecvStream {
 
     /// # Errors
     /// `NoMoreData` if data and fin bit were previously read by the application.
-    #[allow(clippy::missing_panics_doc)]// with a >16 exabyte packet on a 128-bit machine, maybe
+    #[allow(clippy::missing_panics_doc)] // with a >16 exabyte packet on a 128-bit machine, maybe
     pub fn read(&mut self, buf: &mut [u8]) -> Res<(usize, bool)> {
         let data_recvd_state = matches!(self.state, RecvStreamState::DataRecvd { .. });
         match &mut self.state {

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -219,7 +219,7 @@ impl RangeTracker {
     /// The only tricky parts are making sure that we maintain `self.acked`,
     /// which is the first acknowledged range.  And making sure that we don't create
     /// ranges of the same type that are adjacent; these need to be merged.
-    #[allow(clippy::missing_panics_doc)]// with a >16 exabyte packet on a 128-bit machine, maybe
+    #[allow(clippy::missing_panics_doc)] // with a >16 exabyte packet on a 128-bit machine, maybe
     pub fn mark_acked(&mut self, new_off: u64, new_len: usize) {
         let end = new_off + u64::try_from(new_len).unwrap();
         let new_off = max(self.acked, new_off);
@@ -317,7 +317,7 @@ impl RangeTracker {
     /// +     SS
     /// = SSSSSS
     /// ```
-    #[allow(clippy::missing_panics_doc)]// not possible
+    #[allow(clippy::missing_panics_doc)] // not possible
     pub fn mark_sent(&mut self, mut new_off: u64, new_len: usize) {
         let new_end = new_off + u64::try_from(new_len).unwrap();
         new_off = max(self.acked, new_off);
@@ -502,7 +502,7 @@ impl TxBuffer {
         can_buffer
     }
 
-    #[allow(clippy::missing_panics_doc)]// These are not possible.
+    #[allow(clippy::missing_panics_doc)] // These are not possible.
     pub fn next_bytes(&mut self) -> Option<(u64, &[u8])> {
         let (start, maybe_len) = self.ranges.first_unmarked_range();
 
@@ -536,7 +536,7 @@ impl TxBuffer {
         self.ranges.mark_sent(offset, len);
     }
 
-    #[allow(clippy::missing_panics_doc)]// Not possible here.
+    #[allow(clippy::missing_panics_doc)] // Not possible here.
     pub fn mark_as_acked(&mut self, offset: u64, len: usize) {
         let prev_retired = self.retired();
         self.ranges.mark_acked(offset, len);
@@ -725,7 +725,7 @@ impl PartialEq for SendStream {
 impl Eq for SendStream {}
 
 impl SendStream {
-    #[allow(clippy::missing_panics_doc)]// not possible
+    #[allow(clippy::missing_panics_doc)] // not possible
     pub fn new(
         stream_id: StreamId,
         max_stream_data: u64,
@@ -831,7 +831,7 @@ impl SendStream {
     }
 
     #[must_use]
-    #[allow(clippy::missing_panics_doc)]// not possible
+    #[allow(clippy::missing_panics_doc)] // not possible
     pub fn bytes_written(&self) -> u64 {
         match &self.state {
             SendStreamState::Send { send_buf, .. } | SendStreamState::DataSent { send_buf, .. } => {
@@ -944,7 +944,7 @@ impl SendStream {
     }
 
     /// Maybe write a `STREAM` frame.
-    #[allow(clippy::missing_panics_doc)]// not possible
+    #[allow(clippy::missing_panics_doc)] // not possible
     pub fn write_stream_frame(
         &mut self,
         priority: TransmissionPriority,
@@ -1107,7 +1107,7 @@ impl SendStream {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)]// not possible
+    #[allow(clippy::missing_panics_doc)] // not possible
     pub fn mark_as_sent(&mut self, offset: u64, len: usize, fin: bool) {
         self.bytes_sent = max(self.bytes_sent, offset + u64::try_from(len).unwrap());
 
@@ -1123,7 +1123,7 @@ impl SendStream {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)]// not possible
+    #[allow(clippy::missing_panics_doc)] // not possible
     pub fn mark_as_acked(&mut self, offset: u64, len: usize, fin: bool) {
         match self.state {
             SendStreamState::Send {
@@ -1161,7 +1161,7 @@ impl SendStream {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)]// not possible
+    #[allow(clippy::missing_panics_doc)] // not possible
     pub fn mark_as_lost(&mut self, offset: u64, len: usize, fin: bool) {
         self.retransmission_offset = max(
             self.retransmission_offset,

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1330,7 +1330,7 @@ impl SendStream {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)] // not possible
     pub fn reset(&mut self, err: AppError) {
         match &self.state {
             SendStreamState::Ready { fc, .. } => {

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -219,7 +219,7 @@ impl RangeTracker {
     /// The only tricky parts are making sure that we maintain `self.acked`,
     /// which is the first acknowledged range.  And making sure that we don't create
     /// ranges of the same type that are adjacent; these need to be merged.
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)]// with a >16 exabyte packet on a 128-bit machine, maybe
     pub fn mark_acked(&mut self, new_off: u64, new_len: usize) {
         let end = new_off + u64::try_from(new_len).unwrap();
         let new_off = max(self.acked, new_off);
@@ -317,7 +317,7 @@ impl RangeTracker {
     /// +     SS
     /// = SSSSSS
     /// ```
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)]// not possible
     pub fn mark_sent(&mut self, mut new_off: u64, new_len: usize) {
         let new_end = new_off + u64::try_from(new_len).unwrap();
         new_off = max(self.acked, new_off);
@@ -502,7 +502,7 @@ impl TxBuffer {
         can_buffer
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)]// These are not possible.
     pub fn next_bytes(&mut self) -> Option<(u64, &[u8])> {
         let (start, maybe_len) = self.ranges.first_unmarked_range();
 
@@ -536,7 +536,7 @@ impl TxBuffer {
         self.ranges.mark_sent(offset, len);
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)]// Not possible here.
     pub fn mark_as_acked(&mut self, offset: u64, len: usize) {
         let prev_retired = self.retired();
         self.ranges.mark_acked(offset, len);
@@ -725,7 +725,7 @@ impl PartialEq for SendStream {
 impl Eq for SendStream {}
 
 impl SendStream {
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)]// not possible
     pub fn new(
         stream_id: StreamId,
         max_stream_data: u64,
@@ -831,7 +831,7 @@ impl SendStream {
     }
 
     #[must_use]
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)]// not possible
     pub fn bytes_written(&self) -> u64 {
         match &self.state {
             SendStreamState::Send { send_buf, .. } | SendStreamState::DataSent { send_buf, .. } => {
@@ -944,7 +944,7 @@ impl SendStream {
     }
 
     /// Maybe write a `STREAM` frame.
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)]// not possible
     pub fn write_stream_frame(
         &mut self,
         priority: TransmissionPriority,
@@ -1107,7 +1107,7 @@ impl SendStream {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)]// not possible
     pub fn mark_as_sent(&mut self, offset: u64, len: usize, fin: bool) {
         self.bytes_sent = max(self.bytes_sent, offset + u64::try_from(len).unwrap());
 
@@ -1123,7 +1123,7 @@ impl SendStream {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)]// not possible
     pub fn mark_as_acked(&mut self, offset: u64, len: usize, fin: bool) {
         match self.state {
             SendStreamState::Send {
@@ -1161,7 +1161,7 @@ impl SendStream {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)]// not possible
     pub fn mark_as_lost(&mut self, offset: u64, len: usize, fin: bool) {
         self.retransmission_offset = max(
             self.retransmission_offset,

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -219,7 +219,7 @@ impl RangeTracker {
     /// The only tricky parts are making sure that we maintain `self.acked`,
     /// which is the first acknowledged range.  And making sure that we don't create
     /// ranges of the same type that are adjacent; these need to be merged.
-    #[allow(clippy::missing_panics_doc)] // with a >16 exabyte packet on a 128-bit machine, maybe
+    #[allow(clippy::missing_panics_doc)]
     pub fn mark_acked(&mut self, new_off: u64, new_len: usize) {
         let end = new_off + u64::try_from(new_len).unwrap();
         let new_off = max(self.acked, new_off);
@@ -317,7 +317,7 @@ impl RangeTracker {
     /// +     SS
     /// = SSSSSS
     /// ```
-    #[allow(clippy::missing_panics_doc)] // not possible
+    #[allow(clippy::missing_panics_doc)]
     pub fn mark_sent(&mut self, mut new_off: u64, new_len: usize) {
         let new_end = new_off + u64::try_from(new_len).unwrap();
         new_off = max(self.acked, new_off);
@@ -502,7 +502,7 @@ impl TxBuffer {
         can_buffer
     }
 
-    #[allow(clippy::missing_panics_doc)] // These are not possible.
+    #[allow(clippy::missing_panics_doc)]
     pub fn next_bytes(&mut self) -> Option<(u64, &[u8])> {
         let (start, maybe_len) = self.ranges.first_unmarked_range();
 
@@ -536,7 +536,7 @@ impl TxBuffer {
         self.ranges.mark_sent(offset, len);
     }
 
-    #[allow(clippy::missing_panics_doc)] // Not possible here.
+    #[allow(clippy::missing_panics_doc)]
     pub fn mark_as_acked(&mut self, offset: u64, len: usize) {
         let prev_retired = self.retired();
         self.ranges.mark_acked(offset, len);
@@ -725,7 +725,7 @@ impl PartialEq for SendStream {
 impl Eq for SendStream {}
 
 impl SendStream {
-    #[allow(clippy::missing_panics_doc)] // not possible
+    #[allow(clippy::missing_panics_doc)]
     pub fn new(
         stream_id: StreamId,
         max_stream_data: u64,
@@ -831,7 +831,7 @@ impl SendStream {
     }
 
     #[must_use]
-    #[allow(clippy::missing_panics_doc)] // not possible
+    #[allow(clippy::missing_panics_doc)]
     pub fn bytes_written(&self) -> u64 {
         match &self.state {
             SendStreamState::Send { send_buf, .. } | SendStreamState::DataSent { send_buf, .. } => {
@@ -944,7 +944,7 @@ impl SendStream {
     }
 
     /// Maybe write a `STREAM` frame.
-    #[allow(clippy::missing_panics_doc)] // not possible
+    #[allow(clippy::missing_panics_doc)]
     pub fn write_stream_frame(
         &mut self,
         priority: TransmissionPriority,
@@ -1107,7 +1107,7 @@ impl SendStream {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)] // not possible
+    #[allow(clippy::missing_panics_doc)]
     pub fn mark_as_sent(&mut self, offset: u64, len: usize, fin: bool) {
         self.bytes_sent = max(self.bytes_sent, offset + u64::try_from(len).unwrap());
 
@@ -1123,7 +1123,7 @@ impl SendStream {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)] // not possible
+    #[allow(clippy::missing_panics_doc)]
     pub fn mark_as_acked(&mut self, offset: u64, len: usize, fin: bool) {
         match self.state {
             SendStreamState::Send {
@@ -1161,7 +1161,7 @@ impl SendStream {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)] // not possible
+    #[allow(clippy::missing_panics_doc)]
     pub fn mark_as_lost(&mut self, offset: u64, len: usize, fin: bool) {
         self.retransmission_offset = max(
             self.retransmission_offset,
@@ -1330,7 +1330,7 @@ impl SendStream {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)] // not possible
+    #[allow(clippy::missing_panics_doc)]
     pub fn reset(&mut self, err: AppError) {
         match &self.state {
             SendStreamState::Ready { fc, .. } => {
@@ -2270,7 +2270,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn tx_buffer_next_bytes_1() {
         let mut txb = TxBuffer::new();
 
@@ -2673,7 +2672,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     // Verify lost frames handle fin properly with zero length fin
     fn send_stream_get_frame_zerolength_fin() {
         let conn_fc = connection_fc(100);

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -112,7 +112,6 @@ pub struct DatagramStats {
 
 /// Connection statistics
 #[derive(Default, Clone)]
-#[allow(clippy::module_name_repetitions)]
 pub struct Stats {
     info: String,
 

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -361,7 +361,6 @@ fn vn_after_retry() {
 // at least 8 bytes long.  Otherwise, the second Initial won't have a
 // long enough connection ID.
 #[test]
-#[allow(clippy::shadow_unrelated)]
 fn mitm_retry() {
     let mut client = default_client();
     let mut retry_server = default_server();

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 #![allow(clippy::missing_errors_doc)] // Functions simply delegate to tokio and quinn-udp.
-#![allow(clippy::missing_panics_doc)] // Functions simply delegate to tokio and quinn-udp.
 
 use std::{
     cell::RefCell,

--- a/qns/interop.sh
+++ b/qns/interop.sh
@@ -27,7 +27,7 @@ server)
     -name "$CERT" -passout pass: -out "$P12CERT"
   pk12util -d "sql:$DB" -i "$P12CERT" -W ''
   certutil -L -d "sql:$DB" -n "$CERT"
-  RUST_LOG=debug RUST_BACKTRACE=1 neqo-server --cc cubic --qns-test "$TESTCASE" \
+  RUST_LOG=trace RUST_BACKTRACE=1 neqo-server --cc cubic --qns-test "$TESTCASE" \
     --qlog-dir "$QLOGDIR" -d "$DB" -k "$CERT" '[::]:443' 2> >(tee -i -a "/logs/$ROLE.log" >&2)
   ;;
 

--- a/qns/interop.sh
+++ b/qns/interop.sh
@@ -27,7 +27,7 @@ server)
     -name "$CERT" -passout pass: -out "$P12CERT"
   pk12util -d "sql:$DB" -i "$P12CERT" -W ''
   certutil -L -d "sql:$DB" -n "$CERT"
-  RUST_LOG=trace RUST_BACKTRACE=1 neqo-server --cc cubic --qns-test "$TESTCASE" \
+  RUST_LOG=debug RUST_BACKTRACE=1 neqo-server --cc cubic --qns-test "$TESTCASE" \
     --qlog-dir "$QLOGDIR" -d "$DB" -k "$CERT" '[::]:443' 2> >(tee -i -a "/logs/$ROLE.log" >&2)
   ;;
 

--- a/test-fixture/src/sim/connection.rs
+++ b/test-fixture/src/sim/connection.rs
@@ -95,12 +95,10 @@ impl ConnectionNode {
         )
     }
 
-    #[allow(dead_code)]
     pub fn clear_goals(&mut self) {
         self.goals.clear();
     }
 
-    #[allow(dead_code)]
     pub fn add_goal(&mut self, goal: Box<dyn ConnectionGoal>) {
         self.goals.push(goal);
     }

--- a/test-fixture/src/sim/drop.rs
+++ b/test-fixture/src/sim/drop.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(clippy::module_name_repetitions)]
-
 use std::{
     fmt::{self, Debug},
     time::Instant,

--- a/test-fixture/src/sim/taildrop.rs
+++ b/test-fixture/src/sim/taildrop.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(clippy::module_name_repetitions)]
-
 use std::{
     cmp::max,
     collections::VecDeque,


### PR DESCRIPTION
Now that nightly has experimental support for
https://rust-lang.github.io/rfcs/2383-lint-reasons.html, use that to identify superfluous clippy allows and remove them.