### PR TITLE
fix: Check for error when looking up packet number space

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1542,7 +1542,12 @@ impl Connection {
 
                     qlog::packet_received(&self.qlog, &packet, &payload);
                     let space = PacketNumberSpace::from(payload.packet_type());
-                    if self.acks.get_mut(space).unwrap().is_duplicate(payload.pn()) {
+                    if self
+                        .acks
+                        .get_mut(space)
+                        .ok_or(Error::ProtocolViolation)?
+                        .is_duplicate(payload.pn())
+                    {
                         qdebug!([self], "Duplicate packet {}-{}", space, payload.pn());
                         self.stats.borrow_mut().dups_rx += 1;
                     } else {

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1542,22 +1542,29 @@ impl Connection {
 
                     qlog::packet_received(&self.qlog, &packet, &payload);
                     let space = PacketNumberSpace::from(payload.packet_type());
-                    if self
-                        .acks
-                        .get_mut(space)
-                        .ok_or(Error::ProtocolViolation)?
-                        .is_duplicate(payload.pn())
-                    {
-                        qdebug!([self], "Duplicate packet {}-{}", space, payload.pn());
-                        self.stats.borrow_mut().dups_rx += 1;
-                    } else {
-                        match self.process_packet(path, &payload, now) {
-                            Ok(migrate) => self.postprocess_packet(path, d, &packet, migrate, now),
-                            Err(e) => {
-                                self.ensure_error_path(path, &packet, now);
-                                return Err(e);
+                    if let Some(space) = self.acks.get_mut(space) {
+                        if space.is_duplicate(payload.pn()) {
+                            qdebug!("Duplicate packet {}-{}", space, payload.pn());
+                            self.stats.borrow_mut().dups_rx += 1;
+                        } else {
+                            match self.process_packet(path, &payload, now) {
+                                Ok(migrate) => {
+                                    self.postprocess_packet(path, d, &packet, migrate, now);
+                                }
+                                Err(e) => {
+                                    self.ensure_error_path(path, &packet, now);
+                                    return Err(e);
+                                }
                             }
                         }
+                    } else {
+                        qdebug!(
+                            [self],
+                            "Received packet {} for untracked space {}",
+                            space,
+                            payload.pn()
+                        );
+                        return Err(Error::ProtocolViolation);
                     }
                 }
                 Err(e) => {

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -588,16 +588,16 @@ impl AckTracker {
         ignore_order: bool,
     ) {
         // Only ApplicationData ever delays ACK.
-        self.get_mut(PacketNumberSpace::ApplicationData)
-            .unwrap()
-            .ack_freq(seqno, tolerance, delay, ignore_order);
+        if let Some(space) = self.get_mut(PacketNumberSpace::ApplicationData) {
+            space.ack_freq(seqno, tolerance, delay, ignore_order);
+        }
     }
 
     // Force an ACK to be generated immediately (a PING was received).
     pub fn immediate_ack(&mut self, now: Instant) {
-        self.get_mut(PacketNumberSpace::ApplicationData)
-            .unwrap()
-            .immediate_ack(now);
+        if let Some(space) = self.get_mut(PacketNumberSpace::ApplicationData) {
+            space.immediate_ack(now);
+        }
     }
 
     /// Determine the earliest time that an ACK might be needed.


### PR DESCRIPTION
The crash signatures don't really give much of an indication of where exactly the issue is. Am kinda guessing it's this `unwrap` of the packet number space which was based on unverified network input (via `PacketNumberSpace::from`).

Possible fix for #1363.