### PR TITLE
feat(transport): add ecn metrics to Stats

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1455,7 +1455,9 @@ impl Connection {
     ) {
         let space = PacketNumberSpace::from(packet.packet_type());
         if let Some(space) = self.acks.get_mut(space) {
-            *space.ecn_marks() += d.tos().into();
+            let space_ecn_marks = space.ecn_marks();
+            *space_ecn_marks += d.tos().into();
+            self.stats.borrow_mut().ecn_rx = *space_ecn_marks;
         } else {
             qtrace!("Not tracking ECN for dropped packet number space");
         }
@@ -2422,7 +2424,10 @@ impl Connection {
                 self.loss_recovery.on_packet_sent(path, initial);
             }
             path.borrow_mut().add_sent(packets.len());
-            Ok(SendOption::Yes(path.borrow_mut().datagram(packets)))
+            Ok(SendOption::Yes(
+                path.borrow_mut()
+                    .datagram(packets, &mut self.stats.borrow_mut()),
+            ))
         }
     }
 

--- a/neqo-transport/src/ecn.rs
+++ b/neqo-transport/src/ecn.rs
@@ -69,6 +69,13 @@ impl EcnValidationState {
 }
 
 /// The counts for different ECN marks.
+///
+/// Note: [`EcnCount`] is used both for outgoing UDP datagrams, returned by
+/// remote through QUIC ACKs and for incoming UDP datagrams, read from IP TOS
+/// header. In the former case, given that QUIC ACKs only carry Ect0, Ect1 and
+/// Ce, but never NotEct, the NotEct value will always be 0.
+///
+/// See also <https://www.rfc-editor.org/rfc/rfc9000.html#section-19.3.2>.
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Default)]
 pub struct EcnCount(EnumMap<IpTosEcn, u64>);
 

--- a/neqo-transport/src/ecn.rs
+++ b/neqo-transport/src/ecn.rs
@@ -56,14 +56,14 @@ impl EcnValidationState {
         let old = std::mem::replace(self, new);
 
         match old {
-            EcnValidationState::Testing { .. } | EcnValidationState::Unknown => {}
-            EcnValidationState::Failed => debug_assert!(false, "Failed is a terminal state"),
-            EcnValidationState::Capable => stats.ecn_paths_capable -= 1,
+            Self::Testing { .. } | Self::Unknown => {}
+            Self::Failed => debug_assert!(false, "Failed is a terminal state"),
+            Self::Capable => stats.ecn_paths_capable -= 1,
         }
         match new {
-            EcnValidationState::Testing { .. } | EcnValidationState::Unknown => {}
-            EcnValidationState::Failed => stats.ecn_paths_not_capable += 1,
-            EcnValidationState::Capable => stats.ecn_paths_capable += 1,
+            Self::Testing { .. } | Self::Unknown => {}
+            Self::Failed => stats.ecn_paths_not_capable += 1,
+            Self::Capable => stats.ecn_paths_capable += 1,
         }
     }
 }

--- a/neqo-transport/src/ecn.rs
+++ b/neqo-transport/src/ecn.rs
@@ -72,8 +72,9 @@ impl EcnValidationState {
 ///
 /// Note: [`EcnCount`] is used both for outgoing UDP datagrams, returned by
 /// remote through QUIC ACKs and for incoming UDP datagrams, read from IP TOS
-/// header. In the former case, given that QUIC ACKs only carry Ect0, Ect1 and
-/// Ce, but never NotEct, the NotEct value will always be 0.
+/// header. In the former case, given that QUIC ACKs only carry
+/// [`IpTosEcn::Ect0`], [`IpTosEcn::Ect1`] and [`IpTosEcn::Ce`], but never
+/// [`IpTosEcn::NotEct`], the [`IpTosEcn::NotEct`] value will always be 0.
 ///
 /// See also <https://www.rfc-editor.org/rfc/rfc9000.html#section-19.3.2>.
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Default)]

--- a/neqo-transport/src/ecn.rs
+++ b/neqo-transport/src/ecn.rs
@@ -12,6 +12,7 @@ use neqo_common::{qdebug, qinfo, qwarn, IpTosEcn};
 use crate::{
     packet::{PacketNumber, PacketType},
     recovery::SentPacket,
+    Stats,
 };
 
 /// The number of packets to use for testing a path for ECN capability.
@@ -25,7 +26,7 @@ const ECN_TEST_COUNT_INITIAL_PHASE: usize = 3;
 
 /// The state information related to testing a path for ECN capability.
 /// See RFC9000, Appendix A.4.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 enum EcnValidationState {
     /// The path is currently being tested for ECN capability, with the number of probes sent so
     /// far on the path during the ECN validation.
@@ -46,6 +47,23 @@ impl Default for EcnValidationState {
         Self::Testing {
             probes_sent: 0,
             initial_probes_lost: 0,
+        }
+    }
+}
+
+impl EcnValidationState {
+    fn set(&mut self, new: Self, stats: &mut Stats) {
+        let old = std::mem::replace(self, new);
+
+        match old {
+            EcnValidationState::Testing { .. } | EcnValidationState::Unknown => {}
+            EcnValidationState::Failed => debug_assert!(false, "Failed is a terminal state"),
+            EcnValidationState::Capable => stats.ecn_paths_capable -= 1,
+        }
+        match new {
+            EcnValidationState::Testing { .. } | EcnValidationState::Unknown => {}
+            EcnValidationState::Failed => stats.ecn_paths_not_capable += 1,
+            EcnValidationState::Capable => stats.ecn_paths_capable += 1,
         }
     }
 }
@@ -126,13 +144,13 @@ impl EcnInfo {
     /// Exit ECN validation if the number of packets sent exceeds `ECN_TEST_COUNT`.
     /// We do not implement the part of the RFC that says to exit ECN validation if the time since
     /// the start of ECN validation exceeds 3 * PTO, since this seems to happen much too quickly.
-    pub fn on_packet_sent(&mut self) {
+    pub fn on_packet_sent(&mut self, stats: &mut Stats) {
         if let EcnValidationState::Testing { probes_sent, .. } = &mut self.state {
             *probes_sent += 1;
             qdebug!("ECN probing: sent {} probes", probes_sent);
             if *probes_sent == ECN_TEST_COUNT {
                 qdebug!("ECN probing concluded with {} probes sent", probes_sent);
-                self.state = EcnValidationState::Unknown;
+                self.state.set(EcnValidationState::Unknown, stats);
             }
         }
     }
@@ -144,16 +162,17 @@ impl EcnInfo {
         &mut self,
         acked_packets: &[SentPacket],
         ack_ecn: Option<EcnCount>,
+        stats: &mut Stats,
     ) -> bool {
         let prev_baseline = self.baseline;
 
-        self.validate_ack_ecn_and_update(acked_packets, ack_ecn);
+        self.validate_ack_ecn_and_update(acked_packets, ack_ecn, stats);
 
         matches!(self.state, EcnValidationState::Capable)
             && (self.baseline - prev_baseline)[IpTosEcn::Ce] > 0
     }
 
-    pub fn on_packets_lost(&mut self, lost_packets: &[SentPacket]) {
+    pub fn on_packets_lost(&mut self, lost_packets: &[SentPacket], stats: &mut Stats) {
         if let EcnValidationState::Testing {
             probes_sent,
             initial_probes_lost: probes_lost,
@@ -170,7 +189,7 @@ impl EcnInfo {
                     "ECN validation failed, all {} initial marked packets were lost",
                     probes_lost
                 );
-                self.state = EcnValidationState::Failed;
+                self.state.set(EcnValidationState::Failed, stats);
             }
         }
     }
@@ -180,6 +199,7 @@ impl EcnInfo {
         &mut self,
         acked_packets: &[SentPacket],
         ack_ecn: Option<EcnCount>,
+        stats: &mut Stats,
     ) {
         // RFC 9000, Appendix A.4:
         //
@@ -212,7 +232,7 @@ impl EcnInfo {
         // > corresponding ECN counts are not present in the ACK frame.
         let Some(ack_ecn) = ack_ecn else {
             qwarn!("ECN validation failed, no ECN counts in ACK frame");
-            self.state = EcnValidationState::Failed;
+            self.state.set(EcnValidationState::Failed, stats);
             return;
         };
 
@@ -229,7 +249,7 @@ impl EcnInfo {
             .unwrap();
         if newly_acked_sent_with_ect0 == 0 {
             qwarn!("ECN validation failed, no ECT(0) packets were newly acked");
-            self.state = EcnValidationState::Failed;
+            self.state.set(EcnValidationState::Failed, stats);
             return;
         }
         let ecn_diff = ack_ecn - self.baseline;
@@ -240,15 +260,16 @@ impl EcnInfo {
                 sum_inc,
                 newly_acked_sent_with_ect0
             );
-            self.state = EcnValidationState::Failed;
+            self.state.set(EcnValidationState::Failed, stats);
         } else if ecn_diff[IpTosEcn::Ect1] > 0 {
             qwarn!("ECN validation failed, ACK counted ECT(1) marks that were never sent");
-            self.state = EcnValidationState::Failed;
+            self.state.set(EcnValidationState::Failed, stats);
         } else if self.state != EcnValidationState::Capable {
             qinfo!("ECN validation succeeded, path is capable");
-            self.state = EcnValidationState::Capable;
+            self.state.set(EcnValidationState::Capable, stats);
         }
         self.baseline = ack_ecn;
+        stats.ecn_tx = ack_ecn;
         self.largest_acked = largest_acked;
     }
 

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -16,7 +16,7 @@ use std::{
 
 use neqo_common::qwarn;
 
-use crate::packet::PacketNumber;
+use crate::{ecn::EcnCount, packet::PacketNumber};
 
 pub const MAX_PTO_COUNTS: usize = 16;
 
@@ -166,6 +166,15 @@ pub struct Stats {
     pub incoming_datagram_dropped: usize,
 
     pub datagram_tx: DatagramStats,
+
+    /// Number of paths known to be ECN capable.
+    pub ecn_paths_capable: usize,
+    /// Number of paths known to be ECN incapable.
+    pub ecn_paths_not_capable: usize,
+    /// ECN counts for outgoing UDP datagrams, returned by remote through QUIC ACKs.
+    pub ecn_tx: EcnCount,
+    /// ECN counts for incoming UDP datagrams, read from IP TOS header.
+    pub ecn_rx: EcnCount,
 }
 
 impl Stats {
@@ -222,7 +231,12 @@ impl Debug for Stats {
         writeln!(f, "  frames rx:")?;
         self.frame_rx.fmt(f)?;
         writeln!(f, "  frames tx:")?;
-        self.frame_tx.fmt(f)
+        self.frame_tx.fmt(f)?;
+        writeln!(
+            f,
+            "  ecn: {:?} for tx {:?} for rx {} capable paths {} not capable paths",
+            self.ecn_tx, self.ecn_rx, self.ecn_paths_capable, self.ecn_paths_not_capable
+        )
     }
 }
 

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -172,6 +172,11 @@ pub struct Stats {
     /// Number of paths known to be ECN incapable.
     pub ecn_paths_not_capable: usize,
     /// ECN counts for outgoing UDP datagrams, returned by remote through QUIC ACKs.
+    ///
+    /// Note: Given that QUIC ACKs only carry Ect0, Ect1 and Ce, but never
+    /// NotEct, the NotEct value will always be 0.
+    ///
+    /// See also <https://www.rfc-editor.org/rfc/rfc9000.html#section-19.3.2>.
     pub ecn_tx: EcnCount,
     /// ECN counts for incoming UDP datagrams, read from IP TOS header.
     pub ecn_rx: EcnCount,

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -173,12 +173,15 @@ pub struct Stats {
     pub ecn_paths_not_capable: usize,
     /// ECN counts for outgoing UDP datagrams, returned by remote through QUIC ACKs.
     ///
-    /// Note: Given that QUIC ACKs only carry [`crate::ecn::IpTosEcn::Ect0`],
-    /// [`crate::ecn::IpTosEcn::Ect1`] and [`crate::ecn::IpTosEcn::Ce`], but
-    /// never [`crate::ecn::IpTosEcn::NotEct`], the
-    /// [`crate::ecn::IpTosEcn::NotEct`] value will always be 0.
+    /// Note: Given that QUIC ACKs only carry [`Ect0`], [`Ect1`] and [`Ce`], but
+    /// never [`NotEct`], the [`NotEct`] value will always be 0.
     ///
     /// See also <https://www.rfc-editor.org/rfc/rfc9000.html#section-19.3.2>.
+    ///
+    /// [`Ect0`]: neqo_common::tos::IpTosEcn::Ect0
+    /// [`Ect1`]: neqo_common::tos::IpTosEcn::Ect1
+    /// [`Ce`]: neqo_common::tos::IpTosEcn::Ce
+    /// [`NotEct`]: neqo_common::tos::IpTosEcn::NotEct
     pub ecn_tx: EcnCount,
     /// ECN counts for incoming UDP datagrams, read from IP TOS header.
     pub ecn_rx: EcnCount,

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -173,8 +173,10 @@ pub struct Stats {
     pub ecn_paths_not_capable: usize,
     /// ECN counts for outgoing UDP datagrams, returned by remote through QUIC ACKs.
     ///
-    /// Note: Given that QUIC ACKs only carry Ect0, Ect1 and Ce, but never
-    /// NotEct, the NotEct value will always be 0.
+    /// Note: Given that QUIC ACKs only carry [`crate::ecn::IpTosEcn::Ect0`],
+    /// [`crate::ecn::IpTosEcn::Ect1`] and [`crate::ecn::IpTosEcn::Ce`], but
+    /// never [`crate::ecn::IpTosEcn::NotEct`], the
+    /// [`crate::ecn::IpTosEcn::NotEct`] value will always be 0.
     ///
     /// See also <https://www.rfc-editor.org/rfc/rfc9000.html#section-19.3.2>.
     pub ecn_tx: EcnCount,


### PR DESCRIPTION
Adding 4 ECN metrics to `neqo-transport` `Stats`:

``` rust
    /// Number of paths known to be ECN capable.
    pub ecn_paths_capable: usize,
    /// Number of paths known to be ECN incapable.
    pub ecn_paths_not_capable: usize,
    /// ECN counts for outgoing UDP datagrams, returned by remote through QUIC ACKs.
    pub ecn_tx: EcnCount,
    /// ECN counts for incoming UDP datagrams, read from IP TOS header.
    pub ecn_rx: EcnCount,
```

---

Fixes https://github.com/mozilla/neqo/issues/2068.

Corresponding Phabricator Differential: https://phabricator.services.mozilla.com/D220062