### PR TITLE
chore: prepare Neqo v0.13.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "criterion",
  "enum-map",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "criterion",
  "enumset",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "log",
  "neqo-common",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "criterion",
  "enum-map",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "cfg_aliases",
  "log",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.13.2"
+version = "0.13.3"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
With the recent performance improvements, I suggest we cut another patch release.

I would like to include https://github.com/mozilla/neqo/pull/2638, and thus unblock the roll out of the _Fast UDP for Firefox_ project on Firefox Release.

Once released, I will land this in Firefox Nightly and request an uplift to Firefox Beta.

---

```
git log --oneline v0.13.2..


548c051c fix: `clippy::iter_over_hash_type` (#2632)
aca21497 fix: `clippy::return_and_then` (#2631)
cb6d430a feat: `clippy::field_scoped_visibility_modifiers` (#2628)
3ecdfa1c fix: `clippy::partial_pub_fields` and `map_with_unused_argument_over_ranges` (#2630)
80bddc30 fix: Move allocations outside of loops (#2620)
d284171c chore: Bump `mtu` to 0.2.8 (#2614)
8e107a36 chore: Bump some deps to what Firefox is now using (#2615)
fc3ce612 fix: Avoid repeated lookups of NSS experimental API functions (#2618)
06c007ee fix: Eliminate expensive log call (#2617)
34ec8dbe fix(transport/qlog): call qlog::packet_io even without log::Level::Debug (#2612)
```