### PR TITLE
chore: Remove `--use-old-http` command line parameter

### DIFF
--- a/neqo-bin/src/lib.rs
+++ b/neqo-bin/src/lib.rs
@@ -63,10 +63,6 @@ pub struct SharedArgs {
     /// Enable special behavior for use with QUIC Network Simulator
     pub qns_test: Option<String>,
 
-    #[arg(name = "use-old-http", short = 'o', long)]
-    /// Use http 0.9 instead of HTTP/3
-    pub use_old_http: bool,
-
     #[command(flatten)]
     pub quic_parameters: QuicParameters,
 }
@@ -83,7 +79,6 @@ impl Default for SharedArgs {
             max_blocked_streams: 10,
             ciphers: vec![],
             qns_test: None,
-            use_old_http: false,
             quic_parameters: QuicParameters::default(),
         }
     }

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -411,11 +411,11 @@ pub async fn server(mut args: Args) -> Res<()> {
     let cid_mgr = Rc::new(RefCell::new(RandomConnectionIdGenerator::new(10)));
 
     let server: Box<dyn HttpServer> = if args.shared.alpn == "h3" {
+        Box::new(http3::HttpServer::new(&args, anti_replay, cid_mgr))
+    } else {
         Box::new(
             http09::HttpServer::new(&args, anti_replay, cid_mgr).expect("We cannot make a server!"),
         )
-    } else {
-        Box::new(http3::HttpServer::new(&args, anti_replay, cid_mgr))
     };
 
     ServerRunner::new(Box::new(move || args.now()), server, sockets)

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -341,8 +341,6 @@ enum Ready {
 }
 
 pub async fn server(mut args: Args) -> Res<()> {
-    const HQ_INTEROP: &str = "hq-interop";
-
     neqo_common::log::init(
         args.shared
             .verbose
@@ -366,13 +364,11 @@ pub async fn server(mut args: Args) -> Res<()> {
         }
 
         // These are the default for all tests except http3.
-        args.shared.use_old_http = true;
-        args.shared.alpn = String::from(HQ_INTEROP);
+        args.shared.alpn = String::from("hq-interop");
         // TODO: More options to deduplicate with client?
         match testcase.as_str() {
             "http3" => {
-                args.shared.use_old_http = false;
-                args.shared.alpn = "h3".into();
+                args.shared.alpn = String::from("h3");
             }
             "zerortt" => args.shared.quic_parameters.max_streams_bidi = 100,
             "handshake" | "transfer" | "resumption" | "multiconnect" | "v2" | "ecn" => {}
@@ -414,7 +410,7 @@ pub async fn server(mut args: Args) -> Res<()> {
         .expect("unable to setup anti-replay");
     let cid_mgr = Rc::new(RefCell::new(RandomConnectionIdGenerator::new(10)));
 
-    let server: Box<dyn HttpServer> = if args.shared.use_old_http {
+    let server: Box<dyn HttpServer> = if args.shared.alpn == "h3" {
         Box::new(
             http09::HttpServer::new(&args, anti_replay, cid_mgr).expect("We cannot make a server!"),
         )

--- a/test/test.sh
+++ b/test/test.sh
@@ -16,7 +16,7 @@ cargo build --bin neqo-client --bin neqo-server
 addr=localhost
 port=4433
 path=/20000
-flags="--verbose --verbose --verbose --qlog-dir $tmp --use-old-http --alpn hq-interop --quic-version 1"
+flags="--verbose --verbose --verbose --qlog-dir $tmp --alpn hq-interop --quic-version 1"
 if [ "$(uname -s)" != "Linux" ]; then
         iface=lo0
 else


### PR DESCRIPTION
It's redundant with `--alpn`.

Fixes #698