### PR TITLE
chore: Use `EnumSet` instead of a Boolean `EnumMap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ version = "0.12.2"
 dependencies = [
  "criterion",
  "enum-map",
+ "enumset",
  "indexmap",
  "log",
  "mtu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rust-version = "1.76.0"
 [workspace.dependencies]
 # Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 enum-map = { version = "2.7", default-features = false }
+enumset = { version = "1.1", default-features = false }
 log = { version = "0.4", default-features = false }
 qlog = { version = "0.13", default-features = false }
 quinn-udp = { version = "0.5.6", default-features = false, features = ["direct-log", "fast-apple-datapath"] }

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 # Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
-enumset = { version = "1.1", default-features = false }
+enumset = { workspace = true }
 log = { workspace = true }
 neqo-common = { path = "./../neqo-common" }
 neqo-crypto = { path = "./../neqo-crypto" }

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [dependencies]
 # Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 enum-map = { workspace = true }
+enumset = { workspace = true }
 indexmap = { version = "2.2", default-features = false } # See https://github.com/mozilla/neqo/issues/1858
 log = { workspace = true }
 neqo-common = { path = "../neqo-common" }

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -16,7 +16,7 @@ use enum_map::{enum_map, Enum, EnumMap};
 use enumset::{EnumSet, EnumSetType};
 use neqo_common::{qdebug, qinfo, qtrace, qwarn, IpTosEcn};
 use neqo_crypto::Epoch;
-use strum::{EnumIter, IntoEnumIterator as _};
+use strum::EnumIter;
 
 use crate::{
     ecn,

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -633,7 +633,7 @@ mod tests {
     use test_fixture::now;
 
     use super::{
-        AckTracker, Duration, Instant, PacketNumberSpace, Recovery Token, RecvdPackets,
+        AckTracker, Duration, Instant, PacketNumberSpace, RecoveryToken, RecvdPackets,
         MAX_TRACKED_RANGES,
     };
     use crate::{

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -629,13 +629,12 @@ impl Default for AckTracker {
 mod tests {
     use std::collections::HashSet;
 
-    use enumset::enum_set;
     use neqo_common::Encoder;
     use test_fixture::now;
 
     use super::{
-        AckTracker, Duration, Instant, PacketNumberSpace, PacketNumberSpaceSet, RecoveryToken,
-        RecvdPackets, MAX_TRACKED_RANGES,
+        AckTracker, Duration, Instant, PacketNumberSpace, Recovery Token, RecvdPackets,
+        MAX_TRACKED_RANGES,
     };
     use crate::{
         frame::Frame,
@@ -1067,42 +1066,6 @@ mod tests {
             tracker.ack_time(now() + Duration::from_millis(1)),
             Some(now())
         );
-    }
-
-    #[test]
-    fn pnspaceset_default() {
-        let set = PacketNumberSpaceSet::default();
-        assert!(!set.contains(PacketNumberSpace::Initial));
-        assert!(!set.contains(PacketNumberSpace::Handshake));
-        assert!(!set.contains(PacketNumberSpace::ApplicationData));
-    }
-
-    #[test]
-    fn pnspaceset_from() {
-        let set = enum_set!(PacketNumberSpace::Initial);
-        assert!(set.contains(PacketNumberSpace::Initial));
-        assert!(!set.contains(PacketNumberSpace::Handshake));
-        assert!(!set.contains(PacketNumberSpace::ApplicationData));
-
-        let set = enum_set!(PacketNumberSpace::Handshake | PacketNumberSpace::Initial);
-        assert!(set.contains(PacketNumberSpace::Initial));
-        assert!(set.contains(PacketNumberSpace::Handshake));
-        assert!(!set.contains(PacketNumberSpace::ApplicationData));
-
-        let set =
-            enum_set!(PacketNumberSpace::ApplicationData | PacketNumberSpace::ApplicationData);
-        assert!(!set.contains(PacketNumberSpace::Initial));
-        assert!(!set.contains(PacketNumberSpace::Handshake));
-        assert!(set.contains(PacketNumberSpace::ApplicationData));
-    }
-
-    #[test]
-    fn pnspaceset_copy() {
-        let set = enum_set!(PacketNumberSpace::Handshake | PacketNumberSpace::ApplicationData);
-        let copy = set;
-        assert!(!copy.contains(PacketNumberSpace::Initial));
-        assert!(copy.contains(PacketNumberSpace::Handshake));
-        assert!(copy.contains(PacketNumberSpace::ApplicationData));
     }
 
     #[test]


### PR DESCRIPTION
For `PacketNumberSpaceSet`. May be faster?