### PR TITLE
ci: Misc. fixes

### DIFF
--- a/.github/workflows/check-vm.yml
+++ b/.github/workflows/check-vm.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os: [
               freebsd,
-              openbsd,
+              # openbsd, # FIXME: libfuzzer/FuzzerPlatform.h:72:2: error: "Support for your platform has not been implemented"
               # netbsd, # FIXME: NSS package is too old.
               # solaris # FIXME: NSS package is too old.
             ]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -119,6 +119,13 @@ jobs:
           RUST_LOG: warn
           BUILD_DIR: ${{ matrix.type == 'release' && 'release' || 'debug' }}
 
+      - name: CodeCov Windows workaround
+        if: matrix.os == 'windows-2025' && matrix.type == 'debug' && matrix.rust-toolchain == 'stable'
+        run: |
+          # FIXME: Without this, the codecov/codecov-action fails. No idea why it's looking under C:/msys64 now, it shouldn't.
+          mkdir -p C:/msys64/home/runneradmin/
+          touch C:/msys64/home/runneradmin/.gitconfig
+
       - uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
         with:
           files: codecov.json

--- a/neqo-common/src/hrtime.rs
+++ b/neqo-common/src/hrtime.rs
@@ -474,6 +474,7 @@ mod test {
         check_delays(ONE_AND_A_BIT);
     }
 
+    #[cfg(not(target_arch = "arm"))] // This test is flaky on linux/arm.
     #[test]
     fn update_multi() {
         let thr = spawn(move || {

--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -287,6 +287,10 @@ fn compatible_upgrade_large_initial() {
     assert!(
         server.stats().dscp_rx[IpTosDscp::Cs0] == server.stats().packets_rx
             || server.stats().dscp_rx[IpTosDscp::Cs0] == server.stats().packets_rx + 1
+            || server.stats().dscp_rx[IpTosDscp::Cs0] == server.stats().packets_rx - 1,
+        "dscp_rx[IpTosDscp::Cs0] {} != packets_rx {} (possibly +/- 1)",
+        server.stats().dscp_rx[IpTosDscp::Cs0],
+        server.stats().packets_rx
     );
 }
 

--- a/qns/Dockerfile
+++ b/qns/Dockerfile
@@ -39,7 +39,7 @@ RUN set -eux; \
 
 # Copy only binaries to the final image to keep it small.
 
-FROM martenseemann/quic-network-simulator-endpoint@sha256:3c373d0bac88ac0a005c56628e551fe980e44bf2dd50b9c6904d58d7f8d54089
+FROM martenseemann/quic-network-simulator-endpoint@sha256:42d79cc04b88f2e4b4c8beb418b0843c123f26852ff6bbba4caa6badc0043d23
 
 ENV LD_LIBRARY_PATH=/neqo/lib
 COPY --from=builder /neqo/target/release/neqo-client /neqo/target/release/neqo-server /neqo/bin/


### PR DESCRIPTION
- Disable the OpenBSD VM run, it's broken (no `libfuzzer-sys`)
- Add workaround for recent CodeCov breakage on Windows
- Disable flaky test on Linux/ARM
- Broaden success criteria for `compatible_upgrade_large_initial` test
- Use older version of QNS to work around recent random failures