### PR TITLE
Adding robustness checking to the QUIC handshake

### DIFF
--- a/neqo-bin/src/lib.rs
+++ b/neqo-bin/src/lib.rs
@@ -125,6 +125,10 @@ pub struct QuicParameters {
     /// Whether to slice the SNI.
     pub no_sni_slicing: bool,
 
+    #[arg(long)]
+    /// Whether to add dummy packets before client Initial packets.
+    pub no_pre_init_noise: bool,
+
     #[arg(name = "preferred-address-v4", long)]
     /// An IPv4 address for the server preferred address.
     pub preferred_address_v4: Option<String>,
@@ -148,6 +152,7 @@ impl Default for QuicParameters {
             preferred_address_v4: None,
             preferred_address_v6: None,
             no_sni_slicing: false,
+            no_pre_init_noise: false,
         }
     }
 }
@@ -221,7 +226,8 @@ impl QuicParameters {
             .cc_algorithm(self.congestion_control)
             .pacing(!self.no_pacing)
             .pmtud(!self.no_pmtud)
-            .sni_slicing(!self.no_sni_slicing);
+            .sni_slicing(!self.no_sni_slicing)
+            .pre_init_noise(!self.no_pre_init_noise);
         params = if let Some(pa) = self.preferred_address() {
             params.preferred_address(pa)
         } else {

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -96,6 +96,8 @@ pub struct ConnectionParameters {
     pmtud_iface_mtu: bool,
     /// Whether the connection should use SNI slicing.
     sni_slicing: bool,
+    /// Whether the connection should enable pre-Initial noise.
+    pre_init_noise: bool,
     /// Whether to enable mlkem768nistp256-sha256.
     mlkem: bool,
 }
@@ -128,6 +130,7 @@ impl Default for ConnectionParameters {
             pmtud_iface_mtu: true,
             sni_slicing: true,
             mlkem: true,
+            pre_init_noise: true,
         }
     }
 }
@@ -407,6 +410,17 @@ impl ConnectionParameters {
     #[must_use]
     pub const fn sni_slicing(mut self, sni_slicing: bool) -> Self {
         self.sni_slicing = sni_slicing;
+        self
+    }
+
+    #[must_use]
+    pub const fn pre_init_noise_enabled(&self) -> bool {
+        self.pre_init_noise
+    }
+
+    #[must_use]
+    pub const fn pre_init_noise(mut self, pre_init_noise: bool) -> Self {
+        self.pre_init_noise = pre_init_noise;
         self
     }
 


### PR DESCRIPTION
This change allows clients to transmit a variable number of pre-initial packets (default 1).