### PR TITLE
fix: Don't stop handler if there is no resumption token

### DIFF
--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -94,10 +94,7 @@ impl<'a> super::Handler for Handler<'a> {
         }
 
         if self.args.resume && self.token.is_none() {
-            let Some(token) = client.take_resumption_token(Instant::now()) else {
-                return Ok(false);
-            };
-            self.token = Some(token);
+            self.token = client.take_resumption_token(Instant::now());
         }
 
         Ok(true)


### PR DESCRIPTION
s2n-quic doesn't send a resumption token for the second connection in the QNS `resumption` test, and this caused us to fail.