### PR TITLE
chore(Cargo.toml): require qlog v0.15.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ enum-map = { version = "2.7", default-features = false }
 enumset = { version = "1.1", default-features = false }
 hex = { version = "0.4", default-features = false }
 log = { version = "0.4", default-features = false }
-qlog = { version = "0.15", default-features = false }
+qlog = { version = "0.15.1", default-features = false }
 quinn-udp = { version = "0.5.11", default-features = false, features = ["direct-log", "fast-apple-datapath"] }
 regex = { version = "1.9", default-features = false }
 static_assertions = { version = "1.1", default-features = false }


### PR DESCRIPTION
https://github.com/mozilla/neqo/pull/2512/ bumped `qlog` to `v0.15.0`, but made use of features only available in `qlog` `v0.15.1`. Thus while using `qlog` `v0.15.0` would be allowed according to Neqo's root `Cargo.toml`, it would not compile.

This commit increases the `qlog` requirement to `v0.15.1`.