### PR TITLE
deps: update quinn-udp to v0.5.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527"
+checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
 dependencies = [
  "cfg_aliases",
  "libc",


### PR DESCRIPTION
Corresponding mozilla-central patch: https://phabricator.services.mozilla.com/D232475