### PR TITLE
fix: Fix condition in #2548

### DIFF
--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -331,9 +331,11 @@ fn setup_standalone(nss: &str) -> Vec<String> {
         "cargo:rustc-link-search=native={}",
         nsslibdir.to_str().unwrap()
     );
-    #[expect(unexpected_cfgs, reason = "cargo-fuzz defines fuzzing")]
     // FIXME: NSPR doesn't build proper dynamic libraries on Windows.
-    if cfg!(any(debug_assertions, fuzzing)) || env::consts::OS == "windows" {
+    if env::var("CARGO_CFG_FUZZING").is_ok()
+        || env::var("DEBUG").is_ok()
+        || env::consts::OS == "windows"
+    {
         static_link();
     } else {
         dynamic_link();


### PR DESCRIPTION
The build script doesn't get the same `cfg` info as the code, so work off environment variables.