### PR TITLE
chore(transport/bench): remove commented out import

### DIFF
--- a/neqo-transport/benches/range_tracker.rs
+++ b/neqo-transport/benches/range_tracker.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use criterion::{criterion_group, criterion_main, Criterion}; // black_box
+use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_transport::send_stream::RangeTracker;
 
 const CHUNK: u64 = 1000;


### PR DESCRIPTION
Given that there is a `black_box` function in `criterion`, I assume this doc comment is a leftover commented out import.

https://docs.rs/criterion/latest/criterion/fn.black_box.html