### PR TITLE
ci: Run benchmarks on draft PRs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -140,6 +140,5 @@ jobs:
     needs: [check]
     if: >
       (github.event_name == 'workflow_dispatch' && github.event.inputs.run_benchmarks) ||
-      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
       (github.event_name != 'workflow_dispatch' && github.event_name != 'pull_request')
     uses: ./.github/workflows/bench.yml


### PR DESCRIPTION
I keep finding that I need to flip a PR from "draft" to "ready for review" prematurely, just to get the CI to run benchmarks.