### PR TITLE
ci(sanitize): ignore leak in std::rt::lang_start_internal

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -72,6 +72,7 @@ jobs:
             {
               echo "leak:dyld4::RuntimeState"
               echo "leak:fetchInitializingClassList"
+              echo "leak:std::rt::lang_start_internal"
             } > suppressions.txt
             PWD=$(pwd)
             export LSAN_OPTIONS="suppressions=$PWD/suppressions.txt"


### PR DESCRIPTION
See for example CI failure:

https://github.com/mozilla/neqo/actions/runs/12463815686/job/34786831894?pr=2300