### PR TITLE
perf(common): make Encoder generic over borrowed or owned buffer

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -469,15 +469,15 @@ impl Debug for Encoder {
     }
 }
 
-impl AsRef<[u8]> for Encoder {
+impl<B: Buffer> AsRef<[u8]> for Encoder<B> {
     fn as_ref(&self) -> &[u8] {
-        self.buf.as_ref()
+        &self.buf.as_slice()[self.start..]
     }
 }
 
-impl AsMut<[u8]> for Encoder {
+impl<B: Buffer> AsMut<[u8]> for Encoder<B> {
     fn as_mut(&mut self) -> &mut [u8] {
-        self.buf.as_mut()
+        &mut self.buf.as_mut()[self.start..]
     }
 }
 
@@ -550,6 +550,8 @@ pub trait Buffer: io::Write {
 
     fn as_slice(&self) -> &[u8];
 
+    fn as_mut(&mut self) -> &mut [u8];
+
     // Functions needed for `Encoder::encode_vvec_with` and `Encoder::encode_vec_with`.
 
     fn write_zeroes(&mut self, n: usize);
@@ -566,6 +568,10 @@ impl Buffer for Vec<u8> {
 
     fn as_slice(&self) -> &[u8] {
         self.as_ref()
+    }
+
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.as_mut_slice()
     }
 
     fn write_zeroes(&mut self, n: usize) {
@@ -590,6 +596,10 @@ impl Buffer for &mut Vec<u8> {
         self.as_ref()
     }
 
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.as_mut_slice()
+    }
+
     fn write_zeroes(&mut self, n: usize) {
         self.resize(self.len() + n, 0);
     }
@@ -610,6 +620,10 @@ impl Buffer for Cursor<&mut [u8]> {
 
     fn as_slice(&self) -> &[u8] {
         self.get_ref()
+    }
+
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.get_mut()
     }
 
     fn write_zeroes(&mut self, n: usize) {

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -228,7 +228,7 @@ impl<B: Buffer> Encoder<B> {
     /// Note: for a view of a slice, use `Decoder::new(&enc[s..e])`
     #[must_use]
     pub fn as_decoder(&self) -> Decoder<'_> {
-        Decoder::new(&self.buf.as_slice())
+        Decoder::new(self.buf.as_slice())
     }
 
     /// Generic encode routine for arbitrary data.

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -549,6 +549,10 @@ impl Buffer for Vec<u8> {
         self.len()
     }
 
+    fn as_slice(&self) -> &[u8] {
+        self.as_ref()
+    }
+
     fn write_zeroes(&mut self, n: usize) {
         self.resize(self.len() + n, 0);
     }
@@ -559,10 +563,6 @@ impl Buffer for Vec<u8> {
 
     fn rotate_right(&mut self, start: usize, count: usize) {
         self[start..].rotate_right(count);
-    }
-
-    fn as_slice(&self) -> &[u8] {
-        self.as_ref()
     }
 }
 
@@ -571,6 +571,10 @@ impl Buffer for &mut Vec<u8> {
         Vec::len(self)
     }
 
+    fn as_slice(&self) -> &[u8] {
+        self.as_ref()
+    }
+
     fn write_zeroes(&mut self, n: usize) {
         self.resize(self.len() + n, 0);
     }
@@ -582,15 +586,15 @@ impl Buffer for &mut Vec<u8> {
     fn rotate_right(&mut self, start: usize, count: usize) {
         self[start..].rotate_right(count);
     }
-
-    fn as_slice(&self) -> &[u8] {
-        self.as_ref()
-    }
 }
 
 impl Buffer for Cursor<&mut [u8]> {
     fn len(&self) -> usize {
         usize::try_from(self.position()).expect("memory allocation not to exceed usize")
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        self.get_ref()
     }
 
     fn write_zeroes(&mut self, n: usize) {
@@ -607,10 +611,6 @@ impl Buffer for Cursor<&mut [u8]> {
 
     fn rotate_right(&mut self, start: usize, count: usize) {
         self.get_mut()[start..].rotate_right(count);
-    }
-
-    fn as_slice(&self) -> &[u8] {
-        self.get_ref()
     }
 }
 

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -598,7 +598,7 @@ impl Buffer for Cursor<&mut [u8]> {
         let end = start + n;
 
         self.get_mut()[start..end].fill(0);
-        self.set_position(end as u64);
+        self.set_position(u64::try_from(end).expect("Position cannot exceed u64"));
     }
 
     fn write_at(&mut self, pos: usize, data: u8) {

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -24,7 +24,7 @@ use strum::Display;
 #[cfg(feature = "build-fuzzing-corpus")]
 pub use self::fuzz::write_item_to_fuzzing_corpus;
 pub use self::{
-    codec::{Decoder, Encoder, MAX_VARINT},
+    codec::{Buffer, Decoder, Encoder, MAX_VARINT},
     datagram::Datagram,
     header::Header,
     incrdecoder::{IncrementalDecoderBuffer, IncrementalDecoderIgnore, IncrementalDecoderUint},

--- a/neqo-http3/src/buffered_send_stream.rs
+++ b/neqo-http3/src/buffered_send_stream.rs
@@ -6,6 +6,7 @@
 
 use std::fmt::{self, Display, Formatter};
 
+use neqo_common::Encoder;
 use neqo_transport::{Connection, StreamId};
 
 use crate::{qlog, Res};
@@ -46,6 +47,14 @@ impl BufferedStream {
         };
     }
 
+    pub fn encode_with<F: FnOnce(&mut Encoder<&mut Vec<u8>>)>(&mut self, f: F) {
+        if let Self::Initialized { buf, .. } = self {
+            f(&mut Encoder::new_borrowed_vec(buf));
+        } else {
+            debug_assert!(false, "Do not encode data before the stream is initialized");
+        }
+    }
+
     /// # Panics
     ///
     /// This function cannot be called before the `BufferedStream` is initialized.
@@ -53,7 +62,7 @@ impl BufferedStream {
         if let Self::Initialized { buf, .. } = self {
             buf.extend_from_slice(to_buf);
         } else {
-            debug_assert!(false, "Do not buffer date before the stream is initialized");
+            debug_assert!(false, "Do not buffer data before the stream is initialized");
         }
     }
 

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -41,9 +41,7 @@ impl ControlStreamLocal {
 
     /// Add a new frame that needs to be send.
     pub fn queue_frame(&mut self, f: &HFrame) {
-        let mut enc = Encoder::default();
-        f.encode(&mut enc);
-        self.stream.buffer(enc.as_ref());
+        self.stream.encode_with(|e| f.encode(e));
     }
 
     pub fn queue_update_priority(&mut self, stream_id: StreamId) {

--- a/neqo-http3/src/frames/hframe.rs
+++ b/neqo-http3/src/frames/hframe.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::{Debug, Write as _};
 
-use neqo_common::{Decoder, Encoder};
+use neqo_common::{Buffer, Decoder, Encoder};
 use neqo_crypto::random;
 use neqo_transport::StreamId;
 
@@ -94,7 +94,7 @@ impl HFrame {
         }
     }
 
-    pub fn encode(&self, enc: &mut Encoder) {
+    pub fn encode<B: Buffer>(&self, enc: &mut Encoder<B>) {
         enc.encode_varint(self.get_type());
 
         match self {

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -12,7 +12,7 @@ use std::{
     rc::Rc,
 };
 
-use neqo_common::{qdebug, qtrace, Encoder, Header, MessageType};
+use neqo_common::{qdebug, qtrace, Buffer, Encoder, Header, MessageType};
 use neqo_qpack::encoder::QPackEncoder;
 use neqo_transport::{Connection, StreamId};
 
@@ -140,20 +140,19 @@ impl SendMessage {
     ///
     /// `ClosedCriticalStream` if the encoder stream is closed.
     /// `InternalError` if an unexpected error occurred.
-    fn encode(
-        encoder: &mut QPackEncoder,
+    fn encode<B: Buffer>(
+        encoder: &mut Encoder<B>,
+        qpack_encoder: &mut QPackEncoder,
         headers: &[Header],
         conn: &mut Connection,
         stream_id: StreamId,
-    ) -> Vec<u8> {
+    ) {
         qdebug!("Encoding headers");
-        let header_block = encoder.encode_header_block(conn, headers, stream_id);
+        let header_block = qpack_encoder.encode_header_block(conn, headers, stream_id);
         let hframe = HFrame::Headers {
             header_block: header_block.to_vec(),
         };
-        let mut d = Encoder::default();
-        hframe.encode(&mut d);
-        d.into()
+        hframe.encode(encoder);
     }
 
     fn stream_id(&self) -> StreamId {
@@ -302,9 +301,7 @@ impl SendStream for SendMessage {
         let data_frame = HFrame::Data {
             len: buf.len() as u64,
         };
-        let mut enc = Encoder::default();
-        data_frame.encode(&mut enc);
-        self.stream.buffer(enc.as_ref());
+        self.stream.encode_with(|e| data_frame.encode(e));
         self.stream.buffer(buf);
         _ = self.stream.send_buffer(conn)?;
         Ok(())
@@ -314,13 +311,10 @@ impl SendStream for SendMessage {
 impl HttpSendStream for SendMessage {
     fn send_headers(&mut self, headers: &[Header], conn: &mut Connection) -> Res<()> {
         self.state.new_headers(headers, self.message_type)?;
-        let buf = Self::encode(
-            &mut self.encoder.borrow_mut(),
-            headers,
-            conn,
-            self.stream_id(),
-        );
-        self.stream.buffer(&buf);
+        let stream_id = self.stream_id();
+        self.stream.encode_with(|e| {
+            Self::encode(e, &mut self.encoder.borrow_mut(), headers, conn, stream_id);
+        });
         Ok(())
     }
 

--- a/neqo-http3/src/settings.rs
+++ b/neqo-http3/src/settings.rs
@@ -6,7 +6,7 @@
 
 use std::ops::Deref;
 
-use neqo_common::{Decoder, Encoder};
+use neqo_common::{Buffer, Decoder, Encoder};
 use neqo_crypto::{ZeroRttCheckResult, ZeroRttChecker};
 
 use crate::{Error, Http3Parameters, Res};
@@ -86,7 +86,7 @@ impl HSettings {
             .map_or_else(|| hsetting_default(setting), |v| v.value)
     }
 
-    pub fn encode_frame_contents(&self, enc: &mut Encoder) {
+    pub fn encode_frame_contents<B: Buffer>(&self, enc: &mut Encoder<B>) {
         enc.encode_vvec_with(|enc_inner| {
             for iter in &self.settings {
                 match iter.setting_type {

--- a/neqo-qpack/src/qpack_send_buf.rs
+++ b/neqo-qpack/src/qpack_send_buf.rs
@@ -25,9 +25,7 @@ impl QpackData {
     }
 
     pub fn encode_varint(&mut self, i: u64) {
-        let mut enc = Encoder::default();
-        enc.encode_varint(i);
-        self.buf.append(&mut enc.into());
+        Encoder::new_borrowed_vec(&mut self.buf).encode_varint(i);
     }
 
     pub(crate) fn encode_prefixed_encoded_int(&mut self, prefix: Prefix, mut val: u64) -> usize {


### PR DESCRIPTION
This allows users of `Encoder` to encode into existing buffers, thus reducing memory allocations and copying.

Example

Previously:

``` rust
let some_existing_buffer = vec![];
// ...
let mut encoder = Encoder::new(); // allocating a new temporary Vec
encoder.encode_varint(42); // writing into the temporary Vec
some_existing_buffer.extend_from_slice(&encoder); // copying latter into former.
```

Now:

``` rust
let some_existing_buffer = vec![];
// ...
let mut encoder = Encoder::new_borrowed_vec(&mut some_existing_buffer);
encoder.encode_varint(42); // writing directly into some_existing_buffer
```

---

Fixes https://github.com/mozilla/neqo/issues/2054.
Discussed in https://github.com/mozilla/neqo/issues/2670.
Simplifies https://github.com/mozilla/neqo/pull/2593.
