### PR TITLE
chore: update to quinn-udp v0.5.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.76.0"
 [workspace.dependencies]
 log = { version = "0.4", default-features = false }
 qlog = { version = "0.13", default-features = false }
-quinn-udp = { version = "0.5.4", default-features = false, features = ["direct-log"] }
+quinn-udp = { version = "0.5.6", default-features = false, features = ["direct-log"] }
 
 [workspace.lints.clippy]
 cargo = { level = "warn", priority = -1 }


### PR DESCRIPTION
Currently we use `quinn-udp` `v0.5.4`.

`quinn-udp` `v0.5.5` fixes [`recvmmsg` calls on Android x86](https://github.com/quinn-rs/quinn/pull/1966).

`quinn-udp` `v0.5.6` adds [experimental multi-message support on Apple platforms](https://github.com/quinn-rs/quinn/pull/1993) and [fixes an unnecessary `windows-sys` version restriction](https://github.com/quinn-rs/quinn/pull/2021).

While not strictly necessary, given that our current version specification (i.e. `version = "0.5.4"`) already allows users to use Neqo with `quinn-udp` `v0.5.6`, this commit updates to `quinn-udp` `v0.5.6` anyways, thus making sure CI tests with latest version.

In case https://github.com/mozilla/neqo/pull/2208 lands, future compatible version updates would touch the `Cargo.lock` file, not `Cargo.toml`.