### PR TITLE
test: Dump simulator RNG seeds

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -129,6 +129,7 @@ jobs:
         run: ls -1 ${{ env.DUMP_SIMULATION_SEEDS }}
 
       - name: Save simulation seeds artifact
+        if: env.DUMP_SIMULATION_SEEDS
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: simulation-seeds-${{ matrix.os }}-${{ matrix.rust-toolchain }}-${{ matrix.type }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -111,6 +111,9 @@ jobs:
         env:
           RUST_LOG: trace
         run: |
+          if [ "${{ env.DUMP_SIMULATION_SEEDS }}" ]; then
+            export DUMP_SIMULATION_SEEDS=${{ env.DUMP_SIMULATION_SEEDS }}/sanitizer
+          fi
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
             TARGET="x86_64-unknown-linux-gnu"
             SANITIZERS="address thread leak"
@@ -126,14 +129,14 @@ jobs:
 
       - name: Print simulation seeds
         if: env.DUMP_SIMULATION_SEEDS
-        run: ls -1 ${{ env.DUMP_SIMULATION_SEEDS }}
+        run: find ${{ env.DUMP_SIMULATION_SEEDS }}
 
       - name: Save simulation seeds artifact
         if: env.DUMP_SIMULATION_SEEDS
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: simulation-seeds-${{ matrix.os }}-${{ matrix.rust-toolchain }}-${{ matrix.type }}
-          path: /tmp/simulation-seeds
+          path: ${{ env.DUMP_SIMULATION_SEEDS }}
           compression-level: 9
 
   bench:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -111,9 +111,6 @@ jobs:
         env:
           RUST_LOG: trace
         run: |
-          if [ "${{ env.DUMP_SIMULATION_SEEDS }}" ]; then
-            export DUMP_SIMULATION_SEEDS=${{ env.DUMP_SIMULATION_SEEDS }}/sanitizer
-          fi
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
             TARGET="x86_64-unknown-linux-gnu"
             SANITIZERS="address thread leak"
@@ -124,6 +121,10 @@ jobs:
           fi
           for sanitizer in $SANITIZERS; do
             echo "Running tests with $sanitizer sanitizer..."
+            # shellcheck disable=SC2078
+            if [ "${{ env.DUMP_SIMULATION_SEEDS }}" ]; then
+              export DUMP_SIMULATION_SEEDS="${{ env.DUMP_SIMULATION_SEEDS }}/sanitizer/$sanitizer"
+            fi
             RUSTFLAGS="-Z sanitizer=$sanitizer" RUSTDOCFLAGS="-Z sanitizer=$sanitizer" cargo +nightly nextest run -Z build-std --features ci --target "$TARGET"
           done
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -128,10 +128,6 @@ jobs:
             RUSTFLAGS="-Z sanitizer=$sanitizer" RUSTDOCFLAGS="-Z sanitizer=$sanitizer" cargo +nightly nextest run -Z build-std --features ci --target "$TARGET"
           done
 
-      - name: Print simulation seeds
-        if: env.DUMP_SIMULATION_SEEDS
-        run: find ${{ env.DUMP_SIMULATION_SEEDS }}
-
       - name: Save simulation seeds artifact
         if: env.DUMP_SIMULATION_SEEDS
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,6 +17,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  DUMP_SIMULATION_SEEDS: /tmp/simulation-seeds
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -68,12 +69,14 @@ jobs:
           cargo +${{ matrix.rust-toolchain }} check $BUILD_TYPE --all-targets --features ci
 
       - name: Run tests and determine coverage
+        env:
+          RUST_LOG: trace
         run: |
           # shellcheck disable=SC2086
           if [ "${{ matrix.rust-toolchain }}" == "stable" ]; then
-            RUST_LOG=trace cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --features ci --no-fail-fast --lcov --output-path lcov.info
+            cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --features ci --no-fail-fast --lcov --output-path lcov.info
           else
-            RUST_LOG=trace cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --features ci --no-fail-fast
+            cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --features ci --no-fail-fast
           fi
 
       - name: Run client/server transfer
@@ -120,6 +123,17 @@ jobs:
             echo "Running tests with $sanitizer sanitizer..."
             RUSTFLAGS="-Z sanitizer=$sanitizer" RUSTDOCFLAGS="-Z sanitizer=$sanitizer" cargo +nightly nextest run -Z build-std --features ci --target "$TARGET"
           done
+
+      - name: Print simulation seeds
+        if: env.DUMP_SIMULATION_SEEDS
+        run: ls -1 ${{ env.DUMP_SIMULATION_SEEDS }}
+
+      - name: Save simulation seeds artifact
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: simulation-seeds
+          path: /tmp/simulation-seeds
+          compression-level: 9
 
   bench:
     needs: [check]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Save simulation seeds artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
-          name: simulation-seeds
+          name: simulation-seeds-${{ matrix.os }}-${{ matrix.rust-toolchain }}-${{ matrix.type }}
           path: /tmp/simulation-seeds
           compression-level: 9
 

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -1,16 +1,13 @@
 name: QNS
-
 on:
   push:
     branches: ["main"]
     paths-ignore: ["*.md", "*.png", "*.svg", "LICENSE-*"]
   pull_request:
     branches: ["main"]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore: ["*.md", "*.png", "*.svg", "LICENSE-*"]
   merge_group:
-  schedule:
-    # Run at 1 AM each day
-    - cron: '0 1 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -11,6 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  DUMP_SIMULATION_SEEDS: /tmp/simulation-seeds
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -76,3 +77,11 @@ jobs:
             export LSAN_OPTIONS="suppressions=$PWD/suppressions.txt"
           fi
           cargo nextest run -Z build-std --features ci --target "$TARGET"
+
+      - name: Save simulation seeds artifact
+        if: env.DUMP_SIMULATION_SEEDS
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: simulation-seeds-${{ matrix.os }}-sanitizer-${{ matrix.sanitizer }}
+          path: ${{ env.DUMP_SIMULATION_SEEDS }}
+          compression-level: 9

--- a/test-fixture/src/sim/mod.rs
+++ b/test-fixture/src/sim/mod.rs
@@ -15,8 +15,9 @@ use std::{
     cell::RefCell,
     cmp::min,
     fmt::Debug,
-    fs::{create_dir_all, write},
+    fs::{create_dir_all, File},
     ops::{Deref, DerefMut},
+    path::PathBuf,
     rc::Rc,
     time::{Duration, Instant},
 };
@@ -164,9 +165,9 @@ impl Simulator {
                 qerror!("Failed to create directory {dir}");
             } else {
                 let seed_str = sim.rng.borrow().seed_str();
-                let path = format!("{dir}/{seed_str}");
+                let path = PathBuf::from(format!("{dir}/{}-{seed_str}", sim.name));
                 if File::create(&path).is_err() {
-                    qerror!("Failed to write seed to {path}");
+                    qerror!("Failed to write seed to {}", path.to_string_lossy());
                 }
             }
         }

--- a/test-fixture/src/sim/mod.rs
+++ b/test-fixture/src/sim/mod.rs
@@ -15,7 +15,7 @@ use std::{
     cell::RefCell,
     cmp::min,
     fmt::Debug,
-    fs::write,
+    fs::{create_dir_all, write},
     ops::{Deref, DerefMut},
     rc::Rc,
     time::{Duration, Instant},
@@ -160,10 +160,14 @@ impl Simulator {
         // Dump the seed to a file to the directory in the `DUMP_SIMULATION_SEEDS` environment
         // variable, if set.
         if let Ok(dir) = std::env::var("DUMP_SIMULATION_SEEDS") {
-            let seed_str = sim.rng.borrow().seed_str();
-            let path = format!("{dir}/{seed_str}");
-            if write(&path, sim.rng.borrow().seed_str()).is_err() {
-                qerror!("Failed to write seed to {path}");
+            if create_dir_all(&dir).is_err() {
+                qerror!("Failed to create directory {dir}");
+            } else {
+                let seed_str = sim.rng.borrow().seed_str();
+                let path = format!("{dir}/{seed_str}");
+                if write(&path, seed_str).is_err() {
+                    qerror!("Failed to write seed to {path}");
+                }
             }
         }
         sim

--- a/test-fixture/src/sim/mod.rs
+++ b/test-fixture/src/sim/mod.rs
@@ -165,7 +165,7 @@ impl Simulator {
             } else {
                 let seed_str = sim.rng.borrow().seed_str();
                 let path = format!("{dir}/{seed_str}");
-                if write(&path, seed_str).is_err() {
+                if File::create(&path).is_err() {
                     qerror!("Failed to write seed to {path}");
                 }
             }

--- a/test-fixture/src/sim/mod.rs
+++ b/test-fixture/src/sim/mod.rs
@@ -15,12 +15,13 @@ use std::{
     cell::RefCell,
     cmp::min,
     fmt::Debug,
+    fs::write,
     ops::{Deref, DerefMut},
     rc::Rc,
     time::{Duration, Instant},
 };
 
-use neqo_common::{qdebug, qinfo, qtrace, Datagram, Encoder};
+use neqo_common::{qdebug, qerror, qinfo, qtrace, Datagram, Encoder};
 use neqo_transport::Output;
 use rng::Random;
 use NodeState::{Active, Idle, Waiting};
@@ -64,11 +65,7 @@ macro_rules! simulate {
                 let f: Box<dyn FnOnce(&_) -> _> = Box::new($v);
                 nodes.push(Box::new(f(&fixture)));
             )*
-            let mut sim = Simulator::new(stringify!($n), nodes);
-            if let Ok(seed) = std::env::var("SIMULATION_SEED") {
-                sim.seed_str(seed);
-            }
-            sim.run();
+            Simulator::new(stringify!($n), nodes).run();
         }
     };
 }
@@ -151,23 +148,33 @@ impl Simulator {
             .into_iter()
             .chain(it.map(|node| NodeHolder { node, state: Idle }))
             .collect::<Vec<_>>();
-        Self {
+        let mut sim = Self {
             name,
             nodes,
             rng: Rc::default(),
+        };
+        // Seed from the `SIMULATION_SEED` environment variable, if set.
+        if let Ok(seed) = std::env::var("SIMULATION_SEED") {
+            sim.seed_str(seed);
         }
-    }
-
-    pub fn seed(&mut self, seed: [u8; 32]) {
-        self.rng = Rc::new(RefCell::new(Random::new(&seed)));
+        // Dump the seed to a file to the directory in the `DUMP_SIMULATION_SEEDS` environment
+        // variable, if set.
+        if let Ok(dir) = std::env::var("DUMP_SIMULATION_SEEDS") {
+            let seed_str = sim.rng.borrow().seed_str();
+            let path = format!("{dir}/{seed_str}");
+            if write(&path, sim.rng.borrow().seed_str()).is_err() {
+                qerror!("Failed to write seed to {path}");
+            }
+        }
+        sim
     }
 
     /// Seed from a hex string.
     /// # Panics
     /// When the provided string is not 32 bytes of hex (64 characters).
     pub fn seed_str(&mut self, seed: impl AsRef<str>) {
-        let seed = Encoder::from_hex(seed);
-        self.seed(<[u8; 32]>::try_from(seed.as_ref()).unwrap());
+        let seed = <[u8; 32]>::try_from(Encoder::from_hex(seed).as_ref()).unwrap();
+        self.rng = Rc::new(RefCell::new(Random::new(&seed)));
     }
 
     fn next_time(&self, now: Instant) -> Instant {

--- a/test-fixture/src/sim/rng.rs
+++ b/test-fixture/src/sim/rng.rs
@@ -69,8 +69,9 @@ impl Random {
     /// Get the seed necessary to continue from the current state of the RNG.
     #[must_use]
     pub fn seed_str(&self) -> String {
+        // Make sure to print leading zeros.
         format!(
-            "{:8x}{:8x}{:8x}{:8x}",
+            "{:08x}{:08x}{:08x}{:08x}",
             self.state[0], self.state[1], self.state[2], self.state[3],
         )
     }

--- a/test-fixture/src/sim/rng.rs
+++ b/test-fixture/src/sim/rng.rs
@@ -71,7 +71,7 @@ impl Random {
     pub fn seed_str(&self) -> String {
         // Make sure to print leading zeros.
         format!(
-            "{:08x}{:08x}{:08x}{:08x}",
+            "{:016x}{:016x}{:016x}{:016x}",
             self.state[0], self.state[1], self.state[2], self.state[3],
         )
     }

--- a/test-fixture/src/sim/rng.rs
+++ b/test-fixture/src/sim/rng.rs
@@ -69,7 +69,6 @@ impl Random {
     /// Get the seed necessary to continue from the current state of the RNG.
     #[must_use]
     pub fn seed_str(&self) -> String {
-        // Make sure to print leading zeros.
         format!(
             "{:016x}{:016x}{:016x}{:016x}",
             self.state[0], self.state[1], self.state[2], self.state[3],


### PR DESCRIPTION
Into the directory given in the `DUMP_SIMULATION_SEEDS` environment variable. Also, export them as artifacts from the CI runs.

Fixes #1645