### PR TITLE
chore: Enable the `unneeded_field_pattern` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ pedantic = { level = "warn", priority = -1 }
 if_then_some_else_none = "warn"
 get_unwrap = "warn"
 pathbuf_init_then_push = "warn"
+unneeded_field_pattern = "warn"
 
 # Optimize build dependencies, because bindgen and proc macros / style
 # compilation take more to run than to build otherwise.

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -83,11 +83,7 @@ fn priority_update() {
     };
 
     match header_event {
-        Http3ServerEvent::Headers {
-            stream: _,
-            headers,
-            fin,
-        } => {
+        Http3ServerEvent::Headers { headers, fin, .. } => {
             let expected_headers = &[
                 Header::new(":method", "GET"),
                 Header::new(":scheme", "https"),


### PR DESCRIPTION
And fix the lint errors in the codebase.