### PR TITLE
deps(Cargo.lock): update to quinn-udp v0.5.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e346e016eacfff12233c243718197ca12f148c84e1e84268a896699b41c71780"
+checksum = "52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527"
 dependencies = [
  "cfg_aliases",
  "libc",


### PR DESCRIPTION
Upstream release:

https://github.com/quinn-rs/quinn/releases/tag/quinn-udp-0.5.8

Downstream patch updating mozilla-central:

https://bugzilla.mozilla.org/show_bug.cgi?id=1935954