### PR TITLE
fix(neqo-crypto): use u32 for SecretDirection enum on mingw

### DIFF
--- a/neqo-crypto/src/secrets.rs
+++ b/neqo-crypto/src/secrets.rs
@@ -25,8 +25,11 @@ experimental_api!(SSL_SecretCallback(
 ));
 
 #[derive(Clone, Copy, Debug, FromRepr)]
-#[cfg_attr(windows, repr(i32))] // Windows has to be different, of course.
-#[cfg_attr(not(windows), repr(u32))]
+// Use i32 for Windows MSVC, unless it is MinGW (see
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1960482). All other platforms
+// use u32.
+#[cfg_attr(all(windows, not(target_env = "gnu")), repr(i32))]
+#[cfg_attr(not(all(windows, not(target_env = "gnu"))), repr(u32))]
 pub enum SecretDirection {
     Read = SSLSecretDirection::ssl_secret_read,
     Write = SSLSecretDirection::ssl_secret_write,


### PR DESCRIPTION
On MinGW (https://en.wikipedia.org/wiki/MinGW) NSS's `SSLSecretDirection` is a `u32`. Given that we asign the `neqo-crypto` type `SecretDirection` to a `SSLSecretDirection`, the former (`neqo-crypto`) has to be same type like the latter (NSS).

See https://bugzilla.mozilla.org/show_bug.cgi?id=1960482 for details.

Follow-up to https://github.com/mozilla/neqo/pull/2440/files#r2048451993.

See the following failure without this patch failing to compile neqo-crypto:

https://treeherder.mozilla.org/jobs?repo=try&revision=2c7f5e2a0877b9ab897340a556f4a6f7c8a35c5c^Z

See the following failure with this patch, succeeding to compile neqo-crypto, failing for a different reason :)

https://treeherder.mozilla.org/jobs?repo=try&revision=59ff8632950ebea827d86c3f601d21207141ecb8&selectedTaskRun=ESNDUhdIQLm3huh3FS95Nw.0