### PR TITLE
chore: Enable the `ref_patterns` clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ pedantic = { level = "warn", priority = -1 }
 if_then_some_else_none = "warn"
 get_unwrap = "warn"
 pathbuf_init_then_push = "warn"
+ref_patterns = "warn"
 
 # Optimize build dependencies, because bindgen and proc macros / style
 # compilation take more to run than to build otherwise.

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1600,7 +1600,7 @@ impl Http3Connection {
         conn: &mut Connection,
     ) -> Option<Box<dyn RecvStream>> {
         let stream = self.recv_streams.remove(&stream_id);
-        if let Some(ref s) = stream {
+        if let Some(s) = &stream {
             if s.stream_type() == Http3StreamType::ExtendedConnect {
                 self.send_streams.remove(&stream_id).unwrap();
                 if let Some(wt) = s.webtransport() {
@@ -1617,7 +1617,7 @@ impl Http3Connection {
         conn: &mut Connection,
     ) -> Option<Box<dyn SendStream>> {
         let stream = self.send_streams.remove(&stream_id);
-        if let Some(ref s) = stream {
+        if let Some(s) = &stream {
             if s.stream_type() == Http3StreamType::ExtendedConnect {
                 if let Some(wt) = self.recv_streams.remove(&stream_id).unwrap().webtransport() {
                     self.remove_extended_connect(&wt, conn);

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -296,10 +296,7 @@ impl RecvMessage {
                         }
                     };
                 }
-                RecvMessageState::DecodingHeaders {
-                    ref header_block,
-                    fin,
-                } => {
+                RecvMessageState::DecodingHeaders { header_block, fin } => {
                     if self
                         .qpack_decoder
                         .borrow()

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -292,7 +292,7 @@ impl NewTokenState {
     /// Is there a token available?
     pub fn has_token(&self) -> bool {
         match self {
-            Self::Client { ref pending, .. } => !pending.is_empty(),
+            Self::Client { pending, .. } => !pending.is_empty(),
             Self::Server(..) => false,
         }
     }
@@ -322,7 +322,7 @@ impl NewTokenState {
     pub fn save_token(&mut self, token: Vec<u8>) {
         if let Self::Client {
             ref mut pending,
-            ref old,
+            old,
         } = self
         {
             for t in old.iter().rev().chain(pending.iter().rev()) {

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -203,7 +203,7 @@ impl AddressValidationInfo {
 
     pub fn generate_new_token(&self, peer_address: SocketAddr, now: Instant) -> Option<Vec<u8>> {
         match self {
-            Self::Server(ref w) => w.upgrade().and_then(|validation| {
+            Self::Server(w) => w.upgrade().and_then(|validation| {
                 validation
                     .borrow()
                     .generate_new_token(peer_address, now)


### PR DESCRIPTION
And fix all the warnings that it generates.