### PR TITLE
fix: Fix compile on 32-bit targets

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -665,6 +665,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")] // Test does not compile on 32-bit targets.
     #[should_panic(expected = "Varint value too large")]
     fn encoded_vvec_length_oob() {
         _ = Encoder::vvec_len(1 << 62);


### PR DESCRIPTION
By disabling a test that panics on 64-bit platforms, but causes a compile error on 32-bit ones.

Fixes #2497