### PR TITLE
docs(README): mention `disable_when_third_party_roots_found` pref

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ something has changed.
 ### Connect with Firefox to local neqo-server
 
 1. Run `neqo-server` via `cargo run --bin neqo-server -- 'localhost:12345' --db ./test-fixture/db`.
-2. On Firefox, set `about:config` preference `network.http.http3.alt-svc-mapping-for-testing` to `localhost;h3=":12345"`.
+2. On Firefox, set `about:config` preferences:
+  - `network.http.http3.alt-svc-mapping-for-testing` to `localhost;h3=":12345"`
+  - `network.http.http3.disable_when_third_party_roots_found` to `false`
 3. Optionally enable logging via `about:logging` or profiling via <https://profiler.firefox.com/>.
 4. Navigate to <https://localhost:12345> and accept self-signed certificate.
 


### PR DESCRIPTION
In order to connect to a neqo-server with a self-signed certificate, one needs to set `network.http.http3.disable_when_third_party_roots_found` to `false`.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1925014 for details.

//CC @justus237 