### PR TITLE
fix(quinn-udp): exclude faulty quinn-udp v0.5.3

### DIFF
--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -38,7 +38,8 @@ neqo-http3 = { path = "./../neqo-http3" }
 neqo-transport = { path = "./../neqo-transport" }
 neqo-udp = { path = "./../neqo-udp" }
 qlog = { workspace = true }
-quinn-udp = { version = "0.5.0", default-features = false }
+# v0.5.3 has compile time bug on Windows. Fixed with https://github.com/quinn-rs/quinn/pull/1932.
+quinn-udp = { version = "<=0.5.2", default-features = false }
 regex = { version = "1.9", default-features = false, features = ["unicode-perl"] }
 tokio = { version = "1", default-features = false, features = ["net", "time", "macros", "rt", "rt-multi-thread"] }
 url = { version = "2.5", default-features = false }

--- a/neqo-udp/Cargo.toml
+++ b/neqo-udp/Cargo.toml
@@ -18,7 +18,8 @@ workspace = true
 [dependencies]
 log = { workspace = true }
 neqo-common = { path = "./../neqo-common" }
-quinn-udp = { version = "0.5.0", default-features = false }
+# v0.5.3 has compile time bug on Windows. Fixed with https://github.com/quinn-rs/quinn/pull/1932.
+quinn-udp = { version = "<=0.5.2", default-features = false }
 
 [package.metadata.cargo-machete]
 ignored = ["log"]


### PR DESCRIPTION
quinn-udp v0.5.3 introduces a compile time error on Windows. This will be fixed with https://github.com/quinn-rs/quinn/pull/1932. To unblock CI in the meantime, exclude v0.5.3.