### PR TITLE
chore(qlog): Add meaningful qlog titles and descriptions.

### DIFF
--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -508,8 +508,8 @@ fn qlog_new(args: &Args, hostname: &str, cid: &ConnectionId) -> Res<NeqoQlog> {
     NeqoQlog::enabled_with_file(
         qlog_dir,
         Role::Client,
-        Some("Example qlog".to_string()),
-        Some("Example qlog description".to_string()),
+        Some("Neqo client qlog".to_string()),
+        Some("Neqo client qlog".to_string()),
         format!("{hostname}-{cid}"),
     )
     .map_err(Error::QlogError)

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -510,7 +510,7 @@ fn qlog_new(args: &Args, hostname: &str, cid: &ConnectionId) -> Res<NeqoQlog> {
         Role::Client,
         Some("Neqo client qlog".to_string()),
         Some("Neqo client qlog".to_string()),
-        format!("{hostname}-{cid}"),
+        format!("client-{hostname}-{cid}"),
     )
     .map_err(Error::QlogError)
 }

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -186,7 +186,7 @@ pub fn new_trace(role: Role) -> qlog::TraceSeq {
             flow: None,
         },
         title: Some(format!("neqo-{role} trace")),
-        description: Some("Example qlog trace description".to_string()),
+        description: Some(format!("neqo-{role} trace")),
         configuration: Some(Configuration {
             time_offset: Some(0.0),
             original_uris: None,

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -260,7 +260,7 @@ impl Server {
                     Role::Server,
                     Some("Neqo server qlog".to_string()),
                     Some("Neqo server qlog".to_string()),
-                    odcid,
+                    format!("server-{odcid}"),
                 )
                 .unwrap_or_else(|e| {
                     qerror!("failed to create NeqoQlog: {}", e);

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -418,6 +418,6 @@ pub fn new_neqo_qlog() -> (NeqoQlog, SharedVec) {
 
 pub const EXPECTED_LOG_HEADER: &str = concat!(
     "\u{1e}",
-    r#"{"qlog_version":"0.3","qlog_format":"JSON-SEQ","trace":{"vantage_point":{"name":"neqo-Client","type":"client"},"title":"neqo-Client trace","description":"Example qlog trace description","configuration":{"time_offset":0.0},"common_fields":{"reference_time":0.0,"time_format":"relative"}}}"#,
+    r#"{"qlog_version":"0.3","qlog_format":"JSON-SEQ","trace":{"vantage_point":{"name":"neqo-Client","type":"client"},"title":"neqo-Client trace","description":"neqo-Client trace","configuration":{"time_offset":0.0},"common_fields":{"reference_time":0.0,"time_format":"relative"}}}"#,
     "\n"
 );


### PR DESCRIPTION
Hey Hey! 👋 

First time neqo contributor here!
I'm Oskar, working student on the necko team, for those that don't already know me 😄 

@mxinden was showing me qvis the other day and we noticed that description and title were just showing something the likes of `Example qlog [...]`. With this change they now show `Neqo [client|server] qlog`. 

I also added a `server-` prefix to the filename of the server qlogs as I found it hard to understand which was which at first glance, but happy to take that out again if it's not wanted.

I hope these small change are somewhat useful and would appreciate a review and maybe a pointer as to what I could work on next. I'm definitely very interested to work more on neqo! 🙂 

Cheers
Oskar