### PR TITLE
bench(bin): spawn new server for each iteration

### DIFF
--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -6,7 +6,9 @@
 
 #![expect(clippy::unwrap_used, reason = "OK in a bench.")]
 
-use std::{env, hint::black_box, path::PathBuf, str::FromStr as _, time::Duration};
+use std::{
+    env, hint::black_box, net::SocketAddr, path::PathBuf, str::FromStr as _, time::Duration,
+};
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 use neqo_bin::{client, server};
@@ -21,7 +23,6 @@ struct Benchmark {
 fn transfer(c: &mut Criterion) {
     neqo_crypto::init_db(PathBuf::from_str("../test-fixture/db").unwrap()).unwrap();
 
-    let done_sender = spawn_server();
     let mtu = env::var("MTU").map_or_else(|_| String::new(), |mtu| format!("/mtu-{mtu}"));
     for Benchmark {
         name,
@@ -59,10 +60,17 @@ fn transfer(c: &mut Criterion) {
         group.bench_function("client", |b| {
             b.to_async(Builder::new_current_thread().enable_all().build().unwrap())
                 .iter_batched(
-                    || client::client(client::Args::new(&requests, upload)),
-                    |client| {
+                    || {
+                        let (server_handle, server_addr) = spawn_server();
+                        let client =
+                            client::client(client::Args::new(Some(server_addr), &requests, upload));
+                        (server_handle, client)
+                    },
+                    |(server_handle, client)| {
                         black_box(async move {
                             client.await.unwrap();
+                            // Tell server to shut down.
+                            server_handle.send(()).unwrap();
                         })
                     },
                     BatchSize::PerIteration,
@@ -70,26 +78,37 @@ fn transfer(c: &mut Criterion) {
         });
         group.finish();
     }
-
-    done_sender.send(()).unwrap();
 }
 
-fn spawn_server() -> tokio::sync::oneshot::Sender<()> {
+fn spawn_server() -> (tokio::sync::oneshot::Sender<()>, SocketAddr) {
     let (done_sender, mut done_receiver) = tokio::sync::oneshot::channel();
+    let (addr_sender, addr_receiver) = std::sync::mpsc::channel::<SocketAddr>();
     std::thread::spawn(move || {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(async {
-                let mut server = Box::pin(server::server(server::Args::default()));
-                tokio::select! {
-                    _ = &mut done_receiver => {}
-                    res = &mut server  => panic!("expect server not to terminate: {res:?}"),
-                };
-            });
+        let runtime = Builder::new_current_thread().enable_all().build().unwrap();
+
+        let mut args = server::Args::default();
+        args.set_hosts(vec!["[::]:0".to_string()]);
+        let server = runtime.block_on(async { server::server(args).unwrap() });
+
+        addr_sender
+            .send(
+                server
+                    .local_addresses()
+                    .into_iter()
+                    .find(SocketAddr::is_ipv6)
+                    .unwrap(),
+            )
+            .unwrap();
+
+        runtime.block_on(async {
+            let mut server = Box::pin(server.run());
+            tokio::select! {
+                _ = &mut done_receiver => {}
+                res = &mut server  => panic!("expect server not to terminate: {res:?}"),
+            };
+        });
     });
-    done_sender
+    (done_sender, addr_receiver.recv().unwrap())
 }
 
 criterion_group! {

--- a/neqo-bin/src/bin/server.rs
+++ b/neqo-bin/src/bin/server.rs
@@ -10,5 +10,5 @@ use clap::Parser as _;
 async fn main() -> Result<(), neqo_bin::server::Error> {
     let args = neqo_bin::server::Args::parse();
 
-    neqo_bin::server::server(args).await
+    neqo_bin::server::server(args)?.run().await
 }

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -184,13 +184,14 @@ impl Args {
     #[must_use]
     #[cfg(any(test, feature = "bench"))]
     #[expect(clippy::missing_panics_doc, reason = "This is example code.")]
-    pub fn new(requests: &[usize], upload: bool) -> Self {
+    pub fn new(server_addr: Option<SocketAddr>, requests: &[usize], upload: bool) -> Self {
         use std::str::FromStr as _;
+        let addr = server_addr.map_or("[::1]:12345".into(), |a| format!("[::1]:{}", a.port()));
         Self {
             shared: SharedArgs::default(),
             urls: requests
                 .iter()
-                .map(|r| Url::from_str(&format!("http://[::1]:12345/{r}")).unwrap())
+                .map(|r| Url::from_str(&format!("http://{addr}/{r}")).unwrap())
                 .collect(),
             method: if upload { "POST".into() } else { "GET".into() },
             header: vec![],

--- a/neqo-bin/src/lib.rs
+++ b/neqo-bin/src/lib.rs
@@ -308,13 +308,13 @@ mod tests {
 
         let temp_dir = TempDir::new();
 
-        let mut client_args = client::Args::new(&[1], false);
+        let mut client_args = client::Args::new(None, &[1], false);
         client_args.set_qlog_dir(temp_dir.path());
         let mut server_args = server::Args::default();
         server_args.set_qlog_dir(temp_dir.path());
 
         let client = client::client(client_args);
-        let server = Box::pin(server::server(server_args));
+        let server = Box::pin(server::server(server_args).unwrap().run());
         tokio::select! {
             _ = client => {}
             res = server  => panic!("expect server not to terminate: {res:?}"),


### PR DESCRIPTION
Spawn a new `neqo-server` for each benchmark iteration.

---

We see `neqo-bin` benchmark performance degrading over time from criterion iteration to iteration. This is especially obvious now that we have https://github.com/mozilla/neqo/pull/2655.

Without this patch I can reproduce the degradation locally, looking at the timing of each iteration (see upwards trend below).

Example:

![image](https://github.com/user-attachments/assets/3698372a-20a4-4b3c-b286-7d75b671f4fb)


With this patch, timing across iterations is stable, with no noticeable increase from first to last.

Still needs cleanups, but proofs the point.

Shout-out to @larseggert who discovered the degradation and actually proposed this fix in the past.

