### PR TITLE
chore: Fix misspellings

### DIFF
--- a/neqo-common/src/tos.rs
+++ b/neqo-common/src/tos.rs
@@ -62,7 +62,7 @@ impl IpTosEcn {
     }
 }
 
-/// Diffserv Codepoints, mapped to the upper six bits of the TOS field.
+/// Diffserv codepoints, mapped to the upper six bits of the TOS field.
 /// <https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml>
 #[derive(Copy, Clone, PartialEq, Eq, Enum, Default, Debug)]
 #[repr(u8)]

--- a/neqo-http3/src/buffered_send_stream.rs
+++ b/neqo-http3/src/buffered_send_stream.rs
@@ -49,7 +49,7 @@ impl BufferedStream {
 
     /// # Panics
     ///
-    /// This functon cannot be called before the `BufferedStream` is initialized.
+    /// This function cannot be called before the `BufferedStream` is initialized.
     pub fn buffer(&mut self, to_buf: &[u8]) {
         if let Self::Initialized { buf, .. } = self {
             buf.extend_from_slice(to_buf);

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -159,7 +159,7 @@ The API consists of:
 Each `Http3Connection` holds a list of stream handlers. Each send and receive-handler is registered in
 `send_streams` and `recv_streams`. Unidirectional streams are registered only on one of the lists
 and bidirectional streams are registered in both lists and the 2 handlers are independent, e.g. one
-can be closed and removed ane second may still be active.
+can be closed and removed and second may still be active.
 
 The only streams that are not registered are the local control stream, local QPACK decoder stream,
 and local QPACK encoder stream. These streams are send-streams and sending data on this stream is
@@ -195,7 +195,7 @@ are local or remote:
     type has been decoded.  After this point the stream:
     - will be regegistered with the appropriate handler,
     - will be canceled if is an unknown stream type or
-    - the connection will fail if it is unallowed stream type (receiveing HTTP request on the
+    - the connection will fail if it is unallowed stream type (receiving HTTP request on the
       client-side).
 
 The output is handled in `handle_new_stream`, for control,  qpack streams and partially
@@ -277,7 +277,7 @@ For example for `Http`   stream the listener will produce  `HeaderReady` and `Da
 
 A `WebTransport` session is connected to a control stream that is in essence an HTTP transaction.
 Therefore, `WebTransportSession` will internally use a `SendMessage` and `RecvMessage` handler to
-handle parsing and sending of HTTP part of the control stream. When HTTP headers are exchenged,
+handle parsing and sending of HTTP part of the control stream. When HTTP headers are exchanged,
 `WebTransportSession` will take over handling of stream data. `WebTransportSession` sets
 `WebTransportSessionListener` as the `RecvMessage` event listener.
 
@@ -501,7 +501,7 @@ impl Http3Connection {
     /// This function handles reading from all streams, i.e. control, qpack, request/response
     /// stream and unidi stream that are still do not have a type.
     /// The function cannot handle:
-    /// 1) a `Push(_)`, `Htttp` or `WebTransportStream(_)` stream
+    /// 1) a `Push(_)`, `Http` or `WebTransportStream(_)` stream
     /// 2) frames `MaxPushId`, `PriorityUpdateRequest`, `PriorityUpdateRequestPush` or `Goaway` must
     ///    be handled by `Http3Client`/`Server`.
     ///
@@ -1236,7 +1236,7 @@ impl Http3Connection {
         error: u32,
         message: &str,
     ) -> Res<()> {
-        qtrace!("Clos WebTransport session {:?}", session_id);
+        qtrace!("Close WebTransport session {:?}", session_id);
         let send_stream = self
             .send_streams
             .get_mut(&session_id)

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -38,7 +38,7 @@ use crate::{
 };
 
 // This is used for filtering send_streams and recv_Streams with a stream_ids greater than or equal
-// a given id. Only the same type (bidirectional or unidirectionsl) streams are filtered.
+// a given id. Only the same type (bidirectional or unidirectional) streams are filtered.
 fn id_gte<U>(base: StreamId) -> impl FnMut((&StreamId, &U)) -> Option<StreamId> + 'static
 where
     U: ?Sized,
@@ -226,7 +226,7 @@ const fn alpn_from_quic_version(version: Version) -> &'static str {
 ///     while let Some(event) = client.next_event() {
 ///         match event {
 ///             Http3ClientEvent::DataReadable{ stream_id } => {
-///                 println!("Data receivedd form the server on WebTransport stream ID {:?}",
+///                 println!("Data received form the server on WebTransport stream ID {:?}",
 ///                     stream_id,
 ///                 );
 ///                 let mut buf = [0; 100];
@@ -262,13 +262,13 @@ const fn alpn_from_quic_version(version: Version) -> &'static str {
 ///                 session_id,
 ///             }) => {
 ///                 println!("New stream received on session{:?}, stream id={:?} stream type={:?}",
-///                     sesson_id.stream_id(),
+///                     session_id.stream_id(),
 ///                     stream_id.stream_id(),
 ///                     stream_id.stream_type()
 ///                 );
 ///             }
 ///             Http3ClientEvent::DataReadable{ stream_id } => {
-///                 println!("Data receivedd form the server on WebTransport stream ID {:?}",
+///                 println!("Data received form the server on WebTransport stream ID {:?}",
 ///                     stream_id,
 ///                 );
 ///                 let mut buf = [0; 100];
@@ -419,7 +419,7 @@ impl Http3Client {
 
     /// The correct way to obtain a resumption token is to wait for the
     /// `Http3ClientEvent::ResumptionToken` event. To emit the event we are waiting for a
-    /// resumtion token and a `NEW_TOKEN` frame to arrive. Some servers don't send `NEW_TOKEN`
+    /// resumption token and a `NEW_TOKEN` frame to arrive. Some servers don't send `NEW_TOKEN`
     /// frames and in this case, we wait for 3xPTO before emitting an event. This is especially a
     /// problem for short-lived connections, where the connection is closed before any events are
     /// released. This function retrieves the token, without waiting for a `NEW_TOKEN` frame to
@@ -573,7 +573,7 @@ impl Http3Client {
     }
 
     /// An application may cancel a stream(request).
-    /// Both sides, the receiviing and sending side, sending and receiving side, will be closed.
+    /// Both sides, the receiving and sending side, sending and receiving side, will be closed.
     ///
     /// # Errors
     ///
@@ -927,7 +927,7 @@ impl Http3Client {
     /// - a [`Output::Datagram(Datagram)`][1]: data that should be sent as a UDP payload,
     /// - a [`Output::Callback(Duration)`][1]: the duration of a  timer. `process_output` should be
     ///   called at least after the time expires,
-    /// - [`Output::None`][1]: this is returned when `Nttp3Client` is done and can be destroyed.
+    /// - [`Output::None`][1]: this is returned when `Http3Client` is done and can be destroyed.
     ///
     /// The application should call this function repeatedly until a timer value or None is
     /// returned. After that, the application should call the function again if a new UDP packet is
@@ -1168,7 +1168,7 @@ impl Http3Client {
                 Rc::clone(&self.base_handler.qpack_decoder),
                 Box::new(RecvPushEvents::new(push_id, Rc::clone(&self.push_handler))),
                 None,
-                // TODO: think about the right prority for the push streams.
+                // TODO: think about the right priority for the push streams.
                 PriorityHandler::new(true, Priority::default()),
             )),
         );
@@ -1655,7 +1655,7 @@ mod tests {
         out
     }
 
-    // Perform only Quic transport handshake.
+    // Perform only QUIC transport handshake.
     fn connect_only_transport_with(client: &mut Http3Client, server: &mut TestServer) {
         let out = handshake_only(client, server);
 
@@ -1668,7 +1668,7 @@ mod tests {
         assert!(server.conn.state().connected());
     }
 
-    // Perform only Quic transport handshake.
+    // Perform only QUIC transport handshake.
     fn connect_only_transport() -> (Http3Client, TestServer) {
         let mut client = default_http3_client();
         let mut server = TestServer::new();
@@ -1683,7 +1683,7 @@ mod tests {
         server.check_client_control_qpack_streams_no_resumption();
     }
 
-    // Perform Quic transport handshake and exchange Http3 settings.
+    // Perform QUIC transport handshake and exchange Http3 settings.
     fn connect_with(client: &mut Http3Client, server: &mut TestServer) {
         connect_only_transport_with(client, server);
 
@@ -1696,11 +1696,11 @@ mod tests {
         let out = server.conn.process(None::<Datagram>, now());
         client.process_input(out.dgram().unwrap(), now());
 
-        // assert no error occured.
+        // assert no error occurred.
         assert_eq!(client.state(), Http3State::Connected);
     }
 
-    // Perform Quic transport handshake and exchange Http3 settings.
+    // Perform QUIC transport handshake and exchange Http3 settings.
     fn connect_with_connection_parameters(
         server_conn_params: ConnectionParameters,
     ) -> (Http3Client, TestServer) {
@@ -1718,7 +1718,7 @@ mod tests {
         (client, server)
     }
 
-    // Perform Quic transport handshake and exchange Http3 settings.
+    // Perform QUIC transport handshake and exchange Http3 settings.
     fn connect() -> (Http3Client, TestServer) {
         let mut client = default_http3_client();
         let mut server = TestServer::new();
@@ -2272,19 +2272,19 @@ mod tests {
         assert_closed(&client, &Error::HttpFrameUnexpected);
     }
 
-    // send DATA frame on a cortrol stream
+    // send DATA frame on a control stream
     #[test]
     fn data_frame_on_control_stream() {
         test_wrong_frame_on_control_stream(&[0x0, 0x2, 0x1, 0x2]);
     }
 
-    // send HEADERS frame on a cortrol stream
+    // send HEADERS frame on a control stream
     #[test]
     fn headers_frame_on_control_stream() {
         test_wrong_frame_on_control_stream(&[0x1, 0x2, 0x1, 0x2]);
     }
 
-    // send PUSH_PROMISE frame on a cortrol stream
+    // send PUSH_PROMISE frame on a control stream
     #[test]
     fn push_promise_frame_on_control_stream() {
         test_wrong_frame_on_control_stream(&[0x5, 0x2, 0x1, 0x2]);
@@ -2571,7 +2571,7 @@ mod tests {
             }
         }
 
-        // after this stream will be removed from hcoon. We will check this by trying to read
+        // after this stream will be removed from conn. We will check this by trying to read
         // from the stream and that should fail.
         let mut buf = [0_u8; 100];
         let res = client.read_data(now(), request_stream_id, &mut buf);
@@ -2795,7 +2795,7 @@ mod tests {
     }
 
     // Send 2 data frames so that the second one cannot fit into the send_buf and it is only
-    // partialy sent. We check that the sent data is correct.
+    // partially sent. We check that the sent data is correct.
     fn fetch_with_two_data_frames(
         first_frame: &[u8],
         expected_first_data_frame_header: &[u8],
@@ -3260,7 +3260,7 @@ mod tests {
         assert!(stop_sending);
         assert!(header_ready);
 
-        // after this, we can sill read data from a sttream.
+        // after this, we can sill read data from a stream.
         let mut buf = [0_u8; 100];
         let (amount, fin) = client
             .read_data(now(), request_stream_id, &mut buf)
@@ -3598,7 +3598,7 @@ mod tests {
         let out = server.conn.process_output(now());
         client.process(out.dgram(), now());
 
-        // Recv HeaderReady wo headers with fin.
+        // Recv HeaderReady without headers with fin.
         let e = client.events().next().unwrap();
         assert_eq!(
             e,
@@ -3617,7 +3617,7 @@ mod tests {
         );
     }
 
-    // Close stream imemediately after headers.
+    // Close stream immediately after headers.
     #[test]
     fn stream_fin_after_headers() {
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
@@ -3660,7 +3660,7 @@ mod tests {
     #[test]
     fn stream_fin_after_headers_are_read_wo_data_frame() {
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
-        // Send some good data wo fin
+        // Send some good data without fin
         server_send_response_and_exchange_packet(
             &mut client,
             &mut server,
@@ -3669,7 +3669,7 @@ mod tests {
             false,
         );
 
-        // Recv headers wo fin
+        // Recv headers without fin
         while let Some(e) = client.next_event() {
             match e {
                 Http3ClientEvent::HeaderReady {
@@ -3696,7 +3696,7 @@ mod tests {
         let out = server.conn.process_output(now());
         client.process(out.dgram(), now());
 
-        // Recv DataReadable wo data with fin
+        // Recv DataReadable without data with fin
         while let Some(e) = client.next_event() {
             match e {
                 Http3ClientEvent::HeaderReady { .. } => {
@@ -3775,11 +3775,11 @@ mod tests {
     }
 
     // Send headers and an empty data frame. Read headers and then close the stream.
-    // We should get a HeaderReady without fin and a DataReadable wo data and with fin.
+    // We should get a HeaderReady without fin and a DataReadable without data and with fin.
     #[test]
     fn stream_fin_after_headers_an_empty_data_frame_are_read() {
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
-        // Send some good data wo fin
+        // Send some good data without fin
         // Send headers.
         _ = server
             .conn
@@ -3794,7 +3794,7 @@ mod tests {
         let out = server.conn.process_output(now());
         client.process(out.dgram(), now());
 
-        // Recv headers wo fin
+        // Recv headers without fin
         while let Some(e) = client.next_event() {
             match e {
                 Http3ClientEvent::HeaderReady {
@@ -3850,7 +3850,7 @@ mod tests {
     #[test]
     fn stream_fin_after_a_data_frame() {
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
-        // Send some good data wo fin
+        // Send some good data without fin
         server_send_response_and_exchange_packet(
             &mut client,
             &mut server,
@@ -3859,7 +3859,7 @@ mod tests {
             false,
         );
 
-        // Recv some good data wo fin
+        // Recv some good data without fin
         while let Some(e) = client.next_event() {
             match e {
                 Http3ClientEvent::HeaderReady {
@@ -3891,7 +3891,7 @@ mod tests {
         let out = server.conn.process_output(now());
         client.process(out.dgram(), now());
 
-        // fin wo data should generate DataReadable
+        // fin without data should generate DataReadable
         let e = client.events().next().unwrap();
         if let Http3ClientEvent::DataReadable { stream_id } = e {
             assert_eq!(stream_id, request_stream_id);
@@ -4320,7 +4320,7 @@ mod tests {
         assert_eq!(make_request(&mut client, false, &[]), 0);
     }
 
-    // Connect to a server, get token and reconnect using 0-rtt. Seerver sends new Settings.
+    // Connect to a server, get token and reconnect using 0-rtt. Server sends new Settings.
     fn zero_rtt_change_settings(
         original_settings: &[HSetting],
         resumption_settings: &[HSetting],
@@ -4903,7 +4903,7 @@ mod tests {
         );
         assert!(!client.events().any(data_readable_event));
 
-        // Now read only until the end of the first frame. The firs framee has 3 bytes.
+        // Now read only until the end of the first frame. The firs frame has 3 bytes.
         let mut buf2 = [0_u8; 2];
         assert_eq!(
             (2, false),
@@ -5991,13 +5991,13 @@ mod tests {
         let encoder_inst_pkt =
             send_push_promise_using_encoder(&mut client, &mut server, request_stream_id, 0);
 
-        // PushPromise is blocked wathing for encoder instructions.
+        // PushPromise is blocked watching for encoder instructions.
         assert!(!check_push_events(&mut client));
 
         // Let client receive the encoder instructions.
         let _out = client.process(encoder_inst_pkt, now());
 
-        // PushPromise is blocked wathing for encoder instructions.
+        // PushPromise is blocked watching for encoder instructions.
         assert!(check_push_events(&mut client));
     }
 
@@ -6020,7 +6020,7 @@ mod tests {
         let encoder_inst_pkt =
             send_push_promise_using_encoder(&mut client, &mut server, request_stream_id, 0);
 
-        // PushPromise is blocked wathing for encoder instructions.
+        // PushPromise is blocked watching for encoder instructions.
         assert!(!check_push_events(&mut client));
 
         // Stream data can be still read
@@ -6037,7 +6037,7 @@ mod tests {
         // Let client receive the encoder instructions.
         let _out = client.process(encoder_inst_pkt, now());
 
-        // PushPromise is blocked wathing for encoder instructions.
+        // PushPromise is blocked watching for encoder instructions.
         assert!(check_push_events(&mut client));
 
         // Stream data can be still read
@@ -6062,7 +6062,7 @@ mod tests {
         let encoder_inst_pkt =
             send_push_promise_using_encoder(&mut client, &mut server, request_stream_id, 0);
 
-        // PushPromise is blocked wathing for encoder instructions.
+        // PushPromise is blocked watching for encoder instructions.
         assert!(!check_push_events(&mut client));
 
         // Send response headers
@@ -6079,7 +6079,7 @@ mod tests {
         // Let client receive the encoder instructions.
         let _out = client.process(encoder_inst_pkt, now());
 
-        // PushPromise is blocked wathing for encoder instructions.
+        // PushPromise is blocked watching for encoder instructions.
         assert!(check_push_events(&mut client));
     }
 
@@ -6090,7 +6090,7 @@ mod tests {
 
         setup_server_side_encoder(&mut client, &mut server);
 
-        // Insert an elemet into a dynamic table.
+        // Insert an element into a dynamic table.
         // insert "content-length: 1234
         server
             .encoder
@@ -6104,7 +6104,7 @@ mod tests {
         let encoder_inst_pkt2 =
             send_push_promise_using_encoder(&mut client, &mut server, request_stream_id, 0);
 
-        // PushPromise is blocked wathing for encoder instructions.
+        // PushPromise is blocked watching for encoder instructions.
         assert!(!check_push_events(&mut client));
 
         let response_headers = vec![
@@ -6165,7 +6165,7 @@ mod tests {
             Header::new("myn1", "myv1"),
         );
 
-        // PushPromise is blocked wathing for encoder instructions.
+        // PushPromise is blocked watching for encoder instructions.
         assert!(!check_push_events(&mut client));
 
         let encoder_inst_pkt2 = send_push_promise_using_encoder_with_custom_headers(
@@ -6176,7 +6176,7 @@ mod tests {
             Header::new("myn2", "myv2"),
         );
 
-        // PushPromise is blocked wathing for encoder instructions.
+        // PushPromise is blocked watching for encoder instructions.
         assert!(!check_push_events(&mut client));
 
         let response_headers = vec![
@@ -6292,7 +6292,7 @@ mod tests {
             false,
         );
 
-        // Headers are blocked waiting fro the encoder instructions.
+        // Headers are blocked waiting for the encoder instructions.
         let header_ready_event = |e| matches!(e, Http3ClientEvent::HeaderReady { .. });
         assert!(!client.events().any(header_ready_event));
 
@@ -6833,7 +6833,7 @@ mod tests {
             true,
         );
 
-        // Stream has been reset because of thei malformed headers.
+        // Stream has been reset because of their malformed headers.
         let push_reset_event = |e| {
             matches!(e, Http3ClientEvent::PushReset {
             push_id,

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -78,7 +78,7 @@ fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
     }
 }
 
-// Perform only Quic transport handshake.
+// Perform only QUIC transport handshake.
 fn connect_with(client: &mut Http3Client, server: &mut Http3Server) {
     assert_eq!(client.state(), Http3State::Initializing);
     let out = client.process_output(now());
@@ -99,7 +99,7 @@ fn connect_with(client: &mut Http3Client, server: &mut Http3Server) {
 
     assert_eq!(client.state(), Http3State::Connected);
 
-    // Exchange H3 setttings
+    // Exchange H3 settings
     let out = server.process(out.dgram(), now());
     let out = client.process(out.dgram(), now());
     let out = server.process(out.dgram(), now());

--- a/neqo-http3/src/frames/reader.rs
+++ b/neqo-http3/src/frames/reader.rs
@@ -24,7 +24,7 @@ pub trait FrameDecoder<T> {
 
     /// # Errors
     ///
-    /// Returns `HttpFrameUnexpected` if frames is not alowed, i.e. is a `H3_RESERVED_FRAME_TYPES`.
+    /// Returns `HttpFrameUnexpected` if frames is not allowed, i.e. is a `H3_RESERVED_FRAME_TYPES`.
     fn frame_type_allowed(_frame_type: HFrameType) -> Res<()> {
         Ok(())
     }
@@ -154,7 +154,7 @@ impl FrameReader {
         }
     }
 
-    /// returns true if quic stream was closed.
+    /// Returns true if QUIC stream was closed.
     ///
     /// # Errors
     ///

--- a/neqo-http3/src/frames/tests/mod.rs
+++ b/neqo-http3/src/frames/tests/mod.rs
@@ -35,7 +35,7 @@ pub fn enc_dec<T: FrameDecoder<T>>(d: &Encoder, st: &str, remaining: usize) -> T
 
     let mut fr: FrameReader = FrameReader::new();
 
-    // conver string into u8 vector
+    // convert string into u8 vector
     let buf = Encoder::from_hex(st);
     conn_s.stream_send(stream_id, buf.as_ref()).unwrap();
     let out = conn_s.process_output(now());

--- a/neqo-http3/src/frames/tests/reader.rs
+++ b/neqo-http3/src/frames/tests/reader.rs
@@ -128,7 +128,7 @@ fn frame_reading_with_stream_data() {
     let frame = fr.process(&[0x0, 0x3, 0x1, 0x2, 0x3]).unwrap();
     assert!(matches!(frame, HFrame::Data { len } if len == 3));
 
-    // payloead is still on the stream.
+    // payload is still on the stream.
     // assert that we have 3 bytes in the stream
     let mut buf = [0_u8; 100];
     let (amount, _) = fr.conn_c.stream_recv(fr.stream_id, &mut buf).unwrap();
@@ -150,7 +150,7 @@ fn unknown_frame() {
     buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
     assert!(fr.process::<HFrame>(&buf).is_none());
 
-    // now receive a CANCEL_PUSH fram to see that frame reader is ok.
+    // now receive a CANCEL_PUSH frame to see that frame reader is ok.
     let frame = fr.process(&[0x03, 0x01, 0x05]);
     assert!(frame.is_some());
     if let HFrame::CancelPush { push_id } = frame.unwrap() {
@@ -194,7 +194,7 @@ fn unknown_wt_frame() {
     buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
     assert!(fr.process::<WebTransportFrame>(&buf).is_none());
 
-    // now receive a WT_FRAME_CLOSE_SESSION fram to see that frame reader is ok.
+    // now receive a WT_FRAME_CLOSE_SESSION frame to see that frame reader is ok.
     let frame = fr.process(&[
         0x68, 0x43, 0x09, 0x00, 0x00, 0x00, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f,
     ]);
@@ -318,7 +318,7 @@ fn test_complete_and_incomplete_frame<T: FrameDecoder<T> + PartialEq + Debug>(
     done_state: usize,
 ) {
     use std::cmp::Ordering;
-    // Let's consume partial frames. It is enough to test partal frames
+    // Let's consume partial frames. It is enough to test partial frames
     // up to 10 byte. 10 byte is greater than frame type and frame
     // length and bit of data.
     let len = std::cmp::min(buf.len() - 1, 10);

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -135,7 +135,7 @@ impl ActivePushStreams {
 ///
 /// The `PushController` handles:
 ///  `PUSH_PROMISE` frame: frames may change the push state from Init to `PushPromise` and from
-/// `OnlyPushStream` to                        `Active`. Frames for a closed steams are ignored.
+/// `OnlyPushStream` to                        `Active`. Frames for a closed streams are ignored.
 ///  `CANCEL_PUSH` frame: (`handle_cancel_push` will be called). If a push is in state `PushPromise`
 /// or `Active`, any                       posted events will be removed and a `PushCanceled` event
 /// will be posted. If a push is in                       state `OnlyPushStream` or `Active` the
@@ -169,7 +169,7 @@ impl PushController {
 
 impl Display for PushController {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Push controler")
+        write!(f, "Push controller")
     }
 }
 

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -502,7 +502,7 @@ mod tests {
         (server, client)
     }
 
-    // Test http3 connection inintialization.
+    // Test http3 connection initialization.
     // The server will open the control and qpack streams and send SETTINGS frame.
     #[test]
     fn server_connect() {
@@ -561,7 +561,7 @@ mod tests {
         let out2 = server.process(out1.dgram(), now());
         mem::drop(neqo_trans_conn.process(out2.dgram(), now()));
 
-        // assert no error occured.
+        // assert no error occurred.
         assert_not_closed(server);
 
         PeerConnection {
@@ -685,13 +685,13 @@ mod tests {
         test_wrong_frame_on_control_stream(&[0x0, 0x2, 0x1, 0x2]);
     }
 
-    // send HEADERS frame on a cortrol stream
+    // send HEADERS frame on a control stream
     #[test]
     fn server_headers_frame_on_control_stream() {
         test_wrong_frame_on_control_stream(&[0x1, 0x2, 0x1, 0x2]);
     }
 
-    // send PUSH_PROMISE frame on a cortrol stream
+    // send PUSH_PROMISE frame on a control stream
     #[test]
     fn server_push_promise_frame_on_control_stream() {
         test_wrong_frame_on_control_stream(&[0x5, 0x2, 0x1, 0x2]);
@@ -836,7 +836,7 @@ mod tests {
     fn test_incomplete_frame(res: &[u8]) {
         let (mut hconn, mut peer_conn) = connect_and_receive_settings();
 
-        // send an incomplete reequest.
+        // send an incomplete request.
         let stream_id = peer_conn.stream_create(StreamType::BiDi).unwrap();
         peer_conn.stream_send(stream_id, res).unwrap();
         peer_conn.stream_close_send(stream_id).unwrap();

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -298,7 +298,7 @@ fn data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::Error>
     exchange_packets(&mut hconn_c, &mut hconn_s, None);
     assert!(hconn_s.events().any(data_writable));
 
-    // Sending more fails, given that each data frame needs to be preceeded by a
+    // Sending more fails, given that each data frame needs to be preceded by a
     // header, i.e. needs more than 1 byte of send space to send 1 byte payload.
     assert_eq!(request.available()?, 1);
     assert_eq!(request.send_data(&buf)?, 0);

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -25,7 +25,7 @@ fn exchange_packets(client: &mut Http3Client, server: &mut Http3Server) {
     }
 }
 
-// Perform only Quic transport handshake.
+// Perform only QUIC transport handshake.
 fn connect_with(client: &mut Http3Client, server: &mut Http3Server) {
     assert_eq!(client.state(), Http3State::Initializing);
     let out = client.process_output(now());
@@ -45,7 +45,7 @@ fn connect_with(client: &mut Http3Client, server: &mut Http3Server) {
     assert!(client.events().any(connected));
 
     assert_eq!(client.state(), Http3State::Connected);
-    // Exchange H3 setttings
+    // Exchange H3 settings
     let out = server.process(out.dgram(), now());
     let out = client.process(out.dgram(), now());
     let out = server.process(out.dgram(), now());

--- a/neqo-http3/tests/webtransport.rs
+++ b/neqo-http3/tests/webtransport.rs
@@ -59,7 +59,7 @@ fn connect() -> (Http3Client, Http3Server) {
 
     assert_eq!(client.state(), Http3State::Connected);
 
-    // Exchange H3 setttings
+    // Exchange H3 settings
     loop {
         out = server.process(out, now()).dgram();
         let dgram_present = out.is_some();

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -203,7 +203,7 @@ impl QPackEncoder {
     }
 
     fn call_instruction(&mut self, instruction: DecoderInstruction, qlog: &NeqoQlog) -> Res<()> {
-        qdebug!([self], "call intruction {:?}", instruction);
+        qdebug!([self], "call instruction {:?}", instruction);
         match instruction {
             DecoderInstruction::InsertCountIncrement { increment } => {
                 qlog::qpack_read_insert_count_increment_instruction(
@@ -891,7 +891,7 @@ mod tests {
         assert!(res.is_ok());
         encoder.send_instructions(HEADER_CONTENT_LENGTH_VALUE_1_NAME_LITERAL);
 
-        // insert "content-length: 12345 which will fail because the ntry in the table cannot be
+        // insert "content-length: 12345 which will fail because the entry in the table cannot be
         // evicted.
         let res =
             encoder
@@ -912,7 +912,7 @@ mod tests {
         encoder.send_instructions(HEADER_CONTENT_LENGTH_VALUE_2_NAME_LITERAL);
     }
 
-    // Test inserts block on waiting for acks
+    // Test inserts block on waiting for ACKs
     // test the table insertion is blocked:
     // 0 - waiting for a header ack
     // 2 - waiting for a stream cancel.
@@ -1220,7 +1220,7 @@ mod tests {
         // receive a header_ack for the first header block.
         recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_1);
 
-        // The stream is not blocking anymore because header ack also acks the instruction.
+        // The stream is not blocking anymore because header ack also ACKs the instruction.
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 0);
     }
 
@@ -1260,7 +1260,7 @@ mod tests {
         // receive a header_ack for the second header block. This will ack the first as well
         recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_2);
 
-        // The stream is not blocking anymore because header ack also acks the instruction.
+        // The stream is not blocking anymore because header ack also ACKs the instruction.
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 0);
     }
 
@@ -1302,7 +1302,7 @@ mod tests {
         // acked. and the second steam will still be blocking.
         recv_instruction(&mut encoder, STREAM_CANCELED_ID_1);
 
-        // The stream is not blocking anymore because header ack also acks the instruction.
+        // The stream is not blocking anymore because header ack also ACKs the instruction.
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 1);
     }
 
@@ -1636,7 +1636,7 @@ mod tests {
                 0x36, 0x04, 0x31, 0x32, 0x33, 0x34
             ]
         );
-        // Also check that ther is no new instruction send by the encoder.
+        // Also check that there is no new instruction send by the encoder.
         assert!(encoder.conn.process_output(now()).dgram().is_none());
     }
 

--- a/neqo-qpack/src/header_block.rs
+++ b/neqo-qpack/src/header_block.rs
@@ -386,7 +386,7 @@ impl<'a> HeaderDecoder<'a> {
     fn read_literal_with_name_ref_dynamic(&mut self, table: &HeaderTable) -> Res<Header> {
         qtrace!(
             [self],
-            "read literal with name reference ot the dynamic table."
+            "read literal with name reference of the dynamic table."
         );
 
         let index = self

--- a/neqo-qpack/src/prefix.rs
+++ b/neqo-qpack/src/prefix.rs
@@ -15,9 +15,9 @@ pub struct Prefix {
 impl Prefix {
     pub fn new(prefix: u8, len: u8) -> Self {
         // len should never be larger than 7.
-        // Most of Prefixes are instantiated as consts bellow. The only place where this
-        // construcrtor is used is in tests and when literals are encoded and the Huffman
-        // bit is added to one of the consts bellow. create_prefix guaranty that all const
+        // Most of Prefixes are instantiated as consts below. The only place where this
+        // constructor is used is in tests and when literals are encoded and the Huffman
+        // bit is added to one of the consts below. create_prefix guaranty that all const
         // have len < 7 so we can safely assert that len is <=7.
         assert!(len <= 7);
         assert!((len == 0) || (prefix & ((1 << (8 - len)) - 1) == 0));

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -156,7 +156,7 @@ pub struct IntReader {
 }
 
 impl IntReader {
-    /// `IntReader` is created by suppling the first byte anf prefix length.
+    /// `IntReader` is created by supplying the first byte and prefix length.
     /// A varint may take only one byte, In that case already the first by has set state to done.
     ///
     /// # Panics
@@ -251,7 +251,7 @@ pub struct LiteralReader {
 
 impl LiteralReader {
     /// Creates `LiteralReader` with the first byte. This constructor is always used
-    /// when a litreral has a prefix.
+    /// when a literal has a prefix.
     /// For literals without a prefix please use the default constructor.
     ///
     /// # Panics

--- a/neqo-qpack/src/stats.rs
+++ b/neqo-qpack/src/stats.rs
@@ -10,7 +10,7 @@
 /// `QPack` statistics
 pub struct Stats {
     pub dynamic_table_inserts: usize,
-    // This is the munber of header blockes that reference the dynamic table.
+    // This is the number of header blocks that reference the dynamic table.
     pub dynamic_table_references: usize,
     pub stream_cancelled_recv: usize,
     pub header_acks_recv: usize,

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -365,7 +365,7 @@ impl HeaderTable {
             let entry = self.get_dynamic(index, self.base, false)?;
             name = entry.name().to_vec();
             value = entry.value().to_vec();
-            qtrace!([self], "dumplicate name={:?} value={:?}", name, value);
+            qtrace!([self], "duplicate name={:?} value={:?}", name, value);
         }
         self.insert(&name, &value)
     }

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -88,7 +88,7 @@ pub trait WindowAdjustment: Display + Debug {
         max_datagram_size: usize,
         now: Instant,
     ) -> usize;
-    /// This function is called when a congestion event has beed detected and it
+    /// This function is called when a congestion event has been detected and it
     /// returns new (decreased) values of `curr_cwnd` and `acked_bytes`.
     /// This value can be very small; the calling code is responsible for ensuring that the
     /// congestion window doesn't drop below the minimum of `CWND_MIN`.

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1699,7 +1699,7 @@ impl Connection {
 
         // Get the next packet number we'll send, for ACK verification.
         // TODO: Once PR #2118 lands, this can move to `input_frame`. For now, it needs to be here,
-        // because we can drop packet number spaces as we parse throught the packet, and if an ACK
+        // because we can drop packet number spaces as we parse through the packet, and if an ACK
         // frame follows a CRYPTO frame that makes us drop a space, we need to know this
         // packet number to verify the ACK against.
         let next_pn = self
@@ -2291,7 +2291,7 @@ impl Connection {
         }
 
         if profile.ack_only(space) {
-            // If we are CC limited we can only send acks!
+            // If we are CC limited we can only send ACKs!
             return (tokens, false, false);
         }
 
@@ -3278,8 +3278,8 @@ impl Connection {
     ///
     /// # Errors
     ///
-    /// `ConnectionState` if the connecton stat does not allow to create streams.
-    /// `StreamLimitError` if we are limiied by server's stream concurence.
+    /// `ConnectionState` if the connection stat does not allow to create streams.
+    /// `StreamLimitError` if we are limited by server's stream concurrence.
     pub fn stream_create(&mut self, st: StreamType) -> Res<StreamId> {
         // Can't make streams while closing, otherwise rely on the stream limits.
         match self.state {
@@ -3548,7 +3548,7 @@ impl Connection {
     /// # Errors
     ///
     /// The function returns `TooMuchData` if the supply buffer is bigger than
-    /// the allowed remote datagram size. The funcion does not check if the
+    /// the allowed remote datagram size. The function does not check if the
     /// datagram can fit into a packet (i.e. MTU limit). This is checked during
     /// creation of an actual packet and the datagram will be dropped if it does
     /// not fit into the packet. The app is encourage to use `max_datagram_size`

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -41,7 +41,7 @@ pub enum PreferredAddressConfig {
     Address(PreferredAddress),
 }
 
-/// `ConnectionParameters` use for setting intitial value for QUIC parameters.
+/// `ConnectionParameters` use for setting initial value for QUIC parameters.
 /// This collects configuration like initial limits, protocol version, and
 /// congestion control algorithm.
 #[allow(clippy::struct_excessive_bools)] // We need that many, sorry.

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -474,7 +474,7 @@ fn keep_alive_lost() {
     assert!(client.process(out, now).dgram().is_none());
 
     // TODO: if we run server.process with current value of now, the server will
-    // return some small timeout for the recovry although it does not have
+    // return some small timeout for the recovery although it does not have
     // any outstanding data. Therefore we call it after AT_LEAST_PTO.
     now += AT_LEAST_PTO;
     assert_idle(&mut server, now, keep_alive_timeout() - AT_LEAST_PTO);
@@ -662,7 +662,7 @@ fn keep_alive_uni() {
     server.stream_keep_alive(stream, true).unwrap();
 }
 
-/// Test a keep-alive ping is send if there are outstading ack-eliciting packets and that
+/// Test a keep-alive ping is send if there are outstanding ack-eliciting packets and that
 /// the connection is closed after the idle timeout passes.
 #[test]
 fn keep_alive_with_ack_eliciting_packet_lost() {
@@ -672,7 +672,7 @@ fn keep_alive_with_ack_eliciting_packet_lost() {
     // + 2pto) After handshake all packets will be lost. The following steps will happen after
     // the handshake:
     //  - data will be sent on a stream that is marked for keep-alive, (at start time)
-    //  - PTO timer will trigger first, and the data will be retransmited toghether with a PING, (at
+    //  - PTO timer will trigger first, and the data will be retransmitted together with a PING, (at
     //    the start time + pto)
     //  - keep-alive timer will trigger and a keep-alive PING will be sent, (at the start time +
     //    IDLE_TIMEOUT / 2)

--- a/neqo-transport/src/connection/tests/priority.rs
+++ b/neqo-transport/src/connection/tests/priority.rs
@@ -208,7 +208,7 @@ fn critical() {
     let now = now();
 
     // Rather than connect, send stream data in 0.5-RTT.
-    // That allows this to test that critical streams pre-empt most frame types.
+    // That allows this to test that critical streams preempt most frame types.
     let dgram = client.process_output(now).dgram();
     let dgram = server.process(dgram, now).dgram();
     client.process_input(dgram.unwrap(), now);
@@ -259,7 +259,7 @@ fn important() {
     let now = now();
 
     // Rather than connect, send stream data in 0.5-RTT.
-    // That allows this to test that important streams pre-empt most frame types.
+    // That allows this to test that important streams preempt most frame types.
     let dgram = client.process_output(now).dgram();
     let dgram = server.process(dgram, now).dgram();
     client.process_input(dgram.unwrap(), now);
@@ -312,7 +312,7 @@ fn high_normal() {
     let now = now();
 
     // Rather than connect, send stream data in 0.5-RTT.
-    // That allows this to test that important streams pre-empt most frame types.
+    // That allows this to test that important streams preempt most frame types.
     let dgram = client.process_output(now).dgram();
     let dgram = server.process(dgram, now).dgram();
     client.process_input(dgram.unwrap(), now);

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -116,7 +116,7 @@ fn transfer() {
     assert!(fin3);
 }
 
-// tests stream sendorder priorization
+// tests stream sendorder prioritization
 fn sendorder_test(order_of_sendorder: &[Option<SendOrder>]) {
     let mut client = default_client();
     let mut server = default_server();
@@ -217,7 +217,7 @@ fn sendorder_4() {
     ]);
 }
 
-// Tests stream sendorder priorization
+// Tests stream sendorder prioritization
 // Converts Vecs of u64's into StreamIds
 fn fairness_test<S, R>(source: S, number_iterates: usize, truncate_to: usize, result_array: &R)
 where
@@ -306,7 +306,7 @@ fn ordergroup_7() {
 }
 
 #[test]
-// Send fin even if a peer closes a reomte bidi send stream before sending any data.
+// Send fin even if a peer closes a remote bidi send stream before sending any data.
 fn report_fin_when_stream_closed_wo_data() {
     // Note that the two servers in this test will get different anti-replay filters.
     // That's OK because we aren't testing anti-replay.
@@ -659,7 +659,7 @@ fn after_stream_stop_sending_is_called_conn_events_for_stream_should_be_removed(
 
     mem::drop(client.process(out, now()));
 
-    // send stop seending.
+    // send stop sending.
     client
         .stream_stop_sending(id, Error::NoError.code())
         .unwrap();

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -86,7 +86,7 @@ const ERROR_AEAD_LIMIT_REACHED: TransportError = 15;
 pub enum Error {
     NoError,
     // Each time this error is returned a different parameter is supplied.
-    // This will be used to distinguish each occurance of this error.
+    // This will be used to distinguish each occurrence of this error.
     InternalError,
     ConnectionRefused,
     FlowControlError,

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -424,7 +424,7 @@ impl Paths {
     #[cfg(test)]
     pub fn rtt(&self) -> Duration {
         // Rather than have this fail when there is no active path,
-        // make a new RTT esimate and interrogate that.
+        // make a new RTT estimate and interrogate that.
         // That is more expensive, but it should be rare and breaking encapsulation
         // is worse, especially as this is only used in tests.
         self.primary().map_or_else(

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -144,7 +144,7 @@ impl QuicDatagrams {
     /// # Error
     ///
     /// The function returns `TooMuchData` if the supply buffer is bigger than
-    /// the allowed remote datagram size. The funcion does not check if the
+    /// the allowed remote datagram size. The function does not check if the
     /// datagram can fit into a packet (i.e. MTU limit). This is checked during
     /// creation of an actual packet and the datagram will be dropped if it does
     /// not fit into the packet.

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -570,7 +570,7 @@ impl RecvStream {
 
         match new_state {
             // Receiving all data, or receiving or requesting RESET_STREAM
-            // is cause to stop keep-alives.
+            // is cause to stop keepalives.
             RecvStreamState::DataRecvd { .. }
             | RecvStreamState::AbortReading { .. }
             | RecvStreamState::ResetRecvd { .. } => {
@@ -1839,7 +1839,7 @@ mod tests {
         assert_eq!(s.read(&mut buf).unwrap(), (1, false));
         check_fc(&fc.borrow(), SW / 4 + 1, SW / 4 + 1);
         check_fc(s.fc().unwrap(), SW / 4 + 1, SW / 4 + 1);
-        // Data are retired and the sttream fc will send an update.
+        // Data are retired and the stream fc will send an update.
         assert!(!fc.borrow().frame_needed());
         assert!(s.fc().unwrap().frame_needed());
 

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -202,7 +202,7 @@ impl Streams {
             }
             Frame::StreamsBlocked { .. } => {
                 stats.streams_blocked += 1;
-                // We send an update evry time we retire a stream. There is no need to
+                // We send an update every time we retire a stream. There is no need to
                 // trigger flow updates here.
             }
             _ => unreachable!("This is not a stream Frame"),
@@ -337,7 +337,7 @@ impl Streams {
         let (removed_bidi, removed_uni) = self.recv.clear_terminal(&self.send, self.role);
 
         // Send max_streams updates if we removed remote-initiated recv streams.
-        // The updates will be send if any steams has been removed.
+        // The updates will be send if any streams has been removed.
         self.remote_stream_limits[StreamType::BiDi].add_retired(removed_bidi);
         self.remote_stream_limits[StreamType::UniDi].add_retired(removed_uni);
     }

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -1055,9 +1055,9 @@ mod tests {
         for i in INTEGER_KEYS {
             let mut tps_b = tps_a.clone();
             tps_b.remove(*i);
-            // A value that is missing from what is rememebered is OK.
+            // A value that is missing from what is remembered is OK.
             assert!(tps_a.ok_for_0rtt(&tps_b));
-            // A value that is rememebered, but not current is not OK.
+            // A value that is remembered, but not current is not OK.
             assert!(!tps_b.ok_for_0rtt(&tps_a));
         }
     }

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Tracking of received packets and generating acks thereof.
+// Tracking of received packets and generating ACKs thereof.
 
 use std::{
     cmp::min,
@@ -158,7 +158,7 @@ impl PacketRange {
         }
     }
 
-    /// Get the number of acknowleged packets in the range.
+    /// Get the number of acknowledged packets in the range.
     pub const fn len(&self) -> u64 {
         self.largest - self.smallest + 1
     }


### PR DESCRIPTION
In comments and strings, fix misspellings found by `codespell` and the vscode checker.