### PR TITLE
chore: Enable the `shadow_same` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ pedantic = { level = "warn", priority = -1 }
 if_then_some_else_none = "warn"
 get_unwrap = "warn"
 pathbuf_init_then_push = "warn"
+shadow_same = "warn"
 
 # Optimize build dependencies, because bindgen and proc macros / style
 # compilation take more to run than to build otherwise.

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -190,13 +190,12 @@ impl crate::connection::test_internal::FrameWriter for PingWriter {
 fn handshake_with_modifier(
     client: &mut Connection,
     server: &mut Connection,
-    now: Instant,
+    mut now: Instant,
     rtt: Duration,
     modifier: fn(Datagram) -> Option<Datagram>,
 ) -> Instant {
     let mut a = client;
     let mut b = server;
-    let mut now = now;
 
     let mut input = None;
     let is_done = |c: &mut Connection| {


### PR DESCRIPTION
And fix the lint errors in the codebase.