### PR TITLE
chore(transport): Remove `module_name_repetitions`

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -38,7 +38,7 @@ use crate::{
         ConnectionIdRef, ConnectionIdStore, LOCAL_ACTIVE_CID_LIMIT,
     },
     crypto::{Crypto, CryptoDxState, CryptoSpace},
-    ecn::Count,
+    ecn,
     events::{ConnectionEvent, ConnectionEvents, OutgoingDatagramOutcome},
     frame::{
         CloseError, Frame, FrameType, FRAME_TYPE_CONNECTION_CLOSE_APPLICATION,
@@ -3136,7 +3136,7 @@ impl Connection {
         &mut self,
         space: PacketNumberSpace,
         ack_ranges: R,
-        ack_ecn: Option<Count>,
+        ack_ecn: Option<ecn::Count>,
         ack_delay: u64,
         now: Instant,
     ) where

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -6,6 +6,8 @@
 
 // The class implementing a QUIC connection.
 
+#![allow(clippy::module_name_repetitions)]
+
 use std::{
     cell::RefCell,
     cmp::{max, min},

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -36,7 +36,7 @@ use crate::{
         ConnectionIdRef, ConnectionIdStore, LOCAL_ACTIVE_CID_LIMIT,
     },
     crypto::{Crypto, CryptoDxState, CryptoSpace},
-    ecn::EcnCount,
+    ecn::Count,
     events::{ConnectionEvent, ConnectionEvents, OutgoingDatagramOutcome},
     frame::{
         CloseError, Frame, FrameType, FRAME_TYPE_CONNECTION_CLOSE_APPLICATION,
@@ -3134,7 +3134,7 @@ impl Connection {
         &mut self,
         space: PacketNumberSpace,
         ack_ranges: R,
-        ack_ecn: Option<EcnCount>,
+        ack_ecn: Option<Count>,
         ack_delay: u64,
         now: Instant,
     ) where

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -143,12 +143,12 @@ fn stats() {
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
 
-    for _ in 0..ecn::ECN_TEST_COUNT {
+    for _ in 0..ecn::TEST_COUNT {
         let ack = send_and_receive(&mut client, &mut server, now);
         client.process_input(ack.unwrap(), now);
     }
 
-    for _ in 0..ecn::ECN_TEST_COUNT {
+    for _ in 0..ecn::TEST_COUNT {
         let ack = send_and_receive(&mut server, &mut client, now);
         server.process_input(ack.unwrap(), now);
     }
@@ -182,7 +182,7 @@ fn disables_on_loss() {
     let client_pkt = send_something(&mut client, now);
     assert_ecn_enabled(client_pkt.tos());
 
-    for _ in 0..ecn::ECN_TEST_COUNT {
+    for _ in 0..ecn::TEST_COUNT {
         send_something(&mut client, now);
     }
 
@@ -198,7 +198,7 @@ fn disables_on_remark() {
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
 
-    for _ in 0..ecn::ECN_TEST_COUNT {
+    for _ in 0..ecn::TEST_COUNT {
         if let Some(ack) = send_with_modifier_and_receive(&mut client, &mut server, now, remark()) {
             client.process_input(ack, now);
         }
@@ -373,7 +373,7 @@ fn ecn_migration_zero_burst_all_cases() {
 
 #[test]
 fn ecn_migration_noop_bleach_data() {
-    let (before, after, migrated) = migration_with_modifiers(noop(), bleach(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(noop(), bleach(), ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration.
     assert_ecn_disabled(after); // ECN validation fails after migration due to bleaching.
     assert!(migrated);
@@ -381,7 +381,7 @@ fn ecn_migration_noop_bleach_data() {
 
 #[test]
 fn ecn_migration_noop_remark_data() {
-    let (before, after, migrated) = migration_with_modifiers(noop(), remark(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(noop(), remark(), ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration.
     assert_ecn_disabled(after); // ECN validation fails after migration due to remarking.
     assert!(migrated);
@@ -389,7 +389,7 @@ fn ecn_migration_noop_remark_data() {
 
 #[test]
 fn ecn_migration_noop_ce_data() {
-    let (before, after, migrated) = migration_with_modifiers(noop(), ce(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(noop(), ce(), ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration.
     assert_ecn_enabled(after); // ECN validation concludes after migration, despite all CE marks.
     assert!(migrated);
@@ -397,7 +397,7 @@ fn ecn_migration_noop_ce_data() {
 
 #[test]
 fn ecn_migration_noop_drop_data() {
-    let (before, after, migrated) = migration_with_modifiers(noop(), drop(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(noop(), drop(), ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration.
     assert_ecn_enabled(after); // Migration failed, ECN on original path is still validated.
     assert!(!migrated);
@@ -405,7 +405,7 @@ fn ecn_migration_noop_drop_data() {
 
 #[test]
 fn ecn_migration_bleach_noop_data() {
-    let (before, after, migrated) = migration_with_modifiers(bleach(), noop(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(bleach(), noop(), ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
     assert_ecn_enabled(after); // ECN validation concludes after migration.
     assert!(migrated);
@@ -413,8 +413,7 @@ fn ecn_migration_bleach_noop_data() {
 
 #[test]
 fn ecn_migration_bleach_bleach_data() {
-    let (before, after, migrated) =
-        migration_with_modifiers(bleach(), bleach(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(bleach(), bleach(), ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
     assert_ecn_disabled(after); // ECN validation fails after migration due to bleaching.
     assert!(migrated);
@@ -422,8 +421,7 @@ fn ecn_migration_bleach_bleach_data() {
 
 #[test]
 fn ecn_migration_bleach_remark_data() {
-    let (before, after, migrated) =
-        migration_with_modifiers(bleach(), remark(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(bleach(), remark(), ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
     assert_ecn_disabled(after); // ECN validation fails after migration due to remarking.
     assert!(migrated);
@@ -431,7 +429,7 @@ fn ecn_migration_bleach_remark_data() {
 
 #[test]
 fn ecn_migration_bleach_ce_data() {
-    let (before, after, migrated) = migration_with_modifiers(bleach(), ce(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(bleach(), ce(), ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
     assert_ecn_enabled(after); // ECN validation concludes after migration, despite all CE marks.
     assert!(migrated);
@@ -439,7 +437,7 @@ fn ecn_migration_bleach_ce_data() {
 
 #[test]
 fn ecn_migration_bleach_drop_data() {
-    let (before, after, migrated) = migration_with_modifiers(bleach(), drop(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(bleach(), drop(), ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
                                  // Migration failed, ECN on original path is still disabled.
     assert_ecn_disabled(after);
@@ -448,7 +446,7 @@ fn ecn_migration_bleach_drop_data() {
 
 #[test]
 fn ecn_migration_remark_noop_data() {
-    let (before, after, migrated) = migration_with_modifiers(remark(), noop(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(remark(), noop(), ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_enabled(after); // ECN validation succeeds after migration.
     assert!(migrated);
@@ -456,8 +454,7 @@ fn ecn_migration_remark_noop_data() {
 
 #[test]
 fn ecn_migration_remark_bleach_data() {
-    let (before, after, migrated) =
-        migration_with_modifiers(remark(), bleach(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(remark(), bleach(), ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_disabled(after); // ECN validation fails after migration due to bleaching.
     assert!(migrated);
@@ -465,8 +462,7 @@ fn ecn_migration_remark_bleach_data() {
 
 #[test]
 fn ecn_migration_remark_remark_data() {
-    let (before, after, migrated) =
-        migration_with_modifiers(remark(), remark(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(remark(), remark(), ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_disabled(after); // ECN validation fails after migration due to remarking.
     assert!(migrated);
@@ -474,7 +470,7 @@ fn ecn_migration_remark_remark_data() {
 
 #[test]
 fn ecn_migration_remark_ce_data() {
-    let (before, after, migrated) = migration_with_modifiers(remark(), ce(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(remark(), ce(), ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_enabled(after); // ECN validation concludes after migration, despite all CE marks.
     assert!(migrated);
@@ -482,7 +478,7 @@ fn ecn_migration_remark_ce_data() {
 
 #[test]
 fn ecn_migration_remark_drop_data() {
-    let (before, after, migrated) = migration_with_modifiers(remark(), drop(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(remark(), drop(), ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_disabled(after); // Migration failed, ECN on original path is still disabled.
     assert!(!migrated);
@@ -490,7 +486,7 @@ fn ecn_migration_remark_drop_data() {
 
 #[test]
 fn ecn_migration_ce_noop_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce(), noop(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce(), noop(), ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
     assert_ecn_enabled(after); // ECN validation concludes after migration.
     assert!(migrated);
@@ -498,7 +494,7 @@ fn ecn_migration_ce_noop_data() {
 
 #[test]
 fn ecn_migration_ce_bleach_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce(), bleach(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce(), bleach(), ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
     assert_ecn_disabled(after); // ECN validation fails after migration due to bleaching
     assert!(migrated);
@@ -506,7 +502,7 @@ fn ecn_migration_ce_bleach_data() {
 
 #[test]
 fn ecn_migration_ce_remark_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce(), remark(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce(), remark(), ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
     assert_ecn_disabled(after); // ECN validation fails after migration due to remarking.
     assert!(migrated);
@@ -514,7 +510,7 @@ fn ecn_migration_ce_remark_data() {
 
 #[test]
 fn ecn_migration_ce_ce_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce(), ce(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce(), ce(), ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
     assert_ecn_enabled(after); // ECN validation concludes after migration, despite all CE marks.
     assert!(migrated);
@@ -522,7 +518,7 @@ fn ecn_migration_ce_ce_data() {
 
 #[test]
 fn ecn_migration_ce_drop_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce(), drop(), ecn::ECN_TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce(), drop(), ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
                                 // Migration failed, ECN on original path is still enabled.
     assert_ecn_enabled(after);

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -19,7 +19,7 @@ use crate::{
         new_server, send_and_receive, send_something, send_something_with_modifier,
         send_with_modifier_and_receive, DEFAULT_RTT,
     },
-    ecn::{EcnValidationOutcome, ECN_TEST_COUNT},
+    ecn::{ValidationOutcome, ECN_TEST_COUNT},
     path::MAX_PATH_PROBES,
     ConnectionId, ConnectionParameters, StreamType,
 };
@@ -156,8 +156,8 @@ fn stats() {
     for stats in [client.stats(), server.stats()] {
         for (outcome, count) in stats.ecn_path_validation.iter() {
             match outcome {
-                EcnValidationOutcome::Capable => assert_eq!(*count, 1),
-                EcnValidationOutcome::NotCapable(_) => assert_eq!(*count, 0),
+                ValidationOutcome::Capable => assert_eq!(*count, 1),
+                ValidationOutcome::NotCapable(_) => assert_eq!(*count, 0),
             }
         }
 

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(clippy::module_name_repetitions)]
+
 use std::{
     cell::RefCell,
     cmp::{max, min},

--- a/neqo-transport/src/ecn.rs
+++ b/neqo-transport/src/ecn.rs
@@ -16,13 +16,13 @@ use crate::{
 };
 
 /// The number of packets to use for testing a path for ECN capability.
-pub const ECN_TEST_COUNT: usize = 10;
+pub const TEST_COUNT: usize = 10;
 
 /// The number of packets to use for testing a path for ECN capability when exchanging
-/// Initials during the handshake. This is a lower number than [`ECN_TEST_COUNT`] to avoid
-/// unnecessarily delaying the handshake; we would otherwise double the PTO [`ECN_TEST_COUNT`]
+/// Initials during the handshake. This is a lower number than [`TEST_COUNT`] to avoid
+/// unnecessarily delaying the handshake; we would otherwise double the PTO [`TEST_COUNT`]
 /// times.
-const ECN_TEST_COUNT_INITIAL_PHASE: usize = 3;
+const TEST_COUNT_INITIAL_PHASE: usize = 3;
 
 /// The state information related to testing a path for ECN capability.
 /// See RFC9000, Appendix A.4.
@@ -181,14 +181,14 @@ impl Info {
     }
 
     /// Count the number of packets sent out on this path during ECN validation.
-    /// Exit ECN validation if the number of packets sent exceeds `ECN_TEST_COUNT`.
+    /// Exit ECN validation if the number of packets sent exceeds `TEST_COUNT`.
     /// We do not implement the part of the RFC that says to exit ECN validation if the time since
     /// the start of ECN validation exceeds 3 * PTO, since this seems to happen much too quickly.
     pub fn on_packet_sent(&mut self, stats: &mut Stats) {
         if let ValidationState::Testing { probes_sent, .. } = &mut self.state {
             *probes_sent += 1;
             qdebug!("ECN probing: sent {} probes", probes_sent);
-            if *probes_sent == ECN_TEST_COUNT {
+            if *probes_sent == TEST_COUNT {
                 qdebug!("ECN probing concluded with {} probes sent", probes_sent);
                 self.state.set(ValidationState::Unknown, stats);
             }
@@ -229,7 +229,7 @@ impl Info {
                 .count();
             // If we have lost all initial probes a bunch of times, we can conclude that the path
             // is not ECN capable and likely drops all ECN marked packets.
-            if probes_sent == probes_lost && *probes_lost == ECN_TEST_COUNT_INITIAL_PHASE {
+            if probes_sent == probes_lost && *probes_lost == TEST_COUNT_INITIAL_PHASE {
                 qdebug!(
                     "ECN validation failed, all {} initial marked packets were lost",
                     probes_lost

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -12,7 +12,7 @@ use neqo_common::{qtrace, Decoder, Encoder};
 
 use crate::{
     cid::MAX_CONNECTION_ID_LEN,
-    ecn::Count,
+    ecn,
     packet::PacketType,
     stream_id::{StreamId, StreamType},
     AppError, CloseReason, Error, Res, TransportError,
@@ -119,7 +119,7 @@ pub enum Frame<'a> {
         ack_delay: u64,
         first_ack_range: u64,
         ack_ranges: Vec<AckRange>,
-        ecn_count: Option<Count>,
+        ecn_count: Option<ecn::Count>,
     },
     ResetStream {
         stream_id: StreamId,
@@ -452,7 +452,7 @@ impl<'a> Frame<'a> {
 
             // Now check for the values for ACK_ECN.
             let ecn_count = if ecn {
-                Some(Count::new(0, dv(dec)?, dv(dec)?, dv(dec)?))
+                Some(ecn::Count::new(0, dv(dec)?, dv(dec)?, dv(dec)?))
             } else {
                 None
             };

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -452,7 +452,9 @@ impl<'a> Frame<'a> {
 
             // Now check for the values for ACK_ECN.
             let ecn_count = ecn
-                .then(|| -> Res<ecn::Count> { Ok(ecn::Count::new(0, dv(dec)?, dv(dec)?, dv(dec)?)) })
+                .then(|| -> Res<ecn::Count> {
+                    Ok(ecn::Count::new(0, dv(dec)?, dv(dec)?, dv(dec)?))
+                })
                 .transpose()?;
 
             Ok(Frame::Ack {

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -12,7 +12,7 @@ use neqo_common::{qtrace, Decoder, Encoder};
 
 use crate::{
     cid::MAX_CONNECTION_ID_LEN,
-    ecn::EcnCount,
+    ecn::Count,
     packet::PacketType,
     stream_id::{StreamId, StreamType},
     AppError, CloseReason, Error, Res, TransportError,
@@ -119,7 +119,7 @@ pub enum Frame<'a> {
         ack_delay: u64,
         first_ack_range: u64,
         ack_ranges: Vec<AckRange>,
-        ecn_count: Option<EcnCount>,
+        ecn_count: Option<Count>,
     },
     ResetStream {
         stream_id: StreamId,
@@ -452,7 +452,7 @@ impl<'a> Frame<'a> {
 
             // Now check for the values for ACK_ECN.
             let ecn_count = if ecn {
-                Some(EcnCount::new(0, dv(dec)?, dv(dec)?, dv(dec)?))
+                Some(Count::new(0, dv(dec)?, dv(dec)?, dv(dec)?))
             } else {
                 None
             };
@@ -665,7 +665,7 @@ mod tests {
 
     use crate::{
         cid::MAX_CONNECTION_ID_LEN,
-        ecn::EcnCount,
+        ecn::Count,
         frame::{AckRange, Frame, FRAME_TYPE_ACK},
         CloseError, Error, StreamId, StreamType,
     };
@@ -710,7 +710,7 @@ mod tests {
         assert_eq!(Frame::decode(&mut dec).unwrap_err(), Error::NoMoreData);
 
         // Try to parse ACK_ECN with ECN values
-        let ecn_count = Some(EcnCount::new(0, 1, 2, 3));
+        let ecn_count = Some(Count::new(0, 1, 2, 3));
         let fe = Frame::Ack {
             largest_acknowledged: 0x1234,
             ack_delay: 0x1235,

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(clippy::module_name_repetitions)] // This lint doesn't work here.
-
 use neqo_common::qwarn;
 use neqo_crypto::Error as CryptoError;
 

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(clippy::module_name_repetitions)]
+
 // Encoding and decoding packets off the wire.
 use std::{
     cmp::min,

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -24,7 +24,7 @@ use crate::{
     ackrate::{AckRate, PeerAckDelay},
     cc::CongestionControlAlgorithm,
     cid::{ConnectionId, ConnectionIdRef, ConnectionIdStore, RemoteConnectionIdEntry},
-    ecn::{Count, Info},
+    ecn,
     frame::{FRAME_TYPE_PATH_CHALLENGE, FRAME_TYPE_PATH_RESPONSE, FRAME_TYPE_RETIRE_CONNECTION_ID},
     packet::PacketBuilder,
     pmtud::Pmtud,
@@ -200,7 +200,7 @@ impl Paths {
     ) -> bool {
         debug_assert!(!self.is_temporary(path));
         let baseline = self.primary().map_or_else(
-            || Info::default().baseline(),
+            || ecn::Info::default().baseline(),
             |p| p.borrow().ecn_info.baseline(),
         );
         path.borrow_mut().set_ecn_baseline(baseline);
@@ -519,7 +519,7 @@ pub struct Path {
     /// The number of bytes sent on this path.
     sent_bytes: usize,
     /// The ECN-related state for this path (see RFC9000, Section 13.4 and Appendix A.4)
-    ecn_info: Info,
+    ecn_info: ecn::Info,
     /// For logging of events.
     qlog: NeqoQlog,
 }
@@ -562,12 +562,12 @@ impl Path {
             sender,
             received_bytes: 0,
             sent_bytes: 0,
-            ecn_info: Info::default(),
+            ecn_info: ecn::Info::default(),
             qlog,
         }
     }
 
-    pub fn set_ecn_baseline(&mut self, baseline: Count) {
+    pub fn set_ecn_baseline(&mut self, baseline: ecn::Count) {
         self.ecn_info.set_baseline(baseline);
     }
 
@@ -971,7 +971,7 @@ impl Path {
     pub fn on_packets_acked(
         &mut self,
         acked_pkts: &[SentPacket],
-        ack_ecn: Option<Count>,
+        ack_ecn: Option<ecn::Count>,
         now: Instant,
         stats: &mut Stats,
     ) {

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -24,7 +24,7 @@ use crate::{
     ackrate::{AckRate, PeerAckDelay},
     cc::CongestionControlAlgorithm,
     cid::{ConnectionId, ConnectionIdRef, ConnectionIdStore, RemoteConnectionIdEntry},
-    ecn::{EcnCount, EcnInfo},
+    ecn::{Count, Info},
     frame::{FRAME_TYPE_PATH_CHALLENGE, FRAME_TYPE_PATH_RESPONSE, FRAME_TYPE_RETIRE_CONNECTION_ID},
     packet::PacketBuilder,
     pmtud::Pmtud,
@@ -200,7 +200,7 @@ impl Paths {
     ) -> bool {
         debug_assert!(!self.is_temporary(path));
         let baseline = self.primary().map_or_else(
-            || EcnInfo::default().baseline(),
+            || Info::default().baseline(),
             |p| p.borrow().ecn_info.baseline(),
         );
         path.borrow_mut().set_ecn_baseline(baseline);
@@ -519,7 +519,7 @@ pub struct Path {
     /// The number of bytes sent on this path.
     sent_bytes: usize,
     /// The ECN-related state for this path (see RFC9000, Section 13.4 and Appendix A.4)
-    ecn_info: EcnInfo,
+    ecn_info: Info,
     /// For logging of events.
     qlog: NeqoQlog,
 }
@@ -562,12 +562,12 @@ impl Path {
             sender,
             received_bytes: 0,
             sent_bytes: 0,
-            ecn_info: EcnInfo::default(),
+            ecn_info: Info::default(),
             qlog,
         }
     }
 
-    pub fn set_ecn_baseline(&mut self, baseline: EcnCount) {
+    pub fn set_ecn_baseline(&mut self, baseline: Count) {
         self.ecn_info.set_baseline(baseline);
     }
 
@@ -688,7 +688,7 @@ impl Path {
 
     /// Make a datagram.
     pub fn datagram<V: Into<Vec<u8>>>(&mut self, payload: V, stats: &mut Stats) -> Datagram {
-        // Make sure to use the TOS value from before calling EcnInfo::on_packet_sent, which may
+        // Make sure to use the TOS value from before calling ecn::Info::on_packet_sent, which may
         // update the ECN state and can hence change it - this packet should still be sent
         // with the current value.
         let tos = self.tos();
@@ -752,7 +752,7 @@ impl Path {
                     "Possible ECN blackhole, disabling ECN and re-probing path"
                 );
                 self.ecn_info
-                    .disable_ecn(stats, crate::ecn::EcnValidationError::BlackHole);
+                    .disable_ecn(stats, crate::ecn::ValidationError::BlackHole);
                 ProbeState::ProbeNeeded { probe_count: 0 }
             } else {
                 qinfo!([self], "Probing failed");
@@ -971,7 +971,7 @@ impl Path {
     pub fn on_packets_acked(
         &mut self,
         acked_pkts: &[SentPacket],
-        ack_ecn: Option<EcnCount>,
+        ack_ecn: Option<Count>,
         now: Instant,
         stats: &mut Stats,
     ) {

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -6,6 +6,8 @@
 
 // Functions that handle capturing QLOG traces.
 
+#![allow(clippy::module_name_repetitions)]
+
 use std::{
     ops::{Deref, RangeInclusive},
     time::{Duration, Instant},

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -26,7 +26,7 @@ use sent::SentPackets;
 pub use token::{RecoveryToken, StreamRecoveryToken};
 
 use crate::{
-    ecn::EcnCount,
+    ecn::Count,
     packet::PacketNumber,
     path::{Path, PathRef},
     qlog::{self, QlogMetric},
@@ -608,7 +608,7 @@ impl LossRecovery {
         primary_path: &PathRef,
         pn_space: PacketNumberSpace,
         acked_ranges: R,
-        ack_ecn: Option<EcnCount>,
+        ack_ecn: Option<Count>,
         ack_delay: Duration,
         now: Instant,
     ) -> (Vec<SentPacket>, Vec<SentPacket>)
@@ -986,7 +986,7 @@ mod tests {
     use crate::{
         cc::CongestionControlAlgorithm,
         cid::{ConnectionId, ConnectionIdEntry},
-        ecn::EcnCount,
+        ecn::Count,
         packet::{PacketNumber, PacketType},
         path::{Path, PathRef},
         stats::{Stats, StatsCell},
@@ -1014,7 +1014,7 @@ mod tests {
             &mut self,
             pn_space: PacketNumberSpace,
             acked_ranges: Vec<RangeInclusive<PacketNumber>>,
-            ack_ecn: Option<EcnCount>,
+            ack_ecn: Option<Count>,
             ack_delay: Duration,
             now: Instant,
         ) -> (Vec<SentPacket>, Vec<SentPacket>) {

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -6,6 +6,8 @@
 
 // Tracking of sent packets and detecting their loss.
 
+#![allow(clippy::module_name_repetitions)]
+
 #[cfg(feature = "bench")]
 pub mod sent;
 #[cfg(not(feature = "bench"))]

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -28,7 +28,7 @@ use sent::SentPackets;
 pub use token::{RecoveryToken, StreamRecoveryToken};
 
 use crate::{
-    ecn::Count,
+    ecn,
     packet::PacketNumber,
     path::{Path, PathRef},
     qlog::{self, QlogMetric},
@@ -610,7 +610,7 @@ impl LossRecovery {
         primary_path: &PathRef,
         pn_space: PacketNumberSpace,
         acked_ranges: R,
-        ack_ecn: Option<Count>,
+        ack_ecn: Option<ecn::Count>,
         ack_delay: Duration,
         now: Instant,
     ) -> (Vec<SentPacket>, Vec<SentPacket>)
@@ -988,7 +988,7 @@ mod tests {
     use crate::{
         cc::CongestionControlAlgorithm,
         cid::{ConnectionId, ConnectionIdEntry},
-        ecn::Count,
+        ecn,
         packet::{PacketNumber, PacketType},
         path::{Path, PathRef},
         stats::{Stats, StatsCell},
@@ -1016,7 +1016,7 @@ mod tests {
             &mut self,
             pn_space: PacketNumberSpace,
             acked_ranges: Vec<RangeInclusive<PacketNumber>>,
-            ack_ecn: Option<Count>,
+            ack_ecn: Option<ecn::Count>,
             ack_delay: Duration,
             now: Instant,
         ) -> (Vec<SentPacket>, Vec<SentPacket>) {

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -7,6 +7,8 @@
 // Building a stream of ordered bytes to give the application from a series of
 // incoming STREAM frames.
 
+#![allow(clippy::module_name_repetitions)]
+
 use std::{
     cell::RefCell,
     cmp::max,

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -6,6 +6,8 @@
 
 // Tracking of sent packets and detecting their loss.
 
+#![allow(clippy::module_name_repetitions)]
+
 use std::{
     cmp::{max, min},
     time::{Duration, Instant},

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -6,6 +6,8 @@
 
 // Buffering data to send until it is acked.
 
+#![allow(clippy::module_name_repetitions)]
+
 use std::{
     cell::RefCell,
     cmp::{max, min, Ordering},

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -16,10 +16,7 @@ use std::{
 
 use neqo_common::qwarn;
 
-use crate::{
-    ecn::{Count, ValidationCount},
-    packet::PacketNumber,
-};
+use crate::{ecn, packet::PacketNumber};
 
 pub const MAX_PTO_COUNTS: usize = 16;
 
@@ -202,7 +199,7 @@ pub struct Stats {
     pub datagram_tx: DatagramStats,
 
     /// ECN path validation count, indexed by validation outcome.
-    pub ecn_path_validation: ValidationCount,
+    pub ecn_path_validation: ecn::ValidationCount,
     /// ECN counts for outgoing UDP datagrams, returned by remote through QUIC ACKs.
     ///
     /// Note: Given that QUIC ACKs only carry [`Ect0`], [`Ect1`] and [`Ce`], but
@@ -214,9 +211,9 @@ pub struct Stats {
     /// [`Ect1`]: neqo_common::tos::IpTosEcn::Ect1
     /// [`Ce`]: neqo_common::tos::IpTosEcn::Ce
     /// [`NotEct`]: neqo_common::tos::IpTosEcn::NotEct
-    pub ecn_tx: Count,
+    pub ecn_tx: ecn::Count,
     /// ECN counts for incoming UDP datagrams, read from IP TOS header.
-    pub ecn_rx: Count,
+    pub ecn_rx: ecn::Count,
 }
 
 impl Stats {

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -17,7 +17,7 @@ use std::{
 use neqo_common::qwarn;
 
 use crate::{
-    ecn::{EcnCount, EcnValidationCount},
+    ecn::{Count, ValidationCount},
     packet::PacketNumber,
 };
 
@@ -202,7 +202,7 @@ pub struct Stats {
     pub datagram_tx: DatagramStats,
 
     /// ECN path validation count, indexed by validation outcome.
-    pub ecn_path_validation: EcnValidationCount,
+    pub ecn_path_validation: ValidationCount,
     /// ECN counts for outgoing UDP datagrams, returned by remote through QUIC ACKs.
     ///
     /// Note: Given that QUIC ACKs only carry [`Ect0`], [`Ect1`] and [`Ce`], but
@@ -214,9 +214,9 @@ pub struct Stats {
     /// [`Ect1`]: neqo_common::tos::IpTosEcn::Ect1
     /// [`Ce`]: neqo_common::tos::IpTosEcn::Ce
     /// [`NotEct`]: neqo_common::tos::IpTosEcn::NotEct
-    pub ecn_tx: EcnCount,
+    pub ecn_tx: Count,
     /// ECN counts for incoming UDP datagrams, read from IP TOS header.
-    pub ecn_rx: EcnCount,
+    pub ecn_rx: Count,
 }
 
 impl Stats {

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -18,7 +18,7 @@ use neqo_common::{qdebug, qinfo, qtrace, qwarn, IpTosEcn};
 use neqo_crypto::{Epoch, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL};
 
 use crate::{
-    ecn::EcnCount,
+    ecn::Count,
     frame::{FRAME_TYPE_ACK, FRAME_TYPE_ACK_ECN},
     packet::{PacketBuilder, PacketNumber, PacketType},
     recovery::RecoveryToken,
@@ -271,7 +271,7 @@ pub struct RecvdPackets {
     /// for the purposes of generating immediate acknowledgment.
     ignore_order: bool,
     // The counts of different ECN marks that have been received.
-    ecn_count: EcnCount,
+    ecn_count: Count,
 }
 
 impl RecvdPackets {
@@ -294,12 +294,12 @@ impl RecvdPackets {
                 0
             },
             ignore_order: false,
-            ecn_count: EcnCount::default(),
+            ecn_count: Count::default(),
         }
     }
 
     /// Get the ECN counts.
-    pub fn ecn_marks(&mut self) -> &mut EcnCount {
+    pub fn ecn_marks(&mut self) -> &mut Count {
         &mut self.ecn_count
     }
 

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -18,7 +18,7 @@ use neqo_common::{qdebug, qinfo, qtrace, qwarn, IpTosEcn};
 use neqo_crypto::{Epoch, TLS_EPOCH_HANDSHAKE, TLS_EPOCH_INITIAL};
 
 use crate::{
-    ecn::Count,
+    ecn,
     frame::{FRAME_TYPE_ACK, FRAME_TYPE_ACK_ECN},
     packet::{PacketBuilder, PacketNumber, PacketType},
     recovery::RecoveryToken,
@@ -271,7 +271,7 @@ pub struct RecvdPackets {
     /// for the purposes of generating immediate acknowledgment.
     ignore_order: bool,
     // The counts of different ECN marks that have been received.
-    ecn_count: Count,
+    ecn_count: ecn::Count,
 }
 
 impl RecvdPackets {
@@ -294,12 +294,12 @@ impl RecvdPackets {
                 0
             },
             ignore_order: false,
-            ecn_count: Count::default(),
+            ecn_count: ecn::Count::default(),
         }
     }
 
     /// Get the ECN counts.
-    pub fn ecn_marks(&mut self) -> &mut Count {
+    pub fn ecn_marks(&mut self) -> &mut ecn::Count {
         &mut self.ecn_count
     }
 

--- a/neqo-transport/src/version.rs
+++ b/neqo-transport/src/version.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(clippy::module_name_repetitions)]
+
 use neqo_common::qdebug;
 
 use crate::{Error, Res};


### PR DESCRIPTION
This pull-request does two things:

1. It removes `module_name_repetitions` in `neqo-transport/src/ecn.rs`
2. It prepares the rest of the `neqo-transport` crate for refactoring by removing the crate-wide 
`#![allow(clippy::module_name_repetitions)]` and adding them on a module-level where necessary

One thing I'd like some feedback on is that because we are explicitly only importing the things we need from a module (e.g. `use ecn::Info;`) it's not always as clear where things come from as it was described in https://github.com/mozilla/neqo/issues/2284#issuecomment-2571313915. See for example in `neqo-transport/src/path.rs` line 203:

```rust
        let baseline = self.primary().map_or_else(
//            || EcnInfo::default().baseline(), <-- before refactor
            || Info::default().baseline(), // <-- after refactor
            |p| p.borrow().ecn_info.baseline(),
        );
```

Should we rather import like `use ecn;` or is it fine to leave like this?

Related: #2284 