### PR TITLE
fix: Replace `find_path_with_rebinding` with `find_path`

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1532,7 +1532,7 @@ impl Connection {
     /// This takes two times: when the datagram was received, and the current time.
     fn input(&mut self, d: &Datagram, received: Instant, now: Instant) {
         // First determine the path.
-        let path = self.paths.find_path_with_rebinding(
+        let path = self.paths.find_path(
             d.destination(),
             d.source(),
             self.conn_params.get_cc_algorithm(),

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -83,7 +83,7 @@ impl Paths {
         self.paths
             .iter()
             .find_map(|p| {
-                if p.borrow().received_on(local, remote, false) {
+                if p.borrow().received_on(local, remote) {
                     Some(Rc::clone(p))
                 } else {
                     None
@@ -580,12 +580,8 @@ impl Path {
     }
 
     /// Determine if this path was the one that the provided datagram was received on.
-    /// This uses the full local socket address, but ignores the port number on the peer
-    /// if `flexible` is true, allowing for NAT rebinding that retains the same IP.
-    fn received_on(&self, local: SocketAddr, remote: SocketAddr, flexible: bool) -> bool {
-        self.local == local
-            && self.remote.ip() == remote.ip()
-            && (flexible || self.remote.port() == remote.port())
+    fn received_on(&self, local: SocketAddr, remote: SocketAddr) -> bool {
+        self.local == local && self.remote == remote
     }
 
     /// Update the remote port number.  Any flexibility we allow in `received_on`

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -98,48 +98,6 @@ impl Paths {
             })
     }
 
-    /// Find the path, but allow for rebinding.  That matches the pair of addresses
-    /// to paths that match the remote address only based on IP addres, not port.
-    /// We use this when the other side migrates to skip address validation and
-    /// creating a new path.
-    pub fn find_path_with_rebinding(
-        &self,
-        local: SocketAddr,
-        remote: SocketAddr,
-        cc: CongestionControlAlgorithm,
-        pacing: bool,
-        now: Instant,
-    ) -> PathRef {
-        self.paths
-            .iter()
-            .find_map(|p| {
-                if p.borrow().received_on(local, remote, false) {
-                    Some(Rc::clone(p))
-                } else {
-                    None
-                }
-            })
-            .or_else(|| {
-                self.paths.iter().find_map(|p| {
-                    if p.borrow().received_on(local, remote, true) {
-                        Some(Rc::clone(p))
-                    } else {
-                        None
-                    }
-                })
-            })
-            .unwrap_or_else(|| {
-                Rc::new(RefCell::new(Path::temporary(
-                    local,
-                    remote,
-                    cc,
-                    pacing,
-                    self.qlog.clone(),
-                    now,
-                )))
-            })
-    }
-
     /// Get a reference to the primary path, if one exists.
     pub fn primary(&self) -> Option<PathRef> {
         self.primary.clone()


### PR DESCRIPTION
We need to do a path challenge even if only the remote port changes.

This makes us pass the `rebind-port` QNS test.