### PR TITLE
fix: Handle migrating to a path that is an ECN blackhole

### DIFF
--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -106,8 +106,8 @@ fn migration_delay_to_ecn_blackhole() {
         .migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR_V4), false, now)
         .unwrap();
 
-    // The client should send MAX_PATH_PROBES path challenges with ECN enabled, and then another one
-    // without ECN.
+    // The client should send MAX_PATH_PROBES path challenges with ECN enabled, and then another
+    // MAX_PATH_PROBES without ECN.
     let mut probes = 0;
     while probes <= MAX_PATH_PROBES + 1 {
         match client.process_output(now) {

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -98,7 +98,7 @@ fn migration_delay_to_ecn_blackhole() {
     let mut client = default_client();
     let mut server = default_server();
 
-    // Do a handshake,
+    // Do a handshake.
     connect_force_idle(&mut client, &mut server);
 
     // Migrate the client.

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -19,6 +19,7 @@ use crate::{
         send_something, send_something_with_modifier, send_with_modifier_and_receive, DEFAULT_RTT,
     },
     ecn::ECN_TEST_COUNT,
+    path::MAX_PATH_PROBES,
     ConnectionId, ConnectionParameters, StreamType,
 };
 
@@ -89,6 +90,48 @@ fn handshake_delay_with_ecn_blackhole() {
         15,
         "expected 6 RTT for client to detect blackhole, 6 RTT for server to detect blackhole and 3 RTT for handshake to be confirmed.",
     );
+}
+
+#[test]
+fn migration_delay_to_ecn_blackhole() {
+    let mut now = now();
+    let mut client = default_client();
+    let mut server = default_server();
+
+    // Do a handshake,
+    connect_force_idle(&mut client, &mut server);
+
+    // Migrate the client.
+    client
+        .migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR_V4), false, now)
+        .unwrap();
+
+    // The client should send MAX_PATH_PROBES path challenges with ECN enabled, and then another one
+    // without ECN.
+    let mut probes = 0;
+    while probes <= MAX_PATH_PROBES + 1 {
+        match client.process_output(now) {
+            crate::Output::Callback(t) => {
+                now += t;
+            }
+            crate::Output::Datagram(d) => {
+                // The new path is IPv4.
+                if d.source().is_ipv4() {
+                    // This should be a PATH_CHALLENGE.
+                    assert_eq!(client.stats().frame_tx.path_challenge, probes + 1);
+                    probes += 1;
+                    if probes <= MAX_PATH_PROBES {
+                        // The first probes should be sent with ECN.
+                        assert_ecn_enabled(d.tos());
+                    } else {
+                        // The next probe should be sent without ECN.
+                        assert_ecn_disabled(d.tos());
+                    }
+                }
+            }
+            crate::Output::None => panic!("unexpected output"),
+        }
+    }
 }
 
 #[test]

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -109,7 +109,7 @@ fn migration_delay_to_ecn_blackhole() {
     // The client should send MAX_PATH_PROBES path challenges with ECN enabled, and then another
     // MAX_PATH_PROBES without ECN.
     let mut probes = 0;
-    while probes <= MAX_PATH_PROBES + 1 {
+    while probes <= MAX_PATH_PROBES * 2 {
         match client.process_output(now) {
             crate::Output::Callback(t) => {
                 now += t;

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -109,7 +109,7 @@ fn migration_delay_to_ecn_blackhole() {
     // The client should send MAX_PATH_PROBES path challenges with ECN enabled, and then another
     // MAX_PATH_PROBES without ECN.
     let mut probes = 0;
-    while probes <= MAX_PATH_PROBES * 2 {
+    while probes < MAX_PATH_PROBES * 2 {
         match client.process_output(now) {
             crate::Output::Callback(t) => {
                 now += t;

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -124,7 +124,7 @@ fn migration_delay_to_ecn_blackhole() {
                         // The first probes should be sent with ECN.
                         assert_ecn_enabled(d.tos());
                     } else {
-                        // The next probe should be sent without ECN.
+                        // The next probes should be sent without ECN.
                         assert_ecn_disabled(d.tos());
                     }
                 }

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -118,8 +118,8 @@ fn migration_delay_to_ecn_blackhole() {
                 // The new path is IPv4.
                 if d.source().is_ipv4() {
                     // This should be a PATH_CHALLENGE.
-                    assert_eq!(client.stats().frame_tx.path_challenge, probes + 1);
                     probes += 1;
+                    assert_eq!(client.stats().frame_tx.path_challenge, probes);
                     if probes <= MAX_PATH_PROBES {
                         // The first probes should be sent with ECN.
                         assert_ecn_enabled(d.tos());

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -28,6 +28,7 @@ use crate::{
     connection::tests::send_something_paced,
     frame::FRAME_TYPE_NEW_CONNECTION_ID,
     packet::PacketBuilder,
+    path::MAX_PATH_PROBES,
     pmtud::Pmtud,
     tparams::{self, PreferredAddress, TransportParameter},
     CloseReason, ConnectionId, ConnectionIdDecoder, ConnectionIdGenerator, ConnectionIdRef,
@@ -236,7 +237,8 @@ fn migrate_immediate_fail() {
     let probe = client.process_output(now).dgram().unwrap();
     assert_v4_path(&probe, true); // Contains PATH_CHALLENGE.
 
-    for _ in 0..2 {
+    // -1 because first PATH_CHALLENGE already sent above
+    for _ in 0..MAX_PATH_PROBES * 2 - 1 {
         let cb = client.process_output(now).callback();
         assert_ne!(cb, Duration::new(0, 0));
         now += cb;
@@ -311,7 +313,8 @@ fn migrate_same_fail() {
     let probe = client.process_output(now).dgram().unwrap();
     assert_v6_path(&probe, true); // Contains PATH_CHALLENGE.
 
-    for _ in 0..2 {
+    // -1 because first PATH_CHALLENGE already sent above
+    for _ in 0..MAX_PATH_PROBES * 2 - 1 {
         let cb = client.process_output(now).callback();
         assert_ne!(cb, Duration::new(0, 0));
         now += cb;

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -35,6 +35,9 @@ use crate::{
 };
 
 /// The number of times that a path will be probed before it is considered failed.
+///
+/// Note that with [`crate::ecn`], a path is probed [`MAX_PATH_PROBES`] with ECN
+/// marks and [`MAX_PATH_PROBES`] without.
 pub const MAX_PATH_PROBES: usize = 3;
 /// The maximum number of paths that `Paths` will track.
 const MAX_PATHS: usize = 15;

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -15,7 +15,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{hex, qdebug, qinfo, qlog::NeqoQlog, qtrace, Datagram, Encoder, IpTos};
+use neqo_common::{hex, qdebug, qinfo, qlog::NeqoQlog, qtrace, Datagram, Encoder, IpTos, IpTosEcn};
 use neqo_crypto::random;
 
 use crate::{
@@ -35,7 +35,7 @@ use crate::{
 };
 
 /// The number of times that a path will be probed before it is considered failed.
-const MAX_PATH_PROBES: usize = 3;
+pub const MAX_PATH_PROBES: usize = 3;
 /// The maximum number of paths that `Paths` will track.
 const MAX_PATHS: usize = 15;
 
@@ -225,7 +225,7 @@ impl Paths {
     /// Otherwise, migration will occur after probing succeeds.
     /// The path is always probed and will be abandoned if probing fails.
     /// Returns `true` if the path was migrated.
-    pub fn migrate(&mut self, path: &PathRef, force: bool, now: Instant) -> bool {
+    pub fn migrate(&mut self, path: &PathRef, force: bool, now: Instant, stats: &mut Stats) -> bool {
         debug_assert!(!self.is_temporary(path));
         let baseline = self.primary().map_or_else(
             || EcnInfo::default().baseline(),
@@ -239,7 +239,7 @@ impl Paths {
         } else {
             self.migration_target = Some(Rc::clone(path));
         }
-        path.borrow_mut().probe();
+        path.borrow_mut().probe(stats);
         self.migration_target.is_none()
     }
 
@@ -248,11 +248,11 @@ impl Paths {
     ///
     /// TODO(mt) - the paths should own the RTT estimator, so they can find the PTO
     /// for themselves.
-    pub fn process_timeout(&mut self, now: Instant, pto: Duration) -> bool {
+    pub fn process_timeout(&mut self, now: Instant, pto: Duration, stats: &mut Stats) -> bool {
         let to_retire = &mut self.to_retire;
         let mut primary_failed = false;
         self.paths.retain(|p| {
-            if p.borrow_mut().process_timeout(now, pto) {
+            if p.borrow_mut().process_timeout(now, pto, stats) {
                 true
             } else {
                 qdebug!([p.borrow()], "Retiring path");
@@ -301,7 +301,7 @@ impl Paths {
 
     /// Set the identified path to be primary.
     /// This panics if `make_permanent` hasn't been called.
-    pub fn handle_migration(&mut self, path: &PathRef, remote: SocketAddr, now: Instant) {
+    pub fn handle_migration(&mut self, path: &PathRef, remote: SocketAddr, now: Instant, stats: &mut Stats) {
         // The update here needs to match the checks in `Path::received_on`.
         // Here, we update the remote port number to match the source port on the
         // datagram that was received.  This ensures that we send subsequent
@@ -316,7 +316,7 @@ impl Paths {
 
         if let Some(old_path) = self.select_primary(path) {
             // Need to probe the old path if the peer migrates.
-            old_path.borrow_mut().probe();
+            old_path.borrow_mut().probe(stats);
             // TODO(mt) - suppress probing if the path was valid within 3PTO.
         }
     }
@@ -339,11 +339,11 @@ impl Paths {
     /// A `PATH_RESPONSE` was received.
     /// Returns `true` if migration occurred.
     #[must_use]
-    pub fn path_response(&mut self, response: [u8; 8], now: Instant) -> bool {
+    pub fn path_response(&mut self, response: [u8; 8], now: Instant, stats: &mut Stats) -> bool {
         // TODO(mt) consider recording an RTT measurement here as we don't train
         // RTT for non-primary paths.
         for p in &self.paths {
-            if p.borrow_mut().path_response(response, now) {
+            if p.borrow_mut().path_response(response, now, stats) {
                 // The response was accepted.  If this path is one we intend
                 // to migrate to, then migrate.
                 if self
@@ -723,14 +723,14 @@ impl Path {
     }
 
     /// Handle a `PATH_RESPONSE` frame. Returns true if the response was accepted.
-    pub fn path_response(&mut self, response: [u8; 8], now: Instant) -> bool {
+    pub fn path_response(&mut self, response: [u8; 8], now: Instant, stats: &mut Stats) -> bool {
         if let ProbeState::Probing { data, mtu, .. } = &mut self.state {
             if response == *data {
                 let need_full_probe = !*mtu;
                 self.set_valid(now);
                 if need_full_probe {
                     qdebug!([self], "Sub-MTU probe successful, reset probe count");
-                    self.probe();
+                    self.probe(stats);
                 }
                 true
             } else {
@@ -749,15 +749,25 @@ impl Path {
 
     /// At the next opportunity, send a probe.
     /// If the probe count has been exhausted already, marks the path as failed.
-    fn probe(&mut self) {
+    fn probe(&mut self, stats: &mut Stats) {
         let probe_count = match &self.state {
             ProbeState::Probing { probe_count, .. } => *probe_count + 1,
             ProbeState::ProbeNeeded { probe_count, .. } => *probe_count,
             _ => 0,
         };
         self.state = if probe_count >= MAX_PATH_PROBES {
-            qinfo!([self], "Probing failed");
-            ProbeState::Failed
+            if self.ecn_info.ecn_mark() == IpTosEcn::NotEct {
+                qinfo!([self], "Probing failed");
+                ProbeState::Failed
+            } else {
+                // The path validation failure may be due to ECN blackholing, try again without ECN.
+                qinfo!(
+                    [self],
+                    "Possible ECN blackhole, disabling ECN and re-probing path"
+                );
+                self.ecn_info.disable_ecn(stats);
+                ProbeState::ProbeNeeded { probe_count: 0 }
+            }
         } else {
             qdebug!([self], "Initiating probe");
             ProbeState::ProbeNeeded { probe_count }
@@ -841,10 +851,10 @@ impl Path {
 
     /// Process a timer for this path.
     /// This returns true if the path is viable and can be kept alive.
-    pub fn process_timeout(&mut self, now: Instant, pto: Duration) -> bool {
+    pub fn process_timeout(&mut self, now: Instant, pto: Duration, stats: &mut Stats) -> bool {
         if let ProbeState::Probing { sent, .. } = &self.state {
             if now >= *sent + pto {
-                self.probe();
+                self.probe(stats);
             }
         }
         if matches!(self.state, ProbeState::Failed) {

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -768,10 +768,7 @@ impl Path {
             _ => 0,
         };
         self.state = if probe_count >= MAX_PATH_PROBES {
-            if self.ecn_info.ecn_mark() == IpTosEcn::NotEct {
-                qinfo!([self], "Probing failed");
-                ProbeState::Failed
-            } else {
+            if self.ecn_info.ecn_mark() == IpTosEcn::Ect0 {
                 // The path validation failure may be due to ECN blackholing, try again without ECN.
                 qinfo!(
                     [self],
@@ -779,6 +776,10 @@ impl Path {
                 );
                 self.ecn_info.disable_ecn(stats);
                 ProbeState::ProbeNeeded { probe_count: 0 }
+                
+            } else {
+                qinfo!([self], "Probing failed");
+                ProbeState::Failed
             }
         } else {
             qdebug!([self], "Initiating probe");

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -779,7 +779,6 @@ impl Path {
                 );
                 self.ecn_info.disable_ecn(stats);
                 ProbeState::ProbeNeeded { probe_count: 0 }
-                
             } else {
                 qinfo!([self], "Probing failed");
                 ProbeState::Failed

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -225,7 +225,13 @@ impl Paths {
     /// Otherwise, migration will occur after probing succeeds.
     /// The path is always probed and will be abandoned if probing fails.
     /// Returns `true` if the path was migrated.
-    pub fn migrate(&mut self, path: &PathRef, force: bool, now: Instant, stats: &mut Stats) -> bool {
+    pub fn migrate(
+        &mut self,
+        path: &PathRef,
+        force: bool,
+        now: Instant,
+        stats: &mut Stats,
+    ) -> bool {
         debug_assert!(!self.is_temporary(path));
         let baseline = self.primary().map_or_else(
             || EcnInfo::default().baseline(),
@@ -301,7 +307,13 @@ impl Paths {
 
     /// Set the identified path to be primary.
     /// This panics if `make_permanent` hasn't been called.
-    pub fn handle_migration(&mut self, path: &PathRef, remote: SocketAddr, now: Instant, stats: &mut Stats) {
+    pub fn handle_migration(
+        &mut self,
+        path: &PathRef,
+        remote: SocketAddr,
+        now: Instant,
+        stats: &mut Stats,
+    ) {
         // The update here needs to match the checks in `Path::received_on`.
         // Here, we update the remote port number to match the source port on the
         // datagram that was received.  This ensures that we send subsequent
@@ -865,9 +877,9 @@ impl Path {
             true
         } else if matches!(self.state, ProbeState::Valid) {
             // Retire validated, non-primary paths.
-            // Allow more than `MAX_PATH_PROBES` times the PTO so that an old
+            // Allow more than 2* `MAX_PATH_PROBES` times the PTO so that an old
             // path remains around until after a previous path fails.
-            let count = u32::try_from(MAX_PATH_PROBES + 1).unwrap();
+            let count = u32::try_from(2 * MAX_PATH_PROBES + 1).unwrap();
             self.validated.unwrap() + (pto * count) > now
         } else {
             // Keep paths that are being actively probed.


### PR DESCRIPTION
This will send `MAX_PATH_PROBES` probes with ECN and then another `MAX_PATH_PROBES` probes without ECN, so with `MAX_PATH_PROBES = 3`, a total of 6 for a non-functional path. Is that OK?