### PR TITLE
ci: Split exported benchmark artifacts

### DIFF
--- a/.github/actions/pr-comment-data-export/action.yml
+++ b/.github/actions/pr-comment-data-export/action.yml
@@ -13,8 +13,8 @@ inputs:
   contents:
     description: 'A filename with a comment (in Markdown) to be added to the PR.'
     required: true
-  log-url:
-    description: 'A URL to a log to be linked from the PR comment.'
+  log-md:
+    description: 'A Markdown string to append to the PR comment.'
     required: false
 
 runs:
@@ -25,15 +25,13 @@ runs:
       env:
         CONTENTS: ${{ inputs.contents }}
         NAME: ${{ inputs.name }}
-        LOG_URL: ${{ inputs.log-url }}
+        LOG_MD: ${{ inputs.log-md }}
       run: |
         mkdir comment-data
         cp "$CONTENTS" comment-data/contents
         echo "$NAME" > comment-data/name
         echo "${{ github.event.number }}" > comment-data/pr-number
-        if [ -n "$LOG_URL" ]; then
-          echo "$LOG_URL" > comment-data/log-url
-        fi
+        echo "$LOG_MD" > comment-data/log-md
     - if: ${{ github.event_name == 'pull_request' }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:

--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -26,11 +26,7 @@ runs:
       run: echo "number=$(cat pr-number)" >> "$GITHUB_OUTPUT"
 
     - shell: bash
-      run: |
-        if [ -s log-url ]; then
-          echo "" >> contents
-          echo "[:arrow_down: Download logs]($(cat log-url))" >> contents
-        fi
+      run: cat log-md >> contents || true
 
     - uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
       with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -461,7 +461,7 @@ jobs:
           cat results.md > "$GITHUB_STEP_SUMMARY"
           echo "$runner.name" > testbed.txt
 
-      - name: Upload benchmark results for bencher.dev
+      - name: Export benchmark results for bencher.dev
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: results
@@ -472,21 +472,30 @@ jobs:
             hyperfine-main
             testbed.txt
 
-      - name: Upload GitHub event for bencher.dev
+      - name: Export GitHub event for bencher.dev
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: event.json
           path: ${{ github.event_path }}
 
-      - name: Export perf data
-        id: export
+      - name: Export profiler.firefox.com data
+        id: export_samply
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ${{ github.event.repository.name }}-${{ github.sha }}
+          name: ${{ github.event.repository.name }}-${{ github.sha }}-samply
           path: |
-            *.svg
             *.samply.json.gz
             *.syms.json
+            binaries
+          compression-level: 9
+
+      - name: Export performance data
+        id: export_perf
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ github.event.repository.name }}-${{ github.sha }}-perf
+          path: |
+            *.svg
             *.txt
             *.md
             results.*
@@ -494,7 +503,6 @@ jobs:
             neqo-main/target/criterion
             hyperfine
             hyperfine-main
-            binaries
           compression-level: 9
 
       - name: Export PR comment data
@@ -502,7 +510,7 @@ jobs:
         with:
           name: ${{ github.workflow }}
           contents: results.md
-          log-url: ${{ steps.export.outputs.artifact-url }}
+          log-md: ${{ format('\n[Download data for `profiler.firefox.com`]({0}) or [download performance comparison data]({1}).', steps.export_samply.outputs.artifact-url, steps.export_perf.outputs.artifact-url) }}
 
       - name: Fail on regression
         # Don't check for regressions when running on main.


### PR DESCRIPTION
Since we're now exporting samply data and binaries, the exported artifact has become very large and slow to download. Split out the samply data into its own artifact, so that the remainder is downloadable more quickly.

(Also change things so both are mentioned in the added PR message.)