### PR TITLE
ci: Pin NSS to prevent build hang on Windows

### DIFF
--- a/.github/actions/nss/action.yml
+++ b/.github/actions/nss/action.yml
@@ -64,8 +64,7 @@ runs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         repository: nss-dev/nss
-        # ref: c631e9cb5ed1806038f7b85fbbc825f856c9d133 works
-        ref: fd36e7f300e1bc7fa933faa6aa55424f81d34426
+        ref: c631e9cb5ed1806038f7b85fbbc825f856c9d133 # later revisions hang when building on Windows
         path: nss
 
     - name: Checkout NSPR

--- a/.github/actions/nss/action.yml
+++ b/.github/actions/nss/action.yml
@@ -141,7 +141,7 @@ runs:
         echo "DYLD_FALLBACK_LIBRARY_PATH=$NSS_OUT/lib" >> "$GITHUB_ENV"
         echo "$NSS_OUT/lib" >> "$GITHUB_PATH"
         echo "NSS_DIR=$NSS_DIR" >> "$GITHUB_ENV"
-        $NSS_DIR/build.sh -g -Ddisable_tests=1 $OPT --static
+        $NSS_DIR/build.sh -g -Ddisable_tests=1 $OPT --static --verbose
       env:
         NSS_DIR: ${{ github.workspace }}/nss
         NSPR_DIR: ${{ github.workspace }}/nspr

--- a/.github/actions/nss/action.yml
+++ b/.github/actions/nss/action.yml
@@ -64,7 +64,8 @@ runs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         repository: nss-dev/nss
-        ref: c631e9cb5ed1806038f7b85fbbc825f856c9d133
+        # ref: c631e9cb5ed1806038f7b85fbbc825f856c9d133 works
+        ref: fd36e7f300e1bc7fa933faa6aa55424f81d34426
         path: nss
 
     - name: Checkout NSPR
@@ -139,7 +140,7 @@ runs:
         echo "DYLD_FALLBACK_LIBRARY_PATH=$NSS_OUT/lib" >> "$GITHUB_ENV"
         echo "$NSS_OUT/lib" >> "$GITHUB_PATH"
         echo "NSS_DIR=$NSS_DIR" >> "$GITHUB_ENV"
-        $NSS_DIR/build.sh -g -Ddisable_tests=1 $OPT --static -v
+        $NSS_DIR/build.sh -g -Ddisable_tests=1 $OPT --static
       env:
         NSS_DIR: ${{ github.workspace }}/nss
         NSPR_DIR: ${{ github.workspace }}/nspr

--- a/.github/actions/nss/action.yml
+++ b/.github/actions/nss/action.yml
@@ -65,12 +65,14 @@ runs:
       with:
         repository: nss-dev/nss
         ref: c631e9cb5ed1806038f7b85fbbc825f856c9d133
+        path: nss
 
     - name: Checkout NSPR
       if: env.BUILD_NSS == '1'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         repository: nss-dev/nspr
+        path: nspr
 
     - name: Install build dependencies (Linux)
       shell: bash

--- a/.github/actions/nss/action.yml
+++ b/.github/actions/nss/action.yml
@@ -141,7 +141,7 @@ runs:
         echo "DYLD_FALLBACK_LIBRARY_PATH=$NSS_OUT/lib" >> "$GITHUB_ENV"
         echo "$NSS_OUT/lib" >> "$GITHUB_PATH"
         echo "NSS_DIR=$NSS_DIR" >> "$GITHUB_ENV"
-        $NSS_DIR/build.sh -g -Ddisable_tests=1 $OPT --static --verbose
+        $NSS_DIR/build.sh -g -Ddisable_tests=1 $OPT --static -v
       env:
         NSS_DIR: ${{ github.workspace }}/nss
         NSPR_DIR: ${{ github.workspace }}/nspr

--- a/.github/actions/nss/action.yml
+++ b/.github/actions/nss/action.yml
@@ -59,35 +59,31 @@ runs:
         echo "System NSS is suitable: $NSS_VERSION"
         echo "BUILD_NSS=0" >> "$GITHUB_ENV"
 
-    # Ideally, we'd use actions/checkout. But things are sufficiently flaky that we're better off
-    # trying both hg and git.
-
     - name: Checkout NSS
-      shell: bash
       if: env.BUILD_NSS == '1'
-      run: |
-        git clone --depth=1 https://github.com/nss-dev/nss "${{ github.workspace }}/nss" || \
-          hg clone https://hg.mozilla.org/projects/nss "${{ github.workspace }}/nss"
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: nss-dev/nss
+        ref: c631e9cb5ed1806038f7b85fbbc825f856c9d133
 
     - name: Checkout NSPR
-      shell: bash
       if: env.BUILD_NSS == '1'
-      run: |
-        git clone --depth=1 https://github.com/nss-dev/nspr "${{ github.workspace }}/nspr" || \
-          hg clone https://hg.mozilla.org/projects/nspr "${{ github.workspace }}/nspr"
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: nss-dev/nspr
 
     - name: Install build dependencies (Linux)
       shell: bash
       if: runner.os == 'Linux' && env.BUILD_NSS == '1' && runner.environment == 'github-hosted'
       env:
         DEBIAN_FRONTEND: noninteractive
-      run: sudo apt-get install -y --no-install-recommends git mercurial gyp ninja-build
+      run: sudo apt-get install -y --no-install-recommends gyp ninja-build
 
     - name: Install build dependencies (MacOS)
       shell: bash
       if: runner.os == 'MacOS' && env.BUILD_NSS == '1'
       run: |
-        brew install mercurial ninja
+        brew install ninja
         echo "gyp-next>=0.18.1" > req.txt
         python3 -m pip install --user --break-system-packages -r req.txt
         echo "$(python3 -m site --user-base)/bin" >> "$GITHUB_PATH"
@@ -101,7 +97,7 @@ runs:
           echo C:/msys64/usr/bin
           echo C:/msys64/mingw64/bin
         } >> "$GITHUB_PATH"
-        /c/msys64/usr/bin/pacman -S --noconfirm python3-pip mercurial nsinstall
+        /c/msys64/usr/bin/pacman -S --noconfirm python3-pip nsinstall
         echo "gyp-next>=0.18.1" > req.txt
         python3 -m pip install -r req.txt
 


### PR DESCRIPTION
The MLKEM patches make the NSS build on Windows hang indefinitely. Until we fix that, pin NSS to the last working revision before MLKEM landed.

(Also switch to using `actions/checkout` and hence don't install mercurial anymore.)

CC @jschanck 