### PR TITLE
Extend panic when pn_len is 0 with metadata

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2000,7 +2000,10 @@ impl Connection {
         // Count how many bytes in this range are non-zero.
         let pn_len = mem::size_of::<PacketNumber>()
             - usize::try_from(unacked_range.leading_zeros() / 8).unwrap();
-        // pn_len can't be zero (unacked_range is > 0)
+        assert!(
+            pn_len > 0,
+            "pn_len can't be zero as unacked_range should be > 0, pn {pn}, largest_acknowledged {largest_acknowledged:?}, tx {tx}"
+        );
         // TODO(mt) also use `4*path CWND/path MTU` to set a minimum length.
         builder.pn(pn, pn_len);
         pn


### PR DESCRIPTION
`Connection::add_packet_number -> PacketBuilder::pn -> Encoder::encode_uint` panics when `pn_len` is `0`. These panics are seen in Firefox crash reports.

To be able to find the root cause of the panic, add additional metadata.

See https://github.com/mozilla/neqo/issues/2132 for details.