### PR TITLE
fix(transport/ecn): don't require probes_sent == probes_lost

### DIFF
--- a/neqo-transport/src/ecn.rs
+++ b/neqo-transport/src/ecn.rs
@@ -231,14 +231,14 @@ impl Info {
         }
 
         if let ValidationState::Testing {
-            probes_sent,
             initial_probes_lost: probes_lost,
+            ..
         } = &mut self.state
         {
             *probes_lost += 1;
             // If we have lost all initial probes a bunch of times, we can conclude that the path
             // is not ECN capable and likely drops all ECN marked packets.
-            if *probes_sent == *probes_lost && *probes_lost == TEST_COUNT_INITIAL_PHASE {
+            if *probes_lost == TEST_COUNT_INITIAL_PHASE {
                 qdebug!(
                     "ECN validation failed, all {probes_lost} initial marked packets were lost"
                 );


### PR DESCRIPTION
During ECN path testing, in case `TEST_COUNT_INITIAL_PHASE` ECN probes get lost, ECN is disabled.

https://github.com/mozilla/neqo/blob/a62c14068ad603f878f13a354f9ce0eddf97231b/neqo-transport/src/ecn.rs#L21-L25

Though only if `*probes_sent == *probes_lost`.

https://github.com/mozilla/neqo/blob/a62c14068ad603f878f13a354f9ce0eddf97231b/neqo-transport/src/ecn.rs#L241-L246

Say that a Neqo client has send 2 ECN marked datagrams, i.e. probes, each of them eventually declared lost. Next the client sends two more datagrams, each again marked.

When the first of the two is declared lost, `probes_sent` is `4` and `probes_lost` is `3`, thus ECN is not disabled.

When the second of the two is declared lost, `probes_sent` is `4` and `probes_lost` is `4`. Given that `probes_lost` is not `== TEST_COUNT_INITIAL_PHASE`, ECN is once more not disabled.

This patch removes the requirement of `*probes_sent == *probes_lost`, thus always disabling ECN after `TEST_COUNT_INITIAL_PHASE` losses.

Note that as of now, this patch isn't relevant yet, as path probing is done at connection establishment time and thus `MAX_PATH_PROBES` already disables ECN marking beforehand.

https://github.com/mozilla/neqo/blob/a62c14068ad603f878f13a354f9ce0eddf97231b/neqo-transport/src/path.rs#L32-L36

That said, this will become relevant once we start ECN validation only after the handshake (https://github.com/mozilla/neqo/pull/2560).

---

~~@larseggert am I missing something? Is `*probes_sent == *probes_lost` relevant here?~~

I assume  `*probes_sent == *probes_lost` is supposed to enforce that the losses are consecutive starting from 0. Is this a requirement we need to uphold?

If yes, we could track the concrete packet numbers of lost packets.

If no, the solution proposed here should work.