### PR TITLE
ci: Use correct SHA from `workflow_run`

### DIFF
--- a/.github/workflows/bencher-upload.yml
+++ b/.github/workflows/bencher-upload.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           run-id: ${{ github.event.workflow_run.id }}
-          name: ${{ github.event.repository.name }}-${{ github.sha }}-perf
+          name: ${{ github.event.repository.name }}-${{ github.event.workflow_run.head_sha }}-perf
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Export PR event data


### PR DESCRIPTION
At least I hope this is the correct one...