### PR TITLE
ci: Skip `sudo` runner steps on self-hosted runner

### DIFF
--- a/.github/actions/nss/action.yml
+++ b/.github/actions/nss/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Install system NSS (Linux)
       shell: bash
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && runner.environment == 'github-hosted'
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
@@ -23,7 +23,7 @@ runs:
 
     - name: Install system NSS (MacOS)
       shell: bash
-      if: runner.os == 'MacOS'
+      if: runner.os == 'MacOS' && runner.environment == 'github-hosted'
       run: |
         brew update
         brew install nss
@@ -90,7 +90,7 @@ runs:
 
     - name: Install build dependencies (Linux)
       shell: bash
-      if: runner.os == 'Linux' && env.BUILD_NSS == '1'
+      if: runner.os == 'Linux' && env.BUILD_NSS == '1' && runner.environment == 'github-hosted'
       env:
         DEBIAN_FRONTEND: noninteractive
       run: sudo apt-get install -y --no-install-recommends git mercurial gyp ninja-build

--- a/neqo-transport/benches/transfer.rs
+++ b/neqo-transport/benches/transfer.rs
@@ -24,7 +24,8 @@ const TRANSFER_AMOUNT: usize = 1 << 22; // 4Mbyte
 fn benchmark_transfer(c: &mut Criterion, label: &str, seed: &Option<impl AsRef<str>>) {
     for pacing in [false, true] {
         let mut group = c.benchmark_group(format!("transfer/pacing-{pacing}"));
-        // Don't let criterion calculate throughput, as that's based on wall-clock time, not simulator time.
+        // Don't let criterion calculate throughput, as that's based on wall-clock time, not
+        // simulator time.
         group.noise_threshold(0.03);
         group.bench_function(label, |b| {
             b.iter_batched(


### PR DESCRIPTION
Because the script runs without `sudo` permissions. Deps must be installed by admin.