### PR TITLE
fix: Don't process timers during Closing or Draining

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -949,8 +949,9 @@ impl Connection {
                     let st = State::Closed(error.clone());
                     self.set_state(st);
                     qinfo!("Closing timer expired");
-                    return;
                 }
+                // Don't do anything else in these states.
+                return;
             }
             State::Closed(_) => {
                 qdebug!("Timer fired while closed");

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -949,9 +949,8 @@ impl Connection {
                     let st = State::Closed(error.clone());
                     self.set_state(st);
                     qinfo!("Closing timer expired");
+                    return;
                 }
-                // Don't do anything else in these states.
-                return;
             }
             State::Closed(_) => {
                 qdebug!("Timer fired while closed");
@@ -964,6 +963,11 @@ impl Connection {
         if self.idle_timeout.expired(now, pto) {
             qinfo!([self], "idle timeout expired");
             self.set_state(State::Closed(CloseReason::Transport(Error::IdleTimeout)));
+            return;
+        }
+
+        if self.state.closing() {
+            qdebug!([self], "Closing, not processing other timers");
             return;
         }
 

--- a/neqo-transport/src/connection/state.rs
+++ b/neqo-transport/src/connection/state.rs
@@ -76,6 +76,11 @@ impl State {
             None
         }
     }
+
+    #[must_use]
+    pub const fn closing(&self) -> bool {
+        matches!(self, Self::Closing { .. } | Self::Draining { .. })
+    }
 }
 
 // Implement `PartialOrd` so that we can enforce monotonic state progression.


### PR DESCRIPTION
The current code doesn't seem to cause any packets to go out when closing, but is a bit wasteful (and also confused me when I saw timers fire in the logs...)