### PR TITLE
refactor(udp): pass SocketAddr instead of &SocketAddr

### DIFF
--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -457,7 +457,7 @@ impl<'a, H: Handler> Runner<'a, H> {
 
     async fn process_multiple_input(&mut self) -> Res<()> {
         loop {
-            let dgrams = self.socket.recv(&self.local_addr)?;
+            let dgrams = self.socket.recv(self.local_addr)?;
             if dgrams.is_empty() {
                 break;
             }

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -289,7 +289,7 @@ impl ServerRunner {
             match self.ready().await? {
                 Ready::Socket(inx) => loop {
                     let (host, socket) = self.sockets.get_mut(inx).unwrap();
-                    let dgrams = socket.recv(host)?;
+                    let dgrams = socket.recv(*host)?;
                     if dgrams.is_empty() {
                         break;
                     }

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -55,7 +55,7 @@ impl Socket {
 
     /// Receive a batch of [`Datagram`]s on the given [`Socket`], each set with
     /// the provided local address.
-    pub fn recv(&self, local_address: &SocketAddr) -> Result<Vec<Datagram>, io::Error> {
+    pub fn recv(&self, local_address: SocketAddr) -> Result<Vec<Datagram>, io::Error> {
         self.inner
             .try_io(tokio::io::Interest::READABLE, || {
                 neqo_udp::recv_inner(local_address, &self.state, &self.inner)


### PR DESCRIPTION
`SocketAddr` implements `Copy`.

https://doc.rust-lang.org/std/net/enum.SocketAddr.html#impl-Copy-for-SocketAddr

Thus there is no need to pass by reference instead of by value.

Broken out of https://github.com/mozilla/neqo/pull/2093.