### PR TITLE
ci: Remove some things from `env`

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,8 +8,6 @@ on:
 env:
   CARGO_PROFILE_BENCH_BUILD_OVERRIDE_DEBUG: true
   CARGO_PROFILE_RELEASE_DEBUG: true
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
   TOOLCHAIN: stable
   RUSTFLAGS: -C link-arg=-fuse-ld=lld -C link-arg=-Wl,--no-rosegment, -C force-frame-pointers=yes
   PERF_OPT: record -F997 --call-graph fp -g

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,9 +14,6 @@ on:
         type: boolean
         required: false
         default: false
-env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Run tests and determine coverage
         env:
           RUST_LOG: trace
+          RUST_BACKTRACE: 1
         run: |
           DUMP_SIMULATION_SEEDS="$(pwd)/simulation-seeds"
           export DUMP_SIMULATION_SEEDS

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -8,9 +8,6 @@ on:
     paths-ignore: ["*.md", "*.png", "*.svg", "LICENSE-*"]
   merge_group:
   workflow_dispatch:
-env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/fuzz-bench.yml
+++ b/.github/workflows/fuzz-bench.yml
@@ -5,9 +5,6 @@ on:
     branches: ["main"]
     paths-ignore: ["*.md", "*.png", "*.svg", "LICENSE-*"]
   merge_group:
-env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -5,9 +5,6 @@ on:
     branches: ["main"]
     paths-ignore: ["*.md", "*.png", "*.svg", "LICENSE-*"]
   merge_group:
-env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -8,9 +8,6 @@ on:
     paths-ignore: ["*.md", "*.png", "*.svg", "LICENSE-*"]
   merge_group:
   workflow_dispatch:
-env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -9,8 +9,6 @@ on:
   merge_group:
   workflow_dispatch:
 env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
   DUMP_SIMULATION_SEEDS: /tmp/simulation-seeds
 
 concurrency:

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -59,6 +59,7 @@ jobs:
           RUSTFLAGS: "-Z sanitizer=${{ matrix.sanitizer }}"
           RUSTDOCFLAGS: "-Z sanitizer=${{ matrix.sanitizer }}"
           ASAN_OPTIONS: detect_leaks=1:detect_stack_use_after_return=1
+          RUST_BACKTRACE: 1
         run: |
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
             sudo apt-get install -y --no-install-recommends llvm


### PR DESCRIPTION
1. `CARGO_TERM_COLOR: always` is always set by `dtolnay/rust-toolchain`
2. `RUST_BACKTRACE` is better set where needed, rather than everywhere.