### PR TITLE
ci: Revamp the QNS CI action timeout

### DIFF
--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Modified "implementations.json" data'
     required: false
     default: ''
+  timeout:
+    description: 'Timeout for the test run in minutes'
+    required: false
+    default: 20
 
 runs:
   using: "composite"
@@ -54,6 +58,7 @@ runs:
       shell: bash
 
     - name: Run tests
+      timeout-minutes: ${{ inputs.timeout }}
       run: |
         cd quic-interop-runner
         if [ -n "${{ inputs.implementations }}" ]; then

--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -19,10 +19,6 @@ inputs:
     description: 'Modified "implementations.json" data'
     required: false
     default: ''
-  timeout:
-    description: 'Timeout for the test run in minutes'
-    required: false
-    default: 20
 
 runs:
   using: "composite"
@@ -58,7 +54,6 @@ runs:
       shell: bash
 
     - name: Run tests
-      timeout-minutes: ${{ inputs.timeout }}
       run: |
         cd quic-interop-runner
         if [ -n "${{ inputs.implementations }}" ]; then

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -23,7 +23,6 @@ permissions:
 env:
   LATEST: neqo-latest
   DELIM: ' vs. '
-  TIMEOUT: 30
 
 jobs:
   docker-image:
@@ -149,11 +148,11 @@ jobs:
 
       # TODO: Replace once https://github.com/quic-interop/quic-interop-runner/pull/356 is merged.
       - uses: ./.github/actions/quic-interop-runner
-        timeout-minutes: ${{ fromJSON(env.TIMEOUT) }}
         with:
           client: ${{ steps.depair.outputs.client }}
           server: ${{ steps.depair.outputs.server }}
           implementations: ${{ needs.implementations.outputs.implementations }}
+          timeout: 20
 
   report:
     name: Report results

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -148,11 +148,11 @@ jobs:
 
       # TODO: Replace once https://github.com/quic-interop/quic-interop-runner/pull/356 is merged.
       - uses: ./.github/actions/quic-interop-runner
+        timeout-minutes: 20
         with:
           client: ${{ steps.depair.outputs.client }}
           server: ${{ steps.depair.outputs.server }}
           implementations: ${{ needs.implementations.outputs.implementations }}
-          timeout: 20
 
   report:
     name: Report results


### PR DESCRIPTION
It seems that the `TIMEOUT` env variable applies to all steps?