### PR TITLE
chore(clippy): add dbg! to clippy.toml disallowed-macros

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,6 +1,9 @@
 disallowed-methods = [
     { path = "std::slice::from_raw_parts", reason = "see null_safe_slice" }
 ]
+disallowed-macros = [
+    { path = "dbg!" }
+]
 allow-mixed-uninlined-format-args = false
 allow-unwrap-in-tests = true
 allow-dbg-in-tests = true


### PR DESCRIPTION
I keep forgetting to remove all `dbg!` statements before marking a pull request as ready for review. Latest occurrence:

https://github.com/mozilla/neqo/pull/2492#discussion_r2026230723

Have CI fail on all `dbg!` statements.

```
➜  neqo git:(main) ✗ cargo +nightly clippy  --tests && cargo +nightly fmt
warning: the `dbg!` macro is intended as a debugging tool
   --> neqo-transport/src/connection/mod.rs:118:40
    |
118 |             Self::Datagram(dg) => Some(dbg!(dg)),
    |                                        ^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#dbg_macro
    = note: requested on the command line with `-W clippy::dbg-macro`
help: remove the invocation before committing it to a version control system
    |
118 |             Self::Datagram(dg) => Some(dg),
```



