### PR TITLE
Revert use of `raw` in "chore: Fix new nightly `clippy` warnings"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "criterion",
  "enum-map",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "criterion",
  "enumset",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "log",
  "neqo-common",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "criterion",
  "enum-map",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "cfg_aliases",
  "log",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.13.3"
+version = "0.13.4"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/neqo-common/src/hrtime.rs
+++ b/neqo-common/src/hrtime.rs
@@ -172,7 +172,7 @@ mod mac {
         const NANOS_PER_MSEC: f64 = 1_000_000.0;
         let mut timebase_info = mach_timebase_info_data_t::default();
         unsafe {
-            mach_timebase_info(&raw mut timebase_info);
+            mach_timebase_info(&mut timebase_info);
         }
         f64::from(timebase_info.denom) * NANOS_PER_MSEC / f64::from(timebase_info.numer)
     }
@@ -203,8 +203,8 @@ mod mac {
                 pthread_mach_thread_np(pthread_self()),
                 THREAD_TIME_CONSTRAINT_POLICY,
                 addr_of_mut!(policy).cast(), // horror!
-                &raw mut count,
-                &raw mut get_default,
+                &mut count,
+                &mut get_default,
             )
         };
         policy

--- a/neqo-crypto/src/aead.rs
+++ b/neqo-crypto/src/aead.rs
@@ -87,7 +87,7 @@ impl RealAead {
             secret,
             p.as_ptr().cast(),
             c_uint::try_from(p.len())?,
-            &raw mut ctx,
+            &mut ctx,
         )?;
         Ok(Self {
             ctx: AeadContext::from_ptr(ctx)?,
@@ -119,7 +119,7 @@ impl RealAead {
                 input.as_ptr(),
                 c_uint::try_from(input.len())?,
                 output.as_mut_ptr(),
-                &raw mut l,
+                &mut l,
                 c_uint::try_from(output.len())?,
             )
         }?;
@@ -154,7 +154,7 @@ impl RealAead {
                 data.as_ptr(),
                 c_uint::try_from(data.len() - self.expansion())?,
                 data.as_ptr(),
-                &raw mut l,
+                &mut l,
                 c_uint::try_from(data.len())?,
             )
         }?;
@@ -186,7 +186,7 @@ impl RealAead {
                 input.as_ptr(),
                 c_uint::try_from(input.len())?,
                 output.as_mut_ptr(),
-                &raw mut l,
+                &mut l,
                 c_uint::try_from(output.len())?,
             )
         }?;
@@ -219,7 +219,7 @@ impl RealAead {
                 data.as_ptr(),
                 c_uint::try_from(data.len())?,
                 data.as_ptr(),
-                &raw mut l,
+                &mut l,
                 c_uint::try_from(data.len())?,
             )
         }?;

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -95,9 +95,9 @@ fn get_alpn(fd: *mut ssl::PRFileDesc, pre: bool) -> Res<Option<String>> {
     secstatus_to_res(unsafe {
         ssl::SSL_GetNextProto(
             fd,
-            &raw mut alpn_state,
+            &mut alpn_state,
             chosen.as_mut_ptr(),
-            &raw mut chosen_len,
+            &mut chosen_len,
             c_uint::try_from(chosen.len())?,
         )
     })?;
@@ -432,7 +432,7 @@ impl SecretAgent {
     /// If the range of versions isn't supported.
     pub fn set_version_range(&mut self, min: Version, max: Version) -> Res<()> {
         let range = ssl::SSLVersionRange { min, max };
-        secstatus_to_res(unsafe { ssl::SSL_VersionRangeSet(self.fd, &raw const range) })
+        secstatus_to_res(unsafe { ssl::SSL_VersionRangeSet(self.fd, &range) })
     }
 
     /// Enable a set of ciphers.  Note that the order of these is not respected.

--- a/neqo-crypto/src/cert.rs
+++ b/neqo-crypto/src/cert.rs
@@ -30,7 +30,7 @@ pub struct CertificateInfo {
 
 fn peer_certificate_chain(fd: *mut PRFileDesc) -> Option<ItemArray> {
     let mut chain_ptr: *mut SECItemArray = std::ptr::null_mut();
-    let rv = unsafe { SSL_PeerCertificateChainDER(fd, &raw mut chain_ptr) };
+    let rv = unsafe { SSL_PeerCertificateChainDER(fd, &mut chain_ptr) };
     if rv.is_ok() {
         ItemArray::from_ptr(chain_ptr).ok()
     } else {

--- a/neqo-crypto/src/ech.rs
+++ b/neqo-crypto/src/ech.rs
@@ -71,13 +71,13 @@ pub fn convert_ech_error(fd: *mut PRFileDesc, err: Error) -> Error {
     } = &err
     {
         let mut item = Item::make_empty();
-        if unsafe { SSL_GetEchRetryConfigs(fd, &raw mut item).is_err() } {
+        if unsafe { SSL_GetEchRetryConfigs(fd, &mut item).is_err() } {
             return Error::InternalError;
         }
         let buf = unsafe {
             let slc = null_safe_slice(item.data, item.len);
             let buf = Vec::from(slc);
-            SECITEM_FreeItem(&raw mut item, PRBool::from(false));
+            SECITEM_FreeItem(&mut item, PRBool::from(false));
             buf
         };
         Error::EchRetry(buf)
@@ -116,7 +116,7 @@ pub fn generate_keys() -> Res<(PrivateKey, PublicKey)> {
                 *slot,
                 p11::CK_MECHANISM_TYPE::from(p11::CKM_EC_KEY_PAIR_GEN),
                 addr_of_mut!(param_item).cast(),
-                &raw mut public_ptr,
+                &mut public_ptr,
                 p11::PK11_ATTR_SESSION | p11::PK11_ATTR_INSENSITIVE | p11::PK11_ATTR_PUBLIC,
                 p11::CK_FLAGS::from(p11::CKF_DERIVE),
                 p11::CK_FLAGS::from(p11::CKF_DERIVE),
@@ -133,7 +133,7 @@ pub fn generate_keys() -> Res<(PrivateKey, PublicKey)> {
                 *slot,
                 p11::CK_MECHANISM_TYPE::from(p11::CKM_EC_KEY_PAIR_GEN),
                 addr_of_mut!(param_item).cast(),
-                &raw mut public_ptr,
+                &mut public_ptr,
                 p11::PK11_ATTR_SESSION | p11::PK11_ATTR_SENSITIVE | p11::PK11_ATTR_PRIVATE,
                 p11::CK_FLAGS::from(p11::CKF_DERIVE),
                 p11::CK_FLAGS::from(p11::CKF_DERIVE),
@@ -192,7 +192,7 @@ pub fn encode_config(config: u8, public_name: &str, pk: &PublicKey) -> Res<Vec<u
             SUITES.as_ptr(),
             c_uint::try_from(SUITES.len())?,
             encoded.as_mut_ptr(),
-            &raw mut encoded_len,
+            &mut encoded_len,
             c_uint::try_from(encoded.len())?,
         )?;
     }

--- a/neqo-crypto/src/hkdf.rs
+++ b/neqo-crypto/src/hkdf.rs
@@ -104,7 +104,7 @@ pub fn extract(
 ) -> Res<SymKey> {
     let mut prk: *mut PK11SymKey = null_mut();
     let salt_ptr: *mut PK11SymKey = salt.map_or(null_mut(), |s| **s);
-    unsafe { SSL_HkdfExtract(version, cipher, salt_ptr, **ikm, &raw mut prk) }?;
+    unsafe { SSL_HkdfExtract(version, cipher, salt_ptr, **ikm, &mut prk) }?;
     SymKey::from_ptr(prk)
 }
 
@@ -134,7 +134,7 @@ pub fn expand_label(
             c_uint::try_from(handshake_hash.len())?,
             l.as_ptr().cast(),
             c_uint::try_from(l.len())?,
-            &raw mut secret,
+            &mut secret,
         )
     }?;
     SymKey::from_ptr(secret)

--- a/neqo-crypto/src/hp.rs
+++ b/neqo-crypto/src/hp.rs
@@ -99,7 +99,7 @@ impl HpKey {
                 c_uint::try_from(l.len())?,
                 mech,
                 key_size,
-                &raw mut secret,
+                &mut secret,
             )
         }?;
         let key = SymKey::from_ptr(secret).or(Err(Error::HkdfError))?;
@@ -156,7 +156,7 @@ impl HpKey {
                     PK11_CipherOp(
                         **context.borrow_mut(),
                         output.as_mut_ptr(),
-                        &raw mut output_len,
+                        &mut output_len,
                         c_int::try_from(output.len())?,
                         sample[..Self::SAMPLE_SIZE].as_ptr().cast(),
                         c_int::try_from(Self::SAMPLE_SIZE)?,
@@ -181,7 +181,7 @@ impl HpKey {
                         CK_MECHANISM_TYPE::from(CKM_CHACHA20),
                         addr_of_mut!(param_item),
                         output[..].as_mut_ptr(),
-                        &raw mut output_len,
+                        &mut output_len,
                         c_uint::try_from(output.len())?,
                         [0; Self::SAMPLE_SIZE].as_ptr(),
                         c_uint::try_from(Self::SAMPLE_SIZE)?,

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -105,7 +105,7 @@ fn version_check() -> Res<()> {
 fn enable_ssl_trace() -> Res<()> {
     let opt = Opt::Locking.as_int();
     let mut v: ::std::os::raw::c_int = 0;
-    secstatus_to_res(unsafe { ssl::SSL_OptionGetDefault(opt, &raw mut v) })
+    secstatus_to_res(unsafe { ssl::SSL_OptionGetDefault(opt, &mut v) })
 }
 
 fn init_once(db: Option<PathBuf>) -> Res<NssLoaded> {

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -102,7 +102,7 @@ impl PublicKey {
             PK11_HPKE_Serialize(
                 **self,
                 buf.as_mut_ptr(),
-                &raw mut len,
+                &mut len,
                 c_uint::try_from(buf.len())?,
             )
         })?;
@@ -149,7 +149,7 @@ impl PrivateKey {
                 PK11ObjectType::PK11_TypePrivKey,
                 (**self).cast(),
                 CK_ATTRIBUTE_TYPE::from(CKA_VALUE),
-                &raw mut key_item,
+                &mut key_item,
             )
         })?;
         let slc = unsafe { null_safe_slice(key_item.data, key_item.len) };
@@ -158,7 +158,7 @@ impl PrivateKey {
         // use the scoped `Item` implementation.  This is OK as long as nothing
         // panics between `PK11_ReadRawAttribute` succeeding and here.
         unsafe {
-            SECITEM_FreeItem(&raw mut key_item, PRBool::from(false));
+            SECITEM_FreeItem(&mut key_item, PRBool::from(false));
         }
         Ok(key)
     }

--- a/neqo-crypto/src/replay.rs
+++ b/neqo-crypto/src/replay.rs
@@ -64,7 +64,7 @@ impl AntiReplay {
                 Interval::from(window).try_into()?,
                 c_uint::try_from(k)?,
                 c_uint::try_from(bits)?,
-                &raw mut ctx,
+                &mut ctx,
             )
         }?;
 


### PR DESCRIPTION
This reverts the use of `raw` in commit 1ffe46c9bc923a9ac67bc5fd247a2cd2483f0759.

Rational:
- Firefox's [minimal Rust version is `1.82.0`](https://searchfox.org/mozilla-central/source/python/mozboot/mozboot/util.py#16).
- Rust `1.82.0` [stabilized `&raw const` and `&raw mut` operators (RFC 2582)](https://doc.rust-lang.org/beta/releases.html#version-1820-2024-10-17).
- Neqo - [uses these new operators in Neqo `0.13.3`](https://github.com/mozilla/neqo/pull/2605).
- Updating https://github.com/mozilla-firefox/firefox to Neqo `0.13.3` fails in `build-linux64-asan/opt` and `build-linux64-tsan/opt` job with the following error message:
    ```
    error[E0658]: raw address of syntax is experimental
    ```
    https://treeherder.mozilla.org/jobs?repo=try&revision=b7905ac4e2900df6c5c493011be71dd7342865a1&selectedTaskRun=GFayRWAqSnaQz0hF5gDceA.0
- These jobs use a Rust version before the official Rust 1.82.0 release, from a time when `&raw` has not yet been stabilized.

I see two ways forward:
1. Patch the Mozilla Rust 1.82.0-dev version as [suggested on Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1968057#c1).
2. Revert the usage of `&raw` in Neqo.

Given that `&raw` is a syntax change only, I don't think it is worth carrying yet another patch on top of the Mozilla Rust 1.82.0-dev fork (i.e. (1) above). Instead I suggest simply reverting the change here for now (i.e. (2) above).

---

Also discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1968057.