### PR TITLE
chore: Pin deps via `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "clap-verbosity-flag"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dcf89bb9d98abb02e9a4a8ef1cce429e547a803460a8245c399860985d5281"
+checksum = "54381ae56ad222eea3f529c692879e9c65e07945ae48d3dc4d1cb18dbec8cf44"
 dependencies = [
  "clap",
  "log",
@@ -797,9 +797,9 @@ checksum = "903970ae2f248d7275214cf8f387f8ba0c4ea7e3d87a320e85493db60ce28616"
 
 [[package]]
 name = "mtu"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6f72a335d87c273d0f1db95778aef6826175556538a72747e1213f9995c16a"
+checksum = "4c30d3771729ec4349aae3b1a7c0b6b4a1500459e60b1fda95fe0657c3711574"
 dependencies = [
  "bindgen",
  "cfg_aliases",
@@ -1008,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1109,18 +1109,18 @@ checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,16 +29,16 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.82.0"
 
 [workspace.dependencies]
-# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 enum-map = { version = "2.7", default-features = false }
 enumset = { version = "1.1", default-features = false }
+hex = { version = "0.4", default-features = false }
 log = { version = "0.4", default-features = false }
 qlog = { version = "0.13", default-features = false }
-quinn-udp = { version = "0.5.6", default-features = false, features = ["direct-log", "fast-apple-datapath"] }
+quinn-udp = { version = "0.5", default-features = false, features = ["direct-log", "fast-apple-datapath"] }
 regex = { version = "1.9", default-features = false, features = ["unicode-perl"] }
 static_assertions = { version = "1.1", default-features = false }
 strum = { version = "0.26", default-features = false, features = ["derive"] }
-url = { version = "2.5.3", default-features = false, features = ["std"] }
+url = { version = "2.5", default-features = false, features = ["std"] }
 
 [workspace.lints.rust]
 absolute_paths_not_starting_with_crate = "warn"

--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -26,11 +26,10 @@ bench = false
 workspace = true
 
 [dependencies]
-# Not used in Firefox, so we can be liberal with dependency versions
-clap = { version = "4.4", default-features = false, features = ["std", "help", "usage", "error-context", "suggestions", "derive"] }
+clap = { version = "4.5", default-features = false, features = ["std", "help", "usage", "error-context", "suggestions", "derive"] }
 clap-verbosity-flag = { version = "3.0", default-features = false, features = ["log"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
-hex = { version = "0.4", default-features = false, features = ["std"] }
+hex = { workspace = true, features = ["std"] }
 log = { workspace = true }
 neqo-common = { path = "./../neqo-common" }
 neqo-crypto = { path = "./../neqo-crypto" }

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -16,16 +16,14 @@ readme.workspace = true
 workspace = true
 
 [dependencies]
-# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 enum-map = { workspace = true }
 env_logger = { version = "0.10", default-features = false }
-hex = { version = "0.4", default-features = false, features = ["alloc"], optional = true }
+hex = { workspace = true, optional = true }
 log = { workspace = true }
 qlog = { workspace = true }
 strum = { workspace = true }
 
 [target."cfg(windows)".dependencies]
-# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 windows = { version = "0.58", default-features = false, features = ["Win32_Media"] }
 
 [dev-dependencies]

--- a/neqo-crypto/Cargo.toml
+++ b/neqo-crypto/Cargo.toml
@@ -16,14 +16,12 @@ readme.workspace = true
 workspace = true
 
 [dependencies]
-# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 enum-map = { workspace = true }
 log = { workspace = true }
 neqo-common = { path = "../neqo-common" }
 strum = { workspace = true}
 
 [build-dependencies]
-# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
 mozbuild = { version = "0.1", default-features = false, optional = true }
 semver = { version = "1.0", default-features = false }

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -16,7 +16,6 @@ readme.workspace = true
 workspace = true
 
 [dependencies]
-# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 enumset = { workspace = true }
 log = { workspace = true }
 neqo-common = { path = "./../neqo-common" }

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -16,7 +16,6 @@ readme.workspace = true
 workspace = true
 
 [dependencies]
-# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 log = { workspace = true }
 neqo-common = { path = "./../neqo-common" }
 neqo-transport = { path = "./../neqo-transport" }

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -23,7 +23,7 @@ indexmap = { version = "2.2", default-features = false } # See https://github.co
 log = { workspace = true }
 neqo-common = { path = "../neqo-common" }
 neqo-crypto = { path = "../neqo-crypto" }
-mtu = { version = "0.2.3", default-features = false } # neqo is only user currently, can bump freely
+mtu = { version = "0.2", default-features = false } # neqo is only user currently, can bump freely
 qlog = { workspace = true }
 smallvec = { version = "1.13", default-features = false }
 static_assertions = { workspace = true }

--- a/neqo-udp/Cargo.toml
+++ b/neqo-udp/Cargo.toml
@@ -16,7 +16,6 @@ readme.workspace = true
 workspace = true
 
 [dependencies]
-# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 log = { workspace = true }
 neqo-common = { path = "./../neqo-common" }
 quinn-udp = { workspace = true }


### PR DESCRIPTION
And use the same versions that Firefox is currently using.