### PR TITLE
docs(README): export LD_LIBRARY_PATH with absolute not relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ on NSS, you need to set an environment as follows:
 ### Linux
 
 ```shell
-export LD_LIBRARY_PATH="$(dirname "$(find . -name libssl3.so -print | head -1)")"
+export LD_LIBRARY_PATH="$(find . -name libssl3.so -print | head -1 | xargs dirname | xargs realpath)"
 ```
 
 ### macOS
 
 ```shell
-export DYLD_LIBRARY_PATH="$(dirname "$(find . -name libssl3.dylib -print | head -1)")"
+export DYLD_LIBRARY_PATH="$(find . -name libssl3.dylib -print | head -1 | xargs dirname | xargs realpath)"
 ```
 
 Note: If you did not already compile NSS separately, you need to have


### PR DESCRIPTION
Use `realpath` in order to export `LD_LIBRARY_PATH` with an absolute path to `libssl3.so` instead of a relative path.

---

I assume `realpath` is available on MacOS.