### PR TITLE
ci: Remove `--mcdc` from coverage runs

### DIFF
--- a/.github/workflows/check-vm.yml
+++ b/.github/workflows/check-vm.yml
@@ -164,7 +164,7 @@ jobs:
 
       - uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
         with:
-          files: lcov.info
+          files: codecov.json
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/check-vm.yml
+++ b/.github/workflows/check-vm.yml
@@ -63,7 +63,7 @@ jobs:
             cargo check --all-targets
             cargo clippy -- -D warnings
             cargo install cargo-llvm-cov --locked
-            cargo llvm-cov test --no-fail-fast --lcov --output-path lcov.info
+            cargo llvm-cov test --no-fail-fast --features ci --profile ci --codecov --output-path codecov.json
             cargo test --no-fail-fast --release
             rm -rf target # Don't sync this back to host
 
@@ -93,7 +93,7 @@ jobs:
             # export LLVM_COV=/usr/local/llvm16/bin/llvm-cov
             # export LLVM_PROFDATA=/usr/local/llvm16/bin/llvm-profdata
             # cargo install cargo-llvm-cov --locked
-            # cargo llvm-cov test --no-fail-fast --lcov --output-path lcov.info
+            # cargo llvm-cov test --no-fail-fast --features ci --profile ci --codecov --output-path codecov.json
             cargo test --no-fail-fast # Remove this once profiler is supported
             cargo test --no-fail-fast --release
             rm -rf target # Don't sync this back to host
@@ -126,7 +126,7 @@ jobs:
             # > error[E0463]: can't find crate for `profiler_builtins`
             # > = note: the compiler may have been built without the profiler runtime
             # cargo install cargo-llvm-cov --locked
-            # cargo llvm-cov test --no-fail-fast --lcov --output-path lcov.info
+            # cargo llvm-cov test --no-fail-fast --features ci --profile ci --codecov --output-path codecov.json
             cargo test --no-fail-fast # Remove this once profiler is supported
             cargo test --no-fail-fast --release
             rm -rf target # Don't sync this back to host
@@ -157,7 +157,7 @@ jobs:
             # > error[E0463]: can't find crate for `profiler_builtins`
             # > = note: the compiler may have been built without the profiler runtime
             # cargo install cargo-llvm-cov --locked
-            # cargo llvm-cov test --no-fail-fast --lcov --output-path lcov.info
+            # cargo llvm-cov test --no-fail-fast --features ci --profile ci --codecov --output-path codecov.json
             cargo test --no-fail-fast # Remove this once profiler is supported
             cargo test --no-fail-fast --release
             rm -rf target # Don't sync this back to host

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -87,7 +87,7 @@ jobs:
           export DUMP_SIMULATION_SEEDS
           # shellcheck disable=SC2086
           if [ "${{ matrix.rust-toolchain }}" == "nightly" ]; then
-            cargo llvm-cov nextest $BUILD_TYPE --mcdc --include-ffi --features ci --profile ci --codecov --output-path codecov.json
+            cargo llvm-cov nextest $BUILD_TYPE --features ci --profile ci --codecov --output-path codecov.json
           else
             cargo nextest run $BUILD_TYPE --features ci --profile ci
           fi


### PR DESCRIPTION
It seems to introduce quite a bit ot fluctuation, which makes the coverage action fail.

Also use the same `llvm-cov` incantation in the `check-vm` workflow.