### PR TITLE
ci: Use `--force` with `quickinstall` to work around caching issue

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -43,9 +43,11 @@ runs:
       shell: bash
       run: |
         {
-          echo "CARGO_INCREMENTAL=0"
           echo "CARGO_PROFILE_RELEASE_LTO=true"
           echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1"
+          # Create different cache entries for different installed tool combinations.
+          # A "RUST"-prefixed environment variable will be picked up by Swatinem/rust-cache automatically.
+          echo "RUST_TOOLS='${{ inputs.tools }}'"
         } >> "$GITHUB_ENV"
 
     - name: Enable sscache

--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -45,9 +45,6 @@ runs:
         {
           echo "CARGO_PROFILE_RELEASE_LTO=true"
           echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1"
-          # Create different cache entries for different installed tool combinations.
-          # A "RUST"-prefixed environment variable will be picked up by Swatinem/rust-cache automatically.
-          echo "RUST_TOOLS='${{ inputs.tools }}'"
         } >> "$GITHUB_ENV"
 
     - name: Enable sscache
@@ -90,4 +87,5 @@ runs:
       if: inputs.tools != ''
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
-      run: cargo quickinstall $(echo ${{ inputs.tools }} | tr -d ",")
+      # FIXME: See https://github.com/Swatinem/rust-cache/issues/204 for why `--force`.
+      run: cargo quickinstall --force $(echo ${{ inputs.tools }} | tr -d ",")


### PR DESCRIPTION
Should unbreak CI.

See https://github.com/Swatinem/rust-cache/issues/204