### PR TITLE
chore: prepare v0.10.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.9.2"
+version = "0.10.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I would like to get https://github.com/mozilla/neqo/pull/2184 into Firefox.

Early integration looks promising.

While previously we would spend significant CPU time in allocating and de-allocating received `Datagram`s:
![Screenshot 2024-10-24 at 13-58-31 Firefox 133 – Linux – 10_24_2024 11 54 41 AM UTC (public) – Firefox Profiler](https://github.com/user-attachments/assets/f2cc5601-6f69-448a-a473-460c914a803e)

https://share.firefox.dev/40bq7Ka

None of this is present with `v0.10.0`:
![Screenshot 2024-10-24 at 14-03-13 Firefox 133 – Linux – 10_24_2024 11 42 38 AM UTC (public) – Firefox Profiler](https://github.com/user-attachments/assets/74a9fc00-355d-42b2-897f-87ca88268aa8)

https://share.firefox.dev/3NCMBfv