### PR TITLE
wrappers for common usage of test_frame_writer

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1146,6 +1146,19 @@ impl Connection {
         }
     }
 
+    /// A test-only output function that uses the provided writer to
+    /// pack something extra into the output.
+    #[cfg(test)]
+    pub fn test_write_frames<W>(&mut self, writer: W, now: Instant) -> Output
+    where
+        W: test_internal::FrameWriter + 'static,
+    {
+        self.test_frame_writer = Some(Box::new(writer));
+        let res = self.process_output(now);
+        self.test_frame_writer = None;
+        res
+    }
+
     /// Process input and generate output.
     #[must_use = "Output of the process function must be handled"]
     pub fn process(&mut self, dgram: Option<&Datagram>, now: Instant) -> Output {

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -399,10 +399,11 @@ fn dgram_no_allowed() {
     let mut client = default_client();
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
-    server.test_frame_writer = Some(Box::new(InsertDatagram { data: DATA_MTU }));
-    let out = server.process_output(now()).dgram().unwrap();
-    server.test_frame_writer = None;
 
+    let out = server
+        .test_write_frames(InsertDatagram { data: DATA_MTU }, now())
+        .dgram()
+        .unwrap();
     client.process_input(&out, now());
 
     assert_error(&client, &CloseReason::Transport(Error::ProtocolViolation));
@@ -415,10 +416,10 @@ fn dgram_too_big() {
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
 
-    server.test_frame_writer = Some(Box::new(InsertDatagram { data: DATA_MTU }));
-    let out = server.process_output(now()).dgram().unwrap();
-    server.test_frame_writer = None;
-
+    let out = server
+        .test_write_frames(InsertDatagram { data: DATA_MTU }, now())
+        .dgram()
+        .unwrap();
     client.process_input(&out, now());
 
     assert_error(&client, &CloseReason::Transport(Error::ProtocolViolation));

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -17,7 +17,7 @@ use neqo_common::{event::Provider, qdebug, qtrace, Datagram, Decoder, Role};
 use neqo_crypto::{random, AllowZeroRtt, AuthenticationStatus, ResumptionToken};
 use test_fixture::{fixture_init, new_neqo_qlog, now, DEFAULT_ADDR};
 
-use super::{CloseReason, Connection, ConnectionId, Output, State};
+use super::{test_internal, CloseReason, Connection, ConnectionId, Output, State};
 use crate::{
     addr_valid::{AddressValidation, ValidateAddress},
     cc::CWND_INITIAL_PKTS,
@@ -613,6 +613,17 @@ fn send_something_with_modifier(
 /// Return the resulting datagram.
 fn send_something(sender: &mut Connection, now: Instant) -> Datagram {
     send_something_with_modifier(sender, now, Some)
+}
+
+/// Send something, but add a little something extra into the output.
+fn send_with_extra<W>(sender: &mut Connection, writer: W, now: Instant) -> Datagram
+where
+    W: test_internal::FrameWriter + 'static,
+{
+    sender.test_frame_writer = Some(Box::new(writer));
+    let res = send_something_with_modifier(sender, now, Some);
+    sender.test_frame_writer = None;
+    res
 }
 
 /// Send something on a stream from `sender` through a modifier to `receiver`.

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -835,9 +835,10 @@ fn ack_for_unsent() {
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
 
-    server.test_frame_writer = Some(Box::new(AckforUnsentWriter {}));
-    let spoofed = server.process_output(now()).dgram().unwrap();
-    server.test_frame_writer = None;
+    let spoofed = server
+        .test_write_frames(AckforUnsentWriter {}, now())
+        .dgram()
+        .unwrap();
 
     // Now deliver the packet with the spoofed ACK frame
     client.process_input(&spoofed, now());


### PR DESCRIPTION
This reduces boilerplate and encapsulates a good pattern of usage. I wasn't able to make `test_frame_writer` private, but this is close enough.