### PR TITLE
refactor: drop time crate in favor of std::time::SystemTime

### DIFF
--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -22,7 +22,6 @@ env_logger = { version = "0.10", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"], optional = true }
 log = { workspace = true }
 qlog = { workspace = true }
-time = { version = "0.3", default-features = false, features = ["formatting"] }
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -153,7 +153,6 @@ impl Drop for NeqoQlogShared {
     }
 }
 
-#[allow(clippy::missing_panics_doc)]
 #[must_use]
 pub fn new_trace(role: Role) -> qlog::TraceSeq {
     TraceSeq {
@@ -174,15 +173,10 @@ pub fn new_trace(role: Role) -> qlog::TraceSeq {
         common_fields: Some(CommonFields {
             group_id: None,
             protocol_type: None,
-            reference_time: {
-                Some(
-                    SystemTime::now()
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .expect("expect UNIX_EPOCH to always be earlier than now")
-                        .as_secs_f64()
-                        * 1_000.0,
-                )
-            },
+            reference_time: SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_secs_f64() * 1_000.0)
+                .ok(),
             time_format: Some("relative".to_string()),
         }),
     }

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -175,15 +175,12 @@ pub fn new_trace(role: Role) -> qlog::TraceSeq {
             group_id: None,
             protocol_type: None,
             reference_time: {
-                // It is better to allow this than deal with a conversion from u128 to f64.
-                // We can't do the obvious two-step conversion with f64::from(i32::try_from(...)),
-                // because that overflows earlier than is ideal.  This should be fine for a while.
-                #[allow(clippy::cast_precision_loss)]
                 Some(
                     SystemTime::now()
                         .duration_since(SystemTime::UNIX_EPOCH)
                         .expect("expect UNIX_EPOCH to always be earlier than now")
-                        .as_millis() as f64,
+                        .as_secs_f64()
+                        * 1_000.0,
                 )
             },
             time_format: Some("relative".to_string()),


### PR DESCRIPTION
Follow-up to https://github.com/mozilla/neqo/pull/2053.