### PR TITLE
chore: adding `*.sqlog` and removing `*.qlog` from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .envrc
 *.qlog
+*.sqlog
 *~
 /.vscode/
 /lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .envrc
+*.qlog
 *.sqlog
 *~
 /.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 .envrc
-*.qlog
 *.sqlog
 *~
 /.vscode/


### PR DESCRIPTION
#2031 changed the `.qlog` file suffix to be `.sqlog`.