### PR TITLE
fix: Flip `NeqoQlog` types around

### DIFF
--- a/neqo-http3/src/qlog.rs
+++ b/neqo-http3/src/qlog.rs
@@ -13,7 +13,7 @@ use qlog::events::{DataRecipient, EventData};
 /// Uses [`NeqoQlog::add_event_data_now`] instead of
 /// [`NeqoQlog::add_event_data_with_instant`], given that `now` is not available
 /// on call-site. See docs on [`NeqoQlog::add_event_data_now`] for details.
-pub fn h3_data_moved_up(qlog: &NeqoQlog, stream_id: StreamId, amount: usize) {
+pub fn h3_data_moved_up(qlog: &mut NeqoQlog, stream_id: StreamId, amount: usize) {
     qlog.add_event_data_now(|| {
         let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
             stream_id: Some(stream_id.as_u64()),
@@ -31,7 +31,7 @@ pub fn h3_data_moved_up(qlog: &NeqoQlog, stream_id: StreamId, amount: usize) {
 /// Uses [`NeqoQlog::add_event_data_now`] instead of
 /// [`NeqoQlog::add_event_data_with_instant`], given that `now` is not available
 /// on call-site. See docs on [`NeqoQlog::add_event_data_now`] for details.
-pub fn h3_data_moved_down(qlog: &NeqoQlog, stream_id: StreamId, amount: usize) {
+pub fn h3_data_moved_down(qlog: &mut NeqoQlog, stream_id: StreamId, amount: usize) {
     qlog.add_event_data_now(|| {
         let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
             stream_id: Some(stream_id.as_u64()),

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -221,7 +221,7 @@ impl QPackEncoder {
         }
     }
 
-    fn call_instruction(&mut self, instruction: DecoderInstruction, qlog: &NeqoQlog) -> Res<()> {
+    fn call_instruction(&mut self, instruction: DecoderInstruction, qlog: &mut NeqoQlog) -> Res<()> {
         qdebug!("[{self}] call instruction {instruction:?}");
         match instruction {
             DecoderInstruction::InsertCountIncrement { increment } => {

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -221,7 +221,11 @@ impl QPackEncoder {
         }
     }
 
-    fn call_instruction(&mut self, instruction: DecoderInstruction, qlog: &mut NeqoQlog) -> Res<()> {
+    fn call_instruction(
+        &mut self,
+        instruction: DecoderInstruction,
+        qlog: &mut NeqoQlog,
+    ) -> Res<()> {
         qdebug!("[{self}] call instruction {instruction:?}");
         match instruction {
             DecoderInstruction::InsertCountIncrement { increment } => {

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -15,7 +15,7 @@ use qlog::events::{
 /// Uses [`NeqoQlog::add_event_data_now`] instead of
 /// [`NeqoQlog::add_event_data_with_instant`], given that `now` is not available
 /// on call-site. See docs on [`NeqoQlog::add_event_data_now`] for details.
-pub fn qpack_read_insert_count_increment_instruction(qlog: &NeqoQlog, increment: u64, data: &[u8]) {
+pub fn qpack_read_insert_count_increment_instruction(qlog: &mut NeqoQlog, increment: u64, data: &[u8]) {
     qlog.add_event_data_now(|| {
         let raw = RawInfo {
             length: Some(8),

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -15,7 +15,11 @@ use qlog::events::{
 /// Uses [`NeqoQlog::add_event_data_now`] instead of
 /// [`NeqoQlog::add_event_data_with_instant`], given that `now` is not available
 /// on call-site. See docs on [`NeqoQlog::add_event_data_now`] for details.
-pub fn qpack_read_insert_count_increment_instruction(qlog: &mut NeqoQlog, increment: u64, data: &[u8]) {
+pub fn qpack_read_insert_count_increment_instruction(
+    qlog: &mut NeqoQlog,
+    increment: u64,
+    data: &[u8],
+) {
     qlog.add_event_data_now(|| {
         let raw = RawInfo {
             length: Some(8),

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -209,7 +209,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
 
             if self.state.in_recovery() {
                 self.set_state(State::CongestionAvoidance, now);
-                qlog::metrics_updated(&self.qlog, &[QlogMetric::InRecovery(false)], now);
+                qlog::metrics_updated(&mut self.qlog, &[QlogMetric::InRecovery(false)], now);
             }
 
             new_acked += pkt.len();
@@ -263,7 +263,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
             self.acked_bytes = min(bytes_for_increase, self.acked_bytes);
         }
         qlog::metrics_updated(
-            &self.qlog,
+            &mut self.qlog,
             &[
                 QlogMetric::CongestionWindow(self.congestion_window),
                 QlogMetric::BytesInFlight(self.bytes_in_flight),
@@ -297,7 +297,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
             self.bytes_in_flight = self.bytes_in_flight.saturating_sub(pkt.len());
         }
         qlog::metrics_updated(
-            &self.qlog,
+            &mut self.qlog,
             &[QlogMetric::BytesInFlight(self.bytes_in_flight)],
             now,
         );
@@ -344,7 +344,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
             assert!(self.bytes_in_flight >= pkt.len());
             self.bytes_in_flight -= pkt.len();
             qlog::metrics_updated(
-                &self.qlog,
+                &mut self.qlog,
                 &[QlogMetric::BytesInFlight(self.bytes_in_flight)],
                 now,
             );
@@ -355,7 +355,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
     fn discard_in_flight(&mut self, now: Instant) {
         self.bytes_in_flight = 0;
         qlog::metrics_updated(
-            &self.qlog,
+            &mut self.qlog,
             &[QlogMetric::BytesInFlight(self.bytes_in_flight)],
             now,
         );
@@ -386,7 +386,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
             pkt.len()
         );
         qlog::metrics_updated(
-            &self.qlog,
+            &mut self.qlog,
             &[QlogMetric::BytesInFlight(self.bytes_in_flight)],
             now,
         );
@@ -514,7 +514,7 @@ impl<T: WindowAdjustment> ClassicCongestionControl<T> {
                     self.acked_bytes = 0;
                     self.set_state(State::PersistentCongestion, now);
                     qlog::metrics_updated(
-                        &self.qlog,
+                        &mut self.qlog,
                         &[QlogMetric::CongestionWindow(self.congestion_window)],
                         now,
                     );
@@ -561,7 +561,7 @@ impl<T: WindowAdjustment> ClassicCongestionControl<T> {
             self.ssthresh
         );
         qlog::metrics_updated(
-            &self.qlog,
+            &mut self.qlog,
             &[
                 QlogMetric::CongestionWindow(self.congestion_window),
                 QlogMetric::SsThresh(self.ssthresh),

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -964,7 +964,7 @@ impl Path {
             );
             stats.rtt_init_guess = true;
             self.rtt.update(
-                &self.qlog,
+                &mut self.qlog,
                 now - sent.time_sent(),
                 Duration::new(0, 0),
                 RttSource::Guesstimate,

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -41,7 +41,7 @@ use crate::{
     version::{Version, VersionConfig, WireVersion},
 };
 
-pub fn connection_tparams_set(qlog: &NeqoQlog, tph: &TransportParametersHandler, now: Instant) {
+pub fn connection_tparams_set(qlog: &mut NeqoQlog, tph: &TransportParametersHandler, now: Instant) {
     qlog.add_event_data_with_instant(
         || {
             let remote = tph.remote();
@@ -89,15 +89,15 @@ pub fn connection_tparams_set(qlog: &NeqoQlog, tph: &TransportParametersHandler,
     );
 }
 
-pub fn server_connection_started(qlog: &NeqoQlog, path: &PathRef, now: Instant) {
+pub fn server_connection_started(qlog: &mut NeqoQlog, path: &PathRef, now: Instant) {
     connection_started(qlog, path, now);
 }
 
-pub fn client_connection_started(qlog: &NeqoQlog, path: &PathRef, now: Instant) {
+pub fn client_connection_started(qlog: &mut NeqoQlog, path: &PathRef, now: Instant) {
     connection_started(qlog, path, now);
 }
 
-fn connection_started(qlog: &NeqoQlog, path: &PathRef, now: Instant) {
+fn connection_started(qlog: &mut NeqoQlog, path: &PathRef, now: Instant) {
     qlog.add_event_data_with_instant(
         || {
             let p = path.deref().borrow();
@@ -123,7 +123,7 @@ fn connection_started(qlog: &NeqoQlog, path: &PathRef, now: Instant) {
 }
 
 #[expect(clippy::similar_names, reason = "new and now are similar.")]
-pub fn connection_state_updated(qlog: &NeqoQlog, new: &State, now: Instant) {
+pub fn connection_state_updated(qlog: &mut NeqoQlog, new: &State, now: Instant) {
     qlog.add_event_data_with_instant(
         || {
             let ev_data = EventData::ConnectionStateUpdated(ConnectionStateUpdated {
@@ -146,7 +146,7 @@ pub fn connection_state_updated(qlog: &NeqoQlog, new: &State, now: Instant) {
 }
 
 pub fn client_version_information_initiated(
-    qlog: &NeqoQlog,
+    qlog: &mut NeqoQlog,
     version_config: &VersionConfig,
     now: Instant,
 ) {
@@ -169,7 +169,7 @@ pub fn client_version_information_initiated(
 }
 
 pub fn client_version_information_negotiated(
-    qlog: &NeqoQlog,
+    qlog: &mut NeqoQlog,
     client: &[Version],
     server: &[WireVersion],
     chosen: Version,
@@ -193,7 +193,7 @@ pub fn client_version_information_negotiated(
 }
 
 pub fn server_version_information_failed(
-    qlog: &NeqoQlog,
+    qlog: &mut NeqoQlog,
     server: &[Version],
     client: WireVersion,
     now: Instant,
@@ -215,7 +215,7 @@ pub fn server_version_information_failed(
     );
 }
 
-pub fn packet_io(qlog: &NeqoQlog, meta: packet::MetaData, now: Instant) {
+pub fn packet_io(qlog: &mut NeqoQlog, meta: packet::MetaData, now: Instant) {
     qlog.add_event_data_with_instant(
         || {
             let mut d = Decoder::from(meta.payload());
@@ -254,7 +254,7 @@ pub fn packet_io(qlog: &NeqoQlog, meta: packet::MetaData, now: Instant) {
     );
 }
 
-pub fn packet_dropped(qlog: &NeqoQlog, public_packet: &PublicPacket, now: Instant) {
+pub fn packet_dropped(qlog: &mut NeqoQlog, public_packet: &PublicPacket, now: Instant) {
     qlog.add_event_data_with_instant(
         || {
             let header =
@@ -276,7 +276,7 @@ pub fn packet_dropped(qlog: &NeqoQlog, public_packet: &PublicPacket, now: Instan
     );
 }
 
-pub fn packets_lost(qlog: &NeqoQlog, pkts: &[SentPacket], now: Instant) {
+pub fn packets_lost(qlog: &mut NeqoQlog, pkts: &[SentPacket], now: Instant) {
     qlog.add_event_with_stream(|stream| {
         for pkt in pkts {
             let header =
@@ -309,7 +309,7 @@ pub enum QlogMetric {
     PacingRate(u64),
 }
 
-pub fn metrics_updated(qlog: &NeqoQlog, updated_metrics: &[QlogMetric], now: Instant) {
+pub fn metrics_updated(qlog: &mut NeqoQlog, updated_metrics: &[QlogMetric], now: Instant) {
     debug_assert!(!updated_metrics.is_empty());
 
     qlog.add_event_data_with_instant(

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -556,7 +556,7 @@ impl LossRecovery {
 
     /// Record an RTT sample.
     fn rtt_sample(
-        &self,
+        &mut self,
         rtt: &mut RttEstimate,
         send_time: Instant,
         now: Instant,
@@ -568,7 +568,7 @@ impl LossRecovery {
             RttSource::Ack
         };
         if let Some(sample) = now.checked_duration_since(send_time) {
-            rtt.update(&self.qlog, sample, ack_delay, source, now);
+            rtt.update(&mut self.qlog, sample, ack_delay, source, now);
         }
     }
 
@@ -814,7 +814,7 @@ impl LossRecovery {
 
         if let Some(st) = &mut self.pto_state {
             st.count_pto(&mut self.stats.borrow_mut());
-            qlog::metrics_updated(&self.qlog, &[QlogMetric::PtoCount(st.count())], now);
+            qlog::metrics_updated(&mut self.qlog, &[QlogMetric::PtoCount(st.count())], now);
         }
     }
 

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -100,7 +100,7 @@ impl RttEstimate {
 
     pub fn update(
         &mut self,
-        qlog: &NeqoQlog,
+        qlog: &mut NeqoQlog,
         mut rtt_sample: Duration,
         ack_delay: Duration,
         source: RttSource,

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -339,7 +339,8 @@ impl Server {
                 qwarn!("[{self}] Unable to create connection");
                 if e == crate::Error::VersionNegotiation {
                     crate::qlog::server_version_information_failed(
-                        &mut self.create_qlog_trace(orig_dcid.unwrap_or(initial.dst_cid).as_cid_ref()),
+                        &mut self
+                            .create_qlog_trace(orig_dcid.unwrap_or(initial.dst_cid).as_cid_ref()),
                         self.conn_params.get_versions().all(),
                         initial.version.wire_version(),
                         now,

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -339,7 +339,7 @@ impl Server {
                 qwarn!("[{self}] Unable to create connection");
                 if e == crate::Error::VersionNegotiation {
                     crate::qlog::server_version_information_failed(
-                        &self.create_qlog_trace(orig_dcid.unwrap_or(initial.dst_cid).as_cid_ref()),
+                        &mut self.create_qlog_trace(orig_dcid.unwrap_or(initial.dst_cid).as_cid_ref()),
                         self.conn_params.get_versions().all(),
                         initial.version.wire_version(),
                         now,
@@ -414,7 +414,7 @@ impl Server {
             );
 
             crate::qlog::server_version_information_failed(
-                &self.create_qlog_trace(packet.dcid()),
+                &mut self.create_qlog_trace(packet.dcid()),
                 self.conn_params.get_versions().all(),
                 packet.wire_version(),
                 now,


### PR DESCRIPTION
From `Rc<RefCell<Option<NeqoQlogShared>>>` to `Option<Rc<RefCell<NeqoQlogShared>>>`.

We spend 1% of runtime in `borrow_mut()` even when qlogs are disabled (= the inner `Option` is `None`.)