### PR TITLE
fix(transport/ecn): track ACK of marked packets

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -3226,8 +3226,9 @@ impl Connection {
                     RecoveryToken::Datagram(dgram_tracker) => self
                         .events
                         .datagram_outcome(dgram_tracker, OutgoingDatagramOutcome::Acked),
+                    RecoveryToken::EcnEct0 => self.paths.acked_ecn(),
                     // We only worry when these are lost
-                    RecoveryToken::HandshakeDone | RecoveryToken::EcnEct0 => (),
+                    RecoveryToken::HandshakeDone => (),
                 }
             }
         }

--- a/neqo-transport/src/ecn.rs
+++ b/neqo-transport/src/ecn.rs
@@ -32,6 +32,7 @@ enum ValidationState {
     /// far on the path during the ECN validation.
     Testing {
         probes_sent: usize,
+        initial_probes_acked: usize,
         initial_probes_lost: usize,
     },
     /// The validation test has concluded but the path's ECN capability is not yet known.
@@ -46,6 +47,7 @@ impl Default for ValidationState {
     fn default() -> Self {
         Self::Testing {
             probes_sent: 0,
+            initial_probes_acked: 0,
             initial_probes_lost: 0,
         }
     }
@@ -225,20 +227,33 @@ impl Info {
             && (self.baseline - prev_baseline)[IpTosEcn::Ce] > 0
     }
 
+    /// An [`IpTosEcn::Ect0`] marked packet has been acked.
+    pub(crate) fn acked_ecn(&mut self) {
+        if let ValidationState::Testing {
+            initial_probes_acked: probes_acked,
+            ..
+        } = &mut self.state
+        {
+            *probes_acked += 1;
+        }
+    }
+
+    /// An [`IpTosEcn::Ect0`] marked packet has been declared lost.
     pub(crate) fn lost_ecn(&mut self, pt: PacketType, stats: &mut Stats) {
         if pt != PacketType::Initial {
             return;
         }
 
         if let ValidationState::Testing {
-            probes_sent,
+            initial_probes_acked: probes_acked,
             initial_probes_lost: probes_lost,
+            ..
         } = &mut self.state
         {
             *probes_lost += 1;
             // If we have lost all initial probes a bunch of times, we can conclude that the path
             // is not ECN capable and likely drops all ECN marked packets.
-            if *probes_sent == *probes_lost && *probes_lost == TEST_COUNT_INITIAL_PHASE {
+            if *probes_acked == 0 && *probes_lost == TEST_COUNT_INITIAL_PHASE {
                 qdebug!(
                     "ECN validation failed, all {probes_lost} initial marked packets were lost"
                 );

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -408,6 +408,12 @@ impl Paths {
         }
     }
 
+    pub fn acked_ecn(&self) {
+        if let Some(path) = self.primary() {
+            path.borrow_mut().acked_ecn();
+        }
+    }
+
     pub fn lost_ecn(&self, pt: PacketType, stats: &mut Stats) {
         if let Some(path) = self.primary() {
             path.borrow_mut().lost_ecn(pt, stats);
@@ -824,6 +830,10 @@ impl Path {
 
     pub fn lost_ack_frequency(&mut self, lost: &AckRate) {
         self.rtt.frame_lost(lost);
+    }
+
+    pub fn acked_ecn(&mut self) {
+        self.ecn_info.acked_ecn();
     }
 
     pub fn lost_ecn(&mut self, pt: PacketType, stats: &mut Stats) {


### PR DESCRIPTION
Alternative to https://github.com/mozilla/neqo/pull/2588.

**Problem**

(Same as https://github.com/mozilla/neqo/pull/2588.)

During ECN path testing, in case `TEST_COUNT_INITIAL_PHASE` ECN probes get lost, ECN is disabled.

https://github.com/mozilla/neqo/blob/a62c14068ad603f878f13a354f9ce0eddf97231b/neqo-transport/src/ecn.rs#L21-L25

Though only if `*probes_sent == *probes_lost`.

https://github.com/mozilla/neqo/blob/a62c14068ad603f878f13a354f9ce0eddf97231b/neqo-transport/src/ecn.rs#L241-L246

Say that a Neqo client has sent 2 ECN marked packets, i.e. probes, each of them eventually declared lost. Next the client sends two more packets, each again marked.

When the first of the two is declared lost, `probes_sent` is `4` and `probes_lost` is `3`, thus ECN is not disabled.

When the second of the two is declared lost, `probes_sent` is `4` and `probes_lost` is `4`. Given that `probes_lost` is not `== TEST_COUNT_INITIAL_PHASE`, ECN is once more not disabled.

**Solution**

(Alternative to https://github.com/mozilla/neqo/pull/2588.)

With this patch `neqo_transport::ecn` keeps track of ACKed marked packets. Instead of requiring `*probes_sent == *probes_lost`, only disable ECN if no marked packet has been acked already.

Note that as of now, this patch isn't relevant yet, as path probing is done at connection establishment time and thus `MAX_PATH_PROBES` already disables ECN marking beforehand.

https://github.com/mozilla/neqo/blob/a62c14068ad603f878f13a354f9ce0eddf97231b/neqo-transport/src/path.rs#L32-L36

That said, this will become relevant once we start ECN validation only after the handshake (https://github.com/mozilla/neqo/pull/2560).

---

@larseggert thank you for the suggestion in https://github.com/mozilla/neqo/pull/2588#issuecomment-2809048830. Is this what you had in mind?

Closes https://github.com/mozilla/neqo/pull/2588.