### PR TITLE
chore: Bump some dependency versions that changed upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,13 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.76.0"
 
 [workspace.dependencies]
+# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
+enum-map = { version = "2.7", default-features = false }
 log = { version = "0.4", default-features = false }
 qlog = { version = "0.13", default-features = false }
 quinn-udp = { version = "0.5.6", default-features = false, features = ["direct-log"] }
+static_assertions = { version = "1.1", default-features = false }
 url = { version = "2.5", default-features = false, features = ["std"] }
-
 
 [workspace.lints.clippy]
 cargo = { level = "warn", priority = -1 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,6 +16,7 @@ readme.workspace = true
 cargo-fuzz = true
 
 [dependencies]
+# Not used in Firefox, so we can be liberal with dependency versions
 neqo-common = { path = "../neqo-common" }
 neqo-crypto = { path = "../neqo-crypto" }
 neqo-transport = { path = "../neqo-transport" }

--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -26,7 +26,7 @@ bench = false
 workspace = true
 
 [dependencies]
-# neqo-bin is not used in Firefox, so we can be liberal with dependency versions
+# Not used in Firefox, so we can be liberal with dependency versions
 clap = { version = "4.4", default-features = false, features = ["std", "help", "usage", "error-context", "suggestions", "derive"] }
 clap-verbosity-flag = { version = "2.2", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -16,15 +16,15 @@ readme.workspace = true
 workspace = true
 
 [dependencies]
-# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
-enum-map = { version = "2.7", default-features = false }
+# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
+enum-map = { workspace = true }
 env_logger = { version = "0.10", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"], optional = true }
 log = { workspace = true }
 qlog = { workspace = true }
 
 [target."cfg(windows)".dependencies]
-# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
+# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 windows = { version = "0.58", default-features = false, features = ["Win32_Media"] }
 
 [dev-dependencies]

--- a/neqo-crypto/Cargo.toml
+++ b/neqo-crypto/Cargo.toml
@@ -16,12 +16,12 @@ readme.workspace = true
 workspace = true
 
 [dependencies]
-# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
+# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 log = { workspace = true }
 neqo-common = { path = "../neqo-common" }
 
 [build-dependencies]
-# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
+# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
 mozbuild = { version = "0.1", default-features = false, optional = true }
 semver = { version = "1.0", default-features = false }

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -16,7 +16,7 @@ readme.workspace = true
 workspace = true
 
 [dependencies]
-# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
+# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 enumset = { version = "1.1", default-features = false }
 log = { workspace = true }
 neqo-common = { path = "./../neqo-common" }

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -16,12 +16,12 @@ readme.workspace = true
 workspace = true
 
 [dependencies]
-# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
+# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 log = { workspace = true }
 neqo-common = { path = "./../neqo-common" }
 neqo-transport = { path = "./../neqo-transport" }
 qlog = { workspace = true }
-static_assertions = { version = "1.1", default-features = false }
+static_assertions = { workspace = true }
 
 [dev-dependencies]
 test-fixture = { path = "../test-fixture" }

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -16,15 +16,15 @@ readme.workspace = true
 workspace = true
 
 [dependencies]
-# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
-enum-map = { version = "2.7", default-features = false }
+# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
+enum-map = { workspace = true }
 indexmap = { version = "2.2", default-features = false } # See https://github.com/mozilla/neqo/issues/1858
 log = { workspace = true }
 neqo-common = { path = "../neqo-common" }
 neqo-crypto = { path = "../neqo-crypto" }
 qlog = { workspace = true }
-smallvec = { version = "1.11", default-features = false }
-static_assertions = { version = "1.1", default-features = false }
+smallvec = { version = "1.13", default-features = false }
+static_assertions = { workspace = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false }

--- a/neqo-udp/Cargo.toml
+++ b/neqo-udp/Cargo.toml
@@ -16,6 +16,7 @@ readme.workspace = true
 workspace = true
 
 [dependencies]
+# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 log = { workspace = true }
 neqo-common = { path = "./../neqo-common" }
 quinn-udp = { workspace = true }

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -16,7 +16,7 @@ readme.workspace = true
 workspace = true
 
 [dependencies]
-# Sync with https://searchfox.org/mozilla-central/source/Cargo.lock 2024-02-08
+# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 log = { workspace = true }
 neqo-common = { path = "../neqo-common" }
 neqo-crypto = { path = "../neqo-crypto" }


### PR DESCRIPTION
And also convert some that are used in multiple crates to workspace dependencies.