### PR TITLE
chore: Guard testing functions properly

### DIFF
--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -37,6 +37,7 @@ regex = { workspace = true }
 bench = ["test-fixture/bench"]
 build-fuzzing-corpus = ["hex"]
 ci = []
+test-fixture = []
 
 [lib]
 # See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -50,6 +50,7 @@ impl<'a> Decoder<'a> {
 
     /// Skip a vector.  Panics if there isn't enough space.
     /// Only use this for tests because we panic rather than reporting a result.
+    #[cfg(any(test, feature = "test-fixture"))]
     pub fn skip_vec(&mut self, n: usize) {
         let len = self.decode_uint(n);
         self.skip_inner(len);
@@ -57,6 +58,7 @@ impl<'a> Decoder<'a> {
 
     /// Skip a variable length vector.  Panics if there isn't enough space.
     /// Only use this for tests because we panic rather than reporting a result.
+    #[cfg(any(test, feature = "test-fixture"))]
     pub fn skip_vvec(&mut self) {
         let len = self.decode_varint();
         self.skip_inner(len);
@@ -272,6 +274,7 @@ impl Encoder {
     /// # Panics
     ///
     /// When `s` contains non-hex values or an odd number of values.
+    #[cfg(any(test, feature = "test-fixture"))]
     #[must_use]
     pub fn from_hex(s: impl AsRef<str>) -> Self {
         let s = s.as_ref();

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 # Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 log = { workspace = true }
-neqo-common = { path = "../neqo-common" }
+neqo-common = { path = "../neqo-common", features = ["test-fixture"] }
 neqo-crypto = { path = "../neqo-crypto" }
 neqo-http3 = { path = "../neqo-http3" }
 neqo-transport = { path = "../neqo-transport" }


### PR DESCRIPTION
We have a bunch of functions that in their doc comments say that they are for testing purposes only. This commit adds guards to those functions to make sure they are not used in production code.