### PR TITLE
ci: Re-enable `Swatinem/rust-cache`

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -38,16 +38,30 @@ runs:
       if: env.SCCACHE_ENABLED != '1' && runner.environment != 'github-hosted'
       uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
 
+    # See https://corrode.dev/blog/tips-for-faster-ci-builds/
+    - name: Set up build environment
+      shell: bash
+      run: |
+        {
+          echo "CARGO_INCREMENTAL=0"
+          echo "CARGO_PROFILE_RELEASE_LTO=true"
+          echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1"
+        } >> "$GITHUB_ENV"
+
     - name: Enable sscache
       if: runner.environment != 'github-hosted'
       shell: bash
       run: |
         echo "SCCACHE_ENABLED=1" >> "$GITHUB_ENV"
         echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-        echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
         if [ "${{ runner.environment }}" == "github-hosted" ]; then
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
         fi
+
+    - name: Enable Rust cache
+      uses: Swatinem/rust-cache@@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
+      with:
+        cache-bin: ${{ runner.environment == 'github-hosted' }}
 
     - name: Set up MSVC (Windows)
       if: runner.os == 'Windows'

--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -59,7 +59,7 @@ runs:
         fi
 
     - name: Enable Rust cache
-      uses: Swatinem/rust-cache@@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
+      uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
       with:
         cache-bin: ${{ runner.environment == 'github-hosted' }}
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Build neqo
         run: |
           cargo "+$TOOLCHAIN" bench --workspace --features bench --no-run
-          cargo "+$TOOLCHAIN" build --release --bin neqo-client --bin neqo-server
+          cargo "+$TOOLCHAIN" build --locked --release --bin neqo-client --bin neqo-server
 
       - name: Build msquic
         run: |

--- a/.github/workflows/check-vm.yml
+++ b/.github/workflows/check-vm.yml
@@ -60,11 +60,11 @@ jobs:
             fi
             sh rustup.sh --default-toolchain stable --profile minimal --component clippy llvm-tools -y
             . "$HOME/.cargo/env"
-            cargo check --all-targets
+            cargo check --locked --all-targets
             cargo clippy -- -D warnings
             cargo install cargo-llvm-cov --locked
-            cargo llvm-cov test --no-fail-fast --lcov --output-path lcov.info
-            cargo test --no-fail-fast --release
+            cargo llvm-cov test --locked --no-fail-fast --lcov --output-path lcov.info
+            cargo test --locked --no-fail-fast --release
             rm -rf target # Don't sync this back to host
 
       - if: matrix.os == 'openbsd'
@@ -85,7 +85,7 @@ jobs:
               exit 0
             fi
             export LIBCLANG_PATH=/usr/local/llvm16/lib
-            cargo check --all-targets
+            cargo check --locked --all-targets
             cargo clippy -- -D warnings
             # FIXME: No profiler support in openbsd currently, error is:
             # > error[E0463]: can't find crate for `profiler_builtins`
@@ -93,9 +93,9 @@ jobs:
             # export LLVM_COV=/usr/local/llvm16/bin/llvm-cov
             # export LLVM_PROFDATA=/usr/local/llvm16/bin/llvm-profdata
             # cargo install cargo-llvm-cov --locked
-            # cargo llvm-cov test --no-fail-fast --lcov --output-path lcov.info
-            cargo test --no-fail-fast # Remove this once profiler is supported
-            cargo test --no-fail-fast --release
+            # cargo llvm-cov test --locked --no-fail-fast --lcov --output-path lcov.info
+            cargo test --locked --no-fail-fast # Remove this once profiler is supported
+            cargo test --locked --no-fail-fast --release
             rm -rf target # Don't sync this back to host
 
       - if: matrix.os == 'netbsd'
@@ -120,15 +120,15 @@ jobs:
             . "$HOME/.cargo/env"
             # FIXME: Why do we need to set this on NetBSD?
             export LD_LIBRARY_PATH=/usr/pkg/lib/nss:/usr/pkg/lib/nspr
-            cargo check --all-targets
+            cargo check --locked --all-targets
             cargo clippy -- -D warnings
             # FIXME: No profiler support in netbsd currently, error is:
             # > error[E0463]: can't find crate for `profiler_builtins`
             # > = note: the compiler may have been built without the profiler runtime
             # cargo install cargo-llvm-cov --locked
-            # cargo llvm-cov test --no-fail-fast --lcov --output-path lcov.info
-            cargo test --no-fail-fast # Remove this once profiler is supported
-            cargo test --no-fail-fast --release
+            # cargo llvm-cov test --locked --no-fail-fast --lcov --output-path lcov.info
+            cargo test --locked --no-fail-fast # Remove this once profiler is supported
+            cargo test --locked --no-fail-fast --release
             rm -rf target # Don't sync this back to host
 
       - if: matrix.os == 'solaris'
@@ -151,15 +151,15 @@ jobs:
             fi
             source <(curl -s https://raw.githubusercontent.com/psumbera/solaris-rust/refs/heads/main/sh.rust-web-install) || true # This doesn't exit with zero on success
             export LIBCLANG_PATH="/usr/lib/amd64"
-            cargo check --all-targets
+            cargo check --locked --all-targets
             cargo clippy -- -D warnings
             # FIXME: No profiler support in openbsd currently, error is:
             # > error[E0463]: can't find crate for `profiler_builtins`
             # > = note: the compiler may have been built without the profiler runtime
             # cargo install cargo-llvm-cov --locked
-            # cargo llvm-cov test --no-fail-fast --lcov --output-path lcov.info
-            cargo test --no-fail-fast # Remove this once profiler is supported
-            cargo test --no-fail-fast --release
+            # cargo llvm-cov test --locked --no-fail-fast --lcov --output-path lcov.info
+            cargo test --locked --no-fail-fast # Remove this once profiler is supported
+            cargo test --locked --no-fail-fast --release
             rm -rf target # Don't sync this back to host
 
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Check
         run: |
           # shellcheck disable=SC2086
-          cargo check $BUILD_TYPE --all-targets --features ci
+          cargo check $BUILD_TYPE --locked --all-targets --features ci
 
       - name: Run tests and determine coverage
         env:
@@ -87,9 +87,9 @@ jobs:
           export DUMP_SIMULATION_SEEDS
           # shellcheck disable=SC2086
           if [ "${{ matrix.rust-toolchain }}" == "nightly" ]; then
-            cargo llvm-cov nextest $BUILD_TYPE --mcdc --include-ffi --features ci --profile ci --codecov --output-path codecov.json
+            cargo llvm-cov nextest $BUILD_TYPE --locked --mcdc --include-ffi --features ci --profile ci --codecov --output-path codecov.json
           else
-            cargo nextest run $BUILD_TYPE --features ci --profile ci
+            cargo nextest run $BUILD_TYPE --locked --features ci --profile ci
           fi
 
       - name: Run client/server transfer

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -76,7 +76,7 @@ jobs:
             PWD=$(pwd)
             export LSAN_OPTIONS="suppressions=$PWD/suppressions.txt"
           fi
-          cargo nextest run -Z build-std --features ci --profile ci --target "$TARGET"
+          cargo nextest run --locked -Z build-std --features ci --profile ci --target "$TARGET"
 
       - name: Save simulation seeds artifact
         if: env.DUMP_SIMULATION_SEEDS

--- a/qns/Dockerfile
+++ b/qns/Dockerfile
@@ -33,7 +33,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 ADD . /neqo
 RUN set -eux; \
     cd /neqo; \
-    CARGO_PROFILE_RELEASE_DEBUG=true cargo build --release --bin neqo-client --bin neqo-server
+    CARGO_PROFILE_RELEASE_DEBUG=true cargo build --locked --release --bin neqo-client --bin neqo-server
 
 # Copy only binaries to the final image to keep it small.
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -11,7 +11,7 @@
 set -e
 tmp=$(mktemp -d)
 
-cargo build --bin neqo-client --bin neqo-server
+cargo build --locked --bin neqo-client --bin neqo-server
 
 addr=localhost
 port=4433
@@ -28,7 +28,7 @@ if [ "$NSS_DIR" ] && [ "$NSS_TARGET" ]; then
         export DYLD_FALLBACK_LIBRARY_PATH="$LD_LIBRARY_PATH"
 fi
 
-client="./target/debug/neqo-client $flags --no-sni-slicing --output-dir $tmp --stats https://$addr:$port$path"
+client="./target/debug/neqo-client $flags --output-dir $tmp --stats https://$addr:$port$path"
 server="SSLKEYLOGFILE=$tmp/test.tlskey ./target/debug/neqo-server $flags $addr:$port"
 
 tcpdump -U -i "$iface" -w "$tmp/test.pcap" host $addr and port $port >/dev/null 2>&1 &


### PR DESCRIPTION
Now that we have `Cargo.lock` in the repository, we can re-enable the `Swatinem/rust-cache` action. This should speed up the CI process.

Also apply some other suggestions from https://corrode.dev/blog/tips-for-faster-ci-builds/