### PR TITLE
ci: Only install sccache action once per workflow

### DIFF
--- a/.github/actions/nss/action.yml
+++ b/.github/actions/nss/action.yml
@@ -60,11 +60,11 @@ runs:
         echo "BUILD_NSS=0" >> "$GITHUB_ENV"
 
     - name: Use sccache
-      if: runner.os != 'Windows'
+      if: env.RUSTC_WRAPPER != 'sccache'
       uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
 
     - name: Enable sscache
-      if: runner.os != 'Windows'
+      if: env.RUSTC_WRAPPER != 'sccache'
       shell: bash
       run: |
         if [ "${{ runner.os }}" != "Windows" ]; then

--- a/.github/actions/nss/action.yml
+++ b/.github/actions/nss/action.yml
@@ -60,9 +60,11 @@ runs:
         echo "BUILD_NSS=0" >> "$GITHUB_ENV"
 
     - name: Use sccache
+      if: runner.os != 'Windows'
       uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
 
     - name: Enable sscache
+      if: runner.os != 'Windows'
       shell: bash
       run: |
         if [ "${{ runner.os }}" != "Windows" ]; then

--- a/.github/actions/nss/action.yml
+++ b/.github/actions/nss/action.yml
@@ -60,11 +60,13 @@ runs:
         echo "BUILD_NSS=0" >> "$GITHUB_ENV"
 
     - name: Use sccache
+      # Apparently the action can't be installed twice in the same workflow, so check if
+      # it's already installed by checking if the RUSTC_WRAPPER environment variable is set
+      # (which every "use" of this action needs to therefore set)
       if: env.RUSTC_WRAPPER != 'sccache'
       uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
 
     - name: Enable sscache
-      if: env.RUSTC_WRAPPER != 'sccache'
       shell: bash
       run: |
         if [ "${{ runner.os }}" != "Windows" ]; then

--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -34,6 +34,10 @@ runs:
         targets: ${{ inputs.targets }}
 
     - name: Use sccache
+      # Apparently the action can't be installed twice in the same workflow, so check if
+      # it's already installed by checking if the RUSTC_WRAPPER environment variable is set
+      # (which every "use" of this action needs to therefore set)
+      if: env.RUSTC_WRAPPER != 'sccache'
       uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
 
     - name: Enable sscache


### PR DESCRIPTION
Without this, the second installation of the action in the same workflow - on WIndows only - fails with:
```
Error: Error: File was unable to be removed Error: EBUSY: resource busy or locked, rmdir 'C:\hostedtoolcache\windows\sccache\0.8.1\x64'
Error: File was unable to be removed Error: EBUSY: resource busy or locked, rmdir 'C:\hostedtoolcache\windows\sccache\0.8.1\x64'
```