### PR TITLE
feat: make fast-apple-datapath optional, off by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ enumset = { version = "1.1", default-features = false }
 hex = { version = "0.4", default-features = false }
 log = { version = "0.4", default-features = false }
 qlog = { version = "0.15.1", default-features = false }
-quinn-udp = { version = "0.5.11", default-features = false, features = ["direct-log", "fast-apple-datapath"] }
+quinn-udp = { version = "0.5.11", default-features = false, features = ["direct-log"] }
 regex = { version = "1.9", default-features = false }
 static_assertions = { version = "1.1", default-features = false }
 strum = { version = "0.27", default-features = false, features = ["derive"] }

--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -51,6 +51,7 @@ tokio = { version = "1", default-features = false, features = ["sync"] }
 
 [features]
 bench = ["neqo-bin/bench", "neqo-http3/bench", "neqo-transport/bench"]
+fast-apple-datapath = ["quinn-udp/fast-apple-datapath"]
 draft-29 = []
 
 [package.metadata.cargo-machete]

--- a/neqo-udp/Cargo.toml
+++ b/neqo-udp/Cargo.toml
@@ -28,6 +28,7 @@ ignored = ["log"]
 
 [features]
 bench = ["neqo-common/bench"]
+fast-apple-datapath = ["quinn-udp/fast-apple-datapath"]
 
 [lib]
 # See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -39,9 +39,9 @@ const RECV_BUF_SIZE: usize = u16::MAX as usize;
 /// - Linux/Android: use segmentation offloading via GRO
 /// - Windows: use segmentation offloading via URO (caveat see <https://github.com/quinn-rs/quinn/issues/2041>)
 /// - Apple: no segmentation offloading available, use multiple buffers
-#[cfg(not(apple))]
+#[cfg(not(all(apple, feature = "fast-apple-datapath")))]
 const NUM_BUFS: usize = 1;
-#[cfg(apple)]
+#[cfg(all(apple, feature = "fast-apple-datapath"))]
 // Value approximated based on neqo-bin "Download" benchmark only.
 const NUM_BUFS: usize = 16;
 


### PR DESCRIPTION
The `quinn-udp` `fast-apple-datapath` Cargo feature allows Neqo to use the private MacOS multi-message IO functions `sendmsg_x` and `recvmsg_x`.

We have seen issues with `fast-apple-datapath`:

- https://github.com/quinn-rs/quinn/issues/2214
- https://github.com/quinn-rs/quinn/pull/2154

To reduce the risk of the upcoming larger roll out of the [Fast UDP for Firefox project](https://bugzilla.mozilla.org/show_bug.cgi?id=1901292) to Firefox Release, disable `fast-apple-datapath` for now.  Enabling it can then be a separate project afterwards.

---

Objections? I know it is a step backwards from a performance perspective. That said, I would like to prioritize getting the larger _Fast UDP for Firefox_ project onto Firefox Release.