### PR TITLE
fix(transport/qlog): call qlog::packet_io even without log::Level::Debug

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -3632,23 +3632,22 @@ impl Connection {
     }
 
     fn log_packet(&self, meta: packet::MetaData, now: Instant) {
-        if !log::log_enabled!(log::Level::Debug) {
-            return;
+        if log::log_enabled!(log::Level::Debug) {
+            let mut s = String::new();
+            let mut d = Decoder::from(meta.payload());
+            while d.remaining() > 0 {
+                let Ok(f) = Frame::decode(&mut d) else {
+                    s.push_str(" [broken]...");
+                    break;
+                };
+                let x = f.dump();
+                if !x.is_empty() {
+                    _ = write!(&mut s, "\n  {} {}", meta.direction(), &x);
+                }
+            }
+            qdebug!("[{self}] {meta}{s}");
         }
 
-        let mut s = String::new();
-        let mut d = Decoder::from(meta.payload());
-        while d.remaining() > 0 {
-            let Ok(f) = Frame::decode(&mut d) else {
-                s.push_str(" [broken]...");
-                break;
-            };
-            let x = f.dump();
-            if !x.is_empty() {
-                _ = write!(&mut s, "\n  {} {}", meta.direction(), &x);
-            }
-        }
-        qdebug!("[{self}] {meta}{s}");
         qlog::packet_io(&self.qlog, meta, now);
     }
 }


### PR DESCRIPTION
https://github.com/mozilla/neqo/pull/2396 consolidated packet logging and logging to qlog.  On a log level < `Debug`, it would return early, i.e. not log the packet and not send it to qlog.

None of our other qlogs are bound to the current log level.

With this commit, all packets are sent to qlog, no matter the log level.

---

@KershawChang this resolves the qlog issue you saw in https://github.com/quic-go/quic-go/issues/5001#issuecomment-2812440458.