### PR TITLE
docs(transport): fix old/new mixup

### DIFF
--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -166,10 +166,10 @@ fn path_forwarding_attack() {
 
     // Until new data is received from the client on the old path.
     server.process_input(&client_data2, now);
-    // The server sends a probe on the "old" path.
+    // The server sends a probe on the new path.
     let server_data3 = send_something(&mut server, now);
     assert_v4_path(&server_data3, true);
-    // But switches data transmission to the "new" path.
+    // But switches data transmission to the old path.
     let server_data4 = server.process_output(now).dgram().unwrap();
     assert_v6_path(&server_data4, false);
 }


### PR DESCRIPTION
In the `path_forwarding_attack` unit test

``` rust
/// This simulates an attack where a valid packet is forwarded on
/// a different path.  This shows how both paths are probed and the
/// server eventually returns to the original path.
fn path_forwarding_attack() {
```

data is send on two paths, a IPv6 path (aka. "old") and an IPv4 path (aka. "new").

Towards the end of the test it asserts one path, but mentions the other in the doc comment.

This commit fixes the mix-up in the doc comment.

---

`new` and `old` is never quoted, but in the last two conflicting lines. Am I missing a special meaning of `old` vs. `"old"`?

Found while debugging https://github.com/mozilla/neqo/pull/2035.