### PR TITLE
bench(bin/client): don't allocate upload payload upfront

### DIFF
--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -28,7 +28,7 @@ use neqo_transport::{
 use url::Url;
 
 use super::{get_output_file, qlog_new, Args, CloseState, Res};
-use crate::STREAM_IO_BUFFER_SIZE;
+use crate::{send_data::SendData, STREAM_IO_BUFFER_SIZE};
 
 pub struct Handler<'a> {
     #[allow(clippy::struct_field_names)]
@@ -312,9 +312,7 @@ impl StreamHandler for DownloadStreamHandler {
 }
 
 struct UploadStreamHandler {
-    data: Vec<u8>,
-    offset: usize,
-    chunk_size: usize,
+    data: SendData,
     start: Instant,
 }
 
@@ -344,21 +342,11 @@ impl StreamHandler for UploadStreamHandler {
     }
 
     fn process_data_writable(&mut self, client: &mut Http3Client, stream_id: StreamId) {
-        while self.offset < self.data.len() {
-            let end = self.offset + self.chunk_size.min(self.data.len() - self.offset);
-            let chunk = &self.data[self.offset..end];
-            match client.send_data(stream_id, chunk) {
-                Ok(amount) => {
-                    if amount == 0 {
-                        break;
-                    }
-                    self.offset += amount;
-                    if self.offset == self.data.len() {
-                        client.stream_close_send(stream_id).unwrap();
-                    }
-                }
-                Err(_) => break,
-            };
+        let done = self
+            .data
+            .send(|chunk| client.send_data(stream_id, chunk).unwrap());
+        if done {
+            client.stream_close_send(stream_id).unwrap();
         }
     }
 }
@@ -416,9 +404,7 @@ impl UrlHandler<'_> {
                         Box::new(DownloadStreamHandler { out_file })
                     }
                     "POST" => Box::new(UploadStreamHandler {
-                        data: vec![42; self.args.upload_size],
-                        offset: 0,
-                        chunk_size: STREAM_IO_BUFFER_SIZE,
+                        data: SendData::zeroes(self.args.upload_size),
                         start: Instant::now(),
                     }),
                     _ => unimplemented!(),

--- a/neqo-bin/src/lib.rs
+++ b/neqo-bin/src/lib.rs
@@ -21,6 +21,7 @@ use neqo_transport::{
 };
 
 pub mod client;
+mod send_data;
 pub mod server;
 pub mod udp;
 

--- a/neqo-bin/src/send_data.rs
+++ b/neqo-bin/src/send_data.rs
@@ -8,7 +8,6 @@ use std::{borrow::Cow, cmp::min};
 
 use crate::STREAM_IO_BUFFER_SIZE;
 
-// TODO: Rename
 #[derive(Debug)]
 pub struct SendData {
     data: Cow<'static, [u8]>,
@@ -70,10 +69,6 @@ impl SendData {
             }
         }
 
-        self.done()
-    }
-
-    const fn done(&self) -> bool {
         self.remaining == 0
     }
 

--- a/neqo-bin/src/send_data.rs
+++ b/neqo-bin/src/send_data.rs
@@ -1,0 +1,83 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{borrow::Cow, cmp::min};
+
+use crate::STREAM_IO_BUFFER_SIZE;
+
+// TODO: Rename
+#[derive(Debug)]
+pub struct SendData {
+    data: Cow<'static, [u8]>,
+    offset: usize,
+    remaining: usize,
+    total: usize,
+}
+
+impl From<&[u8]> for SendData {
+    fn from(data: &[u8]) -> Self {
+        Self::from(data.to_vec())
+    }
+}
+
+impl From<Vec<u8>> for SendData {
+    fn from(data: Vec<u8>) -> Self {
+        let remaining = data.len();
+        Self {
+            total: data.len(),
+            data: Cow::Owned(data),
+            offset: 0,
+            remaining,
+        }
+    }
+}
+
+impl From<&str> for SendData {
+    fn from(data: &str) -> Self {
+        Self::from(data.as_bytes())
+    }
+}
+
+impl SendData {
+    pub const fn zeroes(total: usize) -> Self {
+        const MESSAGE: &[u8] = &[0; STREAM_IO_BUFFER_SIZE];
+        Self {
+            data: Cow::Borrowed(MESSAGE),
+            offset: 0,
+            remaining: total,
+            total,
+        }
+    }
+
+    fn slice(&self) -> &[u8] {
+        let end = min(self.data.len(), self.offset + self.remaining);
+        &self.data[self.offset..end]
+    }
+
+    pub fn send(&mut self, mut f: impl FnMut(&[u8]) -> usize) -> bool {
+        while self.remaining > 0 {
+            match f(self.slice()) {
+                0 => {
+                    return false;
+                }
+                sent => {
+                    self.remaining -= sent;
+                    self.offset = (self.offset + sent) % self.data.len();
+                }
+            }
+        }
+
+        self.done()
+    }
+
+    const fn done(&self) -> bool {
+        self.remaining == 0
+    }
+
+    pub const fn len(&self) -> usize {
+        self.total
+    }
+}

--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -19,12 +19,13 @@ use neqo_http3::{
 };
 use neqo_transport::{server::ValidateAddress, ConnectionIdGenerator};
 
-use super::{qns_read_response, Args, ResponseData};
+use super::{qns_read_response, Args};
+use crate::send_data::SendData;
 
 pub struct HttpServer {
     server: Http3Server,
     /// Progress writing to each stream.
-    remaining_data: HashMap<StreamId, ResponseData>,
+    remaining_data: HashMap<StreamId, SendData>,
     posts: HashMap<Http3OrWebTransportStream, usize>,
     is_qns_test: bool,
 }
@@ -110,7 +111,7 @@ impl super::HttpServer for HttpServer {
 
                     let mut response = if self.is_qns_test {
                         match qns_read_response(path.value()) {
-                            Ok(data) => ResponseData::from(data),
+                            Ok(data) => SendData::from(data),
                             Err(e) => {
                                 qerror!("Failed to read {}: {e}", path.value());
                                 stream
@@ -123,19 +124,19 @@ impl super::HttpServer for HttpServer {
                     } else if let Ok(count) =
                         path.value().trim_matches(|p| p == '/').parse::<usize>()
                     {
-                        ResponseData::zeroes(count)
+                        SendData::zeroes(count)
                     } else {
-                        ResponseData::from(path.value())
+                        SendData::from(path.value())
                     };
 
                     stream
                         .send_headers(&[
                             Header::new(":status", "200"),
-                            Header::new("content-length", response.remaining.to_string()),
+                            Header::new("content-length", response.len().to_string()),
                         ])
                         .unwrap();
-                    response.send_h3(&stream);
-                    if response.done() {
+                    let done = response.send(|chunk| stream.send_data(chunk).unwrap());
+                    if done {
                         stream.stream_close_send().unwrap();
                     } else {
                         self.remaining_data.insert(stream.stream_id(), response);
@@ -144,8 +145,8 @@ impl super::HttpServer for HttpServer {
                 Http3ServerEvent::DataWritable { stream } => {
                     if self.posts.get_mut(&stream).is_none() {
                         if let Some(remaining) = self.remaining_data.get_mut(&stream.stream_id()) {
-                            remaining.send_h3(&stream);
-                            if remaining.done() {
+                            let done = remaining.send(|chunk| stream.send_data(chunk).unwrap());
+                            if done {
                                 self.remaining_data.remove(&stream.stream_id());
                                 stream.stream_close_send().unwrap();
                             }


### PR DESCRIPTION
When POSTing a large request to a server, don't allocate the entire request upfront, but instead, as is done in `neqo-bin/src/server/mod.rs`, iterate over a static buffer.

Reuses the same logic from `neqo-bin/src/server/mod.rs`, i.e. `SendData`.

See previous similar change on server side https://github.com/mozilla/neqo/pull/2008.