### PR TITLE
chore: Invert SNI slicing option to `--no-sni-slicing`

### DIFF
--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -242,10 +242,10 @@ impl Args {
         self.shared.alpn = String::from("hq-interop");
         // Wireshark can't reassemble sliced CRYPTO frames, which causes tests to fail.
         // So let's turn that off by default, and only enable for some known-good QNS tests.
-        self.shared.quic_parameters.sni_slicing = false;
+        self.shared.quic_parameters.no_sni_slicing = true;
         match testcase.as_str() {
             "http3" => {
-                self.shared.quic_parameters.sni_slicing = true;
+                self.shared.quic_parameters.no_sni_slicing = false;
                 self.shared.alpn = String::from("h3");
                 if let Some(testcase) = &self.test {
                     if testcase.as_str() != "upload" {
@@ -269,7 +269,7 @@ impl Args {
                     qerror!("Warning: zerortt test won't work without >1 URL");
                     exit(127);
                 }
-                self.shared.quic_parameters.sni_slicing = true;
+                self.shared.quic_parameters.no_sni_slicing = false;
                 self.resume = true;
                 // PMTUD probes inflate what we sent in 1-RTT, causing QNS to fail the test.
                 self.shared.quic_parameters.no_pmtud = true;
@@ -290,7 +290,7 @@ impl Args {
                 self.key_update = true;
             }
             "v2" => {
-                self.shared.quic_parameters.sni_slicing = true;
+                self.shared.quic_parameters.no_sni_slicing = false;
                 // Use default version set for this test (which allows compatible vneg.)
                 self.shared.quic_parameters.quic_version.clear();
             }

--- a/neqo-bin/src/lib.rs
+++ b/neqo-bin/src/lib.rs
@@ -124,6 +124,10 @@ pub struct QuicParameters {
     /// Whether to disable path MTU discovery.
     pub no_pmtud: bool,
 
+    #[arg(long)]
+    /// Whether to slice the SNI.
+    pub no_sni_slicing: bool,
+
     #[arg(name = "preferred-address-v4", long)]
     /// An IPv4 address for the server preferred address.
     pub preferred_address_v4: Option<String>,
@@ -131,10 +135,6 @@ pub struct QuicParameters {
     #[arg(name = "preferred-address-v6", long)]
     /// An IPv6 address for the server preferred address.
     pub preferred_address_v6: Option<String>,
-
-    #[arg(long, default_value = "true")]
-    /// Whether to slice the SNI.
-    pub sni_slicing: bool,
 }
 
 #[cfg(any(test, feature = "bench"))]
@@ -150,7 +150,7 @@ impl Default for QuicParameters {
             no_pmtud: false,
             preferred_address_v4: None,
             preferred_address_v6: None,
-            sni_slicing: true,
+            no_sni_slicing: false,
         }
     }
 }
@@ -224,7 +224,7 @@ impl QuicParameters {
             .cc_algorithm(self.congestion_control)
             .pacing(!self.no_pacing)
             .pmtud(!self.no_pmtud)
-            .sni_slicing(self.sni_slicing);
+            .sni_slicing(!self.no_sni_slicing);
         params = if let Some(pa) = self.preferred_address() {
             params.preferred_address(pa)
         } else {

--- a/test/test.sh
+++ b/test/test.sh
@@ -28,7 +28,7 @@ if [ "$NSS_DIR" ] && [ "$NSS_TARGET" ]; then
         export DYLD_FALLBACK_LIBRARY_PATH="$LD_LIBRARY_PATH"
 fi
 
-client="./target/debug/neqo-client $flags --output-dir $tmp --stats https://$addr:$port$path"
+client="./target/debug/neqo-client $flags --no-sni-slicing --output-dir $tmp --stats https://$addr:$port$path"
 server="SSLKEYLOGFILE=$tmp/test.tlskey ./target/debug/neqo-server $flags $addr:$port"
 
 tcpdump -U -i "$iface" -w "$tmp/test.pcap" host $addr and port $port >/dev/null 2>&1 &


### PR DESCRIPTION
To be consistent with other options, and so we can actually turn it off.

Also add it to `test.sh`, so that the `tshark` parsing works.