### PR TITLE
chore: Switch to the `windows` crate

### DIFF
--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -25,7 +25,7 @@ qlog = { workspace = true }
 
 [target."cfg(windows)".dependencies]
 # Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
-windows = { version = "0.58", features = ["Win32_Media"] }
+windows = { version = "0.58", default-features = false, features = ["Win32_Media"] }
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -23,16 +23,16 @@ hex = { version = "0.4", default-features = false, features = ["alloc"], optiona
 log = { workspace = true }
 qlog = { workspace = true }
 
+[target."cfg(windows)".dependencies]
+# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
+windows = { version = "0.58", features = ["Win32_Media"] }
+
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }
 
 [features]
 ci = []
 build-fuzzing-corpus = ["hex"]
-
-[target."cfg(windows)".dependencies.winapi]
-version = "0.3"
-features = ["timeapi"]
 
 [lib]
 # See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/neqo-common/src/hrtime.rs
+++ b/neqo-common/src/hrtime.rs
@@ -11,9 +11,7 @@ use std::{
 };
 
 #[cfg(windows)]
-use winapi::shared::minwindef::UINT;
-#[cfg(windows)]
-use winapi::um::timeapi::{timeBeginPeriod, timeEndPeriod};
+use windows::Win32::Media::{timeBeginPeriod, timeEndPeriod};
 
 /// A quantized `Duration`.  This currently just produces 16 discrete values
 /// corresponding to whole milliseconds.  Future implementations might choose
@@ -26,8 +24,8 @@ impl Period {
     const MIN: Self = Self(1);
 
     #[cfg(windows)]
-    fn as_uint(self) -> UINT {
-        UINT::from(self.0)
+    fn as_u32(self) -> u32 {
+        u32::from(self.0)
     }
 
     #[cfg(target_os = "macos")]
@@ -299,7 +297,7 @@ impl Time {
     #[cfg(target_os = "windows")]
     fn start(&self) {
         if let Some(p) = self.active {
-            _ = unsafe { timeBeginPeriod(p.as_uint()) };
+            _ = unsafe { timeBeginPeriod(p.as_u32()) };
         }
     }
 
@@ -310,7 +308,7 @@ impl Time {
     #[cfg(windows)]
     fn stop(&self) {
         if let Some(p) = self.active {
-            _ = unsafe { timeEndPeriod(p.as_uint()) };
+            _ = unsafe { timeEndPeriod(p.as_u32()) };
         }
     }
 


### PR DESCRIPTION
The `winapi` crate isn't being updated anymore, and the `windows` crate is a more modern alternative maintained by Microsoft.