### PR TITLE
deps(common/log): drop env_logger's auto-color and regex features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "enum-map",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bindgen",
  "log",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "enumset",
  "log",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "log",
  "neqo-common",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "enum-map",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "cfg_aliases",
  "log",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,10 +398,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "is-terminal",
  "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1293,15 +1290,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.12.0"
+version = "0.12.1"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 # Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 enum-map = { workspace = true }
-env_logger = { version = "0.10", default-features = false, features = ["auto-color", "regex"] }
+env_logger = { version = "0.10", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"], optional = true }
 log = { workspace = true }
 qlog = { workspace = true }

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -33,18 +33,12 @@ pub fn init(level_filter: Option<log::LevelFilter>) {
         }
         builder.format(|buf, record| {
             let elapsed = since_start();
-            let level_style = buf.default_level_style(record.level());
-            let mut bold = buf.style();
-            bold.set_bold(true);
             writeln!(
                 buf,
-                "{} {} {}",
-                bold.value(format!(
-                    "{}.{:03}",
-                    elapsed.as_secs(),
-                    elapsed.as_millis() % 1000
-                )),
-                level_style.value(record.level()),
+                "{}.{:03} {} {}",
+                elapsed.as_secs(),
+                elapsed.as_millis() % 1000,
+                record.level(),
                 record.args()
             )
         });


### PR DESCRIPTION
https://github.com/mozilla/neqo/pull/2291 added additional formatting to our log output via `env_logger`'s `auto-color` feature. The `auto-color` feature adds the `is-terminal` crate dependency. `is-terminal` depends on `hermit-abi` `v0.4`.

Pulling latest Neqo `v0.12.0` into mozilla-central adds `is-terminal` and `hermit-abi` `v0.4.0` to the Firefox dependency tree.

In order to keep our dependency footprint low, I suggest not enabling the two `env-logger` features.

@larseggert thoughts? Alternatively I can also audit the two dependencies and then introduce them into Firefox. That said, is it worth it?