### PR TITLE
refactor(transport/recovery): use PacketNumberSpace Debug in qdebug

### DIFF
--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -827,7 +827,7 @@ impl LossRecovery {
             if t > now {
                 continue;
             }
-            qdebug!("[{self}] PTO timer fired for {pn_space}");
+            qdebug!("[{self}] PTO timer fired for {pn_space:?}");
             let Some(space) = self.spaces.get_mut(pn_space) else {
                 continue;
             };


### PR DESCRIPTION
Simple change to improve debug level log message:

``` diff
- 0.002 DEBUG [LossRecovery] PTO timer fired for in
+ 0.006 DEBUG [LossRecovery] PTO timer fired for Initial
```

---

Previously it was not obvious to me that "in" meant "Initial" packet number space.