### PR TITLE
chore(transport): export ecn module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "criterion",
  "enum-map",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "bindgen",
  "log",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "enumset",
  "log",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "log",
  "neqo-common",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "criterion",
  "enum-map",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "cfg_aliases",
  "log",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.12.1"
+version = "0.12.2"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -13,7 +13,7 @@ mod cc;
 mod cid;
 mod connection;
 mod crypto;
-mod ecn;
+pub mod ecn;
 mod events;
 mod fc;
 #[cfg(fuzzing)]

--- a/neqo-transport/tests/stats.rs
+++ b/neqo-transport/tests/stats.rs
@@ -1,0 +1,16 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use neqo_transport::ecn;
+
+#[test]
+fn crate_exports_ecn_types() {
+    let stats = neqo_transport::Stats::default();
+
+    let _ = stats.ecn_path_validation[ecn::ValidationOutcome::Capable];
+    let _ = stats.ecn_path_validation
+        [ecn::ValidationOutcome::NotCapable(ecn::ValidationError::BlackHole)];
+}


### PR DESCRIPTION
https://github.com/mozilla/neqo/pull/2270 added ECN path validation failure reasons to `neqo_transport::Stats`. I forgot to expose the `ValidationOutcome` and `ValidationError` `enum`s beyond the `neqo-transport` crate boundaries though. This is needed in order for `neqo_glue` in mozilla-central to convert them into Glean metrics.

This commit exposes the `neqo_transport::ecn` module and makes those types `pub(crate)` which are not needed outside of `neqo_transport`. 