### PR TITLE
refactor(transport): don't implicitly infer PacketBuilder limit

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2100,18 +2100,26 @@ impl Connection {
         address_validation: &AddressValidationInfo,
         version: Version,
         grease_quic_bit: bool,
+        limit: usize,
     ) -> (PacketType, PacketBuilder) {
         let pt = PacketType::from(epoch);
         let mut builder = if pt == PacketType::Short {
             qdebug!("Building Short dcid {:?}", path.remote_cid());
-            PacketBuilder::short(encoder, tx.key_phase(), path.remote_cid())
+            PacketBuilder::short(encoder, tx.key_phase(), path.remote_cid(), Some(limit))
         } else {
             qdebug!(
                 "Building {pt:?} dcid {:?} scid {:?}",
                 path.remote_cid(),
                 path.local_cid(),
             );
-            PacketBuilder::long(encoder, pt, version, path.remote_cid(), path.local_cid())
+            PacketBuilder::long(
+                encoder,
+                pt,
+                version,
+                path.remote_cid(),
+                path.local_cid(),
+                Some(limit),
+            )
         };
         if builder.remaining() > 0 {
             builder.scramble(grease_quic_bit);
@@ -2459,8 +2467,19 @@ impl Connection {
             else {
                 continue;
             };
+            let aead_expansion = tx.expansion();
 
             let header_start = encoder.len();
+
+            // Configure the limits and padding for this packet.
+            let limit = if path.borrow().pmtud().needs_probe() {
+                needs_padding = true;
+                debug_assert!(path.borrow().pmtud().probe_size() >= profile.limit());
+                path.borrow().pmtud().probe_size() - aead_expansion
+            } else {
+                profile.limit() - aead_expansion
+            };
+
             let (pt, mut builder) = Self::build_packet_header(
                 &path.borrow(),
                 epoch,
@@ -2469,6 +2488,7 @@ impl Connection {
                 &self.address_validation,
                 version,
                 grease_quic_bit,
+                limit,
             );
             let pn = Self::add_packet_number(
                 &mut builder,
@@ -2481,17 +2501,6 @@ impl Connection {
                 break;
             }
 
-            // Configure the limits and padding for this packet.
-            let aead_expansion = tx.expansion();
-            needs_padding |= builder.set_initial_limit(
-                &profile,
-                aead_expansion,
-                self.paths
-                    .primary()
-                    .ok_or(Error::InternalError)?
-                    .borrow()
-                    .pmtud(),
-            );
             builder.enable_padding(needs_padding);
             if builder.is_full() {
                 encoder = builder.abort();
@@ -3610,6 +3619,7 @@ impl Connection {
             &self.address_validation,
             version,
             false,
+            2048, // TODO: Previous default. Why?
         );
         _ = Self::add_packet_number(
             &mut builder,

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -27,10 +27,9 @@ use crate::{
     cid::{ConnectionId, ConnectionIdDecoder, ConnectionIdRef, MAX_CONNECTION_ID_LEN},
     crypto::{CryptoDxState, CryptoStates, Epoch},
     frame::FrameType,
-    recovery::SendProfile,
     tracking::PacketNumberSpace,
     version::{Version, WireVersion},
-    Error, Pmtud, Res,
+    Error, Res,
 };
 
 /// `MIN_INITIAL_PACKET_SIZE` is the smallest packet that can be used to establish
@@ -151,14 +150,6 @@ impl PacketBuilder {
     /// The minimum useful frame size.  If space is less than this, we will claim to be full.
     pub const MINIMUM_FRAME_SIZE: usize = 2;
 
-    fn infer_limit(encoder: &Encoder) -> usize {
-        if encoder.capacity() > 64 {
-            encoder.capacity()
-        } else {
-            2048
-        }
-    }
-
     /// Start building a short header packet.
     ///
     /// This doesn't fail if there isn't enough space; instead it returns a builder that
@@ -168,8 +159,9 @@ impl PacketBuilder {
     ///
     /// If, after calling this method, `remaining()` returns 0, then call `abort()` to get
     /// the encoder back.
-    pub fn short<A: AsRef<[u8]>>(mut encoder: Encoder, key_phase: bool, dcid: Option<A>) -> Self {
-        let mut limit = Self::infer_limit(&encoder);
+    pub fn short<A: AsRef<[u8]>>(mut encoder: Encoder, key_phase: bool, dcid: Option<A>, limit: Option<usize>) -> Self {
+        let mut limit =  limit.unwrap_or(2048);
+
         let header_start = encoder.len();
         // Check that there is enough space for the header.
         // 5 = 1 (first byte) + 4 (packet number)
@@ -209,8 +201,10 @@ impl PacketBuilder {
         version: Version,
         mut dcid: Option<A>,
         mut scid: Option<A1>,
+        limit: Option<usize>,
     ) -> Self {
-        let mut limit = Self::infer_limit(&encoder);
+        let mut limit = limit.unwrap_or(2048);
+
         let header_start = encoder.len();
         // Check that there is enough space for the header.
         // 11 = 1 (first byte) + 4 (version) + 2 (dcid+scid length) + 4 (packet number)
@@ -252,24 +246,6 @@ impl PacketBuilder {
     /// is only used voluntarily by users of the builder, through `remaining()`.
     pub fn set_limit(&mut self, limit: usize) {
         self.limit = limit;
-    }
-
-    /// Set the initial limit for the packet, based on the profile and the PMTUD state.
-    /// Returns true if the packet needs padding.
-    pub fn set_initial_limit(
-        &mut self,
-        profile: &SendProfile,
-        aead_expansion: usize,
-        pmtud: &Pmtud,
-    ) -> bool {
-        if pmtud.needs_probe() {
-            debug_assert!(pmtud.probe_size() >= profile.limit());
-            self.limit = pmtud.probe_size() - aead_expansion;
-            true
-        } else {
-            self.limit = profile.limit() - aead_expansion;
-            false
-        }
     }
 
     /// Get the current limit.


### PR DESCRIPTION
Previously when creating a new `PacketBuilder`, it would first infer its limit implicitly based on the capacity of the provided `Encoder`:

```
fn infer_limit(encoder: &Encoder) -> usize {
    if encoder.capacity() > 64 {
        encoder.capacity()
    } else {
        2048
    }
}
```

Once created, it would then later on depend on the user to call `PacketBuilder::set_initial_limit` to set the exact explicit limit:

```
/// Set the initial limit for the packet, based on the profile and the PMTUD state.
/// Returns true if the packet needs padding.
pub fn set_initial_limit(
    &mut self,
    profile: &SendProfile,
    aead_expansion: usize,
    pmtud: &Pmtud,
) -> bool {
    if pmtud.needs_probe() {
        debug_assert!(pmtud.probe_size() >= profile.limit());
        self.limit = pmtud.probe_size() - aead_expansion;
        true
    } else {
        self.limit = profile.limit() - aead_expansion;
        false
    }
}
```

This commit simplifies the process, explicitly passing the exact limit from the start.

---

Draft for now. Unit tests need to be updated.