### PR TITLE
fix: Make anti-replay window 1s for tests

### DIFF
--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -53,7 +53,8 @@ pub fn fixture_init() {
 
 // This needs to be > 2ms to avoid it being rounded to zero.
 // NSS operates in milliseconds and halves any value it is provided.
-pub const ANTI_REPLAY_WINDOW: Duration = Duration::from_millis(10);
+// But make it a second, so that tests with reasonable RTTs don't fail.
+pub const ANTI_REPLAY_WINDOW: Duration = Duration::from_millis(1000);
 
 /// A baseline time for all tests.  This needs to be earlier than what `now()` produces
 /// because of the need to have a span of time elapse for anti-replay purposes.


### PR DESCRIPTION
This caused some test failures, and @martinthomson discovered this as the reason at the IETF 120 hackathon.

Broken out of #1998