### PR TITLE
ci: Treat a QNS `null` result as a failure

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -186,6 +186,7 @@ jobs:
             fi
             jq < "$RUN/result.json" '
                 . as $data |
+                .results[][].result //= "failed" |
                 {
                   results: [.results[] | group_by(.result)[] | {(.[0].result): [.[] | .abbr]}] |
                   add


### PR DESCRIPTION
`null` happens when a client or server is deemed "not compliant" by QNS