### PR TITLE
ci: pin nightly

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -24,7 +24,9 @@ runs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@21dc36fb71dd22e3317045c0c31a3f4249868b17 # master
       with:
-        toolchain: ${{ inputs.version  }}
+        # Nightly pinned due to <https://github.com/mozilla/neqo/issues/2369>
+        # for now.
+        toolchain: ${{ inputs.version == 'nightly' && 'nightly-2025-01-15' || inputs.version }}
         components: ${{ inputs.components }}
         targets: ${{ inputs.targets }}
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/neqo/issues/2369.

Once this is merged, I can tackle https://github.com/mozilla/neqo/issues/2365.

Once https://github.com/mozilla/neqo/issues/2365 is fixed, I can try fixing the sanitizer failures on Ubuntu 22.04.