### PR TITLE
test(transport/connection): apply modifier after Output::Callback

### DIFF
--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -586,10 +586,10 @@ fn send_something_paced_with_modifier(
                 .dgram()
                 .expect("send_something: should have something to send")
         }
-        Output::Datagram(d) => modifier(d).unwrap(),
+        Output::Datagram(d) => d,
         Output::None => panic!("send_something: got Output::None"),
     };
-    (dgram, now)
+    (modifier(dgram).unwrap(), now)
 }
 
 fn send_something_paced(


### PR DESCRIPTION
Previously `send_something_paced_with_modifier` would only apply the `modifier` if `sender.process_output` returned a `Output::Datagram` right away, but not when `sender.process_ouput` returned a datagram after returning a `Output::Callback`.

With this commit, `modifier` is always applied.

---

I am assuming this was the original intention of the function. Am I missing something?