### PR TITLE
ci: Give `zizmor` more permissions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -40,6 +40,8 @@ jobs:
   zizmor:
     name: zizmor 🌈
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
It needs `security-events: write` to integrate with CodeQL.