### PR TITLE
feat(transport): accept borrowed instead of owned input datagram

### DIFF
--- a/fuzz/fuzz_targets/client_initial.rs
+++ b/fuzz/fuzz_targets/client_initial.rs
@@ -17,7 +17,7 @@ fuzz_target!(|data: &[u8]| {
     };
 
     let mut client = default_client();
-    let ci = client.process(None, now()).dgram().expect("a datagram");
+    let ci = client.process_output(now()).dgram().expect("a datagram");
     let Some((header, d_cid, s_cid, payload)) = decode_initial_header(&ci, Role::Client) else {
         return;
     };
@@ -60,7 +60,7 @@ fuzz_target!(|data: &[u8]| {
     let fuzzed_ci = Datagram::new(ci.source(), ci.destination(), ci.tos(), ciphertext);
 
     let mut server = default_server();
-    let _response = server.process(Some(&fuzzed_ci), now());
+    let _response = server.process(Some(fuzzed_ci), now());
 });
 
 #[cfg(any(not(fuzzing), windows))]

--- a/fuzz/fuzz_targets/server_initial.rs
+++ b/fuzz/fuzz_targets/server_initial.rs
@@ -17,12 +17,9 @@ fuzz_target!(|data: &[u8]| {
     };
 
     let mut client = default_client();
-    let ci = client.process(None, now()).dgram().expect("a datagram");
+    let ci = client.process_output(now()).dgram().expect("a datagram");
     let mut server = default_server();
-    let si = server
-        .process(Some(&ci), now())
-        .dgram()
-        .expect("a datagram");
+    let si = server.process(Some(ci), now()).dgram().expect("a datagram");
 
     let Some((header, d_cid, s_cid, payload)) = decode_initial_header(&si, Role::Server) else {
         return;
@@ -64,7 +61,7 @@ fuzz_target!(|data: &[u8]| {
         (header_enc.len() - 1)..header_enc.len(),
     );
     let fuzzed_si = Datagram::new(si.source(), si.destination(), si.tos(), ciphertext);
-    let _response = client.process(Some(&fuzzed_si), now());
+    let _response = client.process(Some(fuzzed_si), now());
 });
 
 #[cfg(any(not(fuzzing), windows))]

--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -181,10 +181,11 @@ impl super::Client for Connection {
         self.process_output(now)
     }
 
-    fn process_multiple_input<'a, I>(&mut self, dgrams: I, now: Instant)
-    where
-        I: IntoIterator<Item = Datagram<&'a [u8]>>,
-    {
+    fn process_multiple_input<'a>(
+        &mut self,
+        dgrams: impl IntoIterator<Item = Datagram<&'a [u8]>>,
+        now: Instant,
+    ) {
         self.process_multiple_input(dgrams, now);
     }
 

--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -183,7 +183,7 @@ impl super::Client for Connection {
 
     fn process_multiple_input<'a, I>(&mut self, dgrams: I, now: Instant)
     where
-        I: IntoIterator<Item = &'a Datagram>,
+        I: IntoIterator<Item = Datagram<&'a [u8]>>,
     {
         self.process_multiple_input(dgrams, now);
     }

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -134,7 +134,7 @@ impl super::Client for Http3Client {
 
     fn process_multiple_input<'a, I>(&mut self, dgrams: I, now: Instant)
     where
-        I: IntoIterator<Item = &'a Datagram>,
+        I: IntoIterator<Item = Datagram<&'a [u8]>>,
     {
         self.process_multiple_input(dgrams, now);
     }

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -132,10 +132,11 @@ impl super::Client for Http3Client {
         self.process_output(now)
     }
 
-    fn process_multiple_input<'a, I>(&mut self, dgrams: I, now: Instant)
-    where
-        I: IntoIterator<Item = Datagram<&'a [u8]>>,
-    {
+    fn process_multiple_input<'a>(
+        &mut self,
+        dgrams: impl IntoIterator<Item = Datagram<&'a [u8]>>,
+        now: Instant,
+    ) {
         self.process_multiple_input(dgrams, now);
     }
 

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -374,9 +374,11 @@ enum CloseState {
 /// Network client, e.g. [`neqo_transport::Connection`] or [`neqo_http3::Http3Client`].
 trait Client {
     fn process_output(&mut self, now: Instant) -> Output;
-    fn process_multiple_input<'a, I>(&mut self, dgrams: I, now: Instant)
-    where
-        I: IntoIterator<Item = Datagram<&'a [u8]>>;
+    fn process_multiple_input<'a>(
+        &mut self,
+        dgrams: impl IntoIterator<Item = Datagram<&'a [u8]>>,
+        now: Instant,
+    );
     fn has_events(&self) -> bool;
     fn close<S>(&mut self, now: Instant, app_error: AppError, msg: S)
     where
@@ -392,9 +394,28 @@ struct Runner<'a, H: Handler> {
     handler: H,
     timeout: Option<Pin<Box<Sleep>>>,
     args: &'a Args,
+    recv_buf: Vec<u8>,
 }
 
 impl<'a, H: Handler> Runner<'a, H> {
+    fn new(
+        local_addr: SocketAddr,
+        socket: &'a mut crate::udp::Socket,
+        client: H::Client,
+        handler: H,
+        args: &'a Args,
+    ) -> Self {
+        Self {
+            local_addr,
+            socket,
+            client,
+            handler,
+            args,
+            timeout: None,
+            recv_buf: vec![0; neqo_udp::RECV_BUF_SIZE],
+        }
+    }
+
     async fn run(mut self) -> Res<Option<ResumptionToken>> {
         loop {
             let handler_done = self.handler.handle(&mut self.client)?;
@@ -457,12 +478,13 @@ impl<'a, H: Handler> Runner<'a, H> {
 
     async fn process_multiple_input(&mut self) -> Res<()> {
         loop {
-            let dgrams = self.socket.recv(&self.local_addr)?;
-            if dgrams.is_empty() {
+            let Some(dgrams) = self.socket.recv(&self.local_addr, &mut self.recv_buf)? else {
+                break;
+            };
+            if dgrams.len() == 0 {
                 break;
             }
-            self.client
-                .process_multiple_input(dgrams.iter().map(Datagram::borrow), Instant::now());
+            self.client.process_multiple_input(dgrams, Instant::now());
             self.process_output().await?;
         }
 
@@ -573,32 +595,18 @@ pub async fn client(mut args: Args) -> Res<()> {
 
                 let handler = http09::Handler::new(to_request, &args);
 
-                Runner {
-                    args: &args,
-                    client,
-                    handler,
-                    local_addr: real_local,
-                    socket: &mut socket,
-                    timeout: None,
-                }
-                .run()
-                .await?
+                Runner::new(real_local, &mut socket, client, handler, &args)
+                    .run()
+                    .await?
             } else {
                 let client = http3::create_client(&args, real_local, remote_addr, &hostname, token)
                     .expect("failed to create client");
 
                 let handler = http3::Handler::new(to_request, &args);
 
-                Runner {
-                    args: &args,
-                    client,
-                    handler,
-                    local_addr: real_local,
-                    socket: &mut socket,
-                    timeout: None,
-                }
-                .run()
-                .await?
+                Runner::new(real_local, &mut socket, client, handler, &args)
+                    .run()
+                    .await?
             };
         }
     }

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -376,7 +376,7 @@ trait Client {
     fn process_output(&mut self, now: Instant) -> Output;
     fn process_multiple_input<'a, I>(&mut self, dgrams: I, now: Instant)
     where
-        I: IntoIterator<Item = &'a Datagram>;
+        I: IntoIterator<Item = Datagram<&'a [u8]>>;
     fn has_events(&self) -> bool;
     fn close<S>(&mut self, now: Instant, app_error: AppError, msg: S)
     where
@@ -462,7 +462,7 @@ impl<'a, H: Handler> Runner<'a, H> {
                 break;
             }
             self.client
-                .process_multiple_input(dgrams.iter(), Instant::now());
+                .process_multiple_input(dgrams.iter().map(Datagram::borrow), Instant::now());
             self.process_output().await?;
         }
 

--- a/neqo-bin/src/server/http09.rs
+++ b/neqo-bin/src/server/http09.rs
@@ -185,7 +185,7 @@ impl HttpServer {
 }
 
 impl super::HttpServer for HttpServer {
-    fn process(&mut self, dgram: Option<&Datagram>, now: Instant) -> Output {
+    fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
         self.server.process(dgram, now)
     }
 

--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -79,7 +79,7 @@ impl Display for HttpServer {
 }
 
 impl super::HttpServer for HttpServer {
-    fn process(&mut self, dgram: Option<&Datagram>, now: Instant) -> neqo_http3::Output {
+    fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> neqo_http3::Output {
         self.server.process(dgram, now)
     }
 

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -7,7 +7,7 @@
 use std::{io, net::SocketAddr};
 
 use neqo_common::Datagram;
-use neqo_transport::RECV_BUFFER_SIZE;
+use neqo_udp::DatagramIter;
 
 /// Ideally this would live in [`neqo-udp`]. [`neqo-udp`] is used in Firefox.
 ///
@@ -56,16 +56,19 @@ impl Socket {
 
     /// Receive a batch of [`Datagram`]s on the given [`Socket`], each set with
     /// the provided local address.
-    pub fn recv(&self, local_address: &SocketAddr) -> Result<Vec<Datagram>, io::Error> {
-        let mut recv_buf = vec![0; RECV_BUFFER_SIZE];
+    pub fn recv<'a>(
+        &self,
+        local_address: &SocketAddr,
+        recv_buf: &'a mut [u8],
+    ) -> Result<Option<DatagramIter<'a>>, io::Error> {
         self.inner
             .try_io(tokio::io::Interest::READABLE, || {
-                neqo_udp::recv_inner(local_address, &self.state, &self.inner, &mut recv_buf)
+                neqo_udp::recv_inner(local_address, &self.state, &self.inner, recv_buf)
             })
-            .map(|dgrams| dgrams.map(|d| d.to_owned()).collect())
+            .map(Some)
             .or_else(|e| {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    Ok(vec![])
+                    Ok(None)
                 } else {
                     Err(e)
                 }

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/negotiation.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/negotiation.rs
@@ -86,9 +86,9 @@ fn zero_rtt(
     assert_eq!(client.webtransport_enabled(), client_org && server_org);
 
     // exchange token
-    let out = server.process(None, now());
+    let out = server.process_output(now());
     // We do not have a token so we need to wait for a resumption token timer to trigger.
-    std::mem::drop(client.process(out.as_dgram_ref(), now() + Duration::from_millis(250)));
+    std::mem::drop(client.process(out.dgram(), now() + Duration::from_millis(250)));
     assert_eq!(client.state(), Http3State::Connected);
     let token = client
         .events()
@@ -233,8 +233,8 @@ fn zero_rtt_wt_settings() {
 fn exchange_packets2(client: &mut Http3Client, server: &mut Connection) {
     let mut out = None;
     loop {
-        out = client.process(out.as_ref(), now()).dgram();
-        out = server.process(out.as_ref(), now()).dgram();
+        out = client.process(out, now()).dgram();
+        out = server.process(out, now()).dgram();
         if out.is_none() {
             break;
         }

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -425,18 +425,18 @@ fn wt_close_session_cannot_be_sent_at_once() {
         Err(Error::InvalidStreamId)
     );
 
-    let out = wt.server.process(None, now());
-    let out = wt.client.process(out.as_dgram_ref(), now());
+    let out = wt.server.process_output(now());
+    let out = wt.client.process(out.dgram(), now());
 
     // Client has not received the full CloseSession frame and it can create more streams.
     let unidi_client = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::UniDi);
 
-    let out = wt.server.process(out.as_dgram_ref(), now());
-    let out = wt.client.process(out.as_dgram_ref(), now());
-    let out = wt.server.process(out.as_dgram_ref(), now());
-    let out = wt.client.process(out.as_dgram_ref(), now());
-    let out = wt.server.process(out.as_dgram_ref(), now());
-    let _out = wt.client.process(out.as_dgram_ref(), now());
+    let out = wt.server.process(out.dgram(), now());
+    let out = wt.client.process(out.dgram(), now());
+    let out = wt.server.process(out.dgram(), now());
+    let out = wt.client.process(out.dgram(), now());
+    let out = wt.server.process(out.dgram(), now());
+    let _out = wt.client.process(out.dgram(), now());
 
     wt.check_events_after_closing_session_client(
         &[],

--- a/neqo-http3/src/frames/tests/mod.rs
+++ b/neqo-http3/src/frames/tests/mod.rs
@@ -22,13 +22,13 @@ pub fn enc_dec<T: FrameDecoder<T>>(d: &Encoder, st: &str, remaining: usize) -> T
 
     let mut conn_c = default_client();
     let mut conn_s = default_server();
-    let out = conn_c.process(None, now());
-    let out = conn_s.process(out.as_dgram_ref(), now());
-    let out = conn_c.process(out.as_dgram_ref(), now());
-    mem::drop(conn_s.process(out.as_dgram_ref(), now()));
+    let out = conn_c.process_output(now());
+    let out = conn_s.process(out.dgram(), now());
+    let out = conn_c.process(out.dgram(), now());
+    mem::drop(conn_s.process(out.dgram(), now()));
     conn_c.authenticated(AuthenticationStatus::Ok, now());
-    let out = conn_c.process(None, now());
-    mem::drop(conn_s.process(out.as_dgram_ref(), now()));
+    let out = conn_c.process_output(now());
+    mem::drop(conn_s.process(out.dgram(), now()));
 
     // create a stream
     let stream_id = conn_s.stream_create(StreamType::BiDi).unwrap();
@@ -38,8 +38,8 @@ pub fn enc_dec<T: FrameDecoder<T>>(d: &Encoder, st: &str, remaining: usize) -> T
     // conver string into u8 vector
     let buf = Encoder::from_hex(st);
     conn_s.stream_send(stream_id, buf.as_ref()).unwrap();
-    let out = conn_s.process(None, now());
-    mem::drop(conn_c.process(out.as_dgram_ref(), now()));
+    let out = conn_s.process_output(now());
+    mem::drop(conn_c.process(out.dgram(), now()));
 
     let (frame, fin) = fr
         .receive::<T>(&mut StreamReaderConnectionWrapper::new(

--- a/neqo-http3/src/frames/tests/reader.rs
+++ b/neqo-http3/src/frames/tests/reader.rs
@@ -39,8 +39,8 @@ impl FrameReaderTest {
 
     fn process<T: FrameDecoder<T>>(&mut self, v: &[u8]) -> Option<T> {
         self.conn_s.stream_send(self.stream_id, v).unwrap();
-        let out = self.conn_s.process(None, now());
-        mem::drop(self.conn_c.process(out.as_dgram_ref(), now()));
+        let out = self.conn_s.process_output(now());
+        mem::drop(self.conn_c.process(out.dgram(), now()));
         let (frame, fin) = self
             .fr
             .receive::<T>(&mut StreamReaderConnectionWrapper::new(
@@ -230,13 +230,13 @@ fn test_reading_frame<T: FrameDecoder<T> + PartialEq + Debug>(
         fr.conn_s.stream_close_send(fr.stream_id).unwrap();
     }
 
-    let out = fr.conn_s.process(None, now());
-    mem::drop(fr.conn_c.process(out.as_dgram_ref(), now()));
+    let out = fr.conn_s.process_output(now());
+    mem::drop(fr.conn_c.process(out.dgram(), now()));
 
     if matches!(test_to_send, FrameReadingTestSend::DataThenFin) {
         fr.conn_s.stream_close_send(fr.stream_id).unwrap();
-        let out = fr.conn_s.process(None, now());
-        mem::drop(fr.conn_c.process(out.as_dgram_ref(), now()));
+        let out = fr.conn_s.process_output(now());
+        mem::drop(fr.conn_c.process(out.dgram(), now()));
     }
 
     let rv = fr.fr.receive::<T>(&mut StreamReaderConnectionWrapper::new(
@@ -478,12 +478,12 @@ fn frame_reading_when_stream_is_closed_before_sending_data() {
     let mut fr = FrameReaderTest::new();
 
     fr.conn_s.stream_send(fr.stream_id, &[0x00]).unwrap();
-    let out = fr.conn_s.process(None, now());
-    mem::drop(fr.conn_c.process(out.as_dgram_ref(), now()));
+    let out = fr.conn_s.process_output(now());
+    mem::drop(fr.conn_c.process(out.dgram(), now()));
 
     assert_eq!(Ok(()), fr.conn_c.stream_close_send(fr.stream_id));
-    let out = fr.conn_c.process(None, now());
-    mem::drop(fr.conn_s.process(out.as_dgram_ref(), now()));
+    let out = fr.conn_c.process_output(now());
+    mem::drop(fr.conn_s.process(out.dgram(), now()));
     assert_eq!(
         Ok((None, true)),
         fr.fr
@@ -501,12 +501,12 @@ fn wt_frame_reading_when_stream_is_closed_before_sending_data() {
     let mut fr = FrameReaderTest::new();
 
     fr.conn_s.stream_send(fr.stream_id, &[0x00]).unwrap();
-    let out = fr.conn_s.process(None, now());
-    mem::drop(fr.conn_c.process(out.as_dgram_ref(), now()));
+    let out = fr.conn_s.process_output(now());
+    mem::drop(fr.conn_c.process(out.dgram(), now()));
 
     assert_eq!(Ok(()), fr.conn_c.stream_close_send(fr.stream_id));
-    let out = fr.conn_c.process(None, now());
-    mem::drop(fr.conn_s.process(out.as_dgram_ref(), now()));
+    let out = fr.conn_c.process_output(now());
+    mem::drop(fr.conn_s.process(out.dgram(), now()));
     assert_eq!(
         Ok((None, true)),
         fr.fr

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -113,7 +113,12 @@ impl Http3Server {
         self.server.ech_config()
     }
 
-    pub fn process(&mut self, dgram: Option<&Datagram>, now: Instant) -> Output {
+    /// Short-hand for [`Http3Server::process`] with no input datagram.
+    pub fn process_output(&mut self, now: Instant) -> Output {
+        self.process(None::<Datagram>, now)
+    }
+
+    pub fn process(&mut self, dgram: Option<Datagram<impl AsRef<[u8]>>>, now: Instant) -> Output {
         qtrace!([self], "Process.");
         let out = self.server.process(dgram, now);
         self.process_http3(now);
@@ -123,7 +128,7 @@ impl Http3Server {
                 qtrace!([self], "Send packet: {:?}", d);
                 Output::Datagram(d)
             }
-            _ => self.server.process(Option::<&Datagram>::None, now),
+            _ => self.server.process(Option::<Datagram>::None, now),
         }
     }
 
@@ -396,29 +401,29 @@ mod tests {
     const SERVER_SIDE_DECODER_STREAM_ID: StreamId = StreamId::new(11);
 
     fn connect_transport(server: &mut Http3Server, client: &mut Connection, resume: bool) {
-        let c1 = client.process(None, now());
-        let s1 = server.process(c1.as_dgram_ref(), now());
-        let c2 = client.process(s1.as_dgram_ref(), now());
+        let c1 = client.process_output(now());
+        let s1 = server.process(c1.dgram(), now());
+        let c2 = client.process(s1.dgram(), now());
         let needs_auth = client
             .events()
             .any(|e| e == ConnectionEvent::AuthenticationNeeded);
         let c2 = if needs_auth {
             assert!(!resume);
             // c2 should just be an ACK, so absorb that.
-            let s_ack = server.process(c2.as_dgram_ref(), now());
-            assert!(s_ack.as_dgram_ref().is_none());
+            let s_ack = server.process(c2.dgram(), now());
+            assert!(s_ack.dgram().is_none());
 
             client.authenticated(AuthenticationStatus::Ok, now());
-            client.process(None, now())
+            client.process_output(now())
         } else {
             assert!(resume);
             c2
         };
         assert!(client.state().connected());
-        let s2 = server.process(c2.as_dgram_ref(), now());
+        let s2 = server.process(c2.dgram(), now());
         assert_connected(server);
-        let c3 = client.process(s2.as_dgram_ref(), now());
-        assert!(c3.as_dgram_ref().is_none());
+        let c3 = client.process(s2.dgram(), now());
+        assert!(c3.dgram().is_none());
     }
 
     // Start a client/server and check setting frame.
@@ -552,9 +557,9 @@ mod tests {
         let decoder_stream = neqo_trans_conn.stream_create(StreamType::UniDi).unwrap();
         sent = neqo_trans_conn.stream_send(decoder_stream, &[0x3]);
         assert_eq!(sent, Ok(1));
-        let out1 = neqo_trans_conn.process(None, now());
-        let out2 = server.process(out1.as_dgram_ref(), now());
-        mem::drop(neqo_trans_conn.process(out2.as_dgram_ref(), now()));
+        let out1 = neqo_trans_conn.process_output(now());
+        let out2 = server.process(out1.dgram(), now());
+        mem::drop(neqo_trans_conn.process(out2.dgram(), now()));
 
         // assert no error occured.
         assert_not_closed(server);
@@ -584,8 +589,8 @@ mod tests {
         let (mut hconn, mut peer_conn) = connect();
         let control = peer_conn.control_stream_id;
         peer_conn.stream_close_send(control).unwrap();
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -599,8 +604,8 @@ mod tests {
         // Send a MAX_PUSH_ID frame instead.
         let sent = neqo_trans_conn.stream_send(control_stream, &[0x0, 0xd, 0x1, 0xf]);
         assert_eq!(sent, Ok(4));
-        let out = neqo_trans_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = neqo_trans_conn.process_output(now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, &Error::HttpMissingSettings);
     }
 
@@ -611,8 +616,8 @@ mod tests {
         let (mut hconn, mut peer_conn) = connect();
         // send the second SETTINGS frame.
         peer_conn.control_send(&[0x4, 0x6, 0x1, 0x40, 0x64, 0x7, 0x40, 0x64]);
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, &Error::HttpFrameUnexpected);
     }
 
@@ -626,8 +631,8 @@ mod tests {
         let mut e = Encoder::default();
         frame.encode(&mut e);
         peer_conn.control_send(e.as_ref());
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
         // check if the given connection got closed on invalid stream ids
         if valid {
             assert_not_closed(&hconn);
@@ -669,8 +674,8 @@ mod tests {
         // receive a frame that is not allowed on the control stream.
         peer_conn.control_send(v);
 
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, &Error::HttpFrameUnexpected);
     }
 
@@ -703,11 +708,11 @@ mod tests {
         _ = peer_conn
             .stream_send(new_stream_id, &[0x41, 0x19, 0x4, 0x4, 0x6, 0x0, 0x8, 0x0])
             .unwrap();
-        let out = peer_conn.process(None, now());
-        let out = hconn.process(out.as_dgram_ref(), now());
-        mem::drop(peer_conn.process(out.as_dgram_ref(), now()));
-        let out = hconn.process(None, now());
-        mem::drop(peer_conn.process(out.as_dgram_ref(), now()));
+        let out = peer_conn.process_output(now());
+        let out = hconn.process(out.dgram(), now());
+        mem::drop(peer_conn.process(out.dgram(), now()));
+        let out = hconn.process_output(now());
+        mem::drop(peer_conn.process(out.dgram(), now()));
 
         // check for stop-sending with Error::HttpStreamCreation.
         let mut stop_sending_event_found = false;
@@ -734,9 +739,9 @@ mod tests {
         // create a push stream.
         let push_stream_id = peer_conn.stream_create(StreamType::UniDi).unwrap();
         _ = peer_conn.stream_send(push_stream_id, &[0x1]).unwrap();
-        let out = peer_conn.process(None, now());
-        let out = hconn.process(out.as_dgram_ref(), now());
-        mem::drop(peer_conn.conn.process(out.as_dgram_ref(), now()));
+        let out = peer_conn.process_output(now());
+        let out = hconn.process(out.dgram(), now());
+        mem::drop(peer_conn.conn.process(out.dgram(), now()));
         assert_closed(&hconn, &Error::HttpStreamCreation);
     }
 
@@ -751,77 +756,77 @@ mod tests {
         // send the stream type
         let mut sent = peer_conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         // start sending SETTINGS frame
         sent = peer_conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x6]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x8]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x0]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         assert_not_closed(&hconn);
 
         // Now test PushPromise
         sent = peer_conn.stream_send(control_stream, &[0x5]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x5]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x4]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x61]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x62]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x63]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         sent = peer_conn.stream_send(control_stream, &[0x64]);
         assert_eq!(sent, Ok(1));
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         // PUSH_PROMISE on a control stream will cause an error
         assert_closed(&hconn, &Error::HttpFrameUnexpected);
@@ -836,8 +841,8 @@ mod tests {
         peer_conn.stream_send(stream_id, res).unwrap();
         peer_conn.stream_close_send(stream_id).unwrap();
 
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         assert_closed(&hconn, &Error::HttpFrame);
     }
@@ -888,8 +893,8 @@ mod tests {
         peer_conn.stream_send(stream_id, REQUEST_WITH_BODY).unwrap();
         peer_conn.stream_close_send(stream_id).unwrap();
 
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         // Check connection event. There should be 1 Header and 2 data events.
         let mut headers_frames = 0;
@@ -935,8 +940,8 @@ mod tests {
             .stream_send(stream_id, &REQUEST_WITH_BODY[..20])
             .unwrap();
 
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         // Check connection event. There should be 1 Header and no data events.
         let mut headers_frames = 0;
@@ -972,7 +977,7 @@ mod tests {
                 | Http3ServerEvent::WebTransport(_) => {}
             }
         }
-        let out = hconn.process(None, now());
+        let out = hconn.process_output(now());
 
         // Send data.
         peer_conn
@@ -980,8 +985,8 @@ mod tests {
             .unwrap();
         peer_conn.stream_close_send(stream_id).unwrap();
 
-        let out = peer_conn.process(out.as_dgram_ref(), now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process(out.dgram(), now());
+        hconn.process(out.dgram(), now());
 
         while let Some(event) = hconn.next_event() {
             match event {
@@ -1012,8 +1017,8 @@ mod tests {
             .stream_send(request_stream_id, &REQUEST_WITH_BODY[..20])
             .unwrap();
 
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         // Check connection event. There should be 1 Header and no data events.
         // The server will reset the stream.
@@ -1043,10 +1048,10 @@ mod tests {
                 | Http3ServerEvent::WebTransport(_) => {}
             }
         }
-        let out = hconn.process(None, now());
+        let out = hconn.process_output(now());
 
-        let out = peer_conn.process(out.as_dgram_ref(), now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process(out.dgram(), now());
+        hconn.process(out.dgram(), now());
 
         // Check that STOP_SENDING and REET has been received.
         let mut reset = 0;
@@ -1077,8 +1082,8 @@ mod tests {
         peer_conn
             .stream_reset_send(CLIENT_SIDE_CONTROL_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -1090,8 +1095,8 @@ mod tests {
         peer_conn
             .stream_reset_send(CLIENT_SIDE_ENCODER_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -1103,8 +1108,8 @@ mod tests {
         peer_conn
             .stream_reset_send(CLIENT_SIDE_DECODER_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -1117,8 +1122,8 @@ mod tests {
         peer_conn
             .stream_stop_sending(SERVER_SIDE_CONTROL_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -1130,8 +1135,8 @@ mod tests {
         peer_conn
             .stream_stop_sending(SERVER_SIDE_ENCODER_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -1143,8 +1148,8 @@ mod tests {
         peer_conn
             .stream_stop_sending(SERVER_SIDE_DECODER_STREAM_ID, Error::HttpNoError.code())
             .unwrap();
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
         assert_closed(&hconn, &Error::HttpClosedCriticalStream);
     }
 
@@ -1251,8 +1256,8 @@ mod tests {
             .stream_send(request_stream_id_2, REQUEST_WITH_BODY)
             .unwrap();
 
-        let out = peer_conn.process(None, now());
-        hconn.process(out.as_dgram_ref(), now());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
 
         let mut requests = HashMap::new();
         while let Some(event) = hconn.next_event() {

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -268,8 +268,8 @@ mod tests {
             let (mut conn_c, mut conn_s) = connect();
             // create a stream
             let stream_id = conn_s.stream_create(stream_type).unwrap();
-            let out = conn_s.process(None, now());
-            mem::drop(conn_c.process(out.as_dgram_ref(), now()));
+            let out = conn_s.process_output(now());
+            mem::drop(conn_c.process(out.dgram(), now()));
 
             Self {
                 conn_c,
@@ -291,8 +291,8 @@ mod tests {
                 self.conn_s
                     .stream_send(self.stream_id, &enc[i..=i])
                     .unwrap();
-                let out = self.conn_s.process(None, now());
-                mem::drop(self.conn_c.process(out.as_dgram_ref(), now()));
+                let out = self.conn_s.process_output(now());
+                mem::drop(self.conn_c.process(out.dgram(), now()));
                 assert_eq!(
                     self.decoder.receive(&mut self.conn_c).unwrap(),
                     (ReceiveOutput::NoOutput, false)
@@ -305,8 +305,8 @@ mod tests {
             if fin {
                 self.conn_s.stream_close_send(self.stream_id).unwrap();
             }
-            let out = self.conn_s.process(None, now());
-            mem::drop(self.conn_c.process(out.dgram().as_ref(), now()));
+            let out = self.conn_s.process_output(now());
+            mem::drop(self.conn_c.process(out.dgram(), now()));
             assert_eq!(&self.decoder.receive(&mut self.conn_c), outcome);
             assert_eq!(self.decoder.done(), done);
         }

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -16,9 +16,9 @@ use test_fixture::*;
 fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
     let mut out = None;
     loop {
-        out = client.process(out.as_ref(), now()).dgram();
+        out = client.process(out, now()).dgram();
         let client_done = out.is_none();
-        out = server.process(out.as_ref(), now()).dgram();
+        out = server.process(out, now()).dgram();
         if out.is_none() && client_done {
             break;
         }
@@ -28,29 +28,29 @@ fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
 // Perform only Quic transport handshake.
 fn connect_with(client: &mut Http3Client, server: &mut Http3Server) {
     assert_eq!(client.state(), Http3State::Initializing);
-    let out = client.process(None, now());
+    let out = client.process_output(now());
     assert_eq!(client.state(), Http3State::Initializing);
 
-    let out = server.process(out.as_dgram_ref(), now());
-    let out = client.process(out.as_dgram_ref(), now());
-    let out = server.process(out.as_dgram_ref(), now());
+    let out = server.process(out.dgram(), now());
+    let out = client.process(out.dgram(), now());
+    let out = server.process(out.dgram(), now());
     assert!(out.as_dgram_ref().is_none());
 
     let authentication_needed = |e| matches!(e, Http3ClientEvent::AuthenticationNeeded);
     assert!(client.events().any(authentication_needed));
     client.authenticated(AuthenticationStatus::Ok, now());
 
-    let out = client.process(out.as_dgram_ref(), now());
+    let out = client.process(out.dgram(), now());
     let connected = |e| matches!(e, Http3ClientEvent::StateChange(Http3State::Connected));
     assert!(client.events().any(connected));
 
     assert_eq!(client.state(), Http3State::Connected);
     // Exchange H3 setttings
-    let out = server.process(out.as_dgram_ref(), now());
-    let out = client.process(out.as_dgram_ref(), now());
-    let out = server.process(out.as_dgram_ref(), now());
-    let out = client.process(out.as_dgram_ref(), now());
-    _ = server.process(out.as_dgram_ref(), now());
+    let out = server.process(out.dgram(), now());
+    let out = client.process(out.dgram(), now());
+    let out = server.process(out.dgram(), now());
+    let out = client.process(out.dgram(), now());
+    _ = server.process(out.dgram(), now());
 }
 
 fn connect() -> (Http3Client, Http3Server) {

--- a/neqo-http3/tests/send_message.rs
+++ b/neqo-http3/tests/send_message.rs
@@ -29,8 +29,8 @@ fn response_header_103() -> &'static Vec<Header> {
 fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
     let mut out = None;
     loop {
-        out = client.process(out.as_ref(), now()).dgram();
-        out = server.process(out.as_ref(), now()).dgram();
+        out = client.process(out, now()).dgram();
+        out = server.process(out, now()).dgram();
         if out.is_none() {
             break;
         }

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -333,8 +333,8 @@ mod tests {
             .peer_conn
             .stream_send(decoder.recv_stream_id, encoder_instruction)
             .unwrap();
-        let out = decoder.peer_conn.process(None, now());
-        mem::drop(decoder.conn.process(out.as_dgram_ref(), now()));
+        let out = decoder.peer_conn.process_output(now());
+        mem::drop(decoder.conn.process(out.dgram(), now()));
         assert_eq!(
             decoder
                 .decoder
@@ -345,8 +345,8 @@ mod tests {
 
     fn send_instructions_and_check(decoder: &mut TestDecoder, decoder_instruction: &[u8]) {
         decoder.decoder.send(&mut decoder.conn).unwrap();
-        let out = decoder.conn.process(None, now());
-        mem::drop(decoder.peer_conn.process(out.as_dgram_ref(), now()));
+        let out = decoder.conn.process_output(now());
+        mem::drop(decoder.peer_conn.process(out.dgram(), now()));
         let mut buf = [0_u8; 100];
         let (amount, fin) = decoder
             .peer_conn

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -572,9 +572,9 @@ mod tests {
 
         pub fn send_instructions(&mut self, encoder_instruction: &[u8]) {
             self.encoder.send_encoder_updates(&mut self.conn).unwrap();
-            let out = self.conn.process(None, now());
-            let out2 = self.peer_conn.process(out.as_dgram_ref(), now());
-            mem::drop(self.conn.process(out2.as_dgram_ref(), now()));
+            let out = self.conn.process_output(now());
+            let out2 = self.peer_conn.process(out.dgram(), now());
+            mem::drop(self.conn.process(out2.dgram(), now()));
             let mut buf = [0_u8; 100];
             let (amount, fin) = self
                 .peer_conn
@@ -635,8 +635,8 @@ mod tests {
             .peer_conn
             .stream_send(encoder.recv_stream_id, decoder_instruction)
             .unwrap();
-        let out = encoder.peer_conn.process(None, now());
-        mem::drop(encoder.conn.process(out.as_dgram_ref(), now()));
+        let out = encoder.peer_conn.process_output(now());
+        mem::drop(encoder.conn.process(out.dgram(), now()));
         assert!(encoder
             .encoder
             .read_instructions(&mut encoder.conn, encoder.recv_stream_id)
@@ -1563,8 +1563,8 @@ mod tests {
         encoder.send_instructions(ONE_INSTRUCTION_1);
 
         // exchange a flow control update.
-        let out = encoder.peer_conn.process(None, now());
-        mem::drop(encoder.conn.process(out.as_dgram_ref(), now()));
+        let out = encoder.peer_conn.process_output(now());
+        mem::drop(encoder.conn.process(out.dgram(), now()));
 
         // Try writing a new header block. Now, headers will be added to the dynamic table again,
         // because instructions can be sent.
@@ -1610,8 +1610,8 @@ mod tests {
             .encoder
             .send_encoder_updates(&mut encoder.conn)
             .unwrap();
-        let out = encoder.conn.process(None, now());
-        mem::drop(encoder.peer_conn.process(out.as_dgram_ref(), now()));
+        let out = encoder.conn.process_output(now());
+        mem::drop(encoder.peer_conn.process(out.dgram(), now()));
         // receive an insert count increment.
         recv_instruction(&mut encoder, &[0x01]);
 

--- a/neqo-transport/src/connection/tests/ackrate.rs
+++ b/neqo-transport/src/connection/tests/ackrate.rs
@@ -72,7 +72,7 @@ fn ack_rate_exit_slow_start() {
     // and to send ACK_FREQUENCY.
     now += DEFAULT_RTT / 2;
     assert_eq!(client.stats().frame_tx.ack_frequency, 0);
-    let af = client.process(Some(&ack), now).dgram();
+    let af = client.process(Some(ack), now).dgram();
     assert!(af.is_some());
     assert_eq!(client.stats().frame_tx.ack_frequency, 1);
 }
@@ -121,11 +121,11 @@ fn ack_rate_client_one_rtt() {
     // The first packet will elicit an immediate ACK however, so do this twice.
     let d = send_something(&mut client, now);
     now += RTT / 2;
-    let ack = server.process(Some(&d), now).dgram();
+    let ack = server.process(Some(d), now).dgram();
     assert!(ack.is_some());
     let d = send_something(&mut client, now);
     now += RTT / 2;
-    let delay = server.process(Some(&d), now).callback();
+    let delay = server.process(Some(d), now).callback();
     assert_eq!(delay, RTT);
 
     assert_eq!(client.stats().frame_tx.ack_frequency, 1);
@@ -144,11 +144,11 @@ fn ack_rate_server_half_rtt() {
     now += RTT / 2;
     // The client now will acknowledge immediately because it has been more than
     // an RTT since it last sent an acknowledgment.
-    let ack = client.process(Some(&d), now);
+    let ack = client.process(Some(d), now);
     assert!(ack.as_dgram_ref().is_some());
     let d = send_something(&mut server, now);
     now += RTT / 2;
-    let delay = client.process(Some(&d), now).callback();
+    let delay = client.process(Some(d), now).callback();
     assert_eq!(delay, RTT / 2);
 
     assert_eq!(server.stats().frame_tx.ack_frequency, 1);
@@ -172,7 +172,7 @@ fn migrate_ack_delay() {
     let client2 = send_something(&mut client, now);
     assertions::assert_v4_path(&client2, false); // Doesn't.  Is dropped.
     now += DEFAULT_RTT / 2;
-    server.process_input(&client1, now);
+    server.process_input(client1, now);
 
     let stream = client.stream_create(StreamType::UniDi).unwrap();
     let now = increase_cwnd(&mut client, &mut server, stream, now);
@@ -188,7 +188,7 @@ fn migrate_ack_delay() {
     // After noticing this new loss, the client sends ACK_FREQUENCY.
     // It has sent a few before (as we dropped `client2`), so ignore those.
     let ad_before = client.stats().frame_tx.ack_frequency;
-    let af = client.process(Some(&ack), now).dgram();
+    let af = client.process(Some(ack), now).dgram();
     assert!(af.is_some());
     assert_eq!(client.stats().frame_tx.ack_frequency, ad_before + 1);
 }

--- a/neqo-transport/src/connection/tests/close.rs
+++ b/neqo-transport/src/connection/tests/close.rs
@@ -41,7 +41,7 @@ fn connection_close() {
     client.close(now, 42, "");
 
     let stats_before = client.stats().frame_tx;
-    let out = client.process(None, now);
+    let out = client.process_output(now);
     let stats_after = client.stats().frame_tx;
     assert_eq!(
         stats_after.connection_close,
@@ -49,7 +49,7 @@ fn connection_close() {
     );
     assert_eq!(stats_after.ack, stats_before.ack + 1);
 
-    server.process_input(&out.dgram().unwrap(), now);
+    server.process_input(out.dgram().unwrap(), now);
     assert_draining(&server, &Error::PeerApplicationError(42));
 }
 
@@ -65,7 +65,7 @@ fn connection_close_with_long_reason_string() {
     client.close(now, 42, long_reason);
 
     let stats_before = client.stats().frame_tx;
-    let out = client.process(None, now);
+    let out = client.process_output(now);
     let stats_after = client.stats().frame_tx;
     assert_eq!(
         stats_after.connection_close,
@@ -73,7 +73,7 @@ fn connection_close_with_long_reason_string() {
     );
     assert_eq!(stats_after.ack, stats_before.ack + 1);
 
-    server.process_input(&out.dgram().unwrap(), now);
+    server.process_input(out.dgram().unwrap(), now);
     assert_draining(&server, &Error::PeerApplicationError(42));
 }
 
@@ -84,17 +84,17 @@ fn early_application_close() {
     let mut server = default_server();
 
     // One flight each.
-    let dgram = client.process(None, now()).dgram();
+    let dgram = client.process_output(now()).dgram();
     assert!(dgram.is_some());
-    let dgram = server.process(dgram.as_ref(), now()).dgram();
+    let dgram = server.process(dgram, now()).dgram();
     assert!(dgram.is_some());
 
     server.close(now(), 77, String::new());
     assert!(server.state().closed());
-    let dgram = server.process(None, now()).dgram();
+    let dgram = server.process_output(now()).dgram();
     assert!(dgram.is_some());
 
-    client.process_input(&dgram.unwrap(), now());
+    client.process_input(dgram.unwrap(), now());
     assert_draining(&client, &Error::PeerError(ERROR_APPLICATION_CLOSE));
 }
 
@@ -109,15 +109,15 @@ fn bad_tls_version() {
         .unwrap();
     let mut server = default_server();
 
-    let dgram = client.process(None, now()).dgram();
+    let dgram = client.process_output(now()).dgram();
     assert!(dgram.is_some());
-    let dgram = server.process(dgram.as_ref(), now()).dgram();
+    let dgram = server.process(dgram, now()).dgram();
     assert_eq!(
         *server.state(),
         State::Closed(CloseReason::Transport(Error::ProtocolViolation))
     );
     assert!(dgram.is_some());
-    client.process_input(&dgram.unwrap(), now());
+    client.process_input(dgram.unwrap(), now());
     assert_draining(&client, &Error::PeerError(Error::ProtocolViolation.code()));
 }
 
@@ -134,21 +134,21 @@ fn closing_timers_interation() {
     // We're going to induce time-based loss recovery so that timer is set.
     let _p1 = send_something(&mut client, now);
     let p2 = send_something(&mut client, now);
-    let ack = server.process(Some(&p2), now).dgram();
+    let ack = server.process(Some(p2), now).dgram();
     assert!(ack.is_some()); // This is an ACK.
 
     // After processing the ACK, we should be on the loss recovery timer.
-    let cb = client.process(ack.as_ref(), now).callback();
+    let cb = client.process(ack, now).callback();
     assert_ne!(cb, Duration::from_secs(0));
     now += cb;
 
     // Rather than let the timer pop, close the connection.
     client.close(now, 0, "");
-    let client_close = client.process(None, now).dgram();
+    let client_close = client.process_output(now).dgram();
     assert!(client_close.is_some());
     // This should now report the end of the closing period, not a
     // zero-duration wait driven by the (now defunct) loss recovery timer.
-    let client_close_timer = client.process(None, now).callback();
+    let client_close_timer = client.process_output(now).callback();
     assert_ne!(client_close_timer, Duration::from_secs(0));
 }
 
@@ -164,20 +164,20 @@ fn closing_and_draining() {
 
     // Close the connection.
     client.close(now(), APP_ERROR, "");
-    let client_close = client.process(None, now()).dgram();
+    let client_close = client.process_output(now()).dgram();
     assert!(client_close.is_some());
-    let client_close_timer = client.process(None, now()).callback();
+    let client_close_timer = client.process_output(now()).callback();
     assert_ne!(client_close_timer, Duration::from_secs(0));
     // The client will spit out the same packet in response to anything it receives.
     let p3 = send_something(&mut server, now());
-    let client_close2 = client.process(Some(&p3), now()).dgram();
+    let client_close2 = client.process(Some(p3), now()).dgram();
     assert_eq!(
         client_close.as_ref().unwrap().len(),
         client_close2.as_ref().unwrap().len()
     );
 
     // After this time, the client should transition to closed.
-    let end = client.process(None, now() + client_close_timer);
+    let end = client.process_output(now() + client_close_timer);
     assert_eq!(end, Output::None);
     assert_eq!(
         *client.state(),
@@ -185,17 +185,17 @@ fn closing_and_draining() {
     );
 
     // When the server receives the close, it too should generate CONNECTION_CLOSE.
-    let server_close = server.process(client_close.as_ref(), now()).dgram();
+    let server_close = server.process(client_close, now()).dgram();
     assert!(server.state().closed());
     assert!(server_close.is_some());
     // .. but it ignores any further close packets.
-    let server_close_timer = server.process(client_close2.as_ref(), now()).callback();
+    let server_close_timer = server.process(client_close2, now()).callback();
     assert_ne!(server_close_timer, Duration::from_secs(0));
     // Even a legitimate packet without a close in it.
-    let server_close_timer2 = server.process(Some(&p1), now()).callback();
+    let server_close_timer2 = server.process(Some(p1), now()).callback();
     assert_eq!(server_close_timer, server_close_timer2);
 
-    let end = server.process(None, now() + server_close_timer);
+    let end = server.process_output(now() + server_close_timer);
     assert_eq!(end, Output::None);
     assert_eq!(
         *server.state(),
@@ -218,6 +218,6 @@ fn stateless_reset_client() {
         .unwrap();
     connect_force_idle(&mut client, &mut server);
 
-    client.process_input(&datagram(vec![77; 21]), now());
+    client.process_input(datagram(vec![77; 21]), now());
     assert_draining(&client, &Error::StatelessReset);
 }

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -143,12 +143,12 @@ fn stats() {
 
     for _ in 0..ECN_TEST_COUNT {
         let ack = send_and_receive(&mut client, &mut server, now);
-        client.process_input(&ack.unwrap(), now);
+        client.process_input(ack.unwrap(), now);
     }
 
     for _ in 0..ECN_TEST_COUNT {
         let ack = send_and_receive(&mut server, &mut client, now);
-        server.process_input(&ack.unwrap(), now);
+        server.process_input(ack.unwrap(), now);
     }
 
     for stats in [client.stats(), server.stats()] {
@@ -194,7 +194,7 @@ fn disables_on_remark() {
 
     for _ in 0..ECN_TEST_COUNT {
         if let Some(ack) = send_with_modifier_and_receive(&mut client, &mut server, now, remark()) {
-            client.process_input(&ack, now);
+            client.process_input(ack, now);
         }
     }
 
@@ -223,21 +223,21 @@ pub fn migration_with_modifiers(
     // Right after the handshake, the ECN validation should still be in progress.
     let client_pkt = send_something(&mut client, now);
     assert_ecn_enabled(client_pkt.tos());
-    server.process_input(&orig_path_modifier(client_pkt).unwrap(), now);
+    server.process_input(orig_path_modifier(client_pkt).unwrap(), now);
 
     // Send some data on the current path.
     for _ in 0..burst {
         let client_pkt = send_something_with_modifier(&mut client, now, orig_path_modifier);
-        server.process_input(&client_pkt, now);
+        server.process_input(client_pkt, now);
     }
 
     if let Some(ack) = server.process_output(now).dgram() {
-        client.process_input(&ack, now);
+        client.process_input(ack, now);
     }
 
     let client_pkt = send_something(&mut client, now);
     let tos_before_migration = client_pkt.tos();
-    server.process_input(&orig_path_modifier(client_pkt).unwrap(), now);
+    server.process_input(orig_path_modifier(client_pkt).unwrap(), now);
 
     client
         .migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR_V4), false, now)
@@ -250,7 +250,7 @@ pub fn migration_with_modifiers(
         assert_eq!(client.stats().frame_tx.path_challenge, 1);
         let probe_cid = ConnectionId::from(get_cid(&probe));
 
-        let resp = new_path_modifier(server.process(Some(&probe), now).dgram().unwrap()).unwrap();
+        let resp = new_path_modifier(server.process(Some(probe), now).dgram().unwrap()).unwrap();
         assert_v4_path(&resp, true);
         assert_eq!(server.stats().frame_tx.path_response, 1);
         assert_eq!(server.stats().frame_tx.path_challenge, 1);
@@ -259,13 +259,13 @@ pub fn migration_with_modifiers(
         let client_data = send_something_with_modifier(&mut client, now, orig_path_modifier);
         assert_ne!(get_cid(&client_data), probe_cid);
         assert_v6_path(&client_data, false);
-        server.process_input(&client_data, now);
+        server.process_input(client_data, now);
         let server_data = send_something_with_modifier(&mut server, now, orig_path_modifier);
         assert_v6_path(&server_data, false);
-        client.process_input(&server_data, now);
+        client.process_input(server_data, now);
 
         // Once the client receives the probe response, it migrates to the new path.
-        client.process_input(&resp, now);
+        client.process_input(resp, now);
         assert_eq!(client.stats().frame_rx.path_challenge, 1);
         migrated = true;
 
@@ -276,7 +276,7 @@ pub fn migration_with_modifiers(
         // However, it will probe the old path again, even though it has just
         // received a response to its last probe, because it needs to verify
         // that the migration is genuine.
-        server.process_input(&migrate_client, now);
+        server.process_input(migrate_client, now);
     }
 
     let stream_before = server.stats().frame_tx.stream;
@@ -301,8 +301,8 @@ pub fn migration_with_modifiers(
         assert_eq!(server.stats().frame_tx.stream, stream_before + 1);
 
         // The client receives these checks and responds to the probe, but uses the new path.
-        client.process_input(&migrate_server, now);
-        client.process_input(&probe_old_server, now);
+        client.process_input(migrate_server, now);
+        client.process_input(probe_old_server, now);
         let old_probe_resp = send_something_with_modifier(&mut client, now, new_path_modifier);
         assert_v6_path(&old_probe_resp, true);
         let client_confirmation = client.process_output(now).dgram().unwrap();
@@ -315,17 +315,17 @@ pub fn migration_with_modifiers(
         let server_confirmation =
             send_something_with_modifier(&mut server, now + server_pacing, new_path_modifier);
         assert_v4_path(&server_confirmation, false);
-        client.process_input(&server_confirmation, now);
+        client.process_input(server_confirmation, now);
 
         // Send some data on the new path.
         for _ in 0..burst {
             now += client.process_output(now).callback();
             let client_pkt = send_something_with_modifier(&mut client, now, new_path_modifier);
-            server.process_input(&client_pkt, now);
+            server.process_input(client_pkt, now);
         }
 
         if let Some(ack) = server.process_output(now).dgram() {
-            client.process_input(&ack, now);
+            client.process_input(ack, now);
         }
     }
 

--- a/neqo-transport/src/connection/tests/keys.rs
+++ b/neqo-transport/src/connection/tests/keys.rs
@@ -33,7 +33,7 @@ fn check_discarded(
     mem::drop(peer.process_output(now()));
 
     let before = peer.stats();
-    let out = peer.process(Some(pkt), now());
+    let out = peer.process(Some(pkt.clone()), now());
     assert_eq!(out.as_dgram_ref().is_some(), response);
     let after = peer.stats();
     assert_eq!(dropped, after.dropped_rx - before.dropped_rx);
@@ -57,17 +57,17 @@ fn overwrite_invocations(n: PacketNumber) {
 fn discarded_initial_keys() {
     qdebug!("---- client: generate CH");
     let mut client = default_client();
-    let init_pkt_c = client.process(None, now()).dgram();
+    let init_pkt_c = client.process_output(now()).dgram();
     assert!(init_pkt_c.is_some());
     assert_eq!(init_pkt_c.as_ref().unwrap().len(), client.plpmtu());
 
     qdebug!("---- server: CH -> SH, EE, CERT, CV, FIN");
     let mut server = default_server();
-    let init_pkt_s = server.process(init_pkt_c.as_ref(), now()).dgram();
+    let init_pkt_s = server.process(init_pkt_c.clone(), now()).dgram();
     assert!(init_pkt_s.is_some());
 
     qdebug!("---- client: cert verification");
-    let out = client.process(init_pkt_s.as_ref(), now()).dgram();
+    let out = client.process(init_pkt_s.clone(), now()).dgram();
     assert!(out.is_some());
 
     // The client has received a handshake packet. It will remove the Initial keys.
@@ -86,12 +86,12 @@ fn discarded_initial_keys() {
     check_discarded(&mut server, &init_pkt_c.clone().unwrap(), false, 1, 1);
 
     qdebug!("---- client: SH..FIN -> FIN");
-    let out = client.process(None, now()).dgram();
+    let out = client.process_output(now()).dgram();
     assert!(out.is_some());
 
     // The server will process the first Handshake packet.
     // After this the Initial keys will be dropped.
-    let out = server.process(out.as_ref(), now()).dgram();
+    let out = server.process(out, now()).dgram();
     assert!(out.is_some());
 
     // Check that the Initial keys are dropped at the server
@@ -116,7 +116,7 @@ fn key_update_client() {
 
     // Initiating an update should only increase the write epoch.
     let idle_timeout = ConnectionParameters::default().get_idle_timeout();
-    assert_eq!(Output::Callback(idle_timeout), client.process(None, now));
+    assert_eq!(Output::Callback(idle_timeout), client.process_output(now));
     assert_eq!(client.get_epochs(), (Some(4), Some(3)));
 
     // Send something to propagate the update.
@@ -125,7 +125,7 @@ fn key_update_client() {
 
     // The server should now be waiting to discharge read keys.
     assert_eq!(server.get_epochs(), (Some(4), Some(3)));
-    let res = server.process(None, now);
+    let res = server.process_output(now);
     if let Output::Callback(t) = res {
         assert!(t < idle_timeout);
     } else {
@@ -142,10 +142,10 @@ fn key_update_client() {
     // But at this point the client hasn't received a key update from the server.
     // It will be stuck with old keys.
     now += AT_LEAST_PTO;
-    let dgram = client.process(None, now).dgram();
+    let dgram = client.process_output(now).dgram();
     assert!(dgram.is_some()); // Drop this packet.
     assert_eq!(client.get_epochs(), (Some(4), Some(3)));
-    mem::drop(server.process(None, now));
+    mem::drop(server.process_output(now));
     assert_eq!(server.get_epochs(), (Some(4), Some(4)));
 
     // Even though the server has updated, it hasn't received an ACK yet.
@@ -155,7 +155,7 @@ fn key_update_client() {
     // The previous PTO packet (see above) was dropped, so we should get an ACK here.
     let dgram = send_and_receive(&mut client, &mut server, now);
     assert!(dgram.is_some());
-    let res = client.process(dgram.as_ref(), now);
+    let res = client.process(dgram, now);
     // This is the first packet that the client has received from the server
     // with new keys, so its read timer just started.
     if let Output::Callback(t) = res {
@@ -170,7 +170,7 @@ fn key_update_client() {
     assert_update_blocked(&mut server);
 
     now += AT_LEAST_PTO;
-    mem::drop(client.process(None, now));
+    mem::drop(client.process_output(now));
     assert_eq!(client.get_epochs(), (Some(4), Some(4)));
 }
 
@@ -194,11 +194,11 @@ fn key_update_consecutive() {
     assert_eq!(client.get_epochs(), (Some(4), Some(3)));
 
     // Have the server process the ACK.
-    if let Output::Callback(_) = server.process(dgram.as_ref(), now) {
+    if let Output::Callback(_) = server.process(dgram, now) {
         assert_eq!(server.get_epochs(), (Some(4), Some(3)));
         // Now move the server temporarily into the future so that it
         // rotates the keys.  The client stays in the present.
-        mem::drop(server.process(None, now + AT_LEAST_PTO));
+        mem::drop(server.process_output(now + AT_LEAST_PTO));
         assert_eq!(server.get_epochs(), (Some(4), Some(4)));
     } else {
         panic!("server should have a timer set");
@@ -224,33 +224,33 @@ fn key_update_before_confirmed() {
     assert_update_blocked(&mut server);
 
     // Client Initial
-    let dgram = client.process(None, now()).dgram();
+    let dgram = client.process_output(now()).dgram();
     assert!(dgram.is_some());
     assert_update_blocked(&mut client);
 
     // Server Initial + Handshake
-    let dgram = server.process(dgram.as_ref(), now()).dgram();
+    let dgram = server.process(dgram, now()).dgram();
     assert!(dgram.is_some());
     assert_update_blocked(&mut server);
 
     // Client Handshake
-    client.process_input(&dgram.unwrap(), now());
+    client.process_input(dgram.unwrap(), now());
     assert_update_blocked(&mut client);
 
     assert!(maybe_authenticate(&mut client));
     assert_update_blocked(&mut client);
 
-    let dgram = client.process(None, now()).dgram();
+    let dgram = client.process_output(now()).dgram();
     assert!(dgram.is_some());
     assert_update_blocked(&mut client);
 
     // Server HANDSHAKE_DONE
-    let dgram = server.process(dgram.as_ref(), now()).dgram();
+    let dgram = server.process(dgram, now()).dgram();
     assert!(dgram.is_some());
     assert!(server.initiate_key_update().is_ok());
 
     // Client receives HANDSHAKE_DONE
-    let dgram = client.process(dgram.as_ref(), now()).dgram();
+    let dgram = client.process(dgram, now()).dgram();
     assert!(dgram.is_none());
     assert!(client.initiate_key_update().is_ok());
 }
@@ -281,13 +281,13 @@ fn exhaust_read_keys() {
     let dgram = send_something(&mut client, now());
 
     overwrite_invocations(0);
-    let dgram = server.process(Some(&dgram), now()).dgram();
+    let dgram = server.process(Some(dgram), now()).dgram();
     assert!(matches!(
         server.state(),
         State::Closed(CloseReason::Transport(Error::KeysExhausted))
     ));
 
-    client.process_input(&dgram.unwrap(), now());
+    client.process_input(dgram.unwrap(), now());
     assert!(matches!(
         client.state(),
         State::Draining {

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -75,7 +75,7 @@ fn rebinding_port() {
     let dgram = send_something(&mut client, now());
     let dgram = change_source_port(&dgram);
 
-    server.process_input(&dgram, now());
+    server.process_input(dgram, now());
     // Have the server send something so that it generates a packet.
     let stream_id = server.stream_create(StreamType::UniDi).unwrap();
     server.stream_close_send(stream_id).unwrap();
@@ -97,7 +97,7 @@ fn path_forwarding_attack() {
 
     let dgram = send_something(&mut client, now);
     let dgram = change_path(&dgram, DEFAULT_ADDR_V4);
-    server.process_input(&dgram, now);
+    server.process_input(dgram, now);
 
     // The server now probes the new (primary) path.
     let new_probe = server.process_output(now).dgram().unwrap();
@@ -117,14 +117,14 @@ fn path_forwarding_attack() {
 
     // The client should respond to the challenge on the new path.
     // The server couldn't pad, so the client is also amplification limited.
-    let new_resp = client.process(Some(&new_probe), now).dgram().unwrap();
+    let new_resp = client.process(Some(new_probe), now).dgram().unwrap();
     assert_eq!(client.stats().frame_rx.path_challenge, 1);
     assert_eq!(client.stats().frame_tx.path_challenge, 1);
     assert_eq!(client.stats().frame_tx.path_response, 1);
     assert_v4_path(&new_resp, false);
 
     // The client also responds to probes on the old path.
-    let old_resp = client.process(Some(&old_probe), now).dgram().unwrap();
+    let old_resp = client.process(Some(old_probe), now).dgram().unwrap();
     assert_eq!(client.stats().frame_rx.path_challenge, 2);
     assert_eq!(client.stats().frame_tx.path_challenge, 1);
     assert_eq!(client.stats().frame_tx.path_response, 2);
@@ -137,12 +137,12 @@ fn path_forwarding_attack() {
     // Receiving the PATH_RESPONSE from the client opens the amplification
     // limit enough for the server to respond.
     // This is padded because it includes PATH_CHALLENGE.
-    let server_data1 = server.process(Some(&new_resp), now).dgram().unwrap();
+    let server_data1 = server.process(Some(new_resp), now).dgram().unwrap();
     assert_v4_path(&server_data1, true);
     assert_eq!(server.stats().frame_tx.path_challenge, 3);
 
     // The client responds to this probe on the new path.
-    client.process_input(&server_data1, now);
+    client.process_input(server_data1, now);
     let stream_before = client.stats().frame_tx.stream;
     let padded_resp = send_something(&mut client, now);
     assert_eq!(stream_before, client.stats().frame_tx.stream);
@@ -157,7 +157,7 @@ fn path_forwarding_attack() {
     assert_v4_path(&server_data2, false);
 
     // Until new data is received from the client on the old path.
-    server.process_input(&client_data2, now);
+    server.process_input(client_data2, now);
     // The server sends a probe on the new path.
     let server_data3 = send_something(&mut server, now);
     assert_v4_path(&server_data3, true);
@@ -185,7 +185,7 @@ fn migrate_immediate() {
     let server_delayed = send_something(&mut server, now);
 
     // The server accepts the first packet and migrates (but probes).
-    let server1 = server.process(Some(&client1), now).dgram().unwrap();
+    let server1 = server.process(Some(client1), now).dgram().unwrap();
     assert_v4_path(&server1, true);
     let server2 = server.process_output(now).dgram().unwrap();
     assert_v6_path(&server2, true);
@@ -193,13 +193,13 @@ fn migrate_immediate() {
     // The second packet has no real effect, it just elicits an ACK.
     let all_before = server.stats().frame_tx.all();
     let ack_before = server.stats().frame_tx.ack;
-    let server3 = server.process(Some(&client2), now).dgram();
+    let server3 = server.process(Some(client2), now).dgram();
     assert!(server3.is_some());
     assert_eq!(server.stats().frame_tx.all(), all_before + 1);
     assert_eq!(server.stats().frame_tx.ack, ack_before + 1);
 
     // Receiving a packet sent by the server before migration doesn't change path.
-    client.process_input(&server_delayed, now);
+    client.process_input(server_delayed, now);
     // The client has sent two unpaced packets and this new path has no RTT estimate
     // so this might be paced.
     let (client3, _t) = send_something_paced(&mut client, now, true);
@@ -287,13 +287,13 @@ fn migrate_same() {
     assert_v6_path(&probe, true); // Contains PATH_CHALLENGE.
     assert_eq!(client.stats().frame_tx.path_challenge, 1);
 
-    let resp = server.process(Some(&probe), now).dgram().unwrap();
+    let resp = server.process(Some(probe), now).dgram().unwrap();
     assert_v6_path(&resp, true);
     assert_eq!(server.stats().frame_tx.path_response, 1);
     assert_eq!(server.stats().frame_tx.path_challenge, 0);
 
     // Everything continues happily.
-    client.process_input(&resp, now);
+    client.process_input(resp, now);
     let contd = send_something(&mut client, now);
     assert_v6_path(&contd, false);
 }
@@ -371,7 +371,7 @@ fn migration(mut client: Connection) {
     assert_eq!(client.stats().frame_tx.path_challenge, 1);
     let probe_cid = ConnectionId::from(get_cid(&probe));
 
-    let resp = server.process(Some(&probe), now).dgram().unwrap();
+    let resp = server.process(Some(probe), now).dgram().unwrap();
     assert_v4_path(&resp, true);
     assert_eq!(server.stats().frame_tx.path_response, 1);
     assert_eq!(server.stats().frame_tx.path_challenge, 1);
@@ -380,12 +380,12 @@ fn migration(mut client: Connection) {
     let client_data = send_something(&mut client, now);
     assert_ne!(get_cid(&client_data), probe_cid);
     assert_v6_path(&client_data, false);
-    server.process_input(&client_data, now);
+    server.process_input(client_data, now);
     let server_data = send_something(&mut server, now);
     assert_v6_path(&server_data, false);
 
     // Once the client receives the probe response, it migrates to the new path.
-    client.process_input(&resp, now);
+    client.process_input(resp, now);
     assert_eq!(client.stats().frame_rx.path_challenge, 1);
     let migrate_client = send_something(&mut client, now);
     assert_v4_path(&migrate_client, true); // Responds to server probe.
@@ -394,7 +394,7 @@ fn migration(mut client: Connection) {
     // However, it will probe the old path again, even though it has just
     // received a response to its last probe, because it needs to verify
     // that the migration is genuine.
-    server.process_input(&migrate_client, now);
+    server.process_input(migrate_client, now);
     let stream_before = server.stats().frame_tx.stream;
     let probe_old_server = send_something(&mut server, now);
     // This is just the double-check probe; no STREAM frames.
@@ -409,8 +409,8 @@ fn migration(mut client: Connection) {
     assert_eq!(server.stats().frame_tx.stream, stream_before + 1);
 
     // The client receives these checks and responds to the probe, but uses the new path.
-    client.process_input(&migrate_server, now);
-    client.process_input(&probe_old_server, now);
+    client.process_input(migrate_server, now);
+    client.process_input(probe_old_server, now);
     let old_probe_resp = send_something(&mut client, now);
     assert_v6_path(&old_probe_resp, true);
     let client_confirmation = client.process_output(now).dgram().unwrap();
@@ -450,11 +450,11 @@ fn migration_client_empty_cid() {
 /// Returns the packet containing `HANDSHAKE_DONE` from the server.
 fn fast_handshake(client: &mut Connection, server: &mut Connection) -> Option<Datagram> {
     let dgram = client.process_output(now()).dgram();
-    let dgram = server.process(dgram.as_ref(), now()).dgram();
-    client.process_input(&dgram.unwrap(), now());
+    let dgram = server.process(dgram, now()).dgram();
+    client.process_input(dgram.unwrap(), now());
     assert!(maybe_authenticate(client));
     let dgram = client.process_output(now()).dgram();
-    server.process(dgram.as_ref(), now()).dgram()
+    server.process(dgram, now()).dgram()
 }
 
 fn preferred_address(hs_client: SocketAddr, hs_server: SocketAddr, preferred: SocketAddr) {
@@ -512,7 +512,7 @@ fn preferred_address(hs_client: SocketAddr, hs_server: SocketAddr, preferred: So
 
     // The client is about to process HANDSHAKE_DONE.
     // It should start probing toward the server's preferred address.
-    let probe = client.process(dgram.as_ref(), now()).dgram().unwrap();
+    let probe = client.process(dgram, now()).dgram().unwrap();
     assert_toward_spa(&probe, true);
     assert_eq!(client.stats().frame_tx.path_challenge, 1);
     assert_ne!(client.process_output(now()).callback(), Duration::new(0, 0));
@@ -522,26 +522,26 @@ fn preferred_address(hs_client: SocketAddr, hs_server: SocketAddr, preferred: So
     assert_orig_path(&data, false);
 
     // The server responds to the probe.
-    let resp = server.process(Some(&probe), now()).dgram().unwrap();
+    let resp = server.process(Some(probe), now()).dgram().unwrap();
     assert_from_spa(&resp, true);
     assert_eq!(server.stats().frame_tx.path_challenge, 1);
     assert_eq!(server.stats().frame_tx.path_response, 1);
 
     // Data continues on the main path for the server.
-    server.process_input(&data, now());
+    server.process_input(data, now());
     let data = send_something(&mut server, now());
     assert_orig_path(&data, false);
 
     // Client gets the probe response back and it migrates.
-    client.process_input(&resp, now());
-    client.process_input(&data, now());
+    client.process_input(resp, now());
+    client.process_input(data, now());
     let data = send_something(&mut client, now());
     assert_toward_spa(&data, true);
     assert_eq!(client.stats().frame_tx.stream, 2);
     assert_eq!(client.stats().frame_tx.path_response, 1);
 
     // The server sees the migration and probes the old path.
-    let probe = server.process(Some(&data), now()).dgram().unwrap();
+    let probe = server.process(Some(data), now()).dgram().unwrap();
     assert_orig_path(&probe, true);
     assert_eq!(server.stats().frame_tx.path_challenge, 2);
 
@@ -583,7 +583,7 @@ fn expect_no_migration(client: &mut Connection, server: &mut Connection) {
     let dgram = fast_handshake(client, server);
 
     // The client won't probe now, though it could; it remains idle.
-    let out = client.process(dgram.as_ref(), now());
+    let out = client.process(dgram, now());
     assert_ne!(out.callback(), Duration::new(0, 0));
 
     // Data continues on the main path for the client.
@@ -708,14 +708,14 @@ fn migration_invalid_state() {
     assert!(client
         .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), false, now())
         .is_err());
-    let close = client.process(None, now()).dgram();
+    let close = client.process_output(now()).dgram();
 
-    let dgram = server.process(close.as_ref(), now()).dgram();
+    let dgram = server.process(close, now()).dgram();
     assert!(server
         .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), false, now())
         .is_err());
 
-    client.process_input(&dgram.unwrap(), now());
+    client.process_input(dgram.unwrap(), now());
     assert!(client
         .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), false, now())
         .is_err());
@@ -814,7 +814,7 @@ fn retire_all() {
 
     let new_cid_before = client.stats().frame_rx.new_connection_id;
     let retire_cid_before = client.stats().frame_tx.retire_connection_id;
-    client.process_input(&ncid, now());
+    client.process_input(ncid, now());
     let retire = send_something(&mut client, now());
     assert_eq!(
         client.stats().frame_rx.new_connection_id,
@@ -861,17 +861,17 @@ fn retire_prior_to_migration_failure() {
     // retire all of the available connection IDs.
     let retire_all = send_with_extra(&mut server, RetireAll { cid_gen }, now());
 
-    let resp = server.process(Some(&probe), now()).dgram().unwrap();
+    let resp = server.process(Some(probe), now()).dgram().unwrap();
     assert_v4_path(&resp, true);
     assert_eq!(server.stats().frame_tx.path_response, 1);
     assert_eq!(server.stats().frame_tx.path_challenge, 1);
 
     // Have the client receive the NEW_CONNECTION_ID with Retire Prior To.
-    client.process_input(&retire_all, now());
+    client.process_input(retire_all, now());
     // This packet contains the probe response, which should be fine, but it
     // also includes PATH_CHALLENGE for the new path, and the client can't
     // respond without a connection ID.  We treat this as a connection error.
-    client.process_input(&resp, now());
+    client.process_input(resp, now());
     assert!(matches!(
         client.state(),
         State::Closing {
@@ -914,15 +914,15 @@ fn retire_prior_to_migration_success() {
     // retire all of the available connection IDs.
     let retire_all = send_with_extra(&mut server, RetireAll { cid_gen }, now());
 
-    let resp = server.process(Some(&probe), now()).dgram().unwrap();
+    let resp = server.process(Some(probe), now()).dgram().unwrap();
     assert_v4_path(&resp, true);
     assert_eq!(server.stats().frame_tx.path_response, 1);
     assert_eq!(server.stats().frame_tx.path_challenge, 1);
 
     // Have the client receive the NEW_CONNECTION_ID with Retire Prior To second.
     // As this occurs in a very specific order, migration succeeds.
-    client.process_input(&resp, now());
-    client.process_input(&retire_all, now());
+    client.process_input(resp, now());
+    client.process_input(retire_all, now());
 
     // Migration succeeds and the new path gets the last connection ID.
     let dgram = send_something(&mut client, now());
@@ -952,12 +952,12 @@ fn error_on_new_path_with_no_connection_id() {
         Rc::new(RefCell::new(CountingConnectionIdGenerator::default()));
     let retire_all = send_with_extra(&mut server, RetireAll { cid_gen }, now());
 
-    client.process_input(&retire_all, now());
+    client.process_input(retire_all, now());
 
     let garbage = send_with_extra(&mut server, GarbageWriter {}, now());
 
     let dgram = change_path(&garbage, DEFAULT_ADDR_V4);
-    client.process_input(&dgram, now());
+    client.process_input(dgram, now());
 
     // See issue #1697. We had a crash when the client had a temporary path and
     // process_output is called.
@@ -972,7 +972,7 @@ fn error_on_new_path_with_no_connection_id() {
     ));
     // Wait until the connection is closed.
     let mut now = now();
-    now += client.process(None, now).callback();
+    now += client.process_output(now).callback();
     _ = client.process_output(now);
     // No closing frames should be sent, and the connection should be closed.
     assert_eq!(client.stats().frame_tx.connection_close, closing_frames);

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -208,7 +208,7 @@ fn handshake_with_modifier(
         if should_ping {
             a.test_frame_writer = Some(Box::new(PingWriter {}));
         }
-        let output = a.process(input.as_ref(), now).dgram();
+        let output = a.process(input, now).dgram();
         if should_ping {
             a.test_frame_writer = None;
             did_ping[a.role()] = true;
@@ -219,7 +219,7 @@ fn handshake_with_modifier(
         mem::swap(&mut a, &mut b);
     }
     if let Some(d) = input {
-        a.process_input(&d, now);
+        a.process_input(d, now);
     }
     now
 }
@@ -299,7 +299,7 @@ fn exchange_ticket(
     server.send_ticket(now, &[]).expect("can send ticket");
     let ticket = server.process_output(now).dgram();
     assert!(ticket.is_some());
-    client.process_input(&ticket.unwrap(), now);
+    client.process_input(ticket.unwrap(), now);
     assert_eq!(*client.state(), State::Confirmed);
     get_tokens(client).pop().expect("should have token")
 }
@@ -397,7 +397,7 @@ fn fill_cwnd(c: &mut Connection, stream: StreamId, mut now: Instant) -> (Vec<Dat
 
     qtrace!(
         "fill_cwnd sent {} bytes",
-        total_dgrams.iter().map(|d| d.len()).sum::<usize>()
+        total_dgrams.iter().map(Datagram::len).sum::<usize>()
     );
     (total_dgrams, now)
 }
@@ -415,7 +415,7 @@ fn increase_cwnd(
         let pkt = sender.process_output(now);
         match pkt {
             Output::Datagram(dgram) => {
-                receiver.process_input(&dgram, now + DEFAULT_RTT / 2);
+                receiver.process_input(dgram, now + DEFAULT_RTT / 2);
             }
             Output::Callback(t) => {
                 if t < DEFAULT_RTT {
@@ -432,7 +432,7 @@ fn increase_cwnd(
     now += DEFAULT_RTT / 2;
     let ack = receiver.process_output(now).dgram();
     now += DEFAULT_RTT / 2;
-    sender.process_input(&ack.unwrap(), now);
+    sender.process_input(ack.unwrap(), now);
     now
 }
 
@@ -453,7 +453,7 @@ where
     let in_dgrams = in_dgrams.into_iter();
     qdebug!([dest], "ack_bytes {} datagrams", in_dgrams.len());
     for dgram in in_dgrams {
-        dest.process_input(&dgram, now);
+        dest.process_input(dgram, now);
     }
 
     loop {
@@ -524,7 +524,7 @@ fn induce_persistent_congestion(
 
     // An ACK for the third PTO causes persistent congestion.
     let s_ack = ack_bytes(server, stream, c_tx_dgrams, now);
-    client.process_input(&s_ack, now);
+    client.process_input(s_ack, now);
     assert_eq!(cwnd(client), cwnd_min(client));
     now
 }
@@ -635,7 +635,7 @@ fn send_with_modifier_and_receive(
     modifier: fn(Datagram) -> Option<Datagram>,
 ) -> Option<Datagram> {
     let dgram = send_something_with_modifier(sender, now, modifier);
-    receiver.process(Some(&dgram), now).dgram()
+    receiver.process(Some(dgram), now).dgram()
 }
 
 /// Send something on a stream from `sender` to `receiver`.

--- a/neqo-transport/src/connection/tests/null.rs
+++ b/neqo-transport/src/connection/tests/null.rs
@@ -26,7 +26,7 @@ fn no_encryption() {
     let client_pkt = client.process_output(now()).dgram().unwrap();
     assert!(client_pkt[..client_pkt.len() - AEAD_NULL_TAG.len()].ends_with(DATA_CLIENT));
 
-    server.process_input(&client_pkt, now());
+    server.process_input(client_pkt, now());
     let mut buf = vec![0; 100];
     let (len, _) = server.stream_recv(stream_id, &mut buf).unwrap();
     assert_eq!(len, DATA_CLIENT.len());
@@ -35,7 +35,7 @@ fn no_encryption() {
     let server_pkt = server.process_output(now()).dgram().unwrap();
     assert!(server_pkt[..server_pkt.len() - AEAD_NULL_TAG.len()].ends_with(DATA_SERVER));
 
-    client.process_input(&server_pkt, now());
+    client.process_input(server_pkt, now());
     let (len, _) = client.stream_recv(stream_id, &mut buf).unwrap();
     assert_eq!(len, DATA_SERVER.len());
     assert_eq!(&buf[..len], DATA_SERVER);

--- a/neqo-transport/src/connection/tests/priority.rs
+++ b/neqo-transport/src/connection/tests/priority.rs
@@ -41,7 +41,7 @@ fn receive_stream() {
     assert_eq!(MESSAGE.len(), client.stream_send(id, MESSAGE).unwrap());
     let dgram = client.process_output(now()).dgram();
 
-    server.process_input(&dgram.unwrap(), now());
+    server.process_input(dgram.unwrap(), now());
     assert_eq!(
         server
             .stream_priority(
@@ -83,7 +83,7 @@ fn relative() {
         .unwrap();
 
     let dgram = client.process_output(now()).dgram();
-    server.process_input(&dgram.unwrap(), now());
+    server.process_input(dgram.unwrap(), now());
 
     // The "id_normal" stream will get a `NewStream` event, but no data.
     for e in server.events() {
@@ -114,7 +114,7 @@ fn reprioritize() {
         .unwrap();
 
     let dgram = client.process_output(now()).dgram();
-    server.process_input(&dgram.unwrap(), now());
+    server.process_input(dgram.unwrap(), now());
 
     // The "id_normal" stream will get a `NewStream` event, but no data.
     for e in server.events() {
@@ -133,7 +133,7 @@ fn reprioritize() {
         )
         .unwrap();
     let dgram = client.process_output(now()).dgram();
-    server.process_input(&dgram.unwrap(), now());
+    server.process_input(dgram.unwrap(), now());
 
     for e in server.events() {
         if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
@@ -164,7 +164,7 @@ fn repairing_loss() {
     let _lost = client.process_output(now).dgram();
     for _ in 0..5 {
         match client.process_output(now) {
-            Output::Datagram(d) => server.process_input(&d, now),
+            Output::Datagram(d) => server.process_input(d, now),
             Output::Callback(delay) => now += delay,
             Output::None => unreachable!(),
         }
@@ -177,9 +177,9 @@ fn repairing_loss() {
     let id_normal = client.stream_create(StreamType::UniDi).unwrap();
     fill_stream(&mut client, id_normal);
 
-    let dgram = client.process(ack.as_ref(), now).dgram();
+    let dgram = client.process(ack, now).dgram();
     assert_eq!(client.stats().lost, 1); // Client should have noticed the loss.
-    server.process_input(&dgram.unwrap(), now);
+    server.process_input(dgram.unwrap(), now);
 
     // Only the low priority stream has data as the retransmission of the data from
     // the lost packet is now more important than new data from the high priority stream.
@@ -195,7 +195,7 @@ fn repairing_loss() {
     // the retransmitted data into a second packet, it will also contain data from the
     // normal priority stream.
     let dgram = client.process_output(now).dgram();
-    server.process_input(&dgram.unwrap(), now);
+    server.process_input(dgram.unwrap(), now);
     assert!(server.events().any(
         |e| matches!(e, ConnectionEvent::RecvStreamReadable { stream_id } if stream_id == id_normal),
     ));
@@ -210,8 +210,8 @@ fn critical() {
     // Rather than connect, send stream data in 0.5-RTT.
     // That allows this to test that critical streams pre-empt most frame types.
     let dgram = client.process_output(now).dgram();
-    let dgram = server.process(dgram.as_ref(), now).dgram();
-    client.process_input(&dgram.unwrap(), now);
+    let dgram = server.process(dgram, now).dgram();
+    client.process_input(dgram.unwrap(), now);
     maybe_authenticate(&mut client);
 
     let id = server.stream_create(StreamType::UniDi).unwrap();
@@ -238,8 +238,8 @@ fn critical() {
     assert_eq!(stats_after.handshake_done, 0);
 
     // Complete the handshake.
-    let dgram = client.process(dgram.as_ref(), now).dgram();
-    server.process_input(&dgram.unwrap(), now);
+    let dgram = client.process(dgram, now).dgram();
+    server.process_input(dgram.unwrap(), now);
 
     // Critical beats everything but HANDSHAKE_DONE.
     let stats_before = server.stats().frame_tx;
@@ -261,8 +261,8 @@ fn important() {
     // Rather than connect, send stream data in 0.5-RTT.
     // That allows this to test that important streams pre-empt most frame types.
     let dgram = client.process_output(now).dgram();
-    let dgram = server.process(dgram.as_ref(), now).dgram();
-    client.process_input(&dgram.unwrap(), now);
+    let dgram = server.process(dgram, now).dgram();
+    client.process_input(dgram.unwrap(), now);
     maybe_authenticate(&mut client);
 
     let id = server.stream_create(StreamType::UniDi).unwrap();
@@ -290,8 +290,8 @@ fn important() {
     assert_eq!(stats_after.stream, stats_before.stream + 1);
 
     // Complete the handshake.
-    let dgram = client.process(dgram.as_ref(), now).dgram();
-    server.process_input(&dgram.unwrap(), now);
+    let dgram = client.process(dgram, now).dgram();
+    server.process_input(dgram.unwrap(), now);
 
     // Important beats everything but flow control.
     let stats_before = server.stats().frame_tx;
@@ -314,8 +314,8 @@ fn high_normal() {
     // Rather than connect, send stream data in 0.5-RTT.
     // That allows this to test that important streams pre-empt most frame types.
     let dgram = client.process_output(now).dgram();
-    let dgram = server.process(dgram.as_ref(), now).dgram();
-    client.process_input(&dgram.unwrap(), now);
+    let dgram = server.process(dgram, now).dgram();
+    client.process_input(dgram.unwrap(), now);
     maybe_authenticate(&mut client);
 
     let id = server.stream_create(StreamType::UniDi).unwrap();
@@ -343,8 +343,8 @@ fn high_normal() {
     assert_eq!(stats_after.stream, stats_before.stream + 1);
 
     // Complete the handshake.
-    let dgram = client.process(dgram.as_ref(), now).dgram();
-    server.process_input(&dgram.unwrap(), now);
+    let dgram = client.process(dgram, now).dgram();
+    server.process_input(dgram.unwrap(), now);
 
     // High or Normal doesn't beat NEW_CONNECTION_ID,
     // but they beat CRYPTO/NEW_TOKEN.

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -45,7 +45,7 @@ fn pto_works_basic() {
 
     let mut now = now();
 
-    let res = client.process(None, now);
+    let res = client.process_output(now);
     let idle_timeout = ConnectionParameters::default().get_idle_timeout();
     assert_eq!(res, Output::Callback(idle_timeout));
 
@@ -59,19 +59,19 @@ fn pto_works_basic() {
 
     // Send a packet after some time.
     now += Duration::from_secs(10);
-    let out = client.process(None, now);
+    let out = client.process_output(now);
     assert!(out.dgram().is_some());
 
     // Nothing to do, should return callback
-    let out = client.process(None, now);
+    let out = client.process_output(now);
     assert!(matches!(out, Output::Callback(_)));
 
     // One second later, it should want to send PTO packet
     now += AT_LEAST_PTO;
-    let out = client.process(None, now);
+    let out = client.process_output(now);
 
     let stream_before = server.stats().frame_rx.stream;
-    server.process_input(&out.dgram().unwrap(), now);
+    server.process_input(out.dgram().unwrap(), now);
     assert_eq!(server.stats().frame_rx.stream, stream_before + 2);
 }
 
@@ -96,7 +96,7 @@ fn pto_works_full_cwnd() {
     // Both datagrams contain one or more STREAM frames.
     for d in dgrams {
         let stream_before = server.stats().frame_rx.stream;
-        server.process_input(&d, now);
+        server.process_input(d, now);
         assert!(server.stats().frame_rx.stream > stream_before);
     }
 }
@@ -115,49 +115,49 @@ fn pto_works_ping() {
     let pkt3 = send_something(&mut client, now);
 
     // Nothing to do, should return callback
-    let cb = client.process(None, now).callback();
+    let cb = client.process_output(now).callback();
     // The PTO timer is calculated with:
     //   RTT + max(rttvar * 4, GRANULARITY) + max_ack_delay
     // With zero RTT and rttvar, max_ack_delay is minimum too (GRANULARITY)
     assert_eq!(cb, GRANULARITY * 2);
 
     // Process these by server, skipping pkt0
-    let srv0 = server.process(Some(&pkt1), now).dgram();
+    let srv0 = server.process(Some(pkt1), now).dgram();
     assert!(srv0.is_some()); // ooo, ack client pkt1
 
     now += Duration::from_millis(20);
 
     // process pkt2 (immediate ack because last ack was more than an RTT ago; RTT=0)
-    let srv1 = server.process(Some(&pkt2), now).dgram();
+    let srv1 = server.process(Some(pkt2), now).dgram();
     assert!(srv1.is_some()); // this is now dropped
 
     now += Duration::from_millis(20);
     // process pkt3 (acked for same reason)
-    let srv2 = server.process(Some(&pkt3), now).dgram();
+    let srv2 = server.process(Some(pkt3), now).dgram();
     // ack client pkt 2 & 3
     assert!(srv2.is_some());
 
     // client processes ack
-    let pkt4 = client.process(srv2.as_ref(), now).dgram();
+    let pkt4 = client.process(srv2, now).dgram();
     // client resends data from pkt0
     assert!(pkt4.is_some());
 
     // server sees ooo pkt0 and generates immediate ack
-    let srv3 = server.process(Some(&pkt0), now).dgram();
+    let srv3 = server.process(Some(pkt0), now).dgram();
     assert!(srv3.is_some());
 
     // Accept the acknowledgment.
-    let pkt5 = client.process(srv3.as_ref(), now).dgram();
+    let pkt5 = client.process(srv3, now).dgram();
     assert!(pkt5.is_none());
 
     now += Duration::from_millis(70);
     // PTO expires. No unacked data. Only send PING.
     let client_pings = client.stats().frame_tx.ping;
-    let pkt6 = client.process(None, now).dgram();
+    let pkt6 = client.process_output(now).dgram();
     assert_eq!(client.stats().frame_tx.ping, client_pings + 1);
 
     let server_pings = server.stats().frame_rx.ping;
-    server.process_input(&pkt6.unwrap(), now);
+    server.process_input(pkt6.unwrap(), now);
     assert_eq!(server.stats().frame_rx.ping, server_pings + 1);
 }
 
@@ -168,40 +168,40 @@ fn pto_initial() {
 
     qdebug!("---- client: generate CH");
     let mut client = default_client();
-    let pkt1 = client.process(None, now).dgram();
+    let pkt1 = client.process_output(now).dgram();
     assert!(pkt1.is_some());
     assert_eq!(pkt1.clone().unwrap().len(), client.plpmtu());
 
-    let delay = client.process(None, now).callback();
+    let delay = client.process_output(now).callback();
     assert_eq!(delay, INITIAL_PTO);
 
     // Resend initial after PTO.
     now += delay;
-    let pkt2 = client.process(None, now).dgram();
+    let pkt2 = client.process_output(now).dgram();
     assert!(pkt2.is_some());
     assert_eq!(pkt2.unwrap().len(), client.plpmtu());
 
-    let delay = client.process(None, now).callback();
+    let delay = client.process_output(now).callback();
     // PTO has doubled.
     assert_eq!(delay, INITIAL_PTO * 2);
 
     // Server process the first initial pkt.
     let mut server = default_server();
-    let out = server.process(pkt1.as_ref(), now).dgram();
+    let out = server.process(pkt1, now).dgram();
     assert!(out.is_some());
 
     // Client receives ack for the first initial packet as well a Handshake packet.
     // After the handshake packet the initial keys and the crypto stream for the initial
     // packet number space will be discarded.
     // Here only an ack for the Handshake packet will be sent.
-    let out = client.process(out.as_ref(), now).dgram();
+    let out = client.process(out, now).dgram();
     assert!(out.is_some());
 
     // We do not have PTO for the resent initial packet any more, but
     // the Handshake PTO timer should be armed.  As the RTT is apparently
     // the same as the initial PTO value, and there is only one sample,
     // the PTO will be 3x the INITIAL PTO.
-    let delay = client.process(None, now).callback();
+    let delay = client.process_output(now).callback();
     assert_eq!(delay, INITIAL_PTO * 3);
 }
 
@@ -215,37 +215,37 @@ fn pto_handshake_complete() {
     let mut client = default_client();
     let mut server = default_server();
 
-    let pkt = client.process(None, now).dgram();
+    let pkt = client.process_output(now).dgram();
     assert_initial(pkt.as_ref().unwrap(), false);
-    let cb = client.process(None, now).callback();
+    let cb = client.process_output(now).callback();
     assert_eq!(cb, Duration::from_millis(300));
 
     now += HALF_RTT;
-    let pkt = server.process(pkt.as_ref(), now).dgram();
+    let pkt = server.process(pkt, now).dgram();
     assert_initial(pkt.as_ref().unwrap(), false);
 
     now += HALF_RTT;
-    let pkt = client.process(pkt.as_ref(), now).dgram();
+    let pkt = client.process(pkt, now).dgram();
     assert_handshake(pkt.as_ref().unwrap());
 
-    let cb = client.process(None, now).callback();
+    let cb = client.process_output(now).callback();
     // The client now has a single RTT estimate (20ms), so
     // the handshake PTO is set based on that.
     assert_eq!(cb, HALF_RTT * 6);
 
     now += HALF_RTT;
-    let pkt = server.process(pkt.as_ref(), now).dgram();
+    let pkt = server.process(pkt, now).dgram();
     assert!(pkt.is_none());
 
     now += HALF_RTT;
     client.authenticated(AuthenticationStatus::Ok, now);
 
     qdebug!("---- client: SH..FIN -> FIN");
-    let pkt1 = client.process(None, now).dgram();
+    let pkt1 = client.process_output(now).dgram();
     assert_handshake(pkt1.as_ref().unwrap());
     assert_eq!(*client.state(), State::Connected);
 
-    let cb = client.process(None, now).callback();
+    let cb = client.process_output(now).callback();
     assert_eq!(cb, HALF_RTT * 6);
 
     let mut pto_counts = [0; MAX_PTO_COUNTS];
@@ -255,7 +255,7 @@ fn pto_handshake_complete() {
     // Wait long enough that the 1-RTT PTO also fires.
     qdebug!("---- client: PTO");
     now += HALF_RTT * 6;
-    let pkt2 = client.process(None, now).dgram();
+    let pkt2 = client.process_output(now).dgram();
     assert_handshake(pkt2.as_ref().unwrap());
 
     pto_counts[0] = 1;
@@ -267,14 +267,14 @@ fn pto_handshake_complete() {
     let stream_id = client.stream_create(StreamType::UniDi).unwrap();
     client.stream_close_send(stream_id).unwrap();
     now += HALF_RTT * 6;
-    let pkt3 = client.process(None, now).dgram();
+    let pkt3 = client.process_output(now).dgram();
     assert_handshake(pkt3.as_ref().unwrap());
     let (pkt3_hs, pkt3_1rtt) = split_datagram(&pkt3.unwrap());
     assert_handshake(&pkt3_hs);
     assert!(pkt3_1rtt.is_some());
 
     // PTO has been doubled.
-    let cb = client.process(None, now).callback();
+    let cb = client.process_output(now).callback();
     assert_eq!(cb, HALF_RTT * 12);
 
     // We still have only a single PTO
@@ -288,8 +288,8 @@ fn pto_handshake_complete() {
     // This should remove the 1-RTT PTO from messing this test up.
     let server_acks = server.stats().frame_tx.ack;
     let server_done = server.stats().frame_tx.handshake_done;
-    server.process_input(&pkt3_1rtt.unwrap(), now);
-    let ack = server.process(pkt1.as_ref(), now).dgram();
+    server.process_input(pkt3_1rtt.unwrap(), now);
+    let ack = server.process(pkt1, now).dgram();
     assert!(ack.is_some());
     assert_eq!(server.stats().frame_tx.ack, server_acks + 2);
     assert_eq!(server.stats().frame_tx.handshake_done, server_done + 1);
@@ -302,14 +302,14 @@ fn pto_handshake_complete() {
     assert!(pkt2_1rtt.is_some());
     let dropped_before1 = server.stats().dropped_rx;
     let server_frames = server.stats().frame_rx.all();
-    server.process_input(&pkt2_hs, now);
+    server.process_input(pkt2_hs, now);
     assert_eq!(1, server.stats().dropped_rx - dropped_before1);
     assert_eq!(server.stats().frame_rx.all(), server_frames);
 
-    server.process_input(&pkt2_1rtt.unwrap(), now);
+    server.process_input(pkt2_1rtt.unwrap(), now);
     let server_frames2 = server.stats().frame_rx.all();
     let dropped_before2 = server.stats().dropped_rx;
-    server.process_input(&pkt3_hs, now);
+    server.process_input(pkt3_hs, now);
     assert_eq!(1, server.stats().dropped_rx - dropped_before2);
     assert_eq!(server.stats().frame_rx.all(), server_frames2);
 
@@ -317,14 +317,14 @@ fn pto_handshake_complete() {
 
     // Let the client receive the ACK.
     // It should now be wait to acknowledge the HANDSHAKE_DONE.
-    let cb = client.process(ack.as_ref(), now).callback();
+    let cb = client.process(ack, now).callback();
     // The default ack delay is the RTT divided by the default ACK ratio of 4.
     let expected_ack_delay = HALF_RTT * 2 / 4;
     assert_eq!(cb, expected_ack_delay);
 
     // Let the ACK delay timer expire.
     now += cb;
-    let out = client.process(None, now).dgram();
+    let out = client.process_output(now).dgram();
     assert!(out.is_some());
 }
 
@@ -334,19 +334,19 @@ fn pto_handshake_frames() {
     let mut now = now();
     qdebug!("---- client: generate CH");
     let mut client = default_client();
-    let pkt = client.process(None, now);
+    let pkt = client.process_output(now);
 
     now += Duration::from_millis(10);
     qdebug!("---- server: CH -> SH, EE, CERT, CV, FIN");
     let mut server = default_server();
-    let pkt = server.process(pkt.as_dgram_ref(), now);
+    let pkt = server.process(pkt.dgram(), now);
 
     now += Duration::from_millis(10);
     qdebug!("---- client: cert verification");
-    let pkt = client.process(pkt.as_dgram_ref(), now);
+    let pkt = client.process(pkt.dgram(), now);
 
     now += Duration::from_millis(10);
-    mem::drop(server.process(pkt.as_dgram_ref(), now));
+    mem::drop(server.process(pkt.dgram(), now));
 
     now += Duration::from_millis(10);
     client.authenticated(AuthenticationStatus::Ok, now);
@@ -355,21 +355,21 @@ fn pto_handshake_frames() {
     assert_eq!(stream, 2);
     assert_eq!(client.stream_send(stream, b"zero").unwrap(), 4);
     qdebug!("---- client: SH..FIN -> FIN and 1RTT packet");
-    let pkt1 = client.process(None, now).dgram();
+    let pkt1 = client.process_output(now).dgram();
     assert!(pkt1.is_some());
 
     // Get PTO timer.
-    let out = client.process(None, now);
+    let out = client.process_output(now);
     assert_eq!(out, Output::Callback(Duration::from_millis(60)));
 
     // Wait for PTO to expire and resend a handshake packet.
     now += Duration::from_millis(60);
-    let pkt2 = client.process(None, now).dgram();
+    let pkt2 = client.process_output(now).dgram();
     assert!(pkt2.is_some());
 
     now += Duration::from_millis(10);
     let crypto_before = server.stats().frame_rx.crypto;
-    server.process_input(&pkt2.unwrap(), now);
+    server.process_input(pkt2.unwrap(), now);
     assert_eq!(server.stats().frame_rx.crypto, crypto_before + 1);
 }
 
@@ -388,21 +388,21 @@ fn handshake_ack_pto() {
     let big = TransportParameter::Bytes(vec![0; Pmtud::default_plpmtu(DEFAULT_ADDR.ip())]);
     server.set_local_tparam(0xce16, big).unwrap();
 
-    let c1 = client.process(None, now).dgram();
+    let c1 = client.process_output(now).dgram();
 
     now += RTT / 2;
-    let s1 = server.process(c1.as_ref(), now).dgram();
+    let s1 = server.process(c1, now).dgram();
     assert!(s1.is_some());
-    let s2 = server.process(None, now).dgram();
+    let s2 = server.process_output(now).dgram();
     assert!(s1.is_some());
 
     // Now let the client have the Initial, but drop the first coalesced Handshake packet.
     now += RTT / 2;
     let (initial, _) = split_datagram(&s1.unwrap());
-    client.process_input(&initial, now);
-    let c2 = client.process(s2.as_ref(), now).dgram();
+    client.process_input(initial, now);
+    let c2 = client.process(s2, now).dgram();
     assert!(c2.is_some()); // This is an ACK.  Drop it.
-    let delay = client.process(None, now).callback();
+    let delay = client.process_output(now).callback();
     assert_eq!(delay, RTT * 3);
 
     let mut pto_counts = [0; MAX_PTO_COUNTS];
@@ -410,26 +410,26 @@ fn handshake_ack_pto() {
 
     // Wait for the PTO and ensure that the client generates a packet.
     now += delay;
-    let c3 = client.process(None, now).dgram();
+    let c3 = client.process_output(now).dgram();
     assert!(c3.is_some());
 
     now += RTT / 2;
     let ping_before = server.stats().frame_rx.ping;
-    server.process_input(&c3.unwrap(), now);
+    server.process_input(c3.unwrap(), now);
     assert_eq!(server.stats().frame_rx.ping, ping_before + 1);
 
     pto_counts[0] = 1;
     assert_eq!(client.stats.borrow().pto_counts, pto_counts);
 
     // Now complete the handshake as cheaply as possible.
-    let dgram = server.process(None, now).dgram();
-    client.process_input(&dgram.unwrap(), now);
+    let dgram = server.process_output(now).dgram();
+    client.process_input(dgram.unwrap(), now);
     maybe_authenticate(&mut client);
-    let dgram = client.process(None, now).dgram();
+    let dgram = client.process_output(now).dgram();
     assert_eq!(*client.state(), State::Connected);
-    let dgram = server.process(dgram.as_ref(), now).dgram();
+    let dgram = server.process(dgram, now).dgram();
     assert_eq!(*server.state(), State::Confirmed);
-    client.process_input(&dgram.unwrap(), now);
+    client.process_input(dgram.unwrap(), now);
     assert_eq!(*client.state(), State::Confirmed);
 
     assert_eq!(client.stats.borrow().pto_counts, pto_counts);
@@ -450,12 +450,12 @@ fn loss_recovery_crash() {
     assert!(ack.is_some());
 
     // Have the server process the ACK.
-    let cb = server.process(ack.as_ref(), now).callback();
+    let cb = server.process(ack, now).callback();
     assert!(cb > Duration::from_secs(0));
 
     // Now we leap into the future.  The server should regard the first
     // packet as lost based on time alone.
-    let dgram = server.process(None, now + AT_LEAST_PTO).dgram();
+    let dgram = server.process_output(now + AT_LEAST_PTO).dgram();
     assert!(dgram.is_some());
 
     // This crashes.
@@ -480,10 +480,10 @@ fn ack_after_pto() {
     now += AT_LEAST_PTO;
     // We can use MAX_PTO_PACKET_COUNT, because we know the handshake is over.
     for _ in 0..MAX_PTO_PACKET_COUNT {
-        let dgram = client.process(None, now).dgram();
+        let dgram = client.process_output(now).dgram();
         assert!(dgram.is_some());
     }
-    assert!(client.process(None, now).dgram().is_none());
+    assert!(client.process_output(now).dgram().is_none());
 
     // The server now needs to send something that will cause the
     // client to want to acknowledge it.  A little out of order
@@ -495,13 +495,13 @@ fn ack_after_pto() {
 
     // The client is now after a PTO, but if it receives something
     // that demands acknowledgment, it will send just the ACK.
-    let ack = client.process(Some(&dgram), now).dgram();
+    let ack = client.process(Some(dgram), now).dgram();
     assert!(ack.is_some());
 
     // Make sure that the packet only contained an ACK frame.
     let all_frames_before = server.stats().frame_rx.all();
     let ack_before = server.stats().frame_rx.ack;
-    server.process_input(&ack.unwrap(), now);
+    server.process_input(ack.unwrap(), now);
     assert_eq!(server.stats().frame_rx.all(), all_frames_before + 1);
     assert_eq!(server.stats().frame_rx.ack, ack_before + 1);
 }
@@ -522,7 +522,7 @@ fn lost_but_kept_and_lr_timer() {
 
     // At t=RTT/2 the server receives the packet and ACKs it.
     now += RTT / 2;
-    let ack = server.process(Some(&p2), now).dgram();
+    let ack = server.process(Some(p2), now).dgram();
     assert!(ack.is_some());
     // The client also sends another two packets (p3, p4), again losing the first.
     let _p3 = send_something(&mut client, now);
@@ -531,24 +531,24 @@ fn lost_but_kept_and_lr_timer() {
     // At t=RTT the client receives the ACK and goes into timed loss recovery.
     // The client doesn't call p1 lost at this stage, but it will soon.
     now += RTT / 2;
-    let res = client.process(ack.as_ref(), now);
+    let res = client.process(ack, now);
     // The client should be on a loss recovery timer as p1 is missing.
     let lr_timer = res.callback();
     // Loss recovery timer should be RTT/8, but only check for 0 or >=RTT/2.
     assert_ne!(lr_timer, Duration::from_secs(0));
     assert!(lr_timer < (RTT / 2));
     // The server also receives and acknowledges p4, again sending an ACK.
-    let ack = server.process(Some(&p4), now).dgram();
+    let ack = server.process(Some(p4), now).dgram();
     assert!(ack.is_some());
 
     // At t=RTT*3/2 the client should declare p1 to be lost.
     now += RTT / 2;
     // So the client will send the data from p1 again.
-    let res = client.process(None, now);
+    let res = client.process_output(now);
     assert!(res.dgram().is_some());
     // When the client processes the ACK, it should engage the
     // loss recovery timer for p3, not p1 (even though it still tracks p1).
-    let res = client.process(ack.as_ref(), now);
+    let res = client.process(ack, now);
     let lr_timer2 = res.callback();
     assert_eq!(lr_timer, lr_timer2);
 }
@@ -569,9 +569,9 @@ fn loss_time_past_largest_acked() {
     let mut now = now();
 
     // Start the handshake.
-    let c_in = client.process(None, now).dgram();
+    let c_in = client.process_output(now).dgram();
     now += RTT / 2;
-    let s_hs1 = server.process(c_in.as_ref(), now).dgram();
+    let s_hs1 = server.process(c_in, now).dgram();
 
     // Get some spare server handshake packets for the client to ACK.
     // This involves a time machine, so be a little cautious.
@@ -579,15 +579,15 @@ fn loss_time_past_largest_acked() {
     // with a much lower RTT estimate, so the PTO at this point should
     // be much smaller than an RTT and so the server shouldn't see
     // time go backwards.
-    let s_pto = server.process(None, now).callback();
+    let s_pto = server.process_output(now).callback();
     assert_ne!(s_pto, Duration::from_secs(0));
     assert!(s_pto < RTT);
-    let s_hs2 = server.process(None, now + s_pto).dgram();
+    let s_hs2 = server.process_output(now + s_pto).dgram();
     assert!(s_hs2.is_some());
-    let s_pto = server.process(None, now).callback();
+    let s_pto = server.process_output(now).callback();
     assert_ne!(s_pto, Duration::from_secs(0));
     assert!(s_pto < RTT);
-    let s_hs3 = server.process(None, now + s_pto).dgram();
+    let s_hs3 = server.process_output(now + s_pto).dgram();
     assert!(s_hs3.is_some());
 
     // We are blocked by the amplification limit now.
@@ -601,26 +601,26 @@ fn loss_time_past_largest_acked() {
     // to generate an ack-eliciting packet.  For that, we use the Finished message.
     // Reordering delivery ensures that the later packet is also acknowledged.
     now += RTT / 2;
-    let c_hs1 = client.process(s_hs1.as_ref(), now).dgram();
+    let c_hs1 = client.process(s_hs1, now).dgram();
     assert!(c_hs1.is_some()); // This comes first, so it's useless.
     maybe_authenticate(&mut client);
-    let c_hs2 = client.process(None, now).dgram();
+    let c_hs2 = client.process_output(now).dgram();
     assert!(c_hs2.is_some()); // This one will elicit an ACK.
 
     // The we need the outstanding packet to be sent after the
     // application data packet, so space these out a tiny bit.
     let _p1 = send_something(&mut client, now + INCR);
-    let c_hs3 = client.process(s_hs2.as_ref(), now + (INCR * 2)).dgram();
+    let c_hs3 = client.process(s_hs2, now + (INCR * 2)).dgram();
     assert!(c_hs3.is_some()); // This will be left outstanding.
-    let c_hs4 = client.process(s_hs3.as_ref(), now + (INCR * 3)).dgram();
+    let c_hs4 = client.process(s_hs3, now + (INCR * 3)).dgram();
     assert!(c_hs4.is_some()); // This will be acknowledged.
 
     // Process c_hs2 and c_hs4, but skip c_hs3.
     // Then get an ACK for the client.
     now += RTT / 2;
     // Deliver c_hs4 first, but don't generate a packet.
-    server.process_input(&c_hs4.unwrap(), now);
-    let s_ack = server.process(c_hs2.as_ref(), now).dgram();
+    server.process_input(c_hs4.unwrap(), now);
+    let s_ack = server.process(c_hs2, now).dgram();
     assert!(s_ack.is_some());
     // This includes an ACK, but it also includes HANDSHAKE_DONE,
     // which we need to remove because that will cause the Handshake loss
@@ -629,12 +629,12 @@ fn loss_time_past_largest_acked() {
 
     // Now the client should start its loss recovery timer based on the ACK.
     now += RTT / 2;
-    let _c_ack = client.process(Some(&s_hs_ack), now).dgram();
+    let _c_ack = client.process(Some(s_hs_ack), now).dgram();
     // This ACK triggers an immediate ACK, due to an ACK loss during handshake.
-    let c_ack = client.process(None, now).dgram();
+    let c_ack = client.process_output(now).dgram();
     assert!(c_ack.is_none());
     // The client should now have the loss recovery timer active.
-    let lr_time = client.process(None, now).callback();
+    let lr_time = client.process_output(now).callback();
     assert_ne!(lr_time, Duration::from_secs(0));
     assert!(lr_time < (RTT / 2));
 }
@@ -648,12 +648,12 @@ fn trickle(sender: &mut Connection, receiver: &mut Connection, mut count: usize,
     while count > 0 {
         qdebug!("trickle: remaining={}", count);
         assert_eq!(sender.stream_send(id, &[9]).unwrap(), 1);
-        let dgram = sender.process(maybe_ack.as_ref(), now).dgram();
+        let dgram = sender.process(maybe_ack, now).dgram();
 
-        maybe_ack = receiver.process(dgram.as_ref(), now).dgram();
+        maybe_ack = receiver.process(dgram, now).dgram();
         count -= usize::from(maybe_ack.is_some());
     }
-    sender.process_input(&maybe_ack.unwrap(), now);
+    sender.process_input(maybe_ack.unwrap(), now);
 }
 
 /// Ensure that a PING frame is sent with ACK sometimes.
@@ -744,7 +744,7 @@ fn fast_pto() {
     let mut server = default_server();
     let mut now = connect_rtt_idle(&mut client, &mut server, DEFAULT_RTT);
 
-    let res = client.process(None, now);
+    let res = client.process_output(now);
     let idle_timeout = ConnectionParameters::default().get_idle_timeout() - (DEFAULT_RTT / 2);
     assert_eq!(res, Output::Callback(idle_timeout));
 
@@ -766,10 +766,10 @@ fn fast_pto() {
 
     // Once the PTO timer expires, a PTO packet should be sent should want to send PTO packet.
     now += cb;
-    let dgram = client.process(None, now).dgram();
+    let dgram = client.process_output(now).dgram();
 
     let stream_before = server.stats().frame_rx.stream;
-    server.process_input(&dgram.unwrap(), now);
+    server.process_input(dgram.unwrap(), now);
     assert_eq!(server.stats().frame_rx.stream, stream_before + 1);
 }
 
@@ -781,7 +781,7 @@ fn fast_pto_persistent_congestion() {
     let mut server = default_server();
     let mut now = connect_rtt_idle(&mut client, &mut server, DEFAULT_RTT);
 
-    let res = client.process(None, now);
+    let res = client.process_output(now);
     let idle_timeout = ConnectionParameters::default().get_idle_timeout() - (DEFAULT_RTT / 2);
     assert_eq!(res, Output::Callback(idle_timeout));
 
@@ -809,9 +809,9 @@ fn fast_pto_persistent_congestion() {
 
     // Now acknowledge the tail packet and enter persistent congestion.
     now += DEFAULT_RTT / 2;
-    let ack = server.process(Some(&dgram), now).dgram();
+    let ack = server.process(Some(dgram), now).dgram();
     now += DEFAULT_RTT / 2;
-    client.process_input(&ack.unwrap(), now);
+    client.process_input(ack.unwrap(), now);
     assert_eq!(cwnd(&client), cwnd_min(&client));
 }
 
@@ -841,7 +841,7 @@ fn ack_for_unsent() {
         .unwrap();
 
     // Now deliver the packet with the spoofed ACK frame
-    client.process_input(&spoofed, now());
+    client.process_input(spoofed, now());
     assert!(matches!(
         client.state(),
         State::Closing {

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -32,14 +32,14 @@ use crate::{
 fn stream_create() {
     let mut client = default_client();
 
-    let out = client.process(None, now());
+    let out = client.process_output(now());
     let mut server = default_server();
-    let out = server.process(out.as_dgram_ref(), now());
+    let out = server.process(out.dgram(), now());
 
-    let out = client.process(out.as_dgram_ref(), now());
-    mem::drop(server.process(out.as_dgram_ref(), now()));
+    let out = client.process(out.dgram(), now());
+    mem::drop(server.process(out.dgram(), now()));
     assert!(maybe_authenticate(&mut client));
-    let out = client.process(None, now());
+    let out = client.process_output(now());
 
     // client now in State::Connected
     assert_eq!(client.stream_create(StreamType::UniDi).unwrap(), 2);
@@ -47,7 +47,7 @@ fn stream_create() {
     assert_eq!(client.stream_create(StreamType::BiDi).unwrap(), 0);
     assert_eq!(client.stream_create(StreamType::BiDi).unwrap(), 4);
 
-    mem::drop(server.process(out.as_dgram_ref(), now()));
+    mem::drop(server.process(out.dgram(), now()));
     // server now in State::Connected
     assert_eq!(server.stream_create(StreamType::UniDi).unwrap(), 3);
     assert_eq!(server.stream_create(StreamType::UniDi).unwrap(), 7);
@@ -86,7 +86,7 @@ fn transfer() {
 
     qdebug!("---- server receives");
     for d in datagrams {
-        let out = server.process(Some(&d), now());
+        let out = server.process(Some(d), now());
         // With an RTT of zero, the server will acknowledge every packet immediately.
         assert!(out.as_dgram_ref().is_some());
         qdebug!("Output={:0x?}", out.as_dgram_ref());
@@ -151,7 +151,7 @@ fn sendorder_test(order_of_sendorder: &[Option<SendOrder>]) {
 
     qdebug!("---- server receives");
     for d in datagrams {
-        let out = server.process(Some(&d), now());
+        let out = server.process(Some(d), now());
         qdebug!("Output={:0x?}", out.as_dgram_ref());
     }
     assert_eq!(*server.state(), State::Confirmed);
@@ -317,12 +317,12 @@ fn report_fin_when_stream_closed_wo_data() {
     // create a stream
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
-    let out = client.process(None, now());
-    mem::drop(server.process(out.as_dgram_ref(), now()));
+    let out = client.process_output(now());
+    mem::drop(server.process(out.dgram(), now()));
 
     server.stream_close_send(stream_id).unwrap();
-    let out = server.process(None, now());
-    mem::drop(client.process(out.as_dgram_ref(), now()));
+    let out = server.process_output(now());
+    mem::drop(client.process(out.dgram(), now()));
     let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
     assert!(client.events().any(stream_readable));
 }
@@ -330,9 +330,9 @@ fn report_fin_when_stream_closed_wo_data() {
 fn exchange_data(client: &mut Connection, server: &mut Connection) {
     let mut input = None;
     loop {
-        let out = client.process(input.as_ref(), now()).dgram();
+        let out = client.process(input, now()).dgram();
         let c_done = out.is_none();
-        let out = server.process(out.as_ref(), now()).dgram();
+        let out = server.process(out, now()).dgram();
         if out.is_none() && c_done {
             break;
         }
@@ -373,8 +373,8 @@ fn sending_max_data() {
     assert_eq!(received, SMALL_MAX_DATA);
     assert!(!fin);
 
-    let out = server.process(None, now()).dgram();
-    client.process_input(&out.unwrap(), now());
+    let out = server.process_output(now()).dgram();
+    client.process_input(out.unwrap(), now());
 
     assert_eq!(
         client
@@ -511,8 +511,8 @@ fn do_not_accept_data_after_stop_sending() {
     // create a stream
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
-    let out = client.process(None, now());
-    mem::drop(server.process(out.as_dgram_ref(), now()));
+    let out = client.process_output(now());
+    mem::drop(server.process(out.dgram(), now()));
 
     let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
     assert!(server.events().any(stream_readable));
@@ -520,7 +520,7 @@ fn do_not_accept_data_after_stop_sending() {
     // Send one more packet from client. The packet should arrive after the server
     // has already requested stop_sending.
     client.stream_send(stream_id, &[0x00]).unwrap();
-    let out_second_data_frame = client.process(None, now());
+    let out_second_data_frame = client.process_output(now());
     // Call stop sending.
     assert_eq!(
         Ok(()),
@@ -529,10 +529,10 @@ fn do_not_accept_data_after_stop_sending() {
 
     // Receive the second data frame. The frame should be ignored and
     // DataReadable events shouldn't be posted.
-    let out = server.process(out_second_data_frame.as_dgram_ref(), now());
+    let out = server.process(out_second_data_frame.dgram(), now());
     assert!(!server.events().any(stream_readable));
 
-    mem::drop(client.process(out.as_dgram_ref(), now()));
+    mem::drop(client.process(out.dgram(), now()));
     assert_eq!(
         Err(Error::FinalSizeError),
         client.stream_send(stream_id, &[0x00])
@@ -549,8 +549,8 @@ fn simultaneous_stop_sending_and_reset() {
     // create a stream
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
-    let out = client.process(None, now());
-    let ack = server.process(out.as_dgram_ref(), now()).dgram();
+    let out = client.process_output(now());
+    let ack = server.process(out.dgram(), now()).dgram();
 
     let stream_readable =
         |e| matches!(e, ConnectionEvent::RecvStreamReadable { stream_id: id } if id == stream_id);
@@ -559,23 +559,23 @@ fn simultaneous_stop_sending_and_reset() {
     // The client resets the stream. The packet with reset should arrive after the server
     // has already requested stop_sending.
     client.stream_reset_send(stream_id, 0).unwrap();
-    let out_reset_frame = client.process(ack.as_ref(), now()).dgram();
+    let out_reset_frame = client.process(ack, now()).dgram();
 
     // Send something out of order to force the server to generate an
     // acknowledgment at the next opportunity.
     let force_ack = send_something(&mut client, now());
-    server.process_input(&force_ack, now());
+    server.process_input(force_ack, now());
 
     // Call stop sending.
     server.stream_stop_sending(stream_id, 0).unwrap();
     // Receive the second data frame. The frame should be ignored and
     // DataReadable events shouldn't be posted.
-    let ack = server.process(out_reset_frame.as_ref(), now()).dgram();
+    let ack = server.process(out_reset_frame, now()).dgram();
     assert!(ack.is_some());
     assert!(!server.events().any(stream_readable));
 
     // The client gets the STOP_SENDING frame.
-    client.process_input(&ack.unwrap(), now());
+    client.process_input(ack.unwrap(), now());
     assert_eq!(
         Err(Error::InvalidStreamId),
         client.stream_send(stream_id, &[0x00])
@@ -588,35 +588,35 @@ fn client_fin_reorder() {
     let mut server = default_server();
 
     // Send ClientHello.
-    let client_hs = client.process(None, now());
+    let client_hs = client.process_output(now());
     assert!(client_hs.as_dgram_ref().is_some());
 
-    let server_hs = server.process(client_hs.as_dgram_ref(), now());
+    let server_hs = server.process(client_hs.dgram(), now());
     assert!(server_hs.as_dgram_ref().is_some()); // ServerHello, etc...
 
-    let client_ack = client.process(server_hs.as_dgram_ref(), now());
+    let client_ack = client.process(server_hs.dgram(), now());
     assert!(client_ack.as_dgram_ref().is_some());
 
-    let server_out = server.process(client_ack.as_dgram_ref(), now());
+    let server_out = server.process(client_ack.dgram(), now());
     assert!(server_out.as_dgram_ref().is_none());
 
     assert!(maybe_authenticate(&mut client));
     assert_eq!(*client.state(), State::Connected);
 
-    let client_fin = client.process(None, now());
+    let client_fin = client.process_output(now());
     assert!(client_fin.as_dgram_ref().is_some());
 
     let client_stream_id = client.stream_create(StreamType::UniDi).unwrap();
     client.stream_send(client_stream_id, &[1, 2, 3]).unwrap();
-    let client_stream_data = client.process(None, now());
+    let client_stream_data = client.process_output(now());
     assert!(client_stream_data.as_dgram_ref().is_some());
 
     // Now stream data gets before client_fin
-    let server_out = server.process(client_stream_data.as_dgram_ref(), now());
+    let server_out = server.process(client_stream_data.dgram(), now());
     assert!(server_out.as_dgram_ref().is_none()); // the packet will be discarded
 
     assert_eq!(*server.state(), State::Handshaking);
-    let server_out = server.process(client_fin.as_dgram_ref(), now());
+    let server_out = server.process(client_fin.dgram(), now());
     assert!(server_out.as_dgram_ref().is_some());
 }
 
@@ -629,10 +629,10 @@ fn after_fin_is_read_conn_events_for_stream_should_be_removed() {
     let id = server.stream_create(StreamType::BiDi).unwrap();
     server.stream_send(id, &[6; 10]).unwrap();
     server.stream_close_send(id).unwrap();
-    let out = server.process(None, now()).dgram();
+    let out = server.process_output(now()).dgram();
     assert!(out.is_some());
 
-    mem::drop(client.process(out.as_ref(), now()));
+    mem::drop(client.process(out, now()));
 
     // read from the stream before checking connection events.
     let mut buf = vec![0; 4000];
@@ -654,10 +654,10 @@ fn after_stream_stop_sending_is_called_conn_events_for_stream_should_be_removed(
     let id = server.stream_create(StreamType::BiDi).unwrap();
     server.stream_send(id, &[6; 10]).unwrap();
     server.stream_close_send(id).unwrap();
-    let out = server.process(None, now()).dgram();
+    let out = server.process_output(now()).dgram();
     assert!(out.is_some());
 
-    mem::drop(client.process(out.as_ref(), now()));
+    mem::drop(client.process(out, now()));
 
     // send stop seending.
     client
@@ -682,11 +682,11 @@ fn stream_data_blocked_generates_max_stream_data() {
     // Send some data and consume some flow control.
     let stream_id = server.stream_create(StreamType::UniDi).unwrap();
     _ = server.stream_send(stream_id, DEFAULT_STREAM_DATA).unwrap();
-    let dgram = server.process(None, now).dgram();
+    let dgram = server.process_output(now).dgram();
     assert!(dgram.is_some());
 
     // Consume the data.
-    client.process_input(&dgram.unwrap(), now);
+    client.process_input(dgram.unwrap(), now);
     let mut buf = [0; 10];
     let (count, end) = client.stream_recv(stream_id, &mut buf[..]).unwrap();
     assert_eq!(count, DEFAULT_STREAM_DATA.len());
@@ -703,14 +703,14 @@ fn stream_data_blocked_generates_max_stream_data() {
     assert!(dgram.is_some());
 
     let sdb_before = client.stats().frame_rx.stream_data_blocked;
-    let dgram = client.process(dgram.as_ref(), now).dgram();
+    let dgram = client.process(dgram, now).dgram();
     assert_eq!(client.stats().frame_rx.stream_data_blocked, sdb_before + 1);
     assert!(dgram.is_some());
 
     // Client should have sent a MAX_STREAM_DATA frame with just a small increase
     // on the default window size.
     let msd_before = server.stats().frame_rx.max_stream_data;
-    server.process_input(&dgram.unwrap(), now);
+    server.process_input(dgram.unwrap(), now);
     assert_eq!(server.stats().frame_rx.max_stream_data, msd_before + 1);
 
     // Test that the entirety of the receive buffer is available now.
@@ -742,22 +742,22 @@ fn max_streams_after_bidi_closed() {
     // Write on the one stream and send that out.
     _ = client.stream_send(stream_id, REQUEST).unwrap();
     client.stream_close_send(stream_id).unwrap();
-    let dgram = client.process(None, now()).dgram();
+    let dgram = client.process_output(now()).dgram();
 
     // Now handle the stream and send an incomplete response.
-    server.process_input(&dgram.unwrap(), now());
+    server.process_input(dgram.unwrap(), now());
     server.stream_send(stream_id, RESPONSE).unwrap();
     let dgram = server.process_output(now()).dgram();
 
     // The server shouldn't have released more stream credit.
-    client.process_input(&dgram.unwrap(), now());
+    client.process_input(dgram.unwrap(), now());
     let e = client.stream_create(StreamType::BiDi).unwrap_err();
     assert!(matches!(e, Error::StreamLimitError));
 
     // Closing the stream isn't enough.
     server.stream_close_send(stream_id).unwrap();
     let dgram = server.process_output(now()).dgram();
-    client.process_input(&dgram.unwrap(), now());
+    client.process_input(dgram.unwrap(), now());
     assert!(client.stream_create(StreamType::BiDi).is_err());
 
     // The server needs to see an acknowledgment from the client for its
@@ -771,12 +771,12 @@ fn max_streams_after_bidi_closed() {
     // We need an ACK from the client now, but that isn't guaranteed,
     // so give the client one more packet just in case.
     let dgram = send_something(&mut server, now());
-    client.process_input(&dgram, now());
+    client.process_input(dgram, now());
 
     // Now get the client to send the ACK and have the server handle that.
     let dgram = send_something(&mut client, now());
-    let dgram = server.process(Some(&dgram), now()).dgram();
-    client.process_input(&dgram.unwrap(), now());
+    let dgram = server.process(Some(dgram), now()).dgram();
+    client.process_input(dgram.unwrap(), now());
     assert!(client.stream_create(StreamType::BiDi).is_ok());
     assert!(client.stream_create(StreamType::BiDi).is_err());
 }
@@ -790,8 +790,8 @@ fn no_dupdata_readable_events() {
     // create a stream
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
-    let out = client.process(None, now());
-    mem::drop(server.process(out.as_dgram_ref(), now()));
+    let out = client.process_output(now());
+    mem::drop(server.process(out.dgram(), now()));
 
     // We have a data_readable event.
     let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
@@ -800,16 +800,16 @@ fn no_dupdata_readable_events() {
     // Send one more data frame from client. The previous stream data has not been read yet,
     // therefore there should not be a new DataReadable event.
     client.stream_send(stream_id, &[0x00]).unwrap();
-    let out_second_data_frame = client.process(None, now());
-    mem::drop(server.process(out_second_data_frame.as_dgram_ref(), now()));
+    let out_second_data_frame = client.process_output(now());
+    mem::drop(server.process(out_second_data_frame.dgram(), now()));
     assert!(!server.events().any(stream_readable));
 
     // One more frame with a fin will not produce a new DataReadable event, because the
     // previous stream data has not been read yet.
     client.stream_send(stream_id, &[0x00]).unwrap();
     client.stream_close_send(stream_id).unwrap();
-    let out_third_data_frame = client.process(None, now());
-    mem::drop(server.process(out_third_data_frame.as_dgram_ref(), now()));
+    let out_third_data_frame = client.process_output(now());
+    mem::drop(server.process(out_third_data_frame.dgram(), now()));
     assert!(!server.events().any(stream_readable));
 }
 
@@ -822,8 +822,8 @@ fn no_dupdata_readable_events_empty_last_frame() {
     // create a stream
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
     client.stream_send(stream_id, &[0x00]).unwrap();
-    let out = client.process(None, now());
-    mem::drop(server.process(out.as_dgram_ref(), now()));
+    let out = client.process_output(now());
+    mem::drop(server.process(out.dgram(), now()));
 
     // We have a data_readable event.
     let stream_readable = |e| matches!(e, ConnectionEvent::RecvStreamReadable { .. });
@@ -832,8 +832,8 @@ fn no_dupdata_readable_events_empty_last_frame() {
     // An empty frame with a fin will not produce a new DataReadable event, because
     // the previous stream data has not been read yet.
     client.stream_close_send(stream_id).unwrap();
-    let out_second_data_frame = client.process(None, now());
-    mem::drop(server.process(out_second_data_frame.as_dgram_ref(), now()));
+    let out_second_data_frame = client.process_output(now());
+    mem::drop(server.process(out_second_data_frame.dgram(), now()));
     assert!(!server.events().any(stream_readable));
 }
 
@@ -854,15 +854,15 @@ fn change_flow_control(stream_type: StreamType, new_fc: u64) {
     assert_eq!(u64::try_from(written1).unwrap(), RECV_BUFFER_START);
 
     // Send the stream to the client.
-    let out = server.process(None, now());
-    mem::drop(client.process(out.as_dgram_ref(), now()));
+    let out = server.process_output(now());
+    mem::drop(client.process(out.dgram(), now()));
 
     // change max_stream_data for stream_id.
     client.set_stream_max_data(stream_id, new_fc).unwrap();
 
     // server should receive a MAX_SREAM_DATA frame if the flow control window is updated.
-    let out2 = client.process(None, now());
-    let out3 = server.process(out2.as_dgram_ref(), now());
+    let out2 = client.process_output(now());
+    let out3 = server.process(out2.dgram(), now());
     let expected = usize::from(RECV_BUFFER_START < new_fc);
     assert_eq!(server.stats().frame_rx.max_stream_data, expected);
 
@@ -875,17 +875,17 @@ fn change_flow_control(stream_type: StreamType, new_fc: u64) {
     }
 
     // Exchange packets so that client gets all data.
-    let out4 = client.process(out3.as_dgram_ref(), now());
-    let out5 = server.process(out4.as_dgram_ref(), now());
-    mem::drop(client.process(out5.as_dgram_ref(), now()));
+    let out4 = client.process(out3.dgram(), now());
+    let out5 = server.process(out4.dgram(), now());
+    mem::drop(client.process(out5.dgram(), now()));
 
     // read all data by client
     let mut buf = [0x0; 10000];
     let (read, _) = client.stream_recv(stream_id, &mut buf).unwrap();
     assert_eq!(u64::try_from(read).unwrap(), max(RECV_BUFFER_START, new_fc));
 
-    let out4 = client.process(None, now());
-    mem::drop(server.process(out4.as_dgram_ref(), now()));
+    let out4 = client.process_output(now());
+    mem::drop(server.process(out4.dgram(), now()));
 
     let written3 = server.stream_send(stream_id, &[0x0; 10000]).unwrap();
     assert_eq!(u64::try_from(written3).unwrap(), new_fc);
@@ -939,13 +939,13 @@ fn session_flow_control_stop_sending_state_recv() {
     // In this case the final size is only known after RESET frame is received.
     // The server sends STOP_SENDING -> the client sends RESET -> the server
     // sends MAX_DATA.
-    let out = server.process(None, now()).dgram();
-    let out = client.process(out.as_ref(), now()).dgram();
+    let out = server.process_output(now()).dgram();
+    let out = client.process(out, now()).dgram();
     // the client is still limited.
     let stream_id2 = client.stream_create(StreamType::UniDi).unwrap();
     assert_eq!(client.stream_avail_send_space(stream_id2).unwrap(), 0);
-    let out = server.process(out.as_ref(), now()).dgram();
-    client.process_input(&out.unwrap(), now());
+    let out = server.process(out, now()).dgram();
+    client.process_input(out.unwrap(), now());
     assert_eq!(
         client.stream_avail_send_space(stream_id2).unwrap(),
         SMALL_MAX_DATA
@@ -977,12 +977,12 @@ fn session_flow_control_stop_sending_state_size_known() {
         SMALL_MAX_DATA
     );
 
-    let out1 = client.process(None, now()).dgram();
+    let out1 = client.process_output(now()).dgram();
     // Delay this packet and let the server receive fin first (it will enter SizeKnown state).
     client.stream_close_send(stream_id).unwrap();
-    let out2 = client.process(None, now()).dgram();
+    let out2 = client.process_output(now()).dgram();
 
-    server.process_input(&out2.unwrap(), now());
+    server.process_input(out2.unwrap(), now());
 
     server
         .stream_stop_sending(stream_id, Error::NoError.code())
@@ -991,8 +991,8 @@ fn session_flow_control_stop_sending_state_size_known() {
     // In this case the final size is known when stream_stop_sending is called
     // and the server releases flow control immediately and sends STOP_SENDING and
     // MAX_DATA in the same packet.
-    let out = server.process(out1.as_ref(), now()).dgram();
-    client.process_input(&out.unwrap(), now());
+    let out = server.process(out1, now()).dgram();
+    client.process_input(out.unwrap(), now());
 
     // The flow control should have been updated and the client can again send
     // SMALL_MAX_DATA.
@@ -1108,16 +1108,16 @@ fn session_flow_control_affects_all_streams() {
 
 fn connect_w_different_limit(bidi_limit: u64, unidi_limit: u64) {
     let mut client = default_client();
-    let out = client.process(None, now());
+    let out = client.process_output(now());
     let mut server = new_server(
         ConnectionParameters::default()
             .max_streams(StreamType::BiDi, bidi_limit)
             .max_streams(StreamType::UniDi, unidi_limit),
     );
-    let out = server.process(out.as_dgram_ref(), now());
+    let out = server.process(out.dgram(), now());
 
-    let out = client.process(out.as_dgram_ref(), now());
-    mem::drop(server.process(out.as_dgram_ref(), now()));
+    let out = client.process(out.dgram(), now());
+    mem::drop(server.process(out.dgram(), now()));
 
     assert!(maybe_authenticate(&mut client));
 

--- a/neqo-transport/src/connection/tests/zerortt.rs
+++ b/neqo-transport/src/connection/tests/zerortt.rs
@@ -52,24 +52,24 @@ fn zero_rtt_send_recv() {
     let mut server = resumed_server(&client);
 
     // Send ClientHello.
-    let client_hs = client.process(None, now());
+    let client_hs = client.process_output(now());
     assert!(client_hs.as_dgram_ref().is_some());
 
     // Now send a 0-RTT packet.
     let client_stream_id = client.stream_create(StreamType::UniDi).unwrap();
     client.stream_send(client_stream_id, &[1, 2, 3]).unwrap();
-    let client_0rtt = client.process(None, now());
+    let client_0rtt = client.process_output(now());
     assert!(client_0rtt.as_dgram_ref().is_some());
     // 0-RTT packets on their own shouldn't be padded to MIN_INITIAL_PACKET_SIZE.
     assert!(client_0rtt.as_dgram_ref().unwrap().len() < MIN_INITIAL_PACKET_SIZE);
 
-    let server_hs = server.process(client_hs.as_dgram_ref(), now());
+    let server_hs = server.process(client_hs.dgram(), now());
     assert!(server_hs.as_dgram_ref().is_some()); // ServerHello, etc...
 
     let all_frames = server.stats().frame_tx.all();
     let ack_frames = server.stats().frame_tx.ack;
-    let server_process_0rtt = server.process(client_0rtt.as_dgram_ref(), now());
-    assert!(server_process_0rtt.as_dgram_ref().is_some());
+    let server_process_0rtt = server.process(client_0rtt.dgram(), now());
+    assert!(server_process_0rtt.dgram().is_some());
     assert_eq!(server.stats().frame_tx.all(), all_frames + 1);
     assert_eq!(server.stats().frame_tx.ack, ack_frames + 1);
 
@@ -100,12 +100,12 @@ fn zero_rtt_send_coalesce() {
     // This should result in a datagram that coalesces Initial and 0-RTT.
     let client_stream_id = client.stream_create(StreamType::UniDi).unwrap();
     client.stream_send(client_stream_id, &[1, 2, 3]).unwrap();
-    let client_0rtt = client.process(None, now());
+    let client_0rtt = client.process_output(now());
     assert!(client_0rtt.as_dgram_ref().is_some());
 
     assertions::assert_coalesced_0rtt(&client_0rtt.as_dgram_ref().unwrap()[..]);
 
-    let server_hs = server.process(client_0rtt.as_dgram_ref(), now());
+    let server_hs = server.process(client_0rtt.dgram(), now());
     assert!(server_hs.as_dgram_ref().is_some()); // Should produce ServerHello etc...
 
     let server_stream_id = server
@@ -153,18 +153,18 @@ fn zero_rtt_send_reject() {
         .expect("enable 0-RTT");
 
     // Send ClientHello.
-    let client_hs = client.process(None, now());
+    let client_hs = client.process_output(now());
     assert!(client_hs.as_dgram_ref().is_some());
 
     // Write some data on the client.
     let stream_id = client.stream_create(StreamType::UniDi).unwrap();
     client.stream_send(stream_id, MESSAGE).unwrap();
-    let client_0rtt = client.process(None, now());
+    let client_0rtt = client.process_output(now());
     assert!(client_0rtt.as_dgram_ref().is_some());
 
-    let server_hs = server.process(client_hs.as_dgram_ref(), now());
+    let server_hs = server.process(client_hs.dgram(), now());
     assert!(server_hs.as_dgram_ref().is_some()); // Should produce ServerHello etc...
-    let server_ignored = server.process(client_0rtt.as_dgram_ref(), now());
+    let server_ignored = server.process(client_0rtt.dgram(), now());
     assert!(server_ignored.as_dgram_ref().is_none());
 
     // The server shouldn't receive that 0-RTT data.
@@ -172,14 +172,14 @@ fn zero_rtt_send_reject() {
     assert!(!server.events().any(recvd_stream_evt));
 
     // Client should get a rejection.
-    let client_fin = client.process(server_hs.as_dgram_ref(), now());
+    let client_fin = client.process(server_hs.dgram(), now());
     let recvd_0rtt_reject = |e| e == ConnectionEvent::ZeroRttRejected;
     assert!(client.events().any(recvd_0rtt_reject));
 
     // Server consume client_fin
-    let server_ack = server.process(client_fin.as_dgram_ref(), now());
+    let server_ack = server.process(client_fin.dgram(), now());
     assert!(server_ack.as_dgram_ref().is_some());
-    let client_out = client.process(server_ack.as_dgram_ref(), now());
+    let client_out = client.process(server_ack.dgram(), now());
     assert!(client_out.as_dgram_ref().is_none());
 
     // ...and the client stream should be gone.
@@ -191,11 +191,11 @@ fn zero_rtt_send_reject() {
     let stream_id_after_reject = client.stream_create(StreamType::UniDi).unwrap();
     assert_eq!(stream_id, stream_id_after_reject);
     client.stream_send(stream_id_after_reject, MESSAGE).unwrap();
-    let client_after_reject = client.process(None, now()).dgram();
+    let client_after_reject = client.process_output(now()).dgram();
     assert!(client_after_reject.is_some());
 
     // The server should receive new stream
-    server.process_input(&client_after_reject.unwrap(), now());
+    server.process_input(client_after_reject.unwrap(), now());
     assert!(server.events().any(recvd_stream_evt));
 }
 
@@ -227,15 +227,15 @@ fn zero_rtt_update_flow_control() {
     );
 
     // Stream limits should be low for 0-RTT.
-    let client_hs = client.process(None, now()).dgram();
+    let client_hs = client.process_output(now()).dgram();
     let uni_stream = client.stream_create(StreamType::UniDi).unwrap();
     assert!(!client.stream_send_atomic(uni_stream, MESSAGE).unwrap());
     let bidi_stream = client.stream_create(StreamType::BiDi).unwrap();
     assert!(!client.stream_send_atomic(bidi_stream, MESSAGE).unwrap());
 
     // Now get the server transport parameters.
-    let server_hs = server.process(client_hs.as_ref(), now()).dgram();
-    client.process_input(&server_hs.unwrap(), now());
+    let server_hs = server.process(client_hs, now()).dgram();
+    client.process_input(server_hs.unwrap(), now());
 
     // The streams should report a writeable event.
     let mut uni_stream_event = false;
@@ -299,7 +299,7 @@ fn zero_rtt_loss_accepted() {
         }
 
         // Process CI/0-RTT
-        let si = server.process(ci.as_dgram_ref(), now);
+        let si = server.process(ci.dgram(), now);
         assert!(si.as_dgram_ref().is_some());
 
         let server_stream_id = server
@@ -312,7 +312,7 @@ fn zero_rtt_loss_accepted() {
         assert_eq!(client_stream_id, server_stream_id.as_u64());
 
         // 0-RTT should be accepted
-        client.process_input(si.as_dgram_ref().unwrap(), now);
+        client.process_input(si.dgram().unwrap(), now);
         let recvd_0rtt_reject = |e| e == ConnectionEvent::ZeroRttRejected;
         assert!(
             !client.events().any(recvd_0rtt_reject),

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -718,7 +718,7 @@ impl Path {
         // with the current value.
         let tos = self.tos();
         self.ecn_info.on_packet_sent(stats);
-        Datagram::new(self.local, self.remote, tos, payload)
+        Datagram::new(self.local, self.remote, tos, payload.into())
     }
 
     /// Get local address as `SocketAddr`

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -195,7 +195,7 @@ impl Server {
     fn handle_initial(
         &mut self,
         initial: InitialDetails,
-        dgram: &Datagram,
+        dgram: Datagram<impl AsRef<[u8]>>,
         now: Instant,
     ) -> Output {
         qdebug!([self], "Handle initial");
@@ -297,7 +297,7 @@ impl Server {
     fn accept_connection(
         &mut self,
         initial: InitialDetails,
-        dgram: &Datagram,
+        dgram: Datagram<impl AsRef<[u8]>>,
         orig_dcid: Option<ConnectionId>,
         now: Instant,
     ) -> Output {
@@ -339,7 +339,7 @@ impl Server {
         }
     }
 
-    fn process_input(&mut self, dgram: &Datagram, now: Instant) -> Output {
+    fn process_input(&mut self, dgram: Datagram<impl AsRef<[u8]>>, now: Instant) -> Output {
         qtrace!("Process datagram: {}", hex(&dgram[..]));
 
         // This is only looking at the first packet header in the datagram.
@@ -430,7 +430,7 @@ impl Server {
         let mut callback = None;
 
         for connection in &mut self.connections {
-            match connection.borrow_mut().process(None, now) {
+            match connection.borrow_mut().process_output(now) {
                 Output::None => {}
                 d @ Output::Datagram(_) => return d,
                 Output::Callback(next) => match callback {
@@ -443,8 +443,14 @@ impl Server {
         callback.map_or(Output::None, Output::Callback)
     }
 
+    /// Short-hand for [`Server::process`] without an input datagram.
     #[must_use]
-    pub fn process(&mut self, dgram: Option<&Datagram>, now: Instant) -> Output {
+    pub fn process_output(&mut self, now: Instant) -> Output {
+        self.process(None::<Datagram>, now)
+    }
+
+    #[must_use]
+    pub fn process(&mut self, dgram: Option<Datagram<impl AsRef<[u8]>>>, now: Instant) -> Output {
         let out = dgram
             .map_or(Output::None, |d| self.process_input(d, now))
             .or_else(|| self.process_next_output(now));

--- a/neqo-transport/tests/common/mod.rs
+++ b/neqo-transport/tests/common/mod.rs
@@ -58,27 +58,27 @@ pub fn connect(client: &mut Connection, server: &mut Server) -> ConnectionRef {
     server.set_validation(ValidateAddress::Never);
 
     assert_eq!(*client.state(), State::Init);
-    let out = client.process(None, now()); // ClientHello
+    let out = client.process_output(now()); // ClientHello
     assert!(out.as_dgram_ref().is_some());
-    let out = server.process(out.as_dgram_ref(), now()); // ServerHello...
+    let out = server.process(out.dgram(), now()); // ServerHello...
     assert!(out.as_dgram_ref().is_some());
 
     // Ingest the server Certificate.
-    let out = client.process(out.as_dgram_ref(), now());
+    let out = client.process(out.dgram(), now());
     assert!(out.as_dgram_ref().is_some()); // This should just be an ACK.
-    let out = server.process(out.as_dgram_ref(), now());
+    let out = server.process(out.dgram(), now());
     assert!(out.as_dgram_ref().is_none()); // So the server should have nothing to say.
 
     // Now mark the server as authenticated.
     client.authenticated(AuthenticationStatus::Ok, now());
-    let out = client.process(None, now());
+    let out = client.process_output(now());
     assert!(out.as_dgram_ref().is_some());
     assert_eq!(*client.state(), State::Connected);
-    let out = server.process(out.as_dgram_ref(), now());
+    let out = server.process(out.dgram(), now());
     assert!(out.as_dgram_ref().is_some()); // ACK + HANDSHAKE_DONE + NST
 
     // Have the client process the HANDSHAKE_DONE.
-    let out = client.process(out.as_dgram_ref(), now());
+    let out = client.process(out.dgram(), now());
     assert!(out.as_dgram_ref().is_none());
     assert_eq!(*client.state(), State::Confirmed);
 
@@ -105,14 +105,14 @@ pub fn generate_ticket(server: &mut Server) -> ResumptionToken {
     let mut server_conn = connect(&mut client, server);
 
     server_conn.borrow_mut().send_ticket(now(), &[]).unwrap();
-    let out = server.process(None, now());
-    client.process_input(out.as_dgram_ref().unwrap(), now()); // Consume ticket, ignore output.
+    let out = server.process_output(now());
+    client.process_input(out.dgram().unwrap(), now()); // Consume ticket, ignore output.
     let ticket = find_ticket(&mut client);
 
     // Have the client close the connection and then let the server clean up.
     client.close(now(), 0, "got a ticket");
     let out = client.process_output(now());
-    mem::drop(server.process(out.as_dgram_ref(), now()));
+    mem::drop(server.process(out.dgram(), now()));
     // Calling active_connections clears the set of active connections.
     assert_eq!(server.active_connections().len(), 1);
     ticket

--- a/neqo-transport/tests/conn_vectors.rs
+++ b/neqo-transport/tests/conn_vectors.rs
@@ -265,7 +265,7 @@ fn process_client_initial(v: Version, packet: &[u8]) {
 
     let dgram = datagram(packet.to_vec());
     assert_eq!(*server.state(), State::Init);
-    let out = server.process(Some(&dgram), now());
+    let out = server.process(Some(dgram), now());
     assert_eq!(*server.state(), State::Handshaking);
     assert!(out.dgram().is_some());
 }

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -35,23 +35,23 @@ fn retry_basic() {
     server.set_validation(ValidateAddress::Always);
     let mut client = default_client();
 
-    let dgram = client.process(None, now()).dgram(); // Initial
+    let dgram = client.process_output(now()).dgram(); // Initial
     assert!(dgram.is_some());
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // Retry
+    let dgram = server.process(dgram, now()).dgram(); // Retry
     assert!(dgram.is_some());
 
     assertions::assert_retry(dgram.as_ref().unwrap());
 
-    let dgram = client.process(dgram.as_ref(), now()).dgram(); // Initial w/token
+    let dgram = client.process(dgram, now()).dgram(); // Initial w/token
     assert!(dgram.is_some());
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // Initial, HS
+    let dgram = server.process(dgram, now()).dgram(); // Initial, HS
     assert!(dgram.is_some());
-    mem::drop(client.process(dgram.as_ref(), now()).dgram()); // Ingest, drop any ACK.
+    mem::drop(client.process(dgram, now()).dgram()); // Ingest, drop any ACK.
     client.authenticated(AuthenticationStatus::Ok, now());
-    let dgram = client.process(None, now()).dgram(); // Send Finished
+    let dgram = client.process_output(now()).dgram(); // Send Finished
     assert!(dgram.is_some());
     assert_eq!(*client.state(), State::Connected);
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // (done)
+    let dgram = server.process(dgram, now()).dgram(); // (done)
     assert!(dgram.is_some()); // Note that this packet will be dropped...
     connected_server(&server);
 }
@@ -66,12 +66,12 @@ fn implicit_rtt_retry() {
     let mut client = default_client();
     let mut now = now();
 
-    let dgram = client.process(None, now).dgram();
+    let dgram = client.process_output(now).dgram();
     now += RTT / 2;
-    let dgram = server.process(dgram.as_ref(), now).dgram();
+    let dgram = server.process(dgram, now).dgram();
     assertions::assert_retry(dgram.as_ref().unwrap());
     now += RTT / 2;
-    client.process_input(&dgram.unwrap(), now);
+    client.process_input(dgram.unwrap(), now);
 
     assert_eq!(client.stats().rtt, RTT);
 }
@@ -83,18 +83,18 @@ fn retry_expired() {
     let mut client = default_client();
     let mut now = now();
 
-    let dgram = client.process(None, now).dgram(); // Initial
+    let dgram = client.process_output(now).dgram(); // Initial
     assert!(dgram.is_some());
-    let dgram = server.process(dgram.as_ref(), now).dgram(); // Retry
+    let dgram = server.process(dgram, now).dgram(); // Retry
     assert!(dgram.is_some());
 
     assertions::assert_retry(dgram.as_ref().unwrap());
 
-    let dgram = client.process(dgram.as_ref(), now).dgram(); // Initial w/token
+    let dgram = client.process(dgram, now).dgram(); // Initial w/token
     assert!(dgram.is_some());
 
     now += Duration::from_secs(60); // Too long for Retry.
-    let dgram = server.process(dgram.as_ref(), now).dgram(); // Initial, HS
+    let dgram = server.process(dgram, now).dgram(); // Initial, HS
     assert!(dgram.is_none());
 }
 
@@ -111,26 +111,26 @@ fn retry_0rtt() {
     let client_stream = client.stream_create(StreamType::UniDi).unwrap();
     client.stream_send(client_stream, &[1, 2, 3]).unwrap();
 
-    let dgram = client.process(None, now()).dgram(); // Initial w/0-RTT
+    let dgram = client.process_output(now()).dgram(); // Initial w/0-RTT
     assert!(dgram.is_some());
     assertions::assert_coalesced_0rtt(dgram.as_ref().unwrap());
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // Retry
+    let dgram = server.process(dgram, now()).dgram(); // Retry
     assert!(dgram.is_some());
     assertions::assert_retry(dgram.as_ref().unwrap());
 
     // After retry, there should be a token and still coalesced 0-RTT.
-    let dgram = client.process(dgram.as_ref(), now()).dgram();
+    let dgram = client.process(dgram, now()).dgram();
     assert!(dgram.is_some());
     assertions::assert_coalesced_0rtt(dgram.as_ref().unwrap());
 
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // Initial, HS
+    let dgram = server.process(dgram, now()).dgram(); // Initial, HS
     assert!(dgram.is_some());
-    let dgram = client.process(dgram.as_ref(), now()).dgram();
+    let dgram = client.process(dgram, now()).dgram();
     // Note: the client doesn't need to authenticate the server here
     // as there is no certificate; authentication is based on the ticket.
     assert!(dgram.is_some());
     assert_eq!(*client.state(), State::Connected);
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // (done)
+    let dgram = server.process(dgram, now()).dgram(); // (done)
     assert!(dgram.is_some());
     connected_server(&server);
     assert!(client.tls_info().unwrap().resumed());
@@ -142,14 +142,14 @@ fn retry_different_ip() {
     server.set_validation(ValidateAddress::Always);
     let mut client = default_client();
 
-    let dgram = client.process(None.as_ref(), now()).dgram(); // Initial
+    let dgram = client.process_output(now()).dgram(); // Initial
     assert!(dgram.is_some());
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // Retry
+    let dgram = server.process(dgram, now()).dgram(); // Retry
     assert!(dgram.is_some());
 
     assertions::assert_retry(dgram.as_ref().unwrap());
 
-    let dgram = client.process(dgram.as_ref(), now()).dgram(); // Initial w/token
+    let dgram = client.process(dgram, now()).dgram(); // Initial w/token
     assert!(dgram.is_some());
 
     // Change the source IP on the address from the client.
@@ -157,7 +157,7 @@ fn retry_different_ip() {
     let other_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
     let other_addr = SocketAddr::new(other_v4, 443);
     let from_other = Datagram::new(other_addr, dgram.destination(), dgram.tos(), &dgram[..]);
-    let dgram = server.process(Some(&from_other), now()).dgram();
+    let dgram = server.process(Some(from_other), now()).dgram();
     assert!(dgram.is_none());
 }
 
@@ -170,7 +170,7 @@ fn new_token_different_ip() {
     let mut client = default_client();
     client.enable_resumption(now(), &token).unwrap();
 
-    let dgram = client.process(None, now()).dgram(); // Initial
+    let dgram = client.process_output(now()).dgram(); // Initial
     assert!(dgram.is_some());
     assertions::assert_initial(dgram.as_ref().unwrap(), true);
 
@@ -178,7 +178,7 @@ fn new_token_different_ip() {
     let d = dgram.unwrap();
     let src = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), d.source().port());
     let dgram = Some(Datagram::new(src, d.destination(), d.tos(), &d[..]));
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // Retry
+    let dgram = server.process(dgram, now()).dgram(); // Retry
     assert!(dgram.is_some());
     assertions::assert_retry(dgram.as_ref().unwrap());
 }
@@ -192,7 +192,7 @@ fn new_token_expired() {
     let mut client = default_client();
     client.enable_resumption(now(), &token).unwrap();
 
-    let dgram = client.process(None, now()).dgram(); // Initial
+    let dgram = client.process_output(now()).dgram(); // Initial
     assert!(dgram.is_some());
     assertions::assert_initial(dgram.as_ref().unwrap(), true);
 
@@ -203,7 +203,7 @@ fn new_token_expired() {
     let d = dgram.unwrap();
     let src = SocketAddr::new(d.source().ip(), d.source().port() + 1);
     let dgram = Some(Datagram::new(src, d.destination(), d.tos(), &d[..]));
-    let dgram = server.process(dgram.as_ref(), the_future).dgram(); // Retry
+    let dgram = server.process(dgram, the_future).dgram(); // Retry
     assert!(dgram.is_some());
     assertions::assert_retry(dgram.as_ref().unwrap());
 }
@@ -215,34 +215,34 @@ fn retry_after_initial() {
     retry_server.set_validation(ValidateAddress::Always);
     let mut client = default_client();
 
-    let cinit = client.process(None, now()).dgram(); // Initial
+    let cinit = client.process_output(now()).dgram(); // Initial
     assert!(cinit.is_some());
-    let server_flight = server.process(cinit.as_ref(), now()).dgram(); // Initial
+    let server_flight = server.process(cinit.clone(), now()).dgram(); // Initial
     assert!(server_flight.is_some());
 
     // We need to have the client just process the Initial.
     let (server_initial, _other) = split_datagram(server_flight.as_ref().unwrap());
-    let dgram = client.process(Some(&server_initial), now()).dgram();
+    let dgram = client.process(Some(server_initial), now()).dgram();
     assert!(dgram.is_some());
     assert!(*client.state() != State::Connected);
 
-    let retry = retry_server.process(cinit.as_ref(), now()).dgram(); // Retry!
+    let retry = retry_server.process(cinit, now()).dgram(); // Retry!
     assert!(retry.is_some());
     assertions::assert_retry(retry.as_ref().unwrap());
 
     // The client should ignore the retry.
-    let junk = client.process(retry.as_ref(), now()).dgram();
+    let junk = client.process(retry, now()).dgram();
     assert!(junk.is_none());
 
     // Either way, the client should still be able to process the server flight and connect.
-    let dgram = client.process(server_flight.as_ref(), now()).dgram();
+    let dgram = client.process(server_flight, now()).dgram();
     assert!(dgram.is_some()); // Drop this one.
     assert!(test_fixture::maybe_authenticate(&mut client));
-    let dgram = client.process(None, now()).dgram();
+    let dgram = client.process_output(now()).dgram();
     assert!(dgram.is_some());
 
     assert_eq!(*client.state(), State::Connected);
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // (done)
+    let dgram = server.process(dgram, now()).dgram(); // (done)
     assert!(dgram.is_some());
     connected_server(&server);
 }
@@ -253,9 +253,9 @@ fn retry_bad_integrity() {
     server.set_validation(ValidateAddress::Always);
     let mut client = default_client();
 
-    let dgram = client.process(None, now()).dgram(); // Initial
+    let dgram = client.process_output(now()).dgram(); // Initial
     assert!(dgram.is_some());
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // Retry
+    let dgram = server.process(dgram, now()).dgram(); // Retry
     assert!(dgram.is_some());
 
     let retry = &dgram.as_ref().unwrap();
@@ -266,7 +266,7 @@ fn retry_bad_integrity() {
     let tweaked_packet = Datagram::new(retry.source(), retry.destination(), retry.tos(), tweaked);
 
     // The client should ignore this packet.
-    let dgram = client.process(Some(&tweaked_packet), now()).dgram();
+    let dgram = client.process(Some(tweaked_packet), now()).dgram();
     assert!(dgram.is_none());
 }
 
@@ -278,16 +278,14 @@ fn retry_bad_token() {
     let mut server = default_server();
 
     // Send a retry to one server, then replay it to the other.
-    let client_initial1 = client.process(None, now()).dgram();
+    let client_initial1 = client.process_output(now()).dgram();
     assert!(client_initial1.is_some());
-    let retry = retry_server
-        .process(client_initial1.as_ref(), now())
-        .dgram();
+    let retry = retry_server.process(client_initial1, now()).dgram();
     assert!(retry.is_some());
-    let client_initial2 = client.process(retry.as_ref(), now()).dgram();
+    let client_initial2 = client.process(retry, now()).dgram();
     assert!(client_initial2.is_some());
 
-    let dgram = server.process(client_initial2.as_ref(), now()).dgram();
+    let dgram = server.process(client_initial2, now()).dgram();
     assert!(dgram.is_none());
 }
 
@@ -303,20 +301,20 @@ fn retry_after_pto() {
     server.set_validation(ValidateAddress::Always);
     let mut now = now();
 
-    let ci = client.process(None, now).dgram();
+    let ci = client.process_output(now).dgram();
     assert!(ci.is_some()); // sit on this for a bit.RefCell
 
     // Let PTO fire on the client and then let it exhaust its PTO packets.
     now += Duration::from_secs(1);
-    let pto = client.process(None, now).dgram();
+    let pto = client.process_output(now).dgram();
     assert!(pto.unwrap().len() >= MIN_INITIAL_PACKET_SIZE);
-    let cb = client.process(None, now).callback();
+    let cb = client.process_output(now).callback();
     assert_ne!(cb, Duration::new(0, 0));
 
-    let retry = server.process(ci.as_ref(), now).dgram();
+    let retry = server.process(ci, now).dgram();
     assertions::assert_retry(retry.as_ref().unwrap());
 
-    let ci2 = client.process(retry.as_ref(), now).dgram();
+    let ci2 = client.process(retry, now).dgram();
     assert!(ci2.unwrap().len() >= MIN_INITIAL_PACKET_SIZE);
 }
 
@@ -326,14 +324,14 @@ fn vn_after_retry() {
     server.set_validation(ValidateAddress::Always);
     let mut client = default_client();
 
-    let dgram = client.process(None, now()).dgram(); // Initial
+    let dgram = client.process_output(now()).dgram(); // Initial
     assert!(dgram.is_some());
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // Retry
+    let dgram = server.process(dgram, now()).dgram(); // Retry
     assert!(dgram.is_some());
 
     assertions::assert_retry(dgram.as_ref().unwrap());
 
-    let dgram = client.process(dgram.as_ref(), now()).dgram(); // Initial w/token
+    let dgram = client.process(dgram, now()).dgram(); // Initial w/token
     assert!(dgram.is_some());
 
     let mut encoder = Encoder::default();
@@ -345,7 +343,7 @@ fn vn_after_retry() {
     let vn = datagram(encoder.into());
 
     assert_ne!(
-        client.process(Some(&vn), now()).callback(),
+        client.process(Some(vn), now()).callback(),
         Duration::from_secs(0)
     );
 }
@@ -368,13 +366,11 @@ fn mitm_retry() {
     let mut server = default_server();
 
     // Trigger initial and a second client Initial.
-    let client_initial1 = client.process(None, now()).dgram();
+    let client_initial1 = client.process_output(now()).dgram();
     assert!(client_initial1.is_some());
-    let retry = retry_server
-        .process(client_initial1.as_ref(), now())
-        .dgram();
+    let retry = retry_server.process(client_initial1, now()).dgram();
     assert!(retry.is_some());
-    let client_initial2 = client.process(retry.as_ref(), now()).dgram();
+    let client_initial2 = client.process(retry, now()).dgram();
     assert!(client_initial2.is_some());
 
     // Now to start the epic process of decrypting the packet,
@@ -432,15 +428,15 @@ fn mitm_retry() {
         notoken_packet,
     );
     qdebug!("passing modified Initial to the main server");
-    let dgram = server.process(Some(&new_datagram), now()).dgram();
+    let dgram = server.process(Some(new_datagram), now()).dgram();
     assert!(dgram.is_some());
 
-    let dgram = client.process(dgram.as_ref(), now()).dgram(); // Generate an ACK.
+    let dgram = client.process(dgram, now()).dgram(); // Generate an ACK.
     assert!(dgram.is_some());
-    let dgram = server.process(dgram.as_ref(), now()).dgram();
+    let dgram = server.process(dgram, now()).dgram();
     assert!(dgram.is_none());
     assert!(test_fixture::maybe_authenticate(&mut client));
-    let dgram = client.process(dgram.as_ref(), now()).dgram();
+    let dgram = client.process(dgram, now()).dgram();
     assert!(dgram.is_some()); // Client sending CLOSE_CONNECTIONs
     assert!(matches!(
         *client.state(),

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -47,8 +47,8 @@ pub fn complete_connection(
     };
     while !is_done(client) {
         _ = test_fixture::maybe_authenticate(client);
-        let out = client.process(datagram.as_ref(), now());
-        let out = server.process(out.as_dgram_ref(), now());
+        let out = client.process(datagram, now());
+        let out = server.process(out.dgram(), now());
         datagram = out.dgram();
     }
 
@@ -111,9 +111,9 @@ fn connect_single_version_server() {
             // Run the version negotiation exchange if necessary.
             let out = client.process_output(now());
             assert!(out.as_dgram_ref().is_some());
-            let dgram = server.process(out.as_dgram_ref(), now()).dgram();
+            let dgram = server.process(out.dgram(), now()).dgram();
             assertions::assert_vn(dgram.as_ref().unwrap());
-            client.process_input(&dgram.unwrap(), now());
+            client.process_input(dgram.unwrap(), now());
         }
 
         let server_conn = connect(&mut client, &mut server);
@@ -133,14 +133,16 @@ fn duplicate_initial() {
     let mut client = default_client();
 
     assert_eq!(*client.state(), State::Init);
-    let initial = client.process(None, now());
+    let initial = client.process_output(now());
     assert!(initial.as_dgram_ref().is_some());
 
     // The server should ignore a packets with the same remote address and
     // destination connection ID as an existing connection attempt.
-    let server_initial = server.process(initial.as_dgram_ref(), now()).dgram();
+    let server_initial = server
+        .process(initial.as_dgram_ref().cloned(), now())
+        .dgram();
     assert!(server_initial.is_some());
-    let dgram = server.process(initial.as_dgram_ref(), now()).dgram();
+    let dgram = server.process(initial.dgram(), now()).dgram();
     assert!(dgram.is_none());
 
     assert_eq!(server.active_connections().len(), 1);
@@ -153,7 +155,7 @@ fn duplicate_initial_new_path() {
     let mut client = default_client();
 
     assert_eq!(*client.state(), State::Init);
-    let initial = client.process(None, now()).dgram().unwrap();
+    let initial = client.process_output(now()).dgram().unwrap();
     let other = Datagram::new(
         SocketAddr::new(initial.source().ip(), initial.source().port() ^ 23),
         initial.destination(),
@@ -161,11 +163,11 @@ fn duplicate_initial_new_path() {
         &initial[..],
     );
 
-    let server_initial = server.process(Some(&initial), now()).dgram();
+    let server_initial = server.process(Some(initial), now()).dgram();
     assert!(server_initial.is_some());
 
     // The server should ignore a packet with the same destination connection ID.
-    let dgram = server.process(Some(&other), now()).dgram();
+    let dgram = server.process(Some(other), now()).dgram();
     assert!(dgram.is_none());
 
     assert_eq!(server.active_connections().len(), 1);
@@ -178,20 +180,16 @@ fn different_initials_same_path() {
     let mut client1 = default_client();
     let mut client2 = default_client();
 
-    let client_initial1 = client1.process(None, now());
+    let client_initial1 = client1.process_output(now());
     assert!(client_initial1.as_dgram_ref().is_some());
-    let client_initial2 = client2.process(None, now());
+    let client_initial2 = client2.process_output(now());
     assert!(client_initial2.as_dgram_ref().is_some());
 
     // The server should respond to both as these came from different addresses.
-    let server_initial1 = server
-        .process(client_initial1.as_dgram_ref(), now())
-        .dgram();
+    let server_initial1 = server.process(client_initial1.dgram(), now()).dgram();
     assert!(server_initial1.is_some());
 
-    let server_initial2 = server
-        .process(client_initial2.as_dgram_ref(), now())
-        .dgram();
+    let server_initial2 = server.process(client_initial2.dgram(), now()).dgram();
     assert!(server_initial2.is_some());
 
     assert_eq!(server.active_connections().len(), 2);
@@ -204,17 +202,19 @@ fn same_initial_after_connected() {
     let mut server = default_server();
     let mut client = default_client();
 
-    let client_initial = client.process(None, now());
+    let client_initial = client.process_output(now());
     assert!(client_initial.as_dgram_ref().is_some());
 
-    let server_initial = server.process(client_initial.as_dgram_ref(), now()).dgram();
+    let server_initial = server
+        .process(client_initial.as_dgram_ref().cloned(), now())
+        .dgram();
     assert!(server_initial.is_some());
     complete_connection(&mut client, &mut server, server_initial);
     assert_eq!(server.active_connections().len(), 1);
 
     // Now make a new connection using the exact same initial as before.
     // The server should respond to an attempt to connect with the same Initial.
-    let dgram = server.process(client_initial.as_dgram_ref(), now()).dgram();
+    let dgram = server.process(client_initial.dgram(), now()).dgram();
     assert!(dgram.is_some());
     // The server should make a new connection object.
     assert_eq!(server.active_connections().len(), 2);
@@ -236,7 +236,7 @@ fn drop_non_initial() {
     bogus_data.resize(MIN_INITIAL_PACKET_SIZE, 66);
 
     let bogus = datagram(bogus_data);
-    assert!(server.process(Some(&bogus), now()).dgram().is_none());
+    assert!(server.process(Some(bogus), now()).dgram().is_none());
 }
 
 #[test]
@@ -255,7 +255,7 @@ fn drop_short_initial() {
     bogus_data.resize(1199, 66);
 
     let bogus = datagram(bogus_data);
-    assert!(server.process(Some(&bogus), now()).dgram().is_none());
+    assert!(server.process(Some(bogus), now()).dgram().is_none());
 }
 
 #[test]
@@ -272,7 +272,7 @@ fn drop_short_header_packet_for_unknown_connection() {
     bogus_data.resize(MIN_INITIAL_PACKET_SIZE, 66);
 
     let bogus = datagram(bogus_data);
-    assert!(server.process(Some(&bogus), now()).dgram().is_none());
+    assert!(server.process(Some(bogus), now()).dgram().is_none());
 }
 
 /// Verify that the server can read 0-RTT properly.  A more robust server would buffer
@@ -286,9 +286,9 @@ fn zero_rtt() {
 
     // Discharge the old connection so that we don't have to worry about it.
     let mut now = now();
-    let t = server.process(None, now).callback();
+    let t = server.process_output(now).callback();
     now += t;
-    assert_eq!(server.process(None, now), Output::None);
+    assert_eq!(server.process_output(now), Output::None);
     assert_eq!(server.active_connections().len(), 0);
 
     let start_time = now;
@@ -298,12 +298,12 @@ fn zero_rtt() {
     let mut client_send = || {
         let client_stream = client.stream_create(StreamType::UniDi).unwrap();
         client.stream_send(client_stream, &[1, 2, 3]).unwrap();
-        match client.process(None, now) {
+        match client.process_output(now) {
             Output::Datagram(d) => d,
             Output::Callback(t) => {
                 // Pacing...
                 now += t;
-                client.process(None, now).dgram().unwrap()
+                client.process_output(now).dgram().unwrap()
             }
             Output::None => panic!(),
         }
@@ -317,12 +317,12 @@ fn zero_rtt() {
     let c4 = client_send();
 
     // 0-RTT packets that arrive before the handshake get dropped.
-    mem::drop(server.process(Some(&c2), now));
+    mem::drop(server.process(Some(c2), now));
     assert!(server.active_connections().is_empty());
 
     // Now handshake and let another 0-RTT packet in.
-    let shs = server.process(Some(&c1), now);
-    mem::drop(server.process(Some(&c3), now));
+    let shs = server.process(Some(c1), now);
+    mem::drop(server.process(Some(c3), now));
     // The server will have received two STREAM frames now if it processed both packets.
     // `ActiveConnectionRef` `Hash` implementation doesn’t access any of the interior mutable types.
     #[allow(clippy::mutable_key_type)]
@@ -343,11 +343,11 @@ fn zero_rtt() {
     // Complete the handshake.  As the client was pacing 0-RTT packets, extend the time
     // a little so that the pacer doesn't prevent the Finished from being sent.
     now += now - start_time;
-    let cfin = client.process(shs.as_dgram_ref(), now);
-    mem::drop(server.process(cfin.as_dgram_ref(), now));
+    let cfin = client.process(shs.dgram(), now);
+    mem::drop(server.process(cfin.dgram(), now));
 
     // The server will drop this last 0-RTT packet.
-    mem::drop(server.process(Some(&c4), now));
+    mem::drop(server.process(Some(c4), now));
     // `ActiveConnectionRef` `Hash` implementation doesn’t access any of the interior mutable types.
     #[allow(clippy::mutable_key_type)]
     let active = server.active_connections();
@@ -377,20 +377,20 @@ fn new_token_0rtt() {
     let client_stream = client.stream_create(StreamType::UniDi).unwrap();
     client.stream_send(client_stream, &[1, 2, 3]).unwrap();
 
-    let out = client.process(None, now()); // Initial w/0-RTT
+    let out = client.process_output(now()); // Initial w/0-RTT
     assert!(out.as_dgram_ref().is_some());
     assertions::assert_initial(out.as_dgram_ref().unwrap(), true);
     assertions::assert_coalesced_0rtt(out.as_dgram_ref().unwrap());
-    let out = server.process(out.as_dgram_ref(), now()); // Initial
+    let out = server.process(out.dgram(), now()); // Initial
     assert!(out.as_dgram_ref().is_some());
     assertions::assert_initial(out.as_dgram_ref().unwrap(), false);
 
-    let dgram = client.process(out.as_dgram_ref(), now());
+    let dgram = client.process(out.as_dgram_ref().cloned(), now());
     // Note: the client doesn't need to authenticate the server here
     // as there is no certificate; authentication is based on the ticket.
     assert!(out.as_dgram_ref().is_some());
     assert_eq!(*client.state(), State::Connected);
-    let dgram = server.process(dgram.as_dgram_ref(), now()); // (done)
+    let dgram = server.process(dgram.dgram(), now()); // (done)
     assert!(dgram.as_dgram_ref().is_some());
     connected_server(&server);
     assert!(client.tls_info().unwrap().resumed());
@@ -405,7 +405,7 @@ fn new_token_different_port() {
     let mut client = default_client();
     client.enable_resumption(now(), &token).unwrap();
 
-    let dgram = client.process(None, now()).dgram(); // Initial
+    let dgram = client.process_output(now()).dgram(); // Initial
     assert!(dgram.is_some());
     assertions::assert_initial(dgram.as_ref().unwrap(), true);
 
@@ -413,7 +413,7 @@ fn new_token_different_port() {
     let d = dgram.unwrap();
     let src = SocketAddr::new(d.source().ip(), d.source().port() + 1);
     let dgram = Some(Datagram::new(src, d.destination(), d.tos(), &d[..]));
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // Retry
+    let dgram = server.process(dgram, now()).dgram(); // Retry
     assert!(dgram.is_some());
     assertions::assert_initial(dgram.as_ref().unwrap(), false);
 }
@@ -423,7 +423,7 @@ fn bad_client_initial() {
     let mut client = default_client();
     let mut server = default_server();
 
-    let dgram = client.process(None, now()).dgram().expect("a datagram");
+    let dgram = client.process_output(now()).dgram().expect("a datagram");
     let (header, d_cid, s_cid, payload) = decode_initial_header(&dgram, Role::Client).unwrap();
     let (aead, hp) = initial_aead_and_hp(d_cid, Role::Client);
     let (fixed_header, pn) = remove_header_protection(&hp, header, payload);
@@ -470,7 +470,7 @@ fn bad_client_initial() {
     let bad_dgram = Datagram::new(dgram.source(), dgram.destination(), dgram.tos(), ciphertext);
 
     // The server should reject this.
-    let response = server.process(Some(&bad_dgram), now());
+    let response = server.process(Some(bad_dgram), now());
     let close_dgram = response.dgram().unwrap();
     // The resulting datagram might contain multiple packets, but each is small.
     let (initial_close, rest) = split_datagram(&close_dgram);
@@ -484,10 +484,10 @@ fn bad_client_initial() {
 
     // The client should accept this new and stop trying to connect.
     // It will generate a CONNECTION_CLOSE first though.
-    let response = client.process(Some(&close_dgram), now()).dgram();
+    let response = client.process(Some(close_dgram), now()).dgram();
     assert!(response.is_some());
     // The client will now wait out its closing period.
-    let delay = client.process(None, now()).callback();
+    let delay = client.process_output(now()).callback();
     assert_ne!(delay, Duration::from_secs(0));
     assert!(matches!(
         *client.state(),
@@ -502,7 +502,7 @@ fn bad_client_initial() {
     }
 
     // After sending the CONNECTION_CLOSE, the server goes idle.
-    let res = server.process(None, now());
+    let res = server.process_output(now());
     assert_eq!(res, Output::None);
 }
 
@@ -511,7 +511,7 @@ fn bad_client_initial_connection_close() {
     let mut client = default_client();
     let mut server = default_server();
 
-    let dgram = client.process(None, now()).dgram().expect("a datagram");
+    let dgram = client.process_output(now()).dgram().expect("a datagram");
     let (header, d_cid, s_cid, payload) = decode_initial_header(&dgram, Role::Client).unwrap();
     let (aead, hp) = initial_aead_and_hp(d_cid, Role::Client);
     let (_, pn) = remove_header_protection(&hp, header, payload);
@@ -553,9 +553,9 @@ fn bad_client_initial_connection_close() {
 
     // The server should ignore this and go to Draining.
     let mut now = now();
-    let response = server.process(Some(&bad_dgram), now);
+    let response = server.process(Some(bad_dgram), now);
     now += response.callback();
-    let response = server.process(None, now);
+    let response = server.process_output(now);
     assert_eq!(response, Output::None);
 }
 
@@ -565,7 +565,7 @@ fn version_negotiation_ignored() {
     let mut client = default_client();
 
     // Any packet will do, but let's make something that looks real.
-    let dgram = client.process(None, now()).dgram().expect("a datagram");
+    let dgram = client.process_output(now()).dgram().expect("a datagram");
     let mut input = dgram.to_vec();
     input[1] ^= 0x12;
     let damaged = Datagram::new(
@@ -574,7 +574,7 @@ fn version_negotiation_ignored() {
         dgram.tos(),
         input.clone(),
     );
-    let vn = server.process(Some(&damaged), now()).dgram();
+    let vn = server.process(Some(damaged), now()).dgram();
 
     let mut dec = Decoder::from(&input[5..]); // Skip past version.
     let d_cid = dec.decode_vec(1).expect("client DCID").to_vec();
@@ -595,7 +595,7 @@ fn version_negotiation_ignored() {
     assert!(found, "valid version not found");
 
     // Client ignores VN packet that contain negotiated version.
-    let res = client.process(Some(&vn), now());
+    let res = client.process(Some(vn), now());
     assert!(res.callback() > Duration::new(0, 120));
     assert_eq!(client.state(), &State::WaitInitial);
 }
@@ -615,9 +615,9 @@ fn version_negotiation() {
     // `connect()` runs a fixed exchange, so manually run the Version Negotiation.
     let dgram = client.process_output(now()).dgram();
     assert!(dgram.is_some());
-    let dgram = server.process(dgram.as_ref(), now()).dgram();
+    let dgram = server.process(dgram, now()).dgram();
     assertions::assert_vn(dgram.as_ref().unwrap());
-    client.process_input(&dgram.unwrap(), now());
+    client.process_input(dgram.unwrap(), now());
 
     let sconn = connect(&mut client, &mut server);
     assert_eq!(client.version(), VN_VERSION);
@@ -651,22 +651,22 @@ fn version_negotiation_and_compatible() {
     let dgram = client.process_output(now()).dgram();
     assert!(dgram.is_some());
     assertions::assert_version(dgram.as_ref().unwrap(), ORIG_VERSION.wire_version());
-    let dgram = server.process(dgram.as_ref(), now()).dgram();
+    let dgram = server.process(dgram, now()).dgram();
     assertions::assert_vn(dgram.as_ref().unwrap());
-    client.process_input(&dgram.unwrap(), now());
+    client.process_input(dgram.unwrap(), now());
 
-    let dgram = client.process(None, now()).dgram(); // ClientHello
+    let dgram = client.process_output(now()).dgram(); // ClientHello
     assertions::assert_version(dgram.as_ref().unwrap(), VN_VERSION.wire_version());
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // ServerHello...
+    let dgram = server.process(dgram, now()).dgram(); // ServerHello...
     assertions::assert_version(dgram.as_ref().unwrap(), COMPAT_VERSION.wire_version());
-    client.process_input(&dgram.unwrap(), now());
+    client.process_input(dgram.unwrap(), now());
 
     client.authenticated(AuthenticationStatus::Ok, now());
     let dgram = client.process_output(now()).dgram();
     assertions::assert_version(dgram.as_ref().unwrap(), COMPAT_VERSION.wire_version());
     assert_eq!(*client.state(), State::Connected);
-    let dgram = server.process(dgram.as_ref(), now()).dgram(); // ACK + HANDSHAKE_DONE + NST
-    client.process_input(&dgram.unwrap(), now());
+    let dgram = server.process(dgram, now()).dgram(); // ACK + HANDSHAKE_DONE + NST
+    client.process_input(dgram.unwrap(), now());
     assert_eq!(*client.state(), State::Confirmed);
 
     let sconn = connected_server(&server);
@@ -698,8 +698,8 @@ fn compatible_upgrade_resumption_and_vn() {
     assert_eq!(server_conn.borrow().version(), COMPAT_VERSION);
 
     server_conn.borrow_mut().send_ticket(now(), &[]).unwrap();
-    let dgram = server.process(None, now()).dgram();
-    client.process_input(&dgram.unwrap(), now()); // Consume ticket, ignore output.
+    let dgram = server.process_output(now()).dgram();
+    client.process_input(dgram.unwrap(), now()); // Consume ticket, ignore output.
     let ticket = find_ticket(&mut client);
 
     // This new server will reject the ticket, but it will also generate a VN packet.
@@ -713,9 +713,9 @@ fn compatible_upgrade_resumption_and_vn() {
     let dgram = client.process_output(now()).dgram();
     assert!(dgram.is_some());
     assertions::assert_version(dgram.as_ref().unwrap(), COMPAT_VERSION.wire_version());
-    let dgram = server.process(dgram.as_ref(), now()).dgram();
+    let dgram = server.process(dgram, now()).dgram();
     assertions::assert_vn(dgram.as_ref().unwrap());
-    client.process_input(&dgram.unwrap(), now());
+    client.process_input(dgram.unwrap(), now());
 
     let server_conn = connect(&mut client, &mut server);
     assert_eq!(client.version(), RESUMPTION_VERSION);
@@ -730,14 +730,14 @@ fn closed() {
     connect(&mut client, &mut server);
 
     // The server will have sent a few things, so it will be on PTO.
-    let res = server.process(None, now());
+    let res = server.process_output(now());
     assert!(res.callback() > Duration::new(0, 0));
     // The client will be on the delayed ACK timer.
-    let res = client.process(None, now());
+    let res = client.process_output(now());
     assert!(res.callback() > Duration::new(0, 0));
 
     qtrace!("60s later");
-    let res = server.process(None, now() + Duration::from_secs(60));
+    let res = server.process_output(now() + Duration::from_secs(60));
     assert_eq!(res, Output::None);
 }
 
@@ -825,8 +825,8 @@ fn max_streams_after_0rtt_rejection() {
     client.enable_resumption(now(), &token).unwrap();
     _ = client.stream_create(StreamType::BiDi).unwrap();
     let dgram = client.process_output(now()).dgram();
-    let dgram = server.process(dgram.as_ref(), now()).dgram();
-    let dgram = client.process(dgram.as_ref(), now()).dgram();
+    let dgram = server.process(dgram, now()).dgram();
+    let dgram = client.process(dgram, now()).dgram();
     assert!(dgram.is_some()); // We're far enough along to complete the test now.
 
     // Make sure that we can create MAX_STREAMS uni- and bidirectional streams.
@@ -863,8 +863,8 @@ fn has_active_connections() {
 
     assert!(!server.has_active_connections());
 
-    let initial = client.process(None, now());
-    _ = server.process(initial.as_dgram_ref(), now()).dgram();
+    let initial = client.process_output(now());
+    _ = server.process(initial.dgram(), now()).dgram();
 
     assert!(server.has_active_connections());
 }

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -7,10 +7,9 @@
 #![allow(clippy::missing_errors_doc)] // Functions simply delegate to tokio and quinn-udp.
 
 use std::{
-    cell::RefCell,
     io::{self, IoSliceMut},
     net::SocketAddr,
-    slice,
+    slice::{self, Chunks},
 };
 
 use neqo_common::{qdebug, qtrace, Datagram, IpTos};
@@ -21,11 +20,7 @@ use quinn_udp::{EcnCodepoint, RecvMeta, Transmit, UdpSocketState};
 /// Allows reading multiple datagrams in a single [`Socket::recv`] call.
 //
 // TODO: Experiment with different values across platforms.
-const RECV_BUF_SIZE: usize = u16::MAX as usize;
-
-std::thread_local! {
-    static RECV_BUF: RefCell<Vec<u8>> = RefCell::new(vec![0; RECV_BUF_SIZE]);
-}
+pub const RECV_BUF_SIZE: usize = u16::MAX as usize;
 
 pub fn send_inner(
     state: &UdpSocketState,
@@ -57,63 +52,89 @@ use std::os::fd::AsFd as SocketRef;
 #[cfg(windows)]
 use std::os::windows::io::AsSocket as SocketRef;
 
-pub fn recv_inner(
+pub fn recv_inner<'a>(
     local_address: &SocketAddr,
     state: &UdpSocketState,
     socket: impl SocketRef,
-) -> Result<Vec<Datagram>, io::Error> {
-    let dgrams = RECV_BUF.with_borrow_mut(|recv_buf| -> Result<Vec<Datagram>, io::Error> {
-        let mut meta;
+    recv_buf: &'a mut [u8],
+) -> Result<DatagramIter<'a>, io::Error> {
+    let mut meta;
 
-        loop {
-            meta = RecvMeta::default();
+    let data = loop {
+        meta = RecvMeta::default();
 
-            state.recv(
-                (&socket).into(),
-                &mut [IoSliceMut::new(recv_buf)],
-                slice::from_mut(&mut meta),
-            )?;
+        state.recv(
+            (&socket).into(),
+            &mut [IoSliceMut::new(recv_buf)],
+            slice::from_mut(&mut meta),
+        )?;
 
-            if meta.len == 0 || meta.stride == 0 {
-                qdebug!(
-                    "ignoring datagram from {} to {} len {} stride {}",
-                    meta.addr,
-                    local_address,
-                    meta.len,
-                    meta.stride
-                );
-                continue;
-            }
-
-            break;
+        if meta.len == 0 || meta.stride == 0 {
+            qdebug!(
+                "ignoring datagram from {} to {} len {} stride {}",
+                meta.addr,
+                local_address,
+                meta.len,
+                meta.stride
+            );
+            continue;
         }
 
-        Ok(recv_buf[0..meta.len]
-            .chunks(meta.stride)
-            .map(|d| {
-                qtrace!(
-                    "received {} bytes from {} to {}",
-                    d.len(),
-                    meta.addr,
-                    local_address,
-                );
-                Datagram::new(
-                    meta.addr,
-                    *local_address,
-                    meta.ecn.map(|n| IpTos::from(n as u8)).unwrap_or_default(),
-                    d,
-                )
-            })
-            .collect())
-    })?;
+        break &recv_buf[..meta.len];
+    };
 
     qtrace!(
-        "received {} datagrams ({:?})",
-        dgrams.len(),
-        dgrams.iter().map(|d| d.len()).collect::<Vec<_>>(),
+        "received {} bytes from {} to {} in {} segments",
+        data.len(),
+        meta.addr,
+        local_address,
+        data.len().div_ceil(meta.stride),
     );
 
-    Ok(dgrams)
+    Ok(DatagramIter {
+        meta,
+        datagrams: data.chunks(meta.stride),
+        local_address: *local_address,
+    })
+}
+
+pub struct DatagramIter<'a> {
+    meta: RecvMeta,
+    datagrams: Chunks<'a, u8>,
+    local_address: SocketAddr,
+}
+
+impl std::fmt::Debug for DatagramIter<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Datagrams")
+            .field("meta", &self.meta)
+            .field("local_address", &self.local_address)
+            .finish()
+    }
+}
+
+impl<'a> Iterator for DatagramIter<'a> {
+    type Item = Datagram<&'a [u8]>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.datagrams.next().map(|d| {
+            Datagram::from_slice(
+                self.meta.addr,
+                self.local_address,
+                self.meta
+                    .ecn
+                    .map(|n| IpTos::from(n as u8))
+                    .unwrap_or_default(),
+                d,
+            )
+        })
+    }
+}
+
+impl ExactSizeIterator for DatagramIter<'_> {
+    fn len(&self) -> usize {
+        self.datagrams.len()
+    }
 }
 
 /// A wrapper around a UDP socket, sending and receiving [`Datagram`]s.
@@ -138,8 +159,12 @@ impl<S: SocketRef> Socket<S> {
 
     /// Receive a batch of [`Datagram`]s on the given [`Socket`], each
     /// set with the provided local address.
-    pub fn recv(&self, local_address: &SocketAddr) -> Result<Vec<Datagram>, io::Error> {
-        recv_inner(local_address, &self.state, &self.inner)
+    pub fn recv<'a>(
+        &self,
+        local_address: &SocketAddr,
+        recv_buf: &'a mut [u8],
+    ) -> Result<DatagramIter<'a>, io::Error> {
+        recv_inner(local_address, &self.state, &self.inner, recv_buf)
     }
 }
 
@@ -170,7 +195,8 @@ mod tests {
         );
 
         sender.send(&datagram)?;
-        let res = receiver.recv(&receiver_addr);
+        let mut recv_buf = vec![0; RECV_BUF_SIZE];
+        let res = receiver.recv(&receiver_addr, &mut recv_buf);
         assert_eq!(res.unwrap_err().kind(), std::io::ErrorKind::WouldBlock);
 
         Ok(())
@@ -191,17 +217,15 @@ mod tests {
 
         sender.send(&datagram)?;
 
-        let received_datagram = receiver
-            .recv(&receiver_addr)
-            .expect("receive to succeed")
-            .into_iter()
-            .next()
-            .expect("receive to yield datagram");
+        let mut recv_buf = vec![0; RECV_BUF_SIZE];
+        let mut received_datagrams = receiver
+            .recv(&receiver_addr, &mut recv_buf)
+            .expect("receive to succeed");
 
         // Assert that the ECN is correct.
         assert_eq!(
             IpTosEcn::from(datagram.tos()),
-            IpTosEcn::from(received_datagram.tos())
+            IpTosEcn::from(received_datagrams.next().unwrap().tos())
         );
 
         Ok(())
@@ -236,11 +260,11 @@ mod tests {
 
         // Allow for one GSO sendmmsg to result in multiple GRO recvmmsg.
         let mut num_received = 0;
+        let mut recv_buf = vec![0; RECV_BUF_SIZE];
         while num_received < max_gso_segments {
             receiver
-                .recv(&receiver_addr)
+                .recv(&receiver_addr, &mut recv_buf)
                 .expect("receive to succeed")
-                .into_iter()
                 .for_each(|d| {
                     assert_eq!(
                         SEGMENT_SIZE,

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -235,7 +235,7 @@ pub fn handshake(client: &mut Connection, server: &mut Connection) {
     };
     while !is_done(a) {
         _ = maybe_authenticate(a);
-        let d = a.process(datagram.as_ref(), now());
+        let d = a.process(datagram, now());
         datagram = d.dgram();
         mem::swap(&mut a, &mut b);
     }

--- a/test-fixture/src/sim/connection.rs
+++ b/test-fixture/src/sim/connection.rs
@@ -141,7 +141,7 @@ impl Node for ConnectionNode {
     fn process(&mut self, mut dgram: Option<Datagram>, now: Instant) -> Output {
         _ = self.process_goals(|goal, c| goal.process(c, now));
         loop {
-            let res = self.c.process(dgram.take().as_ref(), now);
+            let res = self.c.process(dgram.take(), now);
 
             let mut active = false;
             while let Some(e) = self.c.next_event() {


### PR DESCRIPTION
_[Stacked](https://github.com/marketplace/stacked-pull-requests) on top of https://github.com/mozilla/neqo/pull/2184._

Previously `process_input` (and the like) took a `Datagram<Vec<u8>>` as input. In other words, it required allocating each UDP datagram payload in a dedicated `Vec<u8>` before passing it to `process_input`.

With this patch, `process_input` accepts a `Datagram<&[u8]>`. In other words, it accepts a `Datagram` with a borrowed view into an existing buffer (`&[u8]`), e.g. a long lived receive buffer.

---

Extracted out of https://github.com/mozilla/neqo/pull/2093.

Part of https://github.com/mozilla/neqo/issues/1693.

[Pull request stack](https://github.com/marketplace/stacked-pull-requests):

1. https://github.com/mozilla/neqo/pull/2184
2. (this one) https://github.com/mozilla/neqo/pull/2187
3. https://github.com/mozilla/neqo/pull/2188
4. https://github.com/mozilla/neqo/pull/2189