### PR TITLE
deps: enable std feature of url crate

### DIFF
--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -41,7 +41,7 @@ qlog = { workspace = true }
 quinn-udp = { workspace = true }
 regex = { version = "1.9", default-features = false, features = ["unicode-perl"] }
 tokio = { version = "1", default-features = false, features = ["net", "time", "macros", "rt", "rt-multi-thread"] }
-url = { version = "2.5", default-features = false }
+url = { version = "2.5", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["async_tokio"] }

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -25,7 +25,7 @@ neqo-qpack = { path = "./../neqo-qpack" }
 neqo-transport = { path = "./../neqo-transport" }
 qlog = { workspace = true }
 sfv = { version = "0.9", default-features = false }
-url = { version = "2.5", default-features = false }
+url = { version = "2.5", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }


### PR DESCRIPTION
`url` `v0.5.3` and `idna` `v1.0.3` added no-std support: https://github.com/servo/rust-url/pull/831

Since Neqo sets `default-features = false`, the above would break Neqo.

Related: https://github.com/servo/rust-url/pull/831

Sample CI failure: https://github.com/mozilla/neqo/actions/runs/11683021003/job/32531372545