### PR TITLE
ci: Don't use `quickinstall` for `cargo-fuzz`

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -108,5 +108,13 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
         TOOLS: ${{ inputs.tools }}
-      # FIXME: See https://github.com/Swatinem/rust-cache/issues/204 for why `--force`.
-      run: cargo quickinstall --force $(echo $TOOLS | tr -d ",")
+      run: |
+        for tool in $(echo $TOOLS | tr -d ","); do
+          if [ "$tool" = "cargo-fuzz"]; then
+            # FIXME: See https://github.com/rust-fuzz/cargo-fuzz/issues/398 for why no quickinstall/binstall here.
+            cargo install $tool
+          else
+            # FIXME: See https://github.com/Swatinem/rust-cache/issues/204 for why `--force`.
+            cargo quickinstall --force $tool
+          fi
+        done

--- a/.github/workflows/fuzz-bench.yml
+++ b/.github/workflows/fuzz-bench.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14] # FIXME: ubuntu-24.04-arm has issues
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-14] # FIXME: ubuntu-24.04-arm has issues
         check: [fuzz, bench]
     runs-on: ${{ matrix.os }}
 
@@ -45,7 +45,7 @@ jobs:
           UBUNTU: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           # FIXME: https://github.com/rust-fuzz/cargo-fuzz/issues/404
-          [ "$UBUNTU" = "true" ] && FUZZ_FLAGS="-s none"
+          # [ "$UBUNTU" = "true" ] && FUZZ_FLAGS="-s none"
           # shellcheck disable=SC2086
           cargo fuzz build $FUZZ_FLAGS
 


### PR DESCRIPTION
See https://github.com/rust-fuzz/cargo-fuzz/issues/398