### PR TITLE
fix: Unbreak the fuzzer more

### DIFF
--- a/fuzz/fuzz_targets/client_initial.rs
+++ b/fuzz/fuzz_targets/client_initial.rs
@@ -6,17 +6,16 @@ use libfuzzer_sys::fuzz_target;
 #[cfg(all(fuzzing, not(windows)))]
 fuzz_target!(|data: &[u8]| {
     use neqo_common::{Datagram, Encoder, Role};
-    use neqo_transport::{packet::MIN_INITIAL_PACKET_SIZE, Version};
+    use neqo_transport::{packet::MIN_INITIAL_PACKET_SIZE, ConnectionParameters, Version};
     use test_fixture::{
-        default_client, default_server,
         header_protection::{
             apply_header_protection, decode_initial_header, initial_aead_and_hp,
             remove_header_protection,
         },
-        now,
+        new_client, new_server, now, DEFAULT_ALPN,
     };
 
-    let mut client = default_client();
+    let mut client = new_client(ConnectionParameters::default().mlkem(false));
     let ci = client.process_output(now()).dgram().expect("a datagram");
     let Some((header, d_cid, s_cid, payload)) = decode_initial_header(&ci, Role::Client) else {
         return;
@@ -59,7 +58,7 @@ fuzz_target!(|data: &[u8]| {
     );
     let fuzzed_ci = Datagram::new(ci.source(), ci.destination(), ci.tos(), ciphertext);
 
-    let mut server = default_server();
+    let mut server = new_server(DEFAULT_ALPN, ConnectionParameters::default().mlkem(false));
     let _response = server.process(Some(fuzzed_ci), now());
 });
 

--- a/fuzz/fuzz_targets/server_initial.rs
+++ b/fuzz/fuzz_targets/server_initial.rs
@@ -26,7 +26,7 @@ fuzz_target!(|data: &[u8]| {
     };
     let (aead, hp) = initial_aead_and_hp(d_cid, Role::Server);
     let (_, pn) = remove_header_protection(&hp, header, payload);
-
+    println!("pn: {pn}");
     let mut payload_enc = Encoder::with_capacity(MIN_INITIAL_PACKET_SIZE);
     payload_enc.encode(data); // Add fuzzed data.
 
@@ -39,7 +39,7 @@ fuzz_target!(|data: &[u8]| {
         .encode_vec(1, s_cid)
         .encode_vvec(&[])
         .encode_varint(u64::try_from(payload_enc.len() + aead.expansion() + 1).unwrap())
-        .encode_byte(u8::try_from(pn).inspect_err(|e| eprintln!("{pn} {e}")).unwrap());
+        .encode_byte(u8::try_from(pn).inspect_err(|e| println!("{pn} {e}")).unwrap());
 
     let mut ciphertext = header_enc.as_ref().to_vec();
     ciphertext.resize(header_enc.len() + payload_enc.len() + aead.expansion(), 0);

--- a/fuzz/fuzz_targets/server_initial.rs
+++ b/fuzz/fuzz_targets/server_initial.rs
@@ -39,7 +39,7 @@ fuzz_target!(|data: &[u8]| {
         .encode_vec(1, s_cid)
         .encode_vvec(&[])
         .encode_varint(u64::try_from(payload_enc.len() + aead.expansion() + 1).unwrap())
-        .encode_byte(u8::try_from(pn).unwrap());
+        .encode_byte(u8::try_from(pn).inspect_err(|e| eprintln!("{pn} {e}")).unwrap());
 
     let mut ciphertext = header_enc.as_ref().to_vec();
     ciphertext.resize(header_enc.len() + payload_enc.len() + aead.expansion(), 0);

--- a/fuzz/fuzz_targets/server_initial.rs
+++ b/fuzz/fuzz_targets/server_initial.rs
@@ -6,19 +6,18 @@ use libfuzzer_sys::fuzz_target;
 #[cfg(all(fuzzing, not(windows)))]
 fuzz_target!(|data: &[u8]| {
     use neqo_common::{Datagram, Encoder, Role};
-    use neqo_transport::{packet::MIN_INITIAL_PACKET_SIZE, Version};
+    use neqo_transport::{packet::MIN_INITIAL_PACKET_SIZE, ConnectionParameters, Version};
     use test_fixture::{
-        default_client, default_server,
         header_protection::{
             apply_header_protection, decode_initial_header, initial_aead_and_hp,
             remove_header_protection,
         },
-        now,
+        new_client, new_server, now, DEFAULT_ALPN,
     };
 
-    let mut client = default_client();
+    let mut client = new_client(ConnectionParameters::default().mlkem(false));
     let ci = client.process_output(now()).dgram().expect("a datagram");
-    let mut server = default_server();
+    let mut server = new_server(DEFAULT_ALPN, ConnectionParameters::default().mlkem(false));
     let si = server.process(Some(ci), now()).dgram().expect("a datagram");
 
     let Some((header, d_cid, s_cid, payload)) = decode_initial_header(&si, Role::Server) else {
@@ -26,7 +25,7 @@ fuzz_target!(|data: &[u8]| {
     };
     let (aead, hp) = initial_aead_and_hp(d_cid, Role::Server);
     let (_, pn) = remove_header_protection(&hp, header, payload);
-    println!("pn: {pn}");
+
     let mut payload_enc = Encoder::with_capacity(MIN_INITIAL_PACKET_SIZE);
     payload_enc.encode(data); // Add fuzzed data.
 
@@ -39,7 +38,7 @@ fuzz_target!(|data: &[u8]| {
         .encode_vec(1, s_cid)
         .encode_vvec(&[])
         .encode_varint(u64::try_from(payload_enc.len() + aead.expansion() + 1).unwrap())
-        .encode_byte(u8::try_from(pn).inspect_err(|e| println!("{pn} {e}")).unwrap());
+        .encode_byte(u8::try_from(pn).unwrap());
 
     let mut ciphertext = header_enc.as_ref().to_vec();
     ciphertext.resize(header_enc.len() + payload_enc.len() + aead.expansion(), 0);

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -178,6 +178,9 @@ fn static_link() {
         "softokn_static",
         "ssl",
     ];
+    if env::consts::OS != "macos" {
+        static_libs.push("sqlite3");
+    }
     // Hardware specific libs.
     // See https://github.com/mozilla/application-services/blob/0a2dac76f979b8bcfb6bacb5424b50f58520b8fe/components/support/rc_crypto/nss/nss_build_common/src/lib.rs#L127-L157
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -179,7 +179,7 @@ fn static_link() {
         "ssl",
     ];
     if env::consts::OS != "macos" {
-        static_libs.push("sqlite3");
+        static_libs.push("sqlite");
     }
     // Hardware specific libs.
     // See https://github.com/mozilla/application-services/blob/0a2dac76f979b8bcfb6bacb5424b50f58520b8fe/components/support/rc_crypto/nss/nss_build_common/src/lib.rs#L127-L157

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -153,7 +153,7 @@ fn static_link() {
         "certdb",
         "certhi",
         "cryptohi",
-        "freebl",
+        "freebl_static",
         if env::consts::OS == "windows" {
             "libnspr4"
         } else {

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -149,7 +149,7 @@ fn dynamic_link() {
 }
 
 fn static_link() {
-    let mut static_libs = vec![
+    let static_libs = [
         "certdb",
         "certhi",
         "cryptohi",
@@ -164,7 +164,7 @@ fn static_link() {
         "nssdev",
         "nsspki",
         "nssutil",
-        "pk11wrap",
+        "pk11wrap_static",
         "pkcs12",
         "pkcs7",
         if env::consts::OS == "windows" {
@@ -181,38 +181,6 @@ fn static_link() {
         "softokn_static",
         "ssl",
     ];
-    // Hardware specific libs.
-    // See https://github.com/mozilla/application-services/blob/0a2dac76f979b8bcfb6bacb5424b50f58520b8fe/components/support/rc_crypto/nss/nss_build_common/src/lib.rs#L127-L157
-    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    // https://searchfox.org/nss/rev/0d5696b3edce5124353f03159d2aa15549db8306/lib/freebl/freebl.gyp#508-542
-    if target_arch == "arm" || target_arch == "aarch64" {
-        static_libs.push("armv8_c_lib");
-    }
-    if target_arch == "x86_64" || target_arch == "x86" {
-        static_libs.push("gcm-aes-x86_c_lib");
-        static_libs.push("sha-x86_c_lib");
-    }
-    if target_arch == "arm" {
-        static_libs.push("gcm-aes-arm32-neon_c_lib");
-    }
-    if target_arch == "aarch64" {
-        static_libs.push("gcm-aes-aarch64_c_lib");
-    }
-    if target_arch == "x86_64" {
-        static_libs.push("hw-acc-crypto-avx");
-        static_libs.push("hw-acc-crypto-avx2");
-    }
-    // https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#315-324
-    if ((target_os == "android" || target_os == "linux") && target_arch == "x86_64")
-        || target_os == "windows"
-    {
-        static_libs.push("intel-gcm-wrap_c_lib");
-        // https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#43-47
-        if (target_os == "android" || target_os == "linux") && target_arch == "x86_64" {
-            static_libs.push("intel-gcm-s_lib");
-        }
-    }
     for lib in static_libs {
         println!("cargo:rustc-link-lib=static={lib}");
     }

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -149,7 +149,7 @@ fn dynamic_link() {
 }
 
 fn static_link() {
-    let static_libs = [
+    let mut static_libs = vec![
         "certdb",
         "certhi",
         "cryptohi",
@@ -165,8 +165,6 @@ fn static_link() {
         "nsspki",
         "nssutil",
         "pk11wrap_static",
-        "pkcs12",
-        "pkcs7",
         if env::consts::OS == "windows" {
             "libplc4"
         } else {
@@ -177,12 +175,48 @@ fn static_link() {
         } else {
             "plds4"
         },
-        "smime",
         "softokn_static",
         "ssl",
     ];
+    // Hardware specific libs.
+    // See https://github.com/mozilla/application-services/blob/0a2dac76f979b8bcfb6bacb5424b50f58520b8fe/components/support/rc_crypto/nss/nss_build_common/src/lib.rs#L127-L157
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    // https://searchfox.org/nss/rev/0d5696b3edce5124353f03159d2aa15549db8306/lib/freebl/freebl.gyp#508-542
+    if target_arch == "arm" || target_arch == "aarch64" {
+        static_libs.push("armv8_c_lib");
+    }
+    if target_arch == "x86_64" || target_arch == "x86" {
+        static_libs.push("gcm-aes-x86_c_lib");
+        static_libs.push("sha-x86_c_lib");
+    }
+    if target_arch == "arm" {
+        static_libs.push("gcm-aes-arm32-neon_c_lib");
+    }
+    if target_arch == "aarch64" {
+        static_libs.push("gcm-aes-aarch64_c_lib");
+    }
+    if target_arch == "x86_64" {
+        static_libs.push("hw-acc-crypto-avx");
+        static_libs.push("hw-acc-crypto-avx2");
+    }
+    // https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#315-324
+    if ((target_os == "android" || target_os == "linux") && target_arch == "x86_64")
+        || target_os == "windows"
+    {
+        static_libs.push("intel-gcm-wrap_c_lib");
+        // https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#43-47
+        if (target_os == "android" || target_os == "linux") && target_arch == "x86_64" {
+            static_libs.push("intel-gcm-s_lib");
+        }
+    }
     for lib in static_libs {
         println!("cargo:rustc-link-lib=static={lib}");
+    }
+    // Dynamic libs that aren't transitively included by NSS libs.
+    if env::consts::OS == "macos" {
+        println!("cargo:rustc-link-lib=dylib=sqlite3");
+        // static_libs.push("sqlite");
     }
 }
 

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -164,7 +164,7 @@ fn static_link() {
         "nssdev",
         "nsspki",
         "nssutil",
-        "pk11wrap",
+        "pk11wrap_static",
         if env::consts::OS == "windows" {
             "libplc4"
         } else {
@@ -212,6 +212,11 @@ fn static_link() {
     }
     for lib in static_libs {
         println!("cargo:rustc-link-lib=static={lib}");
+    }
+    // Dynamic libs that aren't transitively included by NSS libs.
+    if env::consts::OS == "macos" {
+        println!("cargo:rustc-link-lib=dylib=sqlite3");
+        // static_libs.push("sqlite");
     }
 }
 

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -149,7 +149,7 @@ fn dynamic_link() {
 }
 
 fn static_link() {
-    let static_libs = [
+    let mut static_libs = vec![
         "certdb",
         "certhi",
         "cryptohi",
@@ -181,6 +181,38 @@ fn static_link() {
         "softokn_static",
         "ssl",
     ];
+    // Hardware specific libs.
+    // See https://github.com/mozilla/application-services/blob/0a2dac76f979b8bcfb6bacb5424b50f58520b8fe/components/support/rc_crypto/nss/nss_build_common/src/lib.rs#L127-L157
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    // https://searchfox.org/nss/rev/0d5696b3edce5124353f03159d2aa15549db8306/lib/freebl/freebl.gyp#508-542
+    if target_arch == "arm" || target_arch == "aarch64" {
+        static_libs.push("armv8_c_lib");
+    }
+    if target_arch == "x86_64" || target_arch == "x86" {
+        static_libs.push("gcm-aes-x86_c_lib");
+        static_libs.push("sha-x86_c_lib");
+    }
+    if target_arch == "arm" {
+        static_libs.push("gcm-aes-arm32-neon_c_lib");
+    }
+    if target_arch == "aarch64" {
+        static_libs.push("gcm-aes-aarch64_c_lib");
+    }
+    if target_arch == "x86_64" {
+        static_libs.push("hw-acc-crypto-avx");
+        static_libs.push("hw-acc-crypto-avx2");
+    }
+    // https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#315-324
+    if ((target_os == "android" || target_os == "linux") && target_arch == "x86_64")
+        || target_os == "windows"
+    {
+        static_libs.push("intel-gcm-wrap_c_lib");
+        // https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#43-47
+        if (target_os == "android" || target_os == "linux") && target_arch == "x86_64" {
+            static_libs.push("intel-gcm-s_lib");
+        }
+    }
     for lib in static_libs {
         println!("cargo:rustc-link-lib=static={lib}");
     }

--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -164,7 +164,7 @@ fn static_link() {
         "nssdev",
         "nsspki",
         "nssutil",
-        "pk11wrap_static",
+        "pk11wrap",
         if env::consts::OS == "windows" {
             "libplc4"
         } else {
@@ -212,11 +212,6 @@ fn static_link() {
     }
     for lib in static_libs {
         println!("cargo:rustc-link-lib=static={lib}");
-    }
-    // Dynamic libs that aren't transitively included by NSS libs.
-    if env::consts::OS == "macos" {
-        println!("cargo:rustc-link-lib=dylib=sqlite3");
-        // static_libs.push("sqlite");
     }
 }
 

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -38,7 +38,11 @@ pub mod header_protection;
 pub mod sim;
 
 /// The path for the database used in tests.
-pub const NSS_DB_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/db");
+pub const NSS_DB_PATH: &str = if let Some(dir) = option_env!("NSS_DB_PATH") {
+    dir
+} else {
+    concat!(env!("CARGO_MANIFEST_DIR"), "/db")
+};
 
 /// Initialize the test fixture.  Only call this if you aren't also calling a
 /// fixture function that depends on setup.  Other functions in the fixture

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -52,7 +52,16 @@ pub const NSS_DB_PATH: &str = if let Some(dir) = option_env!("NSS_DB_PATH") {
 ///
 /// When the NSS initialization fails.
 pub fn fixture_init() {
-    init_db(NSS_DB_PATH).unwrap();
+    if NSS_DB_PATH == "$ARGV0" {
+        let mut current_exe = std::env::current_exe().unwrap();
+        current_exe.pop();
+        let nss_db_path = current_exe.to_str().unwrap();
+        eprintln!("NSS_DB_PATH: {nss_db_path}");
+        init_db(nss_db_path).unwrap();
+    } else {
+        eprintln!("NSS_DB_PATH: {NSS_DB_PATH}");
+        init_db(NSS_DB_PATH).unwrap();
+    }
 }
 
 // This needs to be > 2ms to avoid it being rounded to zero.

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -38,6 +38,11 @@ pub mod header_protection;
 pub mod sim;
 
 /// The path for the database used in tests.
+///
+/// Initialized via the `NSS_DB_PATH` environment variable. If that is not set,
+/// it defaults to the `db` directory in the current crate. If the environment
+/// variable is set to `$ARGV0`, it will be initialized to the directory of the
+/// current executable.
 pub const NSS_DB_PATH: &str = if let Some(dir) = option_env!("NSS_DB_PATH") {
     dir
 } else {
@@ -56,10 +61,8 @@ pub fn fixture_init() {
         let mut current_exe = std::env::current_exe().unwrap();
         current_exe.pop();
         let nss_db_path = current_exe.to_str().unwrap();
-        eprintln!("NSS_DB_PATH: {nss_db_path}");
         init_db(nss_db_path).unwrap();
     } else {
-        eprintln!("NSS_DB_PATH: {NSS_DB_PATH}");
         init_db(NSS_DB_PATH).unwrap();
     }
 }


### PR DESCRIPTION
This changes the way we link NSS to a fully static link when fuzzing or doing debug builds.

It also allows setting the `NSS_DB_PATH` env variable to `$ARGV0`, which indicates that the test fixture should look for the NSS database in the same directory as the executing binary.

Thanks, `oss-fuzz` for making us need all of this.