### PR TITLE
ci: Don't cache various QNS docker things

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -34,9 +34,13 @@ jobs:
       packages: write
     steps:
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        with:
+          platforms: arm64
+          cache-image: false
+
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          cache-binary: ${{ github.event_name == 'pull_request' }} # zizmor: ignore[cache-poisoning]
+          cache-binary: false
 
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:


### PR DESCRIPTION
Our CI cache is under too much pressure.