### PR TITLE
fix: Don't count saved packets as received twice

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1319,6 +1319,9 @@ impl Connection {
         );
         self.saved_datagrams.save(epoch, d, now);
         self.stats.borrow_mut().saved_datagrams += 1;
+        // We already counted the datagram as received in `[input_path]`. We
+        // will do so again when we (re-)process it, so reduce the count now.
+        self.stats.borrow_mut().packets_rx -= 1;
     }
 
     /// Perform version negotiation.

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1319,7 +1319,7 @@ impl Connection {
         );
         self.saved_datagrams.save(epoch, d, now);
         self.stats.borrow_mut().saved_datagrams += 1;
-        // We already counted the datagram as received in `[input_path]`. We
+        // We already counted the datagram as received in [`input_path`]. We
         // will do so again when we (re-)process it, so reduce the count now.
         self.stats.borrow_mut().packets_rx -= 1;
     }

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -346,8 +346,11 @@ fn reorder_05rtt() {
 
     // We can't use the standard facility to complete the handshake, so
     // drive it as aggressively as possible.
+    assert_eq!(client.stats().saved_datagrams, 0);
+    assert_eq!(client.stats().packets_rx, 0);
     client.process_input(s2, now());
     assert_eq!(client.stats().saved_datagrams, 1);
+    assert_eq!(client.stats().packets_rx, 0);
 
     // After processing the first packet, the client should go back and
     // process the 0.5-RTT packet data, which should make data available.
@@ -492,7 +495,7 @@ fn coalesce_05rtt() {
     drop(client.process(s2, now).dgram());
     // This packet will contain an ACK, but we can ignore it.
     assert_eq!(client.stats().dropped_rx, 0);
-    assert_eq!(client.stats().packets_rx, 4);
+    assert_eq!(client.stats().packets_rx, 3);
     assert_eq!(client.stats().saved_datagrams, 1);
 
     // After (successful) authentication, the packet is processed.
@@ -500,7 +503,7 @@ fn coalesce_05rtt() {
     let c3 = client.process_output(now).dgram();
     assert!(c3.is_some());
     assert_eq!(client.stats().dropped_rx, 0); // No Initial padding.
-    assert_eq!(client.stats().packets_rx, 5);
+    assert_eq!(client.stats().packets_rx, 4);
     assert_eq!(client.stats().saved_datagrams, 1);
     assert!(client.stats().frame_rx.padding > 0); // Padding uses frames.
 
@@ -548,7 +551,7 @@ fn reorder_handshake() {
     let dgram = client.process(s_hs, now).dgram();
     assertions::assert_initial(dgram.as_ref().unwrap(), false);
     assert_eq!(client.stats().saved_datagrams, 1);
-    assert_eq!(client.stats().packets_rx, 2);
+    assert_eq!(client.stats().packets_rx, 1);
 
     // Get the server to try again.
     // Though we currently allow the server to arm its PTO timer, use
@@ -566,11 +569,11 @@ fn reorder_handshake() {
     now += RTT / 2;
     client.process_input(s_hs.unwrap(), now);
     assert_eq!(client.stats().saved_datagrams, 2);
-    assert_eq!(client.stats().packets_rx, 3);
+    assert_eq!(client.stats().packets_rx, 1);
 
     client.process_input(s_init, now);
     // Each saved packet should now be "received" again.
-    assert_eq!(client.stats().packets_rx, 8);
+    assert_eq!(client.stats().packets_rx, 6);
     maybe_authenticate(&mut client);
     let c3 = client.process_output(now).dgram();
     assert!(c3.is_some());
@@ -627,7 +630,7 @@ fn reorder_1rtt() {
     }
     // The server has now received those packets, and saved them.
     // The six extra received are Initial + the junk we use for padding.
-    assert_eq!(server.stats().packets_rx, PACKETS + 6);
+    assert_eq!(server.stats().packets_rx, PACKETS + 2);
     assert_eq!(server.stats().saved_datagrams, PACKETS);
     assert_eq!(server.stats().dropped_rx, 3);
 
@@ -635,7 +638,7 @@ fn reorder_1rtt() {
     let s2 = server.process(c2, now).dgram();
     // The server has now received those packets, and saved them.
     // The two additional are a Handshake and a 1-RTT (w/ NEW_CONNECTION_ID).
-    assert_eq!(server.stats().packets_rx, PACKETS * 2 + 8);
+    assert_eq!(server.stats().packets_rx, PACKETS + 8);
     assert_eq!(server.stats().saved_datagrams, PACKETS);
     assert_eq!(server.stats().dropped_rx, 3);
     assert_eq!(*server.state(), State::Confirmed);


### PR DESCRIPTION
We count packets as received when they enter `input_path`. Then we may save them, since we can't decrypt them yet. When we re-process them, they again enter `input_path` and are counted as received. Fix that double-counting by only counting them when they are actually processed.