### PR TITLE
fix: Don't encode large RTT guesses in tickets

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -600,7 +600,7 @@ impl Connection {
             || Duration::from_millis(0),
             |p| {
                 let rtt = p.borrow().rtt().estimate();
-                if p.borrow().rtt().first_sample_time().is_none() {
+                if self.stats.borrow().frame_rx.ack == 0 {
                     // When we have no actual RTT sample, do not encode a guestimated RTT larger
                     // than the default initial RTT. (The guess can be very large under lossy
                     // conditions.)

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -600,7 +600,7 @@ impl Connection {
             || Duration::from_millis(0),
             |p| {
                 let rtt = p.borrow().rtt().estimate();
-                if self.stats.borrow().frame_rx.ack == 0 {
+                if p.borrow().rtt().is_guesstimate() {
                     // When we have no actual RTT sample, do not encode a guestimated RTT larger
                     // than the default initial RTT. (The guess can be very large under lossy
                     // conditions.)

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -27,7 +27,7 @@ use crate::{
     packet::PacketBuilder,
     pmtud::Pmtud,
     recovery::{RecoveryToken, SentPacket},
-    rtt::RttEstimate,
+    rtt::{RttEstimate, RttSource},
     sender::PacketSender,
     stats::FrameStats,
     tracking::PacketNumberSpace,
@@ -984,7 +984,7 @@ impl Path {
                 &self.qlog,
                 now - sent.time_sent(),
                 Duration::new(0, 0),
-                false,
+                RttSource::Guesstimate,
                 now,
             );
         }

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -108,14 +108,16 @@ impl RttEstimate {
         source: RttSource,
         now: Instant,
     ) {
+        debug_assert!(source >= self.best_source);
+        self.best_source = max(self.best_source, source);
+
         // Limit ack delay by max_ack_delay if confirmed.
         let mad = self.ack_delay.max();
-        let ack_delay = if source == RttSource::AckConfirmed && ack_delay > mad {
+        let ack_delay = if self.best_source == RttSource::AckConfirmed && ack_delay > mad {
             mad
         } else {
             ack_delay
         };
-        self.best_source = max(self.best_source, source);
 
         // min_rtt ignores ack delay.
         self.min_rtt = min(self.min_rtt, rtt_sample);

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -28,6 +28,17 @@ pub const GRANULARITY: Duration = Duration::from_millis(1);
 // Defined in -recovery 6.2 as 333ms but using lower value.
 pub const INITIAL_RTT: Duration = Duration::from_millis(100);
 
+/// The source of the RTT measurement.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum RttSource {
+    /// RTT guess from a retry or dropping a packet number space.
+    Guesstimate,
+    /// Ack on an unconfirmed connection.
+    Ack,
+    /// Ack on a confirmed connection.
+    AckConfirmed,
+}
+
 #[derive(Debug)]
 #[allow(clippy::module_name_repetitions)]
 pub struct RttEstimate {
@@ -37,6 +48,7 @@ pub struct RttEstimate {
     rttvar: Duration,
     min_rtt: Duration,
     ack_delay: PeerAckDelay,
+    best_source: RttSource,
 }
 
 impl RttEstimate {
@@ -58,6 +70,7 @@ impl RttEstimate {
             rttvar: Duration::from_millis(0),
             min_rtt: rtt,
             ack_delay: PeerAckDelay::Fixed(Duration::from_millis(25)),
+            best_source: RttSource::Ack,
         }
     }
 
@@ -83,21 +96,26 @@ impl RttEstimate {
         self.ack_delay.update(cwnd, mtu, self.smoothed_rtt);
     }
 
+    pub fn is_guesstimate(&self) -> bool {
+        self.best_source == RttSource::Guesstimate
+    }
+
     pub fn update(
         &mut self,
         qlog: &NeqoQlog,
         mut rtt_sample: Duration,
         ack_delay: Duration,
-        confirmed: bool,
+        source: RttSource,
         now: Instant,
     ) {
         // Limit ack delay by max_ack_delay if confirmed.
         let mad = self.ack_delay.max();
-        let ack_delay = if confirmed && ack_delay > mad {
+        let ack_delay = if source == RttSource::AckConfirmed && ack_delay > mad {
             mad
         } else {
             ack_delay
         };
+        self.best_source = max(self.best_source, source);
 
         // min_rtt ignores ack delay.
         self.min_rtt = min(self.min_rtt, rtt_sample);
@@ -205,6 +223,7 @@ impl Default for RttEstimate {
             rttvar: INITIAL_RTT / 2,
             min_rtt: INITIAL_RTT,
             ack_delay: PeerAckDelay::default(),
+            best_source: RttSource::Guesstimate,
         }
     }
 }


### PR DESCRIPTION
Because under lossy conditions (e.g., QNS `handshakeloss` test), the guess can be multiple times the actual RTT, which when encoded in the resumption ticket will cause an extremely slow second handshake, often causing the test to time out.

Broken out of #1998
Fixes #2088