### PR TITLE
chore: prepare v0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "criterion",
  "enum-map",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "criterion",
  "enumset",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "log",
  "neqo-common",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "criterion",
  "enum-map",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cfg_aliases",
  "log",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.13.1"
+version = "0.13.2"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I would like to get https://github.com/mozilla/neqo/pull/2597/ into mozilla-central.

```
git log --oneline v0.13.1..
bc8b9038 (HEAD -> prepare-v0.13.2) chore: prepare v0.13.2
f066a16c (mozilla/main, main) fix(neqo-crypto): use u32 for SecretDirection enum on mingw (#2597)
53144a56 build(deps): bump lukemathwalker/cargo-chef in /qns (#2596)
a316236b build(deps): bump astral-sh/setup-uv from 5.4.1 to 5.4.2 (#2595)
6ffa21b6 build(deps): bump codecov/codecov-action from 5.4.0 to 5.4.2 (#2594)
dcdee555 fix(transport/ecn): track ACK of marked packets (#2589)
a62c1406 ci(bench): fail on regression (#2580)
3e03ab02 bench(h3/streams): reduce variants and increase sample size (#2587)
a9735408 build(deps): bump lukemathwalker/cargo-chef in /qns (#2586)
7a0bf0f5 build(deps): bump martenseemann/quic-network-simulator-endpoint in /qns (#2585)
dadb924a build(deps): bump vmactions/openbsd-vm from 1.1.6 to 1.1.7 (#2584)
e9e698a7 build(deps): bump github/codeql-action from 3.28.13 to 3.28.15 (#2583)
6b4ff7c8 build(deps): bump actions/setup-java from 4.7.0 to 4.7.1 (#2582)
c520e127 fix: Drop of Initial space only after sending 1st Handshake (#2118)
28c0ea7e build(deps): bump tokio from 1.39.2 to 1.43.1 in the cargo group (#2570)
911ee9c7 Revert "ci: Enable MC/DC coverage" (#2575)
c1679d89 (mozilla/gh-readonly-queue/main/pr-2573-0a356afeb45631036df6b3028951a02d16fa8d27) ci: Pin `google-quiche` until `main` compiles again (#2573)
```