### PR TITLE
feat: Set `line-tables-only` for `dev` profile.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,3 +134,7 @@ debug = true
 [profile.profiling]
 inherits = "release"
 debug = true
+
+[profile.dev]
+# See https://kobzol.github.io/rust/rustc/2025/05/20/disable-debuginfo-to-improve-rust-compile-times.html
+debug = "line-tables-only"


### PR DESCRIPTION
See https://kobzol.github.io/rust/rustc/2025/05/20/disable-debuginfo-to-improve-rust-compile-times.html

I doubt anyone is using a debugger regularly?