### PR TITLE
ci: Use bencher.dev

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -163,7 +163,6 @@ jobs:
         run: |
           sudo ip link set dev lo mtu "$MTU"
           mkdir -p binaries
-          touch results.txt
           cd neqo-main
           rm -rf target/criterion
           for BENCH in $BENCHES; do
@@ -175,18 +174,13 @@ jobs:
           rm -rf target/criterion
           cp -r ../neqo-main/target/criterion target/
           for BENCH in $BENCHES; do
-            echo "Running $BENCH"
-            NAME=$(basename "$BENCH" | cut -d- -f1)
-            echo "Running $NAME ($BENCH)"
-            cp -v "$BENCH" ../binaries/
-            echo copied
-            ls -l ../binaries/
+            cp "$BENCH" ../binaries/
             # Run it twice, once without perf for baseline comparison, and once with perf for profiling.
             # (Perf seems to introduce some variability in the results.)
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
-              $BENCH -- --bench | { grep -v '^cset' || test $? = 1; } | tee -a ../results.txt
-            echo "Running $NAME with perf"
+              $BENCH -- --bench --baseline main | { grep -v '^cset' || test $? = 1; } | tee -a ../results.txt
+            NAME=$(basename "$BENCH" | cut -d- -f1)
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               perf -- $PERF_OPT -o "$NAME.perf" $BENCH --bench --noplot --discard-baseline | { grep -v '^cset' || test $? = 1; }
@@ -461,16 +455,18 @@ jobs:
             cat comparison.md
           } >> results.md
           cat results.md > "$GITHUB_STEP_SUMMARY"
+          echo "$runner.name" > testbed.txt
 
       - name: Upload benchmark results for bencher.dev
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: results
           path: |
-            results.txt
             neqo/target/criterion
             neqo-main/target/criterion
             hyperfine
+            hyperfine-main
+            testbed.txt
 
       - name: Upload GitHub event for bencher.dev
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -197,8 +197,8 @@ jobs:
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               $BENCH -- --bench | grep -v '^cset' | tee -a ../results.txt
-            # shellcheck disable=SC2086
             echo "Running $NAME with perf"
+            # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               perf -- $PERF_OPT -o "$NAME.perf" $BENCH --bench --noplot --discard-baseline # | grep -v '^cset'
           done

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,9 @@
 name: Bench
 on:
   workflow_call:
+    secrets:
+      BENCHER_API_TOKEN:
+        required: true
   workflow_dispatch:
   schedule:
     # Run at minute 0 past every 4th hour, so there is a `main`-branch baseline in the cache.
@@ -17,6 +20,7 @@ env:
   CXXFLAGS: -fno-omit-frame-pointer
   WORKSPACE: ${{ github.workspace}}
   BENCHER_PROJECT: neqo
+  BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
   BENCHER_BRANCH: ${{ github.ref_name}}
 
 permissions:
@@ -205,7 +209,6 @@ jobs:
             # (Perf seems to introduce some variability in the results.)
             # shellcheck disable=SC2086
             bencher run \
-              --token '${{ secrets.BENCHER_API_TOKEN }}' \
               --threshold-measure latency \
               --threshold-test t_test \
               --threshold-max-sample-size 64 \
@@ -345,7 +348,6 @@ jobs:
                   transmogrify "${client_cmd[$client]}" "$cc" "$pacing" "${neqo_flags[$server]}"
                   cd "$TMP/out"
                   bencher run \
-                    --token '${{ secrets.BENCHER_API_TOKEN }}' \
                     --threshold-measure latency \
                     --threshold-test t_test \
                     --threshold-max-sample-size 64 \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -193,6 +193,7 @@ jobs:
         run: |
           sudo ip link set dev lo mtu "$MTU"
           mkdir -p binaries
+          touch results.txt
           cd neqo
           for BENCH in $BENCHES; do
             NAME=$(basename "$BENCH" | cut -d- -f1)

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -205,7 +205,7 @@ jobs:
             # (Perf seems to introduce some variability in the results.)
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
-              $BENCH -- --bench | grep -v '^cset' | tee -a ../results.txt
+              $BENCH -- --bench | tee -a ../results.txt # | grep -v '^cset'
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               perf -- $PERF_OPT -o "$NAME.perf" $BENCH --bench --noplot --discard-baseline | grep -v '^cset'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,6 +16,9 @@ env:
   CFLAGS: -fno-omit-frame-pointer
   CXXFLAGS: -fno-omit-frame-pointer
   WORKSPACE: ${{ github.workspace}}
+  BENCHER_PROJECT: neqo
+  BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+  BENCHER_BRANCH: ${{ github.ref_name}}
 
 permissions:
   contents: read
@@ -27,10 +30,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      BENCHER_PROJECT: neqo
-      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-      BENCHER_BRANCH: ${{ github.ref_name}}
 
     steps:
       - uses: bencherdev/bencher@v0.5.1 # zizmor: ignore[unpinned-uses] bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,6 +30,8 @@ jobs:
   bench:
     name: Benchmark
     runs-on: self-hosted # zizmor: ignore[self-hosted-runner]
+    permissions:
+      pull-requests: write
     defaults:
       run:
         shell: bash
@@ -218,7 +220,7 @@ jobs:
               --adapter rust_criterion \
               --github-actions '${{ secrets.GITHUB_TOKEN }}' \
               nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
-                $BENCH -- --bench | tee -a ../results.txt
+                $BENCH -- --bench | grep -v '^cset:' | tee -a ../results.txt
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               perf -- $PERF_OPT -o "$NAME.perf" $BENCH --bench --noplot --discard-baseline
@@ -478,7 +480,6 @@ jobs:
             } | tee sha.md >> results.md
           fi
           sed -E -e 's/^                 //gi' \
-                 -e '/cset:.*last message/d' \
                  -e 's/((change|time|thrpt):[^%]*% )([^%]*%)(.*)/\1<b>\3<\/b>\4/gi' results.txt |\
             perl -p -0777 -e 's/(.*?)\n(.*?)(((No change|Change within|Performance has).*?)(\nFound .*?)?)?\n\n/<details><summary>$1: $4<\/summary><pre>\n$2$6<\/pre><\/details>\n/gs' |\
             sed -E -e 's/(Performance has regressed.)/:broken_heart: <b>\1<\/b>/gi' \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,7 +28,7 @@ jobs:
       run:
         shell: bash
     env:
-      BENCHER_PROJECT: ${{ github.repository}}
+      BENCHER_PROJECT: neqo
       BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
       BENCHER_BRANCH: ${{ github.ref_name}}
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,6 +17,7 @@ env:
   CXXFLAGS: -fno-omit-frame-pointer
   WORKSPACE: ${{ github.workspace}}
   BENCHER_PROJECT: neqo
+  BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
   BENCHER_BRANCH: ${{ github.ref_name}}
 
 permissions:
@@ -205,7 +206,6 @@ jobs:
             # (Perf seems to introduce some variability in the results.)
             # shellcheck disable=SC2086
             bencher run \
-              --token '${{ secrets.BENCHER_API_TOKEN }}' \
               --threshold-measure latency \
               --threshold-test t_test \
               --threshold-max-sample-size 64 \
@@ -345,7 +345,6 @@ jobs:
                   transmogrify "${client_cmd[$client]}" "$cc" "$pacing" "${neqo_flags[$server]}"
                   cd "$TMP/out"
                   bencher run \
-                    --token '${{ secrets.BENCHER_API_TOKEN }}' \
                     --threshold-measure latency \
                     --threshold-test t_test \
                     --threshold-max-sample-size 64 \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -198,6 +198,8 @@ jobs:
             NAME=$(basename "$BENCH" | cut -d- -f1)
             echo "Running $NAME ($BENCH)"
             cp -v "$BENCH" ../binaries/
+            echo copied
+            ls -l ../binaries/
             # Run it twice, once without perf for baseline comparison, and once with perf for profiling.
             # (Perf seems to introduce some variability in the results.)
             # shellcheck disable=SC2086

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,7 +17,6 @@ env:
   CXXFLAGS: -fno-omit-frame-pointer
   WORKSPACE: ${{ github.workspace}}
   BENCHER_PROJECT: neqo
-  BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
   BENCHER_BRANCH: ${{ github.ref_name}}
 
 permissions:
@@ -206,6 +205,7 @@ jobs:
             # (Perf seems to introduce some variability in the results.)
             # shellcheck disable=SC2086
             bencher run \
+              --token '${{ secrets.BENCHER_API_TOKEN }}' \
               --threshold-measure latency \
               --threshold-test t_test \
               --threshold-max-sample-size 64 \
@@ -345,6 +345,7 @@ jobs:
                   transmogrify "${client_cmd[$client]}" "$cc" "$pacing" "${neqo_flags[$server]}"
                   cd "$TMP/out"
                   bencher run \
+                    --token '${{ secrets.BENCHER_API_TOKEN }}' \
                     --threshold-measure latency \
                     --threshold-test t_test \
                     --threshold-max-sample-size 64 \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -196,11 +196,11 @@ jobs:
             # (Perf seems to introduce some variability in the results.)
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
-              $BENCH -- --bench | grep -v '^cset' | tee -a ../results.txt
+              $BENCH -- --bench | { grep -v '^cset' || test $? = 1; } | tee -a ../results.txt
             echo "Running $NAME with perf"
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
-              perf -- $PERF_OPT -o "$NAME.perf" $BENCH --bench --noplot --discard-baseline # | grep -v '^cset'
+              perf -- $PERF_OPT -o "$NAME.perf" $BENCH --bench --noplot --discard-baseline | { grep -v '^cset' || test $? = 1; }
           done
 
       # Compare various configurations of neqo against msquic and google/quiche, and gather perf data

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -196,8 +196,8 @@ jobs:
           cd neqo
           for BENCH in $BENCHES; do
             NAME=$(basename "$BENCH" | cut -d- -f1)
-            echo "Running $NAME"
-            cp "$BENCH" ../binaries/
+            echo "Running $NAME ($BENCH)"
+            cp -v "$BENCH" ../binaries/
             # Run it twice, once without perf for baseline comparison, and once with perf for profiling.
             # (Perf seems to introduce some variability in the results.)
             # shellcheck disable=SC2086

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -196,6 +196,7 @@ jobs:
           cd neqo
           for BENCH in $BENCHES; do
             NAME=$(basename "$BENCH" | cut -d- -f1)
+            echo "Running $NAME"
             cp "$BENCH" ../binaries/
             # Run it twice, once without perf for baseline comparison, and once with perf for profiling.
             # (Perf seems to introduce some variability in the results.)
@@ -204,7 +205,7 @@ jobs:
               $BENCH -- --bench | grep -v '^cset' | tee -a ../results.txt
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
-              perf -- $PERF_OPT -o "$NAME.perf" $BENCH --bench --noplot --discard-baseline
+              perf -- $PERF_OPT -o "$NAME.perf" $BENCH --bench --noplot --discard-baseline | grep -v '^cset'
           done
 
       # Compare various configurations of neqo against msquic and google/quiche, and gather perf data

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -397,9 +397,11 @@ jobs:
                       FORMAT=""
                     fi
                     printf "| %s %s%.1f%s | %s%.1f%%%s |\n" "$SYMBOL" "$FORMAT" "$DELTA" "$FORMAT" "$FORMAT" "$PERCENT" "$FORMAT" >> steps.md
-                  else
+                  elif [ "$client" == "neqo" ] || [ "$server" == "neqo" ]; then
                     echo No cached baseline from main found.
                     echo '| :question: | :question: |' >> steps.md
+                  else
+                    echo '| | |' >> steps.md
                   fi
                 done
               done

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -196,6 +196,7 @@ jobs:
           touch results.txt
           cd neqo
           for BENCH in $BENCHES; do
+            echo "Running $BENCH"
             NAME=$(basename "$BENCH" | cut -d- -f1)
             echo "Running $NAME ($BENCH)"
             cp -v "$BENCH" ../binaries/
@@ -205,10 +206,11 @@ jobs:
             # (Perf seems to introduce some variability in the results.)
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
-              $BENCH -- --bench | tee -a ../results.txt # | grep -v '^cset'
+              $BENCH -- --bench | grep -v '^cset' | tee -a ../results.txt
             # shellcheck disable=SC2086
+            echo "Running $NAME with perf"
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
-              perf -- $PERF_OPT -o "$NAME.perf" $BENCH --bench --noplot --discard-baseline | grep -v '^cset'
+              perf -- $PERF_OPT -o "$NAME.perf" $BENCH --bench --noplot --discard-baseline # | grep -v '^cset'
           done
 
       # Compare various configurations of neqo against msquic and google/quiche, and gather perf data

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,9 +1,6 @@
 name: Bench
 on:
   workflow_call:
-    secrets:
-      BENCHER_API_TOKEN:
-        required: true
   workflow_dispatch:
   schedule:
     # Run at minute 0 past every 4th hour, so there is a `main`-branch baseline in the cache.
@@ -19,9 +16,6 @@ env:
   CFLAGS: -fno-omit-frame-pointer
   CXXFLAGS: -fno-omit-frame-pointer
   WORKSPACE: ${{ github.workspace}}
-  BENCHER_PROJECT: neqo
-  BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-  BENCHER_BRANCH: ${{ github.ref_name}}
 
 permissions:
   contents: read
@@ -30,15 +24,11 @@ jobs:
   bench:
     name: Benchmark
     runs-on: self-hosted # zizmor: ignore[self-hosted-runner]
-    permissions:
-      pull-requests: write
     defaults:
       run:
         shell: bash
 
     steps:
-      - uses: bencherdev/bencher@v0.5.1 # zizmor: ignore[unpinned-uses] bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
-
       - name: Checkout mozilla/neqo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -199,7 +189,6 @@ jobs:
         if: steps.run.outputs.needed == 'true'
         env:
           NSS_DB_PATH: ${{ github.workspace }}/neqo/test-fixture/db
-          BENCHER_TESTBED: ${{ runner.name }}
         run: |
           sudo ip link set dev lo mtu "$MTU"
           mkdir -p binaries
@@ -210,17 +199,8 @@ jobs:
             # Run it twice, once without perf for baseline comparison, and once with perf for profiling.
             # (Perf seems to introduce some variability in the results.)
             # shellcheck disable=SC2086
-            bencher run \
-              --threshold-measure latency \
-              --threshold-test t_test \
-              --threshold-max-sample-size 64 \
-              --threshold-upper-boundary 0.99 \
-              --thresholds-reset \
-              --err \
-              --adapter rust_criterion \
-              --github-actions '${{ secrets.GITHUB_TOKEN }}' \
-              nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
-                $BENCH -- --bench | grep -v '^cset:' | tee -a ../results.txt
+            nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
+              $BENCH -- --bench | grep -v '^cset' | tee -a ../results.txt
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               perf -- $PERF_OPT -o "$NAME.perf" $BENCH --bench --noplot --discard-baseline
@@ -236,7 +216,6 @@ jobs:
           SIZE: 33554432 # 32 MB
           RUNS: 100
           NSS_DB_PATH: ${{ github.workspace }}/neqo/test-fixture/db
-          BENCHER_TESTBED: ${{ runner.name }}
         run: |
           TMP=$(mktemp -d)
           mkdir -p "$TMP/out"
@@ -349,25 +328,15 @@ jobs:
                   SERVER_TAG="$(basename "$(echo "${server_cmd[$server]}" | cut -f1 -d' ')" | cut -c1-15)"
                   transmogrify "${client_cmd[$client]}" "$cc" "$pacing" "${neqo_flags[$server]}"
                   cd "$TMP/out"
-                  bencher run \
-                    --threshold-measure latency \
-                    --threshold-test t_test \
-                    --threshold-max-sample-size 64 \
-                    --threshold-upper-boundary 0.99 \
-                    --thresholds-reset \
-                    --err \
-                    --adapter shell_hyperfine \
-                    --file "$WORKSPACE/hyperfine/$FILENAME.json" \
-                    --github-actions '${{ secrets.GITHUB_TOKEN }}' \
-                    nice -n -20 setarch --addr-no-randomize hyperfine \
-                      --command-name "$TAG" --time-unit millisecond  \
-                      --export-json "$WORKSPACE/hyperfine/$FILENAME.json" \
-                      --export-markdown "$WORKSPACE/hyperfine/$FILENAME.md" \
-                      --output null --warmup 5 --min-runs "$RUNS" \
-                      --prepare "$WORKSPACE/$SERVER_CMD & echo \$! >> /cpusets/cpu2/tasks; sleep 0.1" \
-                      --conclude "pkill $SERVER_TAG" \
-                      "echo \$\$ >> /cpusets/cpu3/tasks; $WORKSPACE/$CMD" |
-                    tee -a "$WORKSPACE/comparison.txt"
+                  nice -n -20 setarch --addr-no-randomize hyperfine \
+                    --command-name "$TAG" --time-unit millisecond  \
+                    --export-json "$WORKSPACE/hyperfine/$FILENAME.json" \
+                    --export-markdown "$WORKSPACE/hyperfine/$FILENAME.md" \
+                    --output null --warmup 5 --min-runs "$RUNS" \
+                    --prepare "$WORKSPACE/$SERVER_CMD & echo \$! >> /cpusets/cpu2/tasks; sleep 0.1" \
+                    --conclude "pkill $SERVER_TAG" \
+                    "echo \$\$ >> /cpusets/cpu3/tasks; $WORKSPACE/$CMD" |
+                  tee -a "$WORKSPACE/comparison.txt"
                   echo >> "$WORKSPACE/comparison.txt"
 
                   # Sanity check the size of the last retrieved file.
@@ -510,15 +479,16 @@ jobs:
             hyperfine
           key: bench-results-${{ runner.name }}-${{ github.sha }}
 
-      - name: Upload benchmark results
+      - name: Upload benchmark results for bencher.dev
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: results
           path: |
+            results.txt
             neqo/target/criterion
             hyperfine
 
-      - name: Upload GitHub event
+      - name: Upload GitHub event for bencher.dev
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: event.json

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -33,7 +33,7 @@ jobs:
       BENCHER_BRANCH: ${{ github.ref_name}}
 
     steps:
-      - uses: bencherdev/bencher@v0.5.1 # bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
+      - uses: bencherdev/bencher@v0.5.1 # zizmor: ignore[unpinned-uses] bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
 
       - name: Checkout mozilla/neqo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -82,6 +82,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: google/quiche
+          ref: 23785904d54861f341ffef0ce5513b6c0a5beebc # TODO: Unpin when `main` compiles again.
           path: google-quiche
           submodules: 'recursive'
           persist-credentials: false

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -27,8 +27,14 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      BENCHER_PROJECT: ${{ github.repository}}
+      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+      BENCHER_BRANCH: ${{ github.ref_name}}
 
     steps:
+      - uses: bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
+
       - name: Checkout mozilla/neqo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -188,6 +194,7 @@ jobs:
         if: steps.run.outputs.needed == 'true'
         env:
           NSS_DB_PATH: ${{ github.workspace }}/neqo/test-fixture/db
+          BENCHER_TESTBED: ${{ runner.name }}
         run: |
           sudo ip link set dev lo mtu "$MTU"
           mkdir -p binaries
@@ -198,8 +205,17 @@ jobs:
             # Run it twice, once without perf for baseline comparison, and once with perf for profiling.
             # (Perf seems to introduce some variability in the results.)
             # shellcheck disable=SC2086
-            nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
-              $BENCH -- --bench | tee -a ../results.txt
+            bencher run \
+              --threshold-measure latency \
+              --threshold-test t_test \
+              --threshold-max-sample-size 64 \
+              --threshold-upper-boundary 0.99 \
+              --thresholds-reset \
+              --err \
+              --adapter rust_criterion \
+              --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+              nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
+                $BENCH -- --bench | tee -a ../results.txt
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               perf -- $PERF_OPT -o "$NAME.perf" $BENCH --bench --noplot --discard-baseline
@@ -215,6 +231,7 @@ jobs:
           SIZE: 33554432 # 32 MB
           RUNS: 100
           NSS_DB_PATH: ${{ github.workspace }}/neqo/test-fixture/db
+          BENCHER_TESTBED: ${{ runner.name }}
         run: |
           TMP=$(mktemp -d)
           mkdir -p "$TMP/out"
@@ -327,15 +344,25 @@ jobs:
                   SERVER_TAG="$(basename "$(echo "${server_cmd[$server]}" | cut -f1 -d' ')" | cut -c1-15)"
                   transmogrify "${client_cmd[$client]}" "$cc" "$pacing" "${neqo_flags[$server]}"
                   cd "$TMP/out"
-                  nice -n -20 setarch --addr-no-randomize hyperfine \
-                    --command-name "$TAG" --time-unit millisecond  \
-                    --export-json "$WORKSPACE/hyperfine/$FILENAME.json" \
-                    --export-markdown "$WORKSPACE/hyperfine/$FILENAME.md" \
-                    --output null --warmup 5 --min-runs "$RUNS" \
-                    --prepare "$WORKSPACE/$SERVER_CMD & echo \$! >> /cpusets/cpu2/tasks; sleep 0.1" \
-                    --conclude "pkill $SERVER_TAG" \
-                    "echo \$\$ >> /cpusets/cpu3/tasks; $WORKSPACE/$CMD" |
-                  tee -a "$WORKSPACE/comparison.txt"
+                  bencher run \
+                    --threshold-measure latency \
+                    --threshold-test t_test \
+                    --threshold-max-sample-size 64 \
+                    --threshold-upper-boundary 0.99 \
+                    --thresholds-reset \
+                    --err \
+                    --adapter shell_hyperfine \
+                    --file "$WORKSPACE/hyperfine/$FILENAME.json" \
+                    --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+                    nice -n -20 setarch --addr-no-randomize hyperfine \
+                      --command-name "$TAG" --time-unit millisecond  \
+                      --export-json "$WORKSPACE/hyperfine/$FILENAME.json" \
+                      --export-markdown "$WORKSPACE/hyperfine/$FILENAME.md" \
+                      --output null --warmup 5 --min-runs "$RUNS" \
+                      --prepare "$WORKSPACE/$SERVER_CMD & echo \$! >> /cpusets/cpu2/tasks; sleep 0.1" \
+                      --conclude "pkill $SERVER_TAG" \
+                      "echo \$\$ >> /cpusets/cpu3/tasks; $WORKSPACE/$CMD" |
+                    tee -a "$WORKSPACE/comparison.txt"
                   echo >> "$WORKSPACE/comparison.txt"
 
                   # Sanity check the size of the last retrieved file.
@@ -478,6 +505,20 @@ jobs:
             neqo/target/criterion
             hyperfine
           key: bench-results-${{ runner.name }}-${{ github.sha }}
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: results
+          path: |
+            neqo/target/criterion
+            hyperfine
+
+      - name: Upload GitHub event
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: event.json
+          path: ${{ github.event_path }}
 
       - name: Export perf data
         if: steps.run.outputs.needed == 'true'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -33,7 +33,7 @@ jobs:
       BENCHER_BRANCH: ${{ github.ref_name}}
 
     steps:
-      - uses: bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
+      - uses: bencherdev/bencher@v0.5.1 # bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
 
       - name: Checkout mozilla/neqo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/bencher-archive.yml
+++ b/.github/workflows/bencher-archive.yml
@@ -10,7 +10,7 @@ jobs:
     name: Archive closed fork PR branch with Bencher
     runs-on: ubuntu-latest
     env:
-      BENCHER_PROJECT: ${{ github.repository}}
+      BENCHER_PROJECT: neqo
       BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
       BENCHER_BRANCH: ${{ github.ref_name}}
     steps:

--- a/.github/workflows/bencher-archive.yml
+++ b/.github/workflows/bencher-archive.yml
@@ -1,5 +1,6 @@
 on:
   pull_request_target:
+    # SAFETY: We are not running any code from the triggering PR, so this is safe.
     types: [closed] # zizmor: ignore[dangerous-triggers]
 
 permissions:

--- a/.github/workflows/bencher-archive.yml
+++ b/.github/workflows/bencher-archive.yml
@@ -6,8 +6,8 @@ permissions:
   contents: read
 
 jobs:
-  archive_fork_pr_branch:
-    name: Archive closed fork PR branch with Bencher
+  bencher_archive:
+    name: Archive bencher.dev PR branch
     runs-on: ubuntu-latest
     env:
       BENCHER_PROJECT: neqo
@@ -17,5 +17,5 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: bencherdev/bencher@v0.5.1 # zizmor: ignore[unpinned-uses] bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
+      - uses: bencherdev/bencher@v0.5.1 # zizmor: ignore[unpinned-uses]
       - run: bencher archive

--- a/.github/workflows/bencher-archive.yml
+++ b/.github/workflows/bencher-archive.yml
@@ -17,5 +17,5 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: bencherdev/bencher@v0.5.1 # bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
+      - uses: bencherdev/bencher@v0.5.1 # zizmor: ignore[unpinned-uses] bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
       - run: bencher archive

--- a/.github/workflows/bencher-archive.yml
+++ b/.github/workflows/bencher-archive.yml
@@ -1,0 +1,21 @@
+on:
+  pull_request_target:
+    types: [closed] # zizmor: ignore[dangerous-triggers]
+
+permissions:
+  contents: read
+
+jobs:
+  archive_fork_pr_branch:
+    name: Archive closed fork PR branch with Bencher
+    runs-on: ubuntu-latest
+    env:
+      BENCHER_PROJECT: ${{ github.repository}}
+      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+      BENCHER_BRANCH: ${{ github.ref_name}}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
+      - run: bencher archive

--- a/.github/workflows/bencher-archive.yml
+++ b/.github/workflows/bencher-archive.yml
@@ -17,5 +17,5 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
+      - uses: bencherdev/bencher@v0.5.1 # bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
       - run: bencher archive

--- a/.github/workflows/bencher-upload.yml
+++ b/.github/workflows/bencher-upload.yml
@@ -3,8 +3,8 @@ name: bencher.dev Upload
 on:
   workflow_run:
     workflows: ["CI"]
-    types:
-      - completed # zizmor: ignore[dangerous-triggers]
+    # SAFETY: We are not running any code from the triggering PR, so this is safe.
+    types: [completed] # zizmor: ignore[dangerous-triggers]
 
 permissions:
   contents: read

--- a/.github/workflows/bencher-upload.yml
+++ b/.github/workflows/bencher-upload.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       BENCHMARK_RESULTS: results
       PR_EVENT: event.json
-      BENCHER_PROJECT: ${{ github.repository}}
+      BENCHER_PROJECT: neqo
       BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
       BENCHER_BRANCH: ${{ github.ref_name}}
     steps:

--- a/.github/workflows/bencher-upload.yml
+++ b/.github/workflows/bencher-upload.yml
@@ -1,4 +1,4 @@
-name: Bencher Upload
+name: bencher.dev Upload
 
 on:
   workflow_run:
@@ -10,28 +10,30 @@ permissions:
   contents: read
 
 jobs:
-  track_fork_pr_branch:
+  bencher_upload:
     if: github.event.workflow_run.conclusion == 'success'
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
     env:
-      BENCHMARK_RESULTS: results
       PR_EVENT: event.json
       BENCHER_PROJECT: neqo
       BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-      BENCHER_BRANCH: ${{ github.ref_name}}
     steps:
       - name: Download benchmark results
-        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: ${{ env.BENCHMARK_RESULTS }}
-          run_id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: results
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Download PR event
-        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
+          run-id: ${{ github.event.workflow_run.id }}
           name: ${{ env.PR_EVENT }}
-          run_id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Export PR event data
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
@@ -42,12 +44,15 @@ jobs:
             core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
             core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
             core.exportVariable("PR_NUMBER", prEvent.number);
-      - uses: bencherdev/bencher@v0.5.1 # zizmor: ignore[unpinned-uses] bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
-      - name: Track benchmarks with Bencher
-        env:
-          BENCHER_TESTBED: ${{ runner.name }}
+
+      - uses: bencherdev/bencher@v0.5.1 # zizmor: ignore[unpinned-uses]
+      - name: Upload results to bencher.dev
         run: |
+          BENCHER_TESTBED=$(cat testbed.txt)
+
+          # Upload PR branch results
           bencher run \
+            --branch "$PR_HEAD" \
             --start-point "$PR_BASE" \
             --start-point-hash "$PR_BASE_SHA" \
             --start-point-clone-thresholds \
@@ -59,6 +64,7 @@ jobs:
             --file "neqo/target/criterion"
           for file in hyperfine/*.json; do
             bencher run \
+              --branch "$PR_HEAD" \
               --start-point "$PR_BASE" \
               --start-point-hash "$PR_BASE_SHA" \
               --start-point-clone-thresholds \
@@ -67,5 +73,33 @@ jobs:
               --adapter shell_hyperfine \
               --github-actions '${{ secrets.GITHUB_TOKEN }}' \
               --ci-number "$PR_NUMBER" \
+              --file "$file"
+          done
+
+          # Now upload main branch results
+          bencher run \
+            --branch main \
+            --testbed "$BENCHER_TESTBED" \
+            --threshold-measure latency \
+            --threshold-test t_test \
+            --threshold-max-sample-size 64 \
+            --threshold-upper-boundary 0.99 \
+            --thresholds-reset \
+            --err \
+            --adapter rust_criterion \
+            --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+            --file "neqo-main/target/criterion"
+          for file in hyperfine-main/*.json; do
+            bencher run \
+              --branch main \
+              --testbed "$BENCHER_TESTBED" \
+              --threshold-measure latency \
+              --threshold-test t_test \
+              --threshold-max-sample-size 64 \
+              --threshold-upper-boundary 0.99 \
+              --thresholds-reset \
+              --err \
+              --adapter shell_hyperfine \
+              --github-actions '${{ secrets.GITHUB_TOKEN }}' \
               --file "$file"
           done

--- a/.github/workflows/bencher-upload.yml
+++ b/.github/workflows/bencher-upload.yml
@@ -2,7 +2,7 @@ name: Bencher Upload
 
 on:
   workflow_run:
-    workflows: ["Bench"]
+    workflows: ["CI"]
     types:
       - completed # zizmor: ignore[dangerous-triggers]
 
@@ -12,6 +12,8 @@ permissions:
 jobs:
   track_fork_pr_branch:
     if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     env:
       BENCHMARK_RESULTS: results

--- a/.github/workflows/bencher-upload.yml
+++ b/.github/workflows/bencher-upload.yml
@@ -40,7 +40,7 @@ jobs:
             core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
             core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
             core.exportVariable("PR_NUMBER", prEvent.number);
-      - uses: bencherdev/bencher@v0.5.1 # bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
+      - uses: bencherdev/bencher@v0.5.1 # zizmor: ignore[unpinned-uses] bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
       - name: Track benchmarks with Bencher
         env:
           BENCHER_TESTBED: ${{ runner.name }}

--- a/.github/workflows/bencher-upload.yml
+++ b/.github/workflows/bencher-upload.yml
@@ -40,7 +40,7 @@ jobs:
             core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
             core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
             core.exportVariable("PR_NUMBER", prEvent.number);
-      - uses: bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
+      - uses: bencherdev/bencher@v0.5.1 # bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
       - name: Track benchmarks with Bencher
         env:
           BENCHER_TESTBED: ${{ runner.name }}

--- a/.github/workflows/bencher-upload.yml
+++ b/.github/workflows/bencher-upload.yml
@@ -1,0 +1,69 @@
+name: Bencher Upload
+
+on:
+  workflow_run:
+    workflows: ["Bench"]
+    types:
+      - completed # zizmor: ignore[dangerous-triggers]
+
+permissions:
+  contents: read
+
+jobs:
+  track_fork_pr_branch:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    env:
+      BENCHMARK_RESULTS: results
+      PR_EVENT: event.json
+      BENCHER_PROJECT: ${{ github.repository}}
+      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+      BENCHER_BRANCH: ${{ github.ref_name}}
+    steps:
+      - name: Download benchmark results
+        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
+        with:
+          name: ${{ env.BENCHMARK_RESULTS }}
+          run_id: ${{ github.event.workflow_run.id }}
+      - name: Download PR event
+        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
+        with:
+          name: ${{ env.PR_EVENT }}
+          run_id: ${{ github.event.workflow_run.id }}
+      - name: Export PR event data
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            let fs = require('fs');
+            let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
+            core.exportVariable("PR_HEAD", prEvent.pull_request.head.ref);
+            core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
+            core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
+            core.exportVariable("PR_NUMBER", prEvent.number);
+      - uses: bencherdev/bencher@54d78b95feda17a1b2761d3332c488d37261ca4e #v0.5.1
+      - name: Track benchmarks with Bencher
+        env:
+          BENCHER_TESTBED: ${{ runner.name }}
+        run: |
+          bencher run \
+            --start-point "$PR_BASE" \
+            --start-point-hash "$PR_BASE_SHA" \
+            --start-point-clone-thresholds \
+            --start-point-reset \
+            --err \
+            --adapter rust_criterion \
+            --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+            --ci-number "$PR_NUMBER" \
+            --file "neqo/target/criterion"
+          for file in hyperfine/*.json; do
+            bencher run \
+              --start-point "$PR_BASE" \
+              --start-point-hash "$PR_BASE_SHA" \
+              --start-point-clone-thresholds \
+              --start-point-reset \
+              --err \
+              --adapter shell_hyperfine \
+              --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+              --ci-number "$PR_NUMBER" \
+              --file "$file"
+          done

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -184,6 +184,7 @@ jobs:
     needs: [check]
     if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || github.event.inputs.run_benchmarks) && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
     permissions:
+      contents: read
       pull-requests: write
     uses: ./.github/workflows/bench.yml
     secrets:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -183,6 +183,8 @@ jobs:
   bench:
     needs: [check]
     if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || github.event.inputs.run_benchmarks) && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/bench.yml
     secrets:
       BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -184,6 +184,8 @@ jobs:
     needs: [check]
     if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || github.event.inputs.run_benchmarks) && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
     uses: ./.github/workflows/bench.yml
+    secrets:
+      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
 
   check-android:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -195,12 +195,7 @@ jobs:
   bench:
     needs: [check]
     if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || github.event.inputs.run_benchmarks) && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
-    permissions:
-      contents: read
-      pull-requests: write
     uses: ./.github/workflows/bench.yml
-    secrets:
-      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
 
   check-android:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Feed our benchmark data into bencher.dev, to be shown over time at https://bencher.dev/console/projects/neqo.