### PR TITLE
ci: Don't run baseline bench if cache exists

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,8 +3,8 @@ on:
   workflow_call:
   workflow_dispatch:
   schedule:
-    # Run at minute 0 past every 8th hour, so there is a `main`-branch baseline in the cache.
-    - cron: '0 */8 * * *'
+    # Run at minute 0 past every 4th hour, so there is a `main`-branch baseline in the cache.
+    - cron: '0 */4 * * *'
 env:
   CARGO_PROFILE_BENCH_BUILD_OVERRIDE_DEBUG: true
   CARGO_PROFILE_RELEASE_DEBUG: true
@@ -38,7 +38,18 @@ jobs:
           persist-credentials: false
           clean: false
 
+      - name: Download cached main-branch results
+        id: cache
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            neqo/target/criterion
+            hyperfine
+          key: bench-results-${{ runner.name }}-${{ github.sha }}
+          restore-keys: bench-results-${{ runner.name }}-
+
       - name: Checkout microsoft/msquic
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: microsoft/msquic
@@ -48,6 +59,7 @@ jobs:
           clean: false
 
       - name: Checkout google/quiche
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: google/quiche
@@ -57,6 +69,7 @@ jobs:
           clean: false
 
       - name: Checkout cloudflare/quiche
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: cloudflare/quiche
@@ -66,6 +79,7 @@ jobs:
           clean: false
 
       - name: Checkout aws/s2n-quic
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: aws/s2n-quic
@@ -75,10 +89,12 @@ jobs:
           clean: false
 
       - name: Set PATH and environment
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         run: |
           echo "/home/bench/.cargo/bin" >> "${GITHUB_PATH}"
 
       - name: Install Rust
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         uses: ./neqo/.github/actions/rust
         with:
           version: ${{ env.RUSTUP_TOOLCHAIN }}
@@ -90,16 +106,19 @@ jobs:
             s2n-quic
 
       - name: Get minimum NSS version
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         id: nss-version
         run: echo "minimum=$(cat neqo/neqo-crypto/min_version.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Install NSS
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         id: nss
         uses: ./neqo/.github/actions/nss
         with:
           minimum-version: ${{ steps.nss-version.outputs.minimum }}
 
       - name: Build neqo
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         run: |
           cd neqo
           # See https://github.com/flamegraph-rs/flamegraph for why we append to RUSTFLAGS here.
@@ -111,6 +130,7 @@ jobs:
           cargo build --locked --release --bin neqo-client --bin neqo-server
 
       - name: Build msquic
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         run: |
           mkdir -p msquic/build
           cd msquic/build
@@ -118,33 +138,28 @@ jobs:
           cmake --build .
 
       - name: Build google/quiche
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         run: |
           cd google-quiche
           bazel build -c opt --copt=-fno-omit-frame-pointer --copt=-g --strip=never --sandbox_writable_path=/home/bench/.cache/sccache quiche:quic_server quiche:quic_client
           bazel shutdown
 
       - name: Build cloudflare/quiche
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         run: |
           # We already changed RUSTFLAGS above; this depends on that having happened.
           cd quiche
           cargo build --release --bin quiche-client --bin quiche-server # --locked not working
 
       - name: Build aws/s2n-quic
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         run: |
           # We already changed RUSTFLAGS above; this depends on that having happened.
           cd s2n-quic
           cargo build --release --bin s2n-quic-qns # --locked not working
 
-      - name: Download cached main-branch results
-        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          path: |
-            neqo/target/criterion
-            hyperfine
-          key: bench-results-${{ runner.name }}-${{ github.sha }}
-          restore-keys: bench-results-${{ runner.name }}-
-
       - name: Move cached hyperfine results
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         run: |
           mv hyperfine hyperfine-main || true
           mkdir -p hyperfine
@@ -153,9 +168,11 @@ jobs:
       # Also creates "cpu23", "cpu2" and "cpu3" CPU sets for use with cset.
       # On the bencher, logical cores 2 and 3 have been isolated for use by the benchmarks.
       - name: Prepare machine
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         run: sudo /root/bin/prep.sh
 
       - name: Run cargo bench
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         env:
           NSS_DB_PATH: ${{ github.workspace }}/neqo/test-fixture/db
         run: |
@@ -178,6 +195,7 @@ jobs:
       # Compare various configurations of neqo against msquic and google/quiche, and gather perf data
       # during the hyperfine runs.
       - name: Compare QUIC implementations
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         env:
           HOST: 127.0.0.1
           PORT: 4433
@@ -387,13 +405,14 @@ jobs:
 
       # Re-enable turboboost, hyperthreading and use powersave governor. Remove all CPU sets.
       - name: Restore machine
+        if: ${{ success() || failure() || cancelled() }}
         run: |
           sudo /root/bin/unprep.sh
           # In case the previous test failed:
           sudo ip link set dev lo mtu 65536
-        if: ${{ success() || failure() || cancelled() }}
 
       - name: Post-process perf data
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         run: |
           for f in *.perf; do
             # Convert for profiler.firefox.com
@@ -403,6 +422,7 @@ jobs:
           done
 
       - name: Format results as Markdown
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         id: results
         run: |
           {
@@ -436,11 +456,11 @@ jobs:
           cat results.md > "$GITHUB_STEP_SUMMARY"
 
       - name: Remember main-branch push URL
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && steps.cache.outputs.cache-hit == 'false' }}
         run: echo "${{ github.sha }}" > neqo/target/criterion/baseline-sha.txt
 
       - name: Cache main-branch results
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && steps.cache.outputs.cache-hit == 'false' }}
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
@@ -449,6 +469,7 @@ jobs:
           key: bench-results-${{ runner.name }}-${{ github.sha }}
 
       - name: Export perf data
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         id: export
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -466,6 +487,7 @@ jobs:
           compression-level: 9
 
       - name: Export PR comment data
+        if: ${{ github.ref != 'refs/heads/main' || steps.cache.outputs.cache-hit == 'false' }}
         uses: ./neqo/.github/actions/pr-comment-data-export
         with:
           name: ${{ github.workflow }}


### PR DESCRIPTION
Because as long as a cache entry exists, GitHub doesn't allow it to be overwritten, so why run at all in that case.

Also check more frequently if we need to re-create the baseline bench cache.