### PR TITLE
tests(udp): use blocking socket to receive empty datagram

### DIFF
--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -233,7 +233,7 @@ mod tests {
         // platforms. Use `std` socket instead.  See also
         // <https://github.com/quinn-rs/quinn/pull/2123>.
         let sender = std::net::UdpSocket::bind("127.0.0.1:0")?;
-        let receiver = Socket::new(std::net::UdpSocket::bind("127.0.0.1:0")?)?;
+        let receiver = socket()?;
         let receiver_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
         sender.send_to(&[], receiver.inner.local_addr()?)?;


### PR DESCRIPTION
The `handle_empty_datagram` unit tests sends and receives an empty datagram. To prevent a race condition where the receiver tries to receive the datagram before it is available (error `WouldBlock`), use a blocking socket via `socket()` instead.

---

See e.g. CI failure in https://github.com/mozilla/neqo/actions/runs/12704862858/job/35414911552?pr=2133#step:5:3588.