### PR TITLE
feat: Sock puppets for CHs

### DIFF
--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -83,6 +83,8 @@ pub struct ConnectionParameters {
     pacing: bool,
     /// Whether the connection performs PLPMTUD.
     pmtud: bool,
+    /// Whether the connection should use sock puppet CHs.
+    sock_puppet: bool,
 }
 
 impl Default for ConnectionParameters {
@@ -107,6 +109,7 @@ impl Default for ConnectionParameters {
             disable_migration: false,
             pacing: true,
             pmtud: false,
+            sock_puppet: true,
         }
     }
 }
@@ -364,6 +367,17 @@ impl ConnectionParameters {
     #[must_use]
     pub const fn pmtud(mut self, pmtud: bool) -> Self {
         self.pmtud = pmtud;
+        self
+    }
+
+    #[must_use]
+    pub const fn sock_puppet_enabled(&self) -> bool {
+        self.sock_puppet
+    }
+
+    #[must_use]
+    pub const fn sock_puppet(mut self, sock_puppet: bool) -> Self {
+        self.sock_puppet = sock_puppet;
         self
     }
 

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -85,6 +85,8 @@ pub struct ConnectionParameters {
     pmtud: bool,
     /// Whether the connection should use sock puppet CHs.
     sock_puppet: bool,
+    /// Whether the connection should use SNI slicing.
+    sni_slicing: bool,
 }
 
 impl Default for ConnectionParameters {
@@ -110,6 +112,7 @@ impl Default for ConnectionParameters {
             pacing: true,
             pmtud: false,
             sock_puppet: true,
+            sni_slicing: true,
         }
     }
 }
@@ -378,6 +381,17 @@ impl ConnectionParameters {
     #[must_use]
     pub const fn sock_puppet(mut self, sock_puppet: bool) -> Self {
         self.sock_puppet = sock_puppet;
+        self
+    }
+
+    #[must_use]
+    pub const fn sni_slicing_enabled(&self) -> bool {
+        self.sni_slicing
+    }
+
+    #[must_use]
+    pub const fn sni_slicing(mut self, sni_slicing: bool) -> Self {
+        self.sni_slicing = sni_slicing;
         self
     }
 

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -112,7 +112,7 @@ impl Default for ConnectionParameters {
             pacing: true,
             pmtud: false,
             sock_puppet: true,
-            sni_slicing: true,
+            sni_slicing: false, // FIXME: This should be true by default.
         }
     }
 }

--- a/neqo-transport/src/connection/sockpuppet.rs
+++ b/neqo-transport/src/connection/sockpuppet.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::{qdebug, Encoder};
+use neqo_common::Encoder;
 use neqo_crypto::random;
 
 use super::AddressValidationInfo;
@@ -13,41 +13,24 @@ use crate::{
     path::PathRef,
     recovery::LossRecovery,
     stats::FrameStats,
+    tparams::TransportParameters,
     tracking::PacketNumberSpace,
     Connection, Version,
 };
 
 /// See <https://tls13.xargs.org/#client-hello/annotated>
-#[expect(clippy::too_many_lines)]
-fn generate_ch() -> Vec<u8> {
+fn generate_ch(sni: &[u8], tps: &TransportParameters) -> Vec<u8> {
     // Extensions
     let mut extensions = Encoder::new();
 
     let mut list_entry = Encoder::new();
-    list_entry.encode_uint(1, 0x00_u8); // list entry is type 0x00 "DNS hostname"
-    list_entry.encode_vec(2, b"github.com");
-
-    let mut server_name_list = Encoder::new();
-    server_name_list.encode_vec(2, list_entry.as_ref()); // first (and only) list entry
-
+    list_entry.encode_uint::<u8>(1, 0x00); // list entry is type 0x00 "DNS hostname"
+    list_entry.encode_vec(2, sni);
     let mut server_name_extension = Encoder::new();
-    server_name_extension.encode_vec(2, server_name_list.as_ref()); // "server name" extension data
+    server_name_extension.encode_vec(2, list_entry.as_ref()); // "server name" extension data
 
-    extensions.encode_uint(2, 0x00_u8); // assigned value for extension "server name"
+    extensions.encode_uint::<u8>(2, 0x00); // assigned value for extension "server name"
     extensions.encode_vec(2, server_name_extension.as_ref()); // server name extension data
-
-    let mut ec_points_formats = Encoder::new();
-    ec_points_formats.encode_vec(
-        1,
-        &[
-            0x00, // assigned value for format "uncompressed"
-            0x01, // assigned value for format "ansiX962_compressed_prime"
-            0x02, // assigned value for format "ansiX962_compressed_char2"
-        ],
-    );
-
-    extensions.encode_uint(2, 0x0b_u8); // assigned value for extension "ec point formats"
-    extensions.encode_vec(2, ec_points_formats.as_ref()); // ec point formats extension data
 
     let mut supported_groups = Encoder::new();
     supported_groups.encode_vec(
@@ -55,24 +38,15 @@ fn generate_ch() -> Vec<u8> {
         &[
             0x00, 0x1d, // assigned value for the curve "x25519"
             0x00, 0x17, // assigned value for the curve "secp256r1"
-            0x00, 0x1e, // assigned value for the curve "x448"
-            0x00, 0x19, // assigned value for the curve "secp521r1"
             0x00, 0x18, // assigned value for the curve "secp384r1"
-            0x01, 0x00, // assigned value for the curve "ffdhe2048"
-            0x01, 0x01, // assigned value for the curve "ffdhe3072"
-            0x01, 0x02, // assigned value for the curve "ffdhe4096"
-            0x01, 0x03, // assigned value for the curve "ffdhe6144"
-            0x01, 0x04, // assigned value for the curve "ffdhe8192"
+            0x00, 0x19, // assigned value for the curve "secp521r1"
         ],
     );
 
-    extensions.encode_uint(2, 0x0a_u8); // assigned value for extension "supported groups"
+    extensions.encode_uint::<u8>(2, 0x0a); // assigned value for extension "supported groups"
     extensions.encode_vec(2, supported_groups.as_ref()); // supported groups extension data
 
-    extensions.encode_uint(2, 0x23_u8); // assigned value for extension "Session Ticket"
-    extensions.encode_vec(2, &[]); // 0 bytes of "Session Ticket" extension data
-
-    extensions.encode_uint(2, 0x17_u8); // assigned value for extension "Extended Master Secret"
+    extensions.encode_uint::<u8>(2, 0x17); // assigned value for extension "Extended Master Secret"
     extensions.encode_vec(2, &[]); // 0 bytes of "Extended Master Secret" extension data
 
     let mut signature_algorithms = Encoder::new();
@@ -82,44 +56,67 @@ fn generate_ch() -> Vec<u8> {
             0x04, 0x03, // assigned value for ECDSA-SECP256r1-SHA256
             0x05, 0x03, // assigned value for ECDSA-SECP384r1-SHA384
             0x06, 0x03, // assigned value for ECDSA-SECP521r1-SHA512
-            0x08, 0x07, // assigned value for ED25519
-            0x08, 0x08, // assigned value for ED448
-            0x08, 0x09, // assigned value for RSA-PSS-PSS-SHA256
-            0x08, 0x0a, // assigned value for RSA-PSS-PSS-SHA384
-            0x08, 0x0b, // assigned value for RSA-PSS-PSS-SHA512
+            0x02, 0x03, // assigned value for ECDSA-SHA1
             0x08, 0x04, // assigned value for RSA-PSS-RSAE-SHA256
             0x08, 0x05, // assigned value for RSA-PSS-RSAE-SHA384
             0x08, 0x06, // assigned value for RSA-PSS-RSAE-SHA512
+            0x08, 0x09, // assigned value for RSA-PSS-PSS-SHA256
             0x04, 0x01, // assigned value for RSA-PKCS1-SHA256
             0x05, 0x01, // assigned value for RSA-PKCS1-SHA384
             0x06, 0x01, // assigned value for RSA-PKCS1-SHA512
+            0x02, 0x01, // assigned value for RSA-PKCS1-SHA1
         ],
     );
 
-    extensions.encode_uint(2, 0x0d_u8); // assigned value for extension "Signature Algorithms"
+    extensions.encode_uint::<u8>(2, 0x0d); // assigned value for extension "Signature Algorithms"
     extensions.encode_vec(2, signature_algorithms.as_ref()); // "Signature Algorithms" extension data
 
     let mut supported_versions = Encoder::new();
     supported_versions.encode_vec(1, &[0x03, 0x04]); // assigned value for TLS 1.3
 
-    extensions.encode_uint(2, 0x2b_u8); // assigned value for extension "Supported Versions"
+    extensions.encode_uint::<u8>(2, 0x2b); // assigned value for extension "Supported Versions"
     extensions.encode_vec(2, supported_versions.as_ref()); // "Supported Versions" extension data
 
     let mut psk_key_exchange_modes = Encoder::new();
     psk_key_exchange_modes.encode_vec(1, &[0x01]); // assigned value for "PSK with (EC)DHE key establishment"
 
-    extensions.encode_uint(2, 0x2d_u8); // assigned value for extension "PSK Key Exchange Modes"
+    extensions.encode_uint::<u8>(2, 0x2d); // assigned value for extension "PSK Key Exchange Modes"
     extensions.encode_vec(2, psk_key_exchange_modes.as_ref()); // "PSK Key Exchange Modes" extension data
 
     let mut key_share = Encoder::new();
-    key_share.encode_uint(2, 0x1d_u8); // assigned value for x25519 (key exchange via curve25519)
+    key_share.encode_uint::<u8>(2, 0x1d); // assigned value for x25519 (key exchange via curve25519)
     key_share.encode_vec(2, &random::<32>()); // 32 bytes of public key
+    key_share.encode_uint::<u8>(2, 0x17); // assigned value for secp256r1 (key exchange via NIST P-256)
+    key_share.encode_vec(2, &random::<65>()); // 32 bytes of public key
 
     let mut key_share_list = Encoder::new();
     key_share_list.encode_vec(2, key_share.as_ref()); // first (and only) key share entry
 
-    extensions.encode_uint(2, 0x33_u8); // assigned value for extension "Key Share"
+    extensions.encode_uint::<u8>(2, 0x33); // assigned value for extension "Key Share"
     extensions.encode_vec(2, key_share_list.as_ref()); // "Key Share" extension data
+
+    let mut transport_parameters = Encoder::default();
+    tps.encode(&mut transport_parameters);
+
+    extensions.encode_uint::<u8>(2, 0x39);
+    extensions.encode_vec(2, transport_parameters.as_ref());
+
+    let mut alpn = Encoder::new();
+    alpn.encode_vec(1, b"h3");
+    let mut alpn_list = Encoder::new();
+    alpn_list.encode_vec(2, alpn.as_ref());
+
+    extensions.encode_uint::<u8>(2, 0x10);
+    extensions.encode_vec(2, alpn_list.as_ref());
+
+    extensions.encode_uint::<u8>(2, 0x1c); // record size limit
+    extensions.encode_vec(2, &[0x40, 0x01]);
+
+    extensions.encode_uint(2, 0xff01_u16); // renegotiation info
+    extensions.encode_vec(2, &[0x00]);
+
+    extensions.encode_uint::<u8>(2, 0x05); // status request
+    extensions.encode_vec(2, &[0x01, 0x00, 0x00, 0x00, 0x00]);
 
     // Handshake Header
     let mut handshake_data = Encoder::new();
@@ -130,42 +127,27 @@ fn generate_ch() -> Vec<u8> {
         2,
         &[
             // Cipher Suites
-            0x13, 0x02, // assigned value for TLS_AES_256_GCM_SHA384
-            0x13, 0x03, // assigned value for TLS_CHACHA20_POLY1305_SHA256
             0x13, 0x01, // assigned value for TLS_AES_128_GCM_SHA256
-            0x00, 0xff, // assigned value for TLS_EMPTY_RENEGOTIATION_INFO_SCSV
+            0x13, 0x03, // assigned value for TLS_CHACHA20_POLY1305_SHA256
+            0x13, 0x02, // assigned value for TLS_AES_256_GCM_SHA384
         ],
     );
-    handshake_data.encode_vec(
-        1,
-        &[
-            // Compression Methods
-            0x00, // assigned value for "null" compression
-        ],
-    );
+    // Compression Methods
+    handshake_data.encode_vec(1, &[0x00]); // assigned value for "null" compression
     handshake_data.encode_vec(2, extensions.as_ref()); // Extensions
 
     let mut handshake_message = Encoder::new();
     handshake_message.encode(&[0x01]); // handshake message type 0x01 (client hello)
     handshake_message.encode_vec(3, handshake_data.as_ref()); // client hello data
 
-    // Record Header
-    let mut record_header = Encoder::new();
-    record_header.encode(&[
-        0x16, // type is 0x16 (handshake record)
-        0x03, 0x01, // protocol version is "3,1" (also known as TLS 1.0)
-    ]);
-    record_header.encode_vec(2, handshake_message.as_ref()); // handshake message
-
-    record_header.as_ref().to_vec()
+    handshake_message.as_ref().to_vec()
 }
 
 pub fn sock_puppet(
     tx: &mut CryptoDxState,
     path: &PathRef,
-    address_validation: &AddressValidationInfo,
-    version: Version,
     loss_recovery: &LossRecovery,
+    tps: &TransportParameters,
 ) -> Vec<u8> {
     let encoder = Encoder::new();
     let (_pt, mut builder) = Connection::build_packet_header(
@@ -173,19 +155,19 @@ pub fn sock_puppet(
         CryptoSpace::Initial,
         encoder,
         tx,
-        address_validation,
-        version,
+        &AddressValidationInfo::None,
+        Version::Version1,
         false,
     );
-    let _pn = Connection::add_packet_number(
+    _ = Connection::add_packet_number(
         &mut builder,
         tx,
         loss_recovery.largest_acknowledged_pn(PacketNumberSpace::Initial),
     );
-    let sp = generate_ch();
-    qdebug!("XXX SOCK PUPPET {:02x?}", sp);
     let mut cstreams = CryptoStreams::default();
-    cstreams.send(PacketNumberSpace::Initial, &sp).unwrap();
+    cstreams
+        .send(PacketNumberSpace::Initial, &generate_ch(b"github.com", tps))
+        .unwrap();
     cstreams.write_frame(
         PacketNumberSpace::Initial,
         false,
@@ -193,5 +175,6 @@ pub fn sock_puppet(
         &mut Vec::new(),
         &mut FrameStats::default(),
     );
+
     builder.build(tx).unwrap().into()
 }

--- a/neqo-transport/src/connection/sockpuppet.rs
+++ b/neqo-transport/src/connection/sockpuppet.rs
@@ -1,0 +1,197 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use neqo_common::{qdebug, Encoder};
+use neqo_crypto::random;
+
+use super::AddressValidationInfo;
+use crate::{
+    crypto::{CryptoDxState, CryptoSpace, CryptoStreams},
+    path::PathRef,
+    recovery::LossRecovery,
+    stats::FrameStats,
+    tracking::PacketNumberSpace,
+    Connection, Version,
+};
+
+/// See <https://tls13.xargs.org/#client-hello/annotated>
+#[expect(clippy::too_many_lines)]
+fn generate_ch() -> Vec<u8> {
+    // Extensions
+    let mut extensions = Encoder::new();
+
+    let mut list_entry = Encoder::new();
+    list_entry.encode_uint(1, 0x00_u8); // list entry is type 0x00 "DNS hostname"
+    list_entry.encode_vec(2, b"github.com");
+
+    let mut server_name_list = Encoder::new();
+    server_name_list.encode_vec(2, list_entry.as_ref()); // first (and only) list entry
+
+    let mut server_name_extension = Encoder::new();
+    server_name_extension.encode_vec(2, server_name_list.as_ref()); // "server name" extension data
+
+    extensions.encode_uint(2, 0x00_u8); // assigned value for extension "server name"
+    extensions.encode_vec(2, server_name_extension.as_ref()); // server name extension data
+
+    let mut ec_points_formats = Encoder::new();
+    ec_points_formats.encode_vec(
+        1,
+        &[
+            0x00, // assigned value for format "uncompressed"
+            0x01, // assigned value for format "ansiX962_compressed_prime"
+            0x02, // assigned value for format "ansiX962_compressed_char2"
+        ],
+    );
+
+    extensions.encode_uint(2, 0x0b_u8); // assigned value for extension "ec point formats"
+    extensions.encode_vec(2, ec_points_formats.as_ref()); // ec point formats extension data
+
+    let mut supported_groups = Encoder::new();
+    supported_groups.encode_vec(
+        2,
+        &[
+            0x00, 0x1d, // assigned value for the curve "x25519"
+            0x00, 0x17, // assigned value for the curve "secp256r1"
+            0x00, 0x1e, // assigned value for the curve "x448"
+            0x00, 0x19, // assigned value for the curve "secp521r1"
+            0x00, 0x18, // assigned value for the curve "secp384r1"
+            0x01, 0x00, // assigned value for the curve "ffdhe2048"
+            0x01, 0x01, // assigned value for the curve "ffdhe3072"
+            0x01, 0x02, // assigned value for the curve "ffdhe4096"
+            0x01, 0x03, // assigned value for the curve "ffdhe6144"
+            0x01, 0x04, // assigned value for the curve "ffdhe8192"
+        ],
+    );
+
+    extensions.encode_uint(2, 0x0a_u8); // assigned value for extension "supported groups"
+    extensions.encode_vec(2, supported_groups.as_ref()); // supported groups extension data
+
+    extensions.encode_uint(2, 0x23_u8); // assigned value for extension "Session Ticket"
+    extensions.encode_vec(2, &[]); // 0 bytes of "Session Ticket" extension data
+
+    extensions.encode_uint(2, 0x17_u8); // assigned value for extension "Extended Master Secret"
+    extensions.encode_vec(2, &[]); // 0 bytes of "Extended Master Secret" extension data
+
+    let mut signature_algorithms = Encoder::new();
+    signature_algorithms.encode_vec(
+        2,
+        &[
+            0x04, 0x03, // assigned value for ECDSA-SECP256r1-SHA256
+            0x05, 0x03, // assigned value for ECDSA-SECP384r1-SHA384
+            0x06, 0x03, // assigned value for ECDSA-SECP521r1-SHA512
+            0x08, 0x07, // assigned value for ED25519
+            0x08, 0x08, // assigned value for ED448
+            0x08, 0x09, // assigned value for RSA-PSS-PSS-SHA256
+            0x08, 0x0a, // assigned value for RSA-PSS-PSS-SHA384
+            0x08, 0x0b, // assigned value for RSA-PSS-PSS-SHA512
+            0x08, 0x04, // assigned value for RSA-PSS-RSAE-SHA256
+            0x08, 0x05, // assigned value for RSA-PSS-RSAE-SHA384
+            0x08, 0x06, // assigned value for RSA-PSS-RSAE-SHA512
+            0x04, 0x01, // assigned value for RSA-PKCS1-SHA256
+            0x05, 0x01, // assigned value for RSA-PKCS1-SHA384
+            0x06, 0x01, // assigned value for RSA-PKCS1-SHA512
+        ],
+    );
+
+    extensions.encode_uint(2, 0x0d_u8); // assigned value for extension "Signature Algorithms"
+    extensions.encode_vec(2, signature_algorithms.as_ref()); // "Signature Algorithms" extension data
+
+    let mut supported_versions = Encoder::new();
+    supported_versions.encode_vec(1, &[0x03, 0x04]); // assigned value for TLS 1.3
+
+    extensions.encode_uint(2, 0x2b_u8); // assigned value for extension "Supported Versions"
+    extensions.encode_vec(2, supported_versions.as_ref()); // "Supported Versions" extension data
+
+    let mut psk_key_exchange_modes = Encoder::new();
+    psk_key_exchange_modes.encode_vec(1, &[0x01]); // assigned value for "PSK with (EC)DHE key establishment"
+
+    extensions.encode_uint(2, 0x2d_u8); // assigned value for extension "PSK Key Exchange Modes"
+    extensions.encode_vec(2, psk_key_exchange_modes.as_ref()); // "PSK Key Exchange Modes" extension data
+
+    let mut key_share = Encoder::new();
+    key_share.encode_uint(2, 0x1d_u8); // assigned value for x25519 (key exchange via curve25519)
+    key_share.encode_vec(2, &random::<32>()); // 32 bytes of public key
+
+    let mut key_share_list = Encoder::new();
+    key_share_list.encode_vec(2, key_share.as_ref()); // first (and only) key share entry
+
+    extensions.encode_uint(2, 0x33_u8); // assigned value for extension "Key Share"
+    extensions.encode_vec(2, key_share_list.as_ref()); // "Key Share" extension data
+
+    // Handshake Header
+    let mut handshake_data = Encoder::new();
+    handshake_data.encode(&[0x03, 0x03]); // Client Version
+    handshake_data.encode(&random::<32>()); // Client Random
+    handshake_data.encode_vec(1, &random::<32>()); // 32 bytes of session ID
+    handshake_data.encode_vec(
+        2,
+        &[
+            // Cipher Suites
+            0x13, 0x02, // assigned value for TLS_AES_256_GCM_SHA384
+            0x13, 0x03, // assigned value for TLS_CHACHA20_POLY1305_SHA256
+            0x13, 0x01, // assigned value for TLS_AES_128_GCM_SHA256
+            0x00, 0xff, // assigned value for TLS_EMPTY_RENEGOTIATION_INFO_SCSV
+        ],
+    );
+    handshake_data.encode_vec(
+        1,
+        &[
+            // Compression Methods
+            0x00, // assigned value for "null" compression
+        ],
+    );
+    handshake_data.encode_vec(2, extensions.as_ref()); // Extensions
+
+    let mut handshake_message = Encoder::new();
+    handshake_message.encode(&[0x01]); // handshake message type 0x01 (client hello)
+    handshake_message.encode_vec(3, handshake_data.as_ref()); // client hello data
+
+    // Record Header
+    let mut record_header = Encoder::new();
+    record_header.encode(&[
+        0x16, // type is 0x16 (handshake record)
+        0x03, 0x01, // protocol version is "3,1" (also known as TLS 1.0)
+    ]);
+    record_header.encode_vec(2, handshake_message.as_ref()); // handshake message
+
+    record_header.as_ref().to_vec()
+}
+
+pub fn sock_puppet(
+    tx: &mut CryptoDxState,
+    path: &PathRef,
+    address_validation: &AddressValidationInfo,
+    version: Version,
+    loss_recovery: &LossRecovery,
+) -> Vec<u8> {
+    let encoder = Encoder::new();
+    let (_pt, mut builder) = Connection::build_packet_header(
+        &path.borrow(),
+        CryptoSpace::Initial,
+        encoder,
+        tx,
+        address_validation,
+        version,
+        false,
+    );
+    let _pn = Connection::add_packet_number(
+        &mut builder,
+        tx,
+        loss_recovery.largest_acknowledged_pn(PacketNumberSpace::Initial),
+    );
+    let sp = generate_ch();
+    qdebug!("XXX SOCK PUPPET {:02x?}", sp);
+    let mut cstreams = CryptoStreams::default();
+    cstreams.send(PacketNumberSpace::Initial, &sp).unwrap();
+    cstreams.write_frame(
+        PacketNumberSpace::Initial,
+        false,
+        &mut builder,
+        &mut Vec::new(),
+        &mut FrameStats::default(),
+    );
+    builder.build(tx).unwrap().into()
+}

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -572,18 +572,19 @@ fn reorder_1rtt() {
         server.process_input(d, now + RTT / 2);
     }
     // The server has now received those packets, and saved them.
-    // The two extra received are Initial + the junk we use for padding.
-    assert_eq!(server.stats().packets_rx, PACKETS + 2);
+    // The three extra received are sock puppet CH + Initial + the junk we use for padding.
+    assert_eq!(server.stats().packets_rx, PACKETS + 3);
     assert_eq!(server.stats().saved_datagrams, PACKETS);
-    assert_eq!(server.stats().dropped_rx, 1);
+    assert_eq!(server.stats().dropped_rx, 2);
 
     now += RTT / 2;
     let s2 = server.process(c2, now).dgram();
     // The server has now received those packets, and saved them.
-    // The two additional are a Handshake and a 1-RTT (w/ NEW_CONNECTION_ID).
-    assert_eq!(server.stats().packets_rx, PACKETS * 2 + 4);
+    // The three additional are a Handshake and a 1-RTT (w/ NEW_CONNECTION_ID) and its sock puppet
+    // CH.
+    assert_eq!(server.stats().packets_rx, PACKETS * 2 + 5);
     assert_eq!(server.stats().saved_datagrams, PACKETS);
-    assert_eq!(server.stats().dropped_rx, 1);
+    assert_eq!(server.stats().dropped_rx, 2);
     assert_eq!(*server.state(), State::Confirmed);
     assert_eq!(server.paths.rtt(), RTT);
 
@@ -630,8 +631,8 @@ fn corrupted_initial() {
     server.process_input(dgram, now());
     // The server should have received two packets,
     // the first should be dropped, the second saved.
-    assert_eq!(server.stats().packets_rx, 2);
-    assert_eq!(server.stats().dropped_rx, 2);
+    assert_eq!(server.stats().packets_rx, 3);
+    assert_eq!(server.stats().dropped_rx, 3);
     assert_eq!(server.stats().saved_datagrams, 0);
 }
 

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -307,6 +307,7 @@ fn idle_caching() {
     let mut tokens = Vec::new();
     server.crypto.streams.write_frame(
         PacketNumberSpace::Initial,
+        server.conn_params.sni_slicing_enabled(),
         &mut builder,
         &mut tokens,
         &mut FrameStats::default(),
@@ -315,6 +316,7 @@ fn idle_caching() {
     tokens.clear();
     server.crypto.streams.write_frame(
         PacketNumberSpace::Initial,
+        server.conn_params.sni_slicing_enabled(),
         &mut builder,
         &mut tokens,
         &mut FrameStats::default(),

--- a/neqo-transport/src/connection/tests/keys.rs
+++ b/neqo-transport/src/connection/tests/keys.rs
@@ -80,8 +80,8 @@ fn discarded_initial_keys() {
     // The server has not removed the Initial keys yet, because it has not yet received a Handshake
     // packet from the client.
     // We will check this by processing init_pkt_c a second time.
-    // The dropped packet is padding. The Initial packet has been mark dup.
-    check_discarded(&mut server, &init_pkt_c.clone().unwrap(), false, 1, 1);
+    // The dropped packets are the sock puppet CH and padding. The Initial packet has been mark dup.
+    check_discarded(&mut server, &init_pkt_c.clone().unwrap(), false, 2, 1);
 
     qdebug!("---- client: SH..FIN -> FIN");
     let out = client.process_output(now()).dgram();

--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -330,10 +330,10 @@ fn invalid_server_version() {
     let dgram = client.process_output(now()).dgram();
     server.process_input(dgram.unwrap(), now());
 
-    // One packet received.
-    assert_eq!(server.stats().packets_rx, 1);
-    // None dropped; the server will have decrypted it successfully.
-    assert_eq!(server.stats().dropped_rx, 0);
+    // Two packets received, one is the sock puppet CH.
+    assert_eq!(server.stats().packets_rx, 2);
+    // Sock puppet CH was dropped.
+    assert_eq!(server.stats().dropped_rx, 1);
     assert_eq!(server.stats().saved_datagrams, 0);
     // The server effectively hasn't reacted here.
     match server.state() {

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -1326,8 +1326,8 @@ impl std::fmt::Display for CryptoStates {
 
 #[derive(Debug, Default)]
 pub struct CryptoStream {
-    tx: TxBuffer,
-    rx: RxStreamOrderer,
+    pub tx: TxBuffer,
+    pub rx: RxStreamOrderer,
 }
 
 #[derive(Debug)]

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -1326,8 +1326,8 @@ impl std::fmt::Display for CryptoStates {
 
 #[derive(Debug, Default)]
 pub struct CryptoStream {
-    pub tx: TxBuffer,
-    pub rx: RxStreamOrderer,
+    tx: TxBuffer,
+    rx: RxStreamOrderer,
 }
 
 #[derive(Debug)]

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -327,11 +327,13 @@ impl Crypto {
     pub fn write_frame(
         &mut self,
         space: PacketNumberSpace,
+        sni_slicing: bool,
         builder: &mut PacketBuilder,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
-        self.streams.write_frame(space, builder, tokens, stats);
+        self.streams
+            .write_frame(space, sni_slicing, builder, tokens, stats);
     }
 
     pub fn acked(&mut self, token: &CryptoRecoveryToken) {
@@ -1475,6 +1477,7 @@ impl CryptoStreams {
     pub fn write_frame(
         &mut self,
         space: PacketNumberSpace,
+        sni_slicing: bool,
         builder: &mut PacketBuilder,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
@@ -1506,7 +1509,7 @@ impl CryptoStreams {
 
         let cs = self.get_mut(space).unwrap();
         if let Some((offset, data)) = cs.tx.next_bytes() {
-            let written = if offset == 0 {
+            let written = if sni_slicing && offset == 0 {
                 if let Some(sni) = find_sni(data) {
                     // Cut the crypto data in two at the midpoint of the SNI and swap the chunks.
                     let mid = sni.start + (sni.end - sni.start) / 2;

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -243,15 +243,15 @@ impl PacketBuilder {
     pub fn set_initial_limit(
         &mut self,
         profile: &SendProfile,
-        aead_expansion: usize,
+        reserved: usize,
         pmtud: &Pmtud,
     ) -> bool {
         if pmtud.needs_probe() {
             debug_assert!(pmtud.probe_size() > profile.limit());
-            self.limit = pmtud.probe_size() - aead_expansion;
+            self.limit = pmtud.probe_size() - reserved;
             true
         } else {
-            self.limit = profile.limit() - aead_expansion;
+            self.limit = profile.limit() - reserved;
             false
         }
     }

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -421,7 +421,8 @@ fn new_token_different_port() {
 
 #[test]
 fn bad_client_initial() {
-    let mut client = default_client();
+    // Sock puppets don't work with the decryption this test uses.
+    let mut client = new_client(ConnectionParameters::default().sock_puppet(false));
     let mut server = default_server();
 
     let dgram = client.process_output(now()).dgram().expect("a datagram");

--- a/test/test.sh
+++ b/test/test.sh
@@ -16,7 +16,7 @@ cargo build --bin neqo-client --bin neqo-server
 addr=localhost
 port=4433
 path=/20000
-flags="--verbose --verbose --verbose --verbose --qlog-dir $tmp --alpn hq-interop --quic-version 1"
+flags="--verbose --verbose --verbose --qlog-dir $tmp --alpn hq-interop --quic-version 1"
 if [ "$(uname -s)" != "Linux" ]; then
         iface=lo0
 else
@@ -35,11 +35,9 @@ tcpdump -U -i "$iface" -w "$tmp/test.pcap" host $addr and port $port >/dev/null 
 tcpdump_pid=$!
 trap 'kill $tcpdump_pid; rm -rf "$tmp"' EXIT
 
-export SSLDEBUG=1
-export SSLTRACE=1
 tmux -CC \
         set-option -g default-shell "$(which bash)" \; \
-        new-session "$client; kill -USR2 $tcpdump_pid; touch $tmp/done" \; \
+        new-session "sleep 1; $client; kill -USR2 $tcpdump_pid; touch $tmp/done" \; \
         split-window -h "$server" \; \
         split-window -v -f "\
                 echo $tmp; \


### PR DESCRIPTION
This is a proof of concept for an idea that was discussed with @martinthomson a while ago. That idea is to prepend the actual CH with an invalid "sock puppet" CH that is invalid but contains an innocuous SNI.

Update: I don't think we can make this work @martinthomson. When the server accepts the first CH enough so that it starts parsing the crypto data, all errors it encounters become connection errors and it will therefore not look further into the packet at the second coalesced CH. If we invalidate the first CH at the QUIC layer, the server will discard the entire packets, also without looking further into it. (We may need a TLS extension that says "ignore this CH and keep going"?)