### PR TITLE
bench(bin): remove sample-size override

### DIFF
--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -13,7 +13,6 @@ use tokio::runtime::Runtime;
 struct Benchmark {
     name: String,
     requests: Vec<u64>,
-    sample_size: Option<usize>,
 }
 
 fn transfer(c: &mut Criterion) {
@@ -22,25 +21,18 @@ fn transfer(c: &mut Criterion) {
 
     let done_sender = spawn_server();
 
-    for Benchmark {
-        name,
-        requests,
-        sample_size,
-    } in [
+    for Benchmark { name, requests } in [
         Benchmark {
             name: "1-conn/1-100mb-resp (aka. Download)".to_string(),
             requests: vec![100 * 1024 * 1024],
-            sample_size: Some(10),
         },
         Benchmark {
             name: "1-conn/10_000-parallel-1b-resp (aka. RPS)".to_string(),
             requests: vec![1; 10_000],
-            sample_size: None,
         },
         Benchmark {
             name: "1-conn/1-1b-resp (aka. HPS)".to_string(),
             requests: vec![1; 1],
-            sample_size: None,
         },
     ] {
         let mut group = c.benchmark_group(name);
@@ -50,9 +42,6 @@ fn transfer(c: &mut Criterion) {
         } else {
             Throughput::Elements(requests.len() as u64)
         });
-        if let Some(size) = sample_size {
-            group.sample_size(size);
-        }
         group.bench_function("client", |b| {
             b.to_async(Runtime::new().unwrap()).iter_batched(
                 || client::client(client::Args::new(&requests)),


### PR DESCRIPTION
Have criterion determine the sample size based on warum-up run time instead.

---

Testing whether this will yield more dependable results.

Related to https://github.com/mozilla/neqo/pull/2008.