### PR TITLE
ci: Fix bench

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -133,7 +133,7 @@ jobs:
           # Flags to pass to neqo when it runs against another implementation.
           declare -A neqo_flags=(
             ["neqo"]=""
-            ["msquic"]="-o -a hq-interop"
+            ["msquic"]="-a hq-interop"
             ["gquiche"]=""
           )
 


### PR DESCRIPTION
The `-o` parameter to the demo client and server was removed in #2287. Should have removed from workflow as well.