### PR TITLE
fix(common/qlog): use BufWriter

### DIFF
--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -8,6 +8,7 @@ use std::{
     cell::RefCell,
     fmt::{self, Display},
     fs::OpenOptions,
+    io::BufWriter,
     path::PathBuf,
     rc::Rc,
 };
@@ -60,7 +61,7 @@ impl NeqoQlog {
             std::time::Instant::now(),
             new_trace(role),
             qlog::events::EventImportance::Base,
-            Box::new(file),
+            Box::new(BufWriter::new(file)),
         );
         Self::enabled(streamer, qlog_path)
     }


### PR DESCRIPTION
Previously, on a `neqo-server` -> `neqo-client` transfer with qlog enabled, `neqo-client` would spend the majority of time writing to the qlog file.

![flamegraph-main](https://github.com/user-attachments/assets/cd392b50-82e0-428f-93e7-c7e27885bd15)

Using a `BufWriter` `qlog` writing takes less than 3% of CPU time.

![flamegraph](https://github.com/user-attachments/assets/380fcaaf-a56e-4eef-8815-c0f43288acb5)

---

Depends on https://github.com/mozilla/neqo/pull/2031.
