### PR TITLE
fix: Fix QNS test errors with `nginx`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "criterion",
  "enum-map",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "criterion",
  "enumset",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "log",
  "neqo-common",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "criterion",
  "enum-map",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cfg_aliases",
  "log",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.13.0"
+version = "0.13.1"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/neqo-transport/src/ecn.rs
+++ b/neqo-transport/src/ecn.rs
@@ -103,16 +103,16 @@ impl Count {
         Self(EnumMap::from_array([not_ect, ect1, ect0, ce]))
     }
 
-    /// Whether any of the ECN counts are non-zero.
+    /// Whether any of the ECT(0), ECT(1) or CE counts are non-zero.
     #[must_use]
     pub fn is_some(&self) -> bool {
-        self.0.iter().any(|(_, &count)| count > 0)
+        self[IpTosEcn::Ect0] > 0 || self[IpTosEcn::Ect1] > 0 || self[IpTosEcn::Ce] > 0
     }
 
-    /// Whether all of the ECN counts are zero.
+    /// Whether all of the ECN counts are zero (including Not-ECT.)
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        !self.is_some()
+        self.iter().all(|(_, count)| *count == 0)
     }
 }
 


### PR DESCRIPTION
And hopefully `haproxy`.

The old code caused ACK-ECN frames to be sent that had all-zero counts, which I don't think is a violation of the RFC, but we still shouldn't do.

Fixes #2566.