### PR TITLE
ci: Terminate `nextest` after a test runs for three minutes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,5 @@
+[profile.ci]
+# Do not cancel the test run on the first failure.
+fail-fast = false
+# Terminate test after three slow periods of 60 seconds.
+slow-timeout = { period = "60s", terminate-after = 3 }

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           DUMP_SIMULATION_SEEDS="$(mktemp -d)"
           export DUMP_SIMULATION_SEEDS
-          echo "seeds=\"$DUMP_SIMULATION_SEEDS\"" >> "$GITHUB_OUTPUT"
+          echo "seeds=$DUMP_SIMULATION_SEEDS" >> "$GITHUB_OUTPUT"
           # shellcheck disable=SC2086
           if [ "${{ matrix.rust-toolchain }}" == "stable" ]; then
             cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --features ci --profile ci --lcov --output-path lcov.info

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,13 +82,11 @@ jobs:
           cargo +${{ matrix.rust-toolchain }} check $BUILD_TYPE --all-targets --features ci
 
       - name: Run tests and determine coverage
-        id: tests
         env:
           RUST_LOG: trace
         run: |
-          DUMP_SIMULATION_SEEDS="$(mktemp -d)"
+          DUMP_SIMULATION_SEEDS="$(pwd)/simulation-seeds"
           export DUMP_SIMULATION_SEEDS
-          echo "seeds=$DUMP_SIMULATION_SEEDS" >> "$GITHUB_OUTPUT"
           # shellcheck disable=SC2086
           if [ "${{ matrix.rust-toolchain }}" == "stable" ]; then
             cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --features ci --profile ci --lcov --output-path lcov.info
@@ -128,7 +126,7 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: simulation-seeds-${{ matrix.os }}-${{ matrix.rust-toolchain }}-${{ matrix.type }}
-          path: ${{ steps.tests.outputs.seeds }}
+          path: simulation-seeds
           compression-level: 9
 
   bench:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -88,9 +88,9 @@ jobs:
         run: |
           # shellcheck disable=SC2086
           if [ "${{ matrix.rust-toolchain }}" == "stable" ]; then
-            cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --features ci --no-fail-fast --lcov --output-path lcov.info
+            cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --features ci --profile ci --lcov --output-path lcov.info
           else
-            cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --features ci --no-fail-fast
+            cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --features ci --profile ci
           fi
 
       - name: Run client/server transfer

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  DUMP_SIMULATION_SEEDS: /tmp/simulation-seeds
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -83,9 +82,13 @@ jobs:
           cargo +${{ matrix.rust-toolchain }} check $BUILD_TYPE --all-targets --features ci
 
       - name: Run tests and determine coverage
+        id: tests
         env:
           RUST_LOG: trace
         run: |
+          DUMP_SIMULATION_SEEDS="$(mktemp -d)"
+          export DUMP_SIMULATION_SEEDS
+          echo "seeds=\"$DUMP_SIMULATION_SEEDS\"" >> "$GITHUB_OUTPUT"
           # shellcheck disable=SC2086
           if [ "${{ matrix.rust-toolchain }}" == "stable" ]; then
             cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --features ci --profile ci --lcov --output-path lcov.info
@@ -121,11 +124,11 @@ jobs:
         if: matrix.type == 'debug' && matrix.rust-toolchain == 'stable'
 
       - name: Save simulation seeds artifact
-        if: env.DUMP_SIMULATION_SEEDS
+        if: always()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: simulation-seeds-${{ matrix.os }}-${{ matrix.rust-toolchain }}-${{ matrix.type }}
-          path: ${{ env.DUMP_SIMULATION_SEEDS }}
+          path: ${{ steps.tests.outputs.seeds }}
           compression-level: 9
 
   bench:

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -76,7 +76,7 @@ jobs:
             PWD=$(pwd)
             export LSAN_OPTIONS="suppressions=$PWD/suppressions.txt"
           fi
-          cargo nextest run -Z build-std --features ci --target "$TARGET"
+          cargo nextest run -Z build-std --features ci --profile ci --target "$TARGET"
 
       - name: Save simulation seeds artifact
         if: env.DUMP_SIMULATION_SEEDS


### PR DESCRIPTION
Terminating it ourselves means that later CI steps run (like exporting the simulator seeds), which doesn't happen when GitHub terminates the entire runner.

Also make simulation seed exporting work on Windows, while I'm here.