### PR TITLE
deps(quinn-udp): enable `direct-log` feature to log via `log`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rust-version = "1.76.0"
 [workspace.dependencies]
 log = { version = "0.4", default-features = false }
 qlog = { version = "0.13", default-features = false }
-quinn-udp = { version = "0.5.0", default-features = false }
+quinn-udp = { version = "0.5.4", default-features = false }
 
 [workspace.lints.clippy]
 cargo = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rust-version = "1.76.0"
 [workspace.dependencies]
 log = { version = "0.4", default-features = false }
 qlog = { version = "0.13", default-features = false }
-quinn-udp = { version = "0.5.4", default-features = false }
+quinn-udp = { version = "0.5.4", default-features = false, features = ["direct-log"] }
 
 [workspace.lints.clippy]
 cargo = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rust-version = "1.76.0"
 [workspace.dependencies]
 log = { version = "0.4", default-features = false }
 qlog = { version = "0.13", default-features = false }
+quinn-udp = { version = "0.5.0", default-features = false }
 
 [workspace.lints.clippy]
 cargo = { level = "warn", priority = -1 }

--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -38,7 +38,7 @@ neqo-http3 = { path = "./../neqo-http3" }
 neqo-transport = { path = "./../neqo-transport" }
 neqo-udp = { path = "./../neqo-udp" }
 qlog = { workspace = true }
-quinn-udp = { version = "0.5.0", default-features = false }
+quinn-udp = { workspace = true }
 regex = { version = "1.9", default-features = false, features = ["unicode-perl"] }
 tokio = { version = "1", default-features = false, features = ["net", "time", "macros", "rt", "rt-multi-thread"] }
 url = { version = "2.5", default-features = false }

--- a/neqo-udp/Cargo.toml
+++ b/neqo-udp/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 log = { workspace = true }
 neqo-common = { path = "./../neqo-common" }
-quinn-udp = { version = "0.5.0", default-features = false }
+quinn-udp = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["log"]


### PR DESCRIPTION
This pull request contains 3 commits, where the first two build up to the second:

- deps(quinn-udp): move to workspace dependency
- deps(quinn-udp): bump to latest version
- deps(quinn-udp): enable direct-log feature
     https://github.com/quinn-rs/quinn/pull/1923 made the `tracing` dependency optional. In addition, when `direct-log` is enabled, it allows using `log` instead of `tracing` for logging.

