### PR TITLE
ci: Schedule benches on CPUs 2 and 3

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -108,7 +108,7 @@ jobs:
           mkdir -p hyperfine
 
       # Disable turboboost, hyperthreading and use performance governor.
-      # Also creates "cpu2" and "cpu3" CPU sets for use with cset.
+      # Also creates "cpu23", "cpu2" and "cpu3" CPU sets for use with cset.
       # On the bencher, logical cores 2 and 3 have been isolated for use by the benchmarks.
       - name: Prepare machine
         run: sudo /root/bin/prep.sh
@@ -121,7 +121,7 @@ jobs:
             NAME=$(basename "$BENCH" | cut -d- -f1)
             # shellcheck disable=SC2086
             perf $PERF_OPT -o "$NAME.perf" \
-              nice -n -20 setarch --addr-no-randomize cset proc --set=cpu2 --exec "$BENCH" -- --bench --noplot | tee -a results.txt
+              nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec "$BENCH" -- --bench --noplot | tee -a results.txt
           done
 
       # Compare various configurations of neqo against msquic and google/quiche, and gather perf data


### PR DESCRIPTION
Because the `transfer` bench creates two threads, and forcing both onto a single (isolated) CPU is hurting performance. As one might have expected.