### PR TITLE
ci: Delete `results-main` before `mv`

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -259,6 +259,7 @@ jobs:
 
       - if: github.ref == 'refs/heads/main'
         run: |
+          rm -rf results-main || true
           mv results results-main
           echo "${{ github.sha }}" > results-main/baseline-sha.txt
 


### PR DESCRIPTION
Because otherwise the `mv` command will fail.