### PR TITLE
chore: prepare v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "enum-map",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bindgen",
  "log",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "enumset",
  "log",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "log",
  "neqo-common",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "enum-map",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "cfg_aliases",
  "log",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.11.0"
+version = "0.12.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I would like to get the following pull requests into Firefox:

- https://github.com/mozilla/neqo/pull/2307
- https://github.com/mozilla/neqo/pull/2270
- https://github.com/mozilla/neqo/pull/2269
- https://github.com/mozilla/neqo/pull/2259
- https://github.com/mozilla/neqo/pull/2228