### PR TITLE
ci: Pin `cargo-quickinstall` to 0.3.5

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -67,7 +67,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       # TODO: Unpin cargo-quickinstall once our MSRV is > 1.76
-      run: cargo +${{ inputs.version }} install cargo-quickinstall@0.3.4
+      run: cargo +${{ inputs.version }} install --locked cargo-quickinstall@0.3.5
 
     - name: Install Rust tools
       shell: bash

--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -67,7 +67,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       # TODO: Unpin cargo-quickinstall once our MSRV is > 1.76
-      run: cargo +${{ inputs.version }} install cargo-quickinstall@0.3.5
+      run: cargo +${{ inputs.version }} install cargo-quickinstall@0.3.4
 
     - name: Install Rust tools
       shell: bash

--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -66,7 +66,8 @@ runs:
       if: inputs.tools != ''
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
-      run: cargo +${{ inputs.version }} install cargo-quickinstall
+      # TODO: Unpin cargo-quickinstall once our MSRV is > 1.76
+      run: cargo +${{ inputs.version }} install cargo-quickinstall@0.3.5
 
     - name: Install Rust tools
       shell: bash


### PR DESCRIPTION
Because newer versions have an MSRV > 1.76.