### PR TITLE
Add a benchmark for the decoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *~
 /.vscode/
 /lcov.info
+/mutants.out*/
 /target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,10 +821,12 @@ dependencies = [
 name = "neqo-common"
 version = "0.11.0"
 dependencies = [
+ "criterion",
  "enum-map",
  "env_logger",
  "hex",
  "log",
+ "neqo-crypto",
  "qlog",
  "regex",
  "test-fixture",

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -28,6 +28,8 @@ qlog = { workspace = true }
 windows = { version = "0.58", default-features = false, features = ["Win32_Media"] }
 
 [dev-dependencies]
+criterion = { version = "0.5", default-features = false }
+neqo-crypto = { path = "../neqo-crypto" }
 test-fixture = { path = "../test-fixture" }
 regex = { workspace = true }
 
@@ -38,3 +40,7 @@ build-fuzzing-corpus = ["hex"]
 [lib]
 # See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 bench = false
+
+[[bench]]
+name = "decoder"
+harness = false

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -34,8 +34,9 @@ test-fixture = { path = "../test-fixture" }
 regex = { workspace = true }
 
 [features]
-ci = []
+bench = ["test-fixture/bench"]
 build-fuzzing-corpus = ["hex"]
+ci = []
 
 [lib]
 # See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
@@ -44,3 +45,4 @@ bench = false
 [[bench]]
 name = "decoder"
 harness = false
+required-features = ["bench"]

--- a/neqo-common/benches/decoder.rs
+++ b/neqo-common/benches/decoder.rs
@@ -1,0 +1,48 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use neqo_common::Decoder;
+use neqo_crypto::{init, randomize};
+
+fn randomize_buffer(n: usize, mask: u8) -> Vec<u8> {
+    let mut buf = vec![0; n];
+    for chunk in buf.chunks_mut(1024) {
+        // NSS doesn't like randomizing larger buffers, so chunk them up.
+        randomize(chunk);
+    }
+    for x in &mut buf[..] {
+        *x &= mask;
+    }
+    buf
+}
+
+fn decoder(c: &mut Criterion, count: usize, mask: u8) {
+    c.bench_function(&format!("decode {count} bytes, mask {mask:x}"), |b| {
+        b.iter_batched_ref(
+            || randomize_buffer(count, mask),
+            |buf| {
+                let mut dec = Decoder::new(&buf[..]);
+                while black_box(dec.decode_varint()).is_some() {
+                    // Do nothing;
+                }
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+}
+
+fn benchmark_decoder(c: &mut Criterion) {
+    init().unwrap();
+    for mask in [0xff, 0x7f, 0x3f] {
+        for count in [10, 15, 20] {
+            decoder(c, 1 << count, mask);
+        }
+    }
+}
+
+criterion_group!(benches, benchmark_decoder);
+criterion_main!(benches);


### PR DESCRIPTION
This adds a fairly simple varint decoding benchmark to neqo-common.  The next patch will include some improvements to the decoder.