### PR TITLE
fix: Use 1MB socket RX buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
+checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ enumset = { version = "1.1", default-features = false }
 hex = { version = "0.4", default-features = false }
 log = { version = "0.4", default-features = false }
 qlog = { version = "0.15", default-features = false }
-quinn-udp = { version = "0.5.10", default-features = false, features = ["direct-log", "fast-apple-datapath"] }
+quinn-udp = { version = "0.5.11", default-features = false, features = ["direct-log", "fast-apple-datapath"] }
 regex = { version = "1.9", default-features = false }
 static_assertions = { version = "1.1", default-features = false }
 strum = { version = "0.26", default-features = false, features = ["derive"] }

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -30,26 +30,28 @@ impl Socket {
         let socket = std::net::UdpSocket::bind(addr)?;
         let state = quinn_udp::UdpSocketState::new((&socket).into())?;
 
-        let send_buf = state.send_buffer_size((&socket).into())?;
+        let send_buf_before = state.send_buffer_size((&socket).into())?;
         // FIXME: We need to experiment if increasing this actually improves performance.
         // Also, on BSD and Apple targets, this seems to increase the `net.inet.udp.maxdgram`
         // sysctl, which is not the same as the socket buffer.
-        // if send_buf < ONE_MB {
-        //     qdebug!("Increasing socket send buffer size from {send_buf} to {ONE_MB}");
+        // if send_buf_before < ONE_MB {
         //     state.set_send_buffer_size((&socket).into(), ONE_MB)?;
+        //     let send_buf_after = state.send_buffer_size((&socket).into())?;
+        //     qdebug!("Increasing socket send buffer size from {send_buf_before} to {ONE_MB}, now: {send_buf_after}");
         // } else {
-        //     qdebug!("Default socket send buffer size is {send_buf}, not changing");
+        //     qdebug!("Default socket send buffer size is {send_buf_before}, not changing");
         // }
-        qdebug!("Default socket send buffer size is {send_buf}");
+        qdebug!("Default socket send buffer size is {send_buf_before}");
 
-        let recv_buf = state.recv_buffer_size((&socket).into())?;
-        if recv_buf < ONE_MB {
-            qdebug!("Increasing socket receive buffer size from {recv_buf} to {ONE_MB}");
+        let recv_buf_before = state.recv_buffer_size((&socket).into())?;
+        if recv_buf_before < ONE_MB {
             // Same as Firefox.
             // <https://searchfox.org/mozilla-central/source/modules/libpref/init/StaticPrefList.yaml#13474-13478>
             state.set_recv_buffer_size((&socket).into(), ONE_MB)?;
+            let recv_buf_after = state.recv_buffer_size((&socket).into())?;
+            qdebug!("Increasing socket recv buffer size from {recv_buf_before} to {ONE_MB}, now: {recv_buf_after}");
         } else {
-            qdebug!("Default socket receive buffer size is {recv_buf}, not changing");
+            qdebug!("Default socket receive buffer size is {recv_buf_before}, not changing");
         }
 
         Ok(Self {

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -31,19 +31,23 @@ impl Socket {
         let state = quinn_udp::UdpSocketState::new((&socket).into())?;
 
         let send_buf = state.send_buffer_size((&socket).into())?;
-        if send_buf < ONE_MB {
-            qdebug!("Increasing send buffer size from {send_buf} to {ONE_MB}");
-            state.set_send_buffer_size((&socket).into(), ONE_MB)?;
-        } else {
-            qdebug!("Default send buffer size is {send_buf}, not changing");
-        }
+        // FIXME: We need to experiment if increasing this actually improves performance.
+        // Also, on BSD and Apple targets, this seems to increase the `net.inet.udp.maxdgram`
+        // sysctl, which is not the same as the socket buffer.
+        // if send_buf < ONE_MB {
+        //     qdebug!("Increasing socket send buffer size from {send_buf} to {ONE_MB}");
+        //     state.set_send_buffer_size((&socket).into(), ONE_MB)?;
+        // } else {
+        //     qdebug!("Default socket send buffer size is {send_buf}, not changing");
+        // }
+        qdebug!("Default socket send buffer size is {send_buf}");
 
         let recv_buf = state.recv_buffer_size((&socket).into())?;
         if recv_buf < ONE_MB {
-            qdebug!("Increasing receive buffer size from {recv_buf} to {ONE_MB}");
+            qdebug!("Increasing socket receive buffer size from {recv_buf} to {ONE_MB}");
             state.set_recv_buffer_size((&socket).into(), ONE_MB)?;
         } else {
-            qdebug!("Default receive buffer size is {recv_buf}, not changing");
+            qdebug!("Default socket receive buffer size is {recv_buf}, not changing");
         }
 
         Ok(Self {

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -8,7 +8,7 @@
 
 use std::{io, net::SocketAddr};
 
-use neqo_common::{qdebug, Datagram};
+use neqo_common::{qwarn, Datagram};
 use neqo_udp::{DatagramIter, RecvBuf};
 
 /// Ideally this would live in [`neqo-udp`]. [`neqo-udp`] is used in Firefox.
@@ -32,18 +32,18 @@ impl Socket {
 
         let send_buf = state.send_buffer_size((&socket).into())?;
         if send_buf < ONE_MB {
-            qdebug!("Increasing send buffer size from {send_buf} to {ONE_MB}");
+            qwarn!("Increasing send buffer size from {send_buf} to {ONE_MB}");
             state.set_send_buffer_size((&socket).into(), ONE_MB)?;
         } else {
-            qdebug!("Default send buffer size is {send_buf}, not changing");
+            qwarn!("Default send buffer size is {send_buf}, not changing");
         }
 
         let recv_buf = state.recv_buffer_size((&socket).into())?;
         if recv_buf < ONE_MB {
-            qdebug!("Increasing receive buffer size from {recv_buf} to {ONE_MB}");
+            qwarn!("Increasing receive buffer size from {recv_buf} to {ONE_MB}");
             state.set_recv_buffer_size((&socket).into(), ONE_MB)?;
         } else {
-            qdebug!("Default receive buffer size is {recv_buf}, not changing");
+            qwarn!("Default receive buffer size is {recv_buf}, not changing");
         }
 
         Ok(Self {

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -45,6 +45,8 @@ impl Socket {
         let recv_buf = state.recv_buffer_size((&socket).into())?;
         if recv_buf < ONE_MB {
             qdebug!("Increasing socket receive buffer size from {recv_buf} to {ONE_MB}");
+            // Same as Firefox.
+            // <https://searchfox.org/mozilla-central/source/modules/libpref/init/StaticPrefList.yaml#13474-13478>
             state.set_recv_buffer_size((&socket).into(), ONE_MB)?;
         } else {
             qdebug!("Default socket receive buffer size is {recv_buf}, not changing");

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -8,7 +8,7 @@
 
 use std::{io, net::SocketAddr};
 
-use neqo_common::{qwarn, Datagram};
+use neqo_common::{qdebug, Datagram};
 use neqo_udp::{DatagramIter, RecvBuf};
 
 /// Ideally this would live in [`neqo-udp`]. [`neqo-udp`] is used in Firefox.
@@ -32,18 +32,18 @@ impl Socket {
 
         let send_buf = state.send_buffer_size((&socket).into())?;
         if send_buf < ONE_MB {
-            qwarn!("Increasing send buffer size from {send_buf} to {ONE_MB}");
+            qdebug!("Increasing send buffer size from {send_buf} to {ONE_MB}");
             state.set_send_buffer_size((&socket).into(), ONE_MB)?;
         } else {
-            qwarn!("Default send buffer size is {send_buf}, not changing");
+            qdebug!("Default send buffer size is {send_buf}, not changing");
         }
 
         let recv_buf = state.recv_buffer_size((&socket).into())?;
         if recv_buf < ONE_MB {
-            qwarn!("Increasing receive buffer size from {recv_buf} to {ONE_MB}");
+            qdebug!("Increasing receive buffer size from {recv_buf} to {ONE_MB}");
             state.set_recv_buffer_size((&socket).into(), ONE_MB)?;
         } else {
-            qwarn!("Default receive buffer size is {recv_buf}, not changing");
+            qdebug!("Default receive buffer size is {recv_buf}, not changing");
         }
 
         Ok(Self {

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -37,8 +37,8 @@ impl Socket {
         // if send_buf_before < ONE_MB {
         //     state.set_send_buffer_size((&socket).into(), ONE_MB)?;
         //     let send_buf_after = state.send_buffer_size((&socket).into())?;
-        //     qdebug!("Increasing socket send buffer size from {send_buf_before} to {ONE_MB}, now: {send_buf_after}");
-        // } else {
+        //     qdebug!("Increasing socket send buffer size from {send_buf_before} to {ONE_MB}, now:
+        // {send_buf_after}"); } else {
         //     qdebug!("Default socket send buffer size is {send_buf_before}, not changing");
         // }
         qdebug!("Default socket send buffer size is {send_buf_before}");


### PR DESCRIPTION
We need to do the same for `neqo-glue`.

Fixes #1962