### PR TITLE
chore: keep neqo_transport::Error internal errors sorted

### DIFF
--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -127,6 +127,7 @@ pub enum Error {
     KeyUpdateBlocked,
     NoAvailablePath,
     NoMoreData,
+    NotAvailable,
     NotConnected,
     PacketNumberOverlap,
     PeerApplicationError(AppError),
@@ -138,7 +139,6 @@ pub enum Error {
     UnknownFrameType,
     VersionNegotiation,
     WrongRole,
-    NotAvailable,
 }
 
 impl Error {


### PR DESCRIPTION
As per the comment:

https://github.com/mozilla/neqo/blob/1708886bc9750677b1c43f4d8fc4b89367736198/neqo-transport/src/lib.rs#L102