### PR TITLE
ci: Key the Rust cache with the installed targets

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -79,6 +79,7 @@ runs:
       uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
       with:
         cache-bin: ${{ runner.environment == 'github-hosted' }}
+        key: ${{ inputs.targets }}
         save-if: ${{ github.ref == 'refs/heads/main' }} # Only cache runs from `main`
 
     - name: Set up MSVC (Windows)


### PR DESCRIPTION
So we don't mix toolchains.