### PR TITLE
ci(bench): do not override main branch bench binaries

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -112,16 +112,10 @@ jobs:
           mkdir -p binaries/neqo
           cd neqo
           git checkout origin/main
-          cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches-main.txt
-          BENCHES_MAIN=$(grep Executable benches-main.txt | cut -d\( -f2 | cut -d\) -f1 | tr -s '\n' ' ')
-          echo "BENCHES_MAIN=$BENCHES_MAIN" >> "$GITHUB_ENV"
           cargo build --locked --release --bin neqo-client --bin neqo-server
           cp target/release/neqo-client ../binaries/neqo-main/
           cp target/release/neqo-server ../binaries/neqo-main/
           git checkout -
-          cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches.txt
-          BENCHES=$(grep Executable benches.txt | cut -d\( -f2 | cut -d\) -f1 | tr -s '\n' ' ')
-          echo "BENCHES=$BENCHES" >> "$GITHUB_ENV"
           cargo build --locked --release --bin neqo-client --bin neqo-server
           cp target/release/neqo-client ../binaries/neqo/
           cp target/release/neqo-server ../binaries/neqo/
@@ -165,6 +159,8 @@ jobs:
           cd neqo
           rm -rf target/criterion
           git checkout origin/main
+          cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches-main.txt
+          BENCHES_MAIN=$(grep Executable benches-main.txt | cut -d\( -f2 | cut -d\) -f1 | tr -s '\n' ' ')
           # Run the builds from the main branch first, to establish a baseline.
           for BENCH in $BENCHES_MAIN; do
             cp "$BENCH" ../binaries/neqo-main/
@@ -175,6 +171,8 @@ jobs:
           # Copy the main branch results to a separate directory for bencher.dev.
           cp -r target/criterion ../criterion-main
           git checkout -
+          cargo bench --locked --workspace --features bench --no-run 2>&1 | tee benches.txt
+          BENCHES=$(grep Executable benches.txt | cut -d\( -f2 | cut -d\) -f1 | tr -s '\n' ' ')
           # Run pull request builds twice, once without perf for baseline comparison, and once with perf for profiling.
           # (Perf seems to introduce some variability in the results.)
           for BENCH in $BENCHES; do


### PR DESCRIPTION
Previously `bench.yml` would:

1. Build main branch benchmark binaries.
2. Build PR branch benchmark binaries.
3. Execute main branch benchmark binaries.
4. Execute PR branch benchmark binaries.

While benchmark binary names are suffixed with a hash (see samples below), that hash is not unique across branches, instead it is unique across build-config changes (e.g. changes to Cargo.toml).

In other words, (2) overrides the binaries of (1) and thus (3) executes the same binaries as (4).

This fixes the issue by building the binaries just in time, interleaving building and executing.

Sample build output, note that executable names are the same across main and PR builds:

```
Previous HEAD position was d9cdd59 Merge b875854bedd3070aad7a870e44107a36fc40b6c7 into 68c6a9376dc380291e10e0460498cb0584562739
HEAD is now at 68c6a93 perf(common): make Encoder generic over borrowed or owned buffer (#2677)
   Compiling neqo-common v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-common)
   Compiling neqo-transport v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-transport)
   Compiling neqo-udp v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-udp)
   Compiling neqo-crypto v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-crypto)
   Compiling neqo-qpack v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-qpack)
   Compiling neqo-http3 v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-http3)
   Compiling test-fixture v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/test-fixture)
   Compiling neqo-bin v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-bin)
    Finished `bench` profile [optimized + debuginfo] target(s) in 2m 41s
  Executable benches/main.rs (target/release/deps/main-8112265e3a34ae08)
  Executable benches/decoder.rs (target/release/deps/decoder-164c8a6d0438d1f5)
  Executable benches/streams.rs (target/release/deps/streams-79d90748efbe8383)
  Executable benches/min_bandwidth.rs (target/release/deps/min_bandwidth-15b80e5b2659a531)
  Executable benches/range_tracker.rs (target/release/deps/range_tracker-8b0afe17a90922a6)
  Executable benches/rx_stream_orderer.rs (target/release/deps/rx_stream_orderer-ab62e853b69711fa)
  Executable benches/sent_packets.rs (target/release/deps/sent_packets-f9c8113c60037ffc)
  Executable benches/transfer.rs (target/release/deps/transfer-207cad1904568f18)
   Compiling neqo-common v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-common)
   Compiling neqo-transport v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-transport)
   Compiling neqo-udp v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-udp)
   Compiling neqo-crypto v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-crypto)
   Compiling neqo-qpack v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-qpack)
   Compiling neqo-http3 v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-http3)
   Compiling neqo-bin v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-bin)
    Finished `release` profile [optimized + debuginfo] target(s) in 42.81s
```
```
Previous HEAD position was 68c6a93 perf(common): make Encoder generic over borrowed or owned buffer (#2677)
HEAD is now at d9cdd59 Merge b875854bedd3070aad7a870e44107a36fc40b6c7 into 68c6a9376dc380291e10e0460498cb0584562739
   Compiling neqo-common v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-common)
   Compiling neqo-transport v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-transport)
   Compiling neqo-udp v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-udp)
   Compiling neqo-crypto v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-crypto)
   Compiling neqo-qpack v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-qpack)
   Compiling neqo-http3 v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-http3)
   Compiling test-fixture v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/test-fixture)
   Compiling neqo-bin v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-bin)
    Finished `bench` profile [optimized + debuginfo] target(s) in 3m 18s
  Executable benches/main.rs (target/release/deps/main-8112265e3a34ae08)
  Executable benches/decoder.rs (target/release/deps/decoder-164c8a6d0438d1f5)
  Executable benches/streams.rs (target/release/deps/streams-79d90748efbe8383)
  Executable benches/min_bandwidth.rs (target/release/deps/min_bandwidth-15b80e5b2659a531)
  Executable benches/range_tracker.rs (target/release/deps/range_tracker-8b0afe17a90922a6)
  Executable benches/rx_stream_orderer.rs (target/release/deps/rx_stream_orderer-ab62e853b69711fa)
  Executable benches/sent_packets.rs (target/release/deps/sent_packets-f9c8113c60037ffc)
  Executable benches/transfer.rs (target/release/deps/transfer-207cad1904568f18)
   Compiling neqo-common v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-common)
   Compiling neqo-transport v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-transport)
   Compiling neqo-udp v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-udp)
   Compiling neqo-crypto v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-crypto)
   Compiling neqo-qpack v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-qpack)
   Compiling neqo-http3 v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-http3)
   Compiling neqo-bin v0.13.4 (/opt/actions-runner/_work/neqo/neqo/neqo/neqo-bin)
    Finished `release` profile [optimized + debuginfo] target(s) in 1m 10s
```

---
Bug introduced in https://github.com/mozilla/neqo/pull/2688.

We might want to re-run some of the recent performance related pull requests, e.g. https://github.com/mozilla/neqo/pull/2729.