### PR TITLE
ci(check): use Rust 1.82 instead of 1.81 on Windows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,6 +59,25 @@ jobs:
           - os: windows-2025
             rust-toolchain: stable
             type: release
+          # TODO: Remove once Neqo's MSRV is increased to 1.82.0. NSS build
+          # fails on Windows with Rust 1.81.0. Firefox does not use Rust 1.81.0
+          # (except for testing, see
+          # https://bugzilla.mozilla.org/show_bug.cgi?id=1968057#c1). Firefox
+          # uses Rust 1.82.0. Thus this is not worth fixing. Let's explicitly
+          # use Rust 1.82.0 here for now.
+          - os: windows-2025
+            rust-toolchain: 1.82.0
+            type: debug
+        exclude:
+          # TODO: Remove once Neqo's MSRV is increased to 1.82.0. NSS build
+          # fails on Windows with Rust 1.81.0. Firefox does not use Rust 1.81.0
+          # (except for testing, see
+          # https://bugzilla.mozilla.org/show_bug.cgi?id=1968057#c1). Firefox
+          # uses Rust 1.82.0. Thus this is not worth fixing. Let's explicitly
+          # use Rust 1.82.0 here for now.
+          - os: windows-2025
+            rust-toolchain: 1.81.0
+            type: debug
     env:
       BUILD_TYPE: ${{ matrix.type == 'release' && '--release' || '' }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
NSS build fails on Windows with Rust 1.81.0. Firefox does not use Rust 1.81.0 (except for testing, see
https://bugzilla.mozilla.org/show_bug.cgi?id=1968057#c1). Firefox uses Rust 1.82.0. Thus this is not worth fixing. Let's explicitly use Rust 1.82.0 here for now.