### PR TITLE
ci(bench): use single Neqo Git checkout

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,15 +32,9 @@ jobs:
           path: neqo
           submodules: 'recursive'
           persist-credentials: false
-
-      - name: Checkout mozilla/neqo@main
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: mozilla/neqo
-          ref: main
-          path: neqo-main
-          submodules: 'recursive'
-          persist-credentials: false
+      - run: |
+          cd neqo
+          git fetch --no-tags --depth=1 origin main
 
       - name: Checkout microsoft/msquic
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -91,15 +85,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           workspaces: |
             neqo
-            neqo-main
             quiche
             s2n-quic
 
       - name: Get minimum NSS version
         id: nss-version
         run: |
-          cat neqo/neqo-crypto/min_version.txt > versions.txt
-          cat neqo-main/neqo-crypto/min_version.txt >> versions.txt
+          cd neqo
+          cat neqo-crypto/min_version.txt > versions.txt
+          git show origin/main:neqo-crypto/min_version.txt >> versions.txt
           # Use the maximum version from both branches.
           echo "minimum=$(sort -u versions.txt | tail -n1)" >> "$GITHUB_OUTPUT"
 
@@ -114,14 +108,14 @@ jobs:
           # See https://github.com/flamegraph-rs/flamegraph for why we append to RUSTFLAGS here.
           export RUSTFLAGS="-C link-arg=-Wl,--no-rosegment, -C force-frame-pointers=yes $RUSTFLAGS"
           echo "RUSTFLAGS=$RUSTFLAGS" >> "$GITHUB_ENV"
-          cd neqo-main
+          cd neqo
           cargo clean
-          cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches.txt
+          git checkout origin/main
+          cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches-main.txt
           cargo build --locked --release --bin neqo-client --bin neqo-server
-          BENCHES_MAIN=$(grep Executable benches.txt | cut -d\( -f2 | cut -d\) -f1 | tr -s '\n' ' ')
+          BENCHES_MAIN=$(grep Executable benches-main.txt | cut -d\( -f2 | cut -d\) -f1 | tr -s '\n' ' ')
           echo "BENCHES_MAIN=$BENCHES_MAIN" >> "$GITHUB_ENV"
-          cd ../neqo
-          cargo clean
+          git checkout -
           cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches.txt
           cargo build --locked --release --bin neqo-client --bin neqo-server
           BENCHES=$(grep Executable benches.txt | cut -d\( -f2 | cut -d\) -f1 | tr -s '\n' ' ')
@@ -165,17 +159,16 @@ jobs:
           sudo ip link set dev lo mtu "$MTU"
           mkdir -p binaries/neqo-main
           mkdir -p binaries/neqo
-          cd neqo-main
+          cd neqo
           rm -rf target/criterion
+          git checkout origin/main
           for BENCH in $BENCHES_MAIN; do
             cp "$BENCH" ../binaries/neqo-main/
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               $BENCH -- --bench --save-baseline main
           done
-          cd ../neqo
-          rm -rf target/criterion
-          cp -r ../neqo-main/target/criterion target/
+          git checkout -
           for BENCH in $BENCHES; do
             cp "$BENCH" ../binaries/neqo/
             # Run it twice, once without perf for baseline comparison, and once with perf for profiling.
@@ -437,7 +430,7 @@ jobs:
       - name: Format results as Markdown
         id: results
         run: |
-          SHA=$(cd neqo-main && git log -1 --format=%H)
+          SHA=$(git log origin/main -1 --format=%H)
           {
             echo "Performance differences relative to $SHA."
             echo
@@ -469,7 +462,6 @@ jobs:
           name: results
           path: |
             neqo/target/criterion
-            neqo-main/target/criterion
             hyperfine
             hyperfine-main
             testbed.txt
@@ -493,7 +485,6 @@ jobs:
             *.md
             results.*
             neqo/target/criterion
-            neqo-main/target/criterion
             hyperfine
             hyperfine-main
             binaries

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -430,7 +430,7 @@ jobs:
       - name: Format results as Markdown
         id: results
         run: |
-          SHA=$(git log origin/main -1 --format=%H)
+          SHA=$(cd neqo && git log origin/main -1 --format=%H)
           {
             echo "Performance differences relative to $SHA."
             echo

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: mozilla/neqo
+          ref: main
           path: neqo-main
           submodules: 'recursive'
           persist-credentials: false
@@ -164,14 +165,17 @@ jobs:
           sudo ip link set dev lo mtu "$MTU"
           mkdir -p binaries/neqo-main
           mkdir -p binaries/neqo
-          cd neqo
+          cd neqo-main
           rm -rf target/criterion
-          for BENCH in $BENCHES; do
+          for BENCH in $BENCHES_MAIN; do
             cp "$BENCH" ../binaries/neqo-main/
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               $BENCH -- --bench --save-baseline main
           done
+          cd ../neqo
+          rm -rf target/criterion
+          cp -r ../neqo-main/target/criterion target/
           for BENCH in $BENCHES; do
             cp "$BENCH" ../binaries/neqo/
             # Run it twice, once without perf for baseline comparison, and once with perf for profiling.

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -117,10 +117,11 @@ jobs:
           export RUSTFLAGS="-C link-arg=-Wl,--no-rosegment, -C force-frame-pointers=yes $RUSTFLAGS"
           echo "RUSTFLAGS=$RUSTFLAGS" >> "$GITHUB_ENV"
           cd neqo-main
+          cargo clean
           cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches.txt
           cargo build --locked --release --bin neqo-client --bin neqo-server
           cd ../neqo
-          cp -r ../neqo-main/target .
+          cargo clean
           cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches.txt
           cargo build --locked --release --bin neqo-client --bin neqo-server
           BENCHES=$(grep Executable benches.txt | cut -d\( -f2 | cut -d\) -f1 | tr -s '\n' ' ')
@@ -180,6 +181,8 @@ jobs:
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               $BENCH -- --bench --baseline main | { grep -v '^cset' || test $? = 1; } | tee -a ../results.txt
+          done
+          for BENCH in $BENCHES; do
             NAME=$(basename "$BENCH" | cut -d- -f1)
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,6 +32,7 @@ jobs:
           path: neqo
           submodules: 'recursive'
           persist-credentials: false
+          clean: false
       - run: |
           cd neqo
           git fetch --no-tags --depth=1 origin main
@@ -109,7 +110,6 @@ jobs:
           export RUSTFLAGS="-C link-arg=-Wl,--no-rosegment, -C force-frame-pointers=yes $RUSTFLAGS"
           echo "RUSTFLAGS=$RUSTFLAGS" >> "$GITHUB_ENV"
           cd neqo
-          cargo clean
           git checkout origin/main
           cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches-main.txt
           cargo build --locked --release --bin neqo-client --bin neqo-server
@@ -162,6 +162,7 @@ jobs:
           cd neqo
           rm -rf target/criterion
           git checkout origin/main
+          # Run the builds from the main branch first, to establish a baseline.
           for BENCH in $BENCHES_MAIN; do
             cp "$BENCH" ../binaries/neqo-main/
             # shellcheck disable=SC2086
@@ -169,10 +170,10 @@ jobs:
               $BENCH -- --bench --save-baseline main
           done
           git checkout -
+          # Run pull request builds twice, once without perf for baseline comparison, and once with perf for profiling.
+          # (Perf seems to introduce some variability in the results.)
           for BENCH in $BENCHES; do
             cp "$BENCH" ../binaries/neqo/
-            # Run it twice, once without perf for baseline comparison, and once with perf for profiling.
-            # (Perf seems to introduce some variability in the results.)
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               $BENCH -- --bench --baseline main | { grep -v '^cset' || test $? = 1; } | tee -a ../results.txt
@@ -187,7 +188,6 @@ jobs:
       # Compare various configurations of neqo against msquic and google/quiche, and gather perf data
       # during the hyperfine runs.
       - name: Compare QUIC implementations
-        if: false
         env:
           HOST: 127.0.0.1
           PORT: 4433

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,7 +32,6 @@ jobs:
           path: neqo
           submodules: 'recursive'
           persist-credentials: false
-          clean: false
 
       - name: Checkout mozilla/neqo@main
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -41,7 +40,6 @@ jobs:
           path: neqo-main
           submodules: 'recursive'
           persist-credentials: false
-          clean: false
 
       - name: Checkout microsoft/msquic
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: mozilla/neqo
-          ref: main
           path: neqo-main
           submodules: 'recursive'
           persist-credentials: false

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -189,6 +189,7 @@ jobs:
       # Compare various configurations of neqo against msquic and google/quiche, and gather perf data
       # during the hyperfine runs.
       - name: Compare QUIC implementations
+        if: false
         env:
           HOST: 127.0.0.1
           PORT: 4433

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -169,6 +169,9 @@ jobs:
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               $BENCH -- --bench --save-baseline main
           done
+          # Copy the main branch results to a separate directory for bencher.dev.
+          rm -rf ../neqo-main/ && mkdir -p ../neqo-main/
+          cp -r target/criterion ../neqo-main/
           git checkout -
           # Run pull request builds twice, once without perf for baseline comparison, and once with perf for profiling.
           # (Perf seems to introduce some variability in the results.)
@@ -462,6 +465,7 @@ jobs:
           name: results
           path: |
             neqo/target/criterion
+            neqo-main/target/criterion
             hyperfine
             hyperfine-main
             testbed.txt

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -161,16 +161,13 @@ jobs:
         run: |
           sudo ip link set dev lo mtu "$MTU"
           mkdir -p binaries
-          cd neqo-main
+          cd neqo
           rm -rf target/criterion
           for BENCH in $BENCHES; do
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               $BENCH -- --bench --save-baseline main
           done
-          cd ../neqo
-          rm -rf target/criterion
-          cp -r ../neqo-main/target/criterion target/
           for BENCH in $BENCHES; do
             cp "$BENCH" ../binaries/
             # Run it twice, once without perf for baseline comparison, and once with perf for profiling.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -193,7 +193,8 @@ jobs:
       - run: cargo update -w --locked
 
   bench:
-    needs: [check]
+    # TODO
+    # needs: [check]
     if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || github.event.inputs.run_benchmarks) && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
     uses: ./.github/workflows/bench.yml
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -193,8 +193,7 @@ jobs:
       - run: cargo update -w --locked
 
   bench:
-    # TODO
-    # needs: [check]
+    needs: [check]
     if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || github.event.inputs.run_benchmarks) && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
     uses: ./.github/workflows/bench.yml
 


### PR DESCRIPTION
Our criterion benchmarks report a difference between `main` and non-Rust PRs. That is unexpected. On each run we checkout Neqo twice, once for `main`, once for the corresponding PR. I assume the deviation is due to Criterion not being able to compare across checkouts.

Instead of using two Neqo checkouts, this pull request uses a single checkout, switching between `main` and PR branch.

Fixes https://github.com/mozilla/neqo/issues/2657.

See https://github.com/mozilla/neqo/pull/2673#issuecomment-2930071659.