### PR TITLE
chore: prepare v0.9.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.9.1"
+version = "0.9.2"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I suggest we cut a new release once https://github.com/mozilla/neqo/pull/2150/ is merged.

https://github.com/mozilla/neqo/pull/2150/ will likely fix [bugzilla#1919678](https://bugzilla.mozilla.org/show_bug.cgi?id=1919678) which is currently "# 2 topcrash in Nightly 133".