### PR TITLE
ci: Run `clippy` on all platforms

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,9 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
-        # Don't increase beyond what Firefox is currently using:
-        # https://searchfox.org/mozilla-central/search?q=MINIMUM_RUST_VERSION&path=python/mozboot/mozboot/util.py
+        os: [ubuntu-latest, macos-latest, windows-latest]
         # Keep in sync with Cargo.toml
         rust-toolchain: [1.76.0, stable, nightly]
         type: [debug]

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -21,7 +21,15 @@ permissions:
 
 jobs:
   clippy:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: ./.github/actions/rust

--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         type: [debug, release]
     runs-on: ${{ matrix.os }}
     defaults:


### PR DESCRIPTION
So that we get issues for platform-specific code.

Also change `macos-14` -> `macos-latest` everywhere.