### PR TITLE
fix: Don't construct `Http3StreamInfo` on every call to `get_info`

### DIFF
--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -112,14 +112,14 @@ pub struct Http3ClientEvents {
 
 impl RecvStreamEvents for Http3ClientEvents {
     /// Add a new `DataReadable` event
-    fn data_readable(&self, stream_info: Http3StreamInfo) {
+    fn data_readable(&self, stream_info: &Http3StreamInfo) {
         self.insert(Http3ClientEvent::DataReadable {
             stream_id: stream_info.stream_id(),
         });
     }
 
     /// Add a new `Reset` event.
-    fn recv_closed(&self, stream_info: Http3StreamInfo, close_type: CloseType) {
+    fn recv_closed(&self, stream_info: &Http3StreamInfo, close_type: CloseType) {
         let stream_id = stream_info.stream_id();
         let (local, error) = match close_type {
             CloseType::ResetApp(_) => {
@@ -149,7 +149,7 @@ impl HttpRecvStreamEvents for Http3ClientEvents {
     /// Add a new `HeaderReady` event.
     fn header_ready(
         &self,
-        stream_info: Http3StreamInfo,
+        stream_info: &Http3StreamInfo,
         headers: Vec<Header>,
         interim: bool,
         fin: bool,
@@ -165,13 +165,13 @@ impl HttpRecvStreamEvents for Http3ClientEvents {
 
 impl SendStreamEvents for Http3ClientEvents {
     /// Add a new `DataWritable` event.
-    fn data_writable(&self, stream_info: Http3StreamInfo) {
+    fn data_writable(&self, stream_info: &Http3StreamInfo) {
         self.insert(Http3ClientEvent::DataWritable {
             stream_id: stream_info.stream_id(),
         });
     }
 
-    fn send_closed(&self, stream_info: Http3StreamInfo, close_type: CloseType) {
+    fn send_closed(&self, stream_info: &Http3StreamInfo, close_type: CloseType) {
         let stream_id = stream_info.stream_id();
         self.remove_send_stream_events(stream_id);
         if let CloseType::ResetRemote(error) = close_type {

--- a/neqo-http3/src/features/extended_connect/webtransport_session.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_session.rs
@@ -527,7 +527,7 @@ impl RecvStreamEvents for Rc<RefCell<WebTransportSessionListener>> {}
 impl HttpRecvStreamEvents for Rc<RefCell<WebTransportSessionListener>> {
     fn header_ready(
         &self,
-        _stream_info: Http3StreamInfo,
+        _stream_info: &Http3StreamInfo,
         headers: Vec<Header>,
         interim: bool,
         fin: bool,

--- a/neqo-http3/src/features/extended_connect/webtransport_streams.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_streams.rs
@@ -21,6 +21,7 @@ pub const WEBTRANSPORT_STREAM: u64 = 0x41;
 #[derive(Debug)]
 pub struct WebTransportRecvStream {
     stream_id: StreamId,
+    stream_info: Http3StreamInfo,
     events: Box<dyn RecvStreamEvents>,
     session: Rc<RefCell<WebTransportSession>>,
     session_id: StreamId,
@@ -36,6 +37,7 @@ impl WebTransportRecvStream {
     ) -> Self {
         Self {
             stream_id,
+            stream_info: Http3StreamInfo::new(stream_id, Http3StreamType::WebTransport(session_id)),
             events,
             session_id,
             session,
@@ -43,8 +45,8 @@ impl WebTransportRecvStream {
         }
     }
 
-    fn get_info(&self) -> Http3StreamInfo {
-        Http3StreamInfo::new(self.stream_id, self.stream_type())
+    const fn get_info(&self) -> &Http3StreamInfo {
+        &self.stream_info
     }
 }
 
@@ -117,6 +119,7 @@ enum WebTransportSenderStreamState {
 #[derive(Debug)]
 pub struct WebTransportSendStream {
     stream_id: StreamId,
+    stream_info: Http3StreamInfo,
     state: WebTransportSenderStreamState,
     events: Box<dyn SendStreamEvents>,
     session: Rc<RefCell<WebTransportSession>>,
@@ -133,6 +136,7 @@ impl WebTransportSendStream {
     ) -> Self {
         Self {
             stream_id,
+            stream_info: Http3StreamInfo::new(stream_id, Http3StreamType::WebTransport(session_id)),
             state: if local {
                 let mut d = Encoder::default();
                 if stream_id.is_uni() {
@@ -160,8 +164,8 @@ impl WebTransportSendStream {
         self.session.borrow_mut().remove_send_stream(self.stream_id);
     }
 
-    fn get_info(&self) -> Http3StreamInfo {
-        Http3StreamInfo::new(self.stream_id, self.stream_type())
+    const fn get_info(&self) -> &Http3StreamInfo {
+        &self.stream_info
     }
 }
 

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -544,14 +544,14 @@ impl Http3StreamInfo {
 }
 
 trait RecvStreamEvents: Debug {
-    fn data_readable(&self, _stream_info: Http3StreamInfo) {}
-    fn recv_closed(&self, _stream_info: Http3StreamInfo, _close_type: CloseType) {}
+    fn data_readable(&self, _stream_info: &Http3StreamInfo) {}
+    fn recv_closed(&self, _stream_info: &Http3StreamInfo, _close_type: CloseType) {}
 }
 
 trait HttpRecvStreamEvents: RecvStreamEvents {
     fn header_ready(
         &self,
-        stream_info: Http3StreamInfo,
+        stream_info: &Http3StreamInfo,
         headers: Vec<Header>,
         interim: bool,
         fin: bool,
@@ -623,8 +623,8 @@ trait HttpSendStream: SendStream {
 }
 
 trait SendStreamEvents: Debug {
-    fn send_closed(&self, _stream_info: Http3StreamInfo, _close_type: CloseType) {}
-    fn data_writable(&self, _stream_info: Http3StreamInfo) {}
+    fn send_closed(&self, _stream_info: &Http3StreamInfo, _close_type: CloseType) {}
+    fn data_writable(&self, _stream_info: &Http3StreamInfo) {}
 }
 
 /// This enum is used to mark a different type of closing a stream:

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -463,7 +463,7 @@ impl RecvPushEvents {
 }
 
 impl RecvStreamEvents for RecvPushEvents {
-    fn data_readable(&self, _stream_info: Http3StreamInfo) {
+    fn data_readable(&self, _stream_info: &Http3StreamInfo) {
         self.push_handler.borrow_mut().new_stream_event(
             self.push_id,
             Http3ClientEvent::PushDataReadable {
@@ -472,7 +472,7 @@ impl RecvStreamEvents for RecvPushEvents {
         );
     }
 
-    fn recv_closed(&self, _stream_info: Http3StreamInfo, close_type: CloseType) {
+    fn recv_closed(&self, _stream_info: &Http3StreamInfo, close_type: CloseType) {
         match close_type {
             CloseType::ResetApp(_) => {}
             CloseType::ResetRemote(_) | CloseType::LocalError(_) => self
@@ -487,7 +487,7 @@ impl RecvStreamEvents for RecvPushEvents {
 impl HttpRecvStreamEvents for RecvPushEvents {
     fn header_ready(
         &self,
-        _stream_info: Http3StreamInfo,
+        _stream_info: &Http3StreamInfo,
         headers: Vec<Header>,
         interim: bool,
         fin: bool,

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -73,6 +73,7 @@ struct PushInfo {
 #[derive(Debug)]
 pub struct RecvMessage {
     state: RecvMessageState,
+    stream_info: Http3StreamInfo,
     message_type: MessageType,
     stream_type: Http3StreamType,
     qpack_decoder: Rc<RefCell<QPackDecoder>>,
@@ -105,6 +106,7 @@ impl RecvMessage {
                         FrameReader::new_with_type(HFrameType(frame_type))
                     }),
             },
+            stream_info:Http3StreamInfo::new(message_info.stream_id, Http3StreamType::Http),
             message_type: message_info.message_type,
             stream_type: message_info.stream_type,
             qpack_decoder,
@@ -365,8 +367,8 @@ impl RecvMessage {
         )
     }
 
-    const fn get_stream_info(&self) -> Http3StreamInfo {
-        Http3StreamInfo::new(self.stream_id, Http3StreamType::Http)
+    const fn get_stream_info(&self) -> &Http3StreamInfo {
+        &self.stream_info
     }
 }
 

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -110,6 +110,7 @@ impl MessageState {
 #[derive(Debug)]
 pub struct SendMessage {
     state: MessageState,
+    stream_info: Http3StreamInfo,
     message_type: MessageType,
     stream_type: Http3StreamType,
     stream: BufferedStream,
@@ -128,6 +129,7 @@ impl SendMessage {
         qdebug!("Create a request stream_id={stream_id}");
         Self {
             state: MessageState::WaitingForHeaders,
+            stream_info: Http3StreamInfo::new(stream_id, Http3StreamType::Http),
             message_type,
             stream_type,
             stream: BufferedStream::new(stream_id),
@@ -160,8 +162,8 @@ impl SendMessage {
         Option::<StreamId>::from(&self.stream).expect("stream has ID")
     }
 
-    fn get_stream_info(&self) -> Http3StreamInfo {
-        Http3StreamInfo::new(self.stream_id(), Http3StreamType::Http)
+    const fn get_stream_info(&self) -> &Http3StreamInfo {
+        &self.stream_info
     }
 }
 


### PR DESCRIPTION
Suggested by @martinthomson in https://github.com/mozilla/neqo/pull/2623#discussion_r2084522167