### PR TITLE
ci: Only cache Rust artifacts from `main` runs

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -78,6 +78,7 @@ runs:
       uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
       with:
         cache-bin: ${{ runner.environment == 'github-hosted' }}
+        save-if: ${{ github.ref == 'refs/heads/main' }} # Only cache runs from `main`
 
     - name: Set up MSVC (Windows)
       if: runner.os == 'Windows'


### PR DESCRIPTION
To hopefully reduce cache pressure.