### PR TITLE
fix: forward bench feature to test-fixtures crate

### DIFF
--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -48,7 +48,7 @@ criterion = { version = "0.5", default-features = false, features = ["async_toki
 tokio = { version = "1", default-features = false, features = ["sync"] }
 
 [features]
-bench = []
+bench = ["neqo-transport/bench"]
 
 [lib]
 # See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -31,7 +31,7 @@ criterion = { version = "0.5", default-features = false }
 test-fixture = { path = "../test-fixture" }
 
 [features]
-bench = []
+bench = ["test-fixture/bench"]
 build-fuzzing-corpus = [
         "neqo-common/build-fuzzing-corpus",
         "neqo-crypto/disable-encryption",


### PR DESCRIPTION
Previously `neqo-bin`, `neqo-transport` and `test-fixtures` would each define a `bench` feature. But enabling e.g. `bench` in `neqo-transport` would not enable `bench` in `test-fixtures`. Thus a benchmark in e.g. `neqo-transport` with `--features bench` would still be serializing qlog traces.

This commit makes `neqo-bin` and `neqo-transport` forward their `bench` feature to `test-fixtures`.