### PR TITLE
refactor: pass `now` to qlog

### DIFF
--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -53,7 +53,7 @@ impl Handler<'_> {
 impl super::Handler for Handler<'_> {
     type Client = Connection;
 
-    fn handle(&mut self, client: &mut Self::Client) -> Res<bool> {
+    fn handle(&mut self, client: &mut Self::Client, now: Instant) -> Res<bool> {
         while let Some(event) = client.next_event() {
             if self.needs_key_update {
                 match client.initiate_key_update() {
@@ -69,7 +69,7 @@ impl super::Handler for Handler<'_> {
 
             match event {
                 ConnectionEvent::AuthenticationNeeded => {
-                    client.authenticated(AuthenticationStatus::Ok, Instant::now());
+                    client.authenticated(AuthenticationStatus::Ok, now);
                 }
                 ConnectionEvent::RecvStreamReadable { stream_id } => {
                     self.read(client, stream_id)?;

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -361,7 +361,7 @@ async fn ready(
 trait Handler {
     type Client: Client;
 
-    fn handle(&mut self, client: &mut Self::Client) -> Res<bool>;
+    fn handle(&mut self, client: &mut Self::Client, now: Instant) -> Res<bool>;
     fn take_token(&mut self) -> Option<ResumptionToken>;
 }
 
@@ -418,7 +418,7 @@ impl<'a, H: Handler> Runner<'a, H> {
 
     async fn run(mut self) -> Res<Option<ResumptionToken>> {
         loop {
-            let handler_done = self.handler.handle(&mut self.client)?;
+            let handler_done = self.handler.handle(&mut self.client, Instant::now())?;
             self.process_output().await?;
             if self.client.has_events() {
                 continue;

--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -84,7 +84,7 @@ impl super::HttpServer for HttpServer {
         self.server.process(dgram, now)
     }
 
-    fn process_events(&mut self, _now: Instant) {
+    fn process_events(&mut self, now: Instant) {
         while let Some(event) = self.server.next_event() {
             match event {
                 Http3ServerEvent::Headers {
@@ -117,7 +117,7 @@ impl super::HttpServer for HttpServer {
                                 stream
                                     .send_headers(&[Header::new(":status", "404")])
                                     .unwrap();
-                                stream.stream_close_send().unwrap();
+                                stream.stream_close_send(now).unwrap();
                                 continue;
                             }
                         }
@@ -135,9 +135,9 @@ impl super::HttpServer for HttpServer {
                             Header::new("content-length", response.len().to_string()),
                         ])
                         .unwrap();
-                    let done = response.send(|chunk| stream.send_data(chunk).unwrap());
+                    let done = response.send(|chunk| stream.send_data(chunk, now).unwrap());
                     if done {
-                        stream.stream_close_send().unwrap();
+                        stream.stream_close_send(now).unwrap();
                     } else {
                         self.remaining_data.insert(stream.stream_id(), response);
                     }
@@ -145,10 +145,11 @@ impl super::HttpServer for HttpServer {
                 Http3ServerEvent::DataWritable { stream } => {
                     if self.posts.get_mut(&stream).is_none() {
                         if let Some(remaining) = self.remaining_data.get_mut(&stream.stream_id()) {
-                            let done = remaining.send(|chunk| stream.send_data(chunk).unwrap());
+                            let done =
+                                remaining.send(|chunk| stream.send_data(chunk, now).unwrap());
                             if done {
                                 self.remaining_data.remove(&stream.stream_id());
-                                stream.stream_close_send().unwrap();
+                                stream.stream_close_send(now).unwrap();
                             }
                         }
                     }
@@ -164,8 +165,8 @@ impl super::HttpServer for HttpServer {
                             stream
                                 .send_headers(&[Header::new(":status", "200")])
                                 .unwrap();
-                            stream.send_data(&msg).unwrap();
-                            stream.stream_close_send().unwrap();
+                            stream.send_data(&msg, now).unwrap();
+                            stream.stream_close_send(now).unwrap();
                         }
                     }
                 }

--- a/neqo-http3/src/buffered_send_stream.rs
+++ b/neqo-http3/src/buffered_send_stream.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::time::Instant;
+
 use neqo_common::qtrace;
 use neqo_transport::{Connection, StreamId};
 
@@ -61,7 +63,7 @@ impl BufferedStream {
     /// # Errors
     ///
     /// Returns `neqo_transport` errors.
-    pub fn send_buffer(&mut self, conn: &mut Connection) -> Res<usize> {
+    pub fn send_buffer(&mut self, conn: &mut Connection, now: Instant) -> Res<usize> {
         let label = ::neqo_common::log_subject!(::log::Level::Debug, self);
         let Self::Initialized { stream_id, buf } = self else {
             return Ok(0);
@@ -79,16 +81,21 @@ impl BufferedStream {
             let b = buf.split_off(sent);
             *buf = b;
         }
-        qlog::h3_data_moved_down(conn.qlog_mut(), *stream_id, sent);
+        qlog::h3_data_moved_down(conn.qlog_mut(), *stream_id, sent, now);
         Ok(sent)
     }
 
     /// # Errors
     ///
     /// Returns `neqo_transport` errors.
-    pub fn send_atomic(&mut self, conn: &mut Connection, to_send: &[u8]) -> Res<bool> {
+    pub fn send_atomic(
+        &mut self,
+        conn: &mut Connection,
+        to_send: &[u8],
+        now: Instant,
+    ) -> Res<bool> {
         // First try to send anything that is in the buffer.
-        self.send_buffer(conn)?;
+        self.send_buffer(conn, now)?;
         let Self::Initialized { stream_id, buf } = self else {
             return Ok(false);
         };
@@ -97,7 +104,7 @@ impl BufferedStream {
         }
         let res = conn.stream_send_atomic(*stream_id, to_send)?;
         if res {
-            qlog::h3_data_moved_down(conn.qlog_mut(), *stream_id, to_send.len());
+            qlog::h3_data_moved_down(conn.qlog_mut(), *stream_id, to_send.len(), now);
         }
         Ok(res)
     }

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -63,13 +63,14 @@ impl Http3ServerHandler {
         stream_id: StreamId,
         data: &[u8],
         conn: &mut Connection,
+        now: Instant,
     ) -> Res<usize> {
         let n = self
             .base_handler
             .send_streams
             .get_mut(&stream_id)
             .ok_or(Error::InvalidStreamId)?
-            .send_data(conn, data)?;
+            .send_data(conn, data, now)?;
         if n > 0 {
             self.base_handler.stream_has_pending_data(stream_id);
         }
@@ -101,9 +102,14 @@ impl Http3ServerHandler {
     /// # Errors
     ///
     /// An error will be returned if stream does not exist.
-    pub fn stream_close_send(&mut self, stream_id: StreamId, conn: &mut Connection) -> Res<()> {
+    pub fn stream_close_send(
+        &mut self,
+        stream_id: StreamId,
+        conn: &mut Connection,
+        now: Instant,
+    ) -> Res<()> {
         qdebug!([self], "Close sending side stream={}.", stream_id);
-        self.base_handler.stream_close_send(conn, stream_id)?;
+        self.base_handler.stream_close_send(conn, stream_id, now)?;
         self.needs_processing = true;
         Ok(())
     }
@@ -154,6 +160,7 @@ impl Http3ServerHandler {
         conn: &mut Connection,
         stream_id: StreamId,
         accept: &WebTransportSessionAcceptAction,
+        now: Instant,
     ) -> Res<()> {
         self.needs_processing = true;
         self.base_handler.webtransport_session_accept(
@@ -161,6 +168,7 @@ impl Http3ServerHandler {
             stream_id,
             Box::new(self.events.clone()),
             accept,
+            now,
         )
     }
 
@@ -179,10 +187,11 @@ impl Http3ServerHandler {
         session_id: StreamId,
         error: u32,
         message: &str,
+        now: Instant,
     ) -> Res<()> {
         self.needs_processing = true;
         self.base_handler
-            .webtransport_close_session(conn, session_id, error, message)
+            .webtransport_close_session(conn, session_id, error, message, now)
     }
 
     pub fn webtransport_create_stream(
@@ -222,7 +231,7 @@ impl Http3ServerHandler {
 
         let res = self.check_connection_events(conn, now);
         if !self.check_result(conn, now, &res) && self.base_handler.state().active() {
-            let res = self.base_handler.process_sending(conn);
+            let res = self.base_handler.process_sending(conn, now);
             self.check_result(conn, now, &res);
         }
     }
@@ -271,7 +280,7 @@ impl Http3ServerHandler {
                     self.base_handler.add_new_stream(stream_id);
                 }
                 ConnectionEvent::RecvStreamReadable { stream_id } => {
-                    self.handle_stream_readable(conn, stream_id)?;
+                    self.handle_stream_readable(conn, stream_id, now)?;
                 }
                 ConnectionEvent::RecvStreamReset {
                     stream_id,
@@ -315,8 +324,16 @@ impl Http3ServerHandler {
         Ok(())
     }
 
-    fn handle_stream_readable(&mut self, conn: &mut Connection, stream_id: StreamId) -> Res<()> {
-        match self.base_handler.handle_stream_readable(conn, stream_id)? {
+    fn handle_stream_readable(
+        &mut self,
+        conn: &mut Connection,
+        stream_id: StreamId,
+        now: Instant,
+    ) -> Res<()> {
+        match self
+            .base_handler
+            .handle_stream_readable(conn, stream_id, now)?
+        {
             ReceiveOutput::NewStream(NewStreamType::Push(_)) => Err(Error::HttpStreamCreation),
             ReceiveOutput::NewStream(NewStreamType::Http(first_frame_type)) => {
                 self.base_handler.add_streams(
@@ -341,7 +358,9 @@ impl Http3ServerHandler {
                         PriorityHandler::new(false, Priority::default()),
                     )),
                 );
-                let res = self.base_handler.handle_stream_readable(conn, stream_id)?;
+                let res = self
+                    .base_handler
+                    .handle_stream_readable(conn, stream_id, now)?;
                 assert_eq!(ReceiveOutput::NoOutput, res);
                 Ok(())
             }
@@ -352,7 +371,9 @@ impl Http3ServerHandler {
                     Box::new(self.events.clone()),
                     Box::new(self.events.clone()),
                 )?;
-                let res = self.base_handler.handle_stream_readable(conn, stream_id)?;
+                let res = self
+                    .base_handler
+                    .handle_stream_readable(conn, stream_id, now)?;
                 assert_eq!(ReceiveOutput::NoOutput, res);
                 Ok(())
             }
@@ -412,7 +433,7 @@ impl Http3ServerHandler {
         buf: &mut [u8],
     ) -> Res<(usize, bool)> {
         qdebug!([self], "read_data from stream {}.", stream_id);
-        let res = self.base_handler.read_data(conn, stream_id, buf);
+        let res = self.base_handler.read_data(conn, stream_id, buf, now);
         if let Err(e) = &res {
             if e.connection_error() {
                 self.close(conn, now, e);

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -4,7 +4,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::{HashMap, VecDeque};
+use std::{
+    collections::{HashMap, VecDeque},
+    time::Instant,
+};
 
 use neqo_common::{qtrace, Encoder};
 use neqo_transport::{Connection, StreamId, StreamType};
@@ -51,15 +54,17 @@ impl ControlStreamLocal {
         &mut self,
         conn: &mut Connection,
         recv_conn: &mut HashMap<StreamId, Box<dyn RecvStream>>,
+        now: Instant,
     ) -> Res<()> {
-        self.stream.send_buffer(conn)?;
-        self.send_priority_update(conn, recv_conn)
+        self.stream.send_buffer(conn, now)?;
+        self.send_priority_update(conn, recv_conn, now)
     }
 
     fn send_priority_update(
         &mut self,
         conn: &mut Connection,
         recv_conn: &mut HashMap<StreamId, Box<dyn RecvStream>>,
+        now: Instant,
     ) -> Res<()> {
         // send all necessary priority updates
         while let Some(update_id) = self.outstanding_priority_update.pop_front() {
@@ -79,7 +84,7 @@ impl ControlStreamLocal {
             if let Some(hframe) = stream.priority_update_frame() {
                 let mut enc = Encoder::new();
                 hframe.encode(&mut enc);
-                if self.stream.send_atomic(conn, enc.as_ref())? {
+                if self.stream.send_atomic(conn, enc.as_ref(), now)? {
                     stream.priority_update_sent();
                 } else {
                     self.outstanding_priority_update.push_front(update_id);

--- a/neqo-http3/src/control_stream_remote.rs
+++ b/neqo-http3/src/control_stream_remote.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::time::Instant;
+
 use neqo_common::qdebug;
 use neqo_transport::{Connection, StreamId};
 
@@ -35,14 +37,12 @@ impl ControlStreamRemote {
     }
 
     /// Check if a stream is the control stream and read received data.
-    pub fn receive_single(&mut self, conn: &mut Connection) -> Res<Option<HFrame>> {
+    pub fn receive_single(&mut self, conn: &mut Connection, now: Instant) -> Res<Option<HFrame>> {
         qdebug!([self], "Receiving data.");
-        match self
-            .frame_reader
-            .receive(&mut StreamReaderConnectionWrapper::new(
-                conn,
-                self.stream_id,
-            ))? {
+        match self.frame_reader.receive(
+            &mut StreamReaderConnectionWrapper::new(conn, self.stream_id),
+            now,
+        )? {
             (_, true) => Err(Error::HttpClosedCriticalStream),
             (s, false) => {
                 qdebug!([self], "received {:?}", s);
@@ -63,11 +63,11 @@ impl RecvStream for ControlStreamRemote {
         Err(Error::HttpClosedCriticalStream)
     }
 
-    fn receive(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)> {
+    fn receive(&mut self, conn: &mut Connection, now: Instant) -> Res<(ReceiveOutput, bool)> {
         let mut control_frames = Vec::new();
 
         loop {
-            if let Some(f) = self.receive_single(conn)? {
+            if let Some(f) = self.receive_single(conn, now)? {
                 control_frames.push(f);
             } else {
                 return Ok((ReceiveOutput::ControlFrames(control_frames), false));

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -157,7 +157,7 @@ mod server_events;
 mod settings;
 mod stream_type_reader;
 
-use std::{cell::RefCell, fmt::Debug, rc::Rc};
+use std::{cell::RefCell, fmt::Debug, rc::Rc, time::Instant};
 
 use buffered_send_stream::BufferedStream;
 pub use client_events::{Http3ClientEvent, WebTransportEvent};
@@ -451,7 +451,7 @@ trait RecvStream: Stream {
     /// # Errors
     ///
     /// An error may happen while reading a stream, e.g. early close, protocol error, etc.
-    fn receive(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)>;
+    fn receive(&mut self, conn: &mut Connection, now: Instant) -> Res<(ReceiveOutput, bool)>;
 
     /// # Errors
     ///
@@ -465,7 +465,12 @@ trait RecvStream: Stream {
     /// # Errors
     ///
     /// An error may happen while reading a stream, e.g. early close, protocol error, etc.
-    fn read_data(&mut self, _conn: &mut Connection, _buf: &mut [u8]) -> Res<(usize, bool)> {
+    fn read_data(
+        &mut self,
+        _conn: &mut Connection,
+        _buf: &mut [u8],
+        _now: Instant,
+    ) -> Res<(usize, bool)> {
         Err(Error::InvalidStreamId)
     }
 
@@ -491,7 +496,11 @@ trait HttpRecvStream: RecvStream {
     /// # Errors
     ///
     /// An error may happen while reading a stream, e.g. early close, protocol error, etc.
-    fn header_unblocked(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)>;
+    fn header_unblocked(
+        &mut self,
+        conn: &mut Connection,
+        now: Instant,
+    ) -> Res<(ReceiveOutput, bool)>;
 
     fn maybe_update_priority(&mut self, priority: Priority) -> bool;
     fn priority_update_frame(&mut self) -> Option<HFrame>;
@@ -558,7 +567,7 @@ trait SendStream: Stream {
     /// # Errors
     ///
     /// Error may occur during sending data, e.g. protocol error, etc.
-    fn send(&mut self, conn: &mut Connection) -> Res<()>;
+    fn send(&mut self, conn: &mut Connection, now: Instant) -> Res<()>;
     fn has_data_to_send(&self) -> bool;
     fn stream_writable(&self);
     fn done(&self) -> bool;
@@ -566,12 +575,12 @@ trait SendStream: Stream {
     /// # Errors
     ///
     /// Error may occur during sending data, e.g. protocol error, etc.
-    fn send_data(&mut self, _conn: &mut Connection, _buf: &[u8]) -> Res<usize>;
+    fn send_data(&mut self, _conn: &mut Connection, _buf: &[u8], now: Instant) -> Res<usize>;
 
     /// # Errors
     ///
     /// It may happen that the transport stream is already closed. This is unlikely.
-    fn close(&mut self, conn: &mut Connection) -> Res<()>;
+    fn close(&mut self, conn: &mut Connection, now: Instant) -> Res<()>;
 
     /// # Errors
     ///
@@ -581,6 +590,7 @@ trait SendStream: Stream {
         _conn: &mut Connection,
         _error: u32,
         _message: &str,
+        _now: Instant,
     ) -> Res<()> {
         Err(Error::InvalidStreamId)
     }
@@ -595,7 +605,7 @@ trait SendStream: Stream {
     /// # Errors
     ///
     /// It may happen that the transport stream is already closed. This is unlikely.
-    fn send_data_atomic(&mut self, _conn: &mut Connection, _buf: &[u8]) -> Res<()> {
+    fn send_data_atomic(&mut self, _conn: &mut Connection, _buf: &[u8], _now: Instant) -> Res<()> {
         Err(Error::InvalidStreamId)
     }
 

--- a/neqo-http3/src/qlog.rs
+++ b/neqo-http3/src/qlog.rs
@@ -6,36 +6,44 @@
 
 // Functions that handle capturing QLOG traces.
 
+use std::time::Instant;
+
 use neqo_common::qlog::NeqoQlog;
 use neqo_transport::StreamId;
 use qlog::events::{DataRecipient, EventData};
 
-pub fn h3_data_moved_up(qlog: &NeqoQlog, stream_id: StreamId, amount: usize) {
-    qlog.add_event_data(|| {
-        let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
-            stream_id: Some(stream_id.as_u64()),
-            offset: None,
-            length: Some(u64::try_from(amount).unwrap()),
-            from: Some(DataRecipient::Transport),
-            to: Some(DataRecipient::Application),
-            raw: None,
-        });
+pub fn h3_data_moved_up(qlog: &NeqoQlog, stream_id: StreamId, amount: usize, now: Instant) {
+    qlog.add_event_data(
+        || {
+            let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
+                stream_id: Some(stream_id.as_u64()),
+                offset: None,
+                length: Some(u64::try_from(amount).unwrap()),
+                from: Some(DataRecipient::Transport),
+                to: Some(DataRecipient::Application),
+                raw: None,
+            });
 
-        Some(ev_data)
-    });
+            Some(ev_data)
+        },
+        now,
+    );
 }
 
-pub fn h3_data_moved_down(qlog: &NeqoQlog, stream_id: StreamId, amount: usize) {
-    qlog.add_event_data(|| {
-        let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
-            stream_id: Some(stream_id.as_u64()),
-            offset: None,
-            length: Some(u64::try_from(amount).unwrap()),
-            from: Some(DataRecipient::Application),
-            to: Some(DataRecipient::Transport),
-            raw: None,
-        });
+pub fn h3_data_moved_down(qlog: &NeqoQlog, stream_id: StreamId, amount: usize, now: Instant) {
+    qlog.add_event_data(
+        || {
+            let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
+                stream_id: Some(stream_id.as_u64()),
+                offset: None,
+                length: Some(u64::try_from(amount).unwrap()),
+                from: Some(DataRecipient::Application),
+                to: Some(DataRecipient::Transport),
+                raw: None,
+            });
 
-        Some(ev_data)
-    });
+            Some(ev_data)
+        },
+        now,
+    );
 }

--- a/neqo-http3/src/qpack_decoder_receiver.rs
+++ b/neqo-http3/src/qpack_decoder_receiver.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::Rc, time::Instant};
 
 use neqo_qpack::QPackDecoder;
 use neqo_transport::{Connection, StreamId};
@@ -34,7 +34,7 @@ impl RecvStream for DecoderRecvStream {
         Err(Error::HttpClosedCriticalStream)
     }
 
-    fn receive(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)> {
+    fn receive(&mut self, conn: &mut Connection, _now: Instant) -> Res<(ReceiveOutput, bool)> {
         Ok((
             ReceiveOutput::UnblockedStreams(
                 self.decoder.borrow_mut().receive(conn, self.stream_id)?,

--- a/neqo-http3/src/qpack_encoder_receiver.rs
+++ b/neqo-http3/src/qpack_encoder_receiver.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::Rc, time::Instant};
 
 use neqo_qpack::QPackEncoder;
 use neqo_transport::{Connection, StreamId};
@@ -34,8 +34,10 @@ impl RecvStream for EncoderRecvStream {
         Err(Error::HttpClosedCriticalStream)
     }
 
-    fn receive(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)> {
-        self.encoder.borrow_mut().receive(conn, self.stream_id)?;
+    fn receive(&mut self, conn: &mut Connection, now: Instant) -> Res<(ReceiveOutput, bool)> {
+        self.encoder
+            .borrow_mut()
+            .receive(conn, self.stream_id, now)?;
         Ok((ReceiveOutput::NoOutput, false))
     }
 }

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -11,6 +11,7 @@ use std::{
     collections::VecDeque,
     ops::{Deref, DerefMut},
     rc::Rc,
+    time::Instant,
 };
 
 use neqo_common::{qdebug, Encoder, Header};
@@ -78,10 +79,10 @@ impl StreamHandler {
     /// # Errors
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn send_data(&self, buf: &[u8]) -> Res<usize> {
+    pub fn send_data(&self, buf: &[u8], now: Instant) -> Res<usize> {
         self.handler
             .borrow_mut()
-            .send_data(self.stream_id(), buf, &mut self.conn.borrow_mut())
+            .send_data(self.stream_id(), buf, &mut self.conn.borrow_mut(), now)
     }
 
     /// Bytes sendable on stream at the QUIC layer.
@@ -102,10 +103,12 @@ impl StreamHandler {
     /// # Errors
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn stream_close_send(&self) -> Res<()> {
-        self.handler
-            .borrow_mut()
-            .stream_close_send(self.stream_id(), &mut self.conn.borrow_mut())
+    pub fn stream_close_send(&self, now: Instant) -> Res<()> {
+        self.handler.borrow_mut().stream_close_send(
+            self.stream_id(),
+            &mut self.conn.borrow_mut(),
+            now,
+        )
     }
 
     /// Request a peer to stop sending a stream.
@@ -201,9 +204,9 @@ impl Http3OrWebTransportStream {
     /// # Errors
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn send_data(&self, data: &[u8]) -> Res<usize> {
+    pub fn send_data(&self, data: &[u8], now: Instant) -> Res<usize> {
         qdebug!([self], "Set new response.");
-        self.stream_handler.send_data(data)
+        self.stream_handler.send_data(data, now)
     }
 
     /// Close sending side.
@@ -211,9 +214,9 @@ impl Http3OrWebTransportStream {
     /// # Errors
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn stream_close_send(&self) -> Res<()> {
+    pub fn stream_close_send(&self, now: Instant) -> Res<()> {
         qdebug!([self], "Set new response.");
-        self.stream_handler.stream_close_send()
+        self.stream_handler.stream_close_send(now)
     }
 }
 
@@ -282,7 +285,7 @@ impl WebTransportRequest {
     /// # Errors
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn response(&self, accept: &WebTransportSessionAcceptAction) -> Res<()> {
+    pub fn response(&self, accept: &WebTransportSessionAcceptAction, now: Instant) -> Res<()> {
         qdebug!([self], "Set a response for a WebTransport session.");
         self.stream_handler
             .handler
@@ -291,6 +294,7 @@ impl WebTransportRequest {
                 &mut self.stream_handler.conn.borrow_mut(),
                 self.stream_handler.stream_info.stream_id(),
                 accept,
+                now,
             )
     }
 
@@ -299,7 +303,7 @@ impl WebTransportRequest {
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     /// Also return an error if the stream was closed on the transport layer,
     /// but that information is not yet consumed on the  http/3 layer.
-    pub fn close_session(&self, error: u32, message: &str) -> Res<()> {
+    pub fn close_session(&self, error: u32, message: &str, now: Instant) -> Res<()> {
         self.stream_handler
             .handler
             .borrow_mut()
@@ -308,6 +312,7 @@ impl WebTransportRequest {
                 self.stream_handler.stream_info.stream_id(),
                 error,
                 message,
+                now,
             )
     }
 

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::time::Instant;
+
 use neqo_common::{qtrace, Decoder, IncrementalDecoderUint, Role};
 use neqo_qpack::{decoder::QPACK_UNI_STREAM_TYPE_DECODER, encoder::QPACK_UNI_STREAM_TYPE_ENCODER};
 use neqo_transport::{Connection, StreamId, StreamType};
@@ -226,7 +228,7 @@ impl RecvStream for NewStreamHeadReader {
         Ok(())
     }
 
-    fn receive(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)> {
+    fn receive(&mut self, conn: &mut Connection, _now: Instant) -> Res<(ReceiveOutput, bool)> {
         let t = self.get_type(conn)?;
         Ok((
             t.map_or(ReceiveOutput::NoOutput, ReceiveOutput::NewStream),

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -45,20 +45,20 @@ fn receive_request(server: &Http3Server) -> Option<Http3OrWebTransportStream> {
     None
 }
 
-fn set_response(request: &Http3OrWebTransportStream) {
+fn set_response(request: &Http3OrWebTransportStream, now: Instant) {
     request
         .send_headers(&[
             Header::new(":status", "200"),
             Header::new("content-length", "3"),
         ])
         .unwrap();
-    request.send_data(RESPONSE_DATA).unwrap();
-    request.stream_close_send().unwrap();
+    request.send_data(RESPONSE_DATA, now).unwrap();
+    request.stream_close_send(now).unwrap();
 }
 
-fn process_server_events(server: &Http3Server) {
+fn process_server_events(server: &Http3Server, now: Instant) {
     let request = receive_request(server).unwrap();
-    set_response(&request);
+    set_response(&request, now);
 }
 
 fn process_client_events(conn: &mut Http3Client) {

--- a/neqo-http3/tests/send_message.rs
+++ b/neqo-http3/tests/send_message.rs
@@ -135,7 +135,9 @@ fn process_client_events_no_data(conn: &mut Http3Client) {
     assert!(fin_received);
 }
 
-fn connect_send_and_receive_request() -> (Http3Client, Http3Server, Http3OrWebTransportStream) {
+fn connect_send_and_receive_request(
+    now: Instant,
+) -> (Http3Client, Http3Server, Http3OrWebTransportStream) {
     let mut hconn_c = default_http3_client();
     let mut hconn_s = default_http3_server();
 
@@ -155,7 +157,7 @@ fn connect_send_and_receive_request() -> (Http3Client, Http3Server, Http3OrWebTr
         )
         .unwrap();
     assert_eq!(req, 0);
-    hconn_c.stream_close_send(req).unwrap();
+    hconn_c.stream_close_send(req, now).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s);
 
     let request = receive_request(&hconn_s).unwrap();

--- a/neqo-http3/tests/webtransport.rs
+++ b/neqo-http3/tests/webtransport.rs
@@ -82,7 +82,11 @@ fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
     }
 }
 
-fn create_wt_session(client: &mut Http3Client, server: &mut Http3Server) -> WebTransportRequest {
+fn create_wt_session(
+    client: &mut Http3Client,
+    server: &mut Http3Server,
+    now: Instant,
+) -> WebTransportRequest {
     let wt_session_id = client
         .webtransport_create_session(now(), &("https", "something.com", "/"), &[])
         .unwrap();
@@ -104,7 +108,7 @@ fn create_wt_session(client: &mut Http3Client, server: &mut Http3Server) -> WebT
                             .any(|h| h.name() == ":protocol" && h.value() == "webtransport")
                 );
                 session
-                    .response(&WebTransportSessionAcceptAction::Accept)
+                    .response(&WebTransportSessionAcceptAction::Accept, now)
                     .unwrap();
                 wt_server_session = Some(session);
             }
@@ -143,8 +147,12 @@ fn send_data_client(
     server: &mut Http3Server,
     wt_stream_id: StreamId,
     data: &[u8],
+    now: Instant,
 ) {
-    assert_eq!(client.send_data(wt_stream_id, data).unwrap(), data.len());
+    assert_eq!(
+        client.send_data(wt_stream_id, data, now).unwrap(),
+        data.len()
+    );
     exchange_packets(client, server);
 }
 

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -6,27 +6,37 @@
 
 // Functions that handle capturing QLOG traces.
 
+use std::time::Instant;
+
 use neqo_common::{hex, qlog::NeqoQlog};
 use qlog::events::{
     qpack::{QPackInstruction, QpackInstructionParsed, QpackInstructionTypeName},
     EventData, RawInfo,
 };
 
-pub fn qpack_read_insert_count_increment_instruction(qlog: &NeqoQlog, increment: u64, data: &[u8]) {
-    qlog.add_event_data(|| {
-        let raw = RawInfo {
-            length: Some(8),
-            payload_length: None,
-            data: Some(hex(data)),
-        };
-        let ev_data = EventData::QpackInstructionParsed(QpackInstructionParsed {
-            instruction: QPackInstruction::InsertCountIncrementInstruction {
-                instruction_type: QpackInstructionTypeName::InsertCountIncrementInstruction,
-                increment,
-            },
-            raw: Some(raw),
-        });
+pub fn qpack_read_insert_count_increment_instruction(
+    qlog: &NeqoQlog,
+    increment: u64,
+    data: &[u8],
+    now: Instant,
+) {
+    qlog.add_event_data(
+        || {
+            let raw = RawInfo {
+                length: Some(8),
+                payload_length: None,
+                data: Some(hex(data)),
+            };
+            let ev_data = EventData::QpackInstructionParsed(QpackInstructionParsed {
+                instruction: QPackInstruction::InsertCountIncrementInstruction {
+                    instruction_type: QpackInstructionTypeName::InsertCountIncrementInstruction,
+                    increment,
+                },
+                raw: Some(raw),
+            });
 
-        Some(ev_data)
-    });
+            Some(ev_data)
+        },
+        now,
+    );
 }

--- a/neqo-transport/src/cc/mod.rs
+++ b/neqo-transport/src/cc/mod.rs
@@ -60,19 +60,20 @@ pub trait CongestionControl: Display + Debug {
         prev_largest_acked_sent: Option<Instant>,
         pto: Duration,
         lost_packets: &[SentPacket],
+        now: Instant,
     ) -> bool;
 
     /// Returns true if the congestion window was reduced.
-    fn on_ecn_ce_received(&mut self, largest_acked_pkt: &SentPacket) -> bool;
+    fn on_ecn_ce_received(&mut self, largest_acked_pkt: &SentPacket, now: Instant) -> bool;
 
     #[must_use]
     fn recovery_packet(&self) -> bool;
 
-    fn discard(&mut self, pkt: &SentPacket);
+    fn discard(&mut self, pkt: &SentPacket, now: Instant);
 
-    fn on_packet_sent(&mut self, pkt: &SentPacket);
+    fn on_packet_sent(&mut self, pkt: &SentPacket, now: Instant);
 
-    fn discard_in_flight(&mut self);
+    fn discard_in_flight(&mut self, now: Instant);
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -921,7 +921,7 @@ impl Connection {
                 State::Init => {
                     // We have not even sent anything just close the connection without sending any
                     // error. This may happen when client_start fails.
-                    self.set_state(State::Closed(error));
+                    self.set_state(State::Closed(error), now);
                 }
                 State::WaitInitial => {
                     // We don't have any state yet, so don't bother with
@@ -930,22 +930,25 @@ impl Connection {
                         self.state_signaling
                             .close(path, error.clone(), frame_type, msg);
                     }
-                    self.set_state(State::Closed(error));
+                    self.set_state(State::Closed(error), now);
                 }
                 _ => {
                     if let Some(path) = path.or_else(|| self.paths.primary()) {
                         self.state_signaling
                             .close(path, error.clone(), frame_type, msg);
                         if matches!(v, Error::KeysExhausted) {
-                            self.set_state(State::Closed(error));
+                            self.set_state(State::Closed(error), now);
                         } else {
-                            self.set_state(State::Closing {
-                                error,
-                                timeout: self.get_closing_period_time(now),
-                            });
+                            self.set_state(
+                                State::Closing {
+                                    error,
+                                    timeout: self.get_closing_period_time(now),
+                                },
+                                now,
+                            );
                         }
                     } else {
-                        self.set_state(State::Closed(error));
+                        self.set_state(State::Closed(error), now);
                     }
                 }
             }
@@ -967,7 +970,7 @@ impl Connection {
             State::Closing { error, timeout } | State::Draining { error, timeout } => {
                 if *timeout <= now {
                     let st = State::Closed(error.clone());
-                    self.set_state(st);
+                    self.set_state(st, now);
                     qinfo!("Closing timer expired");
                     return;
                 }
@@ -982,7 +985,10 @@ impl Connection {
         let pto = self.pto();
         if self.idle_timeout.expired(now, pto) {
             qinfo!([self], "idle timeout expired");
-            self.set_state(State::Closed(CloseReason::Transport(Error::IdleTimeout)));
+            self.set_state(
+                State::Closed(CloseReason::Transport(Error::IdleTimeout)),
+                now,
+            );
             return;
         }
 
@@ -999,7 +1005,7 @@ impl Connection {
         if let Some(path) = self.paths.primary() {
             let lost = self.loss_recovery.timeout(&path, now);
             self.handle_lost_packets(&lost);
-            qlog::packets_lost(&self.qlog, &lost);
+            qlog::packets_lost(&self.qlog, &lost, now);
         }
 
         if self.release_resumption_token_timer.is_some() {
@@ -1264,10 +1270,13 @@ impl Connection {
             // indicate that there is a stateless reset present.
             qdebug!([self], "Stateless reset: {}", hex(&d[d.len() - 16..]));
             self.state_signaling.reset();
-            self.set_state(State::Draining {
-                error: CloseReason::Transport(Error::StatelessReset),
-                timeout: self.get_closing_period_time(now),
-            });
+            self.set_state(
+                State::Draining {
+                    error: CloseReason::Transport(Error::StatelessReset),
+                    timeout: self.get_closing_period_time(now),
+                },
+                now,
+            );
             Err(Error::StatelessReset)
         } else {
             Ok(())
@@ -1339,14 +1348,16 @@ impl Connection {
                 self.conn_params.get_versions().all(),
                 supported,
                 version,
+                now,
             );
             Ok(())
         } else {
             qinfo!([self], "Version negotiation: failed with {:?}", supported);
             // This error goes straight to closed.
-            self.set_state(State::Closed(CloseReason::Transport(
-                Error::VersionNegotiation,
-            )));
+            self.set_state(
+                State::Closed(CloseReason::Transport(Error::VersionNegotiation)),
+                now,
+            );
             Err(Error::VersionNegotiation)
         }
     }
@@ -1399,7 +1410,7 @@ impl Connection {
                 let dcid = ConnectionId::from(packet.dcid());
                 self.crypto.states.init_server(version, &dcid)?;
                 self.original_destination_cid = Some(dcid);
-                self.set_state(State::WaitInitial);
+                self.set_state(State::WaitInitial, now);
 
                 // We need to make sure that we set this transport parameter.
                 // This has to happen prior to processing the packet so that
@@ -1659,7 +1670,7 @@ impl Connection {
                     // the rest of the datagram on the floor, but don't generate an error.
                     self.check_stateless_reset(path, &d, dcid.is_none(), now)?;
                     self.stats.borrow_mut().pkt_dropped("Decryption failure");
-                    qlog::packet_dropped(&self.qlog, &packet);
+                    qlog::packet_dropped(&self.qlog, &packet, now);
                 }
             }
             slc = remainder;
@@ -1759,6 +1770,7 @@ impl Connection {
                     .unwrap()
                     .clone(),
             ),
+            now,
         );
         if self.role == Role::Client {
             path.borrow_mut().set_valid(now);
@@ -1766,13 +1778,13 @@ impl Connection {
     }
 
     /// If the path isn't permanent, assign it a connection ID to make it so.
-    fn ensure_permanent(&mut self, path: &PathRef) -> Res<()> {
+    fn ensure_permanent(&mut self, path: &PathRef, now: Instant) -> Res<()> {
         if self.paths.is_temporary(path) {
             // If there isn't a connection ID to use for this path, the packet
             // will be processed, but it won't be attributed to a path.  That means
             // no path probes or PATH_RESPONSE.  But it's not fatal.
             if let Some(cid) = self.connection_ids.next() {
-                self.paths.make_permanent(path, None, cid);
+                self.paths.make_permanent(path, None, cid, now);
                 Ok(())
             } else if let Some(primary) = self.paths.primary() {
                 if primary
@@ -1781,7 +1793,7 @@ impl Connection {
                     .map_or(true, |id| id.is_empty())
                 {
                     self.paths
-                        .make_permanent(path, None, ConnectionIdEntry::empty_remote());
+                        .make_permanent(path, None, ConnectionIdEntry::empty_remote(), now);
                     Ok(())
                 } else {
                     qtrace!([self], "Unable to make path permanent: {}", path.borrow());
@@ -1808,7 +1820,7 @@ impl Connection {
                 self.setup_handshake_path(path, now);
             } else {
                 // Otherwise try to get a usable connection ID.
-                mem::drop(self.ensure_permanent(path));
+                mem::drop(self.ensure_permanent(path, now));
             }
         }
     }
@@ -1843,9 +1855,9 @@ impl Connection {
             self.stats.borrow().frame_rx.crypto > 0
         };
         if got_version {
-            self.set_state(State::Handshaking);
+            self.set_state(State::Handshaking, now);
         } else {
-            self.set_state(State::WaitVersion);
+            self.set_state(State::WaitVersion, now);
         }
     }
 
@@ -1905,7 +1917,7 @@ impl Connection {
             self.conn_params.pacing_enabled(),
             now,
         );
-        self.ensure_permanent(&path)?;
+        self.ensure_permanent(&path, now)?;
         qinfo!(
             [self],
             "Migrate to {} probe {}",
@@ -1981,7 +1993,7 @@ impl Connection {
             return;
         }
 
-        if self.ensure_permanent(path).is_ok() {
+        if self.ensure_permanent(path, now).is_ok() {
             self.paths
                 .handle_migration(path, d.source(), now, &mut self.stats.borrow_mut());
         } else {
@@ -2441,6 +2453,7 @@ impl Connection {
                 pn,
                 builder.len() - header_start + aead_expansion,
                 &builder.as_ref()[payload_start..],
+                now,
             );
 
             self.stats.borrow_mut().packets_tx += 1;
@@ -2466,7 +2479,7 @@ impl Connection {
             );
             if padded {
                 needs_padding = false;
-                self.loss_recovery.on_packet_sent(path, sent);
+                self.loss_recovery.on_packet_sent(path, sent, now);
             } else if pt == PacketType::Initial && (self.role == Role::Client || ack_eliciting) {
                 // Packets containing Initial packets might need padding, and we want to
                 // track that padding along with the Initial packet.  So defer tracking.
@@ -2476,7 +2489,7 @@ impl Connection {
                 if pt == PacketType::Handshake && self.role == Role::Client {
                     needs_padding = false;
                 }
-                self.loss_recovery.on_packet_sent(path, sent);
+                self.loss_recovery.on_packet_sent(path, sent, now);
             }
 
             if *space == PacketNumberSpace::Handshake
@@ -2508,7 +2521,7 @@ impl Connection {
                     // packet, which is why we don't increase `frame_tx.padding` count here.
                     packets.resize(profile.limit(), 0);
                 }
-                self.loss_recovery.on_packet_sent(path, initial);
+                self.loss_recovery.on_packet_sent(path, initial, now);
             }
             path.borrow_mut().add_sent(packets.len());
             Ok(SendOption::Yes(
@@ -2542,12 +2555,16 @@ impl Connection {
         qdebug!([self], "client_start");
         debug_assert_eq!(self.role, Role::Client);
         if let Some(path) = self.paths.primary() {
-            qlog::client_connection_started(&self.qlog, &path);
+            qlog::client_connection_started(&self.qlog, &path, now);
         }
-        qlog::client_version_information_initiated(&self.qlog, self.conn_params.get_versions());
+        qlog::client_version_information_initiated(
+            &self.qlog,
+            self.conn_params.get_versions(),
+            now,
+        );
 
         self.handshake(now, self.version, PacketNumberSpace::Initial, None)?;
-        self.set_state(State::WaitInitial);
+        self.set_state(State::WaitInitial, now);
         self.zero_rtt_state = if self.crypto.enable_0rtt(self.version, self.role)? {
             qdebug!([self], "Enabled 0-RTT");
             ZeroRttState::Sending
@@ -2568,9 +2585,9 @@ impl Connection {
         let timeout = self.get_closing_period_time(now);
         if let Some(path) = self.paths.primary() {
             self.state_signaling.close(path, error.clone(), 0, msg);
-            self.set_state(State::Closing { error, timeout });
+            self.set_state(State::Closing { error, timeout }, now);
         } else {
-            self.set_state(State::Closed(error));
+            self.set_state(State::Closed(error), now);
         }
     }
 
@@ -2600,7 +2617,7 @@ impl Connection {
     }
 
     /// Process the final set of transport parameters.
-    fn process_tps(&mut self) -> Res<()> {
+    fn process_tps(&mut self, now: Instant) -> Res<()> {
         self.validate_cids()?;
         self.validate_versions()?;
         {
@@ -2645,7 +2662,7 @@ impl Connection {
             self.cid_manager.set_limit(max_active_cids);
         }
         self.set_initial_limits();
-        qlog::connection_tparams_set(&self.qlog, &self.tps.borrow());
+        qlog::connection_tparams_set(&self.qlog, &self.tps.borrow(), now);
         Ok(())
     }
 
@@ -2848,8 +2865,8 @@ impl Connection {
         Ok(())
     }
 
-    fn set_confirmed(&mut self) -> Res<()> {
-        self.set_state(State::Confirmed);
+    fn set_confirmed(&mut self, now: Instant) -> Res<()> {
+        self.set_state(State::Confirmed, now);
         if self.conn_params.pmtud_enabled() {
             self.paths
                 .primary()
@@ -2970,7 +2987,7 @@ impl Connection {
                 self.stats.borrow_mut().frame_rx.path_challenge += 1;
                 // If we were challenged, try to make the path permanent.
                 // Report an error if we don't have enough connection IDs.
-                self.ensure_permanent(path)?;
+                self.ensure_permanent(path, now)?;
                 path.borrow_mut().challenged(data);
             }
             Frame::PathResponse { data } => {
@@ -3012,17 +3029,20 @@ impl Connection {
                 let error = CloseReason::Transport(detail);
                 self.state_signaling
                     .drain(Rc::clone(path), error.clone(), frame_type, "");
-                self.set_state(State::Draining {
-                    error,
-                    timeout: self.get_closing_period_time(now),
-                });
+                self.set_state(
+                    State::Draining {
+                        error,
+                        timeout: self.get_closing_period_time(now),
+                    },
+                    now,
+                );
             }
             Frame::HandshakeDone => {
                 self.stats.borrow_mut().frame_rx.handshake_done += 1;
                 if self.role == Role::Server || !self.state.connected() {
                     return Err(Error::ProtocolViolation);
                 }
-                self.set_confirmed()?;
+                self.set_confirmed(now)?;
                 self.discard_keys(PacketNumberSpace::Handshake, now);
                 self.migrate_to_preferred_address(now)?;
             }
@@ -3140,7 +3160,7 @@ impl Connection {
             }
         }
         self.handle_lost_packets(&lost_packets);
-        qlog::packets_lost(&self.qlog, &lost_packets);
+        qlog::packets_lost(&self.qlog, &lost_packets, now);
         let stats = &mut self.stats.borrow_mut().frame_rx;
         stats.ack += 1;
         if let Some(largest_acknowledged) = largest_acknowledged {
@@ -3182,7 +3202,7 @@ impl Connection {
             let path = self.paths.primary().ok_or(Error::NoAvailablePath)?;
             path.borrow_mut().set_valid(now);
             // Generate a qlog event that the server connection started.
-            qlog::server_connection_started(&self.qlog, &path);
+            qlog::server_connection_started(&self.qlog, &path, now);
         } else {
             self.zero_rtt_state = if self
                 .crypto
@@ -3202,8 +3222,8 @@ impl Connection {
         let pto = self.pto();
         self.crypto
             .install_application_keys(self.version, now + pto)?;
-        self.process_tps()?;
-        self.set_state(State::Connected);
+        self.process_tps(now)?;
+        self.set_state(State::Connected, now);
         self.create_resumption_token(now);
         self.saved_datagrams
             .make_available(CryptoSpace::ApplicationData);
@@ -3215,13 +3235,13 @@ impl Connection {
             .resumed();
         if self.role == Role::Server {
             self.state_signaling.handshake_done();
-            self.set_confirmed()?;
+            self.set_confirmed(now)?;
         }
         qinfo!([self], "Connection established");
         Ok(())
     }
 
-    fn set_state(&mut self, state: State) {
+    fn set_state(&mut self, state: State, now: Instant) {
         if state > self.state {
             qdebug!([self], "State change from {:?} -> {:?}", self.state, state);
             self.state = state.clone();
@@ -3229,7 +3249,7 @@ impl Connection {
                 self.streams.clear_streams();
             }
             self.events.connection_state_change(state);
-            qlog::connection_state_updated(&self.qlog, &self.state);
+            qlog::connection_state_updated(&self.qlog, &self.state, now);
         } else if mem::discriminant(&state) != mem::discriminant(&self.state) {
             // Only tolerate a regression in state if the new state is closing
             // and the connection is already closed.

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -154,6 +154,7 @@ impl RttEstimate {
                 QlogMetric::SmoothedRtt(self.smoothed_rtt),
                 QlogMetric::RttVariance(self.rttvar),
             ],
+            now,
         );
     }
 

--- a/neqo-transport/src/sender.rs
+++ b/neqo-transport/src/sender.rs
@@ -128,6 +128,7 @@ impl PacketSender {
             prev_largest_acked_sent,
             pto,
             lost_packets,
+            now,
         );
         // Call below may change the size of MTU probes, so it needs to happen after the CC
         // reaction above, which needs to ignore probes based on their size.
@@ -137,24 +138,24 @@ impl PacketSender {
     }
 
     /// Called when ECN CE mark received.  Returns true if the congestion window was reduced.
-    pub fn on_ecn_ce_received(&mut self, largest_acked_pkt: &SentPacket) -> bool {
-        self.cc.on_ecn_ce_received(largest_acked_pkt)
+    pub fn on_ecn_ce_received(&mut self, largest_acked_pkt: &SentPacket, now: Instant) -> bool {
+        self.cc.on_ecn_ce_received(largest_acked_pkt, now)
     }
 
-    pub fn discard(&mut self, pkt: &SentPacket) {
-        self.cc.discard(pkt);
+    pub fn discard(&mut self, pkt: &SentPacket, now: Instant) {
+        self.cc.discard(pkt, now);
     }
 
     /// When we migrate, the congestion controller for the previously active path drops
     /// all bytes in flight.
-    pub fn discard_in_flight(&mut self) {
-        self.cc.discard_in_flight();
+    pub fn discard_in_flight(&mut self, now: Instant) {
+        self.cc.discard_in_flight(now);
     }
 
-    pub fn on_packet_sent(&mut self, pkt: &SentPacket, rtt: Duration) {
+    pub fn on_packet_sent(&mut self, pkt: &SentPacket, rtt: Duration, now: Instant) {
         self.pacer
             .spend(pkt.time_sent(), rtt, self.cc.cwnd(), pkt.len());
-        self.cc.on_packet_sent(pkt);
+        self.cc.on_packet_sent(pkt, now);
     }
 
     #[must_use]

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -332,6 +332,7 @@ impl Server {
                         &self.create_qlog_trace(orig_dcid.unwrap_or(initial.dst_cid).as_cid_ref()),
                         self.conn_params.get_versions().all(),
                         initial.version.wire_version(),
+                        now,
                     );
                 }
                 Output::None
@@ -390,6 +391,7 @@ impl Server {
                 &self.create_qlog_trace(packet.dcid()),
                 self.conn_params.get_versions().all(),
                 packet.wire_version(),
+                now,
             );
 
             return Output::Datagram(Datagram::new(


### PR DESCRIPTION
Instead of using `QLogStream::add_event_data_now`, which internally calls `std::time::Instant::now()`, pass `now` to
`QLogStream::add_event_data_with_instant`.

This **would** close https://github.com/mozilla/neqo/issues/2211. That said, given that this change is very noisy, passing `now` across all layers and adding `now` to many  of our public APIs (see `neqo-bin/src` for examples), **I don't think it is worth it**.

Let me know if you think otherwise.

Alternative: We could only do this change in `neqo-transport`, having all `neqo-http3` functions calling `neqo-transport` functions with a fresh `std::time::Instant::now()`. That would give us proper qlogs when using `test_fixtures::Simulator` as that is only concerned with `neqo-transport` and that would reduce the noise. Downside, additional complexity, as the problem itself is only half fixed, i.e. in `neqo-transport` but not `neqo-http3`.

