### PR TITLE
feat(bin): don't allocate in server UDP recv path

### DIFF
--- a/neqo-bin/src/server/http09.rs
+++ b/neqo-bin/src/server/http09.rs
@@ -185,7 +185,7 @@ impl HttpServer {
 }
 
 impl super::HttpServer for HttpServer {
-    fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> Output {
+    fn process(&mut self, dgram: Option<Datagram<&[u8]>>, now: Instant) -> Output {
         self.server.process(dgram, now)
     }
 

--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -79,7 +79,7 @@ impl Display for HttpServer {
 }
 
 impl super::HttpServer for HttpServer {
-    fn process(&mut self, dgram: Option<Datagram>, now: Instant) -> neqo_http3::Output {
+    fn process(&mut self, dgram: Option<Datagram<&[u8]>>, now: Instant) -> neqo_http3::Output {
         self.server.process(dgram, now)
     }
 

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -238,15 +238,12 @@ impl ServerRunner {
                     input_dgrams = socket.recv(*host, &mut self.recv_buf)?;
                 }
                 // Then take the first datagram, if any.
-                input_dgrams.iter_mut().flatten().next().map_or_else(
-                    || {
-                        // Reading from the socket returned no datagrams. Don't try again.
-                        ready_socket_index = None;
-                        input_dgrams = None;
-                        None
-                    },
-                    Some,
-                )
+                input_dgrams.iter_mut().flatten().next().or_else(|| {
+                    // Reading from the socket returned no datagrams. Don't try again.
+                    ready_socket_index = None;
+                    input_dgrams = None;
+                    None
+                })
             };
 
             // Have server process in- and output datagrams.

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -241,6 +241,34 @@ impl ServerRunner {
             .unwrap_or(first_socket)
     }
 
+    // Free function (i.e. not taking `&mut self: ServerRunner`) to be callable by
+    // `ServerRunner::read_and_process` while holding a reference to
+    // `ServerRunner::recv_buf`.
+    async fn process_inner(
+        server: &mut Box<dyn HttpServer>,
+        timeout: &mut Option<Pin<Box<Sleep>>>,
+        sockets: &mut [(SocketAddr, crate::udp::Socket)],
+        now: &dyn Fn() -> Instant,
+        mut input_dgram: Option<Datagram<&[u8]>>,
+    ) -> Result<(), io::Error> {
+        loop {
+            match server.process(input_dgram.take(), now()) {
+                Output::Datagram(dgram) => {
+                    let socket = Self::find_socket(sockets, dgram.source());
+                    socket.writable().await?;
+                    socket.send(&dgram)?;
+                }
+                Output::Callback(new_timeout) => {
+                    qdebug!("Setting timeout of {:?}", new_timeout);
+                    *timeout = Some(Box::pin(tokio::time::sleep(new_timeout)));
+                    break;
+                }
+                Output::None => break,
+            }
+        }
+        Ok(())
+    }
+
     async fn read_and_process(&mut self, sockets_index: usize) -> Result<(), io::Error> {
         loop {
             let (host, socket) = self.sockets.get_mut(sockets_index).unwrap();
@@ -272,34 +300,6 @@ impl ServerRunner {
             None,
         )
         .await
-    }
-
-    // Free function (i.e. not taking `&mut self: ServerRunner`) to be callable by
-    // `ServerRunner::read_and_process` while holding a reference to
-    // `ServerRunner::recv_buf`.
-    async fn process_inner(
-        server: &mut Box<dyn HttpServer>,
-        timeout: &mut Option<Pin<Box<Sleep>>>,
-        sockets: &mut [(SocketAddr, crate::udp::Socket)],
-        now: &dyn Fn() -> Instant,
-        mut input_dgram: Option<Datagram<&[u8]>>,
-    ) -> Result<(), io::Error> {
-        loop {
-            match server.process(input_dgram.take(), now()) {
-                Output::Datagram(dgram) => {
-                    let socket = Self::find_socket(sockets, dgram.source());
-                    socket.writable().await?;
-                    socket.send(&dgram)?;
-                }
-                Output::Callback(new_timeout) => {
-                    qdebug!("Setting timeout of {:?}", new_timeout);
-                    *timeout = Some(Box::pin(tokio::time::sleep(new_timeout)));
-                    break;
-                }
-                Output::None => break,
-            }
-        }
-        Ok(())
     }
 
     // Wait for any of the sockets to be readable or the timeout to fire.


### PR DESCRIPTION
Previously the `neqo-bin` server would read a set of datagrams from the socket and allocate them:

``` rust
let dgrams: Vec<Datagram> = dgrams.map(|d| d.to_owned()).collect();
```

This was done out of convenience, as handling `Datagram<&[u8]>`s, each borrowing from `self.recv_buf`, is hard to get right across multiple `&mut self` functions, that is here `self.run`, `self.process` and `self.find_socket`.

This commit combines `self.process` and `self.find_socket` and passes a socket index, instead of the read `Datagram`s from `self.run` to `self.process`, thus making the Rust borrow checker happy to handle borrowing `Datagram<&[u8]>`s
instead of owning `Datagram`s.

---

Follow-up to https://github.com/mozilla/neqo/pull/2184.
Fixes https://github.com/mozilla/neqo/issues/2190.
Hopefully speeds up https://github.com/mozilla/neqo/pull/2199.