### PR TITLE
fix(sim): correct `Waiting` state comparison in `NodeHolder::ready()`

### DIFF
--- a/test-fixture/src/sim/mod.rs
+++ b/test-fixture/src/sim/mod.rs
@@ -110,7 +110,7 @@ impl NodeHolder {
     fn ready(&self, now: Instant) -> bool {
         match self.state {
             Active => true,
-            Waiting(t) => t >= now,
+            Waiting(t) => t <= now,
             Idle => false,
         }
     }


### PR DESCRIPTION
A `Node` (e.g. a `Client`, `Server` or `TailDrop` router) can be in 3 states:

``` rust
enum NodeState {
    /// The node just produced a datagram.  It should be activated again as soon as possible.
    Active,
    /// The node is waiting.
    Waiting(Instant),
    /// The node became idle.
    Idle,
}
```

`NodeHolder::ready()` determines whether a `Node` is ready to be processed again. When `NodeState::Waiting`, it should only be ready when `t <= now`, i.e. the waiting time has passed, not `t >= now`.

``` rust
impl NodeHolder {
    fn ready(&self, now: Instant) -> bool {
        match self.state {
            Active => true,
            Waiting(t) => t <= now, // not >=
            Idle => false,
        }
    }
}
```

The previous behavior lead to wastefull non-ready `Node`s being processed and thus a large test runtime when e.g. simulating a gbit connection (https://github.com/mozilla/neqo/pull/2203).

---

Time to simulate a 100 MB transfer on a 1 Gbit/s 100ms connection on the `Simulator` on my `12th Gen Intel(R) Core(TM) i9-12900HK`:

- Before 40.51s
- After 17.84s