### PR TITLE
docs(transport): remove obsolete comment

### DIFF
--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -752,7 +752,6 @@ impl RecvStream {
         Ok(())
     }
 
-    /// If we should tell the sender they have more credit, return an offset
     fn flow_control_retire_data(
         new_read: u64,
         fc: &mut ReceiverFlowControl<StreamId>,


### PR DESCRIPTION
Doc comment describes return value, but function doesn't return anything.