### PR TITLE
ci(sanitize): downgrade to ubuntu v22.04

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -29,6 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TODO: Unpin ubuntu when https://github.com/rust-lang/rust/issues/111073#issuecomment-2561607617 is fixed.
         os: [ubuntu-22.04, macos-latest] # No Windows support for sanitizers.
         sanitizer: [address, thread, leak] # TODO: memory
         exclude:


### PR DESCRIPTION
Hope to fix https://github.com/mozilla/neqo/actions/runs/12745725202/job/35520285659?pr=2352.

See related upstream issue: https://github.com/rust-lang/rust/issues/111073#issuecomment-2561607617