### PR TITLE
ci: Empty all QNS logs >5MB before artifact upload

### DIFF
--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -78,12 +78,16 @@ runs:
           if grep -q 'RUST_BACKTRACE=full' "$log"; then
             echo "Panic detected in $log"
             tail -n 50 "$log"
-            exit 1
+            FAILED=1
           fi
         done
+        # Remove all log files >10MB to make the artifacts smaller.
+        find ../logs -type f -size +10M -ls -delete
+        exit $FAILED
       shell: bash
 
     - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+      if: always()
       id: upload-logs
       with:
         name: '${{ inputs.client }} vs. ${{ inputs.server }} logs'
@@ -91,6 +95,7 @@ runs:
         compression-level: 9
 
     - name: Store log URL
+      if: always()
       run: |
         jq '. + {log_url: "${{ steps.upload-logs.outputs.artifact-url }}"}' \
           < result.json  > result.json.tmp && \
@@ -98,6 +103,7 @@ runs:
       shell: bash
 
     - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+      if: always()
       with:
         name: '${{ inputs.client }} vs. ${{ inputs.server }} results'
         path: |

--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -81,8 +81,10 @@ runs:
             FAILED=1
           fi
         done
-        # Remove all log files >10MB to make the artifacts smaller.
-        find ../logs -type f -size +10M -ls -delete
+        MAX_SIZE=5M
+        # Remove all log files > $MAX_SIZE to make the artifacts smaller.
+        echo "Removing these log files > $MAX_SIZE:"
+        find ../logs -type f -size +$MAX_SIZE -ls -delete
         exit $FAILED
       shell: bash
 

--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -81,10 +81,11 @@ runs:
             FAILED=1
           fi
         done
-        MAX_SIZE=5M
         # Remove all log files > $MAX_SIZE to make the artifacts smaller.
+        MAX_SIZE=5M
+        echo "Removed log file > $MAX_SIZE during GitHub workflow" > note.txt
         echo "Removing these log files > $MAX_SIZE:"
-        find ../logs -type f -size +$MAX_SIZE -ls -delete
+        find ../logs -type f -size +$MAX_SIZE -ls -exec cp note.txt {} \;
         exit $FAILED
       shell: bash
 


### PR DESCRIPTION
Because these artifacts are huge and those logs are not useful for debugging.