### PR TITLE
chore: lower minimal supported Rust version (MSRV) to 1.81.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 # Don't increase beyond what Firefox is currently using:
 # https://searchfox.org/mozilla-central/search?q=MINIMUM_RUST_VERSION&path=python/mozboot/mozboot/util.py
-rust-version = "1.82.0"
+# In addition, currently Mozilla CI uses a Rust fork before the official Rust 1.82.0 release, thus stay on 1.81.0 for now.
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1968057#c1
+rust-version = "1.81.0"
 
 [workspace.dependencies]
 enum-map = { version = "2.7", default-features = false }


### PR DESCRIPTION
Mozilla CI uses a Rust fork from before the official Rust 1.82.0 release. Be conservative here requring 1.81.0 instead of 1.82.0.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1968057#c1 for details.