### PR TITLE
Simplifcation of ECN tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 # Don't increase beyond what Firefox is currently using:
 # https://searchfox.org/mozilla-central/search?q=MINIMUM_RUST_VERSION&path=python/mozboot/mozboot/util.py
-rust-version = "1.82.0"
+rust-version = "1.85.0"
 
 [workspace.dependencies]
 enum-map = { version = "2.7", default-features = false }

--- a/neqo-crypto/src/time.rs
+++ b/neqo-crypto/src/time.rs
@@ -191,7 +191,7 @@ pub struct TimeHolder {
 }
 
 impl TimeHolder {
-    unsafe extern "C" fn time_func(arg: *mut c_void) -> PRTime {
+    const unsafe extern "C" fn time_func(arg: *mut c_void) -> PRTime {
         let p = arg as *const PRTime;
         *p.as_ref().unwrap()
     }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -396,7 +396,7 @@ impl Http3Client {
     ///
     /// Never, because clients always have this field.
     #[must_use]
-    pub fn connection_id(&self) -> &ConnectionId {
+    pub const fn connection_id(&self) -> &ConnectionId {
         self.conn.odcid().expect("Client always has odcid")
     }
 

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::time::Duration;
+use std::{ptr::fn_addr_eq, time::Duration};
 
 use neqo_common::{Datagram, IpTos, IpTosEcn};
 use test_fixture::{
@@ -37,36 +37,32 @@ fn set_tos(mut d: Datagram, ecn: IpTosEcn) -> Datagram {
     d
 }
 
-fn noop() -> fn(Datagram) -> Option<Datagram> {
-    Some
+fn noop(d: Datagram) -> Option<Datagram> {
+    Some(d)
 }
 
-fn bleach() -> fn(Datagram) -> Option<Datagram> {
-    |d| Some(set_tos(d, IpTosEcn::NotEct))
+fn bleach(d: Datagram) -> Option<Datagram> {
+    Some(set_tos(d, IpTosEcn::NotEct))
 }
 
-fn remark() -> fn(Datagram) -> Option<Datagram> {
-    |d| {
-        if d.tos().is_ecn_marked() {
-            Some(set_tos(d, IpTosEcn::Ect1))
-        } else {
-            Some(d)
-        }
+fn remark(d: Datagram) -> Option<Datagram> {
+    if d.tos().is_ecn_marked() {
+        Some(set_tos(d, IpTosEcn::Ect1))
+    } else {
+        Some(d)
     }
 }
 
-fn ce() -> fn(Datagram) -> Option<Datagram> {
-    |d| {
-        if d.tos().is_ecn_marked() {
-            Some(set_tos(d, IpTosEcn::Ce))
-        } else {
-            Some(d)
-        }
+fn ce(d: Datagram) -> Option<Datagram> {
+    if d.tos().is_ecn_marked() {
+        Some(set_tos(d, IpTosEcn::Ce))
+    } else {
+        Some(d)
     }
 }
 
-fn drop() -> fn(Datagram) -> Option<Datagram> {
-    |_| None
+fn drop(_d: Datagram) -> Option<Datagram> {
+    None
 }
 
 fn drop_ecn_marked_datagrams() -> fn(Datagram) -> Option<Datagram> {
@@ -201,7 +197,7 @@ fn disables_on_remark() {
     connect_force_idle(&mut client, &mut server);
 
     for _ in 0..ecn::TEST_COUNT {
-        if let Some(ack) = send_with_modifier_and_receive(&mut client, &mut server, now, remark()) {
+        if let Some(ack) = send_with_modifier_and_receive(&mut client, &mut server, now, remark) {
             client.process_input(ack, now);
         }
     }
@@ -213,7 +209,7 @@ fn disables_on_remark() {
 
 /// This function performs a handshake over a path that modifies packets via `orig_path_modifier`.
 /// It then sends `burst` packets on that path, and then migrates to a new path that
-/// modifies packets via `new_path_modifier`.  It sends `burst` packets on the new path.
+/// /// modifies packets via `new_path_modifier`.  It sends `burst` packets on the new path.
 /// The function returns the TOS value of the last packet sent on the old path and the TOS value
 /// of the last packet sent on the new path to allow for verification of correct behavior.
 pub fn migration_with_modifiers(
@@ -354,28 +350,22 @@ pub fn migration_with_modifiers(
 
 #[test]
 fn ecn_migration_zero_burst_all_cases() {
-    for orig_path_mod in [noop(), bleach(), remark(), ce()] {
-        for (new_path_mod_name, new_path_mod) in [
-            ("noop", noop()),
-            ("bleach", bleach()),
-            ("remark", remark()),
-            ("ce", ce()),
-            ("drop", drop()),
-        ] {
+    for orig_path_mod in [noop, bleach, remark, ce] {
+        for new_path_mod in [noop, bleach, remark, ce, drop] {
             let (before, after, migrated) =
                 migration_with_modifiers(orig_path_mod, new_path_mod, 0);
             // Too few packets sent before and after migration to conclude ECN validation.
             assert_ecn_enabled(before);
             assert_ecn_enabled(after);
             // Migration succeeds except if the new path drops ECN.
-            assert!(new_path_mod_name == "drop" || migrated);
+            assert!(fn_addr_eq(new_path_mod, drop as fn(_) -> _) || migrated);
         }
     }
 }
 
 #[test]
 fn ecn_migration_noop_bleach_data() {
-    let (before, after, migrated) = migration_with_modifiers(noop(), bleach(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(noop, bleach, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration.
     assert_ecn_disabled(after); // ECN validation fails after migration due to bleaching.
     assert!(migrated);
@@ -383,7 +373,7 @@ fn ecn_migration_noop_bleach_data() {
 
 #[test]
 fn ecn_migration_noop_remark_data() {
-    let (before, after, migrated) = migration_with_modifiers(noop(), remark(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(noop, remark, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration.
     assert_ecn_disabled(after); // ECN validation fails after migration due to remarking.
     assert!(migrated);
@@ -391,7 +381,7 @@ fn ecn_migration_noop_remark_data() {
 
 #[test]
 fn ecn_migration_noop_ce_data() {
-    let (before, after, migrated) = migration_with_modifiers(noop(), ce(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(noop, ce, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration.
     assert_ecn_enabled(after); // ECN validation concludes after migration, despite all CE marks.
     assert!(migrated);
@@ -399,7 +389,7 @@ fn ecn_migration_noop_ce_data() {
 
 #[test]
 fn ecn_migration_noop_drop_data() {
-    let (before, after, migrated) = migration_with_modifiers(noop(), drop(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(noop, drop, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration.
     assert_ecn_enabled(after); // Migration failed, ECN on original path is still validated.
     assert!(!migrated);
@@ -407,7 +397,7 @@ fn ecn_migration_noop_drop_data() {
 
 #[test]
 fn ecn_migration_bleach_noop_data() {
-    let (before, after, migrated) = migration_with_modifiers(bleach(), noop(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(bleach, noop, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
     assert_ecn_enabled(after); // ECN validation concludes after migration.
     assert!(migrated);
@@ -415,7 +405,7 @@ fn ecn_migration_bleach_noop_data() {
 
 #[test]
 fn ecn_migration_bleach_bleach_data() {
-    let (before, after, migrated) = migration_with_modifiers(bleach(), bleach(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(bleach, bleach, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
     assert_ecn_disabled(after); // ECN validation fails after migration due to bleaching.
     assert!(migrated);
@@ -423,7 +413,7 @@ fn ecn_migration_bleach_bleach_data() {
 
 #[test]
 fn ecn_migration_bleach_remark_data() {
-    let (before, after, migrated) = migration_with_modifiers(bleach(), remark(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(bleach, remark, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
     assert_ecn_disabled(after); // ECN validation fails after migration due to remarking.
     assert!(migrated);
@@ -431,7 +421,7 @@ fn ecn_migration_bleach_remark_data() {
 
 #[test]
 fn ecn_migration_bleach_ce_data() {
-    let (before, after, migrated) = migration_with_modifiers(bleach(), ce(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(bleach, ce, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
     assert_ecn_enabled(after); // ECN validation concludes after migration, despite all CE marks.
     assert!(migrated);
@@ -439,7 +429,7 @@ fn ecn_migration_bleach_ce_data() {
 
 #[test]
 fn ecn_migration_bleach_drop_data() {
-    let (before, after, migrated) = migration_with_modifiers(bleach(), drop(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(bleach, drop, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
                                  // Migration failed, ECN on original path is still disabled.
     assert_ecn_disabled(after);
@@ -448,7 +438,7 @@ fn ecn_migration_bleach_drop_data() {
 
 #[test]
 fn ecn_migration_remark_noop_data() {
-    let (before, after, migrated) = migration_with_modifiers(remark(), noop(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(remark, noop, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_enabled(after); // ECN validation succeeds after migration.
     assert!(migrated);
@@ -456,7 +446,7 @@ fn ecn_migration_remark_noop_data() {
 
 #[test]
 fn ecn_migration_remark_bleach_data() {
-    let (before, after, migrated) = migration_with_modifiers(remark(), bleach(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(remark, bleach, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_disabled(after); // ECN validation fails after migration due to bleaching.
     assert!(migrated);
@@ -464,7 +454,7 @@ fn ecn_migration_remark_bleach_data() {
 
 #[test]
 fn ecn_migration_remark_remark_data() {
-    let (before, after, migrated) = migration_with_modifiers(remark(), remark(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(remark, remark, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_disabled(after); // ECN validation fails after migration due to remarking.
     assert!(migrated);
@@ -472,7 +462,7 @@ fn ecn_migration_remark_remark_data() {
 
 #[test]
 fn ecn_migration_remark_ce_data() {
-    let (before, after, migrated) = migration_with_modifiers(remark(), ce(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(remark, ce, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_enabled(after); // ECN validation concludes after migration, despite all CE marks.
     assert!(migrated);
@@ -480,7 +470,7 @@ fn ecn_migration_remark_ce_data() {
 
 #[test]
 fn ecn_migration_remark_drop_data() {
-    let (before, after, migrated) = migration_with_modifiers(remark(), drop(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(remark, drop, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_disabled(after); // Migration failed, ECN on original path is still disabled.
     assert!(!migrated);
@@ -488,7 +478,7 @@ fn ecn_migration_remark_drop_data() {
 
 #[test]
 fn ecn_migration_ce_noop_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce(), noop(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce, noop, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
     assert_ecn_enabled(after); // ECN validation concludes after migration.
     assert!(migrated);
@@ -496,7 +486,7 @@ fn ecn_migration_ce_noop_data() {
 
 #[test]
 fn ecn_migration_ce_bleach_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce(), bleach(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce, bleach, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
     assert_ecn_disabled(after); // ECN validation fails after migration due to bleaching
     assert!(migrated);
@@ -504,7 +494,7 @@ fn ecn_migration_ce_bleach_data() {
 
 #[test]
 fn ecn_migration_ce_remark_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce(), remark(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce, remark, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
     assert_ecn_disabled(after); // ECN validation fails after migration due to remarking.
     assert!(migrated);
@@ -512,7 +502,7 @@ fn ecn_migration_ce_remark_data() {
 
 #[test]
 fn ecn_migration_ce_ce_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce(), ce(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce, ce, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
     assert_ecn_enabled(after); // ECN validation concludes after migration, despite all CE marks.
     assert!(migrated);
@@ -520,7 +510,7 @@ fn ecn_migration_ce_ce_data() {
 
 #[test]
 fn ecn_migration_ce_drop_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce(), drop(), ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce, drop, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
                                 // Migration failed, ECN on original path is still enabled.
     assert_ecn_enabled(after);

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -37,14 +37,17 @@ fn set_tos(mut d: Datagram, ecn: IpTosEcn) -> Datagram {
     d
 }
 
-fn noop(d: Datagram) -> Option<Datagram> {
+#[expect(clippy::unnecessary_wraps)]
+const fn noop(d: Datagram) -> Option<Datagram> {
     Some(d)
 }
 
+#[expect(clippy::unnecessary_wraps)]
 fn bleach(d: Datagram) -> Option<Datagram> {
     Some(set_tos(d, IpTosEcn::NotEct))
 }
 
+#[expect(clippy::unnecessary_wraps)]
 fn remark(d: Datagram) -> Option<Datagram> {
     if d.tos().is_ecn_marked() {
         Some(set_tos(d, IpTosEcn::Ect1))
@@ -53,6 +56,7 @@ fn remark(d: Datagram) -> Option<Datagram> {
     }
 }
 
+#[expect(clippy::unnecessary_wraps)]
 fn ce(d: Datagram) -> Option<Datagram> {
     if d.tos().is_ecn_marked() {
         Some(set_tos(d, IpTosEcn::Ce))
@@ -65,8 +69,8 @@ fn drop(_d: Datagram) -> Option<Datagram> {
     None
 }
 
-fn drop_ecn_marked_datagrams() -> fn(Datagram) -> Option<Datagram> {
-    |d| (!d.tos().is_ecn_marked()).then_some(d)
+fn drop_ecn_marked_datagrams(d: Datagram) -> Option<Datagram> {
+    (!d.tos().is_ecn_marked()).then_some(d)
 }
 
 #[test]
@@ -81,7 +85,7 @@ fn handshake_delay_with_ecn_blackhole() {
         &mut server,
         start,
         DEFAULT_RTT,
-        drop_ecn_marked_datagrams(),
+        drop_ecn_marked_datagrams,
     );
 
     assert_eq!(


### PR DESCRIPTION
The main blocker here is a function pointer comparison, which has a new lint and a new function in 1.85.  This moves MSRV to 1.85, which is still too new, so marking this as a draft.