### PR TITLE
ci: `bench` improvements

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           cd gquiche
           bazel build -c opt --sandbox_writable_path=/home/bench/.cache/sccache quiche:quic_server quiche:quic_client
+          bazel shutdown
 
       - name: Download cached main-branch results
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -113,9 +114,9 @@ jobs:
       - name: Run cargo bench
         run: |
           sudo ip link set dev lo mtu "$MTU"
-          taskset -c 2 nice -n -20 setarch --addr-no-randomize \
+          cset shield --exec taskset -c 2 nice -n -20 setarch --addr-no-randomize \
             cargo "+$TOOLCHAIN" bench --workspace --exclude neqo-bin --features bench -- --noplot | tee results.txt
-          taskset -c 2 nice -n -20 setarch --addr-no-randomize \
+          cset shield --exec taskset -c 2 nice -n -20 setarch --addr-no-randomize \
             cargo "+$TOOLCHAIN" bench --package neqo-bin --features bench -- --noplot | tee -a results.txt
 
       # Compare various configurations of neqo against msquic and google/quiche, and gather perf data
@@ -219,12 +220,12 @@ jobs:
                   transmogrify "${server_cmd[$server]}" "$cc" "$pacing" "${neqo_flags[$client]}"
                   FILENAME="$client-$server$EXT"
                   # shellcheck disable=SC2086
-                  taskset -c 2 nice -n -20 setarch --addr-no-randomize \
+                  cset shield --exec taskset -c 2 nice -n -20 setarch --addr-no-randomize \
                     perf $PERF_OPT -o "$FILENAME.server.perf" $CMD &
                   PID=$!
                   transmogrify "${client_cmd[$client]}" "$cc" "$pacing" "${neqo_flags[$server]}"
                   # shellcheck disable=SC2086
-                  taskset -c 3 nice -n -20 setarch --addr-no-randomize \
+                  cset shield --exec taskset -c 3 nice -n -20 setarch --addr-no-randomize \
                     hyperfine --command-name "$TAG" --time-unit millisecond  \
                       --export-json "hyperfine/$FILENAME.json" \
                       --export-markdown "hyperfine/$FILENAME.md" \
@@ -240,7 +241,7 @@ jobs:
                   # the perf profiles of those different runs.
                   CMD=${CMD//$SIZE/$BIGSIZE}
                   # shellcheck disable=SC2086
-                  taskset -c 3 nice -n -20 setarch --addr-no-randomize \
+                  cset shield --exec taskset -c 3 nice -n -20 setarch --addr-no-randomize \
                     perf $PERF_OPT -o "$FILENAME.client.perf" $CMD > /dev/null 2>&1
                   kill $PID
 
@@ -256,6 +257,10 @@ jobs:
                     # Even though we tell hyperfine to use milliseconds, it still outputs in seconds when dumping to JSON.
                     DELTA=$(bc -l <<< "($MEAN - $BASELINE_MEAN) * 1000")
                     PERCENT=$(bc -l <<< "($MEAN - $BASELINE_MEAN) / ($BASELINE_MEAN + $MEAN)/2 * 100")
+                    MIBS=$(bc -l <<< "$SIZE / ($MEAN * 1000) / 1048576")
+                    RANGE=$(cat "hyperfine/$FILENAME.md" | cut -d'±' -f2 | cut -d' ' -f1)
+                    MIBS_RANGE=$(bc -l <<< "$SIZE / ($RANGE * 1000) / 1048576")
+                    echo "Transfer rate: $MIBS MiB/s ± $MIBS_RANGE"
 
                     # If a performance change is statistically significant, highlight it.
                     jq -r '.results[0].times[]' "$BASELINE" > baseline.txt
@@ -275,8 +280,8 @@ jobs:
                       SYMBOL=""
                       FORMAT=""
                     fi
-                    printf "| %s %s%.1f%s | %s%.1f%%%s |\n" \
-                      "$SYMBOL" "$FORMAT" "$DELTA" "$FORMAT" "$FORMAT" "$PERCENT" "$FORMAT" >> steps.md
+                    printf "| %.1f ± %.1f | %s %s%.1f%s | %s%.1f%%%s |\n" \
+                      "$MIBS" "$MIBS_RANGE" "$SYMBOL" "$FORMAT" "$DELTA" "$FORMAT" "$FORMAT" "$PERCENT" "$FORMAT" >> steps.md
                   else
                     echo No cached baseline from main found.
                     echo '| :question: | :question: |' >> steps.md
@@ -291,8 +296,8 @@ jobs:
             echo "Transfer of $SIZE bytes over loopback, $RUNS runs. All unit-less numbers are in milliseconds."
             echo
             # shellcheck disable=SC2016
-            echo '| Client | Server | CC | Pacing | Mean ± σ | Min | Max | Δ `main` | Δ `main` |'
-            echo '|:---|:---|:---|---|---:|---:|---:|---:|---:|'
+            echo '| Client | Server | CC | Pacing | Mean ± σ | Min | Max | MiB/s ± σ | Δ `main` | Δ `main` |'
+            echo '|:---|:---|:---|---|---:|---:|---:|---:|---:|---:|'
             cat steps.md
           } > comparison.md
           rm -r "$TMP"


### PR DESCRIPTION
- Use `cset` to isolate benchmarks
- Stop `google-quiche`'s `bazel` server
- Show throughputs in results table