### PR TITLE
fix: `function pointer comparisons do not produce meaningful results`

### DIFF
--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -348,15 +348,21 @@ pub fn migration_with_modifiers(
 
 #[test]
 fn ecn_migration_zero_burst_all_cases() {
-    for orig_path_mod in &[noop(), bleach(), remark(), ce()] {
-        for new_path_mod in &[noop(), bleach(), remark(), ce(), drop()] {
+    for orig_path_mod in [noop(), bleach(), remark(), ce()] {
+        for (new_path_mod_name, new_path_mod) in [
+            ("noop", noop()),
+            ("bleach", bleach()),
+            ("remark", remark()),
+            ("ce", ce()),
+            ("drop", drop()),
+        ] {
             let (before, after, migrated) =
-                migration_with_modifiers(*orig_path_mod, *new_path_mod, 0);
+                migration_with_modifiers(orig_path_mod, new_path_mod, 0);
             // Too few packets sent before and after migration to conclude ECN validation.
             assert_ecn_enabled(before);
             assert_ecn_enabled(after);
             // Migration succeeds except if the new path drops ECN.
-            assert!(*new_path_mod == drop() || migrated);
+            assert!(new_path_mod_name == "drop" || migrated);
         }
     }
 }


### PR DESCRIPTION
New clippy warning with the original code:
```
warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
   --> neqo-transport/src/connection/tests/ecn.rs:359:21
    |
359 |             assert!(*new_path_mod == drop() || migrated);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the address of the same function can vary between different codegen units
    = note: furthermore, different functions could have the same address after being merged together
    = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
    = note: `#[warn(unpredictable_function_pointer_comparisons)]` on by default
help: refactor your code, or use `std::ptr::fn_addr_eq` to suppress the lint
    |
359 |             assert!(std::ptr::fn_addr_eq(*new_path_mod, drop()) || migrated);
    |                     +++++++++++++++++++++             ~       +
```