### PR TITLE
fix(transport): don't pace below timer granularity

### DIFF
--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -9,7 +9,7 @@ use std::{
     mem,
     net::{IpAddr, Ipv6Addr, SocketAddr},
     rc::Rc,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use neqo_common::{Datagram, Decoder};

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -65,14 +65,6 @@ fn change_source_port(d: &Datagram) -> Datagram {
     Datagram::new(new_port(d.source()), d.destination(), d.tos(), &d[..])
 }
 
-/// As these tests use a new path, that path often has a non-zero RTT.
-/// Pacing can be a problem when testing that path.  This skips time forward.
-fn skip_pacing(c: &mut Connection, now: Instant) -> Instant {
-    let pacing = c.process_output(now).callback();
-    assert_ne!(pacing, Duration::new(0, 0));
-    now + pacing
-}
-
 #[test]
 fn rebinding_port() {
     let mut client = default_client();
@@ -100,7 +92,7 @@ fn path_forwarding_attack() {
     let mut client = default_client();
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
-    let mut now = now();
+    let now = now();
 
     let dgram = send_something(&mut client, now);
     let dgram = change_path(&dgram, DEFAULT_ADDR_V4);
@@ -160,7 +152,6 @@ fn path_forwarding_attack() {
     assert_v6_path(&client_data2, false);
 
     // The server keeps sending on the new path.
-    now = skip_pacing(&mut server, now);
     let server_data2 = send_something(&mut server, now);
     assert_v4_path(&server_data2, false);
 

--- a/neqo-transport/src/pace.rs
+++ b/neqo-transport/src/pace.rs
@@ -87,13 +87,9 @@ impl Pacer {
         let add = d / u128::try_from(cwnd * PACER_SPEEDUP).unwrap();
         let w = u64::try_from(add).map(Duration::from_nanos).unwrap_or(rtt);
 
-        // If next is below timer granularity, send immediately.
+        // If the increment is below the timer granularity, send immediately.
         if w < GRANULARITY {
-            qtrace!(
-                [self],
-                "next {cwnd}/{rtt:?} below granularity ({w:?} < {GRANULARITY:?}) no wait = {:?}",
-                self.t
-            );
+            qtrace!([self], "next {cwnd}/{rtt:?} below granularity ({w:?})",);
             return self.t;
         }
 

--- a/neqo-transport/src/pace.rs
+++ b/neqo-transport/src/pace.rs
@@ -177,4 +177,18 @@ mod tests {
         p.spend(n, RTT, CWND, PACKET);
         assert_eq!(p.next(RTT, CWND), n);
     }
+
+    #[test]
+    fn send_immediately_below_granularity() {
+        const SHORT_RTT: Duration = Duration::from_millis(10);
+        let n = now();
+        let mut p = Pacer::new(true, n, PACKET, PACKET);
+        assert_eq!(p.next(SHORT_RTT, CWND), n);
+        p.spend(n, SHORT_RTT, CWND, PACKET);
+        assert_eq!(
+            p.next(SHORT_RTT, CWND),
+            n,
+            "Expect packet to be sent immediately, instead of being paced below timer granularity."
+        );
+    }
 }


### PR DESCRIPTION
Neqo assumes a timer granularity of 1ms:

https://github.com/mozilla/neqo/blob/0eb9174d7a67b250607f0c3ea056fe056bcf91f5/neqo-transport/src/rtt.rs#L25-L27

but `neqo_transport::Pacer::next()` might return values `< GRANULARITY`.

https://github.com/mozilla/neqo/blob/0eb9174d7a67b250607f0c3ea056fe056bcf91f5/neqo-transport/src/pace.rs#L71-L90

Under the assumption that a timer implementation rounds small values up to its granularity (e.g. 1ms), packets can be delayed significantly more than intended by `Pacer`.

With this commit `Pacer` does not delay packets that would previously be delayed by less than `GRANULARITY`. The downside is loss in pacing granularity.

See also:

- google/quiche
  - https://github.com/google/quiche/blob/60aec87316d24392b2ea37c391ecf406ef183074/quiche/quic/core/congestion_control/pacing_sender.cc#L167
  - https://github.com/google/quiche/blob/60aec87316d24392b2ea37c391ecf406ef183074/quiche/quic/core/quic_constants.h#L304
- quic-go
  - https://github.com/quic-go/quic-go/blob/d1f9af4cc6b13c96dc302ac9ec5f061ed294d36b/internal/protocol/params.go#L137
- `kGranularity` in RFC 9002 https://datatracker.ietf.org/doc/html/rfc9002#name-constants-of-interest

---

Initial idea from @larseggert.

Would fix performance regression in https://github.com/mozilla/neqo/pull/2008:

```
➜  neqo git:(pace-granularity) ✗ critcmp main main-no-pacing 32k 32k-no-pacing 32k-min-1ms-pacing -f "Download" --list
1-conn/1-100mb-resp (aka. Download)/client
------------------------------------------
32k-no-pacing          1.00    114.8±49.78ms   871.3 MB/sec
32k-min-1ms-pacing     1.04    119.9±63.28ms   834.2 MB/sec
main-no-pacing         1.05    121.0±83.97ms   826.4 MB/sec
main                   1.45    165.9±56.69ms   602.8 MB/sec
32k                   11.39  1307.8±1038.97ms   76.5 MB/sec
```