### PR TITLE
perf: don't allocate in UDP recv path

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -136,5 +136,6 @@ jobs:
 
   bench:
     name: "Benchmark"
-    needs: [check]
+    # TODO
+    # needs: [check]
     uses: ./.github/workflows/bench.yml

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -13,6 +13,9 @@ pub struct Datagram {
     src: SocketAddr,
     dst: SocketAddr,
     tos: IpTos,
+    /// The segment size if this transmission contains multiple datagrams.
+    /// This is `None` if the [`Datagram`] only contains a single datagram
+    segment_size: Option<usize>,
     d: Vec<u8>,
 }
 
@@ -22,6 +25,23 @@ impl Datagram {
             src,
             dst,
             tos,
+            segment_size: None,
+            d: d.into(),
+        }
+    }
+
+    pub fn new_with_segment_size<V: Into<Vec<u8>>>(
+        src: SocketAddr,
+        dst: SocketAddr,
+        tos: IpTos,
+        segment_size: usize,
+        d: V,
+    ) -> Self {
+        Self {
+            src,
+            dst,
+            tos,
+            segment_size: Some(segment_size),
             d: d.into(),
         }
     }
@@ -43,6 +63,14 @@ impl Datagram {
 
     pub fn set_tos(&mut self, tos: IpTos) {
         self.tos = tos;
+    }
+
+    pub fn into_recv_buf(self) -> Vec<u8> {
+        self.d
+    }
+
+    pub fn segment_size(&self) -> Option<usize> {
+        self.segment_size
     }
 }
 

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -333,11 +333,7 @@ fn setup_standalone(nss: &str) -> Vec<String> {
         "cargo:rustc-link-search=native={}",
         nsslibdir.to_str().unwrap()
     );
-    if is_debug() || env::consts::OS == "windows" {
-        static_link();
-    } else {
-        dynamic_link();
-    }
+    static_link();
 
     let mut flags: Vec<String> = Vec::new();
     for i in includes {

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -21,7 +21,7 @@ use quinn_udp::{EcnCodepoint, RecvMeta, Transmit, UdpSocketState};
 /// Allows reading multiple datagrams in a single [`Socket::recv`] call.
 //
 // TODO: Experiment with different values across platforms.
-const RECV_BUF_SIZE: usize = u16::MAX as usize;
+pub const RECV_BUF_SIZE: usize = u16::MAX as usize;
 
 std::thread_local! {
     static RECV_BUF: RefCell<Vec<u8>> = RefCell::new(vec![0; RECV_BUF_SIZE]);
@@ -114,6 +114,64 @@ pub fn recv_inner(
     );
 
     Ok(dgrams)
+}
+
+pub fn recv_inner_2(
+    local_address: &SocketAddr,
+    state: &UdpSocketState,
+    socket: impl SocketRef,
+    mut recv_buf: Vec<u8>,
+) -> Result<Datagram, (io::Error, Vec<u8>)> {
+    assert_eq!(recv_buf.capacity(), RECV_BUF_SIZE);
+    // TODO: unsafe worth it here?
+    unsafe {
+        recv_buf.set_len(RECV_BUF_SIZE);
+    }
+
+    let mut meta;
+
+    loop {
+        meta = RecvMeta::default();
+
+        if let Err(e) = state.recv(
+            (&socket).into(),
+            &mut [IoSliceMut::new(recv_buf.as_mut())],
+            slice::from_mut(&mut meta),
+        ) {
+            return Err((e, recv_buf));
+        }
+
+        if meta.len == 0 || meta.stride == 0 {
+            qdebug!(
+                "ignoring datagram from {} to {} len {} stride {}",
+                meta.addr,
+                local_address,
+                meta.len,
+                meta.stride
+            );
+            continue;
+        }
+
+        recv_buf.truncate(meta.len);
+
+        break;
+    }
+
+    qtrace!(
+        "received {} bytes from {} to {} with {} segments",
+        recv_buf.len(),
+        meta.addr,
+        local_address,
+        meta.len.div_ceil(meta.stride),
+    );
+
+    Ok(Datagram::new_with_segment_size(
+        meta.addr,
+        *local_address,
+        meta.ecn.map(|n| IpTos::from(n as u8)).unwrap_or_default(),
+        meta.stride,
+        recv_buf,
+    ))
 }
 
 /// A wrapper around a UDP socket, sending and receiving [`Datagram`]s.


### PR DESCRIPTION
Previously `neqo-udp` would have one long-lived receive buffer, but after reading into the buffer from the socket, it would allocate a new `Vec` for each UDP segment.

This commit does not allocate each UDP segment in a new `Vec`, but instead passes the single re-used receive buffer to
`neqo_transport::Connection::process_input` directly.

Part of https://github.com/mozilla/neqo/issues/1693.

---

Draft for now. Want to see benchmark results before investing further.