### PR TITLE
fix: Skip interface MTU query on OpenBSD

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -339,8 +339,7 @@ impl Connection {
         let path = Path::temporary(
             local_addr,
             remote_addr,
-            c.conn_params.get_cc_algorithm(),
-            c.conn_params.pacing_enabled(),
+            &c.conn_params,
             NeqoQlog::default(),
             now,
             &mut c.stats.borrow_mut(),
@@ -1580,8 +1579,7 @@ impl Connection {
         let path = self.paths.find_path(
             d.destination(),
             d.source(),
-            self.conn_params.get_cc_algorithm(),
-            self.conn_params.pacing_enabled(),
+            &self.conn_params,
             now,
             &mut self.stats.borrow_mut(),
         );
@@ -1931,8 +1929,7 @@ impl Connection {
         let path = self.paths.find_path(
             local,
             remote,
-            self.conn_params.get_cc_algorithm(),
-            self.conn_params.pacing_enabled(),
+            &self.conn_params,
             now,
             &mut self.stats.borrow_mut(),
         );

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -125,6 +125,7 @@ impl Default for ConnectionParameters {
             pmtud: false,
             // Firefox on OpenBSD is sandboxed and cannot access the routing socket that the mtu
             // crate uses to obtain the local interface MTU. (Trying to do so crashes the process.)
+            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1952304
             pmtud_iface_mtu: cfg!(not(target_os = "openbsd")),
             sni_slicing: true,
             mlkem: true,

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -92,6 +92,8 @@ pub struct ConnectionParameters {
     pacing: bool,
     /// Whether the connection performs PLPMTUD.
     pmtud: bool,
+    /// Whether PMTUD should take the local interface MTU into account.
+    pmtud_iface_mtu: bool,
     /// Whether the connection should use SNI slicing.
     sni_slicing: bool,
     /// Whether to enable mlkem768nistp256-sha256.
@@ -121,6 +123,9 @@ impl Default for ConnectionParameters {
             disable_migration: false,
             pacing: true,
             pmtud: false,
+            // Firefox on OpenBSD is sandboxed and cannot access the routing socket that the mtu
+            // crate uses to obtain the local interface MTU. (Trying to do so crashes the process.)
+            pmtud_iface_mtu: cfg!(not(target_os = "openbsd")),
             sni_slicing: true,
             mlkem: true,
         }
@@ -380,6 +385,17 @@ impl ConnectionParameters {
     #[must_use]
     pub const fn pmtud(mut self, pmtud: bool) -> Self {
         self.pmtud = pmtud;
+        self
+    }
+
+    #[must_use]
+    pub const fn pmtud_iface_mtu_enabled(&self) -> bool {
+        self.pmtud_iface_mtu
+    }
+
+    #[must_use]
+    pub const fn pmtud_iface_mtu(mut self, pmtud_iface_mtu: bool) -> Self {
+        self.pmtud_iface_mtu = pmtud_iface_mtu;
         self
     }
 

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -123,10 +123,7 @@ impl Default for ConnectionParameters {
             disable_migration: false,
             pacing: true,
             pmtud: false,
-            // Firefox on OpenBSD is sandboxed and cannot access the routing socket that the mtu
-            // crate uses to obtain the local interface MTU. (Trying to do so crashes the process.)
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1952304
-            pmtud_iface_mtu: cfg!(not(target_os = "openbsd")),
+            pmtud_iface_mtu: true,
             sni_slicing: true,
             mlkem: true,
         }

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -686,8 +686,7 @@ fn assert_path_challenge_min_len(c: &Connection, d: &Datagram, now: Instant) {
     let path = c.paths.find_path(
         d.source(),
         d.destination(),
-        c.conn_params.get_cc_algorithm(),
-        c.conn_params.pacing_enabled(),
+        &c.conn_params,
         now,
         &mut c.stats.borrow_mut(),
     );

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -19,7 +19,6 @@ use neqo_crypto::random;
 
 use crate::{
     ackrate::{AckRate, PeerAckDelay},
-    cc::CongestionControlAlgorithm,
     cid::{ConnectionId, ConnectionIdRef, ConnectionIdStore, RemoteConnectionIdEntry},
     ecn,
     frame::FrameType,
@@ -29,7 +28,7 @@ use crate::{
     rtt::{RttEstimate, RttSource},
     sender::PacketSender,
     stats::FrameStats,
-    Stats,
+    ConnectionParameters, Stats,
 };
 
 /// The number of times that a path will be probed before it is considered failed.
@@ -75,8 +74,7 @@ impl Paths {
         &self,
         local: SocketAddr,
         remote: SocketAddr,
-        cc: CongestionControlAlgorithm,
-        pacing: bool,
+        conn_params: &ConnectionParameters,
         now: Instant,
         stats: &mut Stats,
     ) -> PathRef {
@@ -85,7 +83,7 @@ impl Paths {
             .find_map(|p| p.borrow().received_on(local, remote).then(|| Rc::clone(p)))
             .unwrap_or_else(|| {
                 let mut p =
-                    Path::temporary(local, remote, cc, pacing, self.qlog.clone(), now, stats);
+                    Path::temporary(local, remote, conn_params, self.qlog.clone(), now, stats);
                 if let Some(primary) = self.primary.as_ref() {
                     p.prime_rtt(primary.borrow().rtt());
                 }
@@ -520,30 +518,33 @@ impl Path {
     pub fn temporary(
         local: SocketAddr,
         remote: SocketAddr,
-        cc: CongestionControlAlgorithm,
-        pacing: bool,
+        conn_params: &ConnectionParameters,
         qlog: NeqoQlog,
         now: Instant,
         stats: &mut Stats,
     ) -> Self {
-        let iface_mtu = match mtu::interface_and_mtu(remote.ip()) {
-            Ok((name, mtu)) => {
-                qdebug!(
-                    "Outbound interface {name} for destination {ip} has MTU {mtu}",
-                    ip = remote.ip()
-                );
-                stats.pmtud_iface_mtu = mtu;
-                Some(mtu)
+        let iface_mtu = if conn_params.pmtud_iface_mtu_enabled() {
+            match mtu::interface_and_mtu(remote.ip()) {
+                Ok((name, mtu)) => {
+                    qdebug!(
+                        "Outbound interface {name} for destination {ip} has MTU {mtu}",
+                        ip = remote.ip()
+                    );
+                    stats.pmtud_iface_mtu = mtu;
+                    Some(mtu)
+                }
+                Err(e) => {
+                    qwarn!(
+                        "Failed to determine outbound interface for destination {ip}: {e}",
+                        ip = remote.ip()
+                    );
+                    None
+                }
             }
-            Err(e) => {
-                qwarn!(
-                    "Failed to determine outbound interface for destination {ip}: {e}",
-                    ip = remote.ip()
-                );
-                None
-            }
+        } else {
+            None
         };
-        let mut sender = PacketSender::new(cc, pacing, Pmtud::new(remote.ip(), iface_mtu), now);
+        let mut sender = PacketSender::new(conn_params, Pmtud::new(remote.ip(), iface_mtu), now);
         sender.set_qlog(qlog.clone());
         Self {
             local,

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -939,12 +939,12 @@ mod tests {
         LossRecovery, LossRecoverySpace, PacketNumberSpace, SendProfile, SentPacket, FAST_PTO_SCALE,
     };
     use crate::{
-        cc::CongestionControlAlgorithm,
         cid::{ConnectionId, ConnectionIdEntry},
         ecn,
         packet::{PacketNumber, PacketType},
         path::{Path, PathRef},
         stats::{Stats, StatsCell},
+        ConnectionParameters,
     };
 
     // Shorthand for a time in milliseconds.
@@ -1004,13 +1004,11 @@ mod tests {
 
     impl Default for Fixture {
         fn default() -> Self {
-            const CC: CongestionControlAlgorithm = CongestionControlAlgorithm::NewReno;
             let stats = StatsCell::default();
             let mut path = Path::temporary(
                 DEFAULT_ADDR,
                 DEFAULT_ADDR,
-                CC,
-                true,
+                &ConnectionParameters::default(),
                 NeqoQlog::default(),
                 now(),
                 &mut stats.borrow_mut(),

--- a/neqo-transport/src/sender.rs
+++ b/neqo-transport/src/sender.rs
@@ -19,7 +19,7 @@ use crate::{
     pmtud::Pmtud,
     recovery::SentPacket,
     rtt::RttEstimate,
-    Stats,
+    ConnectionParameters, Stats,
 };
 
 /// The number of packets we allow to burst from the pacer.
@@ -39,15 +39,10 @@ impl Display for PacketSender {
 
 impl PacketSender {
     #[must_use]
-    pub fn new(
-        alg: CongestionControlAlgorithm,
-        pacing_enabled: bool,
-        pmtud: Pmtud,
-        now: Instant,
-    ) -> Self {
+    pub fn new(conn_params: &ConnectionParameters, pmtud: Pmtud, now: Instant) -> Self {
         let mtu = pmtud.plpmtu();
         Self {
-            cc: match alg {
+            cc: match conn_params.get_cc_algorithm() {
                 CongestionControlAlgorithm::NewReno => {
                     Box::new(ClassicCongestionControl::new(NewReno::default(), pmtud))
                 }
@@ -55,7 +50,12 @@ impl PacketSender {
                     Box::new(ClassicCongestionControl::new(Cubic::default(), pmtud))
                 }
             },
-            pacer: Pacer::new(pacing_enabled, now, mtu * PACING_BURST_SIZE, mtu),
+            pacer: Pacer::new(
+                conn_params.pacing_enabled(),
+                now,
+                mtu * PACING_BURST_SIZE,
+                mtu,
+            ),
         }
     }
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1952304

Since we'd now need to pass multiple `bool`s from the `ConnectionParameters` around, just pass the entire `struct`.