### PR TITLE
ci: Disable some workflows for `dependabot` PRs

### DIFF
--- a/.github/workflows/check-vm.yml
+++ b/.github/workflows/check-vm.yml
@@ -22,6 +22,7 @@ permissions:
 
 jobs:
   check-vm:
+    if: github.actor != 'dependabot[bot]'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -152,5 +152,5 @@ jobs:
 
   bench:
     needs: [check]
-    if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || github.event.inputs.run_benchmarks) }}
+    if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || github.event.inputs.run_benchmarks) && github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/bench.yml

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -28,6 +28,7 @@ env:
 jobs:
   docker-image:
     name: Build Docker image
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     outputs:
       imageID: ${{ steps.docker_build_and_push.outputs.imageID }}

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -24,6 +24,7 @@ defaults:
 
 jobs:
   sanitize:
+    if: github.actor != 'dependabot[bot]'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Because they run a long time and aren't really necessary for PRs that only update dependencies.