### PR TITLE
fix(qpack): make `can_evict_to` iter all evictable entries 

### DIFF
--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -290,7 +290,7 @@ impl QPackEncoder {
         stream_id: StreamId,
     ) -> Res<()> {
         if let Some(cap) = self.next_capacity {
-            // Check if it is possible to reduce the capacity, e.g. if enough space can be make free
+            // Check if it is possible to reduce the capacity, e.g. if enough space can be made free
             // for the reduction.
             if cap < self.table.capacity() && !self.table.can_evict_to(cap) {
                 return Err(Error::DynamicTableFull);

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -113,8 +113,8 @@ impl HeaderTable {
     /// # Errors
     ///
     /// [`Error::ChangeCapacity`] if table capacity cannot be reduced.
-    /// The table cannot be reduced if there are entries that are referred at
-    /// the moment or their inserts are unacked.
+    /// The table cannot be reduced if there are entries that are referred to at
+    /// the moment, or whose inserts are unacked.
     pub fn set_capacity(&mut self, cap: u64) -> Res<()> {
         qtrace!([self], "set capacity to {}", cap);
         if !self.evict_to(cap) {

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -73,7 +73,7 @@ pub struct HeaderTable {
     /// The total number of inserts thus far.
     base: u64,
     /// This is number of inserts that are acked. this correspond to index of the first not acked.
-    /// This is only used by thee encoder.
+    /// This is only used by the encoder.
     acked_inserts_cnt: u64,
 }
 
@@ -112,9 +112,9 @@ impl HeaderTable {
     ///
     /// # Errors
     ///
-    /// `ChangeCapacity` if table capacity cannot be reduced.
-    /// The table cannot be reduce if there are entries that are referred at the moment or their
-    /// inserts are unacked.
+    /// [`Error::ChangeCapacity`] if table capacity cannot be reduced.
+    /// The table cannot be reduced if there are entries that are referred at
+    /// the moment or their inserts are unacked.
     pub fn set_capacity(&mut self, cap: u64) -> Res<()> {
         qtrace!([self], "set capacity to {}", cap);
         if !self.evict_to(cap) {


### PR DESCRIPTION
Previously we had `evict_to` and `can_evict_to`, where the former would actually evict values, whereas the latter would only check how much could be evicted. Both would delegate to `evict_to_internal`.

In the case of `evict_to`, `evict_to_internal` would look at the last entry, and evict it if possible, then repeat.

In the case of `can_evict_to`, `evict_to_internal` would look at the last value as well, and then repeat, but not actualy evict, thus continuously looking at the last entry, instead of all evictable entries.

This commit fixes `can_evict_to` by making it look at all evictable entries.

---

Partially fix https://github.com/mozilla/neqo/issues/2306.