### PR TITLE
fix: Build QNS docker image with debug symbols

### DIFF
--- a/qns/Dockerfile
+++ b/qns/Dockerfile
@@ -33,7 +33,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 ADD . /neqo
 RUN set -eux; \
     cd /neqo; \
-    cargo build --release --bin neqo-client --bin neqo-server
+    CARGO_PROFILE_RELEASE_DEBUG=true cargo build --release --bin neqo-client --bin neqo-server
 
 # Copy only binaries to the final image to keep it small.
 


### PR DESCRIPTION
So panic stack traces are useful.