### PR TITLE
chore: prepare v0.9.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.9.0"
+version = "0.9.1"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I propose cutting a new release to get the following bug fixes into Firefox. Objections?

- https://github.com/mozilla/neqo/pull/2100
- https://github.com/mozilla/neqo/pull/2114
- https://github.com/mozilla/neqo/pull/2119
- https://github.com/mozilla/neqo/pull/2127
- https://github.com/mozilla/neqo/pull/2136
- https://github.com/mozilla/neqo/pull/2134