### PR TITLE
ci: Check for `mold` before trying to install install

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -44,8 +44,11 @@ runs:
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
-        [ "$APT_UPDATED" ] || sudo apt-get update && echo "APT_UPDATED=1" >> "$GITHUB_ENV"
-        sudo apt-get install -y --no-install-recommends mold
+        if [ "$(apt-cache search --names-only '^mold$' | wc -l)" -ge 1 ]; then
+          [ "$APT_UPDATED" ] || sudo apt-get update && echo "APT_UPDATED=1" >> "$GITHUB_ENV"
+          sudo apt-get install -y --no-install-recommends mold
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold $RUSTFLAGS" >> "$GITHUB_ENV"
+        fi
 
     # See https://corrode.dev/blog/tips-for-faster-ci-builds/
     - name: Set up build environment
@@ -54,14 +57,9 @@ runs:
         {
           echo "CARGO_PROFILE_RELEASE_LTO=true"
           echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1"
-          case "${{ runner.os }}" in
-            Linux)
-              echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=mold $RUSTFLAGS"
-              ;;
-            Windows)
+          if [ "${{ runner.os }}" == "Windows"]; then
               echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld $RUSTFLAGS"
-              ;;
-          esac
+            fi
         } >> "$GITHUB_ENV"
 
     - name: Enable sscache


### PR DESCRIPTION
Older Ubuntus don't have it.