### PR TITLE
ci: Lengthen QNS CI timout

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -23,7 +23,7 @@ permissions:
 env:
   LATEST: neqo-latest
   DELIM: ' vs. '
-  TIMEOUT: 20
+  TIMEOUT: 30
 
 jobs:
   docker-image:


### PR DESCRIPTION
On the new `ubuntu-latest` runner, the C compiler is slower.