### PR TITLE
chore: Enable the `str_to_string` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ pedantic = { level = "warn", priority = -1 }
 if_then_some_else_none = "warn"
 get_unwrap = "warn"
 pathbuf_init_then_push = "warn"
+str_to_string = "warn"
 
 # Optimize build dependencies, because bindgen and proc macros / style
 # compilation take more to run than to build otherwise.

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -454,7 +454,7 @@ fn to_headers(values: &[impl AsRef<str>]) -> Vec<Header> {
                 *state = None;
                 Some(Header::new(name, value.as_ref()))
             } else {
-                *state = Some(value.as_ref().to_string());
+                *state = Some(value.as_ref().to_owned());
                 None
             }
         })

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -508,8 +508,8 @@ fn qlog_new(args: &Args, hostname: &str, cid: &ConnectionId) -> Res<NeqoQlog> {
     NeqoQlog::enabled_with_file(
         qlog_dir,
         Role::Client,
-        Some("Neqo client qlog".to_string()),
-        Some("Neqo client qlog".to_string()),
+        Some("Neqo client qlog".to_owned()),
+        Some("Neqo client qlog".to_owned()),
         format!("client-{hostname}-{cid}"),
     )
     .map_err(Error::QlogError)

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -124,9 +124,9 @@ impl Default for Args {
         use std::str::FromStr;
         Self {
             shared: crate::SharedArgs::default(),
-            hosts: vec!["[::]:12345".to_string()],
+            hosts: vec!["[::]:12345".to_owned()],
             db: PathBuf::from_str("../test-fixture/db").unwrap(),
-            key: "key".to_string(),
+            key: "key".to_owned(),
             retry: false,
             ech: false,
         }

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -55,7 +55,7 @@ impl NeqoQlog {
             .map_err(qlog::Error::IoError)?;
 
         let streamer = QlogStreamer::new(
-            qlog::QLOG_VERSION.to_string(),
+            qlog::QLOG_VERSION.to_owned(),
             title,
             description,
             None,
@@ -198,7 +198,7 @@ pub fn new_trace(role: Role) -> qlog::TraceSeq {
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .map(|d| d.as_secs_f64() * 1_000.0)
                 .ok(),
-            time_format: Some("relative".to_string()),
+            time_format: Some("relative".to_owned()),
         }),
     }
 }

--- a/neqo-crypto/src/err.rs
+++ b/neqo-crypto/src/err.rs
@@ -136,7 +136,7 @@ where
     unsafe {
         let p = f();
         if p.is_null() {
-            return dflt.to_string();
+            return dflt.to_owned();
         }
         CStr::from_ptr(p).to_string_lossy().into_owned()
     }

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -249,7 +249,7 @@ fn wt_session_close_frame_client() {
         &wt_session,
         &SessionCloseReason::Clean {
             error: ERROR_NUM,
-            message: ERROR_MESSAGE.to_string(),
+            message: ERROR_MESSAGE.to_owned(),
         },
     );
 }
@@ -268,7 +268,7 @@ fn wt_session_close_frame_server() {
         wt_session.stream_id(),
         &SessionCloseReason::Clean {
             error: ERROR_NUM,
-            message: ERROR_MESSAGE.to_string(),
+            message: ERROR_MESSAGE.to_owned(),
         },
         None,
     );
@@ -318,7 +318,7 @@ fn wt_unknown_session_frame_client() {
             wt_session.stream_id(),
             SessionCloseReason::Clean {
                 error: ERROR_NUM,
-                message: ERROR_MESSAGE.to_string(),
+                message: ERROR_MESSAGE.to_owned(),
             },
         )),
     );
@@ -333,7 +333,7 @@ fn wt_close_session_frame_broken_client() {
     let mut enc = Encoder::default();
     WebTransportFrame::CloseSession {
         error: 5,
-        message: "Hello".to_string(),
+        message: "Hello".to_owned(),
     }
     .encode(&mut enc);
     let mut buf: Vec<_> = enc.into();
@@ -434,7 +434,7 @@ fn wt_close_session_cannot_be_sent_at_once() {
             wt_session.stream_id(),
             SessionCloseReason::Clean {
                 error: ERROR_NUM,
-                message: ERROR_MESSAGE.to_string(),
+                message: ERROR_MESSAGE.to_owned(),
             },
         )),
     );

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
@@ -1124,7 +1124,7 @@ fn wt_session_close_frame_and_streams_client() {
             wt_session.stream_id(),
             SessionCloseReason::Clean {
                 error: ERROR_NUM,
-                message: ERROR_MESSAGE.to_string(),
+                message: ERROR_MESSAGE.to_owned(),
             },
         )),
     );

--- a/neqo-http3/src/features/extended_connect/webtransport_session.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_session.rs
@@ -382,7 +382,7 @@ impl WebTransportSession {
         self.state = SessionState::Done;
         let close_frame = WebTransportFrame::CloseSession {
             error,
-            message: message.to_string(),
+            message: message.to_owned(),
         };
         let mut encoder = Encoder::default();
         close_frame.encode(&mut encoder);

--- a/neqo-http3/src/frames/tests/reader.rs
+++ b/neqo-http3/src/frames/tests/reader.rs
@@ -176,7 +176,7 @@ fn frame_reading_with_stream_wt_close_session() {
     assert!(frame.is_some());
     let WebTransportFrame::CloseSession { error, message } = frame.unwrap();
     assert_eq!(error, 5);
-    assert_eq!(message, "Hello".to_string());
+    assert_eq!(message, "Hello".to_owned());
 }
 
 // Test an unknown frame for WebTransportFrames.
@@ -201,7 +201,7 @@ fn unknown_wt_frame() {
     assert!(frame.is_some());
     let WebTransportFrame::CloseSession { error, message } = frame.unwrap();
     assert_eq!(error, 5);
-    assert_eq!(message, "Hello".to_string());
+    assert_eq!(message, "Hello".to_owned());
 }
 
 enum FrameReadingTestSend {
@@ -468,7 +468,7 @@ fn complete_and_incomplete_wt_frames() {
     // H3_FRAME_TYPE_MAX_PUSH_ID
     let f = WebTransportFrame::CloseSession {
         error: 5,
-        message: "Hello".to_string(),
+        message: "Hello".to_owned(),
     };
     let mut enc = Encoder::default();
     f.encode(&mut enc);

--- a/neqo-http3/src/frames/tests/wtframe.rs
+++ b/neqo-http3/src/frames/tests/wtframe.rs
@@ -11,7 +11,7 @@ use crate::frames::WebTransportFrame;
 fn wt_close_session() {
     let f = WebTransportFrame::CloseSession {
         error: 5,
-        message: "Hello".to_string(),
+        message: "Hello".to_owned(),
     };
     enc_dec_wtframe(&f, "6843090000000548656c6c6f", 0);
 }

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -130,9 +130,9 @@ impl<'a> ReceiverBufferWrapper<'a> {
             .try_into()
             .or(Err(Error::DecompressionFailed))?;
         if use_huffman {
-            Ok(parse_utf8(&decode_huffman(self.slice(length)?)?)?.to_string())
+            Ok(parse_utf8(&decode_huffman(self.slice(length)?)?)?.to_owned())
         } else {
-            Ok(parse_utf8(self.slice(length)?)?.to_string())
+            Ok(parse_utf8(self.slice(length)?)?.to_owned())
         }
     }
 

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -269,8 +269,8 @@ impl Server {
                 NeqoQlog::enabled_with_file(
                     qlog_dir.clone(),
                     Role::Server,
-                    Some("Neqo server qlog".to_string()),
-                    Some("Neqo server qlog".to_string()),
+                    Some("Neqo server qlog".to_owned()),
+                    Some("Neqo server qlog".to_owned()),
                     format!("server-{odcid}"),
                 )
                 .unwrap_or_else(|e| {

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -399,7 +399,7 @@ pub fn new_neqo_qlog() -> (NeqoQlog, SharedVec) {
     trace.common_fields.as_mut().unwrap().reference_time = Some(0.0);
     let contents = buf.clone();
     let streamer = QlogStreamer::new(
-        qlog::QLOG_VERSION.to_string(),
+        qlog::QLOG_VERSION.to_owned(),
         None,
         None,
         None,


### PR DESCRIPTION
And fix all the warnings that it generates.