### PR TITLE
perf: use GSO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ enumset = { version = "1.1", default-features = false }
 hex = { version = "0.4", default-features = false }
 log = { version = "0.4", default-features = false }
 qlog = { version = "0.15.1", default-features = false }
-quinn-udp = { version = "0.5.11", default-features = false, features = ["direct-log"] }
+quinn-udp = { version = "0.5.13", default-features = false, features = ["direct-log"] }
 regex = { version = "1.9", default-features = false }
 rustc-hash = { version = "2.1", default-features = false, features = [ "std" ]}
 static_assertions = { version = "1.1", default-features = false }

--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -15,6 +15,7 @@ use std::{
     fs::File,
     io::{BufWriter, Write as _},
     net::SocketAddr,
+    num::NonZeroUsize,
     path::PathBuf,
     rc::Rc,
     time::Instant,
@@ -24,7 +25,7 @@ use neqo_common::{event::Provider, qdebug, qinfo, qwarn, Datagram};
 use neqo_crypto::{AuthenticationStatus, ResumptionToken};
 use neqo_transport::{
     CloseReason, Connection, ConnectionEvent, ConnectionIdGenerator, EmptyConnectionIdGenerator,
-    Error, Output, RandomConnectionIdGenerator, State, StreamId, StreamType,
+    Error, OutputBatch, RandomConnectionIdGenerator, State, StreamId, StreamType,
 };
 use rustc_hash::FxHashMap as HashMap;
 use url::Url;
@@ -191,8 +192,12 @@ impl TryFrom<&State> for CloseState {
 }
 
 impl super::Client for Connection {
-    fn process_output(&mut self, now: Instant) -> Output {
-        self.process_output(now)
+    fn process_multiple_output(
+        &mut self,
+        now: Instant,
+        max_datagrams: NonZeroUsize,
+    ) -> OutputBatch {
+        self.process_multiple_output(now, max_datagrams)
     }
 
     fn process_multiple_input<'a>(

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -15,6 +15,7 @@ use std::{
     fs::File,
     io::{BufWriter, Write as _},
     net::SocketAddr,
+    num::NonZeroUsize,
     path::PathBuf,
     rc::Rc,
     time::Instant,
@@ -24,8 +25,8 @@ use neqo_common::{event::Provider, hex, qdebug, qerror, qinfo, qwarn, Datagram, 
 use neqo_crypto::{AuthenticationStatus, ResumptionToken};
 use neqo_http3::{Error, Http3Client, Http3ClientEvent, Http3Parameters, Http3State, Priority};
 use neqo_transport::{
-    AppError, CloseReason, Connection, EmptyConnectionIdGenerator, Error as TransportError, Output,
-    RandomConnectionIdGenerator, StreamId,
+    AppError, CloseReason, Connection, EmptyConnectionIdGenerator, Error as TransportError,
+    OutputBatch, RandomConnectionIdGenerator, StreamId,
 };
 use rustc_hash::FxHashMap as HashMap;
 use url::Url;
@@ -134,8 +135,12 @@ impl super::Client for Http3Client {
         self.state().try_into()
     }
 
-    fn process_output(&mut self, now: Instant) -> Output {
-        self.process_output(now)
+    fn process_multiple_output(
+        &mut self,
+        now: Instant,
+        max_datagrams: NonZeroUsize,
+    ) -> OutputBatch {
+        self.process_multiple_output(now, max_datagrams)
     }
 
     fn process_multiple_input<'a>(

--- a/neqo-bin/src/server/http09.rs
+++ b/neqo-bin/src/server/http09.rs
@@ -10,6 +10,7 @@ use std::{
     borrow::Cow,
     cell::RefCell,
     fmt::{self, Display, Formatter},
+    num::NonZeroUsize,
     rc::Rc,
     slice, str,
     time::Instant,
@@ -20,7 +21,7 @@ use neqo_crypto::{generate_ech_keys, random, AllowZeroRtt, AntiReplay};
 use neqo_http3::Error;
 use neqo_transport::{
     server::{ConnectionRef, Server, ValidateAddress},
-    ConnectionEvent, ConnectionIdGenerator, Output, State, StreamId,
+    ConnectionEvent, ConnectionIdGenerator, OutputBatch, State, StreamId,
 };
 use regex::Regex;
 use rustc_hash::FxHashMap as HashMap;
@@ -200,8 +201,13 @@ impl HttpServer {
 }
 
 impl super::HttpServer for HttpServer {
-    fn process(&mut self, dgram: Option<Datagram<&mut [u8]>>, now: Instant) -> Output {
-        self.server.process(dgram, now)
+    fn process_multiple(
+        &mut self,
+        dgram: Option<Datagram<&mut [u8]>>,
+        now: Instant,
+        max_datagrams: NonZeroUsize,
+    ) -> OutputBatch {
+        self.server.process_multiple(dgram, now, max_datagrams)
     }
 
     fn process_events(&mut self, now: Instant) {

--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -9,6 +9,7 @@
 use std::{
     cell::RefCell,
     fmt::{self, Display},
+    num::NonZeroUsize,
     rc::Rc,
     slice,
     time::Instant,
@@ -19,7 +20,7 @@ use neqo_crypto::{generate_ech_keys, random, AntiReplay};
 use neqo_http3::{
     Http3OrWebTransportStream, Http3Parameters, Http3Server, Http3ServerEvent, StreamId,
 };
-use neqo_transport::{server::ValidateAddress, ConnectionIdGenerator};
+use neqo_transport::{server::ValidateAddress, ConnectionIdGenerator, OutputBatch};
 use rustc_hash::FxHashMap as HashMap;
 
 use super::{qns_read_response, Args};
@@ -82,8 +83,13 @@ impl Display for HttpServer {
 }
 
 impl super::HttpServer for HttpServer {
-    fn process(&mut self, dgram: Option<Datagram<&mut [u8]>>, now: Instant) -> neqo_http3::Output {
-        self.server.process(dgram, now)
+    fn process_multiple(
+        &mut self,
+        dgram: Option<Datagram<&mut [u8]>>,
+        now: Instant,
+        max_datagrams: NonZeroUsize,
+    ) -> OutputBatch {
+        self.server.process_multiple(dgram, now, max_datagrams)
     }
 
     fn process_events(&mut self, _now: Instant) {

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -8,7 +8,7 @@
 
 use std::{io, net::SocketAddr};
 
-use neqo_common::{qdebug, Datagram};
+use neqo_common::{qdebug, DatagramBatch};
 use neqo_udp::{DatagramIter, RecvBuf};
 
 /// Ideally this would live in [`neqo-udp`]. [`neqo-udp`] is used in Firefox.
@@ -79,8 +79,8 @@ impl Socket {
         self.inner.readable().await
     }
 
-    /// Send a [`Datagram`] on the given [`Socket`].
-    pub fn send(&self, d: &Datagram) -> io::Result<()> {
+    /// Send a [`DatagramBatch`] on the given [`Socket`].
+    pub fn send(&self, d: &DatagramBatch) -> io::Result<()> {
         self.inner.try_io(tokio::io::Interest::WRITABLE, || {
             neqo_udp::send_inner(&self.state, (&self.inner).into(), d)
         })
@@ -105,5 +105,9 @@ impl Socket {
                     Err(e)
                 }
             })
+    }
+
+    pub fn max_gso_segments(&self) -> usize {
+        self.state.max_gso_segments()
     }
 }

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -86,7 +86,7 @@ impl Socket {
         })
     }
 
-    /// Receive a batch of [`Datagram`]s on the given [`Socket`], each set with
+    /// Receive a batch of [`neqo_common::Datagram`]s on the given [`Socket`], each set with
     /// the provided local address.
     pub fn recv<'a>(
         &self,

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -133,7 +133,7 @@ impl<D: AsRef<[u8]>> AsRef<[u8]> for Datagram<D> {
     }
 }
 
-/// A batch of [`Datagram`]s with same metadata, e.g. destination.
+/// A batch of [`Datagram`]s with the same metadata, e.g., destination.
 ///
 /// Upholds Linux GSO requirement. That is, all but the last datagram in the
 /// batch have the same size. The last datagram may be equal or smaller.

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -173,13 +173,16 @@ impl From<Datagram<Vec<u8>>> for DatagramBatch {
 }
 
 impl DatagramBatch {
-    /// Maximum [`DatagramBatch`] size.
+    /// Maximum [`DatagramBatch`] size in bytes.
     ///
-    /// Value chosen to support batch IO system calls on all supported platforms.
+    /// This value is set conservatively to ensure compatibility with batch IO
+    /// system calls across all supported platforms.
     ///
     /// See for example Linux limit in
     /// <https://github.com/torvalds/linux/blob/fb4d33ab452ea254e2c319bac5703d1b56d895bf/include/linux/netdevice.h#L2402>.
-    pub const MAX: usize = 65536;
+    pub const MAX: usize = 65535 // maximum UDP datagram size
+        - 40 // IPv6 header
+        - 8; // UDP header
 
     #[must_use]
     pub const fn new(

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -142,7 +142,7 @@ pub struct DatagramBatch {
     src: SocketAddr,
     dst: SocketAddr,
     tos: Tos,
-    segment_size: usize,
+    datagram_size: usize,
     d: Vec<u8>,
 }
 
@@ -154,7 +154,7 @@ impl Debug for DatagramBatch {
             self.tos,
             self.src,
             self.dst,
-            self.segment_size,
+            self.datagram_size,
             hex_with_len(&self.d)
         )
     }
@@ -166,7 +166,7 @@ impl From<Datagram<Vec<u8>>> for DatagramBatch {
             src: d.src,
             dst: d.dst,
             tos: d.tos,
-            segment_size: d.d.len(),
+            datagram_size: d.d.len(),
             d: d.d,
         }
     }
@@ -189,14 +189,14 @@ impl DatagramBatch {
         src: SocketAddr,
         dst: SocketAddr,
         tos: Tos,
-        segment_size: usize,
+        datagram_size: usize,
         d: Vec<u8>,
     ) -> Self {
         Self {
             src,
             dst,
             tos,
-            segment_size,
+            datagram_size,
             d,
         }
     }
@@ -218,7 +218,7 @@ impl DatagramBatch {
 
     #[must_use]
     pub const fn datagram_size(&self) -> usize {
-        self.segment_size
+        self.datagram_size
     }
 
     #[must_use]
@@ -228,12 +228,12 @@ impl DatagramBatch {
 
     #[must_use]
     pub fn num_datagrams(&self) -> usize {
-        self.d.len().div_ceil(self.segment_size)
+        self.d.len().div_ceil(self.datagram_size)
     }
 
     #[cfg(feature = "build-fuzzing-corpus")]
     pub fn iter(&self) -> impl Iterator<Item = &[u8]> {
-        self.d.chunks(self.segment_size)
+        self.d.chunks(self.datagram_size)
     }
 }
 

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -227,6 +227,11 @@ impl DatagramBatch {
     pub fn num_datagrams(&self) -> usize {
         self.d.len().div_ceil(self.segment_size)
     }
+
+    #[cfg(feature = "build-fuzzing-corpus")]
+    pub fn iter(&self) -> impl Iterator<Item = &[u8]> {
+        self.d.chunks(self.segment_size)
+    }
 }
 
 #[cfg(test)]

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -25,7 +25,7 @@ use strum::Display;
 pub use self::fuzz::write_item_to_fuzzing_corpus;
 pub use self::{
     codec::{Buffer, Decoder, Encoder, MAX_VARINT},
-    datagram::Datagram,
+    datagram::{Datagram, DatagramBatch},
     header::Header,
     incrdecoder::{IncrementalDecoderBuffer, IncrementalDecoderIgnore, IncrementalDecoderUint},
     tos::{IpTos, IpTosDscp, IpTosEcn},

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -922,7 +922,7 @@ impl Http3Client {
         }
     }
 
-    /// Wrapper around [`Http3Server::process_multiple_output`] that processes a single
+    /// Wrapper around [`Http3Client::process_multiple_output`] that processes a single
     /// output datagram only.
     #[expect(clippy::missing_panics_doc, reason = "see expect()")]
     pub fn process_output(&mut self, now: Instant) -> Output {

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -9,6 +9,7 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
     iter,
     net::SocketAddr,
+    num::NonZeroUsize,
     rc::Rc,
     time::Instant,
 };
@@ -21,8 +22,8 @@ use neqo_crypto::{agent::CertificateInfo, AuthenticationStatus, ResumptionToken,
 use neqo_qpack::Stats as QpackStats;
 use neqo_transport::{
     streams::SendOrder, AppError, Connection, ConnectionEvent, ConnectionId, ConnectionIdGenerator,
-    DatagramTracking, Output, RecvStreamStats, SendStreamStats, Stats as TransportStats, StreamId,
-    StreamType, Version, ZeroRttState,
+    DatagramTracking, Output, OutputBatch, RecvStreamStats, SendStreamStats,
+    Stats as TransportStats, StreamId, StreamType, Version, ZeroRttState,
 };
 
 use crate::{
@@ -915,16 +916,25 @@ impl Http3Client {
         }
     }
 
-    /// The function should be called to check if there is a new UDP packet to be sent. It should
+    /// Wrapper around [`Http3Server::process_multiple_output`] that processes a single
+    /// output datagram only.
+    #[expect(clippy::missing_panics_doc, reason = "see expect()")]
+    pub fn process_output(&mut self, now: Instant) -> Output {
+        self.process_multiple_output(now, 1.try_into().expect(">0"))
+            .try_into()
+            .expect("max_datagrams is 1")
+    }
+
+    /// The function should be called to check if there are new UDP packets to be sent. It should
     /// be called after a new packet is received and processed and after a timer expires (QUIC
     /// needs timers to handle events like PTO detection and timers are not implemented by the neqo
     /// library, but instead must be driven by the application).
     ///
-    /// `process_output` can return:
-    /// - a [`Output::Datagram(Datagram)`][1]: data that should be sent as a UDP payload,
-    /// - a [`Output::Callback(Duration)`][1]: the duration of a  timer. `process_output` should be
-    ///   called at least after the time expires,
-    /// - [`Output::None`][1]: this is returned when `Http3Client` is done and can be destroyed.
+    /// [`Http3Client::process_multiple_output`] can return:
+    /// - a [`OutputBatch::Datagram(Datagram)`]: data that should be sent as a UDP payload,
+    /// - a [`OutputBatch::Callback(Duration)`]: the duration of a  timer. `process_output` should
+    ///   be called at least after the time expires,
+    /// - [`OutputBatch::None`]: this is returned when `Http3Client` is done and can be destroyed.
     ///
     /// The application should call this function repeatedly until a timer value or None is
     /// returned. After that, the application should call the function again if a new UDP packet is
@@ -942,13 +952,17 @@ impl Http3Client {
     /// [1]: ../neqo_transport/enum.Output.html
     /// [2]: ../neqo_transport/struct.ConnectionEvents.html
     /// [3]: ../neqo_transport/struct.Connection.html#method.process_output
-    pub fn process_output(&mut self, now: Instant) -> Output {
+    pub fn process_multiple_output(
+        &mut self,
+        now: Instant,
+        max_datagrams: NonZeroUsize,
+    ) -> OutputBatch {
         qtrace!("[{self}] Process output");
 
         // Maybe send() stuff on http3-managed streams
         self.process_http3(now);
 
-        let out = self.conn.process_output(now);
+        let out = self.conn.process_multiple_output(now, max_datagrams);
 
         // Update H3 for any transport state changes and events
         self.process_http3(now);

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -7,6 +7,7 @@
 use std::{
     cell::{RefCell, RefMut},
     fmt::{self, Display, Formatter},
+    num::NonZeroUsize,
     path::PathBuf,
     rc::Rc,
     time::Instant,
@@ -16,7 +17,7 @@ use neqo_common::{qtrace, Datagram};
 use neqo_crypto::{AntiReplay, Cipher, PrivateKey, PublicKey, ZeroRttChecker};
 use neqo_transport::{
     server::{ConnectionRef, Server, ValidateAddress},
-    ConnectionIdGenerator, Output,
+    ConnectionIdGenerator, Output, OutputBatch,
 };
 use rustc_hash::FxHashMap as HashMap;
 
@@ -117,21 +118,37 @@ impl Http3Server {
         self.process(None::<Datagram>, now)
     }
 
+    /// Wrapper around [`Http3Server::process_multiple`] that processes a single
+    /// output datagram only.
+    #[expect(clippy::missing_panics_doc, reason = "see expect()")]
     pub fn process<A: AsRef<[u8]> + AsMut<[u8]>>(
         &mut self,
         dgram: Option<Datagram<A>>,
         now: Instant,
     ) -> Output {
+        self.process_multiple(dgram, now, 1.try_into().expect(">0"))
+            .try_into()
+            .expect("max_datagrams is 1")
+    }
+
+    pub fn process_multiple(
+        &mut self,
+        dgram: Option<Datagram<impl AsRef<[u8]> + AsMut<[u8]>>>,
+        now: Instant,
+        max_datagrams: NonZeroUsize,
+    ) -> OutputBatch {
         qtrace!("[{self}] Process");
-        let out = self.server.process(dgram, now);
+        let out = self.server.process_multiple(dgram, now, max_datagrams);
         self.process_http3(now);
         // If we do not that a dgram already try again after process_http3.
         match out {
-            Output::Datagram(d) => {
+            OutputBatch::DatagramBatch(d) => {
                 qtrace!("[{self}] Send packet: {d:?}");
-                Output::Datagram(d)
+                OutputBatch::DatagramBatch(d)
             }
-            _ => self.server.process(Option::<Datagram>::None, now),
+            _ => self
+                .server
+                .process_multiple(Option::<Datagram>::None, now, max_datagrams),
         }
     }
 

--- a/neqo-transport/src/ackrate.rs
+++ b/neqo-transport/src/ackrate.rs
@@ -8,7 +8,7 @@
 
 use std::{cmp::max, time::Duration};
 
-use neqo_common::qtrace;
+use neqo_common::{qtrace, Buffer};
 
 use crate::{
     connection::params::ACK_RATIO_SCALE, frame::FrameType, packet::PacketBuilder,
@@ -41,7 +41,7 @@ impl AckRate {
         Self { packets, delay }
     }
 
-    pub fn write_frame(&self, builder: &mut PacketBuilder, seqno: u64) -> bool {
+    pub fn write_frame<B: Buffer>(&self, builder: &mut PacketBuilder<B>, seqno: u64) -> bool {
         builder.write_varint_frame(&[
             u64::from(FrameType::AckFrequency),
             seqno,
@@ -97,9 +97,9 @@ impl FlexibleAckRate {
         }
     }
 
-    fn write_frames(
+    fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
@@ -163,9 +163,9 @@ impl PeerAckDelay {
         ))
     }
 
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{qinfo, qtrace, Decoder, Encoder, Role};
+use neqo_common::{qinfo, qtrace, Buffer, Decoder, Encoder, Role};
 use neqo_crypto::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
     selfencrypt::SelfEncrypt,
@@ -338,9 +338,9 @@ impl NewTokenState {
 
     /// If this is a server, maybe send a frame.
     /// If this is a client, do nothing.
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
@@ -412,9 +412,9 @@ impl NewTokenSender {
         self.next_seqno += 1;
     }
 
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -15,7 +15,7 @@ use std::{
     rc::Rc,
 };
 
-use neqo_common::{hex, hex_with_len, qdebug, qinfo, Decoder, Encoder};
+use neqo_common::{hex, hex_with_len, qdebug, qinfo, Buffer, Decoder, Encoder};
 use neqo_crypto::{random, randomize};
 use smallvec::{smallvec, SmallVec};
 
@@ -300,7 +300,7 @@ impl ConnectionIdEntry<[u8; 16]> {
 
     /// Write the entry out in a `NEW_CONNECTION_ID` frame.
     /// Returns `true` if the frame was written, `false` if there is insufficient space.
-    pub fn write(&self, builder: &mut PacketBuilder, stats: &mut FrameStats) -> bool {
+    pub fn write<B: Buffer>(&self, builder: &mut PacketBuilder<B>, stats: &mut FrameStats) -> bool {
         let len = 1 + Encoder::varint_len(self.seqno) + 1 + 1 + self.cid.len() + 16;
         if builder.remaining() < len {
             return false;
@@ -550,9 +550,9 @@ impl ConnectionIdManager {
         );
     }
 
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1284,8 +1284,10 @@ impl Connection {
         let output = self.process_multiple_output(now, max_datagrams);
         #[cfg(all(feature = "build-fuzzing-corpus", test))]
         if self.test_frame_writer.is_none() {
-            if let Some(d) = output.clone().dgram() {
-                neqo_common::write_item_to_fuzzing_corpus("packet", &d);
+            if let OutputBatch::DatagramBatch(batch) = &output {
+                for dgram in batch.iter() {
+                    neqo_common::write_item_to_fuzzing_corpus("packet", &dgram);
+                }
             }
         }
         output

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1099,7 +1099,7 @@ impl Connection {
         self.cid_manager.is_valid(cid)
     }
 
-    /// Process new input datagram on the connection.
+    /// Process a new input datagram on the connection.
     pub fn process_input<A: AsRef<[u8]> + AsMut<[u8]>>(&mut self, d: Datagram<A>, now: Instant) {
         self.process_multiple_input(iter::once(d), now);
     }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1285,7 +1285,7 @@ impl Connection {
         if self.test_frame_writer.is_none() {
             if let OutputBatch::DatagramBatch(batch) = &output {
                 for dgram in batch.iter() {
-                    neqo_common::write_item_to_fuzzing_corpus("packet", &dgram);
+                    neqo_common::write_item_to_fuzzing_corpus("packet", dgram);
                 }
             }
         }

--- a/neqo-transport/src/connection/state.rs
+++ b/neqo-transport/src/connection/state.rs
@@ -6,7 +6,7 @@
 
 use std::{cmp::min, rc::Rc, time::Instant};
 
-use neqo_common::Encoder;
+use neqo_common::{Buffer, Encoder};
 
 use crate::{
     frame::FrameType, packet::PacketBuilder, path::PathRef, recovery::RecoveryToken, CloseReason,
@@ -120,7 +120,7 @@ impl ClosingFrame {
     /// the value.
     pub const MIN_LENGTH: usize = 1 + 8 + 8 + 2 + 8;
 
-    pub fn write_frame(&self, builder: &mut PacketBuilder) {
+    pub fn write_frame<B: Buffer>(&self, builder: &mut PacketBuilder<B>) {
         if builder.remaining() < Self::MIN_LENGTH {
             return;
         }
@@ -176,7 +176,10 @@ impl StateSignaling {
         *self = Self::HandshakeDone;
     }
 
-    pub fn write_done(&mut self, builder: &mut PacketBuilder) -> Option<RecoveryToken> {
+    pub fn write_done<B: Buffer>(
+        &mut self,
+        builder: &mut PacketBuilder<B>,
+    ) -> Option<RecoveryToken> {
         (matches!(self, Self::HandshakeDone) && builder.remaining() >= 1).then(|| {
             *self = Self::Idle;
             builder.encode_varint(FrameType::HandshakeDone);

--- a/neqo-transport/src/connection/test_internal.rs
+++ b/neqo-transport/src/connection/test_internal.rs
@@ -9,5 +9,5 @@
 use crate::packet::PacketBuilder;
 
 pub trait FrameWriter {
-    fn write_frames(&mut self, builder: &mut PacketBuilder);
+    fn write_frames(&mut self, builder: &mut PacketBuilder<&mut Vec<u8>>);
 }

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -43,7 +43,7 @@ struct InsertDatagram<'a> {
 }
 
 impl crate::connection::test_internal::FrameWriter for InsertDatagram<'_> {
-    fn write_frames(&mut self, builder: &mut PacketBuilder) {
+    fn write_frames(&mut self, builder: &mut PacketBuilder<&mut Vec<u8>>) {
         builder.encode_varint(FrameType::Datagram);
         builder.encode(self.data);
     }
@@ -605,7 +605,7 @@ fn multiple_quic_datagrams_in_one_packet() {
 fn datagram_fill() {
     struct PanickingFrameWriter {}
     impl crate::connection::test_internal::FrameWriter for PanickingFrameWriter {
-        fn write_frames(&mut self, builder: &mut PacketBuilder) {
+        fn write_frames(&mut self, builder: &mut PacketBuilder<&mut Vec<u8>>) {
             panic!(
                 "builder invoked with {} bytes remaining",
                 builder.remaining()
@@ -616,7 +616,7 @@ fn datagram_fill() {
         called: Rc<RefCell<bool>>,
     }
     impl crate::connection::test_internal::FrameWriter for TrackingFrameWriter {
-        fn write_frames(&mut self, builder: &mut PacketBuilder) {
+        fn write_frames(&mut self, builder: &mut PacketBuilder<&mut Vec<u8>>) {
             assert_eq!(builder.remaining(), 2);
             *self.called.borrow_mut() = true;
         }

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -1041,7 +1041,7 @@ struct RetireAll {
 }
 
 impl crate::connection::test_internal::FrameWriter for RetireAll {
-    fn write_frames(&mut self, builder: &mut PacketBuilder) {
+    fn write_frames(&mut self, builder: &mut PacketBuilder<&mut Vec<u8>>) {
         // Use a sequence number that is large enough that all existing values
         // will be lower (so they get retired).  As the code doesn't care about
         // gaps in sequence numbers, this is safe, even though the gap might
@@ -1203,7 +1203,7 @@ fn retire_prior_to_migration_success() {
 struct GarbageWriter {}
 
 impl crate::connection::test_internal::FrameWriter for GarbageWriter {
-    fn write_frames(&mut self, builder: &mut PacketBuilder) {
+    fn write_frames(&mut self, builder: &mut PacketBuilder<&mut Vec<u8>>) {
         // Not a valid frame type.
         builder.encode_varint(u32::MAX);
     }

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -181,7 +181,7 @@ pub fn rttvar_after_n_updates(n: usize, rtt: Duration) -> Duration {
 struct PingWriter {}
 
 impl test_internal::FrameWriter for PingWriter {
-    fn write_frames(&mut self, builder: &mut PacketBuilder) {
+    fn write_frames(&mut self, builder: &mut PacketBuilder<&mut Vec<u8>>) {
         builder.encode_varint(FrameType::Ping);
     }
 }

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -910,7 +910,7 @@ fn ack_for_unsent() {
     struct AckforUnsentWriter {}
 
     impl FrameWriter for AckforUnsentWriter {
-        fn write_frames(&mut self, builder: &mut PacketBuilder) {
+        fn write_frames(&mut self, builder: &mut PacketBuilder<&mut Vec<u8>>) {
             builder.encode_varint(FrameType::Ack);
             builder.encode_varint(666u16); // Largest ACKed
             builder.encode_varint(0u8); // ACK delay

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -532,7 +532,7 @@ fn do_not_accept_data_after_stop_sending() {
 struct Writer(Vec<u64>);
 
 impl crate::connection::test_internal::FrameWriter for Writer {
-    fn write_frames(&mut self, builder: &mut PacketBuilder) {
+    fn write_frames(&mut self, builder: &mut PacketBuilder<&mut Vec<u8>>) {
         builder.write_varint_frame(&self.0);
     }
 }

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use enum_map::EnumMap;
-use neqo_common::{hex, hex_snip_middle, qdebug, qinfo, qtrace, Encoder, Role};
+use neqo_common::{hex, hex_snip_middle, qdebug, qinfo, qtrace, Buffer, Encoder, Role};
 pub use neqo_crypto::Epoch;
 use neqo_crypto::{
     hkdf, hp::HpKey, Aead, Agent, AntiReplay, Cipher, Error as CryptoError, HandshakeState,
@@ -314,11 +314,11 @@ impl Crypto {
         Ok(())
     }
 
-    pub fn write_frame(
+    pub fn write_frame<B: Buffer>(
         &mut self,
         space: PacketNumberSpace,
         sni_slicing: bool,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
@@ -1506,18 +1506,18 @@ impl CryptoStreams {
         }
     }
 
-    pub fn write_frame(
+    pub fn write_frame<B: Buffer>(
         &mut self,
         space: PacketNumberSpace,
         sni_slicing: bool,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
-        fn write_chunk(
+        fn write_chunk<B: Buffer>(
             offset: u64,
             data: &[u8],
-            builder: &mut PacketBuilder,
+            builder: &mut PacketBuilder<B>,
         ) -> Option<(u64, usize)> {
             let mut header_len = 1 + Encoder::varint_len(offset) + 1;
 

--- a/neqo-transport/src/ecn.rs
+++ b/neqo-transport/src/ecn.rs
@@ -342,7 +342,7 @@ impl Info {
         }
     }
 
-    /// The ECN mark ([`IpTosEcn`]) to use for an outgoing UDP datagram.
+    /// The ECN mark ([`Ecn`]) to use for an outgoing UDP datagram.
     pub(crate) const fn ecn_mark(&self) -> Ecn {
         if self.is_marking() {
             Ecn::Ect0

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -15,7 +15,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{qdebug, qtrace, Role, MAX_VARINT};
+use neqo_common::{qdebug, qtrace, Buffer, Role, MAX_VARINT};
 
 use crate::{
     frame::FrameType,
@@ -142,9 +142,9 @@ where
 }
 
 impl SenderFlowControl<()> {
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
@@ -161,9 +161,9 @@ impl SenderFlowControl<()> {
 }
 
 impl SenderFlowControl<StreamId> {
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
@@ -187,9 +187,9 @@ impl SenderFlowControl<StreamId> {
 }
 
 impl SenderFlowControl<StreamType> {
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
@@ -323,9 +323,9 @@ where
 }
 
 impl ReceiverFlowControl<()> {
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
@@ -365,9 +365,9 @@ impl ReceiverFlowControl<()> {
 }
 
 impl ReceiverFlowControl<StreamId> {
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
         now: Instant,
@@ -477,9 +477,9 @@ impl ReceiverFlowControl<StreamId> {
 }
 
 impl ReceiverFlowControl<StreamType> {
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -62,7 +62,7 @@ pub use self::{
     },
     connection::{
         params::{ConnectionParameters, ACK_RATIO_SCALE},
-        Connection, Output, State, ZeroRttState,
+        Connection, Output, OutputBatch, State, ZeroRttState,
     },
     events::{ConnectionEvent, ConnectionEvents},
     frame::CloseError,

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use enum_map::Enum;
-use neqo_common::{hex, hex_with_len, qtrace, qwarn, Decoder, Encoder};
+use neqo_common::{hex, hex_with_len, qtrace, qwarn, Buffer, Decoder, Encoder};
 use neqo_crypto::{random, Aead};
 use strum::{EnumIter, FromRepr};
 
@@ -136,8 +136,8 @@ struct PacketBuilderOffsets {
 
 /// A packet builder that can be used to produce short packets and long packets.
 /// This does not produce Retry or Version Negotiation.
-pub struct PacketBuilder {
-    encoder: Encoder,
+pub struct PacketBuilder<B = Vec<u8>> {
+    encoder: Encoder<B>,
     pn: PacketNumber,
     header: Range<usize>,
     offsets: PacketBuilderOffsets,
@@ -150,6 +150,78 @@ impl PacketBuilder {
     /// The minimum useful frame size.  If space is less than this, we will claim to be full.
     pub const MINIMUM_FRAME_SIZE: usize = 2;
 
+    /// Make a retry packet.
+    /// As this is a simple packet, this is just an associated function.
+    /// As Retry is odd (it has to be constructed with leading bytes),
+    /// this returns a [`Vec<u8>`] rather than building on an encoder.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if AEAD encrypt fails.
+    pub fn retry(
+        version: Version,
+        dcid: &[u8],
+        scid: &[u8],
+        token: &[u8],
+        odcid: &[u8],
+    ) -> Res<Vec<u8>> {
+        let mut encoder = Encoder::default();
+        encoder.encode_vec(1, odcid);
+        let start = encoder.len();
+        encoder.encode_byte(
+            PACKET_BIT_LONG
+                | PACKET_BIT_FIXED_QUIC
+                | (PacketType::Retry.to_byte(version) << 4)
+                | (random::<1>()[0] & 0xf),
+        );
+        encoder.encode_uint(4, version.wire_version());
+        encoder.encode_vec(1, dcid);
+        encoder.encode_vec(1, scid);
+        debug_assert_ne!(token.len(), 0);
+        encoder.encode(token);
+        let tag = retry::use_aead(version, |aead| {
+            let mut buf = vec![0; Aead::expansion()];
+            Ok(aead.encrypt(0, encoder.as_ref(), &[], &mut buf)?.to_vec())
+        })?;
+        encoder.encode(&tag);
+        let mut complete: Vec<u8> = encoder.into();
+        Ok(complete.split_off(start))
+    }
+
+    /// Make a Version Negotiation packet.
+    #[must_use]
+    pub fn version_negotiation(
+        dcid: &[u8],
+        scid: &[u8],
+        client_version: u32,
+        versions: &[Version],
+    ) -> Vec<u8> {
+        let mut encoder = Encoder::default();
+        let mut grease = random::<4>();
+        // This will not include the "QUIC bit" sometimes.  Intentionally.
+        encoder.encode_byte(PACKET_BIT_LONG | (grease[3] & 0x7f));
+        encoder.encode(&[0; 4]); // Zero version == VN.
+        encoder.encode_vec(1, dcid);
+        encoder.encode_vec(1, scid);
+
+        for v in versions {
+            encoder.encode_uint(4, v.wire_version());
+        }
+        // Add a greased version, using the randomness already generated.
+        for g in &mut grease[..3] {
+            *g = *g & 0xf0 | 0x0a;
+        }
+
+        // Ensure our greased version does not collide with the client version
+        // by making the last byte differ from the client initial.
+        grease[3] = (client_version.wrapping_add(0x10) & 0xf0) as u8 | 0x0a;
+        encoder.encode(&grease[..4]);
+
+        Vec::from(encoder)
+    }
+}
+
+impl<B: Buffer> PacketBuilder<B> {
     /// Start building a short header packet.
     ///
     /// This doesn't fail if there isn't enough space; instead it returns a builder that
@@ -160,7 +232,7 @@ impl PacketBuilder {
     /// If, after calling this method, `remaining()` returns 0, then call `abort()` to get
     /// the encoder back.
     pub fn short<A: AsRef<[u8]>>(
-        mut encoder: Encoder,
+        mut encoder: Encoder<B>,
         key_phase: bool,
         dcid: Option<A>,
         limit: usize,
@@ -201,7 +273,7 @@ impl PacketBuilder {
     ///
     /// See `short()` for more on how to handle this in cases where there is no space.
     pub fn long<A: AsRef<[u8]>, A1: AsRef<[u8]>>(
-        mut encoder: Encoder,
+        mut encoder: Encoder<B>,
         pt: PacketType,
         version: Version,
         mut dcid: Option<A>,
@@ -262,19 +334,19 @@ impl PacketBuilder {
     /// How many bytes remain against the size limit for the builder.
     #[must_use]
     pub fn remaining(&self) -> usize {
-        self.limit.saturating_sub(self.encoder.len())
+        self.limit.saturating_sub(self.len())
     }
 
     /// Returns true if the packet has no more space for frames.
     #[must_use]
     pub fn is_full(&self) -> bool {
         // No useful frame is smaller than 2 bytes long.
-        self.limit < self.encoder.len() + Self::MINIMUM_FRAME_SIZE
+        self.limit < self.len() + PacketBuilder::MINIMUM_FRAME_SIZE
     }
 
     /// Adjust the limit to ensure that no more data is added.
     pub fn mark_full(&mut self) {
-        self.limit = self.encoder.len();
+        self.limit = self.len();
     }
 
     /// Mark the packet as needing padding (or not).
@@ -395,7 +467,7 @@ impl PacketBuilder {
     /// # Errors
     ///
     /// This will return an error if the packet is too large.
-    pub fn build(mut self, crypto: &mut CryptoDxState) -> Res<Encoder> {
+    pub fn build(mut self, crypto: &mut CryptoDxState) -> Res<Encoder<B>> {
         if self.len() > self.limit {
             qwarn!("Packet contents are more than the limit");
             debug_assert!(false);
@@ -439,7 +511,7 @@ impl PacketBuilder {
 
     /// Abort writing of this packet and return the encoder.
     #[must_use]
-    pub fn abort(mut self) -> Encoder {
+    pub fn abort(mut self) -> Encoder<B> {
         self.encoder.truncate(self.header.start);
         self.encoder
     }
@@ -450,93 +522,31 @@ impl PacketBuilder {
         self.encoder.len() == self.header.end
     }
 
-    /// Make a retry packet.
-    /// As this is a simple packet, this is just an associated function.
-    /// As Retry is odd (it has to be constructed with leading bytes),
-    /// this returns a [`Vec<u8>`] rather than building on an encoder.
-    ///
-    /// # Errors
-    ///
-    /// This will return an error if AEAD encrypt fails.
-    pub fn retry(
-        version: Version,
-        dcid: &[u8],
-        scid: &[u8],
-        token: &[u8],
-        odcid: &[u8],
-    ) -> Res<Vec<u8>> {
-        let mut encoder = Encoder::default();
-        encoder.encode_vec(1, odcid);
-        let start = encoder.len();
-        encoder.encode_byte(
-            PACKET_BIT_LONG
-                | PACKET_BIT_FIXED_QUIC
-                | (PacketType::Retry.to_byte(version) << 4)
-                | (random::<1>()[0] & 0xf),
-        );
-        encoder.encode_uint(4, version.wire_version());
-        encoder.encode_vec(1, dcid);
-        encoder.encode_vec(1, scid);
-        debug_assert_ne!(token.len(), 0);
-        encoder.encode(token);
-        let tag = retry::use_aead(version, |aead| {
-            let mut buf = vec![0; Aead::expansion()];
-            Ok(aead.encrypt(0, encoder.as_ref(), &[], &mut buf)?.to_vec())
-        })?;
-        encoder.encode(&tag);
-        let mut complete: Vec<u8> = encoder.into();
-        Ok(complete.split_off(start))
+    pub fn len(&self) -> usize {
+        self.encoder.len()
     }
 
-    /// Make a Version Negotiation packet.
-    #[must_use]
-    pub fn version_negotiation(
-        dcid: &[u8],
-        scid: &[u8],
-        client_version: u32,
-        versions: &[Version],
-    ) -> Vec<u8> {
-        let mut encoder = Encoder::default();
-        let mut grease = random::<4>();
-        // This will not include the "QUIC bit" sometimes.  Intentionally.
-        encoder.encode_byte(PACKET_BIT_LONG | (grease[3] & 0x7f));
-        encoder.encode(&[0; 4]); // Zero version == VN.
-        encoder.encode_vec(1, dcid);
-        encoder.encode_vec(1, scid);
-
-        for v in versions {
-            encoder.encode_uint(4, v.wire_version());
-        }
-        // Add a greased version, using the randomness already generated.
-        for g in &mut grease[..3] {
-            *g = *g & 0xf0 | 0x0a;
-        }
-
-        // Ensure our greased version does not collide with the client version
-        // by making the last byte differ from the client initial.
-        grease[3] = (client_version.wrapping_add(0x10) & 0xf0) as u8 | 0x0a;
-        encoder.encode(&grease[..4]);
-
-        Vec::from(encoder)
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }
 
-impl Deref for PacketBuilder {
-    type Target = Encoder;
+impl<B> Deref for PacketBuilder<B> {
+    type Target = Encoder<B>;
 
     fn deref(&self) -> &Self::Target {
         &self.encoder
     }
 }
 
-impl DerefMut for PacketBuilder {
+impl<B> DerefMut for PacketBuilder<B> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.encoder
     }
 }
 
-impl From<PacketBuilder> for Encoder {
-    fn from(v: PacketBuilder) -> Self {
+impl<B> From<PacketBuilder<B>> for Encoder<B> {
+    fn from(v: PacketBuilder<B>) -> Self {
         v.encoder
     }
 }

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -12,7 +12,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{hex, qdebug, qinfo, qlog::NeqoQlog, qtrace, qwarn, Datagram, Encoder, IpTos};
+use neqo_common::{
+    hex, qdebug, qinfo, qlog::NeqoQlog, qtrace, qwarn, Buffer, DatagramBatch, Encoder, IpTos,
+};
 use neqo_crypto::random;
 
 use crate::{
@@ -365,9 +367,9 @@ impl Paths {
     }
 
     /// Write out any `RETIRE_CONNECTION_ID` frames that are outstanding.
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
@@ -575,8 +577,8 @@ impl Path {
     }
 
     /// Return the DSCP/ECN marking to use for outgoing packets on this path.
-    pub fn tos(&self, tokens: &mut Vec<RecoveryToken>) -> IpTos {
-        self.ecn_info.ecn_mark(tokens).into()
+    pub fn tos(&self) -> IpTos {
+        self.ecn_info.ecn_mark().into()
     }
 
     /// Whether this path is the primary or current path for the connection.
@@ -686,17 +688,19 @@ impl Path {
     }
 
     /// Make a datagram.
-    pub fn datagram<V: Into<Vec<u8>>>(
+    pub fn datagram_batch(
         &mut self,
-        payload: V,
+        payload: Vec<u8>,
         tos: IpTos,
+        num_datagrams: usize,
+        datagram_size: usize,
         stats: &mut Stats,
-    ) -> Datagram {
+    ) -> DatagramBatch {
         // Make sure to use the TOS value from before calling ecn::Info::on_packet_sent, which may
         // update the ECN state and can hence change it - this packet should still be sent
         // with the current value.
-        self.ecn_info.on_packet_sent(stats);
-        Datagram::new(self.local, self.remote, tos, payload.into())
+        self.ecn_info.on_packet_sent(num_datagrams, stats);
+        DatagramBatch::new(self.local, self.remote, tos, datagram_size, payload)
     }
 
     /// Get local address as `SocketAddr`
@@ -769,9 +773,9 @@ impl Path {
         self.challenge.is_some() || self.state.probe_needed()
     }
 
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         stats: &mut FrameStats,
         mtu: bool, // Whether the packet we're writing into will be a full MTU.
         now: Instant,
@@ -819,9 +823,9 @@ impl Path {
     }
 
     /// Write `ACK_FREQUENCY` frames.
-    pub fn write_cc_frames(
+    pub fn write_cc_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {

--- a/neqo-transport/src/pmtud.rs
+++ b/neqo-transport/src/pmtud.rs
@@ -10,7 +10,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{qdebug, qinfo};
+use neqo_common::{qdebug, qinfo, Buffer};
 use static_assertions::const_assert;
 
 use crate::{frame::FrameType, packet::PacketBuilder, recovery::SentPacket, Stats};
@@ -117,7 +117,7 @@ impl Pmtud {
     }
 
     /// Sends a PMTUD probe.
-    pub fn send_probe(&mut self, builder: &mut PacketBuilder, stats: &mut Stats) {
+    pub fn send_probe<B: Buffer>(&mut self, builder: &mut PacketBuilder<B>, stats: &mut Stats) {
         // The packet may include ACK-eliciting data already, but rather than check for that, it
         // seems OK to burn one byte here to simply include a PING.
         builder.encode_varint(FrameType::Ping);

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -8,7 +8,7 @@
 
 use std::{cmp::min, collections::VecDeque};
 
-use neqo_common::Encoder;
+use neqo_common::{Buffer, Encoder};
 
 use crate::{
     events::OutgoingDatagramOutcome, frame::FrameType, packet::PacketBuilder,
@@ -97,9 +97,9 @@ impl QuicDatagrams {
     /// This function tries to write a datagram frame into a packet.
     /// If the frame does not fit into the packet, the datagram will
     /// be dropped and a `DatagramLost` event will be posted.
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut Stats,
     ) {

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -22,7 +22,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{qtrace, Role};
+use neqo_common::{qtrace, Buffer, Role};
 use smallvec::SmallVec;
 use strum::Display;
 
@@ -60,9 +60,9 @@ pub struct RecvStreams {
 }
 
 impl RecvStreams {
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
         now: Instant,
@@ -893,9 +893,9 @@ impl RecvStream {
     }
 
     /// Maybe write a `MAX_STREAM_DATA` frame.
-    pub fn write_frame(
+    pub fn write_frame<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
         now: Instant,

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{qlog::NeqoQlog, qtrace};
+use neqo_common::{qlog::NeqoQlog, qtrace, Buffer};
 
 use crate::{
     ackrate::{AckRate, PeerAckDelay},
@@ -193,9 +193,9 @@ impl RttEstimate {
         self.min_rtt
     }
 
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -23,7 +23,7 @@ use std::{
 };
 
 use indexmap::IndexMap;
-use neqo_common::{qdebug, qerror, qtrace, Encoder, Role};
+use neqo_common::{qdebug, qerror, qtrace, Buffer, Encoder, Role};
 use smallvec::SmallVec;
 
 use crate::{
@@ -742,10 +742,10 @@ impl SendStream {
     }
 
     // return false if the builder is full and the caller should stop iterating
-    pub fn write_frames_with_early_return(
+    pub fn write_frames_with_early_return<B: Buffer>(
         &mut self,
         priority: TransmissionPriority,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) -> bool {
@@ -921,10 +921,10 @@ impl SendStream {
         clippy::missing_panics_doc,
         reason = "OK here."
     )]
-    pub fn write_stream_frame(
+    pub fn write_stream_frame<B: Buffer>(
         &mut self,
         priority: TransmissionPriority,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
@@ -1019,10 +1019,10 @@ impl SendStream {
     }
 
     /// Maybe write a `RESET_STREAM` frame.
-    pub fn write_reset_frame(
+    pub fn write_reset_frame<B: Buffer>(
         &mut self,
         p: TransmissionPriority,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) -> bool {
@@ -1067,10 +1067,10 @@ impl SendStream {
     }
 
     /// Maybe write a `STREAM_DATA_BLOCKED` frame.
-    pub fn write_blocked_frame(
+    pub fn write_blocked_frame<B: Buffer>(
         &mut self,
         priority: TransmissionPriority,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
@@ -1693,10 +1693,10 @@ impl SendStreams {
         });
     }
 
-    pub(crate) fn write_frames(
+    pub(crate) fn write_frames<B: Buffer>(
         &mut self,
         priority: TransmissionPriority,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -10,6 +10,7 @@ use std::{
     cell::RefCell,
     cmp::min,
     fmt::{self, Display, Formatter},
+    num::NonZeroUsize,
     ops::{Deref, DerefMut},
     path::PathBuf,
     rc::Rc,
@@ -32,7 +33,7 @@ use crate::{
     cid::{ConnectionId, ConnectionIdGenerator, ConnectionIdRef},
     connection::{Connection, Output, State},
     packet::{PacketBuilder, PacketType, PublicPacket, MIN_INITIAL_PACKET_SIZE},
-    ConnectionParameters, Res, Version,
+    ConnectionParameters, OutputBatch, Res, Version,
 };
 
 /// A `ServerZeroRttChecker` is a simple wrapper around a single checker.
@@ -354,7 +355,8 @@ impl Server {
         &mut self,
         mut dgram: Datagram<impl AsRef<[u8]> + AsMut<[u8]>>,
         now: Instant,
-    ) -> Output {
+        max_datagrams: NonZeroUsize,
+    ) -> OutputBatch {
         qtrace!("Process datagram: {}", hex(&dgram[..]));
 
         // This is only looking at the first packet header in the datagram.
@@ -365,7 +367,7 @@ impl Server {
         let res = PublicPacket::decode(&mut dgram[..], self.cid_generator.borrow().as_decoder());
         let Ok((packet, _remainder)) = res else {
             qtrace!("[{self}] Discarding {dgram:?}");
-            return Output::None;
+            return OutputBatch::None;
         };
 
         // Finding an existing connection. Should be the most common case.
@@ -374,13 +376,15 @@ impl Server {
             .iter_mut()
             .find(|c| c.borrow().is_valid_local_cid(packet.dcid()))
         {
-            return c.borrow_mut().process(Some(dgram), now);
+            return c
+                .borrow_mut()
+                .process_multiple(Some(dgram), now, max_datagrams);
         }
 
         if packet.packet_type() == PacketType::Short {
             // TODO send a stateless reset here.
             qtrace!("[{self}] Short header packet for an unknown connection");
-            return Output::None;
+            return OutputBatch::None;
         }
 
         if packet.packet_type() == PacketType::OtherVersion
@@ -393,7 +397,7 @@ impl Server {
         {
             if len < MIN_INITIAL_PACKET_SIZE {
                 qdebug!("[{self}] Unsupported version: too short");
-                return Output::None;
+                return OutputBatch::None;
             }
 
             qdebug!("[{self}] Unsupported version: {:x}", packet.wire_version());
@@ -420,52 +424,57 @@ impl Server {
                 now,
             );
 
-            return Output::Datagram(Datagram::new(destination, source, IpTos::default(), vn));
+            return OutputBatch::DatagramBatch(
+                Datagram::new(destination, source, IpTos::default(), vn).into(),
+            );
         }
 
         match packet.packet_type() {
             PacketType::Initial => {
                 if len < MIN_INITIAL_PACKET_SIZE {
                     qdebug!("[{self}] Drop initial: too short");
-                    return Output::None;
+                    return OutputBatch::None;
                 }
                 // Copy values from `packet` because they are currently still borrowing from
                 // `dgram`.
                 let initial = InitialDetails::new(&packet);
-                self.handle_initial(initial, dgram, now)
+                self.handle_initial(initial, dgram, now).into()
             }
             PacketType::ZeroRtt => {
                 qdebug!(
                     "[{self}] Dropping 0-RTT for unknown connection {}",
                     ConnectionId::from(packet.dcid())
                 );
-                Output::None
+                OutputBatch::None
             }
             PacketType::OtherVersion => unreachable!(),
             _ => {
                 qtrace!("[{self}] Not an initial packet");
-                Output::None
+                OutputBatch::None
             }
         }
     }
 
     /// Iterate through the pending connections looking for any that might want
     /// to send a datagram.  Stop at the first one that does.
-    fn process_next_output(&mut self, now: Instant) -> Output {
+    fn process_next_output(&mut self, now: Instant, max_datagrams: NonZeroUsize) -> OutputBatch {
         let mut callback = None;
 
         for connection in &mut self.connections {
-            match connection.borrow_mut().process_output(now) {
-                Output::None => {}
-                d @ Output::Datagram(_) => return d,
-                Output::Callback(next) => match callback {
+            match connection
+                .borrow_mut()
+                .process_multiple_output(now, max_datagrams)
+            {
+                OutputBatch::None => {}
+                d @ OutputBatch::DatagramBatch(_) => return d,
+                OutputBatch::Callback(next) => match callback {
                     Some(previous) => callback = Some(min(previous, next)),
                     None => callback = Some(next),
                 },
             }
         }
 
-        callback.map_or(Output::None, Output::Callback)
+        callback.map_or(OutputBatch::None, OutputBatch::Callback)
     }
 
     /// Short-hand for [`Server::process`] without an input datagram.
@@ -474,15 +483,31 @@ impl Server {
         self.process(None::<Datagram>, now)
     }
 
+    /// Wrapper around [`Server::process_multiple`] that processes a single output
+    /// datagram only.
+    #[expect(clippy::missing_panics_doc, reason = "see expect()")]
     #[must_use]
     pub fn process<A: AsRef<[u8]> + AsMut<[u8]>>(
         &mut self,
         dgram: Option<Datagram<A>>,
         now: Instant,
     ) -> Output {
+        self.process_multiple(dgram, now, 1.try_into().expect(">0"))
+            .try_into()
+            .expect("max_datagrams is 1")
+    }
+
+    pub fn process_multiple(
+        &mut self,
+        dgram: Option<Datagram<impl AsRef<[u8]> + AsMut<[u8]>>>,
+        now: Instant,
+        max_datagrams: NonZeroUsize,
+    ) -> OutputBatch {
         let out = dgram
-            .map_or(Output::None, |d| self.process_input(d, now))
-            .or_else(|| self.process_next_output(now));
+            .map_or(OutputBatch::None, |d| {
+                self.process_input(d, now, max_datagrams)
+            })
+            .or_else(|| self.process_next_output(now, max_datagrams));
 
         // Clean-up closed connections.
         self.connections

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{qtrace, qwarn, Role};
+use neqo_common::{qtrace, qwarn, Buffer, Role};
 
 use crate::{
     fc::{LocalStreamLimits, ReceiverFlowControl, RemoteStreamLimits, SenderFlowControl},
@@ -209,9 +209,9 @@ impl Streams {
         Ok(())
     }
 
-    pub fn write_maintenance_frames(
+    pub fn write_maintenance_frames<B: Buffer>(
         &mut self,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
         now: Instant,
@@ -252,10 +252,10 @@ impl Streams {
         self.local_stream_limits[StreamType::UniDi].write_frames(builder, tokens, stats);
     }
 
-    pub fn write_frames(
+    pub fn write_frames<B: Buffer>(
         &mut self,
         priority: TransmissionPriority,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -16,7 +16,7 @@ use std::{
 use enum_map::{Enum, EnumMap};
 use enumset::{EnumSet, EnumSetType};
 use log::{log_enabled, Level};
-use neqo_common::{qdebug, qinfo, qtrace, qwarn, IpTosEcn, MAX_VARINT};
+use neqo_common::{qdebug, qinfo, qtrace, qwarn, Buffer, IpTosEcn, MAX_VARINT};
 use neqo_crypto::Epoch;
 use smallvec::SmallVec;
 use strum::{Display, EnumIter};
@@ -419,11 +419,11 @@ impl RecvdPackets {
     ///
     /// We don't send ranges that have been acknowledged, but they still need
     /// to be tracked so that duplicates can be detected.
-    fn write_frame(
+    fn write_frame<B: Buffer>(
         &mut self,
         now: Instant,
         rtt: Duration,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {
@@ -591,12 +591,12 @@ impl AckTracker {
         }
     }
 
-    pub(crate) fn write_frame(
+    pub(crate) fn write_frame<B: Buffer>(
         &mut self,
         pn_space: PacketNumberSpace,
         now: Instant,
         rtt: Duration,
-        builder: &mut PacketBuilder,
+        builder: &mut PacketBuilder<B>,
         tokens: &mut Vec<RecoveryToken>,
         stats: &mut FrameStats,
     ) {

--- a/neqo-transport/tests/connection.rs
+++ b/neqo-transport/tests/connection.rs
@@ -9,7 +9,7 @@ use common::assert_dscp;
 use neqo_common::{Datagram, Decoder, Encoder, Role};
 use neqo_crypto::Aead;
 use neqo_transport::{
-    CloseReason, ConnectionParameters, Error, State, Version, MIN_INITIAL_PACKET_SIZE,
+    CloseReason, ConnectionParameters, Error, State, StreamType, Version, MIN_INITIAL_PACKET_SIZE,
 };
 use test_fixture::{
     default_client, default_server,
@@ -25,6 +25,23 @@ fn connect() {
     let (client, server) = test_fixture::connect();
     assert_dscp(&client.stats());
     assert_dscp(&server.stats());
+}
+
+#[test]
+fn gso() {
+    let (mut client, _server) = test_fixture::connect();
+
+    let stream_id2 = client.stream_create(StreamType::UniDi).unwrap();
+    client.stream_send(stream_id2, &[42; 2048]).unwrap();
+    client.stream_close_send(stream_id2).unwrap();
+
+    let out = client
+        .process_multiple_output(now(), 64.try_into().expect(">0"))
+        .dgram()
+        .unwrap();
+
+    assert_eq!(out.datagram_size(), 1232);
+    assert!(out.data().len() > out.datagram_size());
 }
 
 #[test]

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -118,7 +118,7 @@ fn is_emsgsize(e: &io::Error) -> bool {
             e == windows::Win32::Networking::WinSock::WSAEMSGSIZE.0
                 // WSAEINVAL is returned when the Windows USO (UDP Segmentation Offload)
                 // segment size exceeds the supported limit.
-                || windows::Win32::Networking::WinSock::WSAEINVAL.0
+                || e == windows::Win32::Networking::WinSock::WSAEINVAL.0
         }
         #[cfg(not(any(unix, windows)))]
         {

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -116,6 +116,9 @@ fn is_emsgsize(e: &io::Error) -> bool {
         #[cfg(windows)]
         {
             e == windows::Win32::Networking::WinSock::WSAEMSGSIZE.0
+                // WSAEINVAL is returned when the Windows USO (UDP Segmentation Offload)
+                // segment size exceeds the supported limit.
+                || windows::Win32::Networking::WinSock::WSAEINVAL.0
         }
         #[cfg(not(any(unix, windows)))]
         {


### PR DESCRIPTION
Use generic send offloading (GSO) on Linux and UDP segment offloading (USO) on Windows.

GSO and USO allow us to batch multiple datagrams into one large payload (up to 64 KB) and pass it in a single system call to the kernel. The kernel either itself segments it, or has the NIC segment it, before sending it out on the network.

Early measurements show an up to 2x throughput improvement on artificial CPU bound localhost transfer benchmark.

---

Attempt 1: https://github.com/mozilla/neqo/commit/f25b0b77ff579b56a4ea882a3ca70404b3c38b03
Attempt 2: https://github.com/mozilla/neqo/pull/2532/

Compared to attempt 2:
- implements the datagram batching in `neqo-transport` instead of `neqo-bin`
- does not copy each datagram in the larger GSO buffer, but instead writes each into the GSO buffer right away.

Once this is merged, we can switch to a long-lived send buffer (see discussed in https://github.com/mozilla/neqo/issues/2670). https://github.com/mozilla/neqo/pull/2677 and this pull request lay the  groundwork for it.