### PR TITLE
Make hrtime tests more robust

### DIFF
--- a/neqo-common/src/hrtime.rs
+++ b/neqo-common/src/hrtime.rs
@@ -406,8 +406,8 @@ mod test {
         for d in durations {
             sleep(d);
             let e = Instant::now();
-            let actual = e - s;
-            let lag = actual - d;
+            let actual = e.saturating_duration_since(s);
+            let lag = actual.saturating_sub(d);
             println!("sleep({d:>4?}) \u{2192} {actual:>11.6?} \u{394}{lag:>10?}");
             if lag > max_lag {
                 return Err(());

--- a/neqo-common/src/hrtime.rs
+++ b/neqo-common/src/hrtime.rs
@@ -432,15 +432,18 @@ mod test {
         };
 
         let mut count = 1;
-        while (1..=max_loops).contains(&count) {
+        while count <= max_loops {
             if validate_delays(max_lag).is_ok() {
                 count -= 1;
             } else {
                 count += 1;
             }
+            if count == 0 {
+                return;
+            }
             sleep(Duration::from_millis(50));
         }
-        assert_eq!(0, count, "timers slipped too often");
+        panic!("timers slipped too often");
     }
 
     /// Note that you have to run this test alone or other tests will


### PR DESCRIPTION
As the timers get tighter, give them more chances, but make the test pass two times for every failure.

Plus better pretty printing.

For #2422, but not claiming to fix it.