### PR TITLE
chore: `use std::fmt` more

### DIFF
--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -11,6 +11,7 @@
 use std::{
     cell::RefCell,
     collections::{HashMap, VecDeque},
+    fmt::Display,
     fs::File,
     io::{BufWriter, Write as _},
     net::SocketAddr,
@@ -203,7 +204,7 @@ impl super::Client for Connection {
 
     fn close<S>(&mut self, now: Instant, app_error: neqo_transport::AppError, msg: S)
     where
-        S: AsRef<str> + std::fmt::Display,
+        S: AsRef<str> + Display,
     {
         if !self.state().closed() {
             self.close(now, app_error, msg);

--- a/neqo-bin/src/server/http09.rs
+++ b/neqo-bin/src/server/http09.rs
@@ -6,7 +6,14 @@
 
 #![expect(clippy::unwrap_used, reason = "This is example code.")]
 
-use std::{borrow::Cow, cell::RefCell, collections::HashMap, fmt::Display, rc::Rc, time::Instant};
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    collections::HashMap,
+    fmt::{self, Display, Formatter},
+    rc::Rc,
+    time::Instant,
+};
 
 use neqo_common::{event::Provider as _, hex, qdebug, qerror, qinfo, qwarn, Datagram};
 use neqo_crypto::{generate_ech_keys, random, AllowZeroRtt, AntiReplay};
@@ -235,7 +242,7 @@ impl super::HttpServer for HttpServer {
 }
 
 impl Display for HttpServer {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Http 0.9 server ")
     }
 }

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Debug;
+use std::fmt::{self, Debug, Formatter};
 
 use crate::hex_with_len;
 
@@ -170,7 +170,7 @@ impl<'a> AsRef<[u8]> for Decoder<'a> {
 }
 
 impl Debug for Decoder<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.write_str(&hex_with_len(self.as_ref()))
     }
 }
@@ -435,7 +435,7 @@ impl Encoder {
 }
 
 impl Debug for Encoder {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.write_str(&hex_with_len(self))
     }
 }

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -5,6 +5,7 @@
 // except according to those terms.
 
 use std::{
+    fmt::{self, Debug, Formatter},
     net::SocketAddr,
     ops::{Deref, DerefMut},
 };
@@ -80,8 +81,8 @@ impl<D: AsRef<[u8]>> Deref for Datagram<D> {
     }
 }
 
-impl<D: AsRef<[u8]>> std::fmt::Debug for Datagram<D> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl<D: AsRef<[u8]>> Debug for Datagram<D> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "Datagram {:?} {:?}->{:?}: {}",

--- a/neqo-common/src/tos.rs
+++ b/neqo-common/src/tos.rs
@@ -9,7 +9,7 @@
     reason = "<https://github.com/mozilla/neqo/issues/2284#issuecomment-2782711813>"
 )]
 
-use std::fmt::Debug;
+use std::fmt::{self, Debug, Formatter};
 
 use enum_map::Enum;
 use strum::{EnumIter, FromRepr};
@@ -172,7 +172,7 @@ impl From<u8> for IpTos {
 }
 
 impl Debug for IpTos {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_tuple("IpTos")
             .field(&IpTosDscp::from(*self))
             .field(&IpTosEcn::from(*self))

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -16,6 +16,7 @@
 use std::{
     cell::RefCell,
     ffi::{CStr, CString},
+    fmt::{self, Debug, Display, Formatter},
     mem::MaybeUninit,
     ops::{Deref, DerefMut},
     os::raw::{c_uint, c_void},
@@ -828,8 +829,8 @@ impl Drop for SecretAgent {
     }
 }
 
-impl ::std::fmt::Display for SecretAgent {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for SecretAgent {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Agent {:p}", self.fd)
     }
 }
@@ -1026,8 +1027,8 @@ impl DerefMut for Client {
     }
 }
 
-impl ::std::fmt::Display for Client {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for Client {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Client {:p}", self.agent.fd)
     }
 }
@@ -1047,7 +1048,7 @@ pub enum ZeroRttCheckResult {
 
 /// A `ZeroRttChecker` is used by the agent to validate the application token (as provided by
 /// `send_ticket`)
-pub trait ZeroRttChecker: std::fmt::Debug + Unpin {
+pub trait ZeroRttChecker: Debug + Unpin {
     fn check(&self, token: &[u8]) -> ZeroRttCheckResult;
 }
 
@@ -1234,8 +1235,8 @@ impl DerefMut for Server {
     }
 }
 
-impl ::std::fmt::Display for Server {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for Server {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Server {:p}", self.agent.fd)
     }
 }

--- a/neqo-crypto/src/agentio.rs
+++ b/neqo-crypto/src/agentio.rs
@@ -11,7 +11,8 @@
 
 use std::{
     cmp::min,
-    fmt, mem,
+    fmt::{self, Display, Formatter},
+    mem,
     ops::Deref,
     os::raw::{c_uint, c_void},
     pin::Pin,
@@ -71,7 +72,7 @@ impl Record {
 }
 
 impl fmt::Debug for Record {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "Record {:?}:{:?} {}",
@@ -205,8 +206,8 @@ impl AgentIoInput {
     }
 }
 
-impl ::std::fmt::Display for AgentIoInput {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for AgentIoInput {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "AgentIoInput {:p}", self.input)
     }
 }
@@ -253,8 +254,8 @@ impl AgentIo {
     }
 }
 
-impl ::std::fmt::Display for AgentIo {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for AgentIo {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "AgentIo")
     }
 }

--- a/neqo-crypto/src/err.rs
+++ b/neqo-crypto/src/err.rs
@@ -4,7 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{os::raw::c_char, str::Utf8Error};
+use std::{
+    fmt::{self, Display, Formatter},
+    os::raw::c_char,
+    str::Utf8Error,
+};
 
 use crate::ssl::{SECStatus, SECSuccess};
 
@@ -91,8 +95,8 @@ impl std::error::Error for Error {
     }
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Error: {self:?}")
     }
 }

--- a/neqo-crypto/src/ext.rs
+++ b/neqo-crypto/src/ext.rs
@@ -11,6 +11,7 @@
 
 use std::{
     cell::RefCell,
+    fmt::{self, Debug, Formatter},
     os::raw::{c_uint, c_void},
     pin::Pin,
     rc::Rc,
@@ -176,8 +177,8 @@ impl ExtensionTracker {
     }
 }
 
-impl std::fmt::Debug for ExtensionTracker {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl Debug for ExtensionTracker {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "ExtensionTracker: {:?}", self.extension)
     }
 }

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -6,6 +6,7 @@
 
 use std::{
     cell::RefCell,
+    fmt::{self, Debug, Formatter},
     ops::{Deref, DerefMut},
     os::raw::c_uint,
     ptr::null_mut,
@@ -114,8 +115,8 @@ impl Clone for PublicKey {
     }
 }
 
-impl std::fmt::Debug for PublicKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl Debug for PublicKey {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         if let Ok(b) = self.key_data() {
             write!(f, "PublicKey {}", hex_with_len(b))
         } else {
@@ -168,8 +169,8 @@ impl Clone for PrivateKey {
     }
 }
 
-impl std::fmt::Debug for PrivateKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl Debug for PrivateKey {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         if let Ok(b) = self.key_data() {
             write!(f, "PrivateKey {}", hex_with_len(b))
         } else {
@@ -215,8 +216,8 @@ impl Clone for SymKey {
     }
 }
 
-impl std::fmt::Debug for SymKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl Debug for SymKey {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         if let Ok(b) = self.as_bytes() {
             write!(f, "SymKey {}", hex_with_len(b))
         } else {

--- a/neqo-http3/src/buffered_send_stream.rs
+++ b/neqo-http3/src/buffered_send_stream.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::fmt::{self, Display, Formatter};
+
 use neqo_transport::{Connection, StreamId};
 
 use crate::{qlog, Res};
@@ -18,8 +20,8 @@ pub enum BufferedStream {
     },
 }
 
-impl ::std::fmt::Display for BufferedStream {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for BufferedStream {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "BufferedStream {:?}", Option::<StreamId>::from(self))
     }
 }

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -7,7 +7,7 @@
 use std::{
     cell::RefCell,
     collections::{BTreeSet, HashMap},
-    fmt::Debug,
+    fmt::{self, Debug, Display, Formatter},
     mem,
     rc::Rc,
 };
@@ -301,8 +301,8 @@ pub struct Http3Connection {
     webtransport: ExtendedConnectFeature,
 }
 
-impl ::std::fmt::Display for Http3Connection {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for Http3Connection {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Http3 connection")
     }
 }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -6,7 +6,7 @@
 
 use std::{
     cell::RefCell,
-    fmt::{Debug, Display},
+    fmt::{self, Debug, Display, Formatter},
     iter,
     net::SocketAddr,
     rc::Rc,
@@ -286,7 +286,7 @@ pub struct Http3Client {
 }
 
 impl Display for Http3Client {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Http3 client")
     }
 }

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -4,7 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{rc::Rc, time::Instant};
+use std::{
+    fmt::{self, Display, Formatter},
+    rc::Rc,
+    time::Instant,
+};
 
 use neqo_common::{event::Provider as _, qdebug, qinfo, qtrace, Header, MessageType, Role};
 use neqo_transport::{
@@ -28,8 +32,8 @@ pub struct Http3ServerHandler {
     needs_processing: bool,
 }
 
-impl ::std::fmt::Display for Http3ServerHandler {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for Http3ServerHandler {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Http3 server connection")
     }
 }

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -4,7 +4,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::{HashMap, VecDeque};
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt::{self, Display, Formatter},
+};
 
 use neqo_common::{qtrace, Encoder};
 use neqo_transport::{Connection, StreamId, StreamType};
@@ -21,8 +24,8 @@ pub struct ControlStreamLocal {
     outstanding_priority_update: VecDeque<StreamId>,
 }
 
-impl ::std::fmt::Display for ControlStreamLocal {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for ControlStreamLocal {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Local control stream {:?}", self.stream)
     }
 }

--- a/neqo-http3/src/control_stream_remote.rs
+++ b/neqo-http3/src/control_stream_remote.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::fmt::{self, Display, Formatter};
+
 use neqo_common::qdebug;
 use neqo_transport::{Connection, StreamId};
 
@@ -20,8 +22,8 @@ pub struct ControlStreamRemote {
     frame_reader: FrameReader,
 }
 
-impl ::std::fmt::Display for ControlStreamRemote {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for ControlStreamRemote {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Http3 remote control stream {:?}", self.stream_id)
     }
 }

--- a/neqo-http3/src/features/extended_connect/webtransport_session.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_session.rs
@@ -4,7 +4,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{cell::RefCell, collections::BTreeSet, mem, rc::Rc};
+use std::{
+    cell::RefCell,
+    collections::BTreeSet,
+    fmt::{self, Display, Formatter},
+    mem,
+    rc::Rc,
+};
 
 use neqo_common::{qtrace, Encoder, Header, MessageType, Role};
 use neqo_qpack::{QPackDecoder, QPackEncoder};
@@ -48,8 +54,8 @@ pub struct WebTransportSession {
     role: Role,
 }
 
-impl ::std::fmt::Display for WebTransportSession {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for WebTransportSession {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "WebTransportSession session={}", self.session_id)
     }
 }

--- a/neqo-http3/src/frames/tests/reader.rs
+++ b/neqo-http3/src/frames/tests/reader.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Debug;
+use std::{cmp::min, fmt::Debug};
 
 use neqo_common::Encoder;
 use neqo_transport::{Connection, StreamId, StreamType};
@@ -277,7 +277,7 @@ fn complete_and_incomplete_unknown_frame() {
     let mut buf: Vec<_> = enc.into();
     buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
 
-    let len = std::cmp::min(buf.len() - 1, 10);
+    let len = min(buf.len() - 1, 10);
     for i in 1..len {
         test_reading_frame::<HFrame>(
             &buf[..i],
@@ -321,7 +321,7 @@ fn test_complete_and_incomplete_frame<T: FrameDecoder<T> + PartialEq + Debug>(
     // Let's consume partial frames. It is enough to test partial frames
     // up to 10 byte. 10 byte is greater than frame type and frame
     // length and bit of data.
-    let len = std::cmp::min(buf.len() - 1, 10);
+    let len = min(buf.len() - 1, 10);
     for i in 1..len {
         test_reading_frame::<T>(
             &buf[..i],

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -158,7 +158,11 @@ mod server_events;
 mod settings;
 mod stream_type_reader;
 
-use std::{cell::RefCell, fmt::Debug, rc::Rc};
+use std::{
+    cell::RefCell,
+    fmt::{self, Debug, Display, Formatter},
+    rc::Rc,
+};
 
 use buffered_send_stream::BufferedStream;
 pub use client_events::{Http3ClientEvent, WebTransportEvent};
@@ -411,8 +415,8 @@ impl ::std::error::Error for Error {
     }
 }
 
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "HTTP/3 error: {self:?}")
     }
 }

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -7,7 +7,7 @@
 use std::{
     cell::RefCell,
     collections::VecDeque,
-    fmt::{Debug, Display},
+    fmt::{self, Debug, Display, Formatter},
     mem,
     rc::Rc,
     slice::SliceIndex,
@@ -157,7 +157,7 @@ pub struct PushController {
 }
 
 impl Display for PushController {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Push controller")
     }
 }

--- a/neqo-http3/src/push_id.rs
+++ b/neqo-http3/src/push_id.rs
@@ -4,7 +4,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::ops::{Add, Sub};
+use std::{
+    fmt::{self, Display, Formatter},
+    ops::{Add, Sub},
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
 pub struct PushId(u64);
@@ -32,8 +35,8 @@ impl From<PushId> for u64 {
     }
 }
 
-impl ::std::fmt::Display for PushId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for PushId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -4,7 +4,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{cell::RefCell, cmp::min, collections::VecDeque, fmt::Debug, rc::Rc};
+use std::{
+    cell::RefCell,
+    cmp::min,
+    collections::VecDeque,
+    fmt::{self, Debug, Display, Formatter},
+    rc::Rc,
+};
 
 use neqo_common::{header::HeadersExt as _, qdebug, qinfo, qtrace, Header};
 use neqo_qpack::decoder::QPackDecoder;
@@ -77,8 +83,8 @@ pub struct RecvMessage {
     blocked_push_promise: VecDeque<PushInfo>,
 }
 
-impl ::std::fmt::Display for RecvMessage {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for RecvMessage {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "RecvMessage stream_id:{}", self.stream_id)
     }
 }

--- a/neqo-http3/src/request_target.rs
+++ b/neqo-http3/src/request_target.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::{Debug, Formatter};
+use std::fmt::{self, Debug, Formatter};
 
 use url::{ParseError, Url};
 
@@ -46,7 +46,7 @@ impl<'s, 'a, 'p> RefRequestTarget<'s, 'a, 'p> {
 }
 
 impl Debug for RefRequestTarget<'_, '_, '_> {
-    fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}://{}{}", self.scheme, self.authority, self.path)
     }
 }
@@ -113,7 +113,7 @@ impl RequestTarget for UrlRequestTarget {
 }
 
 impl Debug for UrlRequestTarget {
-    fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         self.url.fmt(f)
     }
 }

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -4,7 +4,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{cell::RefCell, cmp::min, fmt::Debug, num::NonZeroUsize, rc::Rc};
+use std::{
+    cell::RefCell,
+    cmp::min,
+    fmt::{self, Debug, Display, Formatter},
+    num::NonZeroUsize,
+    rc::Rc,
+};
 
 use neqo_common::{qdebug, qtrace, Encoder, Header, MessageType};
 use neqo_qpack::encoder::QPackEncoder;
@@ -324,8 +330,8 @@ impl HttpSendStream for SendMessage {
     }
 }
 
-impl ::std::fmt::Display for SendMessage {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for SendMessage {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "SendMesage {}", self.stream_id())
     }
 }

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -7,6 +7,7 @@
 use std::{
     cell::{RefCell, RefMut},
     collections::HashMap,
+    fmt::{self, Display, Formatter},
     path::PathBuf,
     rc::Rc,
     time::Instant,
@@ -41,8 +42,8 @@ pub struct Http3Server {
     events: Http3ServerEvents,
 }
 
-impl ::std::fmt::Display for Http3Server {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for Http3Server {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Http3 server ")
     }
 }

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -7,6 +7,7 @@
 use std::{
     cell::RefCell,
     collections::VecDeque,
+    fmt::{self, Display, Formatter},
     ops::{Deref, DerefMut},
     rc::Rc,
 };
@@ -30,8 +31,8 @@ pub struct StreamHandler {
     pub stream_info: Http3StreamInfo,
 }
 
-impl ::std::fmt::Display for StreamHandler {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for StreamHandler {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let conn: &Connection = &self.conn.borrow();
         write!(f, "conn={conn} stream_info={:?}", self.stream_info)
     }
@@ -158,8 +159,8 @@ pub struct Http3OrWebTransportStream {
     stream_handler: StreamHandler,
 }
 
-impl ::std::fmt::Display for Http3OrWebTransportStream {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for Http3OrWebTransportStream {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Stream server {:?}", self.stream_handler)
     }
 }
@@ -242,8 +243,8 @@ pub struct WebTransportRequest {
     stream_handler: StreamHandler,
 }
 
-impl ::std::fmt::Display for WebTransportRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for WebTransportRequest {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "WebTransport session {}", self.stream_handler)
     }
 }

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -9,6 +9,8 @@
     reason = "<https://github.com/mozilla/neqo/issues/2284#issuecomment-2782711813>"
 )]
 
+use std::fmt::{self, Display, Formatter};
+
 use neqo_common::{qdebug, Header};
 use neqo_transport::{Connection, StreamId};
 
@@ -273,8 +275,8 @@ impl QPackDecoder {
     }
 }
 
-impl ::std::fmt::Display for QPackDecoder {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for QPackDecoder {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "QPackDecoder {}", self.capacity())
     }
 }

--- a/neqo-qpack/src/decoder_instructions.rs
+++ b/neqo-qpack/src/decoder_instructions.rs
@@ -4,7 +4,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::mem;
+use std::{
+    fmt::{self, Display, Formatter},
+    mem,
+};
 
 use neqo_common::{qdebug, qtrace};
 use neqo_transport::StreamId;
@@ -69,8 +72,8 @@ pub struct DecoderInstructionReader {
     instruction: DecoderInstruction,
 }
 
-impl ::std::fmt::Display for DecoderInstructionReader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for DecoderInstructionReader {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "InstructionReader")
     }
 }

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -9,7 +9,11 @@
     reason = "<https://github.com/mozilla/neqo/issues/2284#issuecomment-2782711813>"
 )]
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::{
+    cmp::min,
+    collections::{HashMap, HashSet, VecDeque},
+    fmt::{self, Display, Formatter},
+};
 
 use neqo_common::{qdebug, qerror, qlog::NeqoQlog, qtrace, Header};
 use neqo_transport::{Connection, Error as TransportError, StreamId};
@@ -103,7 +107,7 @@ impl QPackEncoder {
             self.max_table_size,
         );
 
-        let new_cap = std::cmp::min(self.max_table_size, cap);
+        let new_cap = min(self.max_table_size, cap);
         // we also set our table to the max allowed.
         self.change_capacity(new_cap);
         Ok(())
@@ -500,8 +504,8 @@ impl QPackEncoder {
     }
 }
 
-impl ::std::fmt::Display for QPackEncoder {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for QPackEncoder {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "QPackEncoder")
     }
 }

--- a/neqo-qpack/src/encoder_instructions.rs
+++ b/neqo-qpack/src/encoder_instructions.rs
@@ -4,7 +4,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::mem;
+use std::{
+    fmt::{self, Display, Formatter},
+    mem,
+};
 
 use neqo_common::{qdebug, qtrace};
 
@@ -135,8 +138,8 @@ pub struct EncoderInstructionReader {
     instruction: DecodedEncoderInstruction,
 }
 
-impl ::std::fmt::Display for EncoderInstructionReader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for EncoderInstructionReader {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "EncoderInstructionReader state={:?} instruction:{:?}",

--- a/neqo-qpack/src/header_block.rs
+++ b/neqo-qpack/src/header_block.rs
@@ -5,6 +5,7 @@
 // except according to those terms.
 
 use std::{
+    fmt::{self, Display, Formatter},
     mem,
     ops::{Deref, Div as _},
 };
@@ -34,8 +35,8 @@ pub struct HeaderEncoder {
     max_dynamic_index_ref: Option<u64>,
 }
 
-impl ::std::fmt::Display for HeaderEncoder {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for HeaderEncoder {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "HeaderEncoder")
     }
 }
@@ -163,8 +164,8 @@ pub struct HeaderDecoder<'a> {
     req_insert_cnt: u64,
 }
 
-impl ::std::fmt::Display for HeaderDecoder<'_> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for HeaderDecoder<'_> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "HeaderDecoder")
     }
 }

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -20,6 +20,8 @@ mod static_table;
 mod stats;
 mod table;
 
+use std::fmt::{self, Display, Formatter};
+
 pub use decoder::QPackDecoder;
 pub use encoder::QPackEncoder;
 pub use stats::Stats;
@@ -96,8 +98,8 @@ impl ::std::error::Error for Error {
     }
 }
 
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "QPACK error: {self:?}")
     }
 }

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -4,7 +4,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::VecDeque;
+use std::{
+    collections::VecDeque,
+    fmt::{self, Display, Formatter},
+};
 
 use neqo_common::qtrace;
 
@@ -87,8 +90,8 @@ pub struct HeaderTable {
     acked_inserts_cnt: u64,
 }
 
-impl ::std::fmt::Display for HeaderTable {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for HeaderTable {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "HeaderTable for (base={} acked_inserts_cnt={} capacity={})",

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -10,6 +10,7 @@ use std::{
     borrow::Borrow,
     cell::{Ref, RefCell},
     cmp::{max, min},
+    fmt::{self, Debug, Display, Formatter},
     ops::Deref,
     rc::Rc,
 };
@@ -100,14 +101,14 @@ impl Deref for ConnectionId {
     }
 }
 
-impl ::std::fmt::Debug for ConnectionId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Debug for ConnectionId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "CID {}", hex_with_len(&self.cid))
     }
 }
 
-impl ::std::fmt::Display for ConnectionId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for ConnectionId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", hex(&self.cid))
     }
 }
@@ -123,14 +124,14 @@ pub struct ConnectionIdRef<'a> {
     cid: &'a [u8],
 }
 
-impl ::std::fmt::Debug for ConnectionIdRef<'_> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Debug for ConnectionIdRef<'_> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "CID {}", hex_with_len(self.cid))
     }
 }
 
-impl ::std::fmt::Display for ConnectionIdRef<'_> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for ConnectionIdRef<'_> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", hex(self.cid))
     }
 }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -9,7 +9,7 @@
 use std::{
     cell::RefCell,
     cmp::{max, min},
-    fmt::{self, Debug, Write as _},
+    fmt::{self, Debug, Display, Formatter, Write as _},
     iter, mem,
     net::{IpAddr, SocketAddr},
     num::NonZeroUsize,
@@ -300,7 +300,7 @@ pub struct Connection {
 }
 
 impl Debug for Connection {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "{:?} Connection: {:?} {:?}",
@@ -3668,11 +3668,11 @@ impl EventProvider for Connection {
     }
 }
 
-impl ::std::fmt::Display for Connection {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for Connection {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{:?} ", self.role)?;
         if let Some(cid) = self.odcid() {
-            fmt::Display::fmt(&cid, f)
+            Display::fmt(&cid, f)
         } else {
             write!(f, "...")
         }

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{cmp::max, collections::HashMap};
+use std::{cmp::max, collections::HashMap, fmt::Debug};
 
 use neqo_common::{event::Provider as _, qdebug};
 use test_fixture::now;
@@ -224,7 +224,7 @@ fn fairness_test<S, R>(source: S, number_iterates: usize, truncate_to: usize, re
 where
     S: IntoIterator,
     S::Item: Into<StreamId>,
-    R: IntoIterator + std::fmt::Debug,
+    R: IntoIterator + Debug,
     R::Item: Into<StreamId>,
     Vec<u64>: PartialEq<R>,
 {

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -7,6 +7,7 @@
 use std::{
     cell::RefCell,
     cmp::{max, min},
+    fmt::{self, Display, Formatter},
     mem,
     ops::{Index, IndexMut, Range},
     rc::Rc,
@@ -398,8 +399,8 @@ impl Crypto {
     }
 }
 
-impl ::std::fmt::Display for Crypto {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for Crypto {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Crypto")
     }
 }
@@ -712,8 +713,8 @@ impl CryptoDxState {
     }
 }
 
-impl std::fmt::Display for CryptoDxState {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for CryptoDxState {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "epoch {} {:?}", self.epoch, self.direction)
     }
 }
@@ -1321,8 +1322,8 @@ impl CryptoStates {
     }
 }
 
-impl std::fmt::Display for CryptoStates {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for CryptoStates {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "CryptoStates")
     }
 }

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::fmt::{self, Display, Formatter};
+
 use neqo_common::qwarn;
 use neqo_crypto::Error as CryptoError;
 
@@ -206,8 +208,8 @@ impl ::std::error::Error for Error {
     }
 }
 
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Transport error: {self:?}")
     }
 }

--- a/neqo-transport/src/pace.rs
+++ b/neqo-transport/src/pace.rs
@@ -8,7 +8,7 @@
 
 use std::{
     cmp::min,
-    fmt::{Debug, Display},
+    fmt::{self, Debug, Display, Formatter},
     time::{Duration, Instant},
 };
 
@@ -127,13 +127,13 @@ impl Pacer {
 }
 
 impl Display for Pacer {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Pacer {}/{}", self.c, self.p)
     }
 }
 
 impl Debug for Pacer {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Pacer@{:?} {}/{}..{}", self.t, self.c, self.p, self.m)
     }
 }

--- a/neqo-transport/src/packet/metadata.rs
+++ b/neqo-transport/src/packet/metadata.rs
@@ -7,7 +7,7 @@
 // Enable just this file for logging to just see packets.
 // e.g. "RUST_LOG=neqo_transport::dump neqo-client ..."
 
-use std::fmt::Display;
+use std::fmt::{self, Display, Formatter};
 
 use neqo_common::IpTos;
 use qlog::events::quic::PacketHeader;
@@ -108,7 +108,7 @@ impl From<MetaData<'_>> for PacketHeader {
 }
 
 impl Display for MetaData<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "pn={} type={:?} {} {:?} len {}",

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -19,6 +19,7 @@ mod token;
 
 use std::{
     cmp::{max, min},
+    fmt::{self, Display, Formatter},
     ops::RangeInclusive,
     time::{Duration, Instant},
 };
@@ -933,8 +934,8 @@ impl LossRecovery {
     }
 }
 
-impl ::std::fmt::Display for LossRecovery {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for LossRecovery {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "LossRecovery")
     }
 }

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -16,6 +16,7 @@ use std::{
     cell::RefCell,
     cmp::max,
     collections::BTreeMap,
+    fmt::Debug,
     mem,
     rc::{Rc, Weak},
     time::{Duration, Instant},
@@ -997,6 +998,7 @@ impl RecvStream {
 mod tests {
     use std::{
         cell::RefCell,
+        fmt::Debug,
         ops::Range,
         rc::Rc,
         time::{Duration, Instant},
@@ -1656,7 +1658,7 @@ mod tests {
         assert!(session_fc.borrow().frame_needed());
     }
 
-    fn check_fc<T: std::fmt::Debug>(fc: &ReceiverFlowControl<T>, consumed: u64, retired: u64) {
+    fn check_fc<T: Debug>(fc: &ReceiverFlowControl<T>, consumed: u64, retired: u64) {
         assert_eq!(fc.consumed(), consumed);
         assert_eq!(fc.retired(), retired);
     }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -15,6 +15,7 @@ use std::{
     cell::RefCell,
     cmp::{max, min, Ordering},
     collections::{btree_map::Entry, BTreeMap, VecDeque},
+    fmt::{self, Display, Formatter},
     mem,
     num::NonZeroUsize,
     ops::Add,
@@ -1386,8 +1387,8 @@ impl SendStream {
     }
 }
 
-impl ::std::fmt::Display for SendStream {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for SendStream {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "SendStream {}", self.stream_id)
     }
 }

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -10,6 +10,7 @@ use std::{
     cell::RefCell,
     cmp::min,
     collections::HashSet,
+    fmt::{self, Display, Formatter},
     ops::{Deref, DerefMut},
     path::PathBuf,
     rc::Rc,
@@ -553,8 +554,8 @@ impl PartialEq for ConnectionRef {
 
 impl Eq for ConnectionRef {}
 
-impl ::std::fmt::Display for Server {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for Server {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Server")
     }
 }

--- a/neqo-transport/src/stream_id.rs
+++ b/neqo-transport/src/stream_id.rs
@@ -6,6 +6,8 @@
 
 // Stream ID and stream index handling.
 
+use std::fmt::{self, Display, Formatter};
+
 use neqo_common::Role;
 
 /// The type of stream, either Bi-Directional or Uni-Directional.
@@ -144,8 +146,8 @@ impl AsRef<u64> for StreamId {
     }
 }
 
-impl ::std::fmt::Display for StreamId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for StreamId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", self.as_u64())
     }
 }

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -10,7 +10,7 @@
 
 use std::{
     cell::RefCell,
-    fmt::Display,
+    fmt::{self, Display, Formatter},
     net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
     rc::Rc,
 };
@@ -69,7 +69,7 @@ pub enum TransportParameterId {
 }
 
 impl Display for TransportParameterId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         format!("{self:?}((0x{:02x}))", u64::from(*self)).fmt(f)
     }
 }

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -9,6 +9,7 @@
 use std::{
     cmp::min,
     collections::VecDeque,
+    fmt::{self, Display, Formatter},
     time::{Duration, Instant},
 };
 
@@ -151,8 +152,8 @@ impl PacketRange {
     }
 }
 
-impl ::std::fmt::Display for PacketRange {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for PacketRange {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}->{}", self.largest, self.smallest)
     }
 }
@@ -505,8 +506,8 @@ impl RecvdPackets {
     }
 }
 
-impl ::std::fmt::Display for RecvdPackets {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl Display for RecvdPackets {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Recvd-{}", self.space)
     }
 }

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -9,7 +9,7 @@
 use std::{
     cell::{OnceCell, RefCell},
     cmp::max,
-    fmt::Display,
+    fmt::{self, Display, Formatter},
     io::{self, Cursor, Result, Write},
     mem,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -432,16 +432,16 @@ impl Write for SharedVec {
 }
 
 impl Display for SharedVec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str(
             &String::from_utf8(
                 self.buf
                     .lock()
-                    .map_err(|_| std::fmt::Error)?
+                    .map_err(|_| fmt::Error)?
                     .clone()
                     .into_inner(),
             )
-            .map_err(|_| std::fmt::Error)?,
+            .map_err(|_| fmt::Error)?,
         )
     }
 }


### PR DESCRIPTION
Instead of qualifying in place.