### PR TITLE
fix(transport/ecn): handle ECN loss on PTO

### DIFF
--- a/neqo-transport/benches/sent_packets.rs
+++ b/neqo-transport/benches/sent_packets.rs
@@ -7,7 +7,6 @@
 use std::time::Instant;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use neqo_common::IpTosEcn;
 use neqo_transport::{
     packet::{PacketNumber, PacketType},
     recovery::sent::{SentPacket, SentPackets},
@@ -21,7 +20,6 @@ fn sent_packets() -> SentPackets {
         pkts.track(SentPacket::new(
             PacketType::Short,
             PacketNumber::from(i),
-            IpTosEcn::default(),
             now,
             true,
             Vec::new(),

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -594,7 +594,7 @@ impl<T: WindowAdjustment> ClassicCongestionControl<T> {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use neqo_common::{qinfo, IpTosEcn};
+    use neqo_common::qinfo;
     use test_fixture::now;
 
     use super::{ClassicCongestionControl, WindowAdjustment, PERSISTENT_CONG_THRESH};
@@ -636,7 +636,6 @@ mod tests {
         SentPacket::new(
             PacketType::Short,
             pn,
-            IpTosEcn::default(),
             now() + t,
             ack_eliciting,
             Vec::new(),
@@ -851,7 +850,6 @@ mod tests {
                 SentPacket::new(
                     PacketType::Short,
                     u64::try_from(i).unwrap(),
-                    IpTosEcn::default(),
                     by_pto(t),
                     true,
                     Vec::new(),
@@ -973,10 +971,9 @@ mod tests {
         lost[0] = SentPacket::new(
             lost[0].packet_type(),
             lost[0].pn(),
-            lost[0].ecn_mark(),
             lost[0].time_sent(),
             false,
-            Vec::new(),
+            lost[0].tokens().to_vec(),
             lost[0].len(),
         );
         assert!(!persistent_congestion_by_pto(
@@ -1075,7 +1072,6 @@ mod tests {
                 let p = SentPacket::new(
                     PacketType::Short,
                     next_pn,
-                    IpTosEcn::default(),
                     now,
                     true,
                     Vec::new(),
@@ -1103,7 +1099,6 @@ mod tests {
             let p = SentPacket::new(
                 PacketType::Short,
                 next_pn,
-                IpTosEcn::default(),
                 now,
                 true,
                 Vec::new(),
@@ -1154,7 +1149,6 @@ mod tests {
         let p_lost = SentPacket::new(
             PacketType::Short,
             1,
-            IpTosEcn::default(),
             now,
             true,
             Vec::new(),
@@ -1168,7 +1162,6 @@ mod tests {
         let p_not_lost = SentPacket::new(
             PacketType::Short,
             2,
-            IpTosEcn::default(),
             now,
             true,
             Vec::new(),
@@ -1192,7 +1185,6 @@ mod tests {
                 let p = SentPacket::new(
                     PacketType::Short,
                     next_pn,
-                    IpTosEcn::default(),
                     now,
                     true,
                     Vec::new(),
@@ -1226,7 +1218,6 @@ mod tests {
             let p = SentPacket::new(
                 PacketType::Short,
                 next_pn,
-                IpTosEcn::default(),
                 now,
                 true,
                 Vec::new(),
@@ -1266,7 +1257,6 @@ mod tests {
         let p_ce = SentPacket::new(
             PacketType::Short,
             1,
-            IpTosEcn::default(),
             now,
             true,
             Vec::new(),

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -15,7 +15,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::IpTosEcn;
 use test_fixture::now;
 
 use super::{IP_ADDR, MTU, RTT};
@@ -47,7 +46,6 @@ fn fill_cwnd(cc: &mut ClassicCongestionControl<Cubic>, mut next_pn: u64, now: In
         let sent = SentPacket::new(
             PacketType::Short,
             next_pn,
-            IpTosEcn::default(),
             now,
             true,
             Vec::new(),
@@ -63,7 +61,6 @@ fn ack_packet(cc: &mut ClassicCongestionControl<Cubic>, pn: u64, now: Instant) {
     let acked = SentPacket::new(
         PacketType::Short,
         pn,
-        IpTosEcn::default(),
         now,
         true,
         Vec::new(),
@@ -77,7 +74,6 @@ fn packet_lost(cc: &mut ClassicCongestionControl<Cubic>, pn: u64) {
     let p_lost = SentPacket::new(
         PacketType::Short,
         pn,
-        IpTosEcn::default(),
         now(),
         true,
         Vec::new(),

--- a/neqo-transport/src/cc/tests/new_reno.rs
+++ b/neqo-transport/src/cc/tests/new_reno.rs
@@ -8,7 +8,6 @@
 
 use std::time::Duration;
 
-use neqo_common::IpTosEcn;
 use test_fixture::now;
 
 use super::{IP_ADDR, MTU, RTT};
@@ -43,7 +42,6 @@ fn issue_876() {
         SentPacket::new(
             PacketType::Short,
             1,
-            IpTosEcn::default(),
             before,
             true,
             Vec::new(),
@@ -52,7 +50,6 @@ fn issue_876() {
         SentPacket::new(
             PacketType::Short,
             2,
-            IpTosEcn::default(),
             before,
             true,
             Vec::new(),
@@ -61,7 +58,6 @@ fn issue_876() {
         SentPacket::new(
             PacketType::Short,
             3,
-            IpTosEcn::default(),
             before,
             true,
             Vec::new(),
@@ -70,7 +66,6 @@ fn issue_876() {
         SentPacket::new(
             PacketType::Short,
             4,
-            IpTosEcn::default(),
             before,
             true,
             Vec::new(),
@@ -79,7 +74,6 @@ fn issue_876() {
         SentPacket::new(
             PacketType::Short,
             5,
-            IpTosEcn::default(),
             before,
             true,
             Vec::new(),
@@ -88,7 +82,6 @@ fn issue_876() {
         SentPacket::new(
             PacketType::Short,
             6,
-            IpTosEcn::default(),
             before,
             true,
             Vec::new(),
@@ -97,7 +90,6 @@ fn issue_876() {
         SentPacket::new(
             PacketType::Short,
             7,
-            IpTosEcn::default(),
             after,
             true,
             Vec::new(),
@@ -153,7 +145,6 @@ fn issue_1465() {
         let p = SentPacket::new(
             PacketType::Short,
             pn,
-            IpTosEcn::default(),
             now,
             true,
             Vec::new(),

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2504,7 +2504,6 @@ impl Connection {
             let sent = SentPacket::new(
                 pt,
                 pn,
-                packet_tos.unwrap_or_default().into(),
                 now,
                 ack_eliciting,
                 tokens,

--- a/neqo-transport/src/packet/metadata.rs
+++ b/neqo-transport/src/packet/metadata.rs
@@ -66,19 +66,20 @@ impl MetaData<'_> {
         }
     }
 
-    pub fn new_out<'a>(
+    pub const fn new_out<'a>(
         path: &'a PathRef,
         packet_type: PacketType,
         packet_number: PacketNumber,
         length: usize,
         payload: &'a [u8],
+        tos: IpTos,
     ) -> MetaData<'a> {
         MetaData {
             path,
             direction: Direction::Tx,
             packet_type,
             packet_number,
-            tos: path.borrow().tos(),
+            tos,
             len: length,
             payload,
         }

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -12,9 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{
-    hex, qdebug, qinfo, qlog::NeqoQlog, qtrace, qwarn, Datagram, Encoder, IpTos, IpTosEcn,
-};
+use neqo_common::{hex, qdebug, qinfo, qlog::NeqoQlog, qtrace, qwarn, Datagram, Encoder, IpTos};
 use neqo_crypto::random;
 
 use crate::{
@@ -22,7 +20,7 @@ use crate::{
     cid::{ConnectionId, ConnectionIdRef, ConnectionIdStore, RemoteConnectionIdEntry},
     ecn,
     frame::FrameType,
-    packet::PacketBuilder,
+    packet::{PacketBuilder, PacketType},
     pmtud::Pmtud,
     recovery::{RecoveryToken, SentPacket},
     rtt::{RttEstimate, RttSource},
@@ -414,6 +412,12 @@ impl Paths {
         }
     }
 
+    pub fn lost_ecn(&self, pt: PacketType, stats: &mut Stats) {
+        if let Some(path) = self.primary() {
+            path.borrow_mut().lost_ecn(pt, stats);
+        }
+    }
+
     /// Get an estimate of the RTT on the primary path.
     #[cfg(test)]
     pub fn rtt(&self) -> Duration {
@@ -569,8 +573,8 @@ impl Path {
     }
 
     /// Return the DSCP/ECN marking to use for outgoing packets on this path.
-    pub fn tos(&self) -> IpTos {
-        self.ecn_info.ecn_mark().into()
+    pub fn tos(&self, tokens: &mut Vec<RecoveryToken>) -> IpTos {
+        self.ecn_info.ecn_mark(tokens).into()
     }
 
     /// Whether this path is the primary or current path for the connection.
@@ -680,11 +684,15 @@ impl Path {
     }
 
     /// Make a datagram.
-    pub fn datagram<V: Into<Vec<u8>>>(&mut self, payload: V, stats: &mut Stats) -> Datagram {
+    pub fn datagram<V: Into<Vec<u8>>>(
+        &mut self,
+        payload: V,
+        tos: IpTos,
+        stats: &mut Stats,
+    ) -> Datagram {
         // Make sure to use the TOS value from before calling ecn::Info::on_packet_sent, which may
         // update the ECN state and can hence change it - this packet should still be sent
         // with the current value.
-        let tos = self.tos();
         self.ecn_info.on_packet_sent(stats);
         Datagram::new(self.local, self.remote, tos, payload.into())
     }
@@ -738,7 +746,7 @@ impl Path {
             _ => 0,
         };
         self.state = if probe_count >= MAX_PATH_PROBES {
-            if self.ecn_info.ecn_mark() == IpTosEcn::Ect0 {
+            if self.ecn_info.is_marking() {
                 // The path validation failure may be due to ECN blackholing, try again without ECN.
                 qinfo!("[{self}] Possible ECN blackhole, disabling ECN and re-probing path");
                 self.ecn_info
@@ -820,6 +828,10 @@ impl Path {
 
     pub fn lost_ack_frequency(&mut self, lost: &AckRate) {
         self.rtt.frame_lost(lost);
+    }
+
+    pub fn lost_ecn(&mut self, pt: PacketType, stats: &mut Stats) {
+        self.ecn_info.lost_ecn(pt, stats);
     }
 
     pub fn acked_ack_frequency(&mut self, acked: &AckRate) {
@@ -996,7 +1008,6 @@ impl Path {
         now: Instant,
     ) {
         debug_assert!(self.is_primary());
-        self.ecn_info.on_packets_lost(lost_packets, stats);
         let cwnd_reduced = self.sender.on_packets_lost(
             self.rtt.first_sample_time(),
             prev_largest_acked_sent,

--- a/neqo-transport/src/pmtud.rs
+++ b/neqo-transport/src/pmtud.rs
@@ -336,7 +336,7 @@ mod tests {
         time::Instant,
     };
 
-    use neqo_common::{qdebug, qinfo, Encoder, IpTosEcn};
+    use neqo_common::{qdebug, qinfo, Encoder};
     use test_fixture::{fixture_init, now};
 
     use crate::{
@@ -357,16 +357,8 @@ mod tests {
         Some(u16::MAX as usize),
     ];
 
-    fn make_sentpacket(pn: u64, now: Instant, len: usize) -> SentPacket {
-        SentPacket::new(
-            PacketType::Short,
-            pn,
-            IpTosEcn::default(),
-            now,
-            true,
-            Vec::new(),
-            len,
-        )
+    const fn make_sentpacket(pn: u64, now: Instant, len: usize) -> SentPacket {
+        SentPacket::new(PacketType::Short, pn, now, true, Vec::new(), len)
     }
 
     /// Asserts that the PMTUD process has stopped at the given MTU.

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -943,7 +943,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use neqo_common::{qlog::NeqoQlog, IpTosEcn};
+    use neqo_common::qlog::NeqoQlog;
     use test_fixture::{now, DEFAULT_ADDR};
 
     use super::{
@@ -1124,7 +1124,6 @@ mod tests {
                 SentPacket::new(
                     PacketType::Short,
                     pn,
-                    IpTosEcn::default(),
                     pn_time(pn),
                     true,
                     Vec::new(),
@@ -1152,7 +1151,6 @@ mod tests {
             lrs.on_packet_sent(SentPacket::new(
                 PacketType::Short,
                 pn,
-                IpTosEcn::default(),
                 pn_time(pn),
                 true,
                 Vec::new(),
@@ -1277,7 +1275,6 @@ mod tests {
             SentPacket::new(
                 PacketType::Short,
                 0,
-                IpTosEcn::default(),
                 pn_time(0),
                 true,
                 Vec::new(),
@@ -1289,7 +1286,6 @@ mod tests {
             SentPacket::new(
                 PacketType::Short,
                 1,
-                IpTosEcn::default(),
                 pn_time(0) + TEST_RTT / 4,
                 true,
                 Vec::new(),
@@ -1388,7 +1384,6 @@ mod tests {
             SentPacket::new(
                 PacketType::Initial,
                 0,
-                IpTosEcn::default(),
                 pn_time(0),
                 true,
                 Vec::new(),
@@ -1400,7 +1395,6 @@ mod tests {
             SentPacket::new(
                 PacketType::Handshake,
                 0,
-                IpTosEcn::default(),
                 pn_time(1),
                 true,
                 Vec::new(),
@@ -1412,7 +1406,6 @@ mod tests {
             SentPacket::new(
                 PacketType::Short,
                 0,
-                IpTosEcn::default(),
                 pn_time(2),
                 true,
                 Vec::new(),
@@ -1427,15 +1420,7 @@ mod tests {
             PacketType::Handshake,
             PacketType::Short,
         ] {
-            let sent_pkt = SentPacket::new(
-                *sp,
-                1,
-                IpTosEcn::default(),
-                pn_time(3),
-                true,
-                Vec::new(),
-                ON_SENT_SIZE,
-            );
+            let sent_pkt = SentPacket::new(*sp, 1, pn_time(3), true, Vec::new(), ON_SENT_SIZE);
             let pn_space = PacketNumberSpace::from(sent_pkt.packet_type());
             lr.on_packet_sent(sent_pkt, Instant::now());
             lr.on_ack_received(
@@ -1467,7 +1452,6 @@ mod tests {
             SentPacket::new(
                 PacketType::Initial,
                 0,
-                IpTosEcn::default(),
                 pn_time(3),
                 true,
                 Vec::new(),
@@ -1485,7 +1469,6 @@ mod tests {
             SentPacket::new(
                 PacketType::Initial,
                 0,
-                IpTosEcn::default(),
                 now(),
                 true,
                 Vec::new(),
@@ -1508,7 +1491,6 @@ mod tests {
             SentPacket::new(
                 PacketType::Handshake,
                 0,
-                IpTosEcn::default(),
                 now(),
                 true,
                 Vec::new(),
@@ -1517,15 +1499,7 @@ mod tests {
             Instant::now(),
         );
         lr.on_packet_sent(
-            SentPacket::new(
-                PacketType::Short,
-                0,
-                IpTosEcn::default(),
-                now(),
-                true,
-                Vec::new(),
-                ON_SENT_SIZE,
-            ),
+            SentPacket::new(PacketType::Short, 0, now(), true, Vec::new(), ON_SENT_SIZE),
             Instant::now(),
         );
 
@@ -1561,7 +1535,6 @@ mod tests {
             SentPacket::new(
                 PacketType::Initial,
                 0,
-                IpTosEcn::default(),
                 now(),
                 true,
                 Vec::new(),

--- a/neqo-transport/src/recovery/sent.rs
+++ b/neqo-transport/src/recovery/sent.rs
@@ -24,6 +24,7 @@ pub struct SentPacket {
     pt: PacketType,
     pn: PacketNumber,
     ecn_mark: IpTosEcn,
+    // TODO: Still needed? Tracked in tokens.
     ack_eliciting: bool,
     time_sent: Instant,
     primary_path: bool,
@@ -73,10 +74,16 @@ impl SentPacket {
         self.pn
     }
 
-    /// The ECN mark of the packet.
-    #[must_use]
     pub const fn ecn_mark(&self) -> IpTosEcn {
         self.ecn_mark
+    }
+
+    /// The ECN mark of the packet.
+    #[must_use]
+    pub fn ecn_marked_ect0(&self) -> bool {
+        self.tokens
+            .iter()
+            .any(|t| matches!(t, RecoveryToken::EcnEct0))
     }
 
     /// The time that this packet was sent.

--- a/neqo-transport/src/recovery/sent.rs
+++ b/neqo-transport/src/recovery/sent.rs
@@ -12,8 +12,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::IpTosEcn;
-
 use crate::{
     packet::{PacketNumber, PacketType},
     recovery::RecoveryToken,
@@ -23,8 +21,6 @@ use crate::{
 pub struct SentPacket {
     pt: PacketType,
     pn: PacketNumber,
-    ecn_mark: IpTosEcn,
-    // TODO: Still needed? Tracked in tokens.
     ack_eliciting: bool,
     time_sent: Instant,
     primary_path: bool,
@@ -42,7 +38,6 @@ impl SentPacket {
     pub const fn new(
         pt: PacketType,
         pn: PacketNumber,
-        ecn_mark: IpTosEcn,
         time_sent: Instant,
         ack_eliciting: bool,
         tokens: Vec<RecoveryToken>,
@@ -51,7 +46,6 @@ impl SentPacket {
         Self {
             pt,
             pn,
-            ecn_mark,
             time_sent,
             ack_eliciting,
             primary_path: true,
@@ -72,10 +66,6 @@ impl SentPacket {
     #[must_use]
     pub const fn pn(&self) -> PacketNumber {
         self.pn
-    }
-
-    pub const fn ecn_mark(&self) -> IpTosEcn {
-        self.ecn_mark
     }
 
     /// The ECN mark of the packet.
@@ -328,8 +318,6 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use neqo_common::IpTosEcn;
-
     use super::{SentPacket, SentPackets};
     use crate::packet::{PacketNumber, PacketType};
 
@@ -343,7 +331,6 @@ mod tests {
         SentPacket::new(
             PacketType::Short,
             PacketNumber::from(n),
-            IpTosEcn::default(),
             start_time() + (PACKET_GAP * n),
             true,
             Vec::new(),

--- a/neqo-transport/src/recovery/token.rs
+++ b/neqo-transport/src/recovery/token.rs
@@ -58,4 +58,6 @@ pub enum RecoveryToken {
     RetireConnectionId(u64),
     AckFrequency(AckRate),
     Datagram(DatagramTracking),
+    /// A packet marked with [`neqo_common::IpTosEcn::Ect0`].
+    EcnEct0,
 }


### PR DESCRIPTION
Previously we would only call `neqo_transport::ecn::Info::on_packets_lost` when an ECN ECT0 marked packet was considered lost due to the [time-threshold]. It would *not* be called when a packet was considered lost due to a PTO.

With https://github.com/mozilla/neqo/pull/2492 one no longer considers a packet lost based on the time-threshold before the first ACK, entirely depending on the PTO until then.

Thus with https://github.com/mozilla/neqo/pull/2492 the ECN path validation mechanism would no longer detect an ECN blackhole, dropping all initial packets.

With this commit the ECN path validation state machine (i.e. `neqo_transport::ecn::Info`) is notified on PTO and can thus react to an ECN blackhole, disabling ECN markings after `TEST_COUNT_INITIAL_PHASE`.

`neqo_transport` already provides the `RecoveryToken` mechanism to track losses. This commit introduces `RecoveryToken::EcnEct0` to track losses of ECN ECT0 marked packets *both* based on [time-threshold] and [PTO].

---

Given that we currently do time threshold based loss detection before the first ACK (bug to be fixed by https://github.com/mozilla/neqo/pull/2492), and given that the time threshold is smaller than the PTO, the fix in this pull request will only be exercised once https://github.com/mozilla/neqo/pull/2492 is merged.

Once https://github.com/mozilla/neqo/pull/2492/ is merged, the bug fix of this pull request will then also be covered by unit tests.

Blocks https://github.com/mozilla/neqo/pull/2492/.

[time-threshold]: https://www.rfc-editor.org/rfc/rfc9002.html#name-time-threshold
[PTO]: https://www.rfc-editor.org/rfc/rfc9002.html#name-probe-timeout