### PR TITLE
chore: update tokio to v1.42.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "libc",


### PR DESCRIPTION
Previous version has unsoundness.

https://rustsec.org/advisories/RUSTSEC-2025-0023

Note, tokio is a dev-dependency only. (`dependency` in `neqo-bin` which itself is not used in Firefox.)