### PR TITLE
ci(bench): introduce BENCHES_MAIN binary list

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -130,6 +130,8 @@ jobs:
           cd neqo-main
           cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches.txt
           cargo build --locked --release --bin neqo-client --bin neqo-server
+          BENCHES_MAIN=$(grep Executable benches.txt | cut -d\( -f2 | cut -d\) -f1 | tr -s '\n' ' ')
+          echo "BENCHES_MAIN=$BENCHES_MAIN" >> "$GITHUB_ENV"
           cd ../neqo
           cp -r ../neqo-main/target .
           cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches.txt
@@ -176,7 +178,7 @@ jobs:
           mkdir -p binaries
           cd neqo-main
           rm -rf target/criterion
-          for BENCH in $BENCHES; do
+          for BENCH in $BENCHES_MAIN; do
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               $BENCH -- --bench --save-baseline main

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -175,10 +175,12 @@ jobs:
           NSS_DB_PATH: ${{ github.workspace }}/neqo/test-fixture/db
         run: |
           sudo ip link set dev lo mtu "$MTU"
-          mkdir -p binaries
+          mkdir -p binaries/neqo-main
+          mkdir -p binaries/neqo
           cd neqo-main
           rm -rf target/criterion
           for BENCH in $BENCHES_MAIN; do
+            cp "$BENCH" ../binaries/neqo-main/
             # shellcheck disable=SC2086
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
               $BENCH -- --bench --save-baseline main
@@ -187,7 +189,7 @@ jobs:
           rm -rf target/criterion
           cp -r ../neqo-main/target/criterion target/
           for BENCH in $BENCHES; do
-            cp "$BENCH" ../binaries/
+            cp "$BENCH" ../binaries/neqo/
             # Run it twice, once without perf for baseline comparison, and once with perf for profiling.
             # (Perf seems to introduce some variability in the results.)
             # shellcheck disable=SC2086


### PR DESCRIPTION
`$BENCHES` contains the benchmark binaries of the PR builds. Sample:

```
➜  neqo git:(main) ✗ cargo bench --profile=dev --locked --workspace --features bench --no-run 2>&1  | tee benches.txt
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
  Executable benches/main.rs (target/debug/deps/main-d713735815617f13)
  Executable benches/decoder.rs (target/debug/deps/decoder-15595b2a50ff4039)
  Executable benches/streams.rs (target/debug/deps/streams-696b71404547e60c)
  Executable benches/min_bandwidth.rs (target/debug/deps/min_bandwidth-fd86000de3dceeb9)
  Executable benches/range_tracker.rs (target/debug/deps/range_tracker-a78947e7c536dd73)
  Executable benches/rx_stream_orderer.rs (target/debug/deps/rx_stream_orderer-06f95e3d033c1cdd)
  Executable benches/sent_packets.rs (target/debug/deps/sent_packets-698f9499d852f3bc)
  Executable benches/transfer.rs (target/debug/deps/transfer-169bd66b648e1c78)
```

Note the hashes at the end.

The binaries of the `main` branch do not necessarily have the same hash.

This commit explicitly introduces the `BENCHES_MAIN` list.

See also discussion in https://github.com/mozilla/neqo/pull/2673#discussion_r2123741353.