### PR TITLE
fix: Reset bench table highlights after each test

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -273,6 +273,8 @@ jobs:
                       fi
                     else
                       echo "No statistically significant change: $BASELINE_MEAN -> $MEAN"
+                      SYMBOL=""
+                      FORMAT=""
                     fi
                     printf "| %s %s%.1f%s | %s%.1f%%%s |\n" \
                       "$SYMBOL" "$FORMAT" "$DELTA" "$FORMAT" "$FORMAT" "$PERCENT" "$FORMAT" >> steps.md


### PR DESCRIPTION
Otherwise the highlight for a significant change will stay in effect for following non-significant changes.