### PR TITLE
ci: fix cache-hit check

### DIFF
--- a/.github/actions/nss/action.yml
+++ b/.github/actions/nss/action.yml
@@ -120,7 +120,7 @@ runs:
       if: env.USE_SYSTEM_NSS == '0'
       shell: bash
       run: |
-        if [ "${{ runner.environment }}" != "github-hosted" ] || [ "${{ steps.cache.outputs.cache-hit }}" == "false" ]; then
+        if [ "${{ runner.environment }}" != "github-hosted" ] || [ "${{ steps.cache.outputs.cache-hit }}" == "" ]; then
           echo "Building NSS from source"
           echo "BUILD_NSS=1" >> "$GITHUB_ENV"
         else


### PR DESCRIPTION
According to the actions/cache docs an empty string represents a cache miss:

> cache-hit - A string value to indicate an exact match was found for the key.
>  - If there's a cache hit, this will be 'true' or 'false' to indicate if there's an exact match for key.
>  - If there's a cache miss, this will be an empty string.

https://github.com/actions/cache?tab=readme-ov-file#outputs

Previously Neqo's CI would check for `"false"`, now it checks for `""`.

Fixes https://github.com/mozilla/neqo/issues/2185.