### PR TITLE
perf(transport): don't rotate_left then truncate stream send buffer

### DIFF
--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -541,13 +541,13 @@ impl TxBuffer {
         self.ranges.mark_acked(offset, len);
 
         // Any newly-retired bytes can be dropped from the buffer.
-        let new_retirable = self.retired() - prev_retired;
-        debug_assert!(new_retirable <= self.buffered() as u64);
-        let keep = self.buffered() - usize::try_from(new_retirable).expect("u64 fits in usize");
+        let new_retirable = usize::try_from(self.retired() - prev_retired).expect("u64 fits in usize");
+        debug_assert!(new_retirable <= self.buffered());
 
         // Truncate front
-        self.send_buf.rotate_left(self.buffered() - keep);
-        self.send_buf.truncate(keep);
+        //
+        // TODO: use `VecDeque::truncate_front` once stable. https://github.com/rust-lang/rust/issues/140667
+        self.send_buf.drain(..new_retirable);
     }
 
     pub fn mark_as_lost(&mut self, offset: u64, len: usize) {


### PR DESCRIPTION
Previously `SendStream::mark_as_acked` would rotate the acked bytes to the end of the send buffer, than truncate the send buffer at the end to remove them.

```
<----------send_buffer---------->
```

ACK comes in.
```
<-acked-><------send_buffer----->
```

`VecDeque::rotate_left`
```
<------send_buffer-----><-acked->
```

`VecDeque::truncate`
```
<------send_buffer----->
```

`VecDeque::rotate_left` is an O(n) operation, and thus expensive on a large send buffer. It does show up in upload profiles, taking low single digit percentage CPU time.

This commit instead uses `VecDeque::drain` to drain the acked bytes from the front of the `VecDeque`. Given that `VecDeque` is implemented as a ring buffer, this should not increase memory churn.

---

Counter to my intuition, this change does not improve performance, actually might even regress. Anyone have an idea why?

```
➜  neqo-transport git:(send-stream-no-rotate-left) ✗ critcmp main no-rotate     
group                                               main                                   no-rotate
-----                                               ----                                   ---------
1-conn/10_000-parallel-1b-resp (aka. RPS)/client    1.00    189.4±4.91ms 51.6 KElem/sec  
transfer/pacing-false/same-seed                     1.00     39.2±0.57ms        ? ?/sec    1.01     39.5±0.70ms        ? ?/sec
transfer/pacing-false/varying-seeds                 1.00     39.2±0.79ms        ? ?/sec    1.00     39.0±0.92ms        ? ?/sec
transfer/pacing-true/same-seed                      1.00     40.0±0.57ms        ? ?/sec    1.01     40.5±0.68ms        ? ?/sec
transfer/pacing-true/varying-seeds                  1.00     40.1±1.13ms        ? ?/sec    1.00     40.1±1.24ms        ? ?/sec
```

```
➜  neqo-bin git:(main) ✗ critcmp main no-rotate                                                      
group                                               main                                   no-rotate
-----                                               ----                                   ---------
1-conn/1-100mb-resp (aka. Download)/client          1.03     57.1±3.30ms  1752.8 MB/sec    1.00     55.5±6.35ms  1801.0 MB/sec
1-conn/10_000-parallel-1b-resp (aka. RPS)/client    1.00    189.4±4.91ms 51.6 KElem/sec  
transfer/pacing-false/same-seed                     1.00     39.2±0.57ms        ? ?/sec    1.01     39.5±0.70ms        ? ?/sec
transfer/pacing-false/varying-seeds                 1.00     39.2±0.79ms        ? ?/sec    1.00     39.0±0.92ms        ? ?/sec
transfer/pacing-true/same-seed                      1.00     40.0±0.57ms        ? ?/sec    1.01     40.5±0.68ms        ? ?/sec
transfer/pacing-true/varying-seeds                  1.00     40.1±1.13ms        ? ?/sec    1.00     40.1±1.24ms        ? ?/sec
```

Obviously we should not merge here before we have proof that it is an improvement.

