### PR TITLE
fix(transport/ecn): start after handshake and path validation

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2509,7 +2509,7 @@ impl Connection {
 
             // If we don't have a TOS for this UDP datagram yet (i.e. `tos` is `None`), get it,
             // adding a `RecoveryToken::EcnEct0` to `tokens` in case of loss.
-            let tos = packet_tos.get_or_insert_with(|| path.borrow().tos(&mut tokens));
+            let tos = packet_tos.get_or_insert_with(|| path.borrow().tos(pt, &mut tokens));
             self.log_packet(
                 packet::MetaData::new_out(
                     path,
@@ -2948,6 +2948,7 @@ impl Connection {
                 .pmtud_mut()
                 .start(now, &mut self.stats.borrow_mut());
         }
+        self.paths.start_ecn();
         Ok(())
     }
 

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use neqo_common::{Datagram, IpTos, IpTosEcn};
+use neqo_common::{event::Provider, Datagram, IpTos, IpTosEcn};
 use strum::IntoEnumIterator as _;
 use test_fixture::{
     assertions::{assert_v4_path, assert_v6_path},
@@ -23,7 +23,7 @@ use crate::{
     ecn,
     packet::PacketType,
     path::MAX_PATH_PROBES,
-    ConnectionId, ConnectionParameters, StreamType,
+    ConnectionEvent, ConnectionId, ConnectionParameters, StreamType,
 };
 
 fn assert_ecn_enabled(tos: IpTos) {
@@ -75,6 +75,8 @@ fn drop_ecn_marked_datagrams() -> fn(Datagram) -> Option<Datagram> {
     |d| (!d.tos().is_ecn_marked()).then_some(d)
 }
 
+/// Given that ECN validation only starts after the handshake, it does not delay
+/// connection establishment.
 #[test]
 fn handshake_delay_with_ecn_blackhole() {
     let start = now();
@@ -95,8 +97,104 @@ fn handshake_delay_with_ecn_blackhole() {
 
     assert_eq!(
         (finish - start).as_millis() / DEFAULT_RTT.as_millis(),
-        45,
-        "expected 3 RTT for first client PTO + 6 RTT for second PTO + 12 RTT for third PTO + another 21 RTT for the same on the server side + 3 RTT for handshake to be confirmed",
+        3,
+        "expect ECN path validation to start after handshake",
+    );
+}
+
+// TODO: Cleanup
+#[test]
+fn request_response_delay_after_handshake_with_ecn_blackhole() {
+    let start = now();
+    let mut now = start;
+    // `handshake_with_modifier` with-multi packet Intial flights will throw off the RTT calculation
+    // below.
+    let mut client = new_client(ConnectionParameters::default().mlkem(false));
+    let mut server = default_server();
+    now = handshake_with_modifier(
+        &mut client,
+        &mut server,
+        now,
+        DEFAULT_RTT,
+        drop_ecn_marked_datagrams(),
+    );
+
+    let request_response_start = now;
+
+    let stream_id = client.stream_create(StreamType::BiDi).unwrap();
+    assert!(client.stream_send(stream_id, b"ping").is_ok());
+    assert!(client.stream_close_send(stream_id).is_ok());
+    let client_dg = loop {
+        let client_dg = match client.process_output(now) {
+            crate::Output::None => unreachable!(),
+            crate::Output::Datagram(datagram) => datagram,
+            crate::Output::Callback(duration) => {
+                now += duration;
+                continue;
+            }
+        };
+        if client_dg.tos().is_ecn_marked() {
+            continue;
+        }
+        break client_dg;
+    };
+
+    // TODO: Introduce respond_to_something?
+    server.process_input(client_dg, now);
+    let stream_id = server
+        .events()
+        .find_map(|e| {
+            if let ConnectionEvent::RecvStreamReadable { stream_id, .. } = e {
+                return Some(stream_id);
+            } else {
+                None
+            }
+        })
+        .expect("stream event");
+    let mut buf = vec![];
+    server.stream_recv(stream_id, &mut buf).unwrap();
+    server.stream_send(stream_id, b"pong").unwrap();
+    server.stream_close_send(stream_id).unwrap();
+
+    loop {
+        let server_dg = match server.process_output(now) {
+            crate::Output::None => unreachable!(),
+            crate::Output::Callback(duration) => {
+                now += duration;
+                continue;
+            }
+            crate::Output::Datagram(datagram) => datagram,
+        };
+        if server_dg.tos().is_ecn_marked() {
+            continue;
+        }
+
+        client.process_input(server_dg, now);
+        let client_stream_id = client.events().find_map(|e| {
+            if let ConnectionEvent::RecvStreamReadable { stream_id, .. } = e {
+                return Some(stream_id);
+            } else {
+                None
+            }
+        });
+
+        if client_stream_id.is_none() {
+            continue;
+        }
+
+        break;
+    }
+
+    let mut buf = vec![];
+    client.stream_recv(stream_id, &mut buf).unwrap();
+
+    assert_eq!(
+        (now - request_response_start).as_millis() / DEFAULT_RTT.as_millis(),
+        // TODO: Application space hasn't received an ACK yet. Thus retransmits
+        // are still based on PTO and not time threshold. PTO doubles each time
+        // thus resulting in the gigantic delay below.
+        244,
+        "expect ECN path validation to start after handshake",
     );
 }
 
@@ -290,7 +388,7 @@ pub fn migration_with_modifiers(
     connect_force_idle_with_modifier(&mut client, &mut server, orig_path_modifier);
     let mut now = now();
 
-    // Right after the handshake, the ECN validation should still be in progress.
+    // Right after the handshake, the ECN validation should be in progress.
     let client_pkt = send_something(&mut client, now);
     assert_ecn_enabled(client_pkt.tos());
     server.process_input(orig_path_modifier(client_pkt).unwrap(), now);
@@ -384,7 +482,7 @@ pub fn migration_with_modifiers(
         let client_confirmation = client.process_output(now).dgram().unwrap();
         assert_v4_path(&client_confirmation, false);
 
-        // The server has now sent 2 packets, so it is blocked on the pacer.  Wait.
+        // The server has now sent 2 packets, so it is blocked on the pacer. Wait.
         let server_pacing = server.process_output(now).callback();
         assert_ne!(server_pacing, Duration::new(0, 0));
         // ... then confirm that the server sends on the new path still.

--- a/neqo-transport/src/ecn.rs
+++ b/neqo-transport/src/ecn.rs
@@ -26,8 +26,12 @@ const TEST_COUNT_INITIAL_PHASE: usize = 3;
 
 /// The state information related to testing a path for ECN capability.
 /// See RFC9000, Appendix A.4.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
 enum ValidationState {
+    /// ECN validation not started yet. Reason might e.g. be still handshaking
+    /// or not being the primary path.
+    #[default]
+    NotStarted,
     /// The path is currently being tested for ECN capability, with the number of probes sent so
     /// far on the path during the ECN validation.
     Testing {
@@ -42,25 +46,18 @@ enum ValidationState {
     Capable,
 }
 
-impl Default for ValidationState {
-    fn default() -> Self {
-        Self::Testing {
-            probes_sent: 0,
-            initial_probes_lost: 0,
-        }
-    }
-}
-
 impl ValidationState {
     fn set(&mut self, new: Self, stats: &mut Stats) {
         let old = std::mem::replace(self, new);
 
         match old {
+            Self::NotStarted => unreachable!("TODO"),
             Self::Testing { .. } | Self::Unknown => {}
             Self::Failed(_) => debug_assert!(false, "Failed is a terminal state"),
             Self::Capable => stats.ecn_path_validation[ValidationOutcome::Capable] -= 1,
         }
         match new {
+            Self::NotStarted => unreachable!("TODO"),
             Self::Testing { .. } | Self::Unknown => {}
             Self::Failed(error) => {
                 stats.ecn_path_validation[ValidationOutcome::NotCapable(error)] += 1;
@@ -178,6 +175,15 @@ pub(crate) struct Info {
 }
 
 impl Info {
+    pub(crate) fn start(&mut self) {
+        // TODO: Panic fine?
+        // assert_eq!(self.state, ValidationState::NotStarted);
+        self.state = ValidationState::Testing {
+            probes_sent: 0,
+            initial_probes_lost: 0,
+        }
+    }
+
     /// Set the baseline (= the ECN counts from the last ACK Frame).
     pub(crate) fn set_baseline(&mut self, baseline: Count) {
         self.baseline = baseline;
@@ -270,7 +276,9 @@ impl Info {
         // > (see Section 13.4.2.1) causes the ECN state for the path to become "capable", unless
         // > no marked packet has been acknowledged.
         match self.state {
-            ValidationState::Testing { .. } | ValidationState::Failed(_) => return,
+            ValidationState::NotStarted
+            | ValidationState::Testing { .. }
+            | ValidationState::Failed(_) => return,
             ValidationState::Unknown | ValidationState::Capable => {}
         }
 
@@ -327,7 +335,9 @@ impl Info {
     pub(crate) const fn is_marking(&self) -> bool {
         match self.state {
             ValidationState::Testing { .. } | ValidationState::Capable => true,
-            ValidationState::Failed(_) | ValidationState::Unknown => false,
+            ValidationState::NotStarted | ValidationState::Failed(_) | ValidationState::Unknown => {
+                false
+            }
         }
     }
 
@@ -335,8 +345,8 @@ impl Info {
     ///
     /// On [`IpTosEcn::Ect0`] adds a [`RecoveryToken::EcnEct0`] to `tokens` in
     /// order to detect potential loss, then handled in [`Info::lost_ecn`].
-    pub(crate) fn ecn_mark(&self, tokens: &mut Vec<RecoveryToken>) -> IpTosEcn {
-        if self.is_marking() {
+    pub(crate) fn ecn_mark(&self, pt: PacketType, tokens: &mut Vec<RecoveryToken>) -> IpTosEcn {
+        if pt == PacketType::Short && self.is_marking() {
             tokens.push(RecoveryToken::EcnEct0);
             IpTosEcn::Ect0
         } else {

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -190,6 +190,7 @@ impl Paths {
             |p| p.borrow().ecn_info.baseline(),
         );
         path.borrow_mut().set_ecn_baseline(baseline);
+        path.borrow_mut().start_ecn();
         if force || path.borrow().is_valid() {
             path.borrow_mut().set_valid(now);
             drop(self.select_primary(path, now));
@@ -414,6 +415,12 @@ impl Paths {
         }
     }
 
+    pub fn start_ecn(&mut self) {
+        if let Some(path) = self.primary() {
+            path.borrow_mut().start_ecn();
+        }
+    }
+
     /// Get an estimate of the RTT on the primary path.
     #[cfg(test)]
     pub fn rtt(&self) -> Duration {
@@ -569,8 +576,8 @@ impl Path {
     }
 
     /// Return the DSCP/ECN marking to use for outgoing packets on this path.
-    pub fn tos(&self, tokens: &mut Vec<RecoveryToken>) -> IpTos {
-        self.ecn_info.ecn_mark(tokens).into()
+    pub fn tos(&self, pt: PacketType, tokens: &mut Vec<RecoveryToken>) -> IpTos {
+        self.ecn_info.ecn_mark(pt, tokens).into()
     }
 
     /// Whether this path is the primary or current path for the connection.
@@ -828,6 +835,10 @@ impl Path {
 
     pub fn lost_ecn(&mut self, pt: PacketType, stats: &mut Stats) {
         self.ecn_info.lost_ecn(pt, stats);
+    }
+
+    pub fn start_ecn(&mut self) {
+        self.ecn_info.start();
     }
 
     pub fn acked_ack_frequency(&mut self, acked: &AckRate) {


### PR DESCRIPTION
Fixes https://github.com/mozilla/neqo/issues/2490.

Only start ECN marking and thus ECN-Path validation when:

- Connection handshake is _confirmed_.
- AND, for any secondary path, path is validated (e.g. via `PATH_RESPONSE`).

----

**Draft for now. Opening up early to prevent duplicate work.**