### PR TITLE
fix: Set bench run length, and use `std::hint::black_box`

### DIFF
--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -43,7 +43,7 @@ tokio = { version = "1", default-features = false, features = ["net", "time", "m
 url = { workspace = true }
 
 [dev-dependencies]
-criterion = { version = "0.6", default-features = false, features = ["async_tokio"] }
+criterion = { version = "0.6", default-features = false, features = ["async_tokio", "cargo_bench_support"] }
 neqo-bin = { path = ".", features = ["draft-29"] }
 neqo-http3 = { path = "./../neqo-http3", features = ["draft-29"] }
 neqo-transport = { path = "./../neqo-transport", features = ["draft-29"] }

--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -6,7 +6,7 @@
 
 #![expect(clippy::unwrap_used, reason = "OK in a bench.")]
 
-use std::{env, path::PathBuf, str::FromStr as _};
+use std::{env, hint::black_box, path::PathBuf, str::FromStr as _, time::Duration};
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 use neqo_bin::{client, server};
@@ -60,8 +60,10 @@ fn transfer(c: &mut Criterion) {
             b.to_async(Builder::new_current_thread().enable_all().build().unwrap())
                 .iter_batched(
                     || client::client(client::Args::new(&requests, upload)),
-                    |client| async move {
-                        client.await.unwrap();
+                    |client| {
+                        black_box(async move {
+                            client.await.unwrap();
+                        })
                     },
                     BatchSize::PerIteration,
                 );
@@ -90,5 +92,9 @@ fn spawn_server() -> tokio::sync::oneshot::Sender<()> {
     done_sender
 }
 
-criterion_group!(benches, transfer);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().warm_up_time(Duration::from_secs(5)).measurement_time(Duration::from_secs(60));
+    targets = transfer
+}
 criterion_main!(benches);

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -27,7 +27,7 @@ strum = { workspace = true }
 windows = { version = "0.58", default-features = false, features = ["Win32_Media"] }
 
 [dev-dependencies]
-criterion = { version = "0.6", default-features = false }
+criterion = { version = "0.6", default-features = false, features = ["cargo_bench_support"] }
 neqo-crypto = { path = "../neqo-crypto" }
 test-fixture = { path = "../test-fixture" }
 regex = { workspace = true }

--- a/neqo-common/benches/decoder.rs
+++ b/neqo-common/benches/decoder.rs
@@ -6,7 +6,7 @@
 
 #![expect(clippy::unwrap_used, reason = "OK in a bench.")]
 
-use std::hint::black_box;
+use std::{hint::black_box, time::Duration};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_common::Decoder;
@@ -52,5 +52,9 @@ fn benchmark_decoder(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, benchmark_decoder);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().warm_up_time(Duration::from_secs(5)).measurement_time(Duration::from_secs(60));
+    targets = benchmark_decoder
+}
 criterion_main!(benches);

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -28,7 +28,7 @@ strum = { workspace = true}
 url = { workspace = true }
 
 [dev-dependencies]
-criterion = { version = "0.6", default-features = false }
+criterion = { version = "0.6", default-features = false, features = ["cargo_bench_support"] }
 neqo-http3 = { path = ".", features = ["draft-29"] }
 neqo-transport = { path = "./../neqo-transport", features = ["draft-29"] }
 test-fixture = { path = "../test-fixture" }

--- a/neqo-http3/benches/streams.rs
+++ b/neqo-http3/benches/streams.rs
@@ -88,7 +88,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             let data = vec![0; data_size];
             b.iter_batched_ref(
                 connect,
-                |(client, server)| black_box(use_streams(client, server, streams, &data)),
+                |_| black_box(|(client, server)| use_streams(client, server, streams, &data)),
                 BatchSize::SmallInput,
             );
         });

--- a/neqo-http3/benches/streams.rs
+++ b/neqo-http3/benches/streams.rs
@@ -6,7 +6,7 @@
 
 #![expect(clippy::unwrap_used, reason = "OK in a bench.")]
 
-use std::iter::repeat_with;
+use std::{hint::black_box, iter::repeat_with, time::Duration};
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use neqo_crypto::AuthenticationStatus;
@@ -88,7 +88,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             let data = vec![0; data_size];
             b.iter_batched_ref(
                 connect,
-                |(client, server)| use_streams(client, server, streams, &data),
+                |(client, server)| black_box(use_streams(client, server, streams, &data)),
                 BatchSize::SmallInput,
             );
         });
@@ -96,5 +96,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().warm_up_time(Duration::from_secs(5)).measurement_time(Duration::from_secs(60));
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -30,7 +30,7 @@ static_assertions = { workspace = true }
 strum = { workspace = true }
 
 [dev-dependencies]
-criterion = { version = "0.6", default-features = false }
+criterion = { version = "0.6", default-features = false, features = ["cargo_bench_support"] }
 neqo-transport = { path = ".", features = ["draft-29"] }
 test-fixture = { path = "../test-fixture" }
 

--- a/neqo-transport/benches/range_tracker.rs
+++ b/neqo-transport/benches/range_tracker.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{hint::black_box, time::Duration};
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_transport::send_stream::RangeTracker;
 
@@ -30,10 +32,12 @@ fn coalesce(c: &mut Criterion, count: u64) {
             b.iter_batched_ref(
                 || build_coalesce(count),
                 |used| {
-                    used.mark_acked(CHUNK, chunk);
-                    let tail = (count + 1) * CHUNK;
-                    used.mark_sent(tail, chunk);
-                    used.mark_acked(tail, chunk);
+                    black_box({
+                        used.mark_acked(CHUNK, chunk);
+                        let tail = (count + 1) * CHUNK;
+                        used.mark_sent(tail, chunk);
+                        used.mark_acked(tail, chunk);
+                    })
                 },
                 criterion::BatchSize::SmallInput,
             );
@@ -48,5 +52,9 @@ fn benchmark_coalesce(c: &mut Criterion) {
     coalesce(c, 1000);
 }
 
-criterion_group!(benches, benchmark_coalesce);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().warm_up_time(Duration::from_secs(5)).measurement_time(Duration::from_secs(60));
+    targets = benchmark_coalesce
+}
 criterion_main!(benches);

--- a/neqo-transport/benches/range_tracker.rs
+++ b/neqo-transport/benches/range_tracker.rs
@@ -31,14 +31,12 @@ fn coalesce(c: &mut Criterion, count: u64) {
         |b| {
             b.iter_batched_ref(
                 || build_coalesce(count),
-                |used| {
-                    black_box({
-                        used.mark_acked(CHUNK, chunk);
-                        let tail = (count + 1) * CHUNK;
-                        used.mark_sent(tail, chunk);
-                        used.mark_acked(tail, chunk);
-                    })
-                },
+                black_box(|used: &mut RangeTracker| {
+                    used.mark_acked(CHUNK, chunk);
+                    let tail = (count + 1) * CHUNK;
+                    used.mark_sent(tail, chunk);
+                    used.mark_acked(tail, chunk);
+                }),
                 criterion::BatchSize::SmallInput,
             );
         },

--- a/neqo-transport/benches/rx_stream_orderer.rs
+++ b/neqo-transport/benches/rx_stream_orderer.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{hint::black_box, time::Duration};
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_transport::recv_stream::RxStreamOrderer;
 
@@ -18,9 +20,13 @@ fn rx_stream_orderer() {
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("RxStreamOrderer::inbound_frame()", |b| {
-        b.iter(rx_stream_orderer);
+        b.iter(black_box(rx_stream_orderer));
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().warm_up_time(Duration::from_secs(5)).measurement_time(Duration::from_secs(60));
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/neqo-transport/benches/sent_packets.rs
+++ b/neqo-transport/benches/sent_packets.rs
@@ -4,7 +4,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::time::Instant;
+use std::{
+    hint::black_box,
+    time::{Duration, Instant},
+};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_transport::{
@@ -40,11 +43,15 @@ fn take_ranges(c: &mut Criterion) {
         b.iter_batched_ref(
             sent_packets,
             // Take the first 90 packets, minus some gaps.
-            |pkts| pkts.take_ranges([70..=89, 40..=59, 10..=29]),
+            |pkts| black_box(pkts.take_ranges([70..=89, 40..=59, 10..=29])),
             criterion::BatchSize::SmallInput,
         );
     });
 }
 
-criterion_group!(benches, take_ranges);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().warm_up_time(Duration::from_secs(5)).measurement_time(Duration::from_secs(60));
+    targets = take_ranges
+}
 criterion_main!(benches);

--- a/neqo-transport/benches/transfer.rs
+++ b/neqo-transport/benches/transfer.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::time::Duration;
+use std::{hint::black_box, time::Duration};
 
 use criterion::{criterion_group, criterion_main, BatchSize::SmallInput, Criterion};
 use neqo_transport::{ConnectionParameters, State};
@@ -62,7 +62,7 @@ fn benchmark_transfer(c: &mut Criterion, label: &str, seed: Option<impl AsRef<st
                     }
                     sim.setup()
                 },
-                ReadySimulator::run,
+                black_box(ReadySimulator::run),
                 SmallInput,
             );
         });
@@ -84,7 +84,7 @@ fn benchmark_transfer_fixed(c: &mut Criterion) {
 
 criterion_group! {
     name = transfer;
-    config = Criterion::default().warm_up_time(Duration::from_secs(5)).measurement_time(Duration::from_secs(15));
+    config = Criterion::default().warm_up_time(Duration::from_secs(5)).measurement_time(Duration::from_secs(60));
     targets = benchmark_transfer_variable, benchmark_transfer_fixed
 }
 criterion_main!(transfer);


### PR DESCRIPTION
No idea if this will make things more stable, but shouldn't hurt.

Also add the `cargo_bench_support` feature to `criterion`. Surprised that lacking that wasn't breaking anything.