### PR TITLE
fix: Eliminate expensive log call

### DIFF
--- a/neqo-http3/src/buffered_send_stream.rs
+++ b/neqo-http3/src/buffered_send_stream.rs
@@ -4,7 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::qtrace;
 use neqo_transport::{Connection, StreamId};
 
 use crate::{qlog, Res};
@@ -60,14 +59,12 @@ impl BufferedStream {
     ///
     /// Returns `neqo_transport` errors.
     pub fn send_buffer(&mut self, conn: &mut Connection) -> Res<usize> {
-        let label = format!("{self}");
         let Self::Initialized { stream_id, buf } = self else {
             return Ok(0);
         };
         if buf.is_empty() {
             return Ok(0);
         }
-        qtrace!("[{label}] sending data");
         let sent = conn.stream_send(*stream_id, &buf[..])?;
         if sent == 0 {
             return Ok(0);


### PR DESCRIPTION
That called `format!` even when the result was never logged.

CC @jrmuizel @mstange