### PR TITLE
chore: Flip `avoid-breaking-exported-api` to `false`

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -7,3 +7,4 @@ disallowed-macros = [
 allow-mixed-uninlined-format-args = false
 allow-unwrap-in-tests = true
 allow-dbg-in-tests = true
+avoid-breaking-exported-api = false # We have one consumer and can afford to break the API.

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -109,17 +109,23 @@ jobs:
           # See https://github.com/flamegraph-rs/flamegraph for why we append to RUSTFLAGS here.
           export RUSTFLAGS="-C link-arg=-Wl,--no-rosegment, -C force-frame-pointers=yes $RUSTFLAGS"
           echo "RUSTFLAGS=$RUSTFLAGS" >> "$GITHUB_ENV"
+          mkdir -p binaries/neqo-main
+          mkdir -p binaries/neqo
           cd neqo
           git checkout origin/main
           cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches-main.txt
-          cargo build --locked --release --bin neqo-client --bin neqo-server
           BENCHES_MAIN=$(grep Executable benches-main.txt | cut -d\( -f2 | cut -d\) -f1 | tr -s '\n' ' ')
           echo "BENCHES_MAIN=$BENCHES_MAIN" >> "$GITHUB_ENV"
+          cargo build --locked --release --bin neqo-client --bin neqo-server
+          cp target/release/neqo-client ../binaries/neqo-main/
+          cp target/release/neqo-server ../binaries/neqo-main/
           git checkout -
           cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches.txt
-          cargo build --locked --release --bin neqo-client --bin neqo-server
           BENCHES=$(grep Executable benches.txt | cut -d\( -f2 | cut -d\) -f1 | tr -s '\n' ' ')
           echo "BENCHES=$BENCHES" >> "$GITHUB_ENV"
+          cargo build --locked --release --bin neqo-client --bin neqo-server
+          cp target/release/neqo-client ../binaries/neqo/
+          cp target/release/neqo-server ../binaries/neqo/
 
       - name: Build msquic
         run: |
@@ -157,8 +163,6 @@ jobs:
           NSS_DB_PATH: ${{ github.workspace }}/neqo/test-fixture/db
         run: |
           sudo ip link set dev lo mtu "$MTU"
-          mkdir -p binaries/neqo-main
-          mkdir -p binaries/neqo
           cd neqo
           rm -rf target/criterion
           git checkout origin/main
@@ -211,14 +215,14 @@ jobs:
           truncate -s "$BIGSIZE" "$TMP/$BIGSIZE"
           # Define the commands to run for each client and server.
           declare -A client_cmd=(
-            ["neqo"]="neqo/target/release/neqo-client _cc _pacing --output-dir . _flags -Q 1 https://$HOST:$PORT/$SIZE"
+            ["neqo"]="binaries/neqo/neqo-client _cc _pacing --output-dir . _flags -Q 1 https://$HOST:$PORT/$SIZE"
             ["msquic"]="msquic/build/bin/Release/quicinterop -test:D -custom:$HOST -port:$PORT -urls:https://$HOST:$PORT/$SIZE"
             ["google"]="google-quiche/bazel-bin/quiche/quic_client --disable_certificate_verification https://$HOST:$PORT/$SIZE > $SIZE"
             ["quiche"]="quiche/target/release/quiche-client --dump-responses . --no-verify https://$HOST:$PORT/$SIZE"
             ["s2n"]="s2n-quic/target/release/s2n-quic-qns interop client --tls rustls --disable-cert-verification --download-dir . --local-ip $HOST https://$HOST:$PORT/$SIZE"
           )
           declare -A server_cmd=(
-            ["neqo"]="neqo/target/release/neqo-server _cc _pacing _flags -Q 1 $HOST:$PORT"
+            ["neqo"]="binaries/neqo/neqo-server _cc _pacing _flags -Q 1 $HOST:$PORT"
             ["msquic"]="msquic/build/bin/Release/quicinteropserver -root:$TMP -listen:$HOST -port:$PORT -file:$TMP/cert -key:$TMP/key -noexit"
             ["google"]="google-quiche/bazel-bin/quiche/quic_server --generate_dynamic_responses --port $PORT --certificate_file $TMP/cert --key_file $TMP/key"
             ["quiche"]="quiche/target/release/quiche-server --root $TMP --listen $HOST:$PORT --cert $TMP/cert --key $TMP/key"

--- a/fuzz/fuzz_targets/client_initial.rs
+++ b/fuzz/fuzz_targets/client_initial.rs
@@ -6,6 +6,7 @@ use libfuzzer_sys::fuzz_target;
 #[cfg(all(fuzzing, not(windows)))]
 fuzz_target!(|data: &[u8]| {
     use neqo_common::{Datagram, Encoder, Role};
+    use neqo_crypto::Aead;
     use neqo_transport::{packet::MIN_INITIAL_PACKET_SIZE, ConnectionParameters, Version};
     use test_fixture::{
         header_protection::{
@@ -34,11 +35,11 @@ fuzz_target!(|data: &[u8]| {
         .encode_vec(1, d_cid)
         .encode_vec(1, s_cid)
         .encode_vvec(&[])
-        .encode_varint(u64::try_from(payload_enc.len() + aead.expansion() + 1).unwrap())
+        .encode_varint(u64::try_from(payload_enc.len() + Aead::expansion() + 1).unwrap())
         .encode_byte(u8::try_from(pn).unwrap());
 
     let mut ciphertext = header_enc.as_ref().to_vec();
-    ciphertext.resize(header_enc.len() + payload_enc.len() + aead.expansion(), 0);
+    ciphertext.resize(header_enc.len() + payload_enc.len() + Aead::expansion(), 0);
     let v = aead
         .encrypt(
             pn,

--- a/fuzz/fuzz_targets/server_initial.rs
+++ b/fuzz/fuzz_targets/server_initial.rs
@@ -5,8 +5,8 @@ use libfuzzer_sys::fuzz_target;
 
 #[cfg(all(fuzzing, not(windows)))]
 fuzz_target!(|data: &[u8]| {
-    use neqo_crypto::Aead;
     use neqo_common::{Datagram, Encoder, Role};
+    use neqo_crypto::Aead;
     use neqo_transport::{packet::MIN_INITIAL_PACKET_SIZE, ConnectionParameters, Version};
     use test_fixture::{
         header_protection::{

--- a/fuzz/fuzz_targets/server_initial.rs
+++ b/fuzz/fuzz_targets/server_initial.rs
@@ -5,6 +5,7 @@ use libfuzzer_sys::fuzz_target;
 
 #[cfg(all(fuzzing, not(windows)))]
 fuzz_target!(|data: &[u8]| {
+    use neqo_crypto::Aead;
     use neqo_common::{Datagram, Encoder, Role};
     use neqo_transport::{packet::MIN_INITIAL_PACKET_SIZE, ConnectionParameters, Version};
     use test_fixture::{
@@ -37,11 +38,11 @@ fuzz_target!(|data: &[u8]| {
         .encode_vec(1, d_cid)
         .encode_vec(1, s_cid)
         .encode_vvec(&[])
-        .encode_varint(u64::try_from(payload_enc.len() + aead.expansion() + 1).unwrap())
+        .encode_varint(u64::try_from(payload_enc.len() + Aead::expansion() + 1).unwrap())
         .encode_byte(u8::try_from(pn).unwrap());
 
     let mut ciphertext = header_enc.as_ref().to_vec();
-    ciphertext.resize(header_enc.len() + payload_enc.len() + aead.expansion(), 0);
+    ciphertext.resize(header_enc.len() + payload_enc.len() + Aead::expansion(), 0);
     let v = aead
         .encrypt(
             pn,

--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -165,7 +165,7 @@ pub fn create_client(
     client.set_qlog(qlog_new(
         args,
         hostname,
-        client.odcid().ok_or(Error::InternalError)?,
+        client.odcid().ok_or(Error::Internal)?,
     )?);
 
     Ok(client)
@@ -275,7 +275,7 @@ impl<'b> Handler<'b> {
                 self.handled_urls.push(url);
                 true
             }
-            Err(e @ (Error::StreamLimitError | Error::ConnectionState)) => {
+            Err(e @ (Error::StreamLimit | Error::ConnectionState)) => {
                 qwarn!("Cannot create stream {e:?}");
                 self.url_queue.push_front(url);
                 false

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -341,7 +341,7 @@ impl StreamHandler for UploadStreamHandler {
             Ok(())
         } else {
             qerror!("Unexpected data [{stream_id}]: 0x{}", hex(data));
-            Err(crate::client::Error::Http3Error(Error::InvalidInput))
+            Err(crate::client::Error::Http3(Error::InvalidInput))
         }
     }
 
@@ -419,8 +419,8 @@ impl UrlHandler<'_> {
                 true
             }
             Err(
-                Error::TransportError(TransportError::StreamLimitError)
-                | Error::StreamLimitError
+                Error::Transport(TransportError::StreamLimit)
+                | Error::StreamLimit
                 | Error::Unavailable,
             ) => {
                 self.url_queue.push_front(url);

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -43,50 +43,50 @@ const BUFWRITER_BUFFER_SIZE: usize = 64 * 1024;
 
 #[derive(Debug)]
 pub enum Error {
-    ArgumentError(&'static str),
-    Http3Error(neqo_http3::Error),
-    IoError(io::Error),
-    QlogError(qlog::Error),
-    TransportError(neqo_transport::Error),
-    ApplicationError(AppError),
-    CryptoError(neqo_crypto::Error),
+    Argument(&'static str),
+    Http3(neqo_http3::Error),
+    Io(io::Error),
+    Qlog(qlog::Error),
+    Transport(neqo_transport::Error),
+    Application(AppError),
+    Crypto(neqo_crypto::Error),
 }
 
 impl From<neqo_crypto::Error> for Error {
     fn from(err: neqo_crypto::Error) -> Self {
-        Self::CryptoError(err)
+        Self::Crypto(err)
     }
 }
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self {
-        Self::IoError(err)
+        Self::Io(err)
     }
 }
 
 impl From<neqo_http3::Error> for Error {
     fn from(err: neqo_http3::Error) -> Self {
-        Self::Http3Error(err)
+        Self::Http3(err)
     }
 }
 
 impl From<qlog::Error> for Error {
     fn from(err: qlog::Error) -> Self {
-        Self::QlogError(err)
+        Self::Qlog(err)
     }
 }
 
 impl From<neqo_transport::Error> for Error {
     fn from(err: neqo_transport::Error) -> Self {
-        Self::TransportError(err)
+        Self::Transport(err)
     }
 }
 
 impl From<CloseReason> for Error {
     fn from(err: CloseReason) -> Self {
         match err {
-            CloseReason::Transport(e) => Self::TransportError(e),
-            CloseReason::Application(e) => Self::ApplicationError(e),
+            CloseReason::Transport(e) => Self::Transport(e),
+            CloseReason::Application(e) => Self::Application(e),
         }
     }
 }
@@ -526,7 +526,7 @@ fn qlog_new(args: &Args, hostname: &str, cid: &ConnectionId) -> Res<NeqoQlog> {
         Some("Neqo client qlog".to_string()),
         format!("client-{hostname}-{cid}"),
     )
-    .map_err(Error::QlogError)
+    .map_err(Error::Qlog)
 }
 
 const fn local_addr_for(remote_addr: &SocketAddr, local_port: u16) -> SocketAddr {

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -51,41 +51,41 @@ mod http3;
 
 #[derive(Debug)]
 pub enum Error {
-    ArgumentError(&'static str),
-    Http3Error(neqo_http3::Error),
-    IoError(io::Error),
-    QlogError,
-    TransportError(neqo_transport::Error),
-    CryptoError(neqo_crypto::Error),
+    Argument(&'static str),
+    Http3(neqo_http3::Error),
+    Io(io::Error),
+    Qlog,
+    Transport(neqo_transport::Error),
+    Crypto(neqo_crypto::Error),
 }
 
 impl From<neqo_crypto::Error> for Error {
     fn from(err: neqo_crypto::Error) -> Self {
-        Self::CryptoError(err)
+        Self::Crypto(err)
     }
 }
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self {
-        Self::IoError(err)
+        Self::Io(err)
     }
 }
 
 impl From<neqo_http3::Error> for Error {
     fn from(err: neqo_http3::Error) -> Self {
-        Self::Http3Error(err)
+        Self::Http3(err)
     }
 }
 
 impl From<qlog::Error> for Error {
     fn from(_err: qlog::Error) -> Self {
-        Self::QlogError
+        Self::Qlog
     }
 }
 
 impl From<neqo_transport::Error> for Error {
     fn from(err: neqo_transport::Error) -> Self {
-        Self::TransportError(err)
+        Self::Transport(err)
     }
 }
 

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -19,7 +19,7 @@ pub struct Decoder<'a> {
 impl<'a> Decoder<'a> {
     /// Make a new view of the provided slice.
     #[must_use]
-    pub const fn new(buf: &[u8]) -> Decoder {
+    pub const fn new(buf: &[u8]) -> Decoder<'_> {
         Decoder { buf, offset: 0 }
     }
 
@@ -266,7 +266,7 @@ impl Encoder {
     /// Create a view of the current contents of the buffer.
     /// Note: for a view of a slice, use `Decoder::new(&enc[s..e])`
     #[must_use]
-    pub fn as_decoder(&self) -> Decoder {
+    pub fn as_decoder(&self) -> Decoder<'_> {
         Decoder::new(self.as_ref())
     }
 

--- a/neqo-common/src/tos.rs
+++ b/neqo-common/src/tos.rs
@@ -51,7 +51,7 @@ impl From<IpTos> for IpTosEcn {
 
 impl IpTosEcn {
     #[must_use]
-    pub const fn is_ecn_marked(&self) -> bool {
+    pub const fn is_ecn_marked(self) -> bool {
         match self {
             Self::Ect0 | Self::Ect1 | Self::Ce => true,
             Self::NotEct => false,
@@ -190,8 +190,8 @@ impl IpTos {
     }
 
     #[must_use]
-    pub fn is_ecn_marked(&self) -> bool {
-        IpTosEcn::from(*self).is_ecn_marked()
+    pub fn is_ecn_marked(self) -> bool {
+        IpTosEcn::from(self).is_ecn_marked()
     }
 }
 

--- a/neqo-crypto/src/aead.rs
+++ b/neqo-crypto/src/aead.rs
@@ -69,6 +69,7 @@ impl RealAead {
     }
 
     #[must_use]
+    #[expect(clippy::unused_self, reason = "We may need this in the future.")]
     pub const fn expansion(&self) -> usize {
         16
     }

--- a/neqo-crypto/src/aead.rs
+++ b/neqo-crypto/src/aead.rs
@@ -69,8 +69,7 @@ impl RealAead {
     }
 
     #[must_use]
-    #[expect(clippy::unused_self, reason = "We may need this in the future.")]
-    pub const fn expansion(&self) -> usize {
+    pub const fn expansion() -> usize {
         16
     }
 
@@ -153,7 +152,7 @@ impl RealAead {
                 aad.as_ptr(),
                 c_uint::try_from(aad.len())?,
                 data.as_ptr(),
-                c_uint::try_from(data.len() - self.expansion())?,
+                c_uint::try_from(data.len() - Self::expansion())?,
                 data.as_ptr(),
                 &mut l,
                 c_uint::try_from(data.len())?,
@@ -224,7 +223,7 @@ impl RealAead {
                 c_uint::try_from(data.len())?,
             )
         }?;
-        debug_assert_eq!(usize::try_from(l)?, data.len() - self.expansion());
+        debug_assert_eq!(usize::try_from(l)?, data.len() - Self::expansion());
         Ok(&mut data[..l.try_into()?])
     }
 }

--- a/neqo-crypto/src/aead_null.rs
+++ b/neqo-crypto/src/aead_null.rs
@@ -33,13 +33,13 @@ impl AeadNull {
     }
 
     #[must_use]
-    #[expect(clippy::unused_self, reason = "We may need this in the future.")]
-    pub const fn expansion(&self) -> usize {
+    pub const fn expansion() -> usize {
         AEAD_NULL_TAG.len()
     }
 
     #[expect(
         clippy::unnecessary_wraps,
+        clippy::unused_self,
         reason = "Need to replicate the API of aead::RealAead."
     )]
     pub fn encrypt<'a>(
@@ -51,12 +51,13 @@ impl AeadNull {
     ) -> Res<&'a [u8]> {
         let l = input.len();
         output[..l].copy_from_slice(input);
-        output[l..l + self.expansion()].copy_from_slice(AEAD_NULL_TAG);
-        Ok(&output[..l + self.expansion()])
+        output[l..l + Self::expansion()].copy_from_slice(AEAD_NULL_TAG);
+        Ok(&output[..l + Self::expansion()])
     }
 
     #[expect(
         clippy::unnecessary_wraps,
+        clippy::unused_self,
         reason = "Need to replicate the API of aead::RealAead."
     )]
     pub fn encrypt_in_place<'a>(
@@ -65,19 +66,23 @@ impl AeadNull {
         _aad: &[u8],
         data: &'a mut [u8],
     ) -> Res<&'a mut [u8]> {
-        let pos = data.len() - self.expansion();
+        let pos = data.len() - Self::expansion();
         data[pos..].copy_from_slice(AEAD_NULL_TAG);
         Ok(data)
     }
 
+    #[expect(
+        clippy::unused_self,
+        reason = "Need to replicate the API of aead::RealAead."
+    )]
     fn decrypt_check(&self, _count: u64, _aad: &[u8], input: &[u8]) -> Res<usize> {
-        if input.len() < self.expansion() {
+        if input.len() < Self::expansion() {
             return Err(Error::from(SEC_ERROR_BAD_DATA));
         }
 
         let len_encrypted = input
             .len()
-            .checked_sub(self.expansion())
+            .checked_sub(Self::expansion())
             .ok_or_else(|| Error::from(SEC_ERROR_BAD_DATA))?;
         // Check that:
         // 1) expansion is all zeros and

--- a/neqo-crypto/src/aead_null.rs
+++ b/neqo-crypto/src/aead_null.rs
@@ -19,6 +19,10 @@ pub const AEAD_NULL_TAG: &[u8] = &[0x0a; 16];
 pub struct AeadNull {}
 
 impl AeadNull {
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "Need to replicate the API of aead::RealAead."
+    )]
     pub const fn new(
         _version: Version,
         _cipher: Cipher,
@@ -29,10 +33,15 @@ impl AeadNull {
     }
 
     #[must_use]
+    #[expect(clippy::unused_self, reason = "We may need this in the future.")]
     pub const fn expansion(&self) -> usize {
         AEAD_NULL_TAG.len()
     }
 
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "Need to replicate the API of aead::RealAead."
+    )]
     pub fn encrypt<'a>(
         &self,
         _count: u64,
@@ -46,6 +55,10 @@ impl AeadNull {
         Ok(&output[..l + self.expansion()])
     }
 
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "Need to replicate the API of aead::RealAead."
+    )]
     pub fn encrypt_in_place<'a>(
         &self,
         _count: u64,

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -112,7 +112,7 @@ fn get_alpn(fd: *mut ssl::PRFileDesc, pre: bool) -> Res<Option<String>> {
             chosen.truncate(usize::try_from(chosen_len)?);
             Some(match String::from_utf8(chosen) {
                 Ok(a) => a,
-                Err(_) => return Err(Error::InternalError),
+                Err(_) => return Err(Error::Internal),
             })
         }
         _ => None,
@@ -443,7 +443,7 @@ impl SecretAgent {
     pub fn set_ciphers(&mut self, ciphers: &[Cipher]) -> Res<()> {
         if self.state != HandshakeState::New {
             qwarn!("[{self}] Cannot enable ciphers in state {:?}", self.state);
-            return Err(Error::InternalError);
+            return Err(Error::Internal);
         }
 
         let all_ciphers = unsafe { ssl::SSL_GetImplementedCiphers() };
@@ -555,7 +555,7 @@ impl SecretAgent {
 
         // NSS inherited an idiosyncratic API as a result of having implemented NPN
         // before ALPN.  For that reason, we need to put the "best" option last.
-        let (first, rest) = protocols.split_first().ok_or(Error::InternalError)?;
+        let (first, rest) = protocols.split_first().ok_or(Error::Internal)?;
         for v in rest {
             add(v.as_ref());
         }

--- a/neqo-crypto/src/cert.rs
+++ b/neqo-crypto/src/cert.rs
@@ -95,12 +95,12 @@ impl CertificateInfo {
     }
 
     #[must_use]
-    pub const fn stapled_ocsp_responses(&self) -> &Option<Vec<Vec<u8>>> {
-        &self.stapled_ocsp_responses
+    pub const fn stapled_ocsp_responses(&self) -> Option<&Vec<Vec<u8>>> {
+        self.stapled_ocsp_responses.as_ref()
     }
 
     #[must_use]
-    pub const fn signed_cert_timestamp(&self) -> &Option<Vec<u8>> {
-        &self.signed_cert_timestamp
+    pub const fn signed_cert_timestamp(&self) -> Option<&Vec<u8>> {
+        self.signed_cert_timestamp.as_ref()
     }
 }

--- a/neqo-crypto/src/ech.rs
+++ b/neqo-crypto/src/ech.rs
@@ -65,14 +65,14 @@ experimental_api!(SSL_EncodeEchConfigId(
 
 /// Convert any result that contains an ECH error into a result with an `EchRetry`.
 pub fn convert_ech_error(fd: *mut PRFileDesc, err: Error) -> Error {
-    if let Error::NssError {
+    if let Error::Nss {
         code: SSL_ERROR_ECH_RETRY_WITH_ECH,
         ..
     } = &err
     {
         let mut item = Item::make_empty();
         if unsafe { SSL_GetEchRetryConfigs(fd, &mut item).is_err() } {
-            return Error::InternalError;
+            return Error::Internal;
         }
         let buf = unsafe {
             let slc = null_safe_slice(item.data, item.len);
@@ -99,7 +99,7 @@ pub fn generate_keys() -> Res<(PrivateKey, PublicKey)> {
     let slot = Slot::internal()?;
 
     let oid_data = unsafe { p11::SECOID_FindOIDByTag(p11::SECOidTag::SEC_OID_CURVE25519) };
-    let oid = unsafe { oid_data.as_ref() }.ok_or(Error::InternalError)?;
+    let oid = unsafe { oid_data.as_ref() }.ok_or(Error::Internal)?;
     let oid_slc = unsafe { null_safe_slice(oid.oid.data, oid.oid.len) };
     let mut params: Vec<u8> = Vec::with_capacity(oid_slc.len() + 2);
     params.push(u8::try_from(p11::SEC_ASN1_OBJECT_ID)?);

--- a/neqo-crypto/src/err.rs
+++ b/neqo-crypto/src/err.rs
@@ -56,26 +56,26 @@ pub type Res<T> = Result<T, Error>;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub enum Error {
-    AeadError,
+    Aead,
     CertificateLoading,
-    CipherInitFailure,
+    CipherInit,
     CreateSslSocket,
     EchRetry(Vec<u8>),
-    HkdfError,
-    InternalError,
+    Hkdf,
+    Internal,
     IntegerOverflow,
     InvalidEpoch,
     MixedHandshakeMethod,
     NoDataAvailable,
-    NssError {
+    Nss {
         name: String,
         code: PRErrorCode,
         desc: String,
     },
-    OverrunError,
-    SelfEncryptFailure,
-    StringError,
-    TimeTravelError,
+    Overrun,
+    SelfEncrypt,
+    String,
+    TimeTravel,
     UnsupportedCipher,
     UnsupportedVersion,
 }
@@ -108,12 +108,12 @@ impl From<std::num::TryFromIntError> for Error {
 }
 impl From<std::ffi::NulError> for Error {
     fn from(_: std::ffi::NulError) -> Self {
-        Self::InternalError
+        Self::Internal
     }
 }
 impl From<Utf8Error> for Error {
     fn from(_: Utf8Error) -> Self {
-        Self::StringError
+        Self::String
     }
 }
 impl From<PRErrorCode> for Error {
@@ -123,7 +123,7 @@ impl From<PRErrorCode> for Error {
             || unsafe { PR_ErrorToString(code, PR_LANGUAGE_I_DEFAULT) },
             "...",
         );
-        Self::NssError { name, code, desc }
+        Self::Nss { name, code, desc }
     }
 }
 
@@ -152,7 +152,7 @@ pub fn secstatus_to_res(rv: SECStatus) -> Res<()> {
 
 pub const fn is_blocked(result: &Res<()>) -> bool {
     match result {
-        Err(Error::NssError { code, .. }) => *code == nspr::PR_WOULD_BLOCK_ERROR,
+        Err(Error::Nss { code, .. }) => *code == nspr::PR_WOULD_BLOCK_ERROR,
         _ => false,
     }
 }
@@ -193,7 +193,7 @@ mod tests {
         let r = secstatus_to_res(SECFailure);
         assert!(r.is_err());
         match r.unwrap_err() {
-            Error::NssError { name, code, desc } => {
+            Error::Nss { name, code, desc } => {
                 assert_eq!(name, "SSL_ERROR_BAD_MAC_READ");
                 assert_eq!(code, -12273);
                 assert_eq!(
@@ -211,7 +211,7 @@ mod tests {
         let r = secstatus_to_res(SECFailure);
         assert!(r.is_err());
         match r.unwrap_err() {
-            Error::NssError { name, code, .. } => {
+            Error::Nss { name, code, .. } => {
                 assert_eq!(name, "UNKNOWN_ERROR");
                 assert_eq!(code, 0);
                 // Note that we don't test |desc| here because that comes from
@@ -228,7 +228,7 @@ mod tests {
         assert!(r.is_err());
         assert!(is_blocked(&r));
         match r.unwrap_err() {
-            Error::NssError { name, code, desc } => {
+            Error::Nss { name, code, desc } => {
                 assert_eq!(name, "PR_WOULD_BLOCK_ERROR");
                 assert_eq!(code, -5998);
                 assert_eq!(desc, "The operation would have blocked");

--- a/neqo-crypto/src/exp.rs
+++ b/neqo-crypto/src/exp.rs
@@ -22,7 +22,7 @@ macro_rules! experimental_api {
                 ExperimentalAPI($crate::ssl::SSL_GetExperimentalAPI(n.as_ptr()))
             });
             if f.0.is_null() {
-                return Err($crate::err::Error::InternalError);
+                return Err($crate::err::Error::Internal);
             }
             let f: unsafe extern "C" fn( $( $t ),* ) -> $crate::ssl::SECStatus = ::std::mem::transmute(f.0);
             let rv = f( $( $a ),* );

--- a/neqo-crypto/src/hp.rs
+++ b/neqo-crypto/src/hp.rs
@@ -102,7 +102,7 @@ impl HpKey {
                 &mut secret,
             )
         }?;
-        let key = SymKey::from_ptr(secret).or(Err(Error::HkdfError))?;
+        let key = SymKey::from_ptr(secret).or(Err(Error::Hkdf))?;
 
         let res = match cipher {
             TLS_AES_128_GCM_SHA256 | TLS_AES_256_GCM_SHA384 => {
@@ -114,7 +114,7 @@ impl HpKey {
                         &Item::wrap(&ZERO[..0])?, // Borrow a zero-length slice of ZERO.
                     )
                 };
-                let context = Context::from_ptr(context_ptr).or(Err(Error::CipherInitFailure))?;
+                let context = Context::from_ptr(context_ptr).or(Err(Error::CipherInit))?;
                 Self::Aes(Rc::new(RefCell::new(context)))
             }
             TLS_CHACHA20_POLY1305_SHA256 => Self::Chacha(key),

--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -118,9 +118,9 @@ fn init_once(db: Option<PathBuf>) -> Res<NssLoaded> {
 
     let state = if let Some(path) = db {
         if !path.is_dir() {
-            return Err(Error::InternalError);
+            return Err(Error::Internal);
         }
-        let pathstr = path.to_str().ok_or(Error::InternalError)?;
+        let pathstr = path.to_str().ok_or(Error::Internal)?;
         let dircstr = CString::new(pathstr)?;
         let empty = CString::new("")?;
         secstatus_to_res(unsafe {
@@ -168,8 +168,8 @@ pub fn init() -> Res<()> {
 /// If NSS cannot be initialized.
 pub fn init_db<P: Into<PathBuf>>(dir: P) -> Res<()> {
     // Allow overriding the NSS database path with an environment variable.
-    let dir = env::var("NSS_DB_PATH")
-        .unwrap_or(dir.into().to_str().ok_or(Error::InternalError)?.to_string());
+    let dir =
+        env::var("NSS_DB_PATH").unwrap_or(dir.into().to_str().ok_or(Error::Internal)?.to_string());
     let res = INITIALIZED.get_or_init(|| init_once(Some(dir.into())));
     res.as_ref().map(|_| ()).map_err(Clone::clone)
 }

--- a/neqo-crypto/src/p11.rs
+++ b/neqo-crypto/src/p11.rs
@@ -206,7 +206,7 @@ impl SymKey {
         let key_item = unsafe { PK11_GetKeyData(self.ptr) };
         // This is accessing a value attached to the key, so we can treat this as a borrow.
         match unsafe { key_item.as_mut() } {
-            None => Err(Error::InternalError),
+            None => Err(Error::Internal),
             Some(key) => Ok(unsafe { null_safe_slice(key.data, key.len) }),
         }
     }

--- a/neqo-crypto/src/selfencrypt.rs
+++ b/neqo-crypto/src/selfencrypt.rs
@@ -129,10 +129,10 @@ impl SelfEncrypt {
     #[expect(clippy::similar_names, reason = "aad is similar to aead.")]
     pub fn open(&self, aad: &[u8], ciphertext: &[u8]) -> Res<Vec<u8>> {
         if ciphertext[0] != Self::VERSION {
-            return Err(Error::SelfEncryptFailure);
+            return Err(Error::SelfEncrypt);
         }
         let Some(key) = self.select_key(ciphertext[1]) else {
-            return Err(Error::SelfEncryptFailure);
+            return Err(Error::SelfEncrypt);
         };
         let offset = 2 + Self::SALT_LENGTH;
 

--- a/neqo-crypto/src/selfencrypt.rs
+++ b/neqo-crypto/src/selfencrypt.rs
@@ -84,7 +84,7 @@ impl SelfEncrypt {
         // AAD covers the entire header, plus the value of the AAD parameter that is provided.
         let salt = random::<{ Self::SALT_LENGTH }>();
         let cipher = self.make_aead(&self.key, &salt)?;
-        let encoded_len = 2 + salt.len() + plaintext.len() + cipher.expansion();
+        let encoded_len = 2 + salt.len() + plaintext.len() + Aead::expansion();
 
         let mut enc = Encoder::with_capacity(encoded_len);
         enc.encode_byte(Self::VERSION);

--- a/neqo-crypto/src/time.rs
+++ b/neqo-crypto/src/time.rs
@@ -107,16 +107,14 @@ impl TryFrom<PRTime> for Time {
     type Error = Error;
     fn try_from(prtime: PRTime) -> Res<Self> {
         let base = get_base();
-        let delta = prtime
-            .checked_sub(base.prtime)
-            .ok_or(Error::TimeTravelError)?;
+        let delta = prtime.checked_sub(base.prtime).ok_or(Error::TimeTravel)?;
         let d = Duration::from_micros(u64::try_from(delta.abs())?);
         let t = if delta >= 0 {
             base.instant.checked_add(d)
         } else {
             base.instant.checked_sub(d)
         };
-        let t = t.ok_or(Error::TimeTravelError)?;
+        let t = t.ok_or(Error::TimeTravel)?;
         Ok(Self { t })
     }
 }
@@ -130,13 +128,13 @@ impl TryInto<PRTime> for Time {
             || {
                 // Try to go backwards from the base time.
                 let backwards = base.instant - self.t; // infallible
-                PRTime::try_from(backwards.as_micros()).map_or(Err(Error::TimeTravelError), |d| {
-                    base.prtime.checked_sub(d).ok_or(Error::TimeTravelError)
+                PRTime::try_from(backwards.as_micros()).map_or(Err(Error::TimeTravel), |d| {
+                    base.prtime.checked_sub(d).ok_or(Error::TimeTravel)
                 })
             },
             |delta| {
-                PRTime::try_from(delta.as_micros()).map_or(Err(Error::TimeTravelError), |d| {
-                    d.checked_add(base.prtime).ok_or(Error::TimeTravelError)
+                PRTime::try_from(delta.as_micros()).map_or(Err(Error::TimeTravel), |d| {
+                    d.checked_add(base.prtime).ok_or(Error::TimeTravel)
                 })
             },
         )

--- a/neqo-crypto/tests/selfencrypt.rs
+++ b/neqo-crypto/tests/selfencrypt.rs
@@ -51,7 +51,7 @@ fn seal_rotate_twice_open() {
     se.rotate().expect("rotate should be infallible");
     se.rotate().expect("rotate should be infallible");
     let res = se.open(AAD, &sealed);
-    assert_eq!(res.unwrap_err(), Error::SelfEncryptFailure);
+    assert_eq!(res.unwrap_err(), Error::SelfEncrypt);
 }
 
 #[test]
@@ -59,11 +59,11 @@ fn damage_version() {
     let (se, mut sealed) = sealed();
     sealed[0] ^= 0x80;
     let res = se.open(AAD, &sealed);
-    assert_eq!(res.unwrap_err(), Error::SelfEncryptFailure);
+    assert_eq!(res.unwrap_err(), Error::SelfEncrypt);
 }
 
 fn assert_bad_data<T>(res: Result<T, Error>) {
-    if let Err(Error::NssError { name, .. }) = res {
+    if let Err(Error::Nss { name, .. }) = res {
         assert_eq!(name, "SEC_ERROR_BAD_DATA");
     }
 }

--- a/neqo-http3/src/conn_params.rs
+++ b/neqo-http3/src/conn_params.rs
@@ -30,9 +30,9 @@ impl Default for Http3Parameters {
         Self {
             conn_params: ConnectionParameters::default(),
             qpack_settings: QpackSettings {
-                table_size_encoder: QPACK_MAX_TABLE_SIZE_DEFAULT,
-                table_size_decoder: QPACK_MAX_TABLE_SIZE_DEFAULT,
-                blocked_streams: QPACK_MAX_BLOCKED_STREAMS_DEFAULT,
+                max_table_size_encoder: QPACK_MAX_TABLE_SIZE_DEFAULT,
+                max_table_size_decoder: QPACK_MAX_TABLE_SIZE_DEFAULT,
+                max_blocked_streams: QPACK_MAX_BLOCKED_STREAMS_DEFAULT,
             },
             max_concurrent_push_streams: MAX_PUSH_STREAM_DEFAULT,
             webtransport: WEBTRANSPORT_DEFAULT,
@@ -60,13 +60,13 @@ impl Http3Parameters {
     pub fn max_table_size_encoder(mut self, mut max_table: u64) -> Self {
         assert!(max_table <= QPACK_TABLE_SIZE_LIMIT);
         max_table = min(max_table, QPACK_TABLE_SIZE_LIMIT);
-        self.qpack_settings.table_size_encoder = max_table;
+        self.qpack_settings.max_table_size_encoder = max_table;
         self
     }
 
     #[must_use]
     pub const fn get_max_table_size_encoder(&self) -> u64 {
-        self.qpack_settings.table_size_encoder
+        self.qpack_settings.max_table_size_encoder
     }
 
     /// # Panics
@@ -76,24 +76,24 @@ impl Http3Parameters {
     pub fn max_table_size_decoder(mut self, mut max_table: u64) -> Self {
         assert!(max_table <= QPACK_TABLE_SIZE_LIMIT);
         max_table = min(max_table, QPACK_TABLE_SIZE_LIMIT);
-        self.qpack_settings.table_size_decoder = max_table;
+        self.qpack_settings.max_table_size_decoder = max_table;
         self
     }
 
     #[must_use]
     pub const fn get_max_table_size_decoder(&self) -> u64 {
-        self.qpack_settings.table_size_decoder
+        self.qpack_settings.max_table_size_decoder
     }
 
     #[must_use]
     pub const fn max_blocked_streams(mut self, max_blocked: u16) -> Self {
-        self.qpack_settings.blocked_streams = max_blocked;
+        self.qpack_settings.max_blocked_streams = max_blocked;
         self
     }
 
     #[must_use]
     pub const fn get_max_blocked_streams(&self) -> u16 {
-        self.qpack_settings.blocked_streams
+        self.qpack_settings.max_blocked_streams
     }
 
     #[must_use]

--- a/neqo-http3/src/conn_params.rs
+++ b/neqo-http3/src/conn_params.rs
@@ -30,9 +30,9 @@ impl Default for Http3Parameters {
         Self {
             conn_params: ConnectionParameters::default(),
             qpack_settings: QpackSettings {
-                max_table_size_encoder: QPACK_MAX_TABLE_SIZE_DEFAULT,
-                max_table_size_decoder: QPACK_MAX_TABLE_SIZE_DEFAULT,
-                max_blocked_streams: QPACK_MAX_BLOCKED_STREAMS_DEFAULT,
+                table_size_encoder: QPACK_MAX_TABLE_SIZE_DEFAULT,
+                table_size_decoder: QPACK_MAX_TABLE_SIZE_DEFAULT,
+                blocked_streams: QPACK_MAX_BLOCKED_STREAMS_DEFAULT,
             },
             max_concurrent_push_streams: MAX_PUSH_STREAM_DEFAULT,
             webtransport: WEBTRANSPORT_DEFAULT,
@@ -60,13 +60,13 @@ impl Http3Parameters {
     pub fn max_table_size_encoder(mut self, mut max_table: u64) -> Self {
         assert!(max_table <= QPACK_TABLE_SIZE_LIMIT);
         max_table = min(max_table, QPACK_TABLE_SIZE_LIMIT);
-        self.qpack_settings.max_table_size_encoder = max_table;
+        self.qpack_settings.table_size_encoder = max_table;
         self
     }
 
     #[must_use]
     pub const fn get_max_table_size_encoder(&self) -> u64 {
-        self.qpack_settings.max_table_size_encoder
+        self.qpack_settings.table_size_encoder
     }
 
     /// # Panics
@@ -76,24 +76,24 @@ impl Http3Parameters {
     pub fn max_table_size_decoder(mut self, mut max_table: u64) -> Self {
         assert!(max_table <= QPACK_TABLE_SIZE_LIMIT);
         max_table = min(max_table, QPACK_TABLE_SIZE_LIMIT);
-        self.qpack_settings.max_table_size_decoder = max_table;
+        self.qpack_settings.table_size_decoder = max_table;
         self
     }
 
     #[must_use]
     pub const fn get_max_table_size_decoder(&self) -> u64 {
-        self.qpack_settings.max_table_size_decoder
+        self.qpack_settings.table_size_decoder
     }
 
     #[must_use]
     pub const fn max_blocked_streams(mut self, max_blocked: u16) -> Self {
-        self.qpack_settings.max_blocked_streams = max_blocked;
+        self.qpack_settings.blocked_streams = max_blocked;
         self
     }
 
     #[must_use]
     pub const fn get_max_blocked_streams(&self) -> u16 {
-        self.qpack_settings.max_blocked_streams
+        self.qpack_settings.blocked_streams
     }
 
     #[must_use]

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -423,7 +423,7 @@ impl Http3Connection {
             Ok(())
             | Err(neqo_qpack::Error::EncoderStreamBlocked | neqo_qpack::Error::DynamicTableFull) => {
             }
-            Err(e) => return Err(Error::QpackError(e)),
+            Err(e) => return Err(Error::Qpack(e)),
         }
         Ok(())
     }
@@ -1419,7 +1419,7 @@ impl Http3Connection {
                     match st {
                         HSettingType::MaxTableCapacity => {
                             if zero_rtt_value != 0 {
-                                return Err(Error::QpackError(neqo_qpack::Error::DecoderStream));
+                                return Err(Error::Qpack(neqo_qpack::Error::DecoderStream));
                             }
                             qpack_changed = true;
                         }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -1405,9 +1405,9 @@ mod tests {
             .unwrap();
             let qpack = Rc::new(RefCell::new(QPackEncoder::new(
                 &QpackSettings {
-                    table_size_encoder: max_table_size,
-                    table_size_decoder: max_table_size,
-                    blocked_streams: max_blocked_streams,
+                    max_table_size_encoder: max_table_size,
+                    max_table_size_decoder: max_table_size,
+                    max_blocked_streams,
                 },
                 true,
             )));
@@ -1427,9 +1427,9 @@ mod tests {
         pub fn new_with_conn(conn: Connection) -> Self {
             let qpack = Rc::new(RefCell::new(QPackEncoder::new(
                 &QpackSettings {
-                    table_size_encoder: 128,
-                    table_size_decoder: 128,
-                    blocked_streams: 0,
+                    max_table_size_encoder: 128,
+                    max_table_size_decoder: 128,
+                    max_blocked_streams: 0,
                 },
                 true,
             )));

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -26,20 +26,20 @@ fn no_datagrams() {
 
     assert_eq!(
         wt_session.max_datagram_size(),
-        Err(Error::TransportError(TransportError::NotAvailable))
+        Err(Error::Transport(TransportError::NotAvailable))
     );
     assert_eq!(
         wt.max_datagram_size(wt_session.stream_id()),
-        Err(Error::TransportError(TransportError::NotAvailable))
+        Err(Error::Transport(TransportError::NotAvailable))
     );
 
     assert_eq!(
         wt_session.send_datagram(DGRAM, None),
-        Err(Error::TransportError(TransportError::TooMuchData))
+        Err(Error::Transport(TransportError::TooMuchData))
     );
     assert_eq!(
         wt.send_datagram(wt_session.stream_id(), DGRAM),
-        Err(Error::TransportError(TransportError::TooMuchData))
+        Err(Error::Transport(TransportError::TooMuchData))
     );
 
     wt.exchange_packets();
@@ -84,7 +84,7 @@ fn datagrams_server_only() {
 
     assert_eq!(
         wt_session.max_datagram_size(),
-        Err(Error::TransportError(TransportError::NotAvailable))
+        Err(Error::Transport(TransportError::NotAvailable))
     );
     assert_eq!(
         wt.max_datagram_size(wt_session.stream_id()),
@@ -94,7 +94,7 @@ fn datagrams_server_only() {
 
     assert_eq!(
         wt_session.send_datagram(DGRAM, None),
-        Err(Error::TransportError(TransportError::TooMuchData))
+        Err(Error::Transport(TransportError::TooMuchData))
     );
     assert_eq!(wt.send_datagram(wt_session.stream_id(), DGRAM), Ok(()));
 
@@ -118,13 +118,13 @@ fn datagrams_client_only() {
     );
     assert_eq!(
         wt.max_datagram_size(wt_session.stream_id()),
-        Err(Error::TransportError(TransportError::NotAvailable))
+        Err(Error::Transport(TransportError::NotAvailable))
     );
 
     assert_eq!(wt_session.send_datagram(DGRAM, None), Ok(()));
     assert_eq!(
         wt.send_datagram(wt_session.stream_id(), DGRAM),
-        Err(Error::TransportError(TransportError::TooMuchData))
+        Err(Error::Transport(TransportError::TooMuchData))
     );
 
     wt.exchange_packets();

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -216,7 +216,7 @@ impl WtTest {
 
     pub fn cancel_session_client(&mut self, wt_stream_id: StreamId) {
         self.client
-            .cancel_fetch(wt_stream_id, Error::HttpNoError.code())
+            .cancel_fetch(wt_stream_id, Error::HttpNone.code())
             .unwrap();
         self.exchange_packets();
     }
@@ -262,7 +262,7 @@ impl WtTest {
     }
 
     pub fn cancel_session_server(&mut self, wt_session: &WebTransportRequest) {
-        wt_session.cancel_fetch(Error::HttpNoError.code()).unwrap();
+        wt_session.cancel_fetch(Error::HttpNone.code()).unwrap();
         self.exchange_packets();
     }
 
@@ -362,7 +362,7 @@ impl WtTest {
 
     fn reset_stream_client(&mut self, wt_stream_id: StreamId) {
         self.client
-            .stream_reset_send(wt_stream_id, Error::HttpNoError.code())
+            .stream_reset_send(wt_stream_id, Error::HttpNone.code())
             .unwrap();
         self.exchange_packets();
     }
@@ -375,7 +375,7 @@ impl WtTest {
                     stream_id,
                     error,
                     local
-                } if stream_id == expected_stream_id && error == Error::HttpNoError.code() && !local
+                } if stream_id == expected_stream_id && error == Error::HttpNone.code() && !local
             )
         };
         assert!(self.client.events().any(wt_reset_event));
@@ -383,7 +383,7 @@ impl WtTest {
 
     fn stream_stop_sending_client(&mut self, stream_id: StreamId) {
         self.client
-            .stream_stop_sending(stream_id, Error::HttpNoError.code())
+            .stream_stop_sending(stream_id, Error::HttpNone.code())
             .unwrap();
         self.exchange_packets();
     }
@@ -395,7 +395,7 @@ impl WtTest {
                 Http3ClientEvent::StopSending {
                     stream_id,
                     error
-                } if stream_id == expected_stream_id && error == Error::HttpNoError.code()
+                } if stream_id == expected_stream_id && error == Error::HttpNone.code()
             )
         };
         assert!(self.client.events().any(wt_stop_sending_event));
@@ -505,15 +505,13 @@ impl WtTest {
     }
 
     fn reset_stream_server(&mut self, wt_stream: &Http3OrWebTransportStream) {
-        wt_stream
-            .stream_reset_send(Error::HttpNoError.code())
-            .unwrap();
+        wt_stream.stream_reset_send(Error::HttpNone.code()).unwrap();
         self.exchange_packets();
     }
 
     fn stream_stop_sending_server(&mut self, wt_stream: &Http3OrWebTransportStream) {
         wt_stream
-            .stream_stop_sending(Error::HttpNoError.code())
+            .stream_stop_sending(Error::HttpNone.code())
             .unwrap();
         self.exchange_packets();
     }

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -49,7 +49,7 @@ fn wt_session_close_client() {
     wt.cancel_session_client(wt_session.stream_id());
     wt.check_session_closed_event_server(
         &wt_session,
-        &SessionCloseReason::Error(Error::HttpNoError.code()),
+        &SessionCloseReason::Error(Error::HttpNone.code()),
     );
 }
 
@@ -61,7 +61,7 @@ fn wt_session_close_server() {
     wt.cancel_session_server(&wt_session);
     wt.check_session_closed_event_client(
         wt_session.stream_id(),
-        &SessionCloseReason::Error(Error::HttpNoError.code()),
+        &SessionCloseReason::Error(Error::HttpNone.code()),
         None,
     );
 }
@@ -89,12 +89,12 @@ fn wt_session_close_server_stop_sending() {
     let wt_session = wt.create_wt_session();
 
     wt_session
-        .stream_stop_sending(Error::HttpNoError.code())
+        .stream_stop_sending(Error::HttpNone.code())
         .unwrap();
     wt.exchange_packets();
     wt.check_session_closed_event_client(
         wt_session.stream_id(),
-        &SessionCloseReason::Error(Error::HttpNoError.code()),
+        &SessionCloseReason::Error(Error::HttpNone.code()),
         None,
     );
 }
@@ -105,12 +105,12 @@ fn wt_session_close_server_reset() {
     let wt_session = wt.create_wt_session();
 
     wt_session
-        .stream_reset_send(Error::HttpNoError.code())
+        .stream_reset_send(Error::HttpNone.code())
         .unwrap();
     wt.exchange_packets();
     wt.check_session_closed_event_client(
         wt_session.stream_id(),
-        &SessionCloseReason::Error(Error::HttpNoError.code()),
+        &SessionCloseReason::Error(Error::HttpNone.code()),
         None,
     );
 }

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
@@ -172,7 +172,7 @@ fn wt_client_stream_uni_reset() {
     wt.send_data_client(wt_stream, BUF_CLIENT);
     drop(wt.receive_data_server(wt_stream, true, BUF_CLIENT, false));
     wt.reset_stream_client(wt_stream);
-    wt.receive_reset_server(wt_stream, Error::HttpNoError.code());
+    wt.receive_reset_server(wt_stream, Error::HttpNone.code());
 }
 
 #[test]
@@ -200,7 +200,7 @@ fn wt_client_stream_bidi_reset() {
     let wt_server_stream = wt.receive_data_server(wt_client_stream, true, BUF_CLIENT, false);
 
     wt.reset_stream_client(wt_client_stream);
-    wt.receive_reset_server(wt_server_stream.stream_id(), Error::HttpNoError.code());
+    wt.receive_reset_server(wt_server_stream.stream_id(), Error::HttpNone.code());
 
     wt.reset_stream_server(&wt_server_stream);
     wt.receive_reset_client(wt_client_stream);
@@ -217,7 +217,7 @@ fn wt_server_stream_bidi_reset() {
     wt.receive_data_client(wt_server_stream.stream_id(), true, BUF_SERVER, false);
 
     wt.reset_stream_client(wt_server_stream.stream_id());
-    wt.receive_reset_server(wt_server_stream.stream_id(), Error::HttpNoError.code());
+    wt.receive_reset_server(wt_server_stream.stream_id(), Error::HttpNone.code());
 
     wt.reset_stream_server(&wt_server_stream);
     wt.receive_reset_client(wt_server_stream.stream_id());
@@ -246,7 +246,7 @@ fn wt_server_stream_uni_stop_sending() {
     wt.send_data_server(&wt_server_stream, BUF_SERVER);
     wt.receive_data_client(wt_server_stream.stream_id(), true, BUF_SERVER, false);
     wt.stream_stop_sending_client(wt_server_stream.stream_id());
-    wt.receive_stop_sending_server(wt_server_stream.stream_id(), Error::HttpNoError.code());
+    wt.receive_stop_sending_server(wt_server_stream.stream_id(), Error::HttpNone.code());
 }
 
 #[test]
@@ -264,7 +264,7 @@ fn wt_client_stream_bidi_stop_sending() {
 
     wt.stream_stop_sending_client(wt_client_stream);
 
-    wt.receive_stop_sending_server(wt_server_stream.stream_id(), Error::HttpNoError.code());
+    wt.receive_stop_sending_server(wt_server_stream.stream_id(), Error::HttpNone.code());
     wt.stream_stop_sending_server(&wt_server_stream);
     wt.receive_stop_sending_client(wt_server_stream.stream_id());
 }
@@ -280,7 +280,7 @@ fn wt_server_stream_bidi_stop_sending() {
     wt.send_data_server(&wt_server_stream, BUF_SERVER);
     wt.receive_data_client(wt_server_stream.stream_id(), true, BUF_SERVER, false);
     wt.stream_stop_sending_client(wt_server_stream.stream_id());
-    wt.receive_stop_sending_server(wt_server_stream.stream_id(), Error::HttpNoError.code());
+    wt.receive_stop_sending_server(wt_server_stream.stream_id(), Error::HttpNone.code());
     wt.stream_stop_sending_server(&wt_server_stream);
     wt.receive_stop_sending_client(wt_server_stream.stream_id());
 }
@@ -324,7 +324,7 @@ fn wt_client_session_close_1() {
         Some(Error::HttpRequestCancelled.code()),
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -359,7 +359,7 @@ fn wt_client_session_close_2() {
         None,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -395,7 +395,7 @@ fn wt_client_session_close_3() {
         None,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -424,7 +424,7 @@ fn wt_client_session_close_4() {
         None,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -432,7 +432,7 @@ fn wt_client_session_close_4() {
         &[],
         None,
         &[unidi_from_client],
-        Some(Error::HttpNoError.code()),
+        Some(Error::HttpNone.code()),
         false,
         None,
     );
@@ -455,12 +455,12 @@ fn wt_client_session_close_5() {
 
     wt.check_events_after_closing_session_server(
         &[unidi_from_client],
-        Some(Error::HttpNoError.code()),
+        Some(Error::HttpNone.code()),
         &[],
         None,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -487,7 +487,7 @@ fn wt_client_session_close_6() {
         Some(Error::HttpRequestCancelled.code()),
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -521,7 +521,7 @@ fn wt_client_session_close_7() {
         Some(Error::HttpRequestCancelled.code()),
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -556,7 +556,7 @@ fn wt_client_session_close_8() {
         None,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -580,10 +580,10 @@ fn wt_client_session_close_9() {
         &[],
         None,
         &[unidi_server.stream_id()],
-        Some(Error::HttpNoError.code()),
+        Some(Error::HttpNone.code()),
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -610,7 +610,7 @@ fn wt_client_session_close_10() {
         None,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -647,7 +647,7 @@ fn wt_client_session_close_11() {
         None,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -675,7 +675,7 @@ fn wt_client_session_close_12() {
         None,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -683,7 +683,7 @@ fn wt_client_session_close_12() {
         &[bidi_server.stream_id()],
         Some(Error::HttpRequestCancelled.code()),
         &[bidi_server.stream_id()],
-        Some(Error::HttpNoError.code()),
+        Some(Error::HttpNone.code()),
         false,
         None,
     );
@@ -712,7 +712,7 @@ fn wt_client_session_close_13() {
         Some(Error::HttpRequestCancelled.code()),
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -760,7 +760,7 @@ fn wt_client_session_server_close_1() {
         false,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -794,7 +794,7 @@ fn wt_client_session_server_close_2() {
         false,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -830,7 +830,7 @@ fn wt_client_session_server_close_3() {
         false,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -855,11 +855,11 @@ fn wt_client_session_server_close_4() {
         &[],
         None,
         &[unidi_client],
-        Some(Error::HttpNoError.code()),
+        Some(Error::HttpNone.code()),
         false,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -887,7 +887,7 @@ fn wt_client_session_server_close_5() {
         false,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -921,7 +921,7 @@ fn wt_client_session_server_close_6() {
         false,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
     wt.check_events_after_closing_session_server(
@@ -956,7 +956,7 @@ fn wt_client_session_server_close_7() {
         false,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -985,7 +985,7 @@ fn wt_client_session_server_close_8() {
         false,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -1017,7 +1017,7 @@ fn wt_client_session_server_close_9() {
         false,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -1042,11 +1042,11 @@ fn wt_client_session_server_close_10() {
         &[bidi_server.stream_id()],
         Some(Error::HttpRequestCancelled.code()),
         &[bidi_server.stream_id()],
-        Some(Error::HttpNoError.code()),
+        Some(Error::HttpNone.code()),
         false,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 
@@ -1077,7 +1077,7 @@ fn wt_client_session_server_close_11() {
         false,
         Some(&(
             wt_session.stream_id(),
-            SessionCloseReason::Error(Error::HttpNoError.code()),
+            SessionCloseReason::Error(Error::HttpNone.code()),
         )),
     );
 

--- a/neqo-http3/src/features/mod.rs
+++ b/neqo-http3/src/features/mod.rs
@@ -30,7 +30,7 @@ pub enum NegotiationState {
         listener: Option<Http3ClientEvents>,
     },
     Negotiated,
-    NegotiationFailed,
+    Failed,
 }
 
 impl NegotiationState {
@@ -71,7 +71,7 @@ impl NegotiationState {
             *self = if settings.get(ft) == 1 {
                 Self::Negotiated
             } else {
-                Self::NegotiationFailed
+                Self::Failed
             };
             if let Some(l) = cb {
                 l.negotiation_done(ft, self.enabled());

--- a/neqo-http3/src/frames/wtframe.rs
+++ b/neqo-http3/src/frames/wtframe.rs
@@ -35,11 +35,11 @@ impl FrameDecoder<Self> for WebTransportFrame {
             let mut dec = Decoder::from(payload);
             if frame_type == HFrameType(WT_FRAME_CLOSE_SESSION) {
                 if frame_len > WT_FRAME_CLOSE_MAX_MESSAGE_SIZE + 4 {
-                    return Err(Error::HttpMessageError);
+                    return Err(Error::HttpMessage);
                 }
-                let error = dec.decode_uint().ok_or(Error::HttpMessageError)?;
+                let error = dec.decode_uint().ok_or(Error::HttpMessage)?;
                 let Ok(message) = String::from_utf8(dec.decode_remainder().to_vec()) else {
-                    return Err(Error::HttpMessageError);
+                    return Err(Error::HttpMessage);
                 };
                 Ok(Some(Self::CloseSession { error, message }))
             } else {

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -192,7 +192,7 @@ type Res<T> = Result<T, Error>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {
-    HttpNoError,
+    HttpNone,
     HttpGeneralProtocol,
     HttpGeneralProtocolStream, /* this is the same as the above but it should only close a
                                 * stream not a connection. */
@@ -212,13 +212,13 @@ pub enum Error {
     HttpRequestIncomplete,
     HttpConnect,
     HttpVersionFallback,
-    HttpMessageError,
-    QpackError(neqo_qpack::Error),
+    HttpMessage,
+    Qpack(neqo_qpack::Error),
 
     // Internal errors from here.
     AlreadyClosed,
     AlreadyInitialized,
-    FatalError,
+    Fatal,
     HttpGoaway,
     Internal,
     InvalidHeader,
@@ -229,8 +229,8 @@ pub enum Error {
     InvalidStreamId,
     NoMoreData,
     NotEnoughData,
-    StreamLimitError,
-    TransportError(TransportError),
+    StreamLimit,
+    Transport(TransportError),
     TransportStreamDoesNotExist,
     Unavailable,
     Unexpected,
@@ -240,7 +240,7 @@ impl Error {
     #[must_use]
     pub const fn code(&self) -> AppError {
         match self {
-            Self::HttpNoError => 0x100,
+            Self::HttpNone => 0x100,
             Self::HttpGeneralProtocol | Self::HttpGeneralProtocolStream | Self::InvalidHeader => {
                 0x101
             }
@@ -256,10 +256,10 @@ impl Error {
             Self::HttpRequestRejected => 0x10b,
             Self::HttpRequestCancelled => 0x10c,
             Self::HttpRequestIncomplete => 0x10d,
-            Self::HttpMessageError => 0x10e,
+            Self::HttpMessage => 0x10e,
             Self::HttpConnect => 0x10f,
             Self::HttpVersionFallback => 0x110,
-            Self::QpackError(e) => e.code(),
+            Self::Qpack(e) => e.code(),
             // These are all internal errors.
             _ => 3,
         }
@@ -279,7 +279,7 @@ impl Error {
                 | Self::HttpId
                 | Self::HttpSettings
                 | Self::HttpMissingSettings
-                | Self::QpackError(QpackError::EncoderStream | QpackError::DecoderStream)
+                | Self::Qpack(QpackError::EncoderStream | QpackError::DecoderStream)
         )
     }
 
@@ -294,10 +294,10 @@ impl Error {
     #[must_use]
     pub fn map_stream_send_errors(err: &Self) -> Self {
         match err {
-            Self::TransportError(
-                TransportError::InvalidStreamId | TransportError::FinalSizeError,
-            ) => Self::TransportStreamDoesNotExist,
-            Self::TransportError(TransportError::InvalidInput) => Self::InvalidInput,
+            Self::Transport(TransportError::InvalidStreamId | TransportError::FinalSize) => {
+                Self::TransportStreamDoesNotExist
+            }
+            Self::Transport(TransportError::InvalidInput) => Self::InvalidInput,
             _ => {
                 debug_assert!(false, "Unexpected error");
                 Self::TransportStreamDoesNotExist
@@ -312,7 +312,7 @@ impl Error {
     pub fn map_stream_create_errors(err: &TransportError) -> Self {
         match err {
             TransportError::ConnectionState => Self::Unavailable,
-            TransportError::StreamLimitError => Self::StreamLimitError,
+            TransportError::StreamLimit => Self::StreamLimit,
             _ => {
                 debug_assert!(false, "Unexpected error");
                 Self::TransportStreamDoesNotExist
@@ -326,13 +326,13 @@ impl Error {
     #[must_use]
     pub fn map_stream_recv_errors(err: &Self) -> Self {
         match err {
-            Self::TransportError(TransportError::NoMoreData) => {
+            Self::Transport(TransportError::NoMoreData) => {
                 debug_assert!(
                     false,
                     "Do not call stream_recv if FIN has been previously read"
                 );
             }
-            Self::TransportError(TransportError::InvalidStreamId) => {}
+            Self::Transport(TransportError::InvalidStreamId) => {}
             _ => {
                 debug_assert!(false, "Unexpected error");
             }
@@ -366,7 +366,7 @@ impl Error {
 
 impl From<TransportError> for Error {
     fn from(err: TransportError) -> Self {
-        Self::TransportError(err)
+        Self::Transport(err)
     }
 }
 
@@ -374,7 +374,7 @@ impl From<QpackError> for Error {
     fn from(err: QpackError) -> Self {
         match err {
             QpackError::ClosedCriticalStream => Self::HttpClosedCriticalStream,
-            e => Self::QpackError(e),
+            e => Self::Qpack(e),
         }
     }
 }
@@ -382,7 +382,7 @@ impl From<QpackError> for Error {
 impl From<AppError> for Error {
     fn from(error: AppError) -> Self {
         match error {
-            0x100 => Self::HttpNoError,
+            0x100 => Self::HttpNone,
             0x101 => Self::HttpGeneralProtocol,
             0x103 => Self::HttpStreamCreation,
             0x104 => Self::HttpClosedCriticalStream,
@@ -397,9 +397,9 @@ impl From<AppError> for Error {
             0x10d => Self::HttpRequestIncomplete,
             0x10f => Self::HttpConnect,
             0x110 => Self::HttpVersionFallback,
-            0x200 => Self::QpackError(QpackError::DecompressionFailed),
-            0x201 => Self::QpackError(QpackError::EncoderStream),
-            0x202 => Self::QpackError(QpackError::DecoderStream),
+            0x200 => Self::Qpack(QpackError::Decompression),
+            0x201 => Self::Qpack(QpackError::EncoderStream),
+            0x202 => Self::Qpack(QpackError::DecoderStream),
             _ => Self::HttpInternal(0),
         }
     }
@@ -408,8 +408,8 @@ impl From<AppError> for Error {
 impl ::std::error::Error for Error {
     fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
         match self {
-            Self::TransportError(e) => Some(e),
-            Self::QpackError(e) => Some(e),
+            Self::Transport(e) => Some(e),
+            Self::Qpack(e) => Some(e),
             _ => None,
         }
     }

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -349,16 +349,16 @@ mod tests {
     use crate::{Error, HFrame, Header, Http3Parameters, Priority};
 
     const DEFAULT_SETTINGS: QpackSettings = QpackSettings {
-        table_size_encoder: 100,
-        table_size_decoder: 100,
-        blocked_streams: 100,
+        max_table_size_encoder: 100,
+        max_table_size_decoder: 100,
+        max_blocked_streams: 100,
     };
 
     fn http3params(qpack_settings: QpackSettings) -> Http3Parameters {
         Http3Parameters::default()
-            .max_table_size_encoder(qpack_settings.table_size_encoder)
-            .max_table_size_decoder(qpack_settings.table_size_decoder)
-            .max_blocked_streams(qpack_settings.blocked_streams)
+            .max_table_size_encoder(qpack_settings.max_table_size_encoder)
+            .max_table_size_decoder(qpack_settings.max_table_size_decoder)
+            .max_blocked_streams(qpack_settings.max_blocked_streams)
     }
 
     pub fn create_server(conn_params: Http3Parameters) -> Http3Server {
@@ -568,9 +568,9 @@ mod tests {
         assert_eq!(sent, Ok(9));
         let mut encoder = QPackEncoder::new(
             &QpackSettings {
-                table_size_encoder: 100,
-                table_size_decoder: 0,
-                blocked_streams: 0,
+                max_table_size_encoder: 100,
+                max_table_size_decoder: 0,
+                max_blocked_streams: 0,
             },
             true,
         );
@@ -1205,7 +1205,7 @@ mod tests {
     fn zero_rtt_larger_decoder_table() {
         zero_rtt_with_settings(
             http3params(QpackSettings {
-                table_size_decoder: DEFAULT_SETTINGS.table_size_decoder + 1,
+                max_table_size_decoder: DEFAULT_SETTINGS.max_table_size_decoder + 1,
                 ..DEFAULT_SETTINGS
             }),
             ZeroRttState::AcceptedClient,
@@ -1217,7 +1217,7 @@ mod tests {
     fn zero_rtt_smaller_decoder_table() {
         zero_rtt_with_settings(
             http3params(QpackSettings {
-                table_size_decoder: DEFAULT_SETTINGS.table_size_decoder - 1,
+                max_table_size_decoder: DEFAULT_SETTINGS.max_table_size_decoder - 1,
                 ..DEFAULT_SETTINGS
             }),
             ZeroRttState::Rejected,
@@ -1229,7 +1229,7 @@ mod tests {
     fn zero_rtt_more_blocked_streams() {
         zero_rtt_with_settings(
             http3params(QpackSettings {
-                blocked_streams: DEFAULT_SETTINGS.blocked_streams + 1,
+                max_blocked_streams: DEFAULT_SETTINGS.max_blocked_streams + 1,
                 ..DEFAULT_SETTINGS
             }),
             ZeroRttState::AcceptedClient,
@@ -1241,7 +1241,7 @@ mod tests {
     fn zero_rtt_fewer_blocked_streams() {
         zero_rtt_with_settings(
             http3params(QpackSettings {
-                blocked_streams: DEFAULT_SETTINGS.blocked_streams - 1,
+                max_blocked_streams: DEFAULT_SETTINGS.max_blocked_streams - 1,
                 ..DEFAULT_SETTINGS
             }),
             ZeroRttState::Rejected,
@@ -1253,7 +1253,7 @@ mod tests {
     fn zero_rtt_smaller_encoder_table() {
         zero_rtt_with_settings(
             http3params(QpackSettings {
-                table_size_encoder: DEFAULT_SETTINGS.table_size_encoder - 1,
+                max_table_size_encoder: DEFAULT_SETTINGS.max_table_size_encoder - 1,
                 ..DEFAULT_SETTINGS
             }),
             ZeroRttState::AcceptedClient,

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -349,16 +349,16 @@ mod tests {
     use crate::{Error, HFrame, Header, Http3Parameters, Priority};
 
     const DEFAULT_SETTINGS: QpackSettings = QpackSettings {
-        max_table_size_encoder: 100,
-        max_table_size_decoder: 100,
-        max_blocked_streams: 100,
+        table_size_encoder: 100,
+        table_size_decoder: 100,
+        blocked_streams: 100,
     };
 
     fn http3params(qpack_settings: QpackSettings) -> Http3Parameters {
         Http3Parameters::default()
-            .max_table_size_encoder(qpack_settings.max_table_size_encoder)
-            .max_table_size_decoder(qpack_settings.max_table_size_decoder)
-            .max_blocked_streams(qpack_settings.max_blocked_streams)
+            .max_table_size_encoder(qpack_settings.table_size_encoder)
+            .max_table_size_decoder(qpack_settings.table_size_decoder)
+            .max_blocked_streams(qpack_settings.blocked_streams)
     }
 
     pub fn create_server(conn_params: Http3Parameters) -> Http3Server {
@@ -568,9 +568,9 @@ mod tests {
         assert_eq!(sent, Ok(9));
         let mut encoder = QPackEncoder::new(
             &QpackSettings {
-                max_table_size_encoder: 100,
-                max_table_size_decoder: 0,
-                max_blocked_streams: 0,
+                table_size_encoder: 100,
+                table_size_decoder: 0,
+                blocked_streams: 0,
             },
             true,
         );
@@ -977,9 +977,7 @@ mod tests {
                     check_request_header(&headers);
                     assert!(!fin);
                     headers_frames += 1;
-                    stream
-                        .stream_stop_sending(Error::HttpNoError.code())
-                        .unwrap();
+                    stream.stream_stop_sending(Error::HttpNone.code()).unwrap();
                     stream
                         .send_headers(&[
                             Header::new(":status", "200"),
@@ -1102,7 +1100,7 @@ mod tests {
     fn server_reset_control_stream() {
         let (mut hconn, mut peer_conn) = connect();
         peer_conn
-            .stream_reset_send(CLIENT_SIDE_CONTROL_STREAM_ID, Error::HttpNoError.code())
+            .stream_reset_send(CLIENT_SIDE_CONTROL_STREAM_ID, Error::HttpNone.code())
             .unwrap();
         let out = peer_conn.process_output(now());
         hconn.process(out.dgram(), now());
@@ -1115,7 +1113,7 @@ mod tests {
     fn server_reset_client_side_encoder_stream() {
         let (mut hconn, mut peer_conn) = connect();
         peer_conn
-            .stream_reset_send(CLIENT_SIDE_ENCODER_STREAM_ID, Error::HttpNoError.code())
+            .stream_reset_send(CLIENT_SIDE_ENCODER_STREAM_ID, Error::HttpNone.code())
             .unwrap();
         let out = peer_conn.process_output(now());
         hconn.process(out.dgram(), now());
@@ -1128,7 +1126,7 @@ mod tests {
     fn server_reset_client_side_decoder_stream() {
         let (mut hconn, mut peer_conn) = connect();
         peer_conn
-            .stream_reset_send(CLIENT_SIDE_DECODER_STREAM_ID, Error::HttpNoError.code())
+            .stream_reset_send(CLIENT_SIDE_DECODER_STREAM_ID, Error::HttpNone.code())
             .unwrap();
         let out = peer_conn.process_output(now());
         hconn.process(out.dgram(), now());
@@ -1142,7 +1140,7 @@ mod tests {
         let (mut hconn, mut peer_conn) = connect();
 
         peer_conn
-            .stream_stop_sending(SERVER_SIDE_CONTROL_STREAM_ID, Error::HttpNoError.code())
+            .stream_stop_sending(SERVER_SIDE_CONTROL_STREAM_ID, Error::HttpNone.code())
             .unwrap();
         let out = peer_conn.process_output(now());
         hconn.process(out.dgram(), now());
@@ -1155,7 +1153,7 @@ mod tests {
     fn server_stop_sending_encoder_stream() {
         let (mut hconn, mut peer_conn) = connect();
         peer_conn
-            .stream_stop_sending(SERVER_SIDE_ENCODER_STREAM_ID, Error::HttpNoError.code())
+            .stream_stop_sending(SERVER_SIDE_ENCODER_STREAM_ID, Error::HttpNone.code())
             .unwrap();
         let out = peer_conn.process_output(now());
         hconn.process(out.dgram(), now());
@@ -1168,7 +1166,7 @@ mod tests {
     fn server_stop_sending_decoder_stream() {
         let (mut hconn, mut peer_conn) = connect();
         peer_conn
-            .stream_stop_sending(SERVER_SIDE_DECODER_STREAM_ID, Error::HttpNoError.code())
+            .stream_stop_sending(SERVER_SIDE_DECODER_STREAM_ID, Error::HttpNone.code())
             .unwrap();
         let out = peer_conn.process_output(now());
         hconn.process(out.dgram(), now());
@@ -1207,7 +1205,7 @@ mod tests {
     fn zero_rtt_larger_decoder_table() {
         zero_rtt_with_settings(
             http3params(QpackSettings {
-                max_table_size_decoder: DEFAULT_SETTINGS.max_table_size_decoder + 1,
+                table_size_decoder: DEFAULT_SETTINGS.table_size_decoder + 1,
                 ..DEFAULT_SETTINGS
             }),
             ZeroRttState::AcceptedClient,
@@ -1219,7 +1217,7 @@ mod tests {
     fn zero_rtt_smaller_decoder_table() {
         zero_rtt_with_settings(
             http3params(QpackSettings {
-                max_table_size_decoder: DEFAULT_SETTINGS.max_table_size_decoder - 1,
+                table_size_decoder: DEFAULT_SETTINGS.table_size_decoder - 1,
                 ..DEFAULT_SETTINGS
             }),
             ZeroRttState::Rejected,
@@ -1231,7 +1229,7 @@ mod tests {
     fn zero_rtt_more_blocked_streams() {
         zero_rtt_with_settings(
             http3params(QpackSettings {
-                max_blocked_streams: DEFAULT_SETTINGS.max_blocked_streams + 1,
+                blocked_streams: DEFAULT_SETTINGS.blocked_streams + 1,
                 ..DEFAULT_SETTINGS
             }),
             ZeroRttState::AcceptedClient,
@@ -1243,7 +1241,7 @@ mod tests {
     fn zero_rtt_fewer_blocked_streams() {
         zero_rtt_with_settings(
             http3params(QpackSettings {
-                max_blocked_streams: DEFAULT_SETTINGS.max_blocked_streams - 1,
+                blocked_streams: DEFAULT_SETTINGS.blocked_streams - 1,
                 ..DEFAULT_SETTINGS
             }),
             ZeroRttState::Rejected,
@@ -1255,7 +1253,7 @@ mod tests {
     fn zero_rtt_smaller_encoder_table() {
         zero_rtt_with_settings(
             http3params(QpackSettings {
-                max_table_size_encoder: DEFAULT_SETTINGS.max_table_size_encoder - 1,
+                table_size_encoder: DEFAULT_SETTINGS.table_size_encoder - 1,
                 ..DEFAULT_SETTINGS
             }),
             ZeroRttState::AcceptedClient,

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -54,11 +54,11 @@ impl QPackDecoder {
             instruction_reader: EncoderInstructionReader::new(),
             table: HeaderTable::new(false),
             acked_inserts: 0,
-            max_entries: qpack_settings.table_size_decoder >> 5,
+            max_entries: qpack_settings.max_table_size_decoder >> 5,
             send_buf,
             local_stream_id: None,
-            max_table_size: qpack_settings.table_size_decoder,
-            max_blocked_streams: usize::from(qpack_settings.blocked_streams),
+            max_table_size: qpack_settings.max_table_size_decoder,
+            max_blocked_streams: usize::from(qpack_settings.max_blocked_streams),
             blocked_streams: Vec::new(),
             stats: Stats::default(),
         }
@@ -317,9 +317,9 @@ mod tests {
 
         // create a decoder
         let mut decoder = QPackDecoder::new(&QpackSettings {
-            table_size_encoder: 0,
-            table_size_decoder: 300,
-            blocked_streams: 100,
+            max_table_size_encoder: 0,
+            max_table_size_decoder: 300,
+            max_blocked_streams: 100,
         });
         decoder.add_send_stream(send_stream_id);
 

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -200,7 +200,7 @@ impl QPackDecoder {
 
     /// # Errors
     ///
-    /// May return `DecompressionFailed` if header block is incorrect or incomplete.
+    /// May return `Error::Decompression` if header block is incorrect or incomplete.
     pub fn refers_dynamic_table(&self, buf: &[u8]) -> Res<bool> {
         HeaderDecoder::new(buf).refers_dynamic_table(self.max_entries, self.table.base())
     }
@@ -210,7 +210,7 @@ impl QPackDecoder {
     ///
     /// # Errors
     ///
-    /// May return `DecompressionFailed` if header block is incorrect or incomplete.
+    /// May return `Error::Decompression` if header block is incorrect or incomplete.
     ///
     /// # Panics
     ///

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -54,11 +54,11 @@ impl QPackDecoder {
             instruction_reader: EncoderInstructionReader::new(),
             table: HeaderTable::new(false),
             acked_inserts: 0,
-            max_entries: qpack_settings.max_table_size_decoder >> 5,
+            max_entries: qpack_settings.table_size_decoder >> 5,
             send_buf,
             local_stream_id: None,
-            max_table_size: qpack_settings.max_table_size_decoder,
-            max_blocked_streams: usize::from(qpack_settings.max_blocked_streams),
+            max_table_size: qpack_settings.table_size_decoder,
+            max_blocked_streams: usize::from(qpack_settings.blocked_streams),
             blocked_streams: Vec::new(),
             stats: Stats::default(),
         }
@@ -226,7 +226,7 @@ impl QPackDecoder {
         match decoder.decode_header_block(&self.table, self.max_entries, self.table.base()) {
             Ok(HeaderDecoderResult::Blocked(req_insert_cnt)) => {
                 if self.blocked_streams.len() > self.max_blocked_streams {
-                    Err(Error::DecompressionFailed)
+                    Err(Error::Decompression)
                 } else {
                     let r = self
                         .blocked_streams
@@ -249,7 +249,7 @@ impl QPackDecoder {
                 }
                 Ok(Some(h))
             }
-            Err(_) => Err(Error::DecompressionFailed),
+            Err(_) => Err(Error::Decompression),
         }
     }
 
@@ -317,9 +317,9 @@ mod tests {
 
         // create a decoder
         let mut decoder = QPackDecoder::new(&QpackSettings {
-            max_table_size_encoder: 0,
-            max_table_size_decoder: 300,
-            max_blocked_streams: 100,
+            table_size_encoder: 0,
+            table_size_decoder: 300,
+            blocked_streams: 100,
         });
         decoder.add_send_stream(send_stream_id);
 

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -72,7 +72,7 @@ impl QPackEncoder {
     pub fn new(qpack_settings: &QpackSettings, use_huffman: bool) -> Self {
         Self {
             table: HeaderTable::new(true),
-            max_table_size: qpack_settings.max_table_size_encoder,
+            max_table_size: qpack_settings.table_size_encoder,
             max_entries: 0,
             instruction_reader: DecoderInstructionReader::new(),
             local_stream: LocalStreamState::NoStream,
@@ -323,7 +323,7 @@ impl QPackEncoder {
                     false,
                     "can_evict_to should have checked and make sure this operation is possible"
                 );
-                return Err(Error::InternalError);
+                return Err(Error::Internal);
             }
             self.max_entries = cap / 32;
             self.next_capacity = None;
@@ -532,12 +532,10 @@ fn map_error(err: &Error) -> Error {
 
 fn map_stream_send_atomic_error(err: &TransportError) -> Error {
     match err {
-        TransportError::InvalidStreamId | TransportError::FinalSizeError => {
-            Error::ClosedCriticalStream
-        }
+        TransportError::InvalidStreamId | TransportError::FinalSize => Error::ClosedCriticalStream,
         _ => {
             debug_assert!(false, "Unexpected error");
-            Error::InternalError
+            Error::Internal
         }
     }
 }
@@ -621,9 +619,9 @@ mod tests {
         // create an encoder
         let mut encoder = QPackEncoder::new(
             &QpackSettings {
-                max_table_size_encoder: 1500,
-                max_table_size_decoder: 0,
-                max_blocked_streams: 0,
+                table_size_encoder: 1500,
+                table_size_decoder: 0,
+                blocked_streams: 0,
             },
             huffman,
         );

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -72,7 +72,7 @@ impl QPackEncoder {
     pub fn new(qpack_settings: &QpackSettings, use_huffman: bool) -> Self {
         Self {
             table: HeaderTable::new(true),
-            max_table_size: qpack_settings.table_size_encoder,
+            max_table_size: qpack_settings.max_table_size_encoder,
             max_entries: 0,
             instruction_reader: DecoderInstructionReader::new(),
             local_stream: LocalStreamState::NoStream,
@@ -619,9 +619,9 @@ mod tests {
         // create an encoder
         let mut encoder = QPackEncoder::new(
             &QpackSettings {
-                table_size_encoder: 1500,
-                table_size_decoder: 0,
-                blocked_streams: 0,
+                max_table_size_encoder: 1500,
+                max_table_size_decoder: 0,
+                max_blocked_streams: 0,
             },
             huffman,
         );

--- a/neqo-qpack/src/encoder_instructions.rs
+++ b/neqo-qpack/src/encoder_instructions.rs
@@ -524,7 +524,7 @@ mod test {
         let mut decoder = EncoderInstructionReader::new();
         assert_eq!(
             decoder.read_instructions(&mut test_receiver),
-            Err(Error::HuffmanDecompressionFailed)
+            Err(Error::HuffmanDecompression)
         );
     }
 }

--- a/neqo-qpack/src/header_block.rs
+++ b/neqo-qpack/src/header_block.rs
@@ -192,7 +192,7 @@ impl<'a> HeaderDecoder<'a> {
     ) -> Res<bool> {
         Error::map_error(
             self.read_base(max_entries, total_num_of_inserts),
-            Error::DecompressionFailed,
+            Error::Decompression,
         )?;
         Ok(self.req_insert_cnt != 0)
     }
@@ -205,7 +205,7 @@ impl<'a> HeaderDecoder<'a> {
     ) -> Res<HeaderDecoderResult> {
         Error::map_error(
             self.read_base(max_entries, total_num_of_inserts),
-            Error::DecompressionFailed,
+            Error::Decompression,
         )?;
 
         if table.base() < self.req_insert_cnt {
@@ -218,41 +218,41 @@ impl<'a> HeaderDecoder<'a> {
         let mut h: Vec<Header> = Vec::new();
 
         while !self.buf.done() {
-            let b = Error::map_error(self.buf.peek(), Error::DecompressionFailed)?;
+            let b = Error::map_error(self.buf.peek(), Error::Decompression)?;
             if HEADER_FIELD_INDEX_STATIC.cmp_prefix(b) {
                 h.push(Error::map_error(
                     self.read_indexed_static(),
-                    Error::DecompressionFailed,
+                    Error::Decompression,
                 )?);
             } else if HEADER_FIELD_INDEX_DYNAMIC.cmp_prefix(b) {
                 h.push(Error::map_error(
                     self.read_indexed_dynamic(table),
-                    Error::DecompressionFailed,
+                    Error::Decompression,
                 )?);
             } else if HEADER_FIELD_INDEX_DYNAMIC_POST.cmp_prefix(b) {
                 h.push(Error::map_error(
                     self.read_indexed_dynamic_post(table),
-                    Error::DecompressionFailed,
+                    Error::Decompression,
                 )?);
             } else if HEADER_FIELD_LITERAL_NAME_REF_STATIC.cmp_prefix(b) {
                 h.push(Error::map_error(
                     self.read_literal_with_name_ref_static(),
-                    Error::DecompressionFailed,
+                    Error::Decompression,
                 )?);
             } else if HEADER_FIELD_LITERAL_NAME_REF_DYNAMIC.cmp_prefix(b) {
                 h.push(Error::map_error(
                     self.read_literal_with_name_ref_dynamic(table),
-                    Error::DecompressionFailed,
+                    Error::Decompression,
                 )?);
             } else if HEADER_FIELD_LITERAL_NAME_LITERAL.cmp_prefix(b) {
                 h.push(Error::map_error(
                     self.read_literal_with_name_literal(),
-                    Error::DecompressionFailed,
+                    Error::Decompression,
                 )?);
             } else if HEADER_FIELD_LITERAL_NAME_REF_DYNAMIC_POST.cmp_prefix(b) {
                 h.push(Error::map_error(
                     self.read_literal_with_name_ref_dynamic_post(table),
-                    Error::DecompressionFailed,
+                    Error::Decompression,
                 )?);
             } else {
                 unreachable!("All prefixes are covered");
@@ -276,13 +276,13 @@ impl<'a> HeaderDecoder<'a> {
         let base_delta = self.buf.read_prefixed_int(1)?;
         self.base = if s {
             if self.req_insert_cnt <= base_delta {
-                return Err(Error::DecompressionFailed);
+                return Err(Error::Decompression);
             }
             self.req_insert_cnt - base_delta - 1
         } else {
             self.req_insert_cnt
                 .checked_add(base_delta)
-                .ok_or(Error::DecompressionFailed)?
+                .ok_or(Error::Decompression)?
         };
         qtrace!(
             "[{self}] requested inserts count is {} and base is {}",
@@ -296,18 +296,18 @@ impl<'a> HeaderDecoder<'a> {
         if encoded == 0 {
             Ok(0)
         } else if max_entries == 0 {
-            Err(Error::DecompressionFailed)
+            Err(Error::Decompression)
         } else {
             let full_range = 2 * max_entries;
             if encoded > full_range {
-                return Err(Error::DecompressionFailed);
+                return Err(Error::Decompression);
             }
             let max_value = total_num_of_inserts + max_entries;
             let max_wrapped = max_value.div(full_range) * full_range;
             let mut req_insert_cnt = max_wrapped + encoded - 1;
             if req_insert_cnt > max_value {
                 if req_insert_cnt < full_range {
-                    return Err(Error::DecompressionFailed);
+                    return Err(Error::Decompression);
                 }
                 req_insert_cnt -= full_range;
             }
@@ -893,7 +893,7 @@ mod tests {
         fill_table(&mut table);
         let mut decoder_h = HeaderDecoder::new(&[0x0, 0x87, 0x01, 0x02, 0x03]);
         assert_eq!(
-            Error::DecompressionFailed,
+            Error::Decompression,
             decoder_h.decode_header_block(&table, 1000, 0).unwrap_err()
         );
     }
@@ -911,7 +911,7 @@ mod tests {
             0x03,
         ]);
         assert_eq!(
-            Error::DecompressionFailed,
+            Error::Decompression,
             decoder_h.decode_header_block(&table, 1000, 0).unwrap_err()
         );
     }

--- a/neqo-qpack/src/huffman.rs
+++ b/neqo-qpack/src/huffman.rs
@@ -74,7 +74,7 @@ impl<'a> BitReader<'a> {
 ///
 /// # Errors
 ///
-/// This function may return `HuffmanDecompressionFailed` if `input` is not a correct
+/// This function may return `Error::HuffmanDecompression` if `input` is not a correct
 /// huffman-encoded array of bits.
 ///
 /// # Panics

--- a/neqo-qpack/src/huffman.rs
+++ b/neqo-qpack/src/huffman.rs
@@ -48,20 +48,20 @@ impl<'a> BitReader<'a> {
 
     pub fn verify_ending(&mut self, i: u8) -> Res<()> {
         if (i + self.current_bit) > 7 {
-            return Err(Error::HuffmanDecompressionFailed);
+            return Err(Error::HuffmanDecompression);
         }
 
         if self.input.is_empty() {
             Ok(())
         } else if self.offset != self.input.len() {
-            Err(Error::HuffmanDecompressionFailed)
+            Err(Error::HuffmanDecompression)
         } else if self.input[self.input.len() - 1] & ((0x1 << (i + self.current_bit)) - 1)
             == ((0x1 << (i + self.current_bit)) - 1)
         {
             self.current_bit = 0;
             Ok(())
         } else {
-            Err(Error::HuffmanDecompressionFailed)
+            Err(Error::HuffmanDecompression)
         }
     }
 
@@ -85,7 +85,7 @@ pub fn decode_huffman(input: &[u8]) -> Res<Vec<u8>> {
     let mut output = Vec::new();
     while reader.has_more_data() {
         if let Some(c) = decode_character(&mut reader)? {
-            output.push(u8::try_from(c).map_err(|_| Error::HuffmanDecompressionFailed)?);
+            output.push(u8::try_from(c).map_err(|_| Error::HuffmanDecompression)?);
         }
     }
 
@@ -257,9 +257,6 @@ mod tests {
 
     #[test]
     fn decoder_error_wrong_ending() {
-        assert_eq!(
-            decode_huffman(WRONG_END),
-            Err(Error::HuffmanDecompressionFailed)
-        );
+        assert_eq!(decode_huffman(WRONG_END), Err(Error::HuffmanDecompression));
     }
 }

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -29,10 +29,11 @@ pub use stats::Stats;
 type Res<T> = Result<T, Error>;
 
 #[derive(Debug, PartialEq, PartialOrd, Ord, Eq, Clone, Copy)]
+#[expect(clippy::struct_field_names, reason = "That's how they are called.")]
 pub struct QpackSettings {
-    pub table_size_decoder: u64,
-    pub table_size_encoder: u64,
-    pub blocked_streams: u16,
+    pub max_table_size_decoder: u64,
+    pub max_table_size_encoder: u64,
+    pub max_blocked_streams: u16,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -74,7 +74,7 @@ pub(crate) struct ReceiverBufferWrapper<'a> {
 impl ReadByte for ReceiverBufferWrapper<'_> {
     fn read_byte(&mut self) -> Res<u8> {
         if self.offset == self.buf.len() {
-            Err(Error::DecompressionFailed)
+            Err(Error::Decompression)
         } else {
             let b = self.buf[self.offset];
             self.offset += 1;
@@ -90,7 +90,7 @@ impl<'a> ReceiverBufferWrapper<'a> {
 
     pub const fn peek(&self) -> Res<u8> {
         if self.offset == self.buf.len() {
-            Err(Error::DecompressionFailed)
+            Err(Error::Decompression)
         } else {
             Ok(self.buf[self.offset])
         }
@@ -133,7 +133,7 @@ impl<'a> ReceiverBufferWrapper<'a> {
         let length: usize = int_reader
             .read(self)?
             .try_into()
-            .or(Err(Error::DecompressionFailed))?;
+            .or(Err(Error::Decompression))?;
         if use_huffman {
             Ok(parse_utf8(&decode_huffman(self.slice(length)?)?)?.to_string())
         } else {
@@ -143,7 +143,7 @@ impl<'a> ReceiverBufferWrapper<'a> {
 
     fn slice(&mut self, len: usize) -> Res<&[u8]> {
         if self.offset + len > self.buf.len() {
-            Err(Error::DecompressionFailed)
+            Err(Error::Decompression)
         } else {
             let start = self.offset;
             self.offset += len;
@@ -588,7 +588,7 @@ mod tests {
         let (buf, prefix_len, _) = &TEST_CASES_NUMBERS[4];
         let mut buffer = ReceiverBufferWrapper::new(&buf[..1]);
         let mut reader = IntReader::new(buffer.read_byte().unwrap(), *prefix_len);
-        assert_eq!(reader.read(&mut buffer), Err(Error::DecompressionFailed));
+        assert_eq!(reader.read(&mut buffer), Err(Error::Decompression));
     }
 
     #[test]
@@ -597,7 +597,7 @@ mod tests {
         let mut buffer = ReceiverBufferWrapper::new(&buf[..6]);
         assert_eq!(
             buffer.read_literal_from_buffer(*prefix_len),
-            Err(Error::DecompressionFailed)
+            Err(Error::Decompression)
         );
     }
 }

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -63,9 +63,9 @@ impl<'a> ReceiverConnWrapper<'a> {
     }
 }
 
-/// This is only used by header decoder therefore all errors are `DecompressionFailed`.
+/// This is only used by header decoder therefore all errors are `Error::Decompression`.
 /// A header block is read entirely before decoding it, therefore if there is not enough
-/// data in the buffer an error `DecompressionFailed` will be return.
+/// data in the buffer an error `Error::Decompression` will be return.
 pub(crate) struct ReceiverBufferWrapper<'a> {
     buf: &'a [u8],
     offset: usize,
@@ -104,7 +104,7 @@ impl<'a> ReceiverBufferWrapper<'a> {
     /// byte.
     /// `ReceiverBufferWrapper` is only used for decoding header blocks. The header blocks are read
     /// entirely before a decoding starts, therefore any incomplete varint because of reaching the
-    /// end of a buffer will be treated as the `DecompressionFailed` error.
+    /// end of a buffer will be treated as the `Error::Decompression` error.
     pub fn read_prefixed_int(&mut self, prefix_len: u8) -> Res<u64> {
         debug_assert!(prefix_len < 8);
 
@@ -123,7 +123,7 @@ impl<'a> ReceiverBufferWrapper<'a> {
     ///
     /// `ReceiverBufferWrapper` is only used for decoding header blocks. The header blocks are read
     /// entirely before a decoding starts, therefore any incomplete varint or literal because of
-    /// reaching the end of a buffer will be treated as the `DecompressionFailed` error.
+    /// reaching the end of a buffer will be treated as the `Error::Decompression` error.
     pub fn read_literal_from_buffer(&mut self, prefix_len: u8) -> Res<String> {
         debug_assert!(prefix_len < 7);
 
@@ -328,7 +328,7 @@ impl LiteralReader {
 }
 
 /// This is a helper function used only by `ReceiverBufferWrapper`, therefore it returns
-/// `DecompressionFailed` if any error happens.
+/// `Error::Decompression` if any error happens.
 ///
 /// # Errors
 ///

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -58,7 +58,7 @@ impl ConnectionId {
     }
 
     #[must_use]
-    pub fn as_cid_ref(&self) -> ConnectionIdRef {
+    pub fn as_cid_ref(&self) -> ConnectionIdRef<'_> {
         ConnectionIdRef::from(&self.cid[..])
     }
 }
@@ -482,7 +482,7 @@ impl ConnectionIdManager {
         Rc::clone(&self.generator)
     }
 
-    pub fn decoder(&self) -> ConnectionIdDecoderRef {
+    pub fn decoder(&self) -> ConnectionIdDecoderRef<'_> {
         ConnectionIdDecoderRef {
             generator: self.generator.deref().borrow(),
         }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2482,7 +2482,7 @@ impl Connection {
             }
 
             // Configure the limits and padding for this packet.
-            let aead_expansion = tx.expansion();
+            let aead_expansion = CryptoDxState::expansion();
             needs_padding |= builder.set_initial_limit(
                 &profile,
                 aead_expansion,
@@ -3609,7 +3609,7 @@ impl Connection {
         );
 
         let data_len_possible =
-            u64::try_from(mtu.saturating_sub(tx.expansion() + builder.len() + 1))?;
+            u64::try_from(mtu.saturating_sub(CryptoDxState::expansion() + builder.len() + 1))?;
         Ok(min(data_len_possible, max_dgram_size))
     }
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -780,7 +780,7 @@ impl Connection {
         }
         self.paths
             .primary()
-            .ok_or(Error::InternalError)?
+            .ok_or(Error::Internal)?
             .borrow_mut()
             .rtt_mut()
             .set_initial(rtt);
@@ -1446,7 +1446,7 @@ impl Connection {
                     if versions.is_empty()
                         || versions.contains(&self.version().wire_version())
                         || versions.contains(&0)
-                        || &packet.scid() != self.odcid().ok_or(Error::InternalError)?
+                        || &packet.scid() != self.odcid().ok_or(Error::Internal)?
                         || matches!(self.address_validation, AddressValidationInfo::Retry { .. })
                     {
                         // Ignore VersionNegotiation packets that contain the current version.
@@ -2080,7 +2080,7 @@ impl Connection {
                         // than reuse a connection ID.
                         let res = if path.borrow().is_temporary() {
                             qerror!("[{self}] Attempting to close with a temporary path");
-                            Err(Error::InternalError)
+                            Err(Error::Internal)
                         } else {
                             self.output_path(&path, now, Some(&details))
                         };
@@ -2488,7 +2488,7 @@ impl Connection {
                 aead_expansion,
                 self.paths
                     .primary()
-                    .ok_or(Error::InternalError)?
+                    .ok_or(Error::Internal)?
                     .borrow()
                     .pmtud(),
             );
@@ -2533,7 +2533,7 @@ impl Connection {
                 .crypto
                 .states_mut()
                 .tx_mut(self.version, epoch)
-                .ok_or(Error::InternalError)?;
+                .ok_or(Error::Internal)?;
             encoder = builder.build(tx)?;
             self.crypto.states_mut().auto_update()?;
 
@@ -2709,9 +2709,7 @@ impl Connection {
         self.validate_versions()?;
         {
             let tps = self.tps.borrow();
-            let remote = tps
-                .remote_handshake()
-                .ok_or(Error::TransportParameterError)?;
+            let remote = tps.remote_handshake().ok_or(Error::TransportParameter)?;
 
             // If the peer provided a preferred address, then we have to be a client
             // and they have to be using a non-empty connection ID.
@@ -2723,12 +2721,12 @@ impl Connection {
                         .ok_or(Error::UnknownConnectionId)?
                         .is_empty())
             {
-                return Err(Error::TransportParameterError);
+                return Err(Error::TransportParameter);
             }
 
             let reset_token = remote.get_bytes(StatelessResetToken).map_or_else(
                 || Ok(ConnectionIdEntry::random_srt()),
-                |token| <[u8; 16]>::try_from(token).map_err(|_| Error::TransportParameterError),
+                |token| <[u8; 16]>::try_from(token).map_err(|_| Error::TransportParameter),
             )?;
             let path = self.paths.primary().ok_or(Error::NoAvailablePath)?;
             path.borrow_mut().set_reset_token(reset_token);
@@ -2737,7 +2735,7 @@ impl Connection {
             let min_ad = if remote.has_value(MinAckDelay) {
                 let min_ad = Duration::from_micros(remote.get_integer(MinAckDelay));
                 if min_ad > max_ad {
-                    return Err(Error::TransportParameterError);
+                    return Err(Error::TransportParameter);
                 }
                 Some(min_ad)
             } else {
@@ -2756,9 +2754,7 @@ impl Connection {
 
     fn validate_cids(&self) -> Res<()> {
         let tph = self.tps.borrow();
-        let remote_tps = tph
-            .remote_handshake()
-            .ok_or(Error::TransportParameterError)?;
+        let remote_tps = tph.remote_handshake().ok_or(Error::TransportParameter)?;
 
         let tp = remote_tps.get_bytes(InitialSourceConnectionId);
         if self
@@ -2815,9 +2811,7 @@ impl Connection {
     /// Validate the `version_negotiation` transport parameter from the peer.
     fn validate_versions(&self) -> Res<()> {
         let tph = self.tps.borrow();
-        let remote_tps = tph
-            .remote_handshake()
-            .ok_or(Error::TransportParameterError)?;
+        let remote_tps = tph.remote_handshake().ok_or(Error::TransportParameter)?;
         // `current` and `other` are the value from the peer's transport parameters.
         // We're checking that these match our expectations.
         if let Some((current, other)) = remote_tps.get_versions() {
@@ -2926,7 +2920,7 @@ impl Connection {
             }
             _ => {
                 qerror!("Crypto state should not be new or failed after successful handshake");
-                return Err(Error::CryptoError(neqo_crypto::Error::InternalError));
+                return Err(Error::Crypto(neqo_crypto::Error::Internal));
             }
         }
 
@@ -2951,7 +2945,7 @@ impl Connection {
         if self.conn_params.pmtud_enabled() {
             self.paths
                 .primary()
-                .ok_or(Error::InternalError)?
+                .ok_or(Error::Internal)?
                 .borrow_mut()
                 .pmtud_mut()
                 .start(now, &mut self.stats.borrow_mut());
@@ -3092,12 +3086,12 @@ impl Connection {
                     // Use a transport error here because we want to send
                     // NO_ERROR in this case.
                     (
-                        Error::PeerApplicationError(error_code.code()),
+                        Error::PeerApplication(error_code.code()),
                         FrameType::ConnectionCloseApplication,
                     )
                 } else {
                     (
-                        Error::PeerError(error_code.code()),
+                        Error::Peer(error_code.code()),
                         FrameType::ConnectionCloseTransport,
                     )
                 };
@@ -3302,7 +3296,7 @@ impl Connection {
                 .crypto
                 .tls()
                 .info()
-                .ok_or(Error::InternalError)?
+                .ok_or(Error::Internal)?
                 .early_data_accepted()
             {
                 ZeroRttState::AcceptedClient
@@ -3320,12 +3314,8 @@ impl Connection {
         self.set_state(State::Connected, now);
         self.create_resumption_token(now);
         self.saved_datagrams.make_available(Epoch::ApplicationData);
-        self.stats.borrow_mut().resumed = self
-            .crypto
-            .tls()
-            .info()
-            .ok_or(Error::InternalError)?
-            .resumed();
+        self.stats.borrow_mut().resumed =
+            self.crypto.tls().info().ok_or(Error::Internal)?.resumed();
         if self.role == Role::Server {
             self.state_signaling.handshake_done();
             self.set_confirmed(now)?;

--- a/neqo-transport/src/connection/state.rs
+++ b/neqo-transport/src/connection/state.rs
@@ -106,7 +106,7 @@ impl ClosingFrame {
             // error code needs to be sent in an Initial or Handshake packet.
             Some(Self {
                 path: Rc::clone(&self.path),
-                error: CloseReason::Transport(Error::ApplicationError),
+                error: CloseReason::Transport(Error::Application),
                 frame_type: FrameType::Padding,
                 reason_phrase: Vec::new(),
             })

--- a/neqo-transport/src/connection/tests/close.rs
+++ b/neqo-transport/src/connection/tests/close.rs
@@ -50,7 +50,7 @@ fn connection_close() {
     assert_eq!(stats_after.ack, stats_before.ack + 1);
 
     server.process_input(out.dgram().unwrap(), now);
-    assert_draining(&server, &Error::PeerApplicationError(42));
+    assert_draining(&server, &Error::PeerApplication(42));
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn connection_close_with_long_reason_string() {
     assert_eq!(stats_after.ack, stats_before.ack + 1);
 
     server.process_input(out.dgram().unwrap(), now);
-    assert_draining(&server, &Error::PeerApplicationError(42));
+    assert_draining(&server, &Error::PeerApplication(42));
 }
 
 // During the handshake, an application close should be sanitized.
@@ -95,7 +95,7 @@ fn early_application_close() {
     assert!(dgram.is_some());
 
     client.process_input(dgram.unwrap(), now());
-    assert_draining(&client, &Error::PeerError(ERROR_APPLICATION_CLOSE));
+    assert_draining(&client, &Error::Peer(ERROR_APPLICATION_CLOSE));
 }
 
 #[test]
@@ -120,7 +120,7 @@ fn bad_tls_version() {
     );
     assert!(dgram.is_some());
     client.process_input(dgram.unwrap(), now());
-    assert_draining(&client, &Error::PeerError(Error::ProtocolViolation.code()));
+    assert_draining(&client, &Error::Peer(Error::ProtocolViolation.code()));
 }
 
 /// Test the interaction between the loss recovery timer
@@ -201,9 +201,7 @@ fn closing_and_draining() {
     assert_eq!(end, Output::None);
     assert_eq!(
         *server.state(),
-        State::Closed(CloseReason::Transport(Error::PeerApplicationError(
-            APP_ERROR
-        )))
+        State::Closed(CloseReason::Transport(Error::PeerApplication(APP_ERROR)))
     );
 }
 

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -142,7 +142,7 @@ fn handshake_failed_authentication() {
     let out = server.process(out.dgram(), now());
     assert!(out.as_dgram_ref().is_some());
     assert_error(&client, &CloseReason::Transport(Error::CryptoAlert(44)));
-    assert_error(&server, &CloseReason::Transport(Error::PeerError(300)));
+    assert_error(&server, &CloseReason::Transport(Error::Peer(300)));
 }
 
 #[test]
@@ -1012,7 +1012,7 @@ fn ech_retry() {
     server.process_input(dgram.unwrap(), now());
     assert_eq!(
         server.state().error(),
-        Some(&CloseReason::Transport(Error::PeerError(0x100 + 121)))
+        Some(&CloseReason::Transport(Error::Peer(0x100 + 121)))
     );
 
     let Some(CloseReason::Transport(Error::EchRetry(updated_config))) = client.state().error()
@@ -1075,13 +1075,13 @@ fn ech_retry_fallback_rejected() {
     server.process_input(dgram.unwrap(), now());
     assert_eq!(
         server.state().error(),
-        Some(&CloseReason::Transport(Error::PeerError(298)))
+        Some(&CloseReason::Transport(Error::Peer(298)))
     ); // A bad_certificate alert.
 }
 
 #[test]
 fn bad_min_ack_delay() {
-    const EXPECTED_ERROR: CloseReason = CloseReason::Transport(Error::TransportParameterError);
+    const EXPECTED_ERROR: CloseReason = CloseReason::Transport(Error::TransportParameter);
     let mut server = default_server();
     let max_ad = u64::try_from(DEFAULT_LOCAL_ACK_DELAY.as_micros()).unwrap();
     server
@@ -1103,8 +1103,8 @@ fn bad_min_ack_delay() {
     server.process_input(dgram.unwrap(), now());
     assert_eq!(
         server.state().error(),
-        Some(&CloseReason::Transport(Error::PeerError(
-            Error::TransportParameterError.code()
+        Some(&CloseReason::Transport(Error::Peer(
+            Error::TransportParameter.code()
         )))
     );
 }

--- a/neqo-transport/src/connection/tests/keys.rs
+++ b/neqo-transport/src/connection/tests/keys.rs
@@ -305,7 +305,7 @@ fn exhaust_read_keys() {
     assert!(matches!(
         client.state(),
         State::Draining {
-            error: CloseReason::Transport(Error::PeerError(ERROR_AEAD_LIMIT_REACHED)),
+            error: CloseReason::Transport(Error::Peer(ERROR_AEAD_LIMIT_REACHED)),
             ..
         }
     ));

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -611,7 +611,7 @@ fn migrate_same_fail() {
 
 /// This gets the connection ID from a datagram using the default
 /// connection ID generator/decoder.
-pub fn get_cid(d: &Datagram) -> ConnectionIdRef {
+pub fn get_cid(d: &Datagram) -> ConnectionIdRef<'_> {
     let gen = CountingConnectionIdGenerator::default();
     assert_eq!(d[0] & 0x80, 0); // Only support short packets for now.
     gen.decode_cid(&mut Decoder::from(&d[1..])).unwrap()
@@ -912,8 +912,8 @@ fn preferred_address_server_empty_cid() {
     connect_fail(
         &mut client,
         &mut server,
-        Error::TransportParameterError,
-        Error::PeerError(Error::TransportParameterError.code()),
+        Error::TransportParameter,
+        Error::Peer(Error::TransportParameter.code()),
     );
 }
 
@@ -933,8 +933,8 @@ fn preferred_address_client() {
     connect_fail(
         &mut client,
         &mut server,
-        Error::PeerError(Error::TransportParameterError.code()),
-        Error::TransportParameterError,
+        Error::Peer(Error::TransportParameter.code()),
+        Error::TransportParameter,
     );
 }
 

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -484,9 +484,9 @@ fn exceed_max_data() {
 
     assert_error(
         &client,
-        &CloseReason::Transport(Error::PeerError(Error::FlowControlError.code())),
+        &CloseReason::Transport(Error::Peer(Error::FlowControl.code())),
     );
-    assert_error(&server, &CloseReason::Transport(Error::FlowControlError));
+    assert_error(&server, &CloseReason::Transport(Error::FlowControl));
 }
 
 #[test]
@@ -514,7 +514,7 @@ fn do_not_accept_data_after_stop_sending() {
     // Call stop sending.
     assert_eq!(
         Ok(()),
-        server.stream_stop_sending(stream_id, Error::NoError.code())
+        server.stream_stop_sending(stream_id, Error::None.code())
     );
 
     // Receive the second data frame. The frame should be ignored and
@@ -524,7 +524,7 @@ fn do_not_accept_data_after_stop_sending() {
 
     drop(client.process(out.dgram(), now()));
     assert_eq!(
-        Err(Error::FinalSizeError),
+        Err(Error::FinalSize),
         client.stream_send(stream_id, &[0x00])
     );
 }
@@ -824,9 +824,7 @@ fn after_stream_stop_sending_is_called_conn_events_for_stream_should_be_removed(
     drop(client.process(out, now()));
 
     // send stop sending.
-    client
-        .stream_stop_sending(id, Error::NoError.code())
-        .unwrap();
+    client.stream_stop_sending(id, Error::None.code()).unwrap();
 
     // Make sure we do not have RecvStreamReadable events for the stream after stream_stop_sending
     // has been called.
@@ -916,7 +914,7 @@ fn max_streams_after_bidi_closed() {
     // The server shouldn't have released more stream credit.
     client.process_input(dgram.unwrap(), now());
     let e = client.stream_create(StreamType::BiDi).unwrap_err();
-    assert!(matches!(e, Error::StreamLimitError));
+    assert!(matches!(e, Error::StreamLimit));
 
     // Closing the stream isn't enough.
     server.stream_close_send(stream_id).unwrap();
@@ -1090,7 +1088,7 @@ fn session_flow_control_stop_sending_state_recv() {
     exchange_data(&mut client, &mut server);
 
     server
-        .stream_stop_sending(stream_id, Error::NoError.code())
+        .stream_stop_sending(stream_id, Error::None.code())
         .unwrap();
 
     assert_eq!(
@@ -1149,7 +1147,7 @@ fn session_flow_control_stop_sending_state_size_known() {
     server.process_input(out2.unwrap(), now());
 
     server
-        .stream_stop_sending(stream_id, Error::NoError.code())
+        .stream_stop_sending(stream_id, Error::None.code())
         .unwrap();
 
     // In this case the final size is known when stream_stop_sending is called
@@ -1198,7 +1196,7 @@ fn session_flow_control_stop_sending_state_data_recvd() {
 
     // The stream is DataRecvd state
     server
-        .stream_stop_sending(stream_id, Error::NoError.code())
+        .stream_stop_sending(stream_id, Error::None.code())
         .unwrap();
 
     exchange_data(&mut client, &mut server);

--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -354,7 +354,7 @@ fn version_negotiation_downgrade() {
         &mut client,
         &mut server,
         Error::VersionNegotiation,
-        Error::PeerError(Error::VersionNegotiation.code()),
+        Error::Peer(Error::VersionNegotiation.code()),
     );
 }
 
@@ -411,7 +411,7 @@ fn invalid_current_version_client() {
     connect_fail(
         &mut client,
         &mut server,
-        Error::PeerError(Error::CryptoAlert(47).code()),
+        Error::Peer(Error::CryptoAlert(47).code()),
         Error::CryptoAlert(47),
     );
 }
@@ -444,7 +444,7 @@ fn invalid_current_version_server() {
         &mut client,
         &mut server,
         Error::CryptoAlert(47),
-        Error::PeerError(Error::CryptoAlert(47).code()),
+        Error::Peer(Error::CryptoAlert(47).code()),
     );
 }
 
@@ -469,7 +469,7 @@ fn no_compatible_version() {
     connect_fail(
         &mut client,
         &mut server,
-        Error::PeerError(Error::CryptoAlert(47).code()),
+        Error::Peer(Error::CryptoAlert(47).code()),
         Error::CryptoAlert(47),
     );
 }

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -207,7 +207,7 @@ impl Crypto {
                 Err(self
                     .tls
                     .alert()
-                    .map_or(Error::CryptoError(e), Error::CryptoAlert))
+                    .map_or(Error::Crypto(e), Error::CryptoAlert))
             }
         }
     }
@@ -231,9 +231,9 @@ impl Crypto {
                 self.tls.read_secret(Epoch::ZeroRtt),
             ),
         };
-        let secret = secret.ok_or(Error::InternalError)?;
+        let secret = secret.ok_or(Error::Internal)?;
         self.states
-            .set_0rtt_keys(version, dir, &secret, cipher.ok_or(Error::InternalError)?)?;
+            .set_0rtt_keys(version, dir, &secret, cipher.ok_or(Error::Internal)?)?;
         Ok(true)
     }
 
@@ -266,12 +266,12 @@ impl Crypto {
         let read_secret = self
             .tls
             .read_secret(Epoch::Handshake)
-            .ok_or(Error::InternalError)?;
+            .ok_or(Error::Internal)?;
         let cipher = match self.tls.info() {
             None => self.tls.preinfo()?.cipher_suite(),
             Some(info) => Some(info.cipher_suite()),
         }
-        .ok_or(Error::InternalError)?;
+        .ok_or(Error::Internal)?;
         self.states
             .set_handshake_keys(self.version, &write_secret, &read_secret, cipher)?;
         qdebug!("[{self}] Handshake keys installed");
@@ -295,7 +295,7 @@ impl Crypto {
         let read_secret = self
             .tls
             .read_secret(Epoch::ApplicationData)
-            .ok_or(Error::InternalError)?;
+            .ok_or(Error::Internal)?;
         self.states
             .set_application_read_key(version, &read_secret, expire_0rtt)?;
         qdebug!("[{self}] application read keys installed");
@@ -1138,7 +1138,7 @@ impl CryptoStates {
         // received an acknowledgement for a packet in the current phase.
         // Also, skip this if we are waiting for read keys on the existing
         // key update to be rolled over.
-        let write = &self.app_write.as_ref().ok_or(Error::InternalError)?.dx;
+        let write = &self.app_write.as_ref().ok_or(Error::Internal)?.dx;
         if write.can_update(largest_acknowledged) && self.read_update_time.is_none() {
             // This call additionally checks that we don't advance to the next
             // epoch while a key update is in progress.
@@ -1160,8 +1160,8 @@ impl CryptoStates {
         // ahead of the read keys.  If we initiated the key update, the write keys
         // will already be ahead.
         debug_assert!(self.read_update_time.is_none());
-        let write = &self.app_write.as_ref().ok_or(Error::InternalError)?;
-        let read = &self.app_read.as_ref().ok_or(Error::InternalError)?;
+        let write = &self.app_write.as_ref().ok_or(Error::Internal)?;
+        let read = &self.app_read.as_ref().ok_or(Error::Internal)?;
         if write.epoch() == read.epoch() {
             qdebug!("[{self}] Update write keys to epoch={}", write.epoch() + 1);
             self.app_write = Some(write.next()?);
@@ -1233,7 +1233,7 @@ impl CryptoStates {
                     qtrace!("[{self}] Rotating read keys");
                     mem::swap(&mut self.app_read, &mut self.app_read_next);
                     self.app_read_next =
-                        Some(self.app_read.as_ref().ok_or(Error::InternalError)?.next()?);
+                        Some(self.app_read.as_ref().ok_or(Error::Internal)?.next()?);
                 }
                 self.read_update_time = None;
             }
@@ -1256,8 +1256,8 @@ impl CryptoStates {
         // We only need to do the check while we are waiting for read keys to be updated.
         if self.read_update_time.is_some() {
             qtrace!("[{self}] Checking for PN overlap");
-            let next_dx = &mut self.app_read_next.as_mut().ok_or(Error::InternalError)?.dx;
-            next_dx.continuation(&self.app_read.as_ref().ok_or(Error::InternalError)?.dx)?;
+            let next_dx = &mut self.app_read_next.as_mut().ok_or(Error::Internal)?.dx;
+            next_dx.continuation(&self.app_read.as_ref().ok_or(Error::Internal)?.dx)?;
         }
         Ok(())
     }
@@ -1418,7 +1418,7 @@ impl CryptoStreams {
     }
 
     pub fn inbound_frame(&mut self, space: PacketNumberSpace, offset: u64, data: &[u8]) -> Res<()> {
-        let rx = &mut self.get_mut(space).ok_or(Error::InternalError)?.rx;
+        let rx = &mut self.get_mut(space).ok_or(Error::Internal)?.rx;
         rx.inbound_frame(offset, data);
         if rx.received() - rx.retired() <= Self::BUFFER_LIMIT {
             Ok(())

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -671,7 +671,7 @@ impl CryptoDxState {
 
         // The numbers in `Self::limit` assume a maximum packet size of `LIMIT`.
         // Adjust them as we encounter larger packets.
-        let body_len = data.len() - hdr.len() - self.aead.expansion();
+        let body_len = data.len() - hdr.len() - Aead::expansion();
         debug_assert!(body_len <= u16::MAX.into());
         if body_len > self.largest_packet_len {
             let new_bits = usize::leading_zeros(self.largest_packet_len - 1)
@@ -693,8 +693,8 @@ impl CryptoDxState {
     }
 
     #[must_use]
-    pub const fn expansion(&self) -> usize {
-        self.aead.expansion()
+    pub const fn expansion() -> usize {
+        Aead::expansion()
     }
 
     pub fn decrypt<'a>(
@@ -733,8 +733,8 @@ impl CryptoDxState {
     /// Get the amount of extra padding packets protected with this profile need.
     /// This is the difference between the size of the header protection sample
     /// and the AEAD expansion.
-    pub const fn extra_padding(&self) -> usize {
-        HpKey::SAMPLE_SIZE.saturating_sub(self.aead.expansion())
+    pub const fn extra_padding() -> usize {
+        HpKey::SAMPLE_SIZE.saturating_sub(Aead::expansion())
     }
 }
 

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -313,9 +313,7 @@ mod tests {
 
         evts.send_stream_writable(9.into());
         evts.send_stream_stop_sending(10.into(), 55);
-        evts.connection_state_change(State::Closed(CloseReason::Transport(
-            Error::StreamStateError,
-        )));
+        evts.connection_state_change(State::Closed(CloseReason::Transport(Error::StreamState)));
         assert_eq!(evts.events().count(), 1);
     }
 }

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -357,7 +357,7 @@ impl ReceiverFlowControl<()> {
                 self.consumed,
                 self.max_allowed
             );
-            return Err(Error::FlowControlError);
+            return Err(Error::FlowControl);
         }
         self.consumed += count;
         Ok(())
@@ -468,7 +468,7 @@ impl ReceiverFlowControl<StreamId> {
 
         if consumed > self.max_allowed {
             qtrace!("Stream RX window exceeded: {consumed}");
-            return Err(Error::FlowControlError);
+            return Err(Error::FlowControl);
         }
         let new_consumed = consumed - self.consumed;
         self.consumed = consumed;
@@ -537,7 +537,7 @@ impl RemoteStreamLimit {
 
     pub fn is_new_stream(&self, stream_id: StreamId) -> Res<bool> {
         if !self.is_allowed(stream_id) {
-            return Err(Error::StreamLimitError);
+            return Err(Error::StreamLimit);
         }
         Ok(stream_id >= self.next_stream)
     }
@@ -889,11 +889,11 @@ mod test {
         // Exceed limits
         assert_eq!(
             fc[StreamType::BiDi].is_new_stream(StreamId::from(bidi + 8)),
-            Err(Error::StreamLimitError)
+            Err(Error::StreamLimit)
         );
         assert_eq!(
             fc[StreamType::UniDi].is_new_stream(StreamId::from(unidi + 4)),
-            Err(Error::StreamLimitError)
+            Err(Error::StreamLimit)
         );
 
         assert_eq!(fc[StreamType::BiDi].take_stream_id(), StreamId::from(bidi));
@@ -925,7 +925,7 @@ mod test {
         // 13 still exceeds limits
         assert_eq!(
             fc[StreamType::BiDi].is_new_stream(StreamId::from(bidi + 12)),
-            Err(Error::StreamLimitError)
+            Err(Error::StreamLimit)
         );
 
         fc[StreamType::UniDi].add_retired(1);
@@ -945,7 +945,7 @@ mod test {
         // 11 exceeds limits
         assert_eq!(
             fc[StreamType::UniDi].is_new_stream(StreamId::from(unidi + 8)),
-            Err(Error::StreamLimitError)
+            Err(Error::StreamLimit)
         );
     }
 

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -118,7 +118,7 @@ impl TryFrom<FrameType> for StreamType {
         match value {
             FrameType::MaxStreamsBiDi | FrameType::StreamsBlockedBiDi => Ok(Self::BiDi),
             FrameType::MaxStreamsUniDi | FrameType::StreamsBlockedUniDi => Ok(Self::UniDi),
-            _ => Err(Error::FrameEncodingError),
+            _ => Err(Error::FrameEncoding),
         }
     }
 }
@@ -149,7 +149,7 @@ impl From<CloseReason> for CloseError {
 
 impl From<std::array::TryFromSliceError> for Error {
     fn from(_err: std::array::TryFromSliceError) -> Self {
-        Self::FrameEncodingError
+        Self::FrameEncoding
     }
 }
 
@@ -367,11 +367,11 @@ impl<'a> Frame<'a> {
         let mut acked_ranges = Vec::with_capacity(ack_ranges.len() + 1);
 
         if largest_acked < first_ack_range {
-            return Err(Error::FrameEncodingError);
+            return Err(Error::FrameEncoding);
         }
         acked_ranges.push((largest_acked - first_ack_range)..=largest_acked);
         if !ack_ranges.is_empty() && largest_acked < first_ack_range + 1 {
-            return Err(Error::FrameEncodingError);
+            return Err(Error::FrameEncoding);
         }
         let mut cur = if ack_ranges.is_empty() {
             0
@@ -380,12 +380,12 @@ impl<'a> Frame<'a> {
         };
         for r in ack_ranges {
             if cur < r.gap + 1 {
-                return Err(Error::FrameEncodingError);
+                return Err(Error::FrameEncoding);
             }
             cur = cur - r.gap - 1;
 
             if cur < r.range {
-                return Err(Error::FrameEncodingError);
+                return Err(Error::FrameEncoding);
             }
             acked_ranges.push((cur - r.range)..=cur);
 
@@ -544,14 +544,14 @@ impl<'a> Frame<'a> {
                 let offset = dv(dec)?;
                 let data = d(dec.decode_vvec())?;
                 if offset + u64::try_from(data.len())? > MAX_VARINT {
-                    return Err(Error::FrameEncodingError);
+                    return Err(Error::FrameEncoding);
                 }
                 Ok(Self::Crypto { offset, data })
             }
             FrameType::NewToken => {
                 let token = d(dec.decode_vvec())?;
                 if token.is_empty() {
-                    return Err(Error::FrameEncodingError);
+                    return Err(Error::FrameEncoding);
                 }
                 Ok(Self::NewToken { token })
             }
@@ -578,7 +578,7 @@ impl<'a> Frame<'a> {
                     d(dec.decode_vvec())?
                 };
                 if o + u64::try_from(data.len())? > MAX_VARINT {
-                    return Err(Error::FrameEncodingError);
+                    return Err(Error::FrameEncoding);
                 }
                 Ok(Self::Stream {
                     fin: t.is_stream_with_fin(),
@@ -598,7 +598,7 @@ impl<'a> Frame<'a> {
             FrameType::MaxStreamsBiDi | FrameType::MaxStreamsUniDi => {
                 let m = dv(dec)?;
                 if m > (1 << 60) {
-                    return Err(Error::StreamLimitError);
+                    return Err(Error::StreamLimit);
                 }
                 Ok(Self::MaxStreams {
                     stream_type: t.try_into()?,
@@ -623,7 +623,7 @@ impl<'a> Frame<'a> {
                 let retire_prior = dv(dec)?;
                 let connection_id = d(dec.decode_vec(1))?;
                 if connection_id.len() > MAX_CONNECTION_ID_LEN {
-                    return Err(Error::FrameEncodingError);
+                    return Err(Error::FrameEncoding);
                 }
                 let srt = d(dec.decode(16))?;
                 let stateless_reset_token = <&[_; 16]>::try_from(srt)?;
@@ -669,13 +669,13 @@ impl<'a> Frame<'a> {
                 let seqno = dv(dec)?;
                 let tolerance = dv(dec)?;
                 if tolerance == 0 {
-                    return Err(Error::FrameEncodingError);
+                    return Err(Error::FrameEncoding);
                 }
                 let delay = dv(dec)?;
                 let ignore_order = match d(dec.decode_uint::<u8>())? {
                     0 => false,
                     1 => true,
-                    _ => return Err(Error::FrameEncodingError),
+                    _ => return Err(Error::FrameEncoding),
                 };
                 Ok(Self::AckFrequency {
                     seqno,
@@ -806,10 +806,7 @@ mod tests {
     #[test]
     fn empty_new_token() {
         let mut dec = Decoder::from(&[0x07, 0x00][..]);
-        assert_eq!(
-            Frame::decode(&mut dec).unwrap_err(),
-            Error::FrameEncodingError
-        );
+        assert_eq!(Frame::decode(&mut dec).unwrap_err(), Error::FrameEncoding);
     }
 
     #[test]
@@ -935,7 +932,7 @@ mod tests {
         enc.encode(&[0x11; 16][..]);
         assert_eq!(
             Frame::decode(&mut enc.as_decoder()).unwrap_err(),
-            Error::FrameEncodingError
+            Error::FrameEncoding
         );
     }
 
@@ -1035,7 +1032,7 @@ mod tests {
         let enc = Encoder::from_hex("40af0a0547d003"); // ignore_order of 3
         assert_eq!(
             Frame::decode(&mut enc.as_decoder()).unwrap_err(),
-            Error::FrameEncodingError
+            Error::FrameEncoding
         );
     }
 
@@ -1045,7 +1042,7 @@ mod tests {
         let enc = Encoder::from_hex("40af0a000101"); // packets of 0
         assert_eq!(
             Frame::decode(&mut enc.as_decoder()).unwrap_err(),
-            Error::FrameEncodingError
+            Error::FrameEncoding
         );
     }
 

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -232,7 +232,7 @@ impl CloseReason {
         }
     }
 
-    /// Checks enclosed error for [`Error::NoError`] and
+    /// Checks enclosed error for [`Error::None`] and
     /// [`CloseReason::Application(0)`].
     #[must_use]
     pub const fn is_error(&self) -> bool {

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -84,23 +84,23 @@ const ERROR_AEAD_LIMIT_REACHED: TransportError = 15;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub enum Error {
-    NoError,
+    None,
     // Each time this error is returned a different parameter is supplied.
     // This will be used to distinguish each occurrence of this error.
-    InternalError,
+    Internal,
     ConnectionRefused,
-    FlowControlError,
-    StreamLimitError,
-    StreamStateError,
-    FinalSizeError,
-    FrameEncodingError,
-    TransportParameterError,
+    FlowControl,
+    StreamLimit,
+    StreamState,
+    FinalSize,
+    FrameEncoding,
+    TransportParameter,
     ProtocolViolation,
     InvalidToken,
-    ApplicationError,
+    Application,
     CryptoBufferExceeded,
-    CryptoError(CryptoError),
-    QlogError,
+    Crypto(CryptoError),
+    Qlog,
     CryptoAlert(u8),
     EchRetry(Vec<u8>),
 
@@ -109,7 +109,7 @@ pub enum Error {
     ConnectionIdLimitExceeded,
     ConnectionIdsExhausted,
     ConnectionState,
-    DecryptError,
+    Decrypt,
     DisabledVersion,
     IdleTimeout,
     IntegerOverflow,
@@ -133,8 +133,8 @@ pub enum Error {
     NotAvailable,
     NotConnected,
     PacketNumberOverlap,
-    PeerApplicationError(AppError),
-    PeerError(TransportError),
+    PeerApplication(AppError),
+    Peer(TransportError),
     StatelessReset,
     TooMuchData,
     UnexpectedMessage,
@@ -149,21 +149,18 @@ impl Error {
     #[must_use]
     pub fn code(&self) -> TransportError {
         match self {
-            Self::NoError
-            | Self::IdleTimeout
-            | Self::PeerError(_)
-            | Self::PeerApplicationError(_) => 0,
+            Self::None | Self::IdleTimeout | Self::Peer(_) | Self::PeerApplication(_) => 0,
             Self::ConnectionRefused => 2,
-            Self::FlowControlError => 3,
-            Self::StreamLimitError => 4,
-            Self::StreamStateError => 5,
-            Self::FinalSizeError => 6,
-            Self::FrameEncodingError => 7,
-            Self::TransportParameterError => 8,
+            Self::FlowControl => 3,
+            Self::StreamLimit => 4,
+            Self::StreamState => 5,
+            Self::FinalSize => 6,
+            Self::FrameEncoding => 7,
+            Self::TransportParameter => 8,
             Self::ProtocolViolation => 10,
             Self::InvalidToken => 11,
             Self::KeysExhausted => ERROR_AEAD_LIMIT_REACHED,
-            Self::ApplicationError => ERROR_APPLICATION_CLOSE,
+            Self::Application => ERROR_APPLICATION_CLOSE,
             Self::NoAvailablePath => 16,
             Self::CryptoBufferExceeded => ERROR_CRYPTO_BUFFER_EXCEEDED,
             Self::CryptoAlert(a) => 0x100 + u64::from(*a),
@@ -182,14 +179,14 @@ impl From<CryptoError> for Error {
         qwarn!("Crypto operation failed {err:?}");
         match err {
             CryptoError::EchRetry(config) => Self::EchRetry(config),
-            _ => Self::CryptoError(err),
+            _ => Self::Crypto(err),
         }
     }
 }
 
 impl From<::qlog::Error> for Error {
     fn from(_err: ::qlog::Error) -> Self {
-        Self::QlogError
+        Self::Qlog
     }
 }
 
@@ -202,7 +199,7 @@ impl From<std::num::TryFromIntError> for Error {
 impl ::std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::CryptoError(e) => Some(e),
+            Self::Crypto(e) => Some(e),
             _ => None,
         }
     }
@@ -239,14 +236,14 @@ impl CloseReason {
     /// [`CloseReason::Application(0)`].
     #[must_use]
     pub const fn is_error(&self) -> bool {
-        !matches!(self, Self::Transport(Error::NoError) | Self::Application(0),)
+        !matches!(self, Self::Transport(Error::None) | Self::Application(0),)
     }
 }
 
 impl From<CloseError> for CloseReason {
     fn from(err: CloseError) -> Self {
         match err {
-            CloseError::Transport(c) => Self::Transport(Error::PeerError(c)),
+            CloseError::Transport(c) => Self::Transport(Error::Peer(c)),
             CloseError::Application(c) => Self::Application(c),
         }
     }

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -20,7 +20,7 @@ use std::{
 
 use enum_map::Enum;
 use neqo_common::{hex, hex_with_len, qtrace, qwarn, Decoder, Encoder};
-use neqo_crypto::random;
+use neqo_crypto::{random, Aead};
 use strum::{EnumIter, FromRepr};
 
 use crate::{
@@ -379,12 +379,12 @@ impl PacketBuilder {
         self.encoder.as_mut()[self.offsets.len + 1] = (len & 0xff) as u8;
     }
 
-    fn pad_for_crypto(&mut self, crypto: &CryptoDxState) {
+    fn pad_for_crypto(&mut self) {
         // Make sure that there is enough data in the packet.
         // The length of the packet number plus the payload length needs to
         // be at least 4 (MAX_PACKET_NUMBER_LEN) plus any amount by which
         // the header protection sample exceeds the AEAD expansion.
-        let crypto_pad = crypto.extra_padding();
+        let crypto_pad = CryptoDxState::extra_padding();
         self.encoder.pad_to(
             self.offsets.pn.start + MAX_PACKET_NUMBER_LEN + crypto_pad,
             0,
@@ -421,9 +421,9 @@ impl PacketBuilder {
             return Err(Error::Internal);
         }
 
-        self.pad_for_crypto(crypto);
+        self.pad_for_crypto();
         if self.offsets.len > 0 {
-            self.write_len(crypto.expansion());
+            self.write_len(CryptoDxState::expansion());
         }
 
         qtrace!(
@@ -435,7 +435,7 @@ impl PacketBuilder {
 
         // Add space for crypto expansion.
         let data_end = self.encoder.len();
-        self.pad_to(data_end + crypto.expansion(), 0);
+        self.pad_to(data_end + CryptoDxState::expansion(), 0);
 
         // Calculate the mask.
         let ciphertext = crypto.encrypt(self.pn, self.header.clone(), self.encoder.as_mut())?;
@@ -499,7 +499,7 @@ impl PacketBuilder {
         debug_assert_ne!(token.len(), 0);
         encoder.encode(token);
         let tag = retry::use_aead(version, |aead| {
-            let mut buf = vec![0; aead.expansion()];
+            let mut buf = vec![0; Aead::expansion()];
             Ok(aead.encrypt(0, encoder.as_ref(), &[], &mut buf)?.to_vec())
         })?;
         encoder.encode(&tag);
@@ -1029,7 +1029,7 @@ mod tests {
         // So burn an encryption:
         let mut burn = [0; 16];
         prot.encrypt(0, 0..0, &mut burn).expect("burn OK");
-        assert_eq!(burn.len(), prot.expansion());
+        assert_eq!(burn.len(), CryptoDxState::expansion());
 
         let mut builder = PacketBuilder::long(
             Encoder::new(),

--- a/neqo-transport/src/packet/retry.rs
+++ b/neqo-transport/src/packet/retry.rs
@@ -50,6 +50,6 @@ where
 
 /// Determine how large the expansion is for a given key.
 pub fn expansion(version: Version) -> usize {
-    use_aead(version, |aead| Ok(aead.expansion()))
+    use_aead(version, |_| Ok(Aead::expansion()))
         .unwrap_or_else(|_| panic!("Unable to access Retry AEAD"))
 }

--- a/neqo-transport/src/packet/retry.rs
+++ b/neqo-transport/src/packet/retry.rs
@@ -44,7 +44,7 @@ where
     .try_with(|aead| f(&aead.borrow()))
     .map_err(|e| {
         qerror!("Unable to access Retry AEAD: {e:?}");
-        Error::InternalError
+        Error::Internal
     })?
 }
 

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -158,7 +158,7 @@ impl QuicDatagrams {
             self.conn_events.datagram_outcome(
                 self.datagrams
                     .pop_front()
-                    .ok_or(Error::InternalError)?
+                    .ok_or(Error::Internal)?
                     .tracking(),
                 OutgoingDatagramOutcome::DroppedQueueFull,
             );

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -482,7 +482,7 @@ impl RecvStreamState {
         };
 
         if !final_size_ok {
-            return Err(Error::FinalSizeError);
+            return Err(Error::FinalSize);
         }
 
         let new_bytes_consumed = fc.set_consumed(consumed)?;
@@ -1650,11 +1650,8 @@ mod tests {
             .unwrap();
         assert!(!session_fc.borrow().frame_needed());
 
-        s.reset(
-            Error::NoError.code(),
-            u64::try_from(SESSION_WINDOW).unwrap(),
-        )
-        .unwrap();
+        s.reset(Error::None.code(), u64::try_from(SESSION_WINDOW).unwrap())
+            .unwrap();
         assert!(session_fc.borrow().frame_needed());
     }
 
@@ -1815,7 +1812,7 @@ mod tests {
         // Receiving frame past the flow control will cause an error.
         assert_eq!(
             s.inbound_stream_frame(false, 0, &[0; SW_US * 3 / 4 + 1]),
-            Err(Error::FlowControlError)
+            Err(Error::FlowControl)
         );
     }
 
@@ -2001,7 +1998,7 @@ mod tests {
         // Receiving frame past the final size of a stream will return an error.
         assert_eq!(
             s.inbound_stream_frame(true, SW / 4, &[0; SW_US / 4 + 1]),
-            Err(Error::FinalSizeError)
+            Err(Error::FinalSize)
         );
         check_fc(&fc.borrow(), SW / 2, 0);
         check_fc(s.fc().unwrap(), SW / 2, 0);
@@ -2057,7 +2054,7 @@ mod tests {
         // Receiving frame past the final size of a stream will return an error.
         assert_eq!(
             s.inbound_stream_frame(true, SW / 4, &[0; SW_US / 4 + 1]),
-            Err(Error::FinalSizeError)
+            Err(Error::FinalSize)
         );
         check_fc(&fc.borrow(), SW / 2, 0);
         check_fc(s.fc().unwrap(), SW / 2, 0);
@@ -2124,7 +2121,7 @@ mod tests {
         check_fc(&fc.borrow(), SW / 2, 0);
         check_fc(s.fc().unwrap(), SW / 2, 0);
 
-        s.stop_sending(Error::NoError.code());
+        s.stop_sending(Error::None.code());
         // All data will de retired
         check_fc(&fc.borrow(), SW / 2, SW / 2);
         check_fc(s.fc().unwrap(), SW / 2, SW / 2);
@@ -2144,7 +2141,7 @@ mod tests {
         // Receiving frame past the final size of a stream will return an error.
         assert_eq!(
             s.inbound_stream_frame(true, SW / 4, &[0; SW_US / 4 + 1]),
-            Err(Error::FinalSizeError)
+            Err(Error::FinalSize)
         );
         check_fc(&fc.borrow(), SW / 2, SW / 2);
         check_fc(s.fc().unwrap(), SW / 2, SW / 2);
@@ -2165,7 +2162,7 @@ mod tests {
         check_fc(&fc.borrow(), SW / 2, 0);
         check_fc(s.fc().unwrap(), SW / 2, 0);
 
-        s.stop_sending(Error::NoError.code());
+        s.stop_sending(Error::None.code());
         // All data will de retired
         check_fc(&fc.borrow(), SW / 2, SW / 2);
         check_fc(s.fc().unwrap(), SW / 2, SW / 2);
@@ -2179,7 +2176,7 @@ mod tests {
         // Receiving data past the flow control limit will cause an error.
         assert_eq!(
             s.inbound_stream_frame(false, 0, &[0; SW_US * 3 / 4 + 1]),
-            Err(Error::FlowControlError)
+            Err(Error::FlowControl)
         );
 
         // The stream can still receive duplicate data without a fin bit.
@@ -2202,7 +2199,7 @@ mod tests {
         // Receiving frame past the final size of a stream will return an error.
         assert_eq!(
             s.inbound_stream_frame(true, SW / 2, &[0; 21]),
-            Err(Error::FinalSizeError)
+            Err(Error::FinalSize)
         );
         check_fc(&fc.borrow(), SW / 2 + 20, SW / 2 + 20);
         check_fc(s.fc().unwrap(), SW / 2 + 20, SW / 2 + 20);
@@ -2223,7 +2220,7 @@ mod tests {
         check_fc(&fc.borrow(), SW / 2, 0);
         check_fc(s.fc().unwrap(), SW / 2, 0);
 
-        s.stop_sending(Error::NoError.code());
+        s.stop_sending(Error::None.code());
         check_fc(&fc.borrow(), SW / 2, SW / 2);
         check_fc(s.fc().unwrap(), SW / 2, SW / 2);
 
@@ -2240,7 +2237,7 @@ mod tests {
         // Receiving data past the flow control limit will cause an error.
         assert_eq!(
             s.inbound_stream_frame(false, 0, &[0; SW_US * 3 / 4 + 1]),
-            Err(Error::FlowControlError)
+            Err(Error::FlowControl)
         );
 
         // The stream can still receive duplicate data without a fin bit.

--- a/neqo-transport/src/stream_id.rs
+++ b/neqo-transport/src/stream_id.rs
@@ -108,7 +108,7 @@ impl StreamId {
 
     /// Return the stream index for this stream ID.
     #[must_use]
-    pub const fn index(&self) -> u64 {
+    pub const fn index(self) -> u64 {
         self.0 >> 2
     }
 

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -192,7 +192,7 @@ impl Streams {
                 // Terminate connection with STREAM_STATE_ERROR if send-only
                 // stream (-transport 19.13)
                 if stream_id.is_send_only(self.role) {
-                    return Err(Error::StreamStateError);
+                    return Err(Error::StreamState);
                 }
 
                 if let (_, Some(rs)) = self.obtain_stream(*stream_id)? {
@@ -204,7 +204,7 @@ impl Streams {
                 // We send an update every time we retire a stream. There is no need to
                 // trigger flow updates here.
             }
-            _ => return Err(Error::InternalError), // This is not a stream frame.
+            _ => return Err(Error::Internal), // This is not a stream frame.
         }
         Ok(())
     }
@@ -417,7 +417,7 @@ impl Streams {
             && !stream_id.is_remote_initiated(self.role)
             && self.local_stream_limits[stream_id.stream_type()].used() <= stream_id.index()
         {
-            return Err(Error::StreamStateError);
+            return Err(Error::StreamState);
         }
         Ok((ss, rs))
     }
@@ -438,7 +438,7 @@ impl Streams {
     /// When a stream cannot be created, which might be temporary.
     pub fn stream_create(&mut self, st: StreamType) -> Res<StreamId> {
         match self.local_stream_limits.take_stream_id(st) {
-            None => Err(Error::StreamLimitError),
+            None => Err(Error::StreamLimit),
             Some(new_id) => {
                 let send_limit_tp = match st {
                     StreamType::UniDi => InitialMaxStreamDataUni,

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -293,7 +293,7 @@ impl RecvdPackets {
                     // If this was the smallest, it might have filled a gap.
                     let nxt = i + 1;
                     if (nxt < self.ranges.len()) && (pn - 1 == self.ranges[nxt].largest) {
-                        let larger = self.ranges.remove(i).ok_or(Error::InternalError)?;
+                        let larger = self.ranges.remove(i).ok_or(Error::Internal)?;
                         self.ranges[i].merge_larger(&larger);
                     }
                     return Ok(());
@@ -313,7 +313,7 @@ impl RecvdPackets {
     fn trim_ranges(&mut self) -> Res<()> {
         // Limit the number of ranges that are tracked to MAX_TRACKED_RANGES.
         if self.ranges.len() > MAX_TRACKED_RANGES {
-            let oldest = self.ranges.pop_back().ok_or(Error::InternalError)?;
+            let oldest = self.ranges.pop_back().ok_or(Error::Internal)?;
             if oldest.ack_needed {
                 qwarn!("[{self}] Dropping unacknowledged ACK range: {oldest}");
             // TODO(mt) Record some statistics about this so we can tune MAX_TRACKED_RANGES.

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -11,7 +11,7 @@ use std::{cell::RefCell, net::SocketAddr, rc::Rc, time::Duration};
 use common::{connect, connected_server, default_server, find_ticket, generate_ticket, new_server};
 use neqo_common::{qtrace, Datagram, Decoder, Encoder, Role};
 use neqo_crypto::{
-    generate_ech_keys, AllowZeroRtt, AuthenticationStatus, ZeroRttCheckResult, ZeroRttChecker,
+    generate_ech_keys, Aead, AllowZeroRtt, AuthenticationStatus, ZeroRttCheckResult, ZeroRttChecker,
 };
 use neqo_transport::{
     server::{ConnectionRef, Server, ValidateAddress},
@@ -457,11 +457,11 @@ fn bad_client_initial() {
         .encode_vec(1, d_cid)
         .encode_vec(1, s_cid)
         .encode_vvec(&[])
-        .encode_varint(u64::try_from(payload_enc.len() + aead.expansion() + 1).unwrap())
+        .encode_varint(u64::try_from(payload_enc.len() + Aead::expansion() + 1).unwrap())
         .encode_byte(u8::try_from(pn).unwrap());
 
     let mut ciphertext = header_enc.as_ref().to_vec();
-    ciphertext.resize(header_enc.len() + payload_enc.len() + aead.expansion(), 0);
+    ciphertext.resize(header_enc.len() + payload_enc.len() + Aead::expansion(), 0);
     let v = aead
         .encrypt(
             pn,
@@ -543,11 +543,11 @@ fn bad_client_initial_connection_close() {
         .encode_vec(1, d_cid)
         .encode_vec(1, s_cid)
         .encode_vvec(&[])
-        .encode_varint(u64::try_from(payload_enc.len() + aead.expansion() + 1).unwrap())
+        .encode_varint(u64::try_from(payload_enc.len() + Aead::expansion() + 1).unwrap())
         .encode_byte(u8::try_from(pn).unwrap());
 
     let mut ciphertext = header_enc.as_ref().to_vec();
-    ciphertext.resize(header_enc.len() + payload_enc.len() + aead.expansion(), 0);
+    ciphertext.resize(header_enc.len() + payload_enc.len() + Aead::expansion(), 0);
     let v = aead
         .encrypt(
             pn,

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -503,7 +503,7 @@ fn bad_client_initial() {
     assert_ne!(delay, Duration::from_secs(0));
     assert!(matches!(
         *client.state(),
-        State::Draining { error: CloseReason::Transport(Error::PeerError(code)), .. } if code == Error::ProtocolViolation.code()
+        State::Draining { error: CloseReason::Transport(Error::Peer(code)), .. } if code == Error::ProtocolViolation.code()
     ));
 
     #[expect(
@@ -769,7 +769,7 @@ fn can_create_streams(c: &mut Connection, t: StreamType, n: u64) {
     for _ in 0..n {
         c.stream_create(t).unwrap();
     }
-    assert_eq!(c.stream_create(t), Err(Error::StreamLimitError));
+    assert_eq!(c.stream_create(t), Err(Error::StreamLimit));
 }
 
 #[test]


### PR DESCRIPTION
And deal with the fallout.

We have one consumer and can afford to break the API, and this unlocks more linting.