### PR TITLE
ci: Fix Rust caching and `mutants`

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -82,7 +82,6 @@ runs:
       with:
         cache-bin: ${{ runner.environment == 'github-hosted' }}
         key: ${{ inputs.targets }}
-        save-if: ${{ github.ref == 'refs/heads/main' }} # Only cache runs from `main`
 
     - name: Set up MSVC (Windows)
       if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: ./.github/actions/rust
         with:
-          tools: cargo-mutants
+          tools: cargo-mutants, cargo-nextest
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Find incremental mutants


### PR DESCRIPTION
Only saving to the Rust cache on CI on `main` caused cache misses.

The `mutants` workflow needs `cargo-nextest`.