### PR TITLE
test(transport/vn): allow dropped_rx of 1

### DIFF
--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -251,7 +251,7 @@ fn compatible_upgrade_large_initial() {
     assert_eq!(server.version(), Version::Version2);
     // Only handshake padding is "dropped".
     assert_eq!(client.stats().dropped_rx, 1);
-    assert_eq!(server.stats().dropped_rx, 2);
+    assert!(matches!(server.stats().dropped_rx, 1 | 2));
 }
 
 /// A server that supports versions 1 and 2 might prefer version 1 and that's OK.


### PR DESCRIPTION
`compatible_upgrade_large_initial` tests whether Neqo can handle an ACK using QUIC version Y on a connection that ends up using QUIC version X.

https://github.com/mozilla/neqo/pull/2228 changed the test, asserting that the server will drop 2 instead of 1 packet. This spuriosly fails on CI:

https://github.com/mozilla/neqo/actions/runs/12796212878/job/35675377711?pr=2295

This commit allows both 1 and 2 packets dropped by the server.

---

@larseggert based on your changes in https://github.com/mozilla/neqo/pull/2228/, is this a valid assumption to make?