### PR TITLE
feat: Remove `FrameStats::all`

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2139,7 +2139,6 @@ impl Connection {
             builder.encode_varint(crate::frame::FRAME_TYPE_PING);
             let stats = &mut self.stats.borrow_mut().frame_tx;
             stats.ping += 1;
-            stats.all += 1;
         }
         probe
     }
@@ -2226,13 +2225,11 @@ impl Connection {
         let stats = &mut self.stats.borrow_mut().frame_tx;
         let padded = if ack_eliciting && full_mtu && builder.pad() {
             stats.padding += 1;
-            stats.all += 1;
             true
         } else {
             false
         };
 
-        stats.all += tokens.len();
         (tokens, ack_eliciting, padded)
     }
 
@@ -2799,7 +2796,6 @@ impl Connection {
             qinfo!("frame not allowed: {:?} {:?}", frame, packet_type);
             return Err(Error::ProtocolViolation);
         }
-        self.stats.borrow_mut().frame_rx.all += 1;
         let space = PacketNumberSpace::from(packet_type);
         if frame.is_stream() {
             return self

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -798,13 +798,13 @@ fn anti_amplification() {
     client.process_input(&s_init1, now);
     client.process_input(&s_init2, now);
     let ack_count = client.stats().frame_tx.ack;
-    let frame_count = client.stats().frame_tx.all;
+    let frame_count = client.stats().frame_tx.all();
     let ack = client.process(Some(&s_init3), now).dgram().unwrap();
     assert!(!maybe_authenticate(&mut client)); // No need yet.
 
     // The client sends a padded datagram, with just ACK for Handshake.
     assert_eq!(client.stats().frame_tx.ack, ack_count + 1);
-    assert_eq!(client.stats().frame_tx.all, frame_count + 1);
+    assert_eq!(client.stats().frame_tx.all(), frame_count + 1);
     assert_ne!(ack.len(), client.plpmtu()); // Not padded (it includes Handshake).
 
     now += DEFAULT_RTT / 2;
@@ -1210,7 +1210,6 @@ fn client_initial_retransmits_identical() {
             client.stats().frame_tx,
             FrameStats {
                 crypto: i,
-                all: i,
                 ..Default::default()
             }
         );
@@ -1238,7 +1237,6 @@ fn server_initial_retransmits_identical() {
             FrameStats {
                 crypto: i * 2,
                 ack: i,
-                all: i * 3,
                 ..Default::default()
             }
         );

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -191,11 +191,11 @@ fn migrate_immediate() {
     assert_v6_path(&server2, true);
 
     // The second packet has no real effect, it just elicits an ACK.
-    let all_before = server.stats().frame_tx.all;
+    let all_before = server.stats().frame_tx.all();
     let ack_before = server.stats().frame_tx.ack;
     let server3 = server.process(Some(&client2), now).dgram();
     assert!(server3.is_some());
-    assert_eq!(server.stats().frame_tx.all, all_before + 1);
+    assert_eq!(server.stats().frame_tx.all(), all_before + 1);
     assert_eq!(server.stats().frame_tx.ack, ack_before + 1);
 
     // Receiving a packet sent by the server before migration doesn't change path.
@@ -249,14 +249,14 @@ fn migrate_immediate_fail() {
         let after = client.stats().frame_tx;
         assert_eq!(after.path_challenge, before.path_challenge + 1);
         assert_eq!(after.padding, before.padding + 1);
-        assert_eq!(after.all, before.all + 2);
+        assert_eq!(after.all(), before.all() + 2);
 
         // This might be a PTO, which will result in sending a probe.
         if let Some(probe) = client.process_output(now).dgram() {
             assert_v4_path(&probe, false); // Contains PATH_CHALLENGE.
             let after = client.stats().frame_tx;
             assert_eq!(after.ping, before.ping + 1);
-            assert_eq!(after.all, before.all + 3);
+            assert_eq!(after.all(), before.all() + 3);
         }
     }
 
@@ -325,14 +325,14 @@ fn migrate_same_fail() {
         let after = client.stats().frame_tx;
         assert_eq!(after.path_challenge, before.path_challenge + 1);
         assert_eq!(after.padding, before.padding + 1);
-        assert_eq!(after.all, before.all + 2);
+        assert_eq!(after.all(), before.all() + 2);
 
         // This might be a PTO, which will result in sending a probe.
         if let Some(probe) = client.process_output(now).dgram() {
             assert_v6_path(&probe, false); // Contains PATH_CHALLENGE.
             let after = client.stats().frame_tx;
             assert_eq!(after.ping, before.ping + 1);
-            assert_eq!(after.all, before.all + 3);
+            assert_eq!(after.all(), before.all() + 3);
         }
     }
 

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -299,17 +299,17 @@ fn pto_handshake_complete() {
     assert_handshake(&pkt2_hs);
     assert!(pkt2_1rtt.is_some());
     let dropped_before1 = server.stats().dropped_rx;
-    let server_frames = server.stats().frame_rx.all;
+    let server_frames = server.stats().frame_rx.all();
     server.process_input(&pkt2_hs, now);
     assert_eq!(1, server.stats().dropped_rx - dropped_before1);
-    assert_eq!(server.stats().frame_rx.all, server_frames);
+    assert_eq!(server.stats().frame_rx.all(), server_frames);
 
     server.process_input(&pkt2_1rtt.unwrap(), now);
-    let server_frames2 = server.stats().frame_rx.all;
+    let server_frames2 = server.stats().frame_rx.all();
     let dropped_before2 = server.stats().dropped_rx;
     server.process_input(&pkt3_hs, now);
     assert_eq!(1, server.stats().dropped_rx - dropped_before2);
-    assert_eq!(server.stats().frame_rx.all, server_frames2);
+    assert_eq!(server.stats().frame_rx.all(), server_frames2);
 
     now += HALF_RTT;
 
@@ -497,10 +497,10 @@ fn ack_after_pto() {
     assert!(ack.is_some());
 
     // Make sure that the packet only contained an ACK frame.
-    let all_frames_before = server.stats().frame_rx.all;
+    let all_frames_before = server.stats().frame_rx.all();
     let ack_before = server.stats().frame_rx.ack;
     server.process_input(&ack.unwrap(), now);
-    assert_eq!(server.stats().frame_rx.all, all_frames_before + 1);
+    assert_eq!(server.stats().frame_rx.all(), all_frames_before + 1);
     assert_eq!(server.stats().frame_rx.ack, ack_before + 1);
 }
 

--- a/neqo-transport/src/connection/tests/zerortt.rs
+++ b/neqo-transport/src/connection/tests/zerortt.rs
@@ -66,11 +66,11 @@ fn zero_rtt_send_recv() {
     let server_hs = server.process(client_hs.as_dgram_ref(), now());
     assert!(server_hs.as_dgram_ref().is_some()); // ServerHello, etc...
 
-    let all_frames = server.stats().frame_tx.all;
+    let all_frames = server.stats().frame_tx.all();
     let ack_frames = server.stats().frame_tx.ack;
     let server_process_0rtt = server.process(client_0rtt.as_dgram_ref(), now());
     assert!(server_process_0rtt.as_dgram_ref().is_some());
-    assert_eq!(server.stats().frame_tx.all, all_frames + 1);
+    assert_eq!(server.stats().frame_tx.all(), all_frames + 1);
     assert_eq!(server.stats().frame_tx.ack, ack_frames + 1);
 
     let server_stream_id = server

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -811,9 +811,7 @@ impl Path {
             builder.encode(&challenge[..]);
 
             // These frames are not retransmitted in the usual fashion.
-            // There is no token, therefore we need to count `all` specially.
             stats.path_response += 1;
-            stats.all += 1;
 
             if builder.remaining() < 9 {
                 return true;
@@ -832,7 +830,6 @@ impl Path {
 
             // As above, no recovery token.
             stats.path_challenge += 1;
-            stats.all += 1;
 
             self.state = ProbeState::Probing {
                 probe_count,

--- a/neqo-transport/src/pmtud.rs
+++ b/neqo-transport/src/pmtud.rs
@@ -126,7 +126,6 @@ impl Pmtud {
         // seems OK to burn one byte here to simply include a PING.
         builder.encode_varint(FRAME_TYPE_PING);
         stats.frame_tx.ping += 1;
-        stats.frame_tx.all += 1;
         stats.pmtud_tx += 1;
         self.probe_count += 1;
         self.probe_state = Probe::Sent;

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -24,7 +24,6 @@ pub const MAX_PTO_COUNTS: usize = 16;
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[allow(clippy::module_name_repetitions)]
 pub struct FrameStats {
-    pub all: usize,
     pub ack: usize,
     pub largest_acknowledged: PacketNumber,
 
@@ -94,6 +93,34 @@ impl Debug for FrameStats {
             self.path_response,
         )?;
         writeln!(f, "    ack_frequency {}", self.ack_frequency)
+    }
+}
+
+#[cfg(test)]
+impl FrameStats {
+    pub const fn all(&self) -> usize {
+        self.ack
+            + self.crypto
+            + self.stream
+            + self.reset_stream
+            + self.stop_sending
+            + self.ping
+            + self.padding
+            + self.max_streams
+            + self.streams_blocked
+            + self.max_data
+            + self.data_blocked
+            + self.max_stream_data
+            + self.stream_data_blocked
+            + self.new_connection_id
+            + self.retire_connection_id
+            + self.path_challenge
+            + self.path_response
+            + self.connection_close
+            + self.handshake_done
+            + self.new_token
+            + self.ack_frequency
+            + self.datagram
     }
 }
 


### PR DESCRIPTION
And just compute it on the fly. It wasn't consistently updated anyway and is only used in tests.