### PR TITLE
ci: Don't fail QNS CI if a test times out

### DIFF
--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -20,6 +20,12 @@ inputs:
     required: false
     default: ''
 
+outputs:
+  result:
+    description: 'One of "success", "failure", or "timeout".'
+    required: true
+    value: ${{ steps.result.outputs.result }}
+
 runs:
   using: "composite"
   steps:
@@ -84,8 +90,10 @@ runs:
             echo "Panic detected in $log"
             tail -n 50 "$log"
             FAILED=1
+            [ -z "$FAILED" ] && echo "FAILED=1" >> "$GITHUB_ENV"
           fi
         done
+        [ -z "$FAILED" ] && echo "FAILED=0" >> "$GITHUB_ENV"
         # Remove all log files > $MAX_SIZE for succeeded tests to make the artifacts smaller.
         MAX_SIZE=2M
         echo "Removed log file > $MAX_SIZE during GitHub workflow" > note.txt
@@ -124,3 +132,15 @@ runs:
           result.json
           summary.txt
         retention-days: 1
+
+    - id: result
+      if: ${{ always() }}
+      run:
+        if [ -z "$FAILED" ]; then
+          echo "result=timeout" >> $GITHUB_OUTPUT
+        elif [ "$FAILED" -eq 0 ]; then
+          echo "result=success" >> $GITHUB_OUTPUT
+        else
+          echo "result=failure" >> $GITHUB_OUTPUT
+        fi
+      shell: bash

--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -134,7 +134,7 @@ runs:
 
     - id: result
       if: ${{ always() }}
-      run:
+      run: |
         if [ -z "$FAILED" ]; then
           echo "result=timeout" >> $GITHUB_OUTPUT
         elif [ "$FAILED" -eq 0 ]; then

--- a/.github/actions/quic-interop-runner/action.yml
+++ b/.github/actions/quic-interop-runner/action.yml
@@ -23,7 +23,6 @@ inputs:
 outputs:
   result:
     description: 'One of "success", "failure", or "timeout".'
-    required: true
     value: ${{ steps.result.outputs.result }}
 
 runs:

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -171,10 +171,17 @@ jobs:
       # TODO: Replace once https://github.com/quic-interop/quic-interop-runner/pull/356 is merged.
       - uses: ./.github/actions/quic-interop-runner
         timeout-minutes: ${{ fromJSON(env.TIMEOUT) }}
+        continue-on-error: true
+        id: run
         with:
           client: ${{ steps.depair.outputs.client }}
           server: ${{ steps.depair.outputs.server }}
           implementations: ${{ needs.implementations.outputs.implementations }}
+
+      - if: ${{ always() }}
+        env:
+          RESULT: ${{ steps.run.outputs.result }}
+        run: test "$RESULT" != "error"
 
   report:
     name: Report results


### PR DESCRIPTION
This gets rid of the :x: on all commits to `main` just because one or two QNS runs timed out.