### PR TITLE
ci: pin GitHub-hosted runners OS versions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash
@@ -39,7 +39,7 @@ jobs:
 
   zizmor:
     name: zizmor 🌈
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/check-vm.yml
+++ b/.github/workflows/check-vm.yml
@@ -32,7 +32,7 @@ jobs:
               # netbsd, # FIXME: NSS package is new enough, but test_fixture::fixture_init dies with `NssError { name: "SEC_ERROR_LEGACY_DATABASE", code: -8015, desc: "The certificate/key database is in an old, unsupported format." }`
               # solaris # FIXME: Re-enable once their NSS package is new enough.
             ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ defaults:
 
 jobs:
   toolchains:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       toolchains: ${{ steps.toolchains.outputs.toolchains }}
     steps:
@@ -47,12 +47,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Switch to ubuntu-latest-arm when available as a tag.
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-14, windows-2025]
         rust-toolchain: ${{ fromJSON(needs.toolchains.outputs.toolchains) }}
         type: [debug]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             rust-toolchain: stable
             type: release
     env:
@@ -143,7 +142,7 @@ jobs:
 
   check-cargo-lock:
     name: Ensure `Cargo.lock` contains all required dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-14, windows-2025]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   deny:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         checks:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-14, windows-2025]
         type: [debug, release]
     runs-on: ${{ matrix.os }}
     defaults:
@@ -165,7 +165,7 @@ jobs:
     name: Comment on PR
     # if: ${{ github.event.pull_request.draft == false }}
     needs: firefox
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/fuzz-bench.yml
+++ b/.github/workflows/fuzz-bench.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   fuzz-bench:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   machete:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   mutants:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -19,7 +19,7 @@ jobs:
   comment:
     permissions:
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: |
       github.event.workflow_run.event == 'pull_request' &&
       (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -29,7 +29,7 @@ jobs:
   docker-image:
     name: Build Docker image
     if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       imageID: ${{ steps.docker_build_and_push.outputs.imageID }}
     permissions:
@@ -86,7 +86,7 @@ jobs:
     name: Determine interop pairs
     if: ${{ github.event_name != 'push' }}
     needs: docker-image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       pairs: ${{ steps.config.outputs.pairs }}
       implementations: ${{ steps.config.outputs.implementations }}
@@ -149,7 +149,7 @@ jobs:
       fail-fast: false
       matrix:
         pair: ${{ fromJson(needs.implementations.outputs.pairs) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
@@ -182,7 +182,7 @@ jobs:
     name: Report results
     if: ${{ !cancelled() && github.event_name != 'push' }}
     needs: [run-qns, implementations]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -28,13 +28,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest] # No Windows support for sanitizers.
+        os: [ubuntu-24.04, macos-14] # No Windows support for sanitizers.
         sanitizer: [address, thread, leak] # TODO: memory
         exclude:
           # Memory and leak sanitizers are not supported on macOS.
-          - os: macos-latest
+          - os: macos-14
             sanitizer: leak
-          # - os: macos-latest
+          # - os: macos-14
           #   sanitizer: memory
     runs-on: ${{ matrix.os }}
 
@@ -66,10 +66,10 @@ jobs:
         run: |
           # Append to RUSTFLAGS, which may already be set by the Rust action.
           export RUSTFLAGS="-Z sanitizer=${{ matrix.sanitizer }} $RUSTFLAGS"
-          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+          if [ "${{ matrix.os }}" = "ubuntu-24.04" ]; then
             sudo apt-get install -y --no-install-recommends llvm
             TARGET="x86_64-unknown-linux-gnu"
-          elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+          elif [ "${{ matrix.os }}" = "macos-14" ]; then
             # llvm-symbolizer (as part of llvm) is installed by default on macOS runners
             TARGET="aarch64-apple-darwin"
             # Suppress non-neqo leaks on macOS. TODO: Check occasionally if these are still needed.


### PR DESCRIPTION
Fixes https://github.com/mozilla/neqo/issues/2480.

See [GitHub docs for latest runner versions](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for--private-repositories).