### PR TITLE
fix: `map_or` -> `map_err`

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2630,9 +2630,7 @@ impl Connection {
                 .get_bytes(tparams::STATELESS_RESET_TOKEN)
                 .map_or_else(
                     || Ok(ConnectionIdEntry::random_srt()),
-                    |token| {
-                        <[u8; 16]>::try_from(token).map_or(Err(Error::TransportParameterError), Ok)
-                    },
+                    |token| <[u8; 16]>::try_from(token).map_err(|_| Error::TransportParameterError),
                 )?;
             let path = self.paths.primary().ok_or(Error::NoAvailablePath)?;
             path.borrow_mut().set_reset_token(reset_token);


### PR DESCRIPTION
Bug in #2294 spotted by @martinthomson in https://github.com/larseggert/neqo/commit/0eb7c5e89bf22a9e99350eb924523798f574da1f#r152054928