### PR TITLE
ci: Fix QNS log failure

### DIFF
--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -112,11 +112,8 @@ runs:
       env:
         ARTIFACT_URL: ${{ steps.upload-logs.outputs.artifact-url }}
       run: |
-        cat result.json
         jq ". + {log_url: \"$ARTIFACT_URL\"}" < result.json  > result.json.tmp
-        ls -l *.json
         mv result.json.tmp result.json
-        cat result.json
       shell: bash
 
     - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -14,7 +14,7 @@ inputs:
   test:
     description: 'test cases (comma-separatated)'
     required: false
-    default: 'handshake,http3' # 'onlyTests'
+    default: 'onlyTests'
   implementations:
     description: 'Modified "implementations.json" data'
     required: false

--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -113,8 +113,8 @@ runs:
         ARTIFACT_URL: ${{ steps.upload-logs.outputs.artifact-url }}
       run: |
         cat result.json
-        jq ". + {log_url: \"$ARTIFACT_URL\"}"
-          < result.json  > result.json.tmp
+        jq ". + {log_url: \"$ARTIFACT_URL\"}" < result.json  > result.json.tmp
+        ls -l *.json
         mv result.json.tmp result.json
         cat result.json
       shell: bash

--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -112,6 +112,7 @@ runs:
       env:
         ARTIFACT_URL: ${{ steps.upload-logs.outputs.artifact-url }}
       run: |
+        cat result.json
         jq ". + {log_url: \"$ARTIFACT_URL\"}"
           < result.json  > result.json.tmp && \
           mv result.json.tmp result.json

--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -114,8 +114,9 @@ runs:
       run: |
         cat result.json
         jq ". + {log_url: \"$ARTIFACT_URL\"}"
-          < result.json  > result.json.tmp && \
-          mv result.json.tmp result.json
+          < result.json  > result.json.tmp
+        mv result.json.tmp result.json
+        cat result.json
       shell: bash
 
     - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -14,7 +14,7 @@ inputs:
   test:
     description: 'test cases (comma-separatated)'
     required: false
-    default: 'onlyTests'
+    default: 'handshake,http3' # 'onlyTests'
   implementations:
     description: 'Modified "implementations.json" data'
     required: false

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -248,14 +248,14 @@ jobs:
                 DIFF=$(wdiff -n "$BASELINE" - <<< "$RESULT" || true)
                 if [ "$GROUP" == "failed" ]; then
                   ADD=":warning:"
-                  ADD_DELIM="~~"
+                  ADD_DELIM="\*\*"
                   DEL=":rocket:"
-                  DEL_DELIM="\*\*"
+                  DEL_DELIM="~~"
                 elif [ "$GROUP" == "succeeded" ]; then
                   ADD=":rocket:"
-                  ADD_DELIM="\*\*"
+                  ADD_DELIM="~~"
                   DEL=":warning:"
-                  DEL_DELIM="~~"
+                  DEL_DELIM="\*\*"
                 else
                   ADD=""
                   ADD_DELIM=""

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -210,6 +210,7 @@ jobs:
           # shellcheck disable=SC2153
           mapfile -t LIST < <(echo "$PAIRS" | jq '.[]' | sort)
           echo "${LIST[@]}"
+          find results -ls
           for PREFIX in "${LIST[@]}"; do
             echo "Processing $PREFIX"
             PREFIX=$(echo "$PREFIX" | tr -d '"')
@@ -223,6 +224,7 @@ jobs:
             RUN="results/${PREFIX} results"
             PAIR="$CLIENT $DELIM $SERVER"
             if [ ! -e "$RUN/result.json" ]; then
+              echo not there
               echo "* $PAIR: run cancelled after $TIMEOUT min" >> "$ROLE.failed.md"
               continue
             fi

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -222,6 +222,7 @@ jobs:
               ROLE=server
             fi
             RUN="results/${PREFIX} results"
+            echo $RUN
             PAIR="$CLIENT $DELIM $SERVER"
             if [ ! -e "$RUN/result.json" ]; then
               echo not there

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -102,14 +102,30 @@ jobs:
     steps:
       - id: config
         run: |
-          # Add neqo-latest to implementations.json
-          curl https://raw.githubusercontent.com/quic-interop/quic-interop-runner/master/implementations.json | \
-            jq --arg key "$LATEST" --argjson newEntry "
-              {
-                \"image\": \"$IMAGE\",
-                \"url\": \"$URL\",
-                \"role\": \"$ROLE\"
-              }" '.[$key] = $newEntry' > implementations.json
+          # Add neqo-latest and some non-default implementations.
+          # tquic: https://github.com/quic-interop/quic-interop-runner/pull/385/files
+          # openssl: https://github.com/quic-interop/quic-interop-runner/pull/402/files
+          cat <<EOF > additional.json
+          {
+            "neqo-latest": {
+              "image": "$IMAGE",
+              "url": "$URL",
+              "role": "$ROLE"
+            },
+            "tquic": {
+              "image": "tquicgroup/tquic:latest",
+              "url": "https://github.com/Tencent/tquic/",
+              "role": "both"
+            },
+            "openssl": {
+              "image": "quay.io/openssl-ci/openssl-quic-interop",
+              "url": "https://github.com/openssl/openssl",
+              "role": "client"
+            }
+          }
+          EOF
+          curl -o runner.json https://raw.githubusercontent.com/quic-interop/quic-interop-runner/master/implementations.json
+          jq '. += input' runner.json additional.json > implementations.json
           {
             echo "implementations<<EOF"
             cat implementations.json
@@ -210,6 +226,7 @@ jobs:
               echo "* $PAIR: run cancelled after $TIMEOUT min" >> "$ROLE.failed.md"
               continue
             fi
+            cat "$RUN/result.json"
             jq < "$RUN/result.json" '
                 . as $data |
                 .results[][].result //= "failed" |
@@ -219,6 +236,7 @@ jobs:
                 } |
                 . + {log_url: $data.log_url}
               ' > "$RUN/$ROLE.grouped.json"
+            cat "$RUN/$ROLE.grouped.json"
             for ROLE in client server; do
               [ ! -e "$RUN/$ROLE.grouped.json" ] && continue
               for GROUP in $(jq -r < "$RUN/$ROLE.grouped.json" '.results | keys[]'); do
@@ -234,6 +252,7 @@ jobs:
                 DIFF=$(wdiff -n "$BASELINE" - <<< "$RESULT" || true)
                 RESULT=$(echo "$DIFF" | sed -E "s/\[-/ :rocket:~~/g; s/-\]/~~ /g; s/\{\+/ :warning:\*\*/g; s/\+\}/\*\* /g")
                 echo "* [$PAIR]($LOG): $RESULT" >> "$ROLE.$GROUP.md"
+                cat "$ROLE.$GROUP.md"
               done
             done
           done
@@ -275,6 +294,7 @@ jobs:
             echo
             echo "</details>"
           } >> comment.md
+          cat comment.md
 
       - if: ${{ github.ref == 'refs/heads/main' }}
         run: |

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -209,10 +209,7 @@ jobs:
         run: |
           # shellcheck disable=SC2153
           mapfile -t LIST < <(echo "$PAIRS" | jq '.[]' | sort)
-          echo "${LIST[@]}"
-          find results -ls
           for PREFIX in "${LIST[@]}"; do
-            echo "Processing $PREFIX"
             PREFIX=$(echo "$PREFIX" | tr -d '"')
             CLIENT=$(echo "$PREFIX" | cut -f1 -d " ")
             SERVER=$(echo "$PREFIX" | cut -f3 -d " ")
@@ -222,14 +219,11 @@ jobs:
               ROLE=server
             fi
             RUN="results/${PREFIX} results"
-            echo $RUN
             PAIR="$CLIENT $DELIM $SERVER"
             if [ ! -e "$RUN/result.json" ]; then
-              echo not there
               echo "* $PAIR: run cancelled after $TIMEOUT min" >> "$ROLE.failed.md"
               continue
             fi
-            cat "$RUN/result.json"
             jq < "$RUN/result.json" '
                 . as $data |
                 .results[][].result //= "failed" |
@@ -239,7 +233,6 @@ jobs:
                 } |
                 . + {log_url: $data.log_url}
               ' > "$RUN/$ROLE.grouped.json"
-            cat "$RUN/$ROLE.grouped.json"
             for ROLE in client server; do
               [ ! -e "$RUN/$ROLE.grouped.json" ] && continue
               for GROUP in $(jq -r < "$RUN/$ROLE.grouped.json" '.results | keys[]'); do
@@ -253,9 +246,24 @@ jobs:
                 fi
                 [ -n "$RESULT" ] || continue
                 DIFF=$(wdiff -n "$BASELINE" - <<< "$RESULT" || true)
-                RESULT=$(echo "$DIFF" | sed -E "s/\[-/ :rocket:~~/g; s/-\]/~~ /g; s/\{\+/ :warning:\*\*/g; s/\+\}/\*\* /g")
+                if [ "$GROUP" == "failed" ]; then
+                  ADD=":warning:"
+                  ADD_DELIM="~~"
+                  DEL=":rocket:"
+                  DEL_DELIM="\*\*"
+                elif [ "$GROUP" == "succeeded" ]; then
+                  ADD=":rocket:"
+                  ADD_DELIM="\*\*"
+                  DEL=":warning:"
+                  DEL_DELIM="~~"
+                else
+                  ADD=""
+                  ADD_DELIM=""
+                  DEL=""
+                  DEL_DELIM=""
+                fi
+                RESULT=$(echo "$DIFF" | sed -E "s/\[-/ $DEL$DEL_DELIM/g; s/-\]/$DEL_DELIM /g; s/\{\+/ $ADD$ADD_DELIM/g; s/\+\}/$ADD_DELIM /g")
                 echo "* [$PAIR]($LOG): $RESULT" >> "$ROLE.$GROUP.md"
-                cat "$ROLE.$GROUP.md"
               done
             done
           done
@@ -297,7 +305,6 @@ jobs:
             echo
             echo "</details>"
           } >> comment.md
-          cat comment.md
 
       - if: ${{ github.ref == 'refs/heads/main' }}
         run: |

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -193,7 +193,9 @@ jobs:
         run: |
           # shellcheck disable=SC2153
           mapfile -t LIST < <(echo "$PAIRS" | jq '.[]' | sort)
+          echo "${LIST[@]}"
           for PREFIX in "${LIST[@]}"; do
+            echo "Processing $PREFIX"
             PREFIX=$(echo "$PREFIX" | tr -d '"')
             CLIENT=$(echo "$PREFIX" | cut -f1 -d " ")
             SERVER=$(echo "$PREFIX" | cut -f3 -d " ")


### PR DESCRIPTION
OK, fixed. I managed to accidentally remove a backslash, which caused everything to explode. Put it back.

Also did a little bonus maintenance while I was here, by adding `tquic` and `openssl` to the interop matrix, and by using the correct highlighting for lines normally hidden under "All results".

I still hate GitHub CI.