### PR TITLE
add initial RTT configurability

### DIFF
--- a/neqo-bin/src/lib.rs
+++ b/neqo-bin/src/lib.rs
@@ -117,6 +117,10 @@ pub struct QuicParameters {
     /// The idle timeout for connections, in seconds.
     pub idle_timeout: u64,
 
+    #[arg(long = "init_rtt", default_value = "100")]
+    /// The initial round-trip time.
+    pub initial_rtt_ms: u64,
+
     #[arg(long = "cc", default_value = "newreno")]
     /// The congestion controller to use.
     pub congestion_control: CongestionControlAlgorithm,
@@ -222,6 +226,7 @@ impl QuicParameters {
             .max_streams(StreamType::BiDi, self.max_streams_bidi)
             .max_streams(StreamType::UniDi, self.max_streams_uni)
             .idle_timeout(Duration::from_secs(self.idle_timeout))
+            .initial_rtt(Duration::from_millis(self.initial_rtt_ms))
             .cc_algorithm(self.congestion_control)
             .pacing(!self.no_pacing)
             .pmtud(!self.no_pmtud);

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -48,7 +48,7 @@ use crate::{
     quic_datagrams::{DatagramTracking, QuicDatagrams},
     recovery::{LossRecovery, RecoveryToken, SendProfile, SentPacket},
     recv_stream::RecvStreamStats,
-    rtt::{RttEstimate, GRANULARITY, INITIAL_RTT},
+    rtt::{RttEstimate, GRANULARITY},
     send_stream::SendStream,
     stats::{Stats, StatsCell},
     stream_id::StreamType,
@@ -604,7 +604,7 @@ impl Connection {
                     // When we have no actual RTT sample, do not encode a guestimated RTT larger
                     // than the default initial RTT. (The guess can be very large under lossy
                     // conditions.)
-                    if rtt < INITIAL_RTT {
+                    if rtt < self.conn_params.get_initial_rtt() {
                         rtt
                     } else {
                         Duration::from_millis(0)
@@ -638,7 +638,7 @@ impl Connection {
     /// only use it where a more precise value is not important.
     fn pto(&self) -> Duration {
         self.paths.primary().map_or_else(
-            || RttEstimate::default().pto(self.confirmed()),
+            || RttEstimate::new(self.conn_params.get_initial_rtt()).pto(self.confirmed()),
             |p| p.borrow().rtt().pto(self.confirmed()),
         )
     }

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -10,7 +10,7 @@ pub use crate::recovery::FAST_PTO_SCALE;
 use crate::{
     connection::{ConnectionIdManager, Role, LOCAL_ACTIVE_CID_LIMIT},
     recv_stream::RECV_BUFFER_SIZE,
-    rtt::{DEFAULT_INITIAL_RTT, GRANULARITY},
+    rtt::{GRANULARITY, INITIAL_RTT},
     stream_id::StreamType,
     tparams::{self, PreferredAddress, TransportParameter, TransportParametersHandler},
     tracking::DEFAULT_ACK_DELAY,
@@ -99,7 +99,7 @@ impl Default for ConnectionParameters {
             max_streams_uni: LOCAL_STREAM_LIMIT_UNI,
             ack_ratio: DEFAULT_ACK_RATIO,
             idle_timeout: DEFAULT_IDLE_TIMEOUT,
-            initial_rtt: DEFAULT_INITIAL_RTT,
+            initial_rtt: INITIAL_RTT,
             preferred_address: PreferredAddressConfig::Default,
             datagram_size: 0,
             outgoing_datagram_queue: MAX_QUEUED_DATAGRAMS_DEFAULT,

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -10,7 +10,7 @@ pub use crate::recovery::FAST_PTO_SCALE;
 use crate::{
     connection::{ConnectionIdManager, Role, LOCAL_ACTIVE_CID_LIMIT},
     recv_stream::RECV_BUFFER_SIZE,
-    rtt::GRANULARITY,
+    rtt::{DEFAULT_INITIAL_RTT, GRANULARITY},
     stream_id::StreamType,
     tparams::{self, PreferredAddress, TransportParameter, TransportParametersHandler},
     tracking::DEFAULT_ACK_DELAY,
@@ -71,6 +71,7 @@ pub struct ConnectionParameters {
     /// acknowledgments every round trip, set the value to `5 * ACK_RATIO_SCALE`.
     /// Values less than `ACK_RATIO_SCALE` are clamped to `ACK_RATIO_SCALE`.
     ack_ratio: u8,
+    initial_rtt: Duration,
     /// The duration of the idle timeout for the connection.
     idle_timeout: Duration,
     preferred_address: PreferredAddressConfig,
@@ -98,6 +99,7 @@ impl Default for ConnectionParameters {
             max_streams_uni: LOCAL_STREAM_LIMIT_UNI,
             ack_ratio: DEFAULT_ACK_RATIO,
             idle_timeout: DEFAULT_IDLE_TIMEOUT,
+            initial_rtt: DEFAULT_INITIAL_RTT,
             preferred_address: PreferredAddressConfig::Default,
             datagram_size: 0,
             outgoing_datagram_queue: MAX_QUEUED_DATAGRAMS_DEFAULT,
@@ -269,6 +271,17 @@ impl ConnectionParameters {
     #[must_use]
     pub const fn get_datagram_size(&self) -> u64 {
         self.datagram_size
+    }
+
+    #[must_use]
+    pub const fn get_initial_rtt(&self) -> Duration {
+        self.initial_rtt
+    }
+
+    #[must_use]
+    pub const fn initial_rtt(mut self, init_rtt: Duration) -> Self {
+        self.initial_rtt = init_rtt;
+        self
     }
 
     #[must_use]

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -24,6 +24,7 @@ use crate::{
     stream_id::{StreamId, StreamType},
     tparams::{self, TransportParameter},
     tracking::PacketNumberSpace,
+    INITIAL_RTT,
 };
 
 fn default_timeout() -> Duration {
@@ -55,9 +56,9 @@ fn test_idle_timeout(client: &mut Connection, server: &mut Connection, timeout: 
 
 #[test]
 fn init_rtt_configuration() {
-    const CUSTOM_INIT_RTT: Duration = Duration::from_millis(200);
-    let client = new_client(ConnectionParameters::default().initial_rtt(CUSTOM_INIT_RTT));
-    assert_eq!(client.conn_params.get_initial_rtt(), CUSTOM_INIT_RTT);
+    let custom_init_rtt = INITIAL_RTT * 2;
+    let client = new_client(ConnectionParameters::default().initial_rtt(custom_init_rtt));
+    assert_eq!(client.conn_params.get_initial_rtt(), custom_init_rtt);
 }
 
 #[test]

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -54,6 +54,13 @@ fn test_idle_timeout(client: &mut Connection, server: &mut Connection, timeout: 
 }
 
 #[test]
+fn init_rtt_configuration() {
+    const CUSTOM_INIT_RTT: Duration = Duration::from_millis(200);
+    let client = new_client(ConnectionParameters::default().initial_rtt(CUSTOM_INIT_RTT));
+    assert_eq!(client.conn_params.get_initial_rtt(), CUSTOM_INIT_RTT);
+}
+
+#[test]
 fn idle_timeout() {
     let mut client = default_client();
     let mut server = default_server();

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -697,8 +697,8 @@ fn create_client() {
     assert!(matches!(client.state(), State::Init));
     let stats = client.stats();
     assert_default_stats(&stats);
-    assert_eq!(stats.rtt, crate::rtt::INITIAL_RTT);
-    assert_eq!(stats.rttvar, crate::rtt::INITIAL_RTT / 2);
+    assert_eq!(stats.rtt, crate::rtt::DEFAULT_INITIAL_RTT);
+    assert_eq!(stats.rttvar, crate::rtt::DEFAULT_INITIAL_RTT / 2);
 }
 
 #[test]

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -697,8 +697,8 @@ fn create_client() {
     assert!(matches!(client.state(), State::Init));
     let stats = client.stats();
     assert_default_stats(&stats);
-    assert_eq!(stats.rtt, crate::rtt::DEFAULT_INITIAL_RTT);
-    assert_eq!(stats.rttvar, crate::rtt::DEFAULT_INITIAL_RTT / 2);
+    assert_eq!(stats.rtt, crate::rtt::INITIAL_RTT);
+    assert_eq!(stats.rttvar, crate::rtt::INITIAL_RTT / 2);
 }
 
 #[test]

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -50,6 +50,8 @@ pub mod tparams;
 mod tracking;
 pub mod version;
 
+pub use rtt::INITIAL_RTT;
+
 pub use self::{
     cc::CongestionControlAlgorithm,
     cid::{

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -25,7 +25,7 @@ use crate::{
 /// `select()`, or similar) can reliably deliver; see `neqo_common::hrtime`.
 pub const GRANULARITY: Duration = Duration::from_millis(1);
 // Defined in -recovery 6.2 as 333ms but using lower value.
-pub const INITIAL_RTT: Duration = Duration::from_millis(100);
+pub const DEFAULT_INITIAL_RTT: Duration = Duration::from_millis(100);
 
 /// The source of the RTT measurement.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
@@ -219,10 +219,10 @@ impl Default for RttEstimate {
     fn default() -> Self {
         Self {
             first_sample_time: None,
-            latest_rtt: INITIAL_RTT,
-            smoothed_rtt: INITIAL_RTT,
-            rttvar: INITIAL_RTT / 2,
-            min_rtt: INITIAL_RTT,
+            latest_rtt: DEFAULT_INITIAL_RTT,
+            smoothed_rtt: DEFAULT_INITIAL_RTT,
+            rttvar: DEFAULT_INITIAL_RTT / 2,
+            min_rtt: DEFAULT_INITIAL_RTT,
             ack_delay: PeerAckDelay::default(),
             best_source: RttSource::Guesstimate,
         }

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -51,6 +51,19 @@ pub struct RttEstimate {
 }
 
 impl RttEstimate {
+    pub fn new(rtt: Duration) -> Self {
+        // Only allow this when there are no samples.
+        Self {
+            first_sample_time: None,
+            latest_rtt: rtt,
+            smoothed_rtt: rtt,
+            rttvar: rtt / 2,
+            min_rtt: rtt,
+            ack_delay: PeerAckDelay::default(),
+            best_source: RttSource::Guesstimate,
+        }
+    }
+
     fn init(&mut self, rtt: Duration) {
         // Only allow this when there are no samples.
         debug_assert!(self.first_sample_time.is_none());
@@ -217,14 +230,6 @@ impl RttEstimate {
 
 impl Default for RttEstimate {
     fn default() -> Self {
-        Self {
-            first_sample_time: None,
-            latest_rtt: INITIAL_RTT,
-            smoothed_rtt: INITIAL_RTT,
-            rttvar: INITIAL_RTT / 2,
-            min_rtt: INITIAL_RTT,
-            ack_delay: PeerAckDelay::default(),
-            best_source: RttSource::Guesstimate,
-        }
+        Self::new(INITIAL_RTT)
     }
 }

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -25,7 +25,7 @@ use crate::{
 /// `select()`, or similar) can reliably deliver; see `neqo_common::hrtime`.
 pub const GRANULARITY: Duration = Duration::from_millis(1);
 // Defined in -recovery 6.2 as 333ms but using lower value.
-pub const DEFAULT_INITIAL_RTT: Duration = Duration::from_millis(100);
+pub const INITIAL_RTT: Duration = Duration::from_millis(100);
 
 /// The source of the RTT measurement.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
@@ -219,10 +219,10 @@ impl Default for RttEstimate {
     fn default() -> Self {
         Self {
             first_sample_time: None,
-            latest_rtt: DEFAULT_INITIAL_RTT,
-            smoothed_rtt: DEFAULT_INITIAL_RTT,
-            rttvar: DEFAULT_INITIAL_RTT / 2,
-            min_rtt: DEFAULT_INITIAL_RTT,
+            latest_rtt: INITIAL_RTT,
+            smoothed_rtt: INITIAL_RTT,
+            rttvar: INITIAL_RTT / 2,
+            min_rtt: INITIAL_RTT,
             ack_delay: PeerAckDelay::default(),
             best_source: RttSource::Guesstimate,
         }


### PR DESCRIPTION
This adds configurability for the initial round-trip time, which has a use-case for something like space-applications where a higher round-trip time might be expected. This is a first draft PR, an end-to-end test with other QUIC stacks still needs to be done.