### PR TITLE
test(transport/ecn): cover disable on remark

### DIFF
--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -614,6 +614,18 @@ fn send_something(sender: &mut Connection, now: Instant) -> Datagram {
     send_something_with_modifier(sender, now, Some)
 }
 
+/// Send something on a stream from `sender` through a modifier to `receiver`.
+/// Return any ACK that might result.
+fn send_with_modifier_and_receive(
+    sender: &mut Connection,
+    receiver: &mut Connection,
+    now: Instant,
+    modifier: fn(Datagram) -> Option<Datagram>,
+) -> Option<Datagram> {
+    let dgram = send_something_with_modifier(sender, now, modifier);
+    receiver.process(Some(&dgram), now).dgram()
+}
+
 /// Send something on a stream from `sender` to `receiver`.
 /// Return any ACK that might result.
 fn send_and_receive(
@@ -621,8 +633,7 @@ fn send_and_receive(
     receiver: &mut Connection,
     now: Instant,
 ) -> Option<Datagram> {
-    let dgram = send_something(sender, now);
-    receiver.process(Some(&dgram), now).dgram()
+    send_with_modifier_and_receive(sender, receiver, now, Some)
 }
 
 fn get_tokens(client: &mut Connection) -> Vec<ResumptionToken> {


### PR DESCRIPTION
Add test coverage for validation failing on `Ect1`.

https://github.com/mozilla/neqo/blob/15cae9be1529e327e575fb7c799acc7521691337/neqo-transport/src/ecn.rs#L244-L246

See missing coverage reported in https://github.com/mozilla/neqo/pull/2072.