### PR TITLE
chore: Enable the `renamed_function_params` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ pedantic = { level = "warn", priority = -1 }
 if_then_some_else_none = "warn"
 get_unwrap = "warn"
 pathbuf_init_then_push = "warn"
+renamed_function_params = "warn"
 
 # Optimize build dependencies, because bindgen and proc macros / style
 # compilation take more to run than to build otherwise.

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -732,8 +732,8 @@ pub struct CryptoState {
 impl Index<CryptoDxDirection> for CryptoState {
     type Output = CryptoDxState;
 
-    fn index(&self, dir: CryptoDxDirection) -> &Self::Output {
-        match dir {
+    fn index(&self, index: CryptoDxDirection) -> &Self::Output {
+        match index {
             CryptoDxDirection::Read => &self.rx,
             CryptoDxDirection::Write => &self.tx,
         }
@@ -741,8 +741,8 @@ impl Index<CryptoDxDirection> for CryptoState {
 }
 
 impl IndexMut<CryptoDxDirection> for CryptoState {
-    fn index_mut(&mut self, dir: CryptoDxDirection) -> &mut Self::Output {
-        match dir {
+    fn index_mut(&mut self, index: CryptoDxDirection) -> &mut Self::Output {
+        match index {
             CryptoDxDirection::Read => &mut self.rx,
             CryptoDxDirection::Write => &mut self.tx,
         }

--- a/neqo-transport/src/ecn.rs
+++ b/neqo-transport/src/ecn.rs
@@ -112,18 +112,18 @@ impl Sub<Self> for Count {
     type Output = Self;
 
     /// Subtract the ECN counts in `other` from `self`.
-    fn sub(self, other: Self) -> Self {
+    fn sub(self, rhs: Self) -> Self {
         let mut diff = Self::default();
         for (ecn, count) in &mut *diff {
-            *count = self[ecn].saturating_sub(other[ecn]);
+            *count = self[ecn].saturating_sub(rhs[ecn]);
         }
         diff
     }
 }
 
 impl AddAssign<IpTosEcn> for Count {
-    fn add_assign(&mut self, ecn: IpTosEcn) {
-        self[ecn] += 1;
+    fn add_assign(&mut self, rhs: IpTosEcn) {
+        self[rhs] += 1;
     }
 }
 

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -500,8 +500,8 @@ impl RemoteStreamLimits {
 impl Index<StreamType> for RemoteStreamLimits {
     type Output = RemoteStreamLimit;
 
-    fn index(&self, idx: StreamType) -> &Self::Output {
-        match idx {
+    fn index(&self, index: StreamType) -> &Self::Output {
+        match index {
             StreamType::BiDi => &self.bidirectional,
             StreamType::UniDi => &self.unidirectional,
         }
@@ -509,8 +509,8 @@ impl Index<StreamType> for RemoteStreamLimits {
 }
 
 impl IndexMut<StreamType> for RemoteStreamLimits {
-    fn index_mut(&mut self, idx: StreamType) -> &mut Self::Output {
-        match idx {
+    fn index_mut(&mut self, index: StreamType) -> &mut Self::Output {
+        match index {
             StreamType::BiDi => &mut self.bidirectional,
             StreamType::UniDi => &mut self.unidirectional,
         }
@@ -555,8 +555,8 @@ impl LocalStreamLimits {
 impl Index<StreamType> for LocalStreamLimits {
     type Output = SenderFlowControl<StreamType>;
 
-    fn index(&self, idx: StreamType) -> &Self::Output {
-        match idx {
+    fn index(&self, index: StreamType) -> &Self::Output {
+        match index {
             StreamType::BiDi => &self.bidirectional,
             StreamType::UniDi => &self.unidirectional,
         }
@@ -564,8 +564,8 @@ impl Index<StreamType> for LocalStreamLimits {
 }
 
 impl IndexMut<StreamType> for LocalStreamLimits {
-    fn index_mut(&mut self, idx: StreamType) -> &mut Self::Output {
-        match idx {
+    fn index_mut(&mut self, index: StreamType) -> &mut Self::Output {
+        match index {
             StreamType::BiDi => &mut self.bidirectional,
             StreamType::UniDi => &mut self.unidirectional,
         }

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -86,14 +86,14 @@ impl PacketNumberSpaceSet {
 impl Index<PacketNumberSpace> for PacketNumberSpaceSet {
     type Output = bool;
 
-    fn index(&self, space: PacketNumberSpace) -> &Self::Output {
-        &self.spaces[space]
+    fn index(&self, index: PacketNumberSpace) -> &Self::Output {
+        &self.spaces[index]
     }
 }
 
 impl IndexMut<PacketNumberSpace> for PacketNumberSpaceSet {
-    fn index_mut(&mut self, space: PacketNumberSpace) -> &mut Self::Output {
-        &mut self.spaces[space]
+    fn index_mut(&mut self, index: PacketNumberSpace) -> &mut Self::Output {
+        &mut self.spaces[index]
     }
 }
 

--- a/test-fixture/src/sim/connection.rs
+++ b/test-fixture/src/sim/connection.rs
@@ -138,10 +138,10 @@ impl Node for ConnectionNode {
         self.setup_goals(now);
     }
 
-    fn process(&mut self, mut dgram: Option<Datagram>, now: Instant) -> Output {
+    fn process(&mut self, mut d: Option<Datagram>, now: Instant) -> Output {
         _ = self.process_goals(|goal, c| goal.process(c, now));
         loop {
-            let res = self.c.process(dgram.take(), now);
+            let res = self.c.process(d.take(), now);
 
             let mut active = false;
             while let Some(e) = self.c.next_event() {


### PR DESCRIPTION
And fix all the warnings.