### PR TITLE
deps: pin url to v2.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ qlog = { version = "0.13", default-features = false }
 quinn-udp = { version = "0.5.6", default-features = false, features = ["direct-log"] }
 regex = { version = "1.9", default-features = false, features = ["unicode-perl"] }
 static_assertions = { version = "1.1", default-features = false }
-url = { version = "2.5", default-features = false, features = ["std"] }
+url = { version = "=2.5.1", default-features = false }
 
 [workspace.lints.clippy]
 cargo = { level = "warn", priority = -1 }


### PR DESCRIPTION
mozilla-central depends on `url` `v2.5.1`:

https://searchfox.org/mozilla-central/rev/6050bf4eca89956c9d91bfd89fa59294ae32a689/Cargo.lock#6715-6725

The latest version of `url` is `v2.5.3`, which cargo automatically updates to, given that `Cargo.lock` is not checked in.

`url` v0.2.5.3` introduced the `std` feature which breaks CI. https://github.com/mozilla/neqo/pull/2219 enabled the feature, unbreaking CI, but breaking mozilla-central, given that mozilla-central still uses `url` `v2.5.1` which does not have the the `std` feature.

This commit pins `url` to `v2.5.1` instead and removes the `std` feature.

---

Follow-up to https://github.com/mozilla/neqo/pull/2239#issuecomment-2485078742.