### PR TITLE
ci(.github/rust): replace `quickinstall` with `cargo install` with `--locked`

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -103,13 +103,6 @@ runs:
       if: ${{ runner.os == 'Windows' }}
       run: rm /usr/bin/link.exe || true
 
-    - name: Install cargo-quickinstall
-      shell: bash
-      if: ${{ inputs.tools != '' }}
-      env:
-        GITHUB_TOKEN: ${{ inputs.token }}
-      run: cargo install --locked cargo-quickinstall
-
     - name: Install Rust tools
       shell: bash
       if: ${{ inputs.tools != '' }}
@@ -119,10 +112,10 @@ runs:
       run: |
         for tool in $(echo $TOOLS | tr -d ","); do
           if [ "$tool" == "samply" ]; then
-            # TODO: Install via quickinstall once `--unstable-presymbolicate` is released.
+            # TODO: Install released version once `--unstable-presymbolicate` is released.
             cargo install --git https://github.com/mstange/samply samply
           else
             # FIXME: See https://github.com/Swatinem/rust-cache/issues/204 for why `--force`.
-            cargo quickinstall --force "$tool"
+            cargo install --locked --force "$tool"
           fi
         done


### PR DESCRIPTION
Previously we would use https://github.com/cargo-bins/cargo-quickinstall to install various Rust based command line tools, e.g. `nextest`.

`quickinstall` does not respect our `Cargo.lock`, nor does it have the option to enable it, e.g. via `--locked`.

The problem with not respecting our `Cargo.lock`:

- The `quickinstall` `nexttest` version uses `backtrace@0.3.75`.
- `backtrace@0.3.75` MSRV is `1.82.0` (https://crates.io/crates/backtrace/0.3.75)
- Our `Cargo.lock` specifies `backtrace@0.3.74`, which `quickinstall` ignores.
- https://github.com/mozilla/neqo/pull/2661/ tries to lower our MSRV to 1.81.0.
- The `check (ubuntu-24.04, 1.81.0, debug)` fails as it is using rustc `1.81.0`, but `backtrace@0.3.75` requires rustc `1.82.0`. https://github.com/mozilla/neqo/actions/runs/15275053671/job/42963962708

This commit removes `quickinstall` and replaces it with a simple `cargo install`. In addition it passes `--locked` to `cargo install`, thus respecting our `Cargo.lock`.

From a quick look at past builds, this does not add significant CI runtime.