### PR TITLE
fix(benches/transfer): remove throughput

### DIFF
--- a/neqo-transport/benches/transfer.rs
+++ b/neqo-transport/benches/transfer.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use criterion::{criterion_group, criterion_main, BatchSize::SmallInput, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BatchSize::SmallInput, Criterion};
 use neqo_transport::{ConnectionParameters, State};
 use test_fixture::{
     boxed,
@@ -24,7 +24,6 @@ const TRANSFER_AMOUNT: usize = 1 << 22; // 4Mbyte
 fn benchmark_transfer(c: &mut Criterion, label: &str, seed: &Option<impl AsRef<str>>) {
     for pacing in [false, true] {
         let mut group = c.benchmark_group(format!("transfer/pacing-{pacing}"));
-        group.throughput(Throughput::Bytes(u64::try_from(TRANSFER_AMOUNT).unwrap()));
         group.noise_threshold(0.03);
         group.bench_function(label, |b| {
             b.iter_batched(

--- a/neqo-transport/benches/transfer.rs
+++ b/neqo-transport/benches/transfer.rs
@@ -24,6 +24,7 @@ const TRANSFER_AMOUNT: usize = 1 << 22; // 4Mbyte
 fn benchmark_transfer(c: &mut Criterion, label: &str, seed: &Option<impl AsRef<str>>) {
     for pacing in [false, true] {
         let mut group = c.benchmark_group(format!("transfer/pacing-{pacing}"));
+        // Don't let criterion calculate throughput, as that's based on wall-clock time, not simulator time.
         group.noise_threshold(0.03);
         group.bench_function(label, |b| {
             b.iter_batched(


### PR DESCRIPTION
The `neqo-transport/benches/transfer.rs` benchmarks use the `test-fixture/src/sim` simulator. The simulator can travel in time, i.e. it simulates time.

The _wall-clock time_ of a single benchmark run is not the amount of time it took to transfer `TRANSFER_AMOUNT`. The _simulated time_ is the amount of time it took to transfer `TRANSFER_AMOUNT`.

`criterion` will use the _wall-clock time_, not the _simulated time_ to calculate the throughput based on `TRANSFER_AMOUNT`. The resulting throughput number is not meaningful.

This commit removes the call to `group.throughput`, thus removing the misleading `criterion` throughput reporting.

---

Related to https://github.com/mozilla/neqo/pull/1998.