### PR TITLE
chore: Enable the `redundant_type_annotations` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ pedantic = { level = "warn", priority = -1 }
 if_then_some_else_none = "warn"
 get_unwrap = "warn"
 pathbuf_init_then_push = "warn"
+redundant_type_annotations = "warn"
 
 # Optimize build dependencies, because bindgen and proc macros / style
 # compilation take more to run than to build otherwise.

--- a/neqo-http3/src/frames/tests/mod.rs
+++ b/neqo-http3/src/frames/tests/mod.rs
@@ -33,7 +33,7 @@ pub fn enc_dec<T: FrameDecoder<T>>(d: &Encoder, st: &str, remaining: usize) -> T
     // create a stream
     let stream_id = conn_s.stream_create(StreamType::BiDi).unwrap();
 
-    let mut fr: FrameReader = FrameReader::new();
+    let mut fr = FrameReader::new();
 
     // convert string into u8 vector
     let buf = Encoder::from_hex(st);

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -200,7 +200,7 @@ fn tcp_phase() {
 #[test]
 fn cubic_phase() {
     let mut cubic = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU));
-    let cwnd_initial_f64: f64 = convert_to_f64(cubic.cwnd_initial());
+    let cwnd_initial_f64 = convert_to_f64(cubic.cwnd_initial());
     // Set last_max_cwnd to a higher number make sure that cc is the cubic phase (cwnd is calculated
     // by the cubic equation).
     cubic.set_last_max_cwnd(cwnd_initial_f64 * 10.0);
@@ -271,7 +271,7 @@ fn congestion_event_slow_start() {
     packet_lost(&mut cubic, 1);
 
     // last_max_cwnd is equal to cwnd before decrease.
-    let cwnd_initial_f64: f64 = convert_to_f64(cubic.cwnd_initial());
+    let cwnd_initial_f64 = convert_to_f64(cubic.cwnd_initial());
     assert_within(
         cubic.last_max_cwnd(),
         cwnd_initial_f64 + convert_to_f64(cubic.max_datagram_size()),
@@ -302,7 +302,7 @@ fn congestion_event_congestion_avoidance() {
     // Trigger a congestion_event in slow start phase
     packet_lost(&mut cubic, 1);
 
-    let cwnd_initial_f64: f64 = convert_to_f64(cubic.cwnd_initial());
+    let cwnd_initial_f64 = convert_to_f64(cubic.cwnd_initial());
     assert_within(cubic.last_max_cwnd(), cwnd_initial_f64, f64::EPSILON);
     assert_eq!(cubic.cwnd(), cwnd_after_loss(cubic.cwnd_initial()));
 }
@@ -315,7 +315,7 @@ fn congestion_event_congestion_avoidance_2() {
     cubic.set_ssthresh(1);
 
     // Set last_max_cwnd to something higher than cwnd so that the fast convergence is triggered.
-    let cwnd_initial_f64: f64 = convert_to_f64(cubic.cwnd_initial());
+    let cwnd_initial_f64 = convert_to_f64(cubic.cwnd_initial());
     cubic.set_last_max_cwnd(cwnd_initial_f64 * 10.0);
 
     _ = fill_cwnd(&mut cubic, 0, now());
@@ -344,7 +344,7 @@ fn congestion_event_congestion_avoidance_no_overflow() {
     cubic.set_ssthresh(1);
 
     // Set last_max_cwnd to something higher than cwnd so that the fast convergence is triggered.
-    let cwnd_initial_f64: f64 = convert_to_f64(cubic.cwnd_initial());
+    let cwnd_initial_f64 = convert_to_f64(cubic.cwnd_initial());
     cubic.set_last_max_cwnd(cwnd_initial_f64 * 10.0);
 
     _ = fill_cwnd(&mut cubic, 0, now());

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -1218,7 +1218,7 @@ fn server_initial_retransmits_identical() {
     // Force the server to retransmit its Initial packet a number of times and make sure the
     // retranmissions are identical to the original. Also, verify the PTO durations.
     let mut server = default_server();
-    let mut total_ptos: Duration = Duration::from_secs(0);
+    let mut total_ptos = Duration::from_secs(0);
     for i in 1..=3 {
         let si = server.process(ci.take(), now).dgram().unwrap();
         assert_eq!(si.len(), server.plpmtu());


### PR DESCRIPTION
And fix all the warnings it generates.