### PR TITLE
test: Add a test case for 0-RTT loss

### DIFF
--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -177,7 +177,7 @@ pub fn new_trace(role: Role) -> qlog::TraceSeq {
                 // We can't do the obvious two-step conversion with f64::from(i32::try_from(...)),
                 // because that overflows earlier than is ideal.  This should be fine for a while.
                 #[allow(clippy::cast_precision_loss)]
-                Some(time::OffsetDateTime::now_utc().unix_timestamp() as f64)
+                Some((time::OffsetDateTime::now_utc().unix_timestamp() * 1000) as f64)
             },
             time_format: Some("relative".to_string()),
         }),

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -91,10 +91,6 @@ impl Drop for NssLoaded {
 
 static INITIALIZED: OnceLock<Res<NssLoaded>> = OnceLock::new();
 
-fn already_initialized() -> bool {
-    unsafe { nss::NSS_IsInitialized() != 0 }
-}
-
 fn version_check() -> Res<()> {
     let min_ver = CString::new(MINIMUM_NSS_VERSION)?;
     if unsafe { nss::NSS_VersionCheck(min_ver.as_ptr()) } == 0 {
@@ -102,36 +98,6 @@ fn version_check() -> Res<()> {
         return Err(Error::UnsupportedVersion);
     }
     Ok(())
-}
-
-/// Initialize NSS.  This only executes the initialization routines once, so if there is any chance
-/// that
-///
-/// # Errors
-///
-/// When NSS initialization fails.
-pub fn init() -> Res<()> {
-    // Set time zero.
-    time::init();
-    let res = INITIALIZED.get_or_init(|| {
-        version_check()?;
-        if already_initialized() {
-            return Ok(NssLoaded::External);
-        }
-
-        secstatus_to_res(unsafe { nss::NSS_NoDB_Init(null()) })?;
-        secstatus_to_res(unsafe { nss::NSS_SetDomesticPolicy() })?;
-        secstatus_to_res(unsafe {
-            p11::NSS_SetAlgorithmPolicy(
-                p11::SECOidTag::SEC_OID_XYBER768D00,
-                p11::NSS_USE_ALG_IN_SSL_KX,
-                0,
-            )
-        })?;
-
-        Ok(NssLoaded::NoDb)
-    });
-    res.as_ref().map(|_| ()).map_err(Clone::clone)
 }
 
 /// This enables SSLTRACE by calling a simple, harmless function to trigger its
@@ -145,20 +111,15 @@ fn enable_ssl_trace() -> Res<()> {
     secstatus_to_res(unsafe { ssl::SSL_OptionGetDefault(opt, &mut v) })
 }
 
-/// Initialize with a database.
-///
-/// # Errors
-///
-/// If NSS cannot be initialized.
-pub fn init_db<P: Into<PathBuf>>(dir: P) -> Res<()> {
+fn init_once(db: Option<PathBuf>) -> Res<NssLoaded> {
+    // Set time zero.
     time::init();
-    let res = INITIALIZED.get_or_init(|| {
-        version_check()?;
-        if already_initialized() {
-            return Ok(NssLoaded::External);
-        }
+    version_check()?;
+    if unsafe { nss::NSS_IsInitialized() != 0 } {
+        return Ok(NssLoaded::External);
+    }
 
-        let path = dir.into();
+    let state = if let Some(path) = db {
         if !path.is_dir() {
             return Err(Error::InternalError);
         }
@@ -175,23 +136,48 @@ pub fn init_db<P: Into<PathBuf>>(dir: P) -> Res<()> {
             )
         })?;
 
-        secstatus_to_res(unsafe { nss::NSS_SetDomesticPolicy() })?;
-        secstatus_to_res(unsafe {
-            p11::NSS_SetAlgorithmPolicy(
-                p11::SECOidTag::SEC_OID_XYBER768D00,
-                p11::NSS_USE_ALG_IN_SSL_KX,
-                0,
-            )
-        })?;
         secstatus_to_res(unsafe {
             ssl::SSL_ConfigServerSessionIDCache(1024, 0, 0, dircstr.as_ptr())
         })?;
+        NssLoaded::Db
+    } else {
+        secstatus_to_res(unsafe { nss::NSS_NoDB_Init(null()) })?;
+        NssLoaded::NoDb
+    };
 
-        #[cfg(debug_assertions)]
-        enable_ssl_trace()?;
+    secstatus_to_res(unsafe { nss::NSS_SetDomesticPolicy() })?;
+    secstatus_to_res(unsafe {
+        p11::NSS_SetAlgorithmPolicy(
+            p11::SECOidTag::SEC_OID_XYBER768D00,
+            p11::NSS_USE_ALG_IN_SSL_KX,
+            0,
+        )
+    })?;
 
-        Ok(NssLoaded::Db)
-    });
+    #[cfg(debug_assertions)]
+    enable_ssl_trace()?;
+
+    Ok(state)
+}
+
+/// Initialize NSS.  This only executes the initialization routines once, so if there is any chance
+/// that this is invoked twice, that's OK.
+///
+/// # Errors
+///
+/// When NSS initialization fails.
+pub fn init() -> Res<()> {
+    let res = INITIALIZED.get_or_init(|| init_once(None));
+    res.as_ref().map(|_| ()).map_err(Clone::clone)
+}
+
+/// Initialize with a database.
+///
+/// # Errors
+///
+/// If NSS cannot be initialized.
+pub fn init_db<P: Into<PathBuf>>(dir: P) -> Res<()> {
+    let res = INITIALIZED.get_or_init(|| init_once(Some(dir.into())));
     res.as_ref().map(|_| ()).map_err(Clone::clone)
 }
 

--- a/neqo-transport/src/connection/tests/zerortt.rs
+++ b/neqo-transport/src/connection/tests/zerortt.rs
@@ -312,7 +312,7 @@ fn zero_rtt_loss_accepted() {
         assert_eq!(client_stream_id, server_stream_id.as_u64());
 
         // 0-RTT should be accepted
-        _ = client.process(si.as_dgram_ref(), now);
+        client.process_input(si.as_dgram_ref().unwrap(), now);
         let recvd_0rtt_reject = |e| e == ConnectionEvent::ZeroRttRejected;
         assert!(
             !client.events().any(recvd_0rtt_reject),

--- a/neqo-transport/src/connection/tests/zerortt.rs
+++ b/neqo-transport/src/connection/tests/zerortt.rs
@@ -286,7 +286,7 @@ fn zero_rtt_loss_accepted() {
         // Make CI/0-RTT
         let client_stream_id = client.stream_create(StreamType::UniDi).unwrap();
         client.stream_send(client_stream_id, &[1, 2, 3]).unwrap();
-        let mut ci = client.process(None, now);
+        let mut ci = client.process_output(now);
         assert!(ci.as_dgram_ref().is_some());
         assertions::assert_coalesced_0rtt(&ci.as_dgram_ref().unwrap()[..]);
 

--- a/neqo-transport/src/connection/tests/zerortt.rs
+++ b/neqo-transport/src/connection/tests/zerortt.rs
@@ -293,8 +293,8 @@ fn zero_rtt_loss_accepted() {
         // Drop CI/0-RTT a number of times
         qdebug!("Drop CI/0-RTT {i} extra times");
         for _ in 0..i {
-            now += client.process(None, now).callback();
-            ci = client.process(None, now);
+            now += client.process_output(now).callback();
+            ci = client.process_output(now);
             assert!(ci.as_dgram_ref().is_some());
         }
 


### PR DESCRIPTION
This currently fails, because we have a bug where the server does not accept retransmitted 0-RTT packets when it should.