### PR TITLE
perf(bin): optimistically send datagram, only await on failure

### DIFF
--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -464,10 +464,19 @@ impl<'a, H: Handler> Runner<'a, H> {
     async fn process_output(&mut self) -> Result<(), io::Error> {
         loop {
             match self.client.process_output(Instant::now()) {
-                Output::Datagram(dgram) => {
-                    self.socket.writable().await?;
-                    self.socket.send(&dgram)?;
-                }
+                Output::Datagram(dgram) => loop {
+                    // Optimistically attempt sending datagram. In case the OS
+                    // buffer is full, wait till socket is writable then try
+                    // again.
+                    match self.socket.send(&dgram) {
+                        Ok(()) => break,
+                        Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                            self.socket.writable().await?;
+                            // Now try again.
+                        }
+                        e @ Err(_) => return e,
+                    }
+                },
                 Output::Callback(new_timeout) => {
                     qdebug!("Setting timeout of {new_timeout:?}");
                     self.timeout = Some(Box::pin(tokio::time::sleep(new_timeout)));


### PR DESCRIPTION
Previously `neqo-bin` would poll a UDP socket to be writable before attempting to send a datagram. This results in 2 syscalls per send.

Instead, optimistically attempt to send the datagram first, on failure `WouldBlock`, await and then try again. Under the assumption that the majority of sends work on the first try, this reduces the number of syscalls.

Follow-up to https://phabricator.services.mozilla.com/D239162#8315719.