### PR TITLE
fix: Don't try `write_maintenance_frames` at all priorities

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2142,15 +2142,26 @@ impl Connection {
             }
         }
 
-        for prio in [
-            TransmissionPriority::Critical,
+        self.streams
+            .write_frames(TransmissionPriority::Critical, builder, tokens, frame_stats);
+        if builder.is_full() {
+            return;
+        }
+
+        self.streams
+            .write_maintenance_frames(builder, tokens, frame_stats);
+        if builder.is_full() {
+            return;
+        }
+
+        self.streams.write_frames(
             TransmissionPriority::Important,
-        ] {
-            self.streams
-                .write_frames(prio, builder, tokens, frame_stats);
-            if builder.is_full() {
-                return;
-            }
+            builder,
+            tokens,
+            frame_stats,
+        );
+        if builder.is_full() {
+            return;
         }
 
         // NEW_CONNECTION_ID, RETIRE_CONNECTION_ID, and ACK_FREQUENCY.

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -204,7 +204,7 @@ impl Streams {
         Ok(())
     }
 
-    fn write_maintenance_frames(
+    pub fn write_maintenance_frames(
         &mut self,
         builder: &mut PacketBuilder,
         tokens: &mut Vec<RecoveryToken>,
@@ -252,13 +252,6 @@ impl Streams {
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
-        if priority == TransmissionPriority::Important {
-            self.write_maintenance_frames(builder, tokens, stats);
-            if builder.is_full() {
-                return;
-            }
-        }
-
         self.send.write_frames(priority, builder, tokens, stats);
     }
 


### PR DESCRIPTION
The old code would try and call `write_maintenance_frames` at priorities other than `TransmissionPriority::Important`, which was useless. Just call it directly once.