### PR TITLE
ci: Key the Rust cache by the OS version

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -67,6 +67,7 @@ runs:
           elif [[ "${{ runner.os }}" == "Windows" ]]; then
             echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld $RUSTFLAGS"
           fi
+          echo "RUNNER_OS=$(uname -srm)"
         } >> "$GITHUB_ENV"
 
     - name: Enable sscache
@@ -86,7 +87,7 @@ runs:
       with:
         cache-bin: ${{ runner.environment != 'github-hosted' }}
         cache-all-crates: true
-        key: ${{ inputs.targets }}
+        key: ${{ inputs.targets }}-${{ env.RUNNER_OS }}
         workspaces: ${{ inputs.workspaces }}
         save-if: ${{ github.ref == 'refs/heads/main' }} # Only cache runs from `main`.
 


### PR DESCRIPTION
The issue in https://github.com/mozilla/mtu/pull/129 seems to be that a cache generated on an `ubuntu-24.04` runner is being restored onto an `ubuntu-22.04` runner.