### PR TITLE
fix: Convert large pass-by-value args to references

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -4,3 +4,4 @@ disallowed-methods = [
 allow-mixed-uninlined-format-args = false
 allow-unwrap-in-tests = true
 allow-dbg-in-tests = true
+pass-by-value-size-limit = 16

--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -126,8 +126,8 @@ impl super::Handler for Handler<'_> {
 
 pub fn create_client(
     args: &Args,
-    local_addr: SocketAddr,
-    remote_addr: SocketAddr,
+    local_addr: &SocketAddr,
+    remote_addr: &SocketAddr,
     hostname: &str,
     resumption_token: Option<ResumptionToken>,
 ) -> Res<Connection> {

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -61,8 +61,8 @@ impl<'a> Handler<'a> {
 
 pub fn create_client(
     args: &Args,
-    local_addr: SocketAddr,
-    remote_addr: SocketAddr,
+    local_addr: &SocketAddr,
+    remote_addr: &SocketAddr,
     hostname: &str,
     resumption_token: Option<ResumptionToken>,
 ) -> Res<Http3Client> {

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -227,14 +227,14 @@ impl ServerRunner {
     }
 
     /// Tries to find a socket, but then just falls back to sending from the first.
-    fn find_socket(
-        sockets: &mut [(SocketAddr, crate::udp::Socket)],
-        addr: SocketAddr,
-    ) -> &mut crate::udp::Socket {
+    fn find_socket<'a>(
+        sockets: &'a mut [(SocketAddr, crate::udp::Socket)],
+        addr: &'a SocketAddr,
+    ) -> &'a mut crate::udp::Socket {
         let ((_host, first_socket), rest) = sockets.split_first_mut().unwrap();
         rest.iter_mut()
             .map(|(_host, socket)| socket)
-            .find(|socket| socket.local_addr().is_ok_and(|a| a == addr))
+            .find(|socket| socket.local_addr().is_ok_and(|a| a == *addr))
             .unwrap_or(first_socket)
     }
 

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -21,13 +21,13 @@ pub struct Datagram<D = Vec<u8>> {
 
 impl<D> Datagram<D> {
     #[must_use]
-    pub const fn source(&self) -> SocketAddr {
-        self.src
+    pub const fn source(&self) -> &SocketAddr {
+        &self.src
     }
 
     #[must_use]
-    pub const fn destination(&self) -> SocketAddr {
-        self.dst
+    pub const fn destination(&self) -> &SocketAddr {
+        &self.dst
     }
 
     #[must_use]
@@ -57,10 +57,10 @@ impl<D: AsMut<[u8]> + AsRef<[u8]>> AsMut<[u8]> for Datagram<D> {
 }
 
 impl Datagram<Vec<u8>> {
-    pub fn new<V: Into<Vec<u8>>>(src: SocketAddr, dst: SocketAddr, tos: IpTos, d: V) -> Self {
+    pub fn new<V: Into<Vec<u8>>>(src: &SocketAddr, dst: &SocketAddr, tos: IpTos, d: V) -> Self {
         Self {
-            src,
-            dst,
+            src: *src,
+            dst: *dst,
             tos,
             d: d.into(),
         }
@@ -95,8 +95,13 @@ impl<D: AsRef<[u8]>> std::fmt::Debug for Datagram<D> {
 
 impl<'a> Datagram<&'a mut [u8]> {
     #[must_use]
-    pub fn from_slice(src: SocketAddr, dst: SocketAddr, tos: IpTos, d: &'a mut [u8]) -> Self {
-        Self { src, dst, tos, d }
+    pub fn from_slice(src: &SocketAddr, dst: &SocketAddr, tos: IpTos, d: &'a mut [u8]) -> Self {
+        Self {
+            src: *src,
+            dst: *dst,
+            tos,
+            d,
+        }
     }
 
     #[must_use]

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -112,14 +112,14 @@ pub struct Http3ClientEvents {
 
 impl RecvStreamEvents for Http3ClientEvents {
     /// Add a new `DataReadable` event
-    fn data_readable(&self, stream_info: Http3StreamInfo) {
+    fn data_readable(&self, stream_info: &Http3StreamInfo) {
         self.insert(Http3ClientEvent::DataReadable {
             stream_id: stream_info.stream_id(),
         });
     }
 
     /// Add a new `Reset` event.
-    fn recv_closed(&self, stream_info: Http3StreamInfo, close_type: CloseType) {
+    fn recv_closed(&self, stream_info: &Http3StreamInfo, close_type: CloseType) {
         let stream_id = stream_info.stream_id();
         let (local, error) = match close_type {
             CloseType::ResetApp(_) => {
@@ -149,7 +149,7 @@ impl HttpRecvStreamEvents for Http3ClientEvents {
     /// Add a new `HeaderReady` event.
     fn header_ready(
         &self,
-        stream_info: Http3StreamInfo,
+        stream_info: &Http3StreamInfo,
         headers: Vec<Header>,
         interim: bool,
         fin: bool,
@@ -165,13 +165,13 @@ impl HttpRecvStreamEvents for Http3ClientEvents {
 
 impl SendStreamEvents for Http3ClientEvents {
     /// Add a new `DataWritable` event.
-    fn data_writable(&self, stream_info: Http3StreamInfo) {
+    fn data_writable(&self, stream_info: &Http3StreamInfo) {
         self.insert(Http3ClientEvent::DataWritable {
             stream_id: stream_info.stream_id(),
         });
     }
 
-    fn send_closed(&self, stream_info: Http3StreamInfo, close_type: CloseType) {
+    fn send_closed(&self, stream_info: &Http3StreamInfo, close_type: CloseType) {
         let stream_id = stream_info.stream_id();
         self.remove_send_stream_events(stream_id);
         if let CloseType::ResetRemote(error) = close_type {
@@ -219,7 +219,7 @@ impl ExtendedConnectEvents for Http3ClientEvents {
         }
     }
 
-    fn extended_connect_new_stream(&self, stream_info: Http3StreamInfo) -> Res<()> {
+    fn extended_connect_new_stream(&self, stream_info: &Http3StreamInfo) -> Res<()> {
         self.insert(Http3ClientEvent::WebTransport(
             WebTransportEvent::NewStream {
                 stream_id: stream_info.stream_id(),

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -299,8 +299,8 @@ impl Http3Client {
     pub fn new(
         server_name: impl Into<String>,
         cid_manager: Rc<RefCell<dyn ConnectionIdGenerator>>,
-        local_addr: SocketAddr,
-        remote_addr: SocketAddr,
+        local_addr: &SocketAddr,
+        remote_addr: &SocketAddr,
         http3_parameters: Http3Parameters,
         now: Instant,
     ) -> Res<Self> {
@@ -1322,8 +1322,8 @@ mod tests {
         Http3Client::new(
             DEFAULT_SERVER_NAME,
             Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
-            DEFAULT_ADDR,
-            DEFAULT_ADDR,
+            &DEFAULT_ADDR,
+            &DEFAULT_ADDR,
             Http3Parameters::default()
                 .connection_parameters(
                     // Disable compatible upgrade, which complicates tests.

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -56,7 +56,7 @@ pub(crate) trait ExtendedConnectEvents: Debug {
         reason: SessionCloseReason,
         headers: Option<Vec<Header>>,
     );
-    fn extended_connect_new_stream(&self, stream_info: Http3StreamInfo) -> Res<()>;
+    fn extended_connect_new_stream(&self, stream_info: &Http3StreamInfo) -> Res<()>;
     fn new_datagram(&self, session_id: StreamId, datagram: Vec<u8>);
 }
 

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -39,8 +39,8 @@ pub fn default_http3_client(client_params: Http3Parameters) -> Http3Client {
     Http3Client::new(
         DEFAULT_SERVER_NAME,
         Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
-        DEFAULT_ADDR,
-        DEFAULT_ADDR,
+        &DEFAULT_ADDR,
+        &DEFAULT_ADDR,
         client_params,
         now(),
     )

--- a/neqo-http3/src/features/extended_connect/webtransport_session.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_session.rs
@@ -302,7 +302,7 @@ impl WebTransportSession {
 
             if !stream_id.is_self_initiated(self.role) {
                 self.events
-                    .extended_connect_new_stream(Http3StreamInfo::new(
+                    .extended_connect_new_stream(&Http3StreamInfo::new(
                         stream_id,
                         ExtendedConnectType::WebTransport.get_stream_type(self.session_id),
                     ))?;
@@ -521,7 +521,7 @@ impl RecvStreamEvents for Rc<RefCell<WebTransportSessionListener>> {}
 impl HttpRecvStreamEvents for Rc<RefCell<WebTransportSessionListener>> {
     fn header_ready(
         &self,
-        _stream_info: Http3StreamInfo,
+        _stream_info: &Http3StreamInfo,
         headers: Vec<Header>,
         interim: bool,
         fin: bool,

--- a/neqo-http3/src/features/extended_connect/webtransport_streams.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_streams.rs
@@ -56,13 +56,13 @@ impl Stream for WebTransportRecvStream {
 
 impl RecvStream for WebTransportRecvStream {
     fn receive(&mut self, _conn: &mut Connection) -> Res<(ReceiveOutput, bool)> {
-        self.events.data_readable(self.get_info());
+        self.events.data_readable(&self.get_info());
         Ok((ReceiveOutput::NoOutput, false))
     }
 
     fn reset(&mut self, close_type: CloseType) -> Res<()> {
         if !matches!(close_type, CloseType::ResetApp(_)) {
-            self.events.recv_closed(self.get_info(), close_type);
+            self.events.recv_closed(&self.get_info(), close_type);
         }
         self.session.borrow_mut().remove_recv_stream(self.stream_id);
         Ok(())
@@ -156,7 +156,7 @@ impl WebTransportSendStream {
 
     fn set_done(&mut self, close_type: CloseType) {
         self.state = WebTransportSenderStreamState::Done;
-        self.events.send_closed(self.get_info(), close_type);
+        self.events.send_closed(&self.get_info(), close_type);
         self.session.borrow_mut().remove_send_stream(self.stream_id);
     }
 
@@ -198,7 +198,7 @@ impl SendStream for WebTransportSendStream {
     }
 
     fn stream_writable(&self) {
-        self.events.data_writable(self.get_info());
+        self.events.data_writable(&self.get_info());
     }
 
     fn done(&self) -> bool {

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -540,14 +540,14 @@ impl Http3StreamInfo {
 }
 
 trait RecvStreamEvents: Debug {
-    fn data_readable(&self, _stream_info: Http3StreamInfo) {}
-    fn recv_closed(&self, _stream_info: Http3StreamInfo, _close_type: CloseType) {}
+    fn data_readable(&self, _stream_info: &Http3StreamInfo) {}
+    fn recv_closed(&self, _stream_info: &Http3StreamInfo, _close_type: CloseType) {}
 }
 
 trait HttpRecvStreamEvents: RecvStreamEvents {
     fn header_ready(
         &self,
-        stream_info: Http3StreamInfo,
+        stream_info: &Http3StreamInfo,
         headers: Vec<Header>,
         interim: bool,
         fin: bool,
@@ -619,8 +619,8 @@ trait HttpSendStream: SendStream {
 }
 
 trait SendStreamEvents: Debug {
-    fn send_closed(&self, _stream_info: Http3StreamInfo, _close_type: CloseType) {}
-    fn data_writable(&self, _stream_info: Http3StreamInfo) {}
+    fn send_closed(&self, _stream_info: &Http3StreamInfo, _close_type: CloseType) {}
+    fn data_writable(&self, _stream_info: &Http3StreamInfo) {}
 }
 
 /// This enum is used to mark a different type of closing a stream:

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -463,7 +463,7 @@ impl RecvPushEvents {
 }
 
 impl RecvStreamEvents for RecvPushEvents {
-    fn data_readable(&self, _stream_info: Http3StreamInfo) {
+    fn data_readable(&self, _stream_info: &Http3StreamInfo) {
         self.push_handler.borrow_mut().new_stream_event(
             self.push_id,
             Http3ClientEvent::PushDataReadable {
@@ -472,7 +472,7 @@ impl RecvStreamEvents for RecvPushEvents {
         );
     }
 
-    fn recv_closed(&self, _stream_info: Http3StreamInfo, close_type: CloseType) {
+    fn recv_closed(&self, _stream_info: &Http3StreamInfo, close_type: CloseType) {
         match close_type {
             CloseType::ResetApp(_) => {}
             CloseType::ResetRemote(_) | CloseType::LocalError(_) => self
@@ -487,7 +487,7 @@ impl RecvStreamEvents for RecvPushEvents {
 impl HttpRecvStreamEvents for RecvPushEvents {
     fn header_ready(
         &self,
-        _stream_info: Http3StreamInfo,
+        _stream_info: &Http3StreamInfo,
         headers: Vec<Header>,
         interim: bool,
         fin: bool,

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -173,7 +173,7 @@ impl RecvMessage {
                 .extended_connect_new_session(self.stream_id, headers);
         } else {
             self.conn_events
-                .header_ready(self.get_stream_info(), headers, interim, fin);
+                .header_ready(&self.get_stream_info(), headers, interim, fin);
         }
 
         if fin {
@@ -211,7 +211,7 @@ impl RecvMessage {
             RecvMessageState::WaitingForData { .. }
             | RecvMessageState::WaitingForFinAfterTrailers { .. } => {
                 if post_readable_event {
-                    self.conn_events.data_readable(self.get_stream_info());
+                    self.conn_events.data_readable(&self.get_stream_info());
                 }
             }
             _ => unreachable!("Closing an already closed transaction"),
@@ -325,7 +325,7 @@ impl RecvMessage {
                 }
                 RecvMessageState::ReadingData { .. } => {
                     if post_readable_event {
-                        self.conn_events.data_readable(self.get_stream_info());
+                        self.conn_events.data_readable(&self.get_stream_info());
                     }
                     break Ok(());
                 }
@@ -349,7 +349,7 @@ impl RecvMessage {
         }
         self.state = RecvMessageState::Closed;
         self.conn_events
-            .recv_closed(self.get_stream_info(), CloseType::Done);
+            .recv_closed(&self.get_stream_info(), CloseType::Done);
     }
 
     const fn closing(&self) -> bool {
@@ -386,7 +386,7 @@ impl RecvStream for RecvMessage {
                 .cancel_stream(self.stream_id);
         }
         self.conn_events
-            .recv_closed(self.get_stream_info(), close_type);
+            .recv_closed(&self.get_stream_info(), close_type);
         self.state = RecvMessageState::Closed;
         Ok(())
     }

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -230,7 +230,7 @@ impl SendStream for SendMessage {
             // DataWritable is just a signal for an application to try to write more data,
             // if writing fails it is fine. Therefore we do not need to properly check
             // whether more credits are available on the transport layer.
-            self.conn_events.data_writable(self.get_stream_info());
+            self.conn_events.data_writable(&self.get_stream_info());
         }
     }
 
@@ -257,7 +257,7 @@ impl SendStream for SendMessage {
                 // DataWritable is just a signal for an application to try to write more data,
                 // if writing fails it is fine. Therefore we do not need to properly check
                 // whether more credits are available on the transport layer.
-                self.conn_events.data_writable(self.get_stream_info());
+                self.conn_events.data_writable(&self.get_stream_info());
             }
         }
         Ok(())
@@ -277,14 +277,14 @@ impl SendStream for SendMessage {
         }
 
         self.conn_events
-            .send_closed(self.get_stream_info(), CloseType::Done);
+            .send_closed(&self.get_stream_info(), CloseType::Done);
         Ok(())
     }
 
     fn handle_stop_sending(&mut self, close_type: CloseType) {
         if !self.state.done() {
             self.conn_events
-                .send_closed(self.get_stream_info(), close_type);
+                .send_closed(&self.get_stream_info(), close_type);
         }
     }
 

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -182,14 +182,14 @@ impl Http3Server {
                         Http3OrWebTransportStream::new(
                             conn.clone(),
                             Rc::clone(handler),
-                            stream_info,
+                            &stream_info,
                         ),
                         headers,
                         fin,
                     ),
                     Http3ServerConnEvent::DataReadable { stream_info } => {
                         prepare_data(
-                            stream_info,
+                            &stream_info,
                             &mut handler_borrowed,
                             conn,
                             handler,
@@ -199,12 +199,12 @@ impl Http3Server {
                     }
                     Http3ServerConnEvent::DataWritable { stream_info } => self
                         .events
-                        .data_writable(conn.clone(), Rc::clone(handler), stream_info),
+                        .data_writable(conn.clone(), Rc::clone(handler), &stream_info),
                     Http3ServerConnEvent::StreamReset { stream_info, error } => {
                         self.events.stream_reset(
                             conn.clone(),
                             Rc::clone(handler),
-                            stream_info,
+                            &stream_info,
                             error,
                         );
                     }
@@ -212,7 +212,7 @@ impl Http3Server {
                         self.events.stream_stop_sending(
                             conn.clone(),
                             Rc::clone(handler),
-                            stream_info,
+                            &stream_info,
                             error,
                         );
                     }
@@ -250,7 +250,7 @@ impl Http3Server {
                         .webtransport_new_stream(Http3OrWebTransportStream::new(
                             conn.clone(),
                             Rc::clone(handler),
-                            stream_info,
+                            &stream_info,
                         )),
                     Http3ServerConnEvent::ExtendedConnectDatagram {
                         session_id,
@@ -288,7 +288,7 @@ impl Http3Server {
     }
 }
 fn prepare_data(
-    stream_info: Http3StreamInfo,
+    stream_info: &Http3StreamInfo,
     handler_borrowed: &mut RefMut<Http3ServerHandler>,
     conn: &ConnectionRef,
     handler: &HandlerRef,
@@ -349,7 +349,7 @@ mod tests {
         max_blocked_streams: 100,
     };
 
-    fn http3params(qpack_settings: QpackSettings) -> Http3Parameters {
+    fn http3params(qpack_settings: &QpackSettings) -> Http3Parameters {
         Http3Parameters::default()
             .max_table_size_encoder(qpack_settings.max_table_size_encoder)
             .max_table_size_decoder(qpack_settings.max_table_size_decoder)
@@ -372,7 +372,7 @@ mod tests {
 
     /// Create a http3 server with default configuration.
     pub fn default_server() -> Http3Server {
-        create_server(http3params(DEFAULT_SETTINGS))
+        create_server(http3params(&DEFAULT_SETTINGS))
     }
 
     fn assert_closed(hconn: &Http3Server, expected: &Error) {
@@ -1194,14 +1194,14 @@ mod tests {
 
     #[test]
     fn zero_rtt() {
-        zero_rtt_with_settings(http3params(DEFAULT_SETTINGS), ZeroRttState::AcceptedClient);
+        zero_rtt_with_settings(http3params(&DEFAULT_SETTINGS), ZeroRttState::AcceptedClient);
     }
 
     /// A larger QPACK decoder table size isn't an impediment to 0-RTT.
     #[test]
     fn zero_rtt_larger_decoder_table() {
         zero_rtt_with_settings(
-            http3params(QpackSettings {
+            http3params(&QpackSettings {
                 max_table_size_decoder: DEFAULT_SETTINGS.max_table_size_decoder + 1,
                 ..DEFAULT_SETTINGS
             }),
@@ -1213,7 +1213,7 @@ mod tests {
     #[test]
     fn zero_rtt_smaller_decoder_table() {
         zero_rtt_with_settings(
-            http3params(QpackSettings {
+            http3params(&QpackSettings {
                 max_table_size_decoder: DEFAULT_SETTINGS.max_table_size_decoder - 1,
                 ..DEFAULT_SETTINGS
             }),
@@ -1225,7 +1225,7 @@ mod tests {
     #[test]
     fn zero_rtt_more_blocked_streams() {
         zero_rtt_with_settings(
-            http3params(QpackSettings {
+            http3params(&QpackSettings {
                 max_blocked_streams: DEFAULT_SETTINGS.max_blocked_streams + 1,
                 ..DEFAULT_SETTINGS
             }),
@@ -1237,7 +1237,7 @@ mod tests {
     #[test]
     fn zero_rtt_fewer_blocked_streams() {
         zero_rtt_with_settings(
-            http3params(QpackSettings {
+            http3params(&QpackSettings {
                 max_blocked_streams: DEFAULT_SETTINGS.max_blocked_streams - 1,
                 ..DEFAULT_SETTINGS
             }),
@@ -1249,7 +1249,7 @@ mod tests {
     #[test]
     fn zero_rtt_smaller_encoder_table() {
         zero_rtt_with_settings(
-            http3params(QpackSettings {
+            http3params(&QpackSettings {
                 max_table_size_encoder: DEFAULT_SETTINGS.max_table_size_encoder - 1,
                 ..DEFAULT_SETTINGS
             }),
@@ -1314,7 +1314,7 @@ mod tests {
             DEFAULT_ALPN,
             anti_replay(),
             Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
-            http3params(DEFAULT_SETTINGS),
+            http3params(&DEFAULT_SETTINGS),
             Some(Box::<RejectZeroRtt>::default()),
         )
         .expect("create a server");

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -68,30 +68,40 @@ pub struct Http3ServerConnEvents {
 }
 
 impl SendStreamEvents for Http3ServerConnEvents {
-    fn send_closed(&self, stream_info: Http3StreamInfo, close_type: CloseType) {
+    fn send_closed(&self, stream_info: &Http3StreamInfo, close_type: CloseType) {
         if close_type != CloseType::Done {
             if let Some(error) = close_type.error() {
-                self.insert(Http3ServerConnEvent::StreamStopSending { stream_info, error });
+                self.insert(Http3ServerConnEvent::StreamStopSending {
+                    stream_info: *stream_info,
+                    error,
+                });
             }
         }
     }
 
-    fn data_writable(&self, stream_info: Http3StreamInfo) {
-        self.insert(Http3ServerConnEvent::DataWritable { stream_info });
+    fn data_writable(&self, stream_info: &Http3StreamInfo) {
+        self.insert(Http3ServerConnEvent::DataWritable {
+            stream_info: *stream_info,
+        });
     }
 }
 
 impl RecvStreamEvents for Http3ServerConnEvents {
     /// Add a new `DataReadable` event
-    fn data_readable(&self, stream_info: Http3StreamInfo) {
-        self.insert(Http3ServerConnEvent::DataReadable { stream_info });
+    fn data_readable(&self, stream_info: &Http3StreamInfo) {
+        self.insert(Http3ServerConnEvent::DataReadable {
+            stream_info: *stream_info,
+        });
     }
 
-    fn recv_closed(&self, stream_info: Http3StreamInfo, close_type: CloseType) {
+    fn recv_closed(&self, stream_info: &Http3StreamInfo, close_type: CloseType) {
         if close_type != CloseType::Done {
             self.remove_events_for_stream_id(stream_info);
             if let Some(error) = close_type.error() {
-                self.insert(Http3ServerConnEvent::StreamReset { stream_info, error });
+                self.insert(Http3ServerConnEvent::StreamReset {
+                    stream_info: *stream_info,
+                    error,
+                });
             }
         }
     }
@@ -101,13 +111,13 @@ impl HttpRecvStreamEvents for Http3ServerConnEvents {
     /// Add a new `HeaderReady` event.
     fn header_ready(
         &self,
-        stream_info: Http3StreamInfo,
+        stream_info: &Http3StreamInfo,
         headers: Vec<Header>,
         _interim: bool,
         fin: bool,
     ) {
         self.insert(Http3ServerConnEvent::Headers {
-            stream_info,
+            stream_info: *stream_info,
             headers,
             fin,
         });
@@ -143,8 +153,8 @@ impl ExtendedConnectEvents for Http3ServerConnEvents {
         });
     }
 
-    fn extended_connect_new_stream(&self, stream_info: Http3StreamInfo) -> Res<()> {
-        self.insert(Http3ServerConnEvent::ExtendedConnectNewStream(stream_info));
+    fn extended_connect_new_stream(&self, stream_info: &Http3StreamInfo) -> Res<()> {
+        self.insert(Http3ServerConnEvent::ExtendedConnectNewStream(*stream_info));
         Ok(())
     }
 
@@ -187,10 +197,10 @@ impl Http3ServerConnEvents {
         });
     }
 
-    fn remove_events_for_stream_id(&self, stream_info: Http3StreamInfo) {
+    fn remove_events_for_stream_id(&self, stream_info: &Http3StreamInfo) {
         self.remove(|evt| {
             matches!(evt,
-                Http3ServerConnEvent::Headers { stream_info: x, .. } | Http3ServerConnEvent::DataReadable { stream_info: x, .. } if *x == stream_info)
+                Http3ServerConnEvent::Headers { stream_info: x, .. } | Http3ServerConnEvent::DataReadable { stream_info: x, .. } if x == stream_info)
         });
     }
 }

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -170,13 +170,13 @@ impl Http3OrWebTransportStream {
     pub(crate) const fn new(
         conn: ConnectionRef,
         handler: Rc<RefCell<Http3ServerHandler>>,
-        stream_info: Http3StreamInfo,
+        stream_info: &Http3StreamInfo,
     ) -> Self {
         Self {
             stream_handler: StreamHandler {
                 conn,
                 handler,
-                stream_info,
+                stream_info: *stream_info,
             },
         }
     }
@@ -329,7 +329,7 @@ impl WebTransportRequest {
         Ok(Http3OrWebTransportStream::new(
             self.stream_handler.conn.clone(),
             Rc::clone(&self.stream_handler.handler),
-            Http3StreamInfo::new(id, Http3StreamType::WebTransport(session_id)),
+            &Http3StreamInfo::new(id, Http3StreamType::WebTransport(session_id)),
         ))
     }
 
@@ -511,7 +511,7 @@ impl Http3ServerEvents {
         &self,
         conn: ConnectionRef,
         handler: Rc<RefCell<Http3ServerHandler>>,
-        stream_info: Http3StreamInfo,
+        stream_info: &Http3StreamInfo,
         data: Vec<u8>,
         fin: bool,
     ) {
@@ -526,7 +526,7 @@ impl Http3ServerEvents {
         &self,
         conn: ConnectionRef,
         handler: Rc<RefCell<Http3ServerHandler>>,
-        stream_info: Http3StreamInfo,
+        stream_info: &Http3StreamInfo,
     ) {
         self.insert(Http3ServerEvent::DataWritable {
             stream: Http3OrWebTransportStream::new(conn, handler, stream_info),
@@ -537,7 +537,7 @@ impl Http3ServerEvents {
         &self,
         conn: ConnectionRef,
         handler: Rc<RefCell<Http3ServerHandler>>,
-        stream_info: Http3StreamInfo,
+        stream_info: &Http3StreamInfo,
         error: AppError,
     ) {
         self.insert(Http3ServerEvent::StreamReset {
@@ -550,7 +550,7 @@ impl Http3ServerEvents {
         &self,
         conn: ConnectionRef,
         handler: Rc<RefCell<Http3ServerHandler>>,
-        stream_info: Http3StreamInfo,
+        stream_info: &Http3StreamInfo,
         error: AppError,
     ) {
         self.insert(Http3ServerEvent::StreamStopSending {

--- a/neqo-http3/tests/webtransport.rs
+++ b/neqo-http3/tests/webtransport.rs
@@ -26,8 +26,8 @@ fn connect() -> (Http3Client, Http3Server) {
     let mut client = Http3Client::new(
         DEFAULT_SERVER_NAME,
         Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
-        DEFAULT_ADDR,
-        DEFAULT_ADDR,
+        &DEFAULT_ADDR,
+        &DEFAULT_ADDR,
         Http3Parameters::default().webtransport(true),
         now(),
     )

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -75,7 +75,7 @@ impl AddressValidation {
         })
     }
 
-    fn encode_aad(peer_address: SocketAddr, retry: bool) -> Encoder {
+    fn encode_aad(peer_address: &SocketAddr, retry: bool) -> Encoder {
         // Let's be "clever" by putting the peer's address in the AAD.
         // We don't need to encode these into the token as they should be
         // available when we need to check the token.
@@ -104,7 +104,7 @@ impl AddressValidation {
     pub fn generate_token(
         &self,
         dcid: Option<&ConnectionId>,
-        peer_address: SocketAddr,
+        peer_address: &SocketAddr,
         now: Instant,
     ) -> Res<Vec<u8>> {
         const EXPIRATION_RETRY: Duration = Duration::from_secs(5);
@@ -137,14 +137,14 @@ impl AddressValidation {
     pub fn generate_retry_token(
         &self,
         dcid: &ConnectionId,
-        peer_address: SocketAddr,
+        peer_address: &SocketAddr,
         now: Instant,
     ) -> Res<Vec<u8>> {
         self.generate_token(Some(dcid), peer_address, now)
     }
 
     /// This generates a token for use with `NEW_TOKEN`.
-    pub fn generate_new_token(&self, peer_address: SocketAddr, now: Instant) -> Res<Vec<u8>> {
+    pub fn generate_new_token(&self, peer_address: &SocketAddr, now: Instant) -> Res<Vec<u8>> {
         self.generate_token(None, peer_address, now)
     }
 
@@ -160,7 +160,7 @@ impl AddressValidation {
     fn decrypt_token(
         &self,
         token: &[u8],
-        peer_address: SocketAddr,
+        peer_address: &SocketAddr,
         retry: bool,
         now: Instant,
     ) -> Option<ConnectionId> {
@@ -197,7 +197,7 @@ impl AddressValidation {
     pub fn validate(
         &self,
         token: &[u8],
-        peer_address: SocketAddr,
+        peer_address: &SocketAddr,
         now: Instant,
     ) -> AddressValidationResult {
         qtrace!("AddressValidation {self:p}: validate {:?}", self.validation);

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -649,11 +649,11 @@ mod tests {
         match cc {
             CongestionControlAlgorithm::NewReno => Box::new(ClassicCongestionControl::new(
                 NewReno::default(),
-                Pmtud::new(IP_ADDR, MTU),
+                Pmtud::new(&IP_ADDR, MTU),
             )),
             CongestionControlAlgorithm::Cubic => Box::new(ClassicCongestionControl::new(
                 Cubic::default(),
-                Pmtud::new(IP_ADDR, MTU),
+                Pmtud::new(&IP_ADDR, MTU),
             )),
         }
     }
@@ -892,13 +892,13 @@ mod tests {
     fn persistent_congestion_no_lost() {
         let lost = make_lost(&[]);
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU)),
             0,
             0,
             &lost
         ));
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU)),
             0,
             0,
             &lost
@@ -910,13 +910,13 @@ mod tests {
     fn persistent_congestion_one_lost() {
         let lost = make_lost(&[1]);
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU)),
             0,
             0,
             &lost
         ));
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU)),
             0,
             0,
             &lost
@@ -930,37 +930,37 @@ mod tests {
         // sample are not considered.  So 0 is ignored.
         let lost = make_lost(&[0, PERSISTENT_CONG_THRESH + 1, PERSISTENT_CONG_THRESH + 2]);
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU)),
             1,
             1,
             &lost
         ));
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU)),
             0,
             1,
             &lost
         ));
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU)),
             1,
             0,
             &lost
         ));
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU)),
             1,
             1,
             &lost
         ));
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU)),
             0,
             1,
             &lost
         ));
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU)),
             1,
             0,
             &lost
@@ -981,13 +981,13 @@ mod tests {
             lost[0].len(),
         );
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU)),
             0,
             0,
             &lost
         ));
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU)),
             0,
             0,
             &lost
@@ -1001,13 +1001,13 @@ mod tests {
     fn persistent_congestion_min() {
         let lost = make_lost(&[1, PERSISTENT_CONG_THRESH + 2]);
         assert!(persistent_congestion_by_pto(
-            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU)),
             0,
             0,
             &lost
         ));
         assert!(persistent_congestion_by_pto(
-            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU)),
             0,
             0,
             &lost
@@ -1020,7 +1020,7 @@ mod tests {
     #[test]
     fn persistent_congestion_no_prev_ack_newreno() {
         let lost = make_lost(&[1, PERSISTENT_CONG_THRESH + 2]);
-        let mut cc = ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU));
+        let mut cc = ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU));
         cc.detect_persistent_congestion(Some(by_pto(0)), None, PTO, lost.iter(), Instant::now());
         assert_eq!(cc.cwnd(), cc.cwnd_min());
     }
@@ -1028,7 +1028,7 @@ mod tests {
     #[test]
     fn persistent_congestion_no_prev_ack_cubic() {
         let lost = make_lost(&[1, PERSISTENT_CONG_THRESH + 2]);
-        let mut cc = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU));
+        let mut cc = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU));
         cc.detect_persistent_congestion(Some(by_pto(0)), None, PTO, lost.iter(), Instant::now());
         assert_eq!(cc.cwnd(), cc.cwnd_min());
     }
@@ -1039,7 +1039,7 @@ mod tests {
     fn persistent_congestion_unsorted_newreno() {
         let lost = make_lost(&[PERSISTENT_CONG_THRESH + 2, 1]);
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU)),
             0,
             0,
             &lost
@@ -1052,7 +1052,7 @@ mod tests {
     fn persistent_congestion_unsorted_cubic() {
         let lost = make_lost(&[PERSISTENT_CONG_THRESH + 2, 1]);
         assert!(!persistent_congestion_by_pto(
-            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU)),
+            ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU)),
             0,
             0,
             &lost
@@ -1063,7 +1063,7 @@ mod tests {
     fn app_limited_slow_start() {
         const BELOW_APP_LIMIT_PKTS: usize = 5;
         const ABOVE_APP_LIMIT_PKTS: usize = BELOW_APP_LIMIT_PKTS + 1;
-        let mut cc = ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU));
+        let mut cc = ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU));
         let cwnd = cc.congestion_window;
         let mut now = now();
         let mut next_pn = 0;
@@ -1147,7 +1147,7 @@ mod tests {
         const BELOW_APP_LIMIT_PKTS: usize = CWND_PKTS_CA - 2;
         const ABOVE_APP_LIMIT_PKTS: usize = BELOW_APP_LIMIT_PKTS + 1;
 
-        let mut cc = ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU));
+        let mut cc = ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU));
         let mut now = now();
 
         // Change state to congestion avoidance by introducing loss.
@@ -1263,7 +1263,7 @@ mod tests {
     #[test]
     fn ecn_ce() {
         let now = now();
-        let mut cc = ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU));
+        let mut cc = ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU));
         let p_ce = SentPacket::new(
             PacketType::Short,
             1,

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -95,7 +95,7 @@ fn expected_tcp_acks(cwnd_rtt_start: usize, mtu: usize) -> u64 {
 
 #[test]
 fn tcp_phase() {
-    let mut cubic = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU));
+    let mut cubic = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU));
 
     // change to congestion avoidance state.
     cubic.set_ssthresh(1);
@@ -202,7 +202,7 @@ fn tcp_phase() {
 
 #[test]
 fn cubic_phase() {
-    let mut cubic = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU));
+    let mut cubic = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU));
     let cwnd_initial_f64 = convert_to_f64(cubic.cwnd_initial());
     // Set last_max_cwnd to a higher number make sure that cc is the cubic phase (cwnd is calculated
     // by the cubic equation).
@@ -257,7 +257,7 @@ fn assert_within<T: Sub<Output = T> + PartialOrd + Copy>(value: T, expected: T, 
 
 #[test]
 fn congestion_event_slow_start() {
-    let mut cubic = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU));
+    let mut cubic = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU));
 
     _ = fill_cwnd(&mut cubic, 0, now());
     ack_packet(&mut cubic, 0, now());
@@ -288,7 +288,7 @@ fn congestion_event_slow_start() {
 
 #[test]
 fn congestion_event_congestion_avoidance() {
-    let mut cubic = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU));
+    let mut cubic = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU));
 
     // Set ssthresh to something small to make sure that cc is in the congection avoidance phase.
     cubic.set_ssthresh(1);
@@ -312,7 +312,7 @@ fn congestion_event_congestion_avoidance() {
 
 #[test]
 fn congestion_event_congestion_avoidance_2() {
-    let mut cubic = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU));
+    let mut cubic = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU));
 
     // Set ssthresh to something small to make sure that cc is in the congection avoidance phase.
     cubic.set_ssthresh(1);
@@ -341,7 +341,7 @@ fn congestion_event_congestion_avoidance_2() {
 #[test]
 fn congestion_event_congestion_avoidance_no_overflow() {
     const PTO: Duration = Duration::from_millis(120);
-    let mut cubic = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(IP_ADDR, MTU));
+    let mut cubic = ClassicCongestionControl::new(Cubic::default(), Pmtud::new(&IP_ADDR, MTU));
 
     // Set ssthresh to something small to make sure that cc is in the congection avoidance phase.
     cubic.set_ssthresh(1);

--- a/neqo-transport/src/cc/tests/new_reno.rs
+++ b/neqo-transport/src/cc/tests/new_reno.rs
@@ -35,7 +35,7 @@ fn cwnd_is_halved(cc: &ClassicCongestionControl<NewReno>) {
 
 #[test]
 fn issue_876() {
-    let mut cc = ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU));
+    let mut cc = ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU));
     let now = now();
     let before = now.checked_sub(Duration::from_millis(100)).unwrap();
     let after = now + Duration::from_millis(150);
@@ -146,7 +146,7 @@ fn issue_876() {
 #[test]
 // https://github.com/mozilla/neqo/pull/1465
 fn issue_1465() {
-    let mut cc = ClassicCongestionControl::new(NewReno::default(), Pmtud::new(IP_ADDR, MTU));
+    let mut cc = ClassicCongestionControl::new(NewReno::default(), Pmtud::new(&IP_ADDR, MTU));
     let mut pn = 0;
     let mut now = now();
     let max_datagram_size = cc.max_datagram_size();

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -205,7 +205,7 @@ impl AddressValidationInfo {
         }
     }
 
-    pub fn generate_new_token(&self, peer_address: SocketAddr, now: Instant) -> Option<Vec<u8>> {
+    pub fn generate_new_token(&self, peer_address: &SocketAddr, now: Instant) -> Option<Vec<u8>> {
         match self {
             Self::Server(w) => w.upgrade().and_then(|validation| {
                 validation
@@ -317,8 +317,8 @@ impl Connection {
         server_name: impl Into<String>,
         protocols: &[impl AsRef<str>],
         cid_generator: Rc<RefCell<dyn ConnectionIdGenerator>>,
-        local_addr: SocketAddr,
-        remote_addr: SocketAddr,
+        local_addr: &SocketAddr,
+        remote_addr: &SocketAddr,
         conn_params: ConnectionParameters,
         now: Instant,
     ) -> Res<Self> {
@@ -818,7 +818,7 @@ impl Connection {
         if let Some(path) = self.paths.primary() {
             if let Some(token) = self
                 .address_validation
-                .generate_new_token(path.borrow().remote_address(), now)
+                .generate_new_token(&path.borrow().remote_address(), now)
             {
                 self.new_token.send_new_token(token);
             }
@@ -1341,8 +1341,8 @@ impl Connection {
                 self.crypto.server_name().ok_or(Error::VersionNegotiation)?,
                 self.crypto.protocols(),
                 self.cid_manager.generator(),
-                local_addr,
-                remote_addr,
+                &local_addr,
+                &remote_addr,
                 conn_params,
                 now,
             )?;
@@ -1520,7 +1520,7 @@ impl Connection {
         &mut self,
         path: &PathRef,
         tos: IpTos,
-        remote: SocketAddr,
+        remote: &SocketAddr,
         packet: &PublicPacket,
         migrate: bool,
         now: Instant,
@@ -1598,7 +1598,7 @@ impl Connection {
     ) -> Res<()> {
         qtrace!("[{self}] {} input {}", path.borrow(), hex(&d));
         let tos = d.tos();
-        let remote = d.source();
+        let remote = *d.source();
         let mut slc = d.as_mut();
         let mut dcid = None;
         let pto = path.borrow().rtt().pto(self.confirmed());
@@ -1653,7 +1653,7 @@ impl Connection {
                             match self.process_packet(path, &payload, now) {
                                 Ok(migrate) => {
                                     self.postprocess_packet(
-                                        path, tos, remote, &packet, migrate, now,
+                                        path, tos, &remote, &packet, migrate, now,
                                     );
                                 }
                                 Err(e) => {
@@ -1889,8 +1889,8 @@ impl Connection {
     /// there are not enough connection IDs available to use.
     pub fn migrate(
         &mut self,
-        local: Option<SocketAddr>,
-        remote: Option<SocketAddr>,
+        local: Option<&SocketAddr>,
+        remote: Option<&SocketAddr>,
         force: bool,
         now: Instant,
     ) -> Res<()> {
@@ -1911,8 +1911,10 @@ impl Connection {
         }
 
         let path = self.paths.primary().ok_or(Error::InvalidMigration)?;
-        let local = local.unwrap_or_else(|| path.borrow().local_address());
-        let remote = remote.unwrap_or_else(|| path.borrow().remote_address());
+        let local_address = &path.borrow().local_address();
+        let remote_address = &path.borrow().remote_address();
+        let local = local.unwrap_or(local_address);
+        let remote = remote.unwrap_or(remote_address);
 
         if mem::discriminant(&local.ip()) != mem::discriminant(&remote.ip()) {
             // Can't mix address families.
@@ -1988,7 +1990,7 @@ impl Connection {
                     return Ok(());
                 }
 
-                if self.migrate(None, Some(remote), false, now).is_err() {
+                if self.migrate(None, Some(&remote), false, now).is_err() {
                     qwarn!("[{self}] Ignoring bad preferred address: {remote}");
                 }
             } else {
@@ -2003,7 +2005,7 @@ impl Connection {
     fn handle_migration(
         &mut self,
         path: &PathRef,
-        remote: SocketAddr,
+        remote: &SocketAddr,
         migrate: bool,
         now: Instant,
     ) {
@@ -2945,7 +2947,7 @@ impl Connection {
 
                 let ranges =
                     Frame::decode_ack_frame(largest_acknowledged, first_ack_range, &ack_ranges)?;
-                self.handle_ack(space, ranges, ecn_count, ack_delay, now)?;
+                self.handle_ack(space, ranges, ecn_count.as_ref(), ack_delay, now)?;
             }
             Frame::Crypto { offset, data } => {
                 qtrace!(
@@ -3137,7 +3139,7 @@ impl Connection {
         &mut self,
         space: PacketNumberSpace,
         ack_ranges: R,
-        ack_ecn: Option<ecn::Count>,
+        ack_ecn: Option<&ecn::Count>,
         ack_delay: u64,
         now: Instant,
     ) -> Res<()>

--- a/neqo-transport/src/connection/tests/ackrate.rs
+++ b/neqo-transport/src/connection/tests/ackrate.rs
@@ -164,7 +164,7 @@ fn migrate_ack_delay() {
     let mut now = connect_rtt_idle(&mut client, &mut server, DEFAULT_RTT);
 
     client
-        .migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR_V4), true, now)
+        .migrate(Some(&DEFAULT_ADDR_V4), Some(&DEFAULT_ADDR_V4), true, now)
         .unwrap();
 
     let client1 = send_something(&mut client, now);

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -106,7 +106,7 @@ fn migration_delay_to_ecn_blackhole() {
 
     // Migrate the client.
     client
-        .migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR_V4), false, now)
+        .migrate(Some(&DEFAULT_ADDR_V4), Some(&DEFAULT_ADDR_V4), false, now)
         .unwrap();
 
     // The client should send MAX_PATH_PROBES path challenges with ECN enabled, and then another
@@ -248,7 +248,7 @@ pub fn migration_with_modifiers(
     server.process_input(orig_path_modifier(client_pkt).unwrap(), now);
 
     client
-        .migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR_V4), false, now)
+        .migrate(Some(&DEFAULT_ADDR_V4), Some(&DEFAULT_ADDR_V4), false, now)
         .unwrap();
 
     let mut migrated = false;
@@ -345,7 +345,7 @@ pub fn migration_with_modifiers(
 
     now += client.process_output(now).callback();
     let mut client_pkt = send_something(&mut client, now);
-    while !migrated && client_pkt.source() == DEFAULT_ADDR_V4 {
+    while !migrated && client_pkt.source() == &DEFAULT_ADDR_V4 {
         client_pkt = send_something(&mut client, now);
     }
     let tos_after_migration = client_pkt.tos();

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -151,8 +151,8 @@ fn no_alpn() {
         "example.com",
         &["bad-alpn"],
         Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
-        DEFAULT_ADDR,
-        DEFAULT_ADDR,
+        &DEFAULT_ADDR,
+        &DEFAULT_ADDR,
         ConnectionParameters::default(),
         now(),
     )
@@ -286,7 +286,7 @@ fn crypto_frame_split() {
 #[test]
 fn chacha20poly1305() {
     let mut server = default_server();
-    let mut client = zero_len_cid_client(DEFAULT_ADDR, DEFAULT_ADDR);
+    let mut client = zero_len_cid_client(&DEFAULT_ADDR, &DEFAULT_ADDR);
     client.set_ciphers(&[TLS_CHACHA20_POLY1305_SHA256]).unwrap();
     connect_force_idle(&mut client, &mut server);
 }
@@ -806,8 +806,8 @@ fn connect_one_version() {
             test_fixture::DEFAULT_SERVER_NAME,
             test_fixture::DEFAULT_ALPN,
             Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
-            DEFAULT_ADDR,
-            DEFAULT_ADDR,
+            &DEFAULT_ADDR,
+            &DEFAULT_ADDR,
             ConnectionParameters::default().versions(version, vec![version]),
             now(),
         )
@@ -913,7 +913,7 @@ fn drop_initial_packet_from_wrong_address() {
 
     let p = out.dgram().unwrap();
     let dgram = Datagram::new(
-        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 2)), 443),
+        &SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 2)), 443),
         p.destination(),
         p.tos(),
         &p[..],
@@ -945,7 +945,7 @@ fn drop_handshake_packet_from_wrong_address() {
 
     let p = s_hs.unwrap();
     let dgram = Datagram::new(
-        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 2)), 443),
+        &SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 2)), 443),
         p.destination(),
         p.tos(),
         &p[..],

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -56,11 +56,11 @@ const fn loopback() -> SocketAddr {
     SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 443)
 }
 
-fn change_path(d: &Datagram, a: SocketAddr) -> Datagram {
+fn change_path(d: &Datagram, a: &SocketAddr) -> Datagram {
     Datagram::new(a, a, d.tos(), &d[..])
 }
 
-const fn new_port(a: SocketAddr) -> SocketAddr {
+const fn new_port(a: &SocketAddr) -> SocketAddr {
     let (port, _) = a.port().overflowing_add(410);
     SocketAddr::new(a.ip(), port)
 }
@@ -69,12 +69,12 @@ fn assert_path_challenge(
     c: &Connection,
     d: &Datagram,
     before: &FrameStats,
-    dst: SocketAddr,
+    dst: &SocketAddr,
     padded: bool,
 ) {
     let after = c.stats().frame_tx;
     assert_eq!(after.path_challenge, before.path_challenge + 1);
-    assert_eq!(d.source(), DEFAULT_ADDR);
+    assert_eq!(d.source(), &DEFAULT_ADDR);
     assert_eq!(d.destination(), dst);
     if padded {
         assert!(d.len() >= MIN_INITIAL_PACKET_SIZE);
@@ -86,8 +86,8 @@ fn assert_path_challenge(
 fn assert_path_response(c: &Connection, d: &Datagram, before: &FrameStats) {
     let after = c.stats().frame_tx;
     assert_eq!(after.path_response, before.path_response + 1);
-    assert_eq!(d.source(), DEFAULT_ADDR);
-    assert_eq!(d.destination(), DEFAULT_ADDR);
+    assert_eq!(d.source(), &DEFAULT_ADDR);
+    assert_eq!(d.destination(), &DEFAULT_ADDR);
 }
 
 fn local_address(c: &Connection) -> SocketAddr {
@@ -113,7 +113,7 @@ fn rebind(
     assert_path_challenge(server, &s1, &before, c1_new.source(), false);
 
     // Restore the original source address, so to the client it looks like the path has not changed.
-    let s1_reb = Datagram::new(s1.source(), local_address(client), s1.tos(), &s1[..]);
+    let s1_reb = Datagram::new(s1.source(), &local_address(client), s1.tos(), &s1[..]);
 
     // The client should respond to the PATH_CHALLENGE, without changing paths.
     let before = client.stats().frame_tx;
@@ -128,7 +128,7 @@ fn rebind(
     assert_path_challenge(server, &s2, &before, c2_new.source(), true);
 
     // Restore the original source address, so to the client it looks like the path has not changed.
-    let s2_reb = Datagram::new(s2.source(), local_address(client), s2.tos(), &s2[..]);
+    let s2_reb = Datagram::new(s2.source(), &local_address(client), s2.tos(), &s2[..]);
 
     // The client should respond to the PATH_CHALLENGE, without changing paths.
     let before = client.stats().frame_tx;
@@ -154,7 +154,7 @@ fn rebind(
     assert_eq!(s4.destination(), c3_new.source());
 
     // Restore the original source address, so to the client it looks like the path has not changed.
-    let s4_reb = Datagram::new(s4.source(), local_address(client), s4.tos(), &s4[..]);
+    let s4_reb = Datagram::new(s4.source(), &local_address(client), s4.tos(), &s4[..]);
 
     // The client should process the ACK and go idle.
     let delay = client.process(Some(s4_reb), now).callback();
@@ -202,7 +202,8 @@ fn rebind(
                     }
                     // Restore the original source address, so to the client it looks like
                     // the path has not changed.
-                    let sx_r = Datagram::new(sx.source(), local_address(client), sx.tos(), &sx[..]);
+                    let sx_r =
+                        Datagram::new(sx.source(), &local_address(client), sx.tos(), &sx[..]);
                     let before = client.stats().frame_tx;
                     let cx = client.process(Some(sx_r), now).dgram().unwrap();
                     let after = client.stats().frame_tx;
@@ -237,7 +238,7 @@ fn inc_port(port: u16, i: usize) -> u16 {
         .0
 }
 
-fn inc_addr(ip: IpAddr, i: usize) -> IpAddr {
+fn inc_addr(ip: &IpAddr, i: usize) -> IpAddr {
     let inc: u8 = i.overflowing_mul(11).0.try_into().unwrap();
     match ip {
         IpAddr::V4(ip) => IpAddr::V4(Ipv4Addr::from(
@@ -251,7 +252,7 @@ fn inc_addr(ip: IpAddr, i: usize) -> IpAddr {
 
 fn change_source_port(d: &Datagram, i: usize) -> Datagram {
     Datagram::new(
-        SocketAddr::new(d.source().ip(), inc_port(d.source().port(), i)),
+        &SocketAddr::new(d.source().ip(), inc_port(d.source().port(), i)),
         d.destination(),
         d.tos(),
         &d[..],
@@ -260,7 +261,10 @@ fn change_source_port(d: &Datagram, i: usize) -> Datagram {
 
 fn change_source_address_and_port(d: &Datagram, i: usize) -> Datagram {
     Datagram::new(
-        SocketAddr::new(inc_addr(d.source().ip(), i), inc_port(d.source().port(), i)),
+        &SocketAddr::new(
+            inc_addr(&d.source().ip(), i),
+            inc_port(d.source().port(), i),
+        ),
         d.destination(),
         d.tos(),
         &d[..],
@@ -317,7 +321,7 @@ fn rebind_port() {
 
 #[test]
 fn rebind_port_zero_len_cid() {
-    let mut client = zero_len_cid_client(DEFAULT_ADDR, DEFAULT_ADDR);
+    let mut client = zero_len_cid_client(&DEFAULT_ADDR, &DEFAULT_ADDR);
     rebind_port_with_client(&mut client);
 }
 
@@ -329,7 +333,7 @@ fn rebind_address_and_port() {
 
 #[test]
 fn rebind_address_and_port_zero_len_cid() {
-    let mut client = zero_len_cid_client(DEFAULT_ADDR, DEFAULT_ADDR);
+    let mut client = zero_len_cid_client(&DEFAULT_ADDR, &DEFAULT_ADDR);
     rebind_address_and_port_with_client(&mut client);
 }
 
@@ -344,7 +348,7 @@ fn path_forwarding_attack() {
     let now = now();
 
     let dgram = send_something(&mut client, now);
-    let dgram = change_path(&dgram, DEFAULT_ADDR_V4);
+    let dgram = change_path(&dgram, &DEFAULT_ADDR_V4);
     server.process_input(dgram, now);
 
     // The server now probes the new (primary) path.
@@ -425,7 +429,7 @@ fn migrate_immediate() {
     let now = now();
 
     client
-        .migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR_V4), true, now)
+        .migrate(Some(&DEFAULT_ADDR_V4), Some(&DEFAULT_ADDR_V4), true, now)
         .unwrap();
 
     let client1 = send_something(&mut client, now);
@@ -468,7 +472,7 @@ fn migrate_rtt() {
     let now = connect_rtt_idle(&mut client, &mut server, RTT);
 
     client
-        .migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR_V4), true, now)
+        .migrate(Some(&DEFAULT_ADDR_V4), Some(&DEFAULT_ADDR_V4), true, now)
         .unwrap();
     // The RTT might be increased for the new path, so allow a little flexibility.
     let rtt = client.paths.rtt();
@@ -484,7 +488,7 @@ fn migrate_immediate_fail() {
     let mut now = now();
 
     client
-        .migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR_V4), true, now)
+        .migrate(Some(&DEFAULT_ADDR_V4), Some(&DEFAULT_ADDR_V4), true, now)
         .unwrap();
 
     let probe = client.process_output(now).dgram().unwrap();
@@ -536,7 +540,7 @@ fn migrate_same() {
     let now = now();
 
     client
-        .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), true, now)
+        .migrate(Some(&DEFAULT_ADDR), Some(&DEFAULT_ADDR), true, now)
         .unwrap();
 
     let probe = client.process_output(now).dgram().unwrap();
@@ -564,7 +568,7 @@ fn migrate_same_fail() {
     let mut now = now();
 
     client
-        .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), true, now)
+        .migrate(Some(&DEFAULT_ADDR), Some(&DEFAULT_ADDR), true, now)
         .unwrap();
 
     let probe = client.process_output(now).dgram().unwrap();
@@ -623,7 +627,7 @@ fn migration(mut client: Connection) {
     let now = now();
 
     client
-        .migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR_V4), false, now)
+        .migrate(Some(&DEFAULT_ADDR_V4), Some(&DEFAULT_ADDR_V4), false, now)
         .unwrap();
 
     let probe = client.process_output(now).dgram().unwrap();
@@ -696,7 +700,7 @@ fn migration_graceful() {
 #[test]
 fn migration_client_empty_cid() {
     fixture_init();
-    let client = zero_len_cid_client(DEFAULT_ADDR, DEFAULT_ADDR);
+    let client = zero_len_cid_client(&DEFAULT_ADDR, &DEFAULT_ADDR);
     migration(client);
 }
 
@@ -715,7 +719,7 @@ fn fast_handshake(client: &mut Connection, server: &mut Connection) -> Option<Da
     server.process(dgram, now()).dgram()
 }
 
-fn preferred_address(hs_client: SocketAddr, hs_server: SocketAddr, preferred: SocketAddr) {
+fn preferred_address(hs_client: &SocketAddr, hs_server: &SocketAddr, preferred: &SocketAddr) {
     let mtu = Pmtud::default_plpmtu(hs_client.ip());
     let assert_orig_path = |d: &Datagram, full_mtu: bool| {
         assert_eq!(
@@ -752,8 +756,8 @@ fn preferred_address(hs_client: SocketAddr, hs_server: SocketAddr, preferred: So
     let mut client = zero_len_cid_client(hs_client, hs_server);
     client.set_qlog(log);
     let spa = match preferred {
-        SocketAddr::V6(v6) => PreferredAddress::new(None, Some(v6)),
-        SocketAddr::V4(v4) => PreferredAddress::new(Some(v4), None),
+        SocketAddr::V6(v6) => PreferredAddress::new(None, Some(*v6)),
+        SocketAddr::V4(v4) => PreferredAddress::new(Some(*v4), None),
     };
     let mut server = new_server(ConnectionParameters::default().preferred_address(spa));
 
@@ -805,8 +809,8 @@ fn preferred_address(hs_client: SocketAddr, hs_server: SocketAddr, preferred: So
 /// Migration works for a new port number.
 #[test]
 fn preferred_address_new_port() {
-    let a = DEFAULT_ADDR;
-    preferred_address(a, a, new_port(a));
+    let a = &DEFAULT_ADDR;
+    preferred_address(a, a, &new_port(a));
 }
 
 /// Migration works for a new address too.
@@ -814,21 +818,21 @@ fn preferred_address_new_port() {
 fn preferred_address_new_address() {
     let mut preferred = DEFAULT_ADDR;
     preferred.set_ip(IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 2)));
-    preferred_address(DEFAULT_ADDR, DEFAULT_ADDR, preferred);
+    preferred_address(&DEFAULT_ADDR, &DEFAULT_ADDR, &preferred);
 }
 
 /// Migration works for IPv4 addresses.
 #[test]
 fn preferred_address_new_port_v4() {
-    let a = DEFAULT_ADDR_V4;
-    preferred_address(a, a, new_port(a));
+    let a = &DEFAULT_ADDR_V4;
+    preferred_address(a, a, &new_port(a));
 }
 
 /// Migrating to a loopback address is OK if we started there.
 #[test]
 fn preferred_address_loopback() {
-    let a = loopback();
-    preferred_address(a, a, new_port(a));
+    let a = &loopback();
+    preferred_address(a, a, &new_port(a));
 }
 
 fn expect_no_migration(client: &mut Connection, server: &mut Connection) {
@@ -880,7 +884,7 @@ fn preferred_address_disabled_client() {
 fn preferred_address_empty_cid() {
     fixture_init();
 
-    let spa = PreferredAddress::new_any(None, Some(new_port(DEFAULT_ADDR)));
+    let spa = PreferredAddress::new_any(None, Some(new_port(&DEFAULT_ADDR)));
     let res = Connection::new_server(
         test_fixture::DEFAULT_KEYS,
         test_fixture::DEFAULT_ALPN,
@@ -943,33 +947,33 @@ fn preferred_address_client() {
 fn migration_invalid_state() {
     let mut client = default_client();
     assert!(client
-        .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), false, now())
+        .migrate(Some(&DEFAULT_ADDR), Some(&DEFAULT_ADDR), false, now())
         .is_err());
 
     let mut server = default_server();
     assert!(server
-        .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), false, now())
+        .migrate(Some(&DEFAULT_ADDR), Some(&DEFAULT_ADDR), false, now())
         .is_err());
     connect_force_idle(&mut client, &mut server);
 
     assert!(server
-        .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), false, now())
+        .migrate(Some(&DEFAULT_ADDR), Some(&DEFAULT_ADDR), false, now())
         .is_err());
 
     client.close(now(), 0, "closing");
     assert!(client
-        .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), false, now())
+        .migrate(Some(&DEFAULT_ADDR), Some(&DEFAULT_ADDR), false, now())
         .is_err());
     let close = client.process_output(now()).dgram();
 
     let dgram = server.process(close, now()).dgram();
     assert!(server
-        .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), false, now())
+        .migrate(Some(&DEFAULT_ADDR), Some(&DEFAULT_ADDR), false, now())
         .is_err());
 
     client.process_input(dgram.unwrap(), now());
     assert!(client
-        .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), false, now())
+        .migrate(Some(&DEFAULT_ADDR), Some(&DEFAULT_ADDR), false, now())
         .is_err());
 }
 
@@ -980,7 +984,7 @@ fn migration_disabled() {
     connect(&mut client, &mut server);
     assert_eq!(
         client
-            .migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR), true, now())
+            .migrate(Some(&DEFAULT_ADDR), Some(&DEFAULT_ADDR), true, now())
             .unwrap_err(),
         Error::InvalidMigration
     );
@@ -1005,30 +1009,31 @@ fn migration_invalid_address() {
     // Providing a zero port number isn't valid.
     let mut zero_port = DEFAULT_ADDR;
     zero_port.set_port(0);
-    cant_migrate(None, Some(zero_port));
-    cant_migrate(Some(zero_port), None);
+    cant_migrate(None, Some(&zero_port));
+    cant_migrate(Some(&zero_port), None);
 
     // An unspecified remote address is bad.
     let mut remote_unspecified = DEFAULT_ADDR;
     remote_unspecified.set_ip(IpAddr::V6(Ipv6Addr::from(0)));
-    cant_migrate(None, Some(remote_unspecified));
+    cant_migrate(None, Some(&remote_unspecified));
 
     // Mixed address families is bad.
-    cant_migrate(Some(DEFAULT_ADDR), Some(DEFAULT_ADDR_V4));
-    cant_migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR));
+    cant_migrate(Some(&DEFAULT_ADDR), Some(&DEFAULT_ADDR_V4));
+    cant_migrate(Some(&DEFAULT_ADDR_V4), Some(&DEFAULT_ADDR));
 
     // Loopback to non-loopback is bad.
-    cant_migrate(Some(DEFAULT_ADDR), Some(loopback()));
-    cant_migrate(Some(loopback()), Some(DEFAULT_ADDR));
+    let loopback = &loopback();
+    cant_migrate(Some(&DEFAULT_ADDR), Some(loopback));
+    cant_migrate(Some(loopback), Some(&DEFAULT_ADDR));
     assert_eq!(
         client
-            .migrate(Some(DEFAULT_ADDR), Some(loopback()), true, now())
+            .migrate(Some(&DEFAULT_ADDR), Some(loopback), true, now())
             .unwrap_err(),
         Error::InvalidMigration
     );
     assert_eq!(
         client
-            .migrate(Some(loopback()), Some(DEFAULT_ADDR), true, now())
+            .migrate(Some(loopback), Some(&DEFAULT_ADDR), true, now())
             .unwrap_err(),
         Error::InvalidMigration
     );
@@ -1112,7 +1117,7 @@ fn retire_prior_to_migration_failure() {
     let original_cid = ConnectionId::from(get_cid(&send_something(&mut client, now())));
 
     client
-        .migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR_V4), false, now())
+        .migrate(Some(&DEFAULT_ADDR_V4), Some(&DEFAULT_ADDR_V4), false, now())
         .unwrap();
 
     // The client now probes the new path.
@@ -1167,7 +1172,7 @@ fn retire_prior_to_migration_success() {
     let original_cid = ConnectionId::from(get_cid(&send_something(&mut client, now())));
 
     client
-        .migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR_V4), false, now())
+        .migrate(Some(&DEFAULT_ADDR_V4), Some(&DEFAULT_ADDR_V4), false, now())
         .unwrap();
 
     // The client now probes the new path.
@@ -1225,7 +1230,7 @@ fn error_on_new_path_with_no_connection_id() {
 
     let garbage = send_with_extra(&mut server, GarbageWriter {}, now());
 
-    let dgram = change_path(&garbage, DEFAULT_ADDR_V4);
+    let dgram = change_path(&garbage, &DEFAULT_ADDR_V4);
     client.process_input(dgram, now());
 
     // See issue #1697. We had a crash when the client had a temporary path and

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -107,8 +107,8 @@ pub fn new_client(params: ConnectionParameters) -> Connection {
         test_fixture::DEFAULT_SERVER_NAME,
         test_fixture::DEFAULT_ALPN,
         Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
-        DEFAULT_ADDR,
-        DEFAULT_ADDR,
+        &DEFAULT_ADDR,
+        &DEFAULT_ADDR,
         params,
         now(),
     )
@@ -121,7 +121,7 @@ pub fn default_client() -> Connection {
     new_client(ConnectionParameters::default())
 }
 
-fn zero_len_cid_client(local_addr: SocketAddr, remote_addr: SocketAddr) -> Connection {
+fn zero_len_cid_client(local_addr: &SocketAddr, remote_addr: &SocketAddr) -> Connection {
     Connection::new_client(
         test_fixture::DEFAULT_SERVER_NAME,
         test_fixture::DEFAULT_ALPN,

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -1533,8 +1533,8 @@ impl CryptoStreams {
 
         #[expect(clippy::type_complexity, reason = "Yeah, a bit complex but still OK.")]
         const fn limit_chunks<'a>(
-            left: (u64, &'a [u8]),
-            right: (u64, &'a [u8]),
+            left: &(u64, &'a [u8]),
+            right: &(u64, &'a [u8]),
             limit: usize,
         ) -> ((u64, &'a [u8]), (u64, &'a [u8])) {
             let (left_offset, mut left) = left;
@@ -1557,7 +1557,7 @@ impl CryptoStreams {
                 (left, _) = left.split_at(limit / 2);
                 (right, _) = right.split_at(limit / 2);
             }
-            ((left_offset, left), (right_offset, right))
+            ((*left_offset, left), (right_offset, right))
         }
 
         let Some(cs) = self.get_mut(space) else {
@@ -1574,7 +1574,7 @@ impl CryptoStreams {
                     let packets_needed = data.len().div_ceil(builder.limit());
                     let limit = data.len() / packets_needed;
                     let ((left_offset, left), (right_offset, right)) =
-                        limit_chunks((offset, left), (offset + mid as u64, right), limit);
+                        limit_chunks(&(offset, left), &(offset + mid as u64, right), limit);
                     (
                         write_chunk(right_offset, right, builder),
                         write_chunk(left_offset, left, builder),

--- a/neqo-transport/src/ecn.rs
+++ b/neqo-transport/src/ecn.rs
@@ -173,8 +173,8 @@ pub(crate) struct Info {
 
 impl Info {
     /// Set the baseline (= the ECN counts from the last ACK Frame).
-    pub(crate) fn set_baseline(&mut self, baseline: Count) {
-        self.baseline = baseline;
+    pub(crate) fn set_baseline(&mut self, baseline: &Count) {
+        self.baseline = *baseline;
     }
 
     /// Expose the current baseline.
@@ -208,7 +208,7 @@ impl Info {
     pub(crate) fn on_packets_acked(
         &mut self,
         acked_packets: &[SentPacket],
-        ack_ecn: Option<Count>,
+        ack_ecn: Option<&Count>,
         stats: &mut Stats,
     ) -> bool {
         let prev_baseline = self.baseline;
@@ -244,7 +244,7 @@ impl Info {
     pub(crate) fn validate_ack_ecn_and_update(
         &mut self,
         acked_packets: &[SentPacket],
-        ack_ecn: Option<Count>,
+        ack_ecn: Option<&Count>,
         stats: &mut Stats,
     ) {
         // RFC 9000, Appendix A.4:
@@ -298,7 +298,7 @@ impl Info {
             self.disable_ecn(stats, ValidationError::Bleaching);
             return;
         }
-        let ecn_diff = ack_ecn - self.baseline;
+        let ecn_diff = *ack_ecn - self.baseline;
         let sum_inc = ecn_diff[IpTosEcn::Ect0] + ecn_diff[IpTosEcn::Ce];
         if sum_inc < newly_acked_sent_with_ect0 {
             qwarn!(
@@ -312,8 +312,8 @@ impl Info {
             qinfo!("ECN validation succeeded, path is capable");
             self.state.set(ValidationState::Capable, stats);
         }
-        self.baseline = ack_ecn;
-        stats.ecn_tx = ack_ecn;
+        self.baseline = *ack_ecn;
+        stats.ecn_tx = *ack_ecn;
         self.largest_acked = largest_acked;
     }
 

--- a/neqo-transport/src/pmtud.rs
+++ b/neqo-transport/src/pmtud.rs
@@ -56,7 +56,7 @@ pub struct Pmtud {
 
 impl Pmtud {
     /// Returns the MTU search table for the given remote IP address family.
-    const fn search_table(remote_ip: IpAddr) -> &'static [usize] {
+    const fn search_table(remote_ip: &IpAddr) -> &'static [usize] {
         match remote_ip {
             IpAddr::V4(_) => MTU_SIZES_V4,
             IpAddr::V6(_) => MTU_SIZES_V6,
@@ -64,7 +64,7 @@ impl Pmtud {
     }
 
     /// Size of the IPv4/IPv6 and UDP headers, in bytes.
-    const fn header_size(remote_ip: IpAddr) -> usize {
+    const fn header_size(remote_ip: &IpAddr) -> usize {
         match remote_ip {
             IpAddr::V4(_) => 20 + 8,
             IpAddr::V6(_) => 40 + 8,
@@ -72,7 +72,7 @@ impl Pmtud {
     }
 
     #[must_use]
-    pub fn new(remote_ip: IpAddr, iface_mtu: Option<usize>) -> Self {
+    pub fn new(remote_ip: &IpAddr, iface_mtu: Option<usize>) -> Self {
         let search_table = Self::search_table(remote_ip);
         let probe_index = 0;
         Self {
@@ -322,8 +322,8 @@ impl Pmtud {
     /// Returns the default PLPMTU for the given remote IP address.
     #[must_use]
     pub const fn default_plpmtu(remote_ip: IpAddr) -> usize {
-        let search_table = Self::search_table(remote_ip);
-        search_table[0] - Self::header_size(remote_ip)
+        let search_table = Self::search_table(&remote_ip);
+        search_table[0] - Self::header_size(&remote_ip)
     }
 }
 
@@ -390,7 +390,7 @@ mod tests {
         pmtud: &mut Pmtud,
         stats: &mut Stats,
         prot: &mut CryptoDxState,
-        addr: IpAddr,
+        addr: &IpAddr,
         mtu: usize,
         now: Instant,
     ) {
@@ -420,7 +420,7 @@ mod tests {
     }
 
     fn find_pmtu(
-        addr: IpAddr,
+        addr: &IpAddr,
         mtu: usize,
         iface_mtu: Option<usize>,
     ) -> (Pmtud, Stats, CryptoDxState, Instant) {
@@ -448,7 +448,7 @@ mod tests {
         (pmtud, stats, prot, now)
     }
 
-    fn find_pmtu_with_reduction(addr: IpAddr, mtu: usize, smaller_mtu: usize) {
+    fn find_pmtu_with_reduction(addr: &IpAddr, mtu: usize, smaller_mtu: usize) {
         assert!(mtu > smaller_mtu);
         let (mut pmtud, mut stats, mut prot, now) = find_pmtu(addr, mtu, None);
 
@@ -464,7 +464,7 @@ mod tests {
         assert_mtu(&pmtud, smaller_mtu);
     }
 
-    fn find_pmtu_with_increase(addr: IpAddr, mtu: usize, larger_mtu: usize) {
+    fn find_pmtu_with_increase(addr: &IpAddr, mtu: usize, larger_mtu: usize) {
         assert!(mtu < larger_mtu);
         let (mut pmtud, mut stats, mut prot, now) = find_pmtu(addr, mtu, None);
 
@@ -496,7 +496,7 @@ mod tests {
             for path_mtu in path_mtus() {
                 for &iface_mtu in IFACE_MTUS {
                     qinfo!("PMTUD for {addr}, path MTU {path_mtu}, iface MTU {iface_mtu:?}");
-                    find_pmtu(addr, path_mtu, iface_mtu);
+                    find_pmtu(&addr, path_mtu, iface_mtu);
                 }
             }
         }
@@ -504,7 +504,7 @@ mod tests {
 
     #[test]
     fn pmtud_with_reduction() {
-        for &addr in &[V4, V6] {
+        for addr in &[V4, V6] {
             for path_mtu in path_mtus() {
                 let path_mtus = path_mtus();
                 let smaller_mtus = path_mtus.iter().filter(|&mtu| *mtu < path_mtu);
@@ -518,7 +518,7 @@ mod tests {
 
     #[test]
     fn pmtud_with_increase() {
-        for &addr in &[V4, V6] {
+        for addr in &[V4, V6] {
             for path_mtu in path_mtus() {
                 let path_mtus = path_mtus();
                 let larger_mtus = path_mtus.iter().filter(|&mtu| *mtu > path_mtu);
@@ -554,7 +554,7 @@ mod tests {
     fn pmtud_on_packets_lost() {
         const MTU: usize = 1500;
         let now = now();
-        let mut pmtud = Pmtud::new(V4, Some(MTU));
+        let mut pmtud = Pmtud::new(&V4, Some(MTU));
         let mut stats = Stats::default();
         // Start with completed PMTUD with MTU 1500.
         pmtud.stop(
@@ -642,7 +642,7 @@ mod tests {
     fn pmtud_on_packets_lost_and_acked() {
         const MTU: usize = 1500;
         let now = now();
-        let mut pmtud = Pmtud::new(V4, Some(MTU));
+        let mut pmtud = Pmtud::new(&V4, Some(MTU));
         let mut stats = Stats::default();
         // Start with completed PMTUD with MTU 1500.
         pmtud.stop(

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -581,7 +581,7 @@ impl LossRecovery {
         primary_path: &PathRef,
         pn_space: PacketNumberSpace,
         acked_ranges: R,
-        ack_ecn: Option<ecn::Count>,
+        ack_ecn: Option<&ecn::Count>,
         ack_delay: Duration,
         now: Instant,
     ) -> (Vec<SentPacket>, Vec<SentPacket>)
@@ -969,7 +969,7 @@ mod tests {
             &mut self,
             pn_space: PacketNumberSpace,
             acked_ranges: Vec<RangeInclusive<PacketNumber>>,
-            ack_ecn: Option<ecn::Count>,
+            ack_ecn: Option<&ecn::Count>,
             ack_delay: Duration,
             now: Instant,
         ) -> (Vec<SentPacket>, Vec<SentPacket>) {
@@ -1007,8 +1007,8 @@ mod tests {
             const CC: CongestionControlAlgorithm = CongestionControlAlgorithm::NewReno;
             let stats = StatsCell::default();
             let mut path = Path::temporary(
-                DEFAULT_ADDR,
-                DEFAULT_ADDR,
+                &DEFAULT_ADDR,
+                &DEFAULT_ADDR,
                 CC,
                 true,
                 NeqoQlog::default(),

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -359,8 +359,8 @@ impl Server {
         // This is only looking at the first packet header in the datagram.
         // All packets in the datagram are routed to the same connection.
         let len = dgram.len();
-        let destination = dgram.destination();
-        let source = dgram.source();
+        let destination = *dgram.destination();
+        let source = *dgram.source();
         let res = PublicPacket::decode(&mut dgram[..], self.cid_generator.borrow().as_decoder());
         let Ok((packet, _remainder)) = res else {
             qtrace!("[{self}] Discarding {dgram:?}");

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -165,7 +165,7 @@ fn retry_different_ip() {
     // Change the source IP on the address from the client.
     let dgram = dgram.unwrap();
     let other_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
-    let other_addr = SocketAddr::new(other_v4, 443);
+    let other_addr = &SocketAddr::new(other_v4, 443);
     let from_other = Datagram::new(other_addr, dgram.destination(), dgram.tos(), &dgram[..]);
     let dgram = server.process(Some(from_other), now()).dgram();
     assert!(dgram.is_none());
@@ -186,7 +186,7 @@ fn new_token_different_ip() {
 
     // Now rewrite the source address.
     let d = dgram.unwrap();
-    let src = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), d.source().port());
+    let src = &SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), d.source().port());
     let dgram = Some(Datagram::new(src, d.destination(), d.tos(), &d[..]));
     let dgram = server.process(dgram, now()).dgram(); // Retry
     assert!(dgram.is_some());
@@ -211,7 +211,7 @@ fn new_token_expired() {
     // but when trying to generate another Retry.  A month is fine.
     let the_future = now() + Duration::from_secs(60 * 60 * 24 * 30);
     let d = dgram.unwrap();
-    let src = SocketAddr::new(d.source().ip(), d.source().port() + 1);
+    let src = &SocketAddr::new(d.source().ip(), d.source().port() + 1);
     let dgram = Some(Datagram::new(src, d.destination(), d.tos(), &d[..]));
     let dgram = server.process(dgram, the_future).dgram(); // Retry
     assert!(dgram.is_some());

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -158,7 +158,7 @@ fn duplicate_initial_new_path() {
     assert_eq!(*client.state(), State::Init);
     let initial = client.process_output(now()).dgram().unwrap();
     let other = Datagram::new(
-        SocketAddr::new(initial.source().ip(), initial.source().port() ^ 23),
+        &SocketAddr::new(initial.source().ip(), initial.source().port() ^ 23),
         initial.destination(),
         initial.tos(),
         &initial[..],
@@ -422,7 +422,7 @@ fn new_token_different_port() {
 
     // Now rewrite the source port, which should not change that the token is OK.
     let d = dgram.unwrap();
-    let src = SocketAddr::new(d.source().ip(), d.source().port() + 1);
+    let src = &SocketAddr::new(d.source().ip(), d.source().port() + 1);
     let dgram = Some(Datagram::new(src, d.destination(), d.tos(), &d[..]));
     let dgram = server.process(dgram, now()).dgram(); // Retry
     assert!(dgram.is_some());

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -67,7 +67,7 @@ pub fn send_inner(
     d: &Datagram,
 ) -> io::Result<()> {
     let transmit = Transmit {
-        destination: d.destination(),
+        destination: *d.destination(),
         ecn: EcnCodepoint::from_bits(Into::<u8>::into(d.tos())),
         contents: d,
         segment_size: None,
@@ -152,8 +152,8 @@ impl<'a> Iterator for DatagramIter<'a> {
                 .and_then(|(meta, ds)| ds.next().map(|d| (meta, d)))
             {
                 return Some(Datagram::from_slice(
-                    meta.addr,
-                    self.local_address,
+                    &meta.addr,
+                    &self.local_address,
                     meta.ecn.map(|n| IpTos::from(n as u8)).unwrap_or_default(),
                     d,
                 ));
@@ -254,8 +254,8 @@ mod tests {
         let receiver_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
         let datagram = Datagram::new(
-            sender.inner.local_addr()?,
-            receiver.inner.local_addr()?,
+            &sender.inner.local_addr()?,
+            &receiver.inner.local_addr()?,
             IpTos::from((IpTosDscp::Le, IpTosEcn::Ect1)),
             b"Hello, world!".to_vec(),
         );

--- a/test-fixture/src/assertions.rs
+++ b/test-fixture/src/assertions.rs
@@ -158,7 +158,7 @@ pub fn assert_no_1rtt(payload: &[u8]) {
 /// # Panics
 ///
 /// When the path doesn't use the given socket address at both ends.
-pub fn assert_path(dgram: &Datagram, path_addr: SocketAddr) {
+pub fn assert_path(dgram: &Datagram, path_addr: &SocketAddr) {
     assert_eq!(dgram.source(), path_addr);
     assert_eq!(dgram.destination(), path_addr);
 }
@@ -167,7 +167,7 @@ pub fn assert_path(dgram: &Datagram, path_addr: SocketAddr) {
 ///
 /// When the path doesn't use the default v4 socket address at both ends.
 pub fn assert_v4_path(dgram: &Datagram, padded: bool) {
-    assert_path(dgram, DEFAULT_ADDR_V4);
+    assert_path(dgram, &DEFAULT_ADDR_V4);
     if padded {
         assert_eq!(dgram.len(), Pmtud::default_plpmtu(DEFAULT_ADDR_V4.ip()));
     }
@@ -177,7 +177,7 @@ pub fn assert_v4_path(dgram: &Datagram, padded: bool) {
 ///
 /// When the path doesn't use the default v6 socket address at both ends.
 pub fn assert_v6_path(dgram: &Datagram, padded: bool) {
-    assert_path(dgram, DEFAULT_ADDR);
+    assert_path(dgram, &DEFAULT_ADDR);
     if padded {
         assert_eq!(dgram.len(), Pmtud::default_plpmtu(DEFAULT_ADDR.ip()));
     }

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -98,7 +98,7 @@ pub const DEFAULT_ADDR_V4: SocketAddr = addr_v4();
 // Create a default datagram with the given data.
 #[must_use]
 pub fn datagram(data: Vec<u8>) -> Datagram {
-    Datagram::new(DEFAULT_ADDR, DEFAULT_ADDR, IpTosEcn::Ect0.into(), data)
+    Datagram::new(&DEFAULT_ADDR, &DEFAULT_ADDR, IpTosEcn::Ect0.into(), data)
 }
 
 /// Create a default socket address.
@@ -161,8 +161,8 @@ pub fn new_client(params: ConnectionParameters) -> Connection {
         DEFAULT_SERVER_NAME,
         DEFAULT_ALPN,
         Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
-        DEFAULT_ADDR,
-        DEFAULT_ADDR,
+        &DEFAULT_ADDR,
+        &DEFAULT_ADDR,
         params.ack_ratio(255), // Tests work better with this set this way.
         now(),
     )
@@ -281,8 +281,8 @@ pub fn http3_client_with_params(params: Http3Parameters) -> Http3Client {
     Http3Client::new(
         DEFAULT_SERVER_NAME,
         Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
-        DEFAULT_ADDR,
-        DEFAULT_ADDR,
+        &DEFAULT_ADDR,
+        &DEFAULT_ADDR,
         params,
         now(),
     )


### PR DESCRIPTION
Let's see if this matters.