### PR TITLE
fix: Send Retry and VN packets with default TOS

### DIFF
--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -238,7 +238,7 @@ impl Server {
                         |p| {
                             qdebug!(
                                 [self],
-                                "type={:?} path:{} {}->{} {:?} len {}",
+                                "type={:?} path:{} {}->{} len {}",
                                 PacketType::Retry,
                                 initial.dst_cid,
                                 dgram.destination(),

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -399,7 +399,7 @@ impl Server {
             );
             qdebug!(
                 [self],
-                "type={:?} path:{} {}->{} {:?} len {}",
+                "type={:?} path:{} {}->{} len {}",
                 PacketType::VersionNegotiation,
                 packet.dcid(),
                 dgram.destination(),

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -238,7 +238,7 @@ impl Server {
                         |p| {
                             qdebug!(
                                 [self],
-                                "type={:?} path:{} {}->{} len {}",
+                                "type={:?} path:{} {}->{} {:?} len {}",
                                 PacketType::Retry,
                                 initial.dst_cid,
                                 dgram.destination(),
@@ -399,7 +399,7 @@ impl Server {
             );
             qdebug!(
                 [self],
-                "type={:?} path:{} {}->{} len {}",
+                "type={:?} path:{} {}->{} {:?} len {}",
                 PacketType::VersionNegotiation,
                 packet.dcid(),
                 dgram.destination(),

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -17,7 +17,8 @@ use std::{
 };
 
 use neqo_common::{
-    event::Provider, hex, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn, Datagram, Role,
+    event::Provider, hex, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn, Datagram, IpTos,
+    Role,
 };
 use neqo_crypto::{
     encode_ech_config, AntiReplay, Cipher, PrivateKey, PublicKey, ZeroRttCheckResult,
@@ -235,10 +236,20 @@ impl Server {
                             Output::None
                         },
                         |p| {
+                            qdebug!(
+                                [self],
+                                "type={:?} path:{} {}->{} {:?} len {}",
+                                PacketType::Retry,
+                                initial.dst_cid,
+                                dgram.destination(),
+                                dgram.source(),
+                                IpTos::default(),
+                                p.len(),
+                            );
                             Output::Datagram(Datagram::new(
                                 dgram.destination(),
                                 dgram.source(),
-                                dgram.tos(),
+                                IpTos::default(),
                                 p,
                             ))
                         },
@@ -386,6 +397,16 @@ impl Server {
                 packet.wire_version(),
                 self.conn_params.get_versions().all(),
             );
+            qdebug!(
+                [self],
+                "type={:?} path:{} {}->{} {:?} len {}",
+                PacketType::VersionNegotiation,
+                packet.dcid(),
+                dgram.destination(),
+                dgram.source(),
+                IpTos::default(),
+                vn.len(),
+            );
 
             crate::qlog::server_version_information_failed(
                 &self.create_qlog_trace(packet.dcid()),
@@ -397,7 +418,7 @@ impl Server {
             return Output::Datagram(Datagram::new(
                 dgram.destination(),
                 dgram.source(),
-                dgram.tos(),
+                IpTos::default(),
                 vn,
             ));
         }

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -37,12 +37,10 @@ fn retry_basic() {
 
     let dgram = client.process_output(now()).dgram(); // Initial
     assert!(dgram.is_some());
-    let dgram = server.process(dgram, now()).dgram(); // Retry
-    assert!(dgram.is_some());
+    let dgram = server.process(dgram, now()).dgram().unwrap(); // Retry
+    assertions::assert_retry(&dgram);
 
-    assertions::assert_retry(dgram.as_ref().unwrap());
-
-    let dgram = client.process(dgram, now()).dgram(); // Initial w/token
+    let dgram = client.process(Some(dgram), now()).dgram(); // Initial w/token
     assert!(dgram.is_some());
     let dgram = server.process(dgram, now()).dgram(); // Initial, HS
     assert!(dgram.is_some());

--- a/test-fixture/src/assertions.rs
+++ b/test-fixture/src/assertions.rs
@@ -6,7 +6,7 @@
 
 use std::net::SocketAddr;
 
-use neqo_common::{Datagram, Decoder};
+use neqo_common::{Datagram, Decoder, IpTos};
 use neqo_transport::{version::WireVersion, Pmtud, Version, MIN_INITIAL_PACKET_SIZE};
 
 use crate::{DEFAULT_ADDR, DEFAULT_ADDR_V4};
@@ -50,8 +50,9 @@ pub fn assert_version(payload: &[u8], v: u32) {
 /// # Panics
 ///
 /// If this is clearly not a Version Negotiation packet.
-pub fn assert_vn(payload: &[u8]) {
-    let mut dec = Decoder::from(payload);
+pub fn assert_vn(dgram: &Datagram) {
+    assert_eq!(dgram.tos(), IpTos::default());
+    let mut dec = Decoder::from(dgram.as_ref());
     assert_eq!(
         dec.decode_uint::<u8>().unwrap() & 0x80,
         0x80,
@@ -86,8 +87,9 @@ pub fn assert_coalesced_0rtt(payload: &[u8]) {
 /// # Panics
 ///
 /// If the tests fail.
-pub fn assert_retry(payload: &[u8]) {
-    let mut dec = Decoder::from(payload);
+pub fn assert_retry(dgram: &Datagram) {
+    assert_eq!(dgram.tos(), IpTos::default());
+    let mut dec = Decoder::from(dgram.as_ref());
     let t = dec.decode_uint::<u8>().unwrap();
     let version = assert_default_version(&mut dec);
     assert_long_packet_type(t, 0b1011_0000, version);

--- a/test-fixture/src/assertions.rs
+++ b/test-fixture/src/assertions.rs
@@ -88,7 +88,7 @@ pub fn assert_coalesced_0rtt(payload: &[u8]) {
 ///
 /// If the tests fail.
 pub fn assert_retry(dgram: &Datagram) {
-    assert_eq!(dgram.tos(), IpTos::default());
+    assert_eq!(dgram.tos(), IpTos::default());  // Retry always uses default IP TOS.
     let mut dec = Decoder::from(dgram.as_ref());
     let t = dec.decode_uint::<u8>().unwrap();
     let version = assert_default_version(&mut dec);

--- a/test-fixture/src/assertions.rs
+++ b/test-fixture/src/assertions.rs
@@ -51,7 +51,7 @@ pub fn assert_version(payload: &[u8], v: u32) {
 ///
 /// If this is clearly not a Version Negotiation packet.
 pub fn assert_vn(dgram: &Datagram) {
-    assert_eq!(dgram.tos(), IpTos::default());
+    assert_eq!(dgram.tos(), IpTos::default());  // VN always uses default IP TOS.
     let mut dec = Decoder::from(dgram.as_ref());
     assert_eq!(
         dec.decode_uint::<u8>().unwrap() & 0x80,

--- a/test-fixture/src/assertions.rs
+++ b/test-fixture/src/assertions.rs
@@ -51,7 +51,7 @@ pub fn assert_version(payload: &[u8], v: u32) {
 ///
 /// If this is clearly not a Version Negotiation packet.
 pub fn assert_vn(dgram: &Datagram) {
-    assert_eq!(dgram.tos(), IpTos::default());  // VN always uses default IP TOS.
+    assert_eq!(dgram.tos(), IpTos::default()); // VN always uses default IP TOS.
     let mut dec = Decoder::from(dgram.as_ref());
     assert_eq!(
         dec.decode_uint::<u8>().unwrap() & 0x80,
@@ -88,7 +88,7 @@ pub fn assert_coalesced_0rtt(payload: &[u8]) {
 ///
 /// If the tests fail.
 pub fn assert_retry(dgram: &Datagram) {
-    assert_eq!(dgram.tos(), IpTos::default());  // Retry always uses default IP TOS.
+    assert_eq!(dgram.tos(), IpTos::default()); // Retry always uses default IP TOS.
     let mut dec = Decoder::from(dgram.as_ref());
     let t = dec.decode_uint::<u8>().unwrap();
     let version = assert_default_version(&mut dec);


### PR DESCRIPTION
Rather than using the TOS value from the incoming packet, which might have gotten ECN marked on the way in.

Also create a debug log entry for those packets that resembles that created by `dump_packet`.