### PR TITLE
chore: Enable the `unused_trait_names` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ pedantic = { level = "warn", priority = -1 }
 if_then_some_else_none = "warn"
 get_unwrap = "warn"
 pathbuf_init_then_push = "warn"
+unused_trait_names = "warn"
 
 # Optimize build dependencies, because bindgen and proc macros / style
 # compilation take more to run than to build otherwise.

--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{env, path::PathBuf, str::FromStr};
+use std::{env, path::PathBuf, str::FromStr as _};
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 use neqo_bin::{client, server};

--- a/neqo-bin/src/bin/client.rs
+++ b/neqo-bin/src/bin/client.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Parser;
+use clap::Parser as _;
 
 #[tokio::main]
 async fn main() -> Result<(), neqo_bin::client::Error> {

--- a/neqo-bin/src/bin/server.rs
+++ b/neqo-bin/src/bin/server.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Parser;
+use clap::Parser as _;
 
 #[tokio::main]
 async fn main() -> Result<(), neqo_bin::server::Error> {

--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -10,14 +10,14 @@ use std::{
     cell::RefCell,
     collections::{HashMap, VecDeque},
     fs::File,
-    io::{BufWriter, Write},
+    io::{BufWriter, Write as _},
     net::SocketAddr,
     path::PathBuf,
     rc::Rc,
     time::Instant,
 };
 
-use neqo_common::{event::Provider, qdebug, qinfo, qwarn, Datagram};
+use neqo_common::{event::Provider as _, qdebug, qinfo, qwarn, Datagram};
 use neqo_crypto::{AuthenticationStatus, ResumptionToken};
 use neqo_transport::{
     CloseReason, Connection, ConnectionEvent, ConnectionIdGenerator, EmptyConnectionIdGenerator,

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -11,14 +11,14 @@ use std::{
     collections::{HashMap, VecDeque},
     fmt::Display,
     fs::File,
-    io::{BufWriter, Write},
+    io::{BufWriter, Write as _},
     net::SocketAddr,
     path::PathBuf,
     rc::Rc,
     time::Instant,
 };
 
-use neqo_common::{event::Provider, hex, qdebug, qinfo, qwarn, Datagram, Header};
+use neqo_common::{event::Provider as _, hex, qdebug, qinfo, qwarn, Datagram, Header};
 use neqo_crypto::{AuthenticationStatus, ResumptionToken};
 use neqo_http3::{Error, Http3Client, Http3ClientEvent, Http3Parameters, Http3State, Priority};
 use neqo_transport::{

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -11,7 +11,7 @@ use std::{
     fmt::{self, Display},
     fs::{create_dir_all, File, OpenOptions},
     io::{self, BufWriter},
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs as _},
     path::PathBuf,
     pin::Pin,
     process::exit,
@@ -21,7 +21,7 @@ use std::{
 use clap::Parser;
 use futures::{
     future::{select, Either},
-    FutureExt, TryFutureExt,
+    FutureExt as _, TryFutureExt as _,
 };
 use neqo_common::{qdebug, qerror, qinfo, qlog::NeqoQlog, qwarn, Datagram, Role};
 use neqo_crypto::{
@@ -181,7 +181,7 @@ impl Args {
     #[cfg(any(test, feature = "bench"))]
     #[allow(clippy::missing_panics_doc)]
     pub fn new(requests: &[usize], upload: bool) -> Self {
-        use std::str::FromStr;
+        use std::str::FromStr as _;
         Self {
             shared: crate::SharedArgs::default(),
             urls: requests

--- a/neqo-bin/src/lib.rs
+++ b/neqo-bin/src/lib.rs
@@ -9,7 +9,7 @@
 
 use std::{
     fmt::{self, Display},
-    net::{SocketAddr, ToSocketAddrs},
+    net::{SocketAddr, ToSocketAddrs as _},
     path::PathBuf,
     time::Duration,
 };
@@ -266,7 +266,7 @@ impl std::error::Error for Error {}
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::PathBuf, str::FromStr, time::SystemTime};
+    use std::{fs, path::PathBuf, str::FromStr as _, time::SystemTime};
 
     use crate::{client, server};
 

--- a/neqo-bin/src/server/http09.rs
+++ b/neqo-bin/src/server/http09.rs
@@ -6,7 +6,7 @@
 
 use std::{borrow::Cow, cell::RefCell, collections::HashMap, fmt::Display, rc::Rc, time::Instant};
 
-use neqo_common::{event::Provider, hex, qdebug, qerror, qinfo, qwarn, Datagram};
+use neqo_common::{event::Provider as _, hex, qdebug, qerror, qinfo, qwarn, Datagram};
 use neqo_crypto::{generate_ech_keys, random, AllowZeroRtt, AntiReplay};
 use neqo_http3::Error;
 use neqo_transport::{

--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -12,7 +12,7 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{header::HeadersExt, hex, qdebug, qerror, qinfo, Datagram, Header};
+use neqo_common::{header::HeadersExt as _, hex, qdebug, qerror, qinfo, Datagram, Header};
 use neqo_crypto::{generate_ech_keys, random, AntiReplay};
 use neqo_http3::{
     Http3OrWebTransportStream, Http3Parameters, Http3Server, Http3ServerEvent, StreamId,

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -10,7 +10,7 @@ use std::{
     cell::RefCell,
     fmt::{self, Display},
     fs, io,
-    net::{SocketAddr, ToSocketAddrs},
+    net::{SocketAddr, ToSocketAddrs as _},
     path::PathBuf,
     pin::Pin,
     process::exit,
@@ -21,7 +21,7 @@ use std::{
 use clap::Parser;
 use futures::{
     future::{select, select_all, Either},
-    FutureExt,
+    FutureExt as _,
 };
 use neqo_common::{qdebug, qerror, qinfo, qwarn, Datagram};
 use neqo_crypto::{
@@ -121,7 +121,7 @@ pub struct Args {
 #[cfg(any(test, feature = "bench"))]
 impl Default for Args {
     fn default() -> Self {
-        use std::str::FromStr;
+        use std::str::FromStr as _;
         Self {
             shared: crate::SharedArgs::default(),
             hosts: vec!["[::]:12345".to_string()],

--- a/neqo-common/src/fuzz.rs
+++ b/neqo-common/src/fuzz.rs
@@ -7,7 +7,7 @@
 use std::{
     collections::hash_map::DefaultHasher,
     fs::File,
-    hash::{Hash, Hasher},
+    hash::{Hash as _, Hasher as _},
     io::Write,
     path::Path,
 };

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -18,7 +18,7 @@ pub mod log;
 pub mod qlog;
 pub mod tos;
 
-use std::fmt::Write;
+use std::fmt::Write as _;
 
 use enum_map::Enum;
 

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 use std::{
-    io::Write,
+    io::Write as _,
     sync::{Once, OnceLock},
     time::{Duration, Instant},
 };

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -35,7 +35,7 @@ use crate::{
     qpack_decoder_receiver::DecoderRecvStream,
     qpack_encoder_receiver::EncoderRecvStream,
     recv_message::{RecvMessage, RecvMessageInfo},
-    request_target::{AsRequestTarget, RequestTarget},
+    request_target::{AsRequestTarget, RequestTarget as _},
     send_message::SendMessage,
     settings::{HSettingType, HSettings, HttpZeroRttChecker},
     stream_type_reader::NewStreamHeadReader,

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -1280,7 +1280,7 @@ impl EventProvider for Http3Client {
 mod tests {
     use std::{mem, time::Duration};
 
-    use neqo_common::{event::Provider, qtrace, Datagram, Decoder, Encoder};
+    use neqo_common::{event::Provider as _, qtrace, Datagram, Decoder, Encoder};
     use neqo_crypto::{AllowZeroRtt, AntiReplay, ResumptionToken};
     use neqo_qpack::{encoder::QPackEncoder, QpackSettings};
     use neqo_transport::{
@@ -1301,7 +1301,7 @@ mod tests {
         frames::{HFrame, H3_FRAME_TYPE_SETTINGS, H3_RESERVED_FRAME_TYPES},
         qpack_encoder_receiver::EncoderRecvStream,
         settings::{HSetting, HSettingType, H3_RESERVED_SETTINGS},
-        Http3Server, Priority, PushId, RecvStream,
+        Http3Server, Priority, PushId, RecvStream as _,
     };
 
     fn assert_closed(client: &Http3Client, expected: &Error) {

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -6,7 +6,7 @@
 
 use std::{rc::Rc, time::Instant};
 
-use neqo_common::{event::Provider, qdebug, qinfo, qtrace, Header, MessageType, Role};
+use neqo_common::{event::Provider as _, qdebug, qinfo, qtrace, Header, MessageType, Role};
 use neqo_transport::{
     AppError, Connection, ConnectionEvent, DatagramTracking, StreamId, StreamType,
 };

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -10,7 +10,7 @@ mod sessions;
 mod streams;
 use std::{cell::RefCell, rc::Rc, time::Duration};
 
-use neqo_common::{event::Provider, header::HeadersExt};
+use neqo_common::{event::Provider as _, header::HeadersExt as _};
 use neqo_crypto::AuthenticationStatus;
 use neqo_transport::{ConnectionParameters, Pmtud, StreamId, StreamType};
 use test_fixture::{

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/negotiation.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/negotiation.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use neqo_common::{event::Provider, Encoder};
+use neqo_common::{event::Provider as _, Encoder};
 use neqo_crypto::AuthenticationStatus;
 use neqo_transport::{CloseReason, Connection, StreamType};
 use test_fixture::{default_server_h3, now};

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -6,7 +6,7 @@
 
 use std::mem;
 
-use neqo_common::{event::Provider, header::HeadersExt, Encoder};
+use neqo_common::{event::Provider as _, header::HeadersExt as _, Encoder};
 use neqo_transport::StreamType;
 use test_fixture::now;
 

--- a/neqo-http3/src/frames/hframe.rs
+++ b/neqo-http3/src/frames/hframe.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{fmt::Debug, io::Write};
+use std::{fmt::Debug, io::Write as _};
 
 use neqo_common::{Decoder, Encoder};
 use neqo_crypto::random;

--- a/neqo-http3/src/headers_checks.rs
+++ b/neqo-http3/src/headers_checks.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 
 use enumset::{enum_set, EnumSet, EnumSetType};
-use neqo_common::{header::HeadersExt, Header};
+use neqo_common::{header::HeadersExt as _, Header};
 
 use crate::{Error, MessageType, Res};
 

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -6,7 +6,7 @@
 
 use std::{cell::RefCell, cmp::min, collections::VecDeque, fmt::Debug, rc::Rc};
 
-use neqo_common::{header::HeadersExt, qdebug, qinfo, qtrace, Header};
+use neqo_common::{header::HeadersExt as _, qdebug, qinfo, qtrace, Header};
 use neqo_qpack::decoder::QPackDecoder;
 use neqo_transport::{Connection, StreamId};
 

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -315,7 +315,7 @@ mod tests {
         ops::{Deref, DerefMut},
     };
 
-    use neqo_common::{event::Provider, Encoder};
+    use neqo_common::{event::Provider as _, Encoder};
     use neqo_crypto::{AuthenticationStatus, ZeroRttCheckResult, ZeroRttChecker};
     use neqo_qpack::{encoder::QPackEncoder, QpackSettings};
     use neqo_transport::{

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -253,7 +253,7 @@ mod tests {
     use crate::{
         control_stream_local::HTTP3_UNI_STREAM_TYPE_CONTROL,
         frames::{H3_FRAME_TYPE_HEADERS, H3_FRAME_TYPE_SETTINGS},
-        CloseType, Error, NewStreamType, PushId, ReceiveOutput, RecvStream, Res,
+        CloseType, Error, NewStreamType, PushId, ReceiveOutput, RecvStream as _, Res,
     };
 
     struct Test {

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{event::Provider, qtrace, Datagram};
+use neqo_common::{event::Provider as _, qtrace, Datagram};
 use neqo_crypto::{AuthenticationStatus, ResumptionToken};
 use neqo_http3::{
     Header, Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3Parameters, Http3Server,

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -6,7 +6,7 @@
 
 use std::time::Instant;
 
-use neqo_common::event::Provider;
+use neqo_common::event::Provider as _;
 use neqo_crypto::AuthenticationStatus;
 use neqo_http3::{
     Header, Http3Client, Http3ClientEvent, Http3Server, Http3ServerEvent, Http3State, Priority,

--- a/neqo-http3/tests/send_message.rs
+++ b/neqo-http3/tests/send_message.rs
@@ -6,7 +6,7 @@
 
 use std::sync::OnceLock;
 
-use neqo_common::event::Provider;
+use neqo_common::event::Provider as _;
 use neqo_crypto::AuthenticationStatus;
 use neqo_http3::{
     Error, Header, Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3Server,

--- a/neqo-http3/tests/webtransport.rs
+++ b/neqo-http3/tests/webtransport.rs
@@ -6,7 +6,7 @@
 
 use std::{cell::RefCell, rc::Rc};
 
-use neqo_common::{event::Provider, header::HeadersExt};
+use neqo_common::{event::Provider as _, header::HeadersExt as _};
 use neqo_crypto::AuthenticationStatus;
 use neqo_http3::{
     Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3Parameters, Http3Server,

--- a/neqo-qpack/src/header_block.rs
+++ b/neqo-qpack/src/header_block.rs
@@ -6,7 +6,7 @@
 
 use std::{
     mem,
-    ops::{Deref, Div},
+    ops::{Deref, Div as _},
 };
 
 use neqo_common::{qtrace, Header};

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -379,7 +379,7 @@ mod tests {
     use test_receiver::TestReceiver;
 
     use super::{
-        parse_utf8, str, test_receiver, Error, IntReader, LiteralReader, ReadByte,
+        parse_utf8, str, test_receiver, Error, IntReader, LiteralReader, ReadByte as _,
         ReceiverBufferWrapper, Res,
     };
 

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -23,7 +23,7 @@ use crate::{
             convert_to_f64, Cubic, CUBIC_ALPHA, CUBIC_BETA_USIZE_DIVIDEND,
             CUBIC_BETA_USIZE_DIVISOR, CUBIC_C, CUBIC_FAST_CONVERGENCE,
         },
-        CongestionControl,
+        CongestionControl as _,
     },
     packet::PacketType,
     pmtud::Pmtud,

--- a/neqo-transport/src/cc/tests/new_reno.rs
+++ b/neqo-transport/src/cc/tests/new_reno.rs
@@ -13,7 +13,7 @@ use test_fixture::now;
 
 use super::{IP_ADDR, MTU, RTT};
 use crate::{
-    cc::{new_reno::NewReno, ClassicCongestionControl, CongestionControl},
+    cc::{new_reno::NewReno, ClassicCongestionControl, CongestionControl as _},
     packet::PacketType,
     pmtud::Pmtud,
     recovery::SentPacket,

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -10,7 +10,7 @@ use std::{
     borrow::Borrow,
     cell::{Ref, RefCell},
     cmp::{max, min},
-    ops::Deref,
+    ops::Deref as _,
     rc::Rc,
 };
 

--- a/neqo-transport/src/connection/dump.rs
+++ b/neqo-transport/src/connection/dump.rs
@@ -7,7 +7,7 @@
 // Enable just this file for logging to just see packets.
 // e.g. "RUST_LOG=neqo_transport::dump neqo-client ..."
 
-use std::fmt::Write;
+use std::fmt::Write as _;
 
 use neqo_common::{qdebug, Decoder, IpTos};
 

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -6,7 +6,7 @@
 
 use std::{cell::RefCell, rc::Rc};
 
-use neqo_common::event::Provider;
+use neqo_common::event::Provider as _;
 use static_assertions::const_assert;
 use test_fixture::now;
 

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use neqo_common::{event::Provider, qdebug, Datagram};
+use neqo_common::{event::Provider as _, qdebug, Datagram};
 use neqo_crypto::{
     constants::TLS_CHACHA20_POLY1305_SHA256, generate_ech_keys, AuthenticationStatus,
 };

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -35,7 +35,7 @@ use crate::{
     pmtud::Pmtud,
     stats::FrameStats,
     tparams::{self, PreferredAddress, TransportParameter},
-    CloseReason, ConnectionId, ConnectionIdDecoder, ConnectionIdGenerator, ConnectionIdRef,
+    CloseReason, ConnectionId, ConnectionIdDecoder as _, ConnectionIdGenerator, ConnectionIdRef,
     ConnectionParameters, EmptyConnectionIdGenerator, Error, MIN_INITIAL_PACKET_SIZE,
 };
 

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use enum_map::enum_map;
-use neqo_common::{event::Provider, qdebug, qtrace, Datagram, Decoder, Role};
+use neqo_common::{event::Provider as _, qdebug, qtrace, Datagram, Decoder, Role};
 use neqo_crypto::{random, AllowZeroRtt, AuthenticationStatus, ResumptionToken};
 use test_fixture::{fixture_init, new_neqo_qlog, now, DEFAULT_ADDR};
 

--- a/neqo-transport/src/connection/tests/priority.rs
+++ b/neqo-transport/src/connection/tests/priority.rs
@@ -6,7 +6,7 @@
 
 use std::{cell::RefCell, mem, rc::Rc};
 
-use neqo_common::event::Provider;
+use neqo_common::event::Provider as _;
 use test_fixture::now;
 
 use super::{

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -6,7 +6,7 @@
 
 use std::{cmp::max, collections::HashMap, mem};
 
-use neqo_common::{event::Provider, qdebug};
+use neqo_common::{event::Provider as _, qdebug};
 use test_fixture::now;
 
 use super::{

--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -6,7 +6,7 @@
 
 use std::{mem, time::Duration};
 
-use neqo_common::{event::Provider, Decoder, Encoder};
+use neqo_common::{event::Provider as _, Decoder, Encoder};
 use test_fixture::{assertions, datagram, now};
 
 use super::{

--- a/neqo-transport/src/connection/tests/zerortt.rs
+++ b/neqo-transport/src/connection/tests/zerortt.rs
@@ -6,7 +6,7 @@
 
 use std::{cell::RefCell, rc::Rc, time::Duration};
 
-use neqo_common::{event::Provider, qdebug};
+use neqo_common::{event::Provider as _, qdebug};
 use neqo_crypto::{AllowZeroRtt, AntiReplay};
 use test_fixture::{assertions, now};
 

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -254,7 +254,7 @@ impl EventProvider for ConnectionEvents {
 
 #[cfg(test)]
 mod tests {
-    use neqo_common::event::Provider;
+    use neqo_common::event::Provider as _;
 
     use crate::{CloseReason, ConnectionEvent, ConnectionEvents, Error, State, StreamId};
 

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -9,7 +9,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 use std::{
-    ops::{Deref, RangeInclusive},
+    ops::{Deref as _, RangeInclusive},
     time::{Duration, Instant},
 };
 

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -16,7 +16,7 @@ mod token;
 
 use std::{
     cmp::{max, min},
-    convert::TryFrom,
+    convert::TryFrom as _,
     ops::RangeInclusive,
     time::{Duration, Instant},
 };
@@ -969,7 +969,7 @@ impl ::std::fmt::Display for LossRecovery {
 mod tests {
     use std::{
         cell::RefCell,
-        convert::TryInto,
+        convert::TryInto as _,
         ops::{Deref, DerefMut, RangeInclusive},
         rc::Rc,
         time::{Duration, Instant},

--- a/neqo-transport/src/recovery/sent.rs
+++ b/neqo-transport/src/recovery/sent.rs
@@ -305,7 +305,7 @@ impl SentPackets {
 mod tests {
     use std::{
         cell::OnceCell,
-        convert::TryFrom,
+        convert::TryFrom as _,
         time::{Duration, Instant},
     };
 

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1793,7 +1793,7 @@ pub struct SendStreamRecoveryToken {
 mod tests {
     use std::{cell::RefCell, collections::VecDeque, num::NonZeroUsize, rc::Rc};
 
-    use neqo_common::{event::Provider, hex_with_len, qtrace, Encoder};
+    use neqo_common::{event::Provider as _, hex_with_len, qtrace, Encoder};
 
     use super::SendStreamRecoveryToken;
     use crate::{

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -17,8 +17,8 @@ use std::{
 };
 
 use neqo_common::{
-    event::Provider, hex, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn, Datagram, IpTos,
-    Role,
+    event::Provider as _, hex, qdebug, qerror, qinfo, qlog::NeqoQlog, qtrace, qwarn, Datagram,
+    IpTos, Role,
 };
 use neqo_crypto::{
     encode_ech_config, AntiReplay, Cipher, PrivateKey, PublicKey, ZeroRttCheckResult,

--- a/neqo-transport/tests/common/mod.rs
+++ b/neqo-transport/tests/common/mod.rs
@@ -8,7 +8,7 @@
 
 use std::{cell::RefCell, mem, ops::Range, rc::Rc};
 
-use neqo_common::{event::Provider, hex_with_len, qtrace, Datagram, Decoder, Role};
+use neqo_common::{event::Provider as _, hex_with_len, qtrace, Datagram, Decoder, Role};
 use neqo_crypto::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
     hkdf,

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use neqo_common::{
-    event::Provider,
+    event::Provider as _,
     hex,
     qlog::{new_trace, NeqoQlog},
     qtrace, Datagram, Decoder, IpTosEcn, Role,

--- a/test-fixture/src/sim/connection.rs
+++ b/test-fixture/src/sim/connection.rs
@@ -12,7 +12,7 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{event::Provider, qdebug, qinfo, qtrace, Datagram};
+use neqo_common::{event::Provider as _, qdebug, qinfo, qtrace, Datagram};
 use neqo_crypto::AuthenticationStatus;
 use neqo_transport::{
     Connection, ConnectionEvent, ConnectionParameters, Output, State, StreamId, StreamType,


### PR DESCRIPTION
And fix all the warnings it generates.