### PR TITLE
fix(transport): handle out-of-order frame on remote init stream

### DIFF
--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -411,13 +411,18 @@ impl Streams {
         stream_id: StreamId,
     ) -> Res<(Option<&mut SendStream>, Option<&mut RecvStream>)> {
         self.ensure_created_if_remote(stream_id)?;
-        // Has this local stream existed in the past, i.e., is its index lower than the number of
-        // used streams?
-        let existed = !stream_id.is_remote_initiated(self.role)
-            && self.local_stream_limits[stream_id.stream_type()].used() > stream_id.index();
         let ss = self.send.get_mut(stream_id).ok();
         let rs = self.recv.get_mut(stream_id).ok();
-        if ss.is_none() && rs.is_none() && !existed {
+        // If it is:
+        // - neither a known send nor receive stream,
+        // - and it must be locally initiated,
+        // - and its index is larger than the local used stream limit,
+        // then it is an illegal stream.
+        if ss.is_none()
+            && rs.is_none()
+            && !stream_id.is_remote_initiated(self.role)
+            && self.local_stream_limits[stream_id.stream_type()].used() <= stream_id.index()
+        {
             return Err(Error::StreamStateError);
         }
         Ok((ss, rs))


### PR DESCRIPTION
https://github.com/mozilla/neqo/pull/2269 made a "stream control or data frame for a stream that is ours to initiate but we haven't yet" illegal.

https://github.com/mozilla/neqo/blob/7bbf900874eb02171dd893810d6895e14ed516e3/neqo-transport/src/streams.rs#L409-L424

Given a remote initiated stream that has been closed and forgotten since. Say that the local node receives an out-of-order frame on said forgotten stream. In such scenario:

- `stream_id.is_remote_initiated` is `true`
- thus `existed` is `false`
- `ss.is_none()` and `rs.is_none()` is `true`
- `ss.is_none() && rs.is_none() && !existed` is `true`
- thus `obtain_stream` falsely returns `Err(Error::StreamStateError);`

This commit fixes the above issue, only returning `Err(Error::StreamStateError);` on locally initiated streams.