### PR TITLE
bench: revert custom benc run length on stable benchmarks

### DIFF
--- a/neqo-common/benches/decoder.rs
+++ b/neqo-common/benches/decoder.rs
@@ -6,7 +6,7 @@
 
 #![expect(clippy::unwrap_used, reason = "OK in a bench.")]
 
-use std::{hint::black_box, time::Duration};
+use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_common::Decoder;
@@ -52,9 +52,5 @@ fn benchmark_decoder(c: &mut Criterion) {
     }
 }
 
-criterion_group! {
-    name = benches;
-    config = Criterion::default().warm_up_time(Duration::from_secs(5)).measurement_time(Duration::from_secs(60));
-    targets = benchmark_decoder
-}
+criterion_group!(benches, benchmark_decoder);
 criterion_main!(benches);

--- a/neqo-transport/benches/range_tracker.rs
+++ b/neqo-transport/benches/range_tracker.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{hint::black_box, time::Duration};
+use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_transport::send_stream::RangeTracker;
@@ -50,9 +50,5 @@ fn benchmark_coalesce(c: &mut Criterion) {
     coalesce(c, 1000);
 }
 
-criterion_group! {
-    name = benches;
-    config = Criterion::default().warm_up_time(Duration::from_secs(5)).measurement_time(Duration::from_secs(60));
-    targets = benchmark_coalesce
-}
+criterion_group!(benches, benchmark_coalesce);
 criterion_main!(benches);

--- a/neqo-transport/benches/rx_stream_orderer.rs
+++ b/neqo-transport/benches/rx_stream_orderer.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{hint::black_box, time::Duration};
+use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_transport::recv_stream::RxStreamOrderer;
@@ -24,9 +24,5 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group! {
-    name = benches;
-    config = Criterion::default().warm_up_time(Duration::from_secs(5)).measurement_time(Duration::from_secs(60));
-    targets = criterion_benchmark
-}
+criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);

--- a/neqo-transport/benches/transfer.rs
+++ b/neqo-transport/benches/transfer.rs
@@ -82,9 +82,9 @@ fn benchmark_transfer_fixed(c: &mut Criterion) {
     );
 }
 
-criterion_group! {
-    name = transfer;
-    config = Criterion::default().warm_up_time(Duration::from_secs(5)).measurement_time(Duration::from_secs(60));
-    targets = benchmark_transfer_variable, benchmark_transfer_fixed
-}
+criterion_group!(
+    transfer,
+    benchmark_transfer_variable,
+    benchmark_transfer_fixed
+);
 criterion_main!(transfer);


### PR DESCRIPTION
https://github.com/mozilla/neqo/pull/2655 increased the benchmark runtime across all benchmarks. This made benchmarks more stable.

Looking at the results of a recent run, this does not seem to be necessary for smaller benchmarks. Thus this commit reverts the custom setting for some in order to save CI runtime.

https://github.com/mozilla/neqo/actions/runs/15251928213/job/42891415533

---

Minor optimization. Don't feel strongly about it.