### PR TITLE
fix: only enable quinn-udp fast-apple-datapath on arm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ rust-version = "1.76.0"
 enum-map = { version = "2.7", default-features = false }
 log = { version = "0.4", default-features = false }
 qlog = { version = "0.13", default-features = false }
-quinn-udp = { version = "0.5.6", default-features = false, features = ["direct-log", "fast-apple-datapath"] }
 regex = { version = "1.9", default-features = false, features = ["unicode-perl"] }
 static_assertions = { version = "1.1", default-features = false }
 url = { version = "2.5.3", default-features = false, features = ["std"] }

--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -38,7 +38,7 @@ neqo-http3 = { path = "./../neqo-http3" }
 neqo-transport = { path = "./../neqo-transport" }
 neqo-udp = { path = "./../neqo-udp" }
 qlog = { workspace = true }
-quinn-udp = { workspace = true }
+quinn-udp = { version = "0.5.6", default-features = false, features = ["direct-log"] }
 regex = { workspace = true }
 tokio = { version = "1", default-features = false, features = ["net", "time", "macros", "rt", "rt-multi-thread"] }
 url = { workspace = true }

--- a/neqo-udp/Cargo.toml
+++ b/neqo-udp/Cargo.toml
@@ -19,7 +19,16 @@ workspace = true
 # Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 log = { workspace = true }
 neqo-common = { path = "./../neqo-common" }
-quinn-udp = { workspace = true }
+quinn-udp = { version = "0.5.6", default-features = false, features = ["direct-log"] }
+
+# Only enable `fast-apple-datapath` on aarch64.
+#
+# Old MacOS versions (e.g. 10.15) don't fully support `sendmsg_x` and
+# `recvmsg_x`, both enabled by `fast-apple-datapath`. Instead of feature gating
+# by OS version, simply do so by CPU arch, leveraging the fact that newer MacOS
+# devices use ARM.
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+quinn-udp = { version = "0.5.6", default-features = false, features = ["direct-log", "fast-apple-datapath"] }
 
 [build-dependencies]
 cfg_aliases = "0.2"


### PR DESCRIPTION
Only enable `fast-apple-datapath` on aarch64.

Old MacOS versions (e.g. 10.15) don't fully support `sendmsg_x` and `recvmsg_x`, both enabled by `fast-apple-datapath`. Instead of feature gating by OS version, simply do so by CPU arch, leveraging the fact that newer MacOS devices use ARM.

---

Draft for now. [Debugging mozilla-central failure on MacOS 10.15.](https://bugzilla.mozilla.org/show_bug.cgi?id=1942325#c4)