### PR TITLE
fix: Don't allow migration if the peer doesn't allow it

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1870,8 +1870,8 @@ impl Connection {
     ///
     /// # Errors
     ///
-    /// Fails if this is not a client, not confirmed, or there are not enough connection
-    /// IDs available to use.
+    /// Fails if this is not a client, not confirmed, the peer disabled connection migration, or
+    /// there are not enough connection IDs available to use.
     pub fn migrate(
         &mut self,
         local: Option<SocketAddr>,
@@ -1883,6 +1883,14 @@ impl Connection {
             return Err(Error::InvalidMigration);
         }
         if !matches!(self.state(), State::Confirmed) {
+            return Err(Error::InvalidMigration);
+        }
+        if self
+            .tps
+            .borrow()
+            .remote()
+            .get_empty(tparams::DISABLE_MIGRATION)
+        {
             return Err(Error::InvalidMigration);
         }
 

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -976,8 +976,6 @@ fn migration_disabled() {
     let mut client = default_client();
     let mut server = new_server(ConnectionParameters::default().disable_migration(true));
     connect(&mut client, &mut server);
-    assert_eq!(client.state(), &State::Confirmed);
-    assert_eq!(server.state(), &State::Confirmed);
     assert_eq!(
         client
             .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), true, now())

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -26,7 +26,9 @@ use super::{
 };
 use crate::{
     cid::LOCAL_ACTIVE_CID_LIMIT,
-    connection::tests::{assert_path_challenge_min_len, send_something_paced, send_with_extra},
+    connection::tests::{
+        assert_path_challenge_min_len, connect, send_something_paced, send_with_extra,
+    },
     frame::FRAME_TYPE_NEW_CONNECTION_ID,
     packet::PacketBuilder,
     path::MAX_PATH_PROBES,
@@ -967,6 +969,21 @@ fn migration_invalid_state() {
     assert!(client
         .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), false, now())
         .is_err());
+}
+
+#[test]
+fn migration_disabled() {
+    let mut client = default_client();
+    let mut server = new_server(ConnectionParameters::default().disable_migration(true));
+    connect(&mut client, &mut server);
+    assert_eq!(client.state(), &State::Confirmed);
+    assert_eq!(server.state(), &State::Confirmed);
+    assert_eq!(
+        client
+            .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), true, now())
+            .unwrap_err(),
+        Error::InvalidMigration
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #2103