### PR TITLE
perf: don't allocate in UDP send path

### DIFF
--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -11,7 +11,7 @@ use std::{
     collections::VecDeque,
     fmt::Display,
     fs::File,
-    io::{BufWriter, Write as _},
+    io::{BufWriter, Cursor, Write as _},
     net::SocketAddr,
     num::NonZeroUsize,
     path::PathBuf,
@@ -190,12 +190,13 @@ impl TryFrom<&State> for CloseState {
 }
 
 impl super::Client for Connection {
-    fn process_multiple_output(
+    fn process_multiple_output<'a>(
         &mut self,
         now: Instant,
+        send_buffer: Cursor<&'a mut [u8]>,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
-        self.process_multiple_output(now, max_datagrams)
+    ) -> OutputBatch<Cursor<&'a mut [u8]>> {
+        self.process_multiple_output(now, send_buffer, max_datagrams)
     }
 
     fn process_multiple_input<'a>(

--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -11,7 +11,7 @@ use std::{
     collections::VecDeque,
     fmt::Display,
     fs::File,
-    io::{BufWriter, Cursor, Write as _},
+    io::{BufWriter, Write as _},
     net::SocketAddr,
     num::NonZeroUsize,
     path::PathBuf,
@@ -29,7 +29,7 @@ use nss::{AuthenticationStatus, ResumptionToken};
 use rustc_hash::FxHashMap as HashMap;
 
 use super::{Args, CloseState, Res, get_output_file, qlog_new};
-use crate::{STREAM_IO_BUFFER_SIZE, now};
+use crate::{STREAM_IO_BUFFER_SIZE, SendBuf, now};
 
 pub struct Handler<'a> {
     streams: HashMap<StreamId, Option<BufWriter<File>>>,
@@ -193,10 +193,10 @@ impl super::Client for Connection {
     fn process_multiple_output<'a>(
         &mut self,
         now: Instant,
-        send_buffer: Cursor<&'a mut [u8]>,
+        send_buf: SendBuf<'a>,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch<Cursor<&'a mut [u8]>> {
-        self.process_multiple_output(now, send_buffer, max_datagrams)
+    ) -> OutputBatch<SendBuf<'a>> {
+        self.process_multiple_output(now, send_buf, max_datagrams)
     }
 
     fn process_multiple_input<'a>(

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -11,7 +11,7 @@ use std::{
     collections::VecDeque,
     fmt::Display,
     fs::File,
-    io::{BufWriter, Write as _},
+    io::{BufWriter, Cursor, Write as _},
     net::SocketAddr,
     num::NonZeroUsize,
     path::PathBuf,
@@ -135,12 +135,13 @@ impl super::Client for Http3Client {
         self.state().try_into()
     }
 
-    fn process_multiple_output(
+    fn process_multiple_output<'a>(
         &mut self,
         now: Instant,
+        send_buf: Cursor<&'a mut [u8]>,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
-        self.process_multiple_output(now, max_datagrams)
+    ) -> OutputBatch<Cursor<&'a mut [u8]>> {
+        self.process_multiple_output(now,  max_datagrams, send_buf,)
     }
 
     fn process_multiple_input<'a>(

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -11,7 +11,7 @@ use std::{
     collections::VecDeque,
     fmt::Display,
     fs::File,
-    io::{BufWriter, Cursor, Write as _},
+    io::{BufWriter, Write as _},
     net::SocketAddr,
     num::NonZeroUsize,
     path::PathBuf,
@@ -31,7 +31,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use super::{Args, CloseState, Res, get_output_file, qlog_new};
 use crate::{
-    STREAM_IO_BUFFER_SIZE, now,
+    STREAM_IO_BUFFER_SIZE, SendBuf, now,
     send_data::{SendData, SendResult},
 };
 
@@ -137,10 +137,10 @@ impl super::Client for Http3Client {
     fn process_multiple_output<'a>(
         &mut self,
         now: Instant,
-        send_buf: Cursor<&'a mut [u8]>,
+        send_buf: SendBuf<'a>,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch<Cursor<&'a mut [u8]>> {
-        self.process_multiple_output(now, max_datagrams, send_buf)
+    ) -> OutputBatch<SendBuf<'a>> {
+        self.process_multiple_output(now, send_buf, max_datagrams)
     }
 
     fn process_multiple_input<'a>(

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -11,7 +11,7 @@ use std::{
     collections::VecDeque,
     fmt::Display,
     fs::File,
-    io::{BufWriter, Write as _},
+    io::{BufWriter, Cursor, Write as _},
     net::SocketAddr,
     num::NonZeroUsize,
     path::PathBuf,
@@ -134,12 +134,13 @@ impl super::Client for Http3Client {
         self.state().try_into()
     }
 
-    fn process_multiple_output(
+    fn process_multiple_output<'a>(
         &mut self,
         now: Instant,
+        send_buf: Cursor<&'a mut [u8]>,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
-        self.process_multiple_output(now, max_datagrams)
+    ) -> OutputBatch<Cursor<&'a mut [u8]>> {
+        self.process_multiple_output(now, max_datagrams, send_buf)
     }
 
     fn process_multiple_input<'a>(

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -10,7 +10,7 @@ use std::{
     collections::VecDeque,
     fmt::Display,
     fs::{File, OpenOptions, create_dir_all},
-    io::{self, BufWriter, ErrorKind},
+    io::{self, BufWriter, Cursor, ErrorKind},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs as _},
     num::NonZeroUsize,
     path::PathBuf,
@@ -388,8 +388,12 @@ enum CloseState {
 
 /// Network client, e.g. [`neqo_transport::Connection`] or [`neqo_http3::Http3Client`].
 trait Client {
-    fn process_multiple_output(&mut self, now: Instant, max_datagrams: NonZeroUsize)
-    -> OutputBatch;
+    fn process_multiple_output<'b>(
+        &mut self,
+        now: Instant,
+        send_buf: Cursor<&'b mut [u8]>,
+        max_datagrams: NonZeroUsize,
+    ) -> OutputBatch<Cursor<&'b mut [u8]>>;
     fn process_multiple_input<'a>(
         &mut self,
         dgrams: impl IntoIterator<Item = Datagram<&'a mut [u8]>>,
@@ -411,6 +415,7 @@ struct Runner<'a, H: Handler> {
     timeout: Option<Pin<Box<Sleep>>>,
     args: &'a Args,
     recv_buf: RecvBuf,
+    send_buf: Vec<u8>,
 }
 
 impl<'a, H: Handler> Runner<'a, H> {
@@ -429,6 +434,7 @@ impl<'a, H: Handler> Runner<'a, H> {
             args,
             timeout: None,
             recv_buf: RecvBuf::default(),
+            send_buf: vec![0; neqo_udp::SEND_BUF_SIZE],
         }
     }
 
@@ -476,7 +482,8 @@ impl<'a, H: Handler> Runner<'a, H> {
                 .inspect_err(|_| qerror!("Socket return GSO size of 0"))
                 .map_err(|_| io::Error::from(ErrorKind::Unsupported))?;
 
-            match self.client.process_multiple_output(now(), max_datagrams) {
+            let send_buffer = Cursor::new(&mut self.send_buf[..]);
+            match self.client.process_multiple_output(now(), send_buffer, max_datagrams) {
                 OutputBatch::DatagramBatch(dgram) => loop {
                     // Optimistically attempt sending datagram. In case the OS
                     // buffer is full, wait till socket is writable then try

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -10,7 +10,7 @@ use std::{
     collections::VecDeque,
     fmt::Display,
     fs::{File, OpenOptions, create_dir_all},
-    io::{self, BufWriter, ErrorKind},
+    io::{self, BufWriter, Cursor, ErrorKind},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs as _},
     num::NonZeroUsize,
     path::PathBuf,
@@ -384,8 +384,12 @@ enum CloseState {
 
 /// Network client, e.g. [`neqo_transport::Connection`] or [`neqo_http3::Http3Client`].
 trait Client {
-    fn process_multiple_output(&mut self, now: Instant, max_datagrams: NonZeroUsize)
-    -> OutputBatch;
+    fn process_multiple_output<'b>(
+        &mut self,
+        now: Instant,
+        send_buf: Cursor<&'b mut [u8]>,
+        max_datagrams: NonZeroUsize,
+    ) -> OutputBatch<Cursor<&'b mut [u8]>>;
     fn process_multiple_input<'a>(
         &mut self,
         dgrams: impl IntoIterator<Item = Datagram<&'a mut [u8]>>,
@@ -407,6 +411,7 @@ struct Runner<'a, H: Handler> {
     timeout: Option<Pin<Box<Sleep>>>,
     args: &'a Args,
     recv_buf: RecvBuf,
+    send_buf: Vec<u8>,
 }
 
 impl<'a, H: Handler> Runner<'a, H> {
@@ -425,6 +430,7 @@ impl<'a, H: Handler> Runner<'a, H> {
             args,
             timeout: None,
             recv_buf: RecvBuf::default(),
+            send_buf: vec![0; neqo_udp::SEND_BUF_SIZE],
         }
     }
 
@@ -472,7 +478,11 @@ impl<'a, H: Handler> Runner<'a, H> {
                 .inspect_err(|_| qerror!("Socket return GSO size of 0"))
                 .map_err(|_| io::Error::from(ErrorKind::Unsupported))?;
 
-            match self.client.process_multiple_output(now(), max_datagrams) {
+            let send_buffer = Cursor::new(&mut self.send_buf[..]);
+            match self
+                .client
+                .process_multiple_output(now(), send_buffer, max_datagrams)
+            {
                 OutputBatch::DatagramBatch(dgram) => loop {
                     // Optimistically attempt sending datagram. In case the OS
                     // buffer is full, wait till socket is writable then try

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -10,7 +10,7 @@ use std::{
     collections::VecDeque,
     fmt::Display,
     fs::{File, OpenOptions, create_dir_all},
-    io::{self, BufWriter, Cursor, ErrorKind},
+    io::{self, BufWriter, ErrorKind},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs as _},
     num::NonZeroUsize,
     path::PathBuf,
@@ -48,7 +48,7 @@ use rustc_hash::FxHashMap as HashMap;
 use thiserror::Error;
 use tokio::time::Sleep;
 
-use crate::{SharedArgs, now};
+use crate::{SendBuf, SharedArgs, now};
 
 mod http09;
 mod http3;
@@ -387,9 +387,9 @@ trait Client {
     fn process_multiple_output<'b>(
         &mut self,
         now: Instant,
-        send_buf: Cursor<&'b mut [u8]>,
+        send_buf: SendBuf<'b>,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch<Cursor<&'b mut [u8]>>;
+    ) -> OutputBatch<SendBuf<'b>>;
     fn process_multiple_input<'a>(
         &mut self,
         dgrams: impl IntoIterator<Item = Datagram<&'a mut [u8]>>,
@@ -478,11 +478,11 @@ impl<'a, H: Handler> Runner<'a, H> {
                 .inspect_err(|_| qerror!("Socket return GSO size of 0"))
                 .map_err(|_| io::Error::from(ErrorKind::Unsupported))?;
 
-            let send_buffer = Cursor::new(&mut self.send_buf[..]);
-            match self
-                .client
-                .process_multiple_output(now(), send_buffer, max_datagrams)
-            {
+            match self.client.process_multiple_output(
+                now(),
+                SendBuf::new(&mut self.send_buf[..]),
+                max_datagrams,
+            ) {
                 OutputBatch::DatagramBatch(dgram) => loop {
                     // Optimistically attempt sending datagram. In case the OS
                     // buffer is full, wait till socket is writable then try

--- a/neqo-bin/src/lib.rs
+++ b/neqo-bin/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 use std::{
+    io::Cursor,
     net::{SocketAddr, ToSocketAddrs as _},
     path::PathBuf,
     time::{Duration, Instant},
@@ -24,6 +25,9 @@ pub mod client;
 mod send_data;
 pub mod server;
 pub mod udp;
+
+/// A view of the long-lived UDP send buffer, handed to `process_*` per call.
+pub type SendBuf<'a> = Cursor<&'a mut [u8]>;
 
 /// Firefox default value
 ///

--- a/neqo-bin/src/server/http09.rs
+++ b/neqo-bin/src/server/http09.rs
@@ -195,7 +195,7 @@ impl super::HttpServer for HttpServer {
         dgrams: D,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         self.server.process_multiple(dgrams, now, max_datagrams)
     }
 

--- a/neqo-bin/src/server/http09.rs
+++ b/neqo-bin/src/server/http09.rs
@@ -24,7 +24,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use super::Args;
 use crate::{
-    STREAM_IO_BUFFER_SIZE,
+    STREAM_IO_BUFFER_SIZE, SendBuf,
     send_data::{SendData, SendResult},
 };
 
@@ -190,13 +190,15 @@ impl HttpServer {
 }
 
 impl super::HttpServer for HttpServer {
-    fn process_multiple<'a, D: IntoIterator<Item = Datagram<&'a mut [u8]>>>(
+    fn process_multiple<'a, 'b, D: IntoIterator<Item = Datagram<&'a mut [u8]>>>(
         &mut self,
         dgrams: D,
         now: Instant,
+        send_buf: SendBuf<'b>,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch<Vec<u8>> {
-        self.server.process_multiple(dgrams, now, max_datagrams)
+    ) -> OutputBatch<SendBuf<'b>> {
+        self.server
+            .process_multiple(dgrams, now, send_buf, max_datagrams)
     }
 
     fn process_events(&mut self, now: Instant) {

--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -5,12 +5,7 @@
 // except according to those terms.
 
 use std::{
-    cell::RefCell,
-    fmt::{self, Display},
-    num::NonZeroUsize,
-    rc::Rc,
-    slice,
-    time::Instant,
+    cell::RefCell, fmt::{self, Display}, num::NonZeroUsize, rc::Rc, slice, time::Instant
 };
 
 use neqo_common::{Datagram, Header, header::HeadersExt as _, qdebug, qerror};
@@ -124,7 +119,7 @@ impl super::HttpServer for HttpServer {
         dgrams: D,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         self.server.process_multiple(dgrams, now, max_datagrams)
     }
 

--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -124,7 +124,7 @@ impl super::HttpServer for HttpServer {
         dgrams: D,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         self.server.process_multiple(dgrams, now, max_datagrams)
     }
 

--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -23,7 +23,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use super::Args;
 use crate::{
-    now,
+    SendBuf, now,
     send_data::{SendData, SendResult},
 };
 
@@ -119,13 +119,15 @@ impl Display for HttpServer {
 }
 
 impl super::HttpServer for HttpServer {
-    fn process_multiple<'a, D: IntoIterator<Item = Datagram<&'a mut [u8]>>>(
+    fn process_multiple<'a, 'b, D: IntoIterator<Item = Datagram<&'a mut [u8]>>>(
         &mut self,
         dgrams: D,
         now: Instant,
+        send_buf: SendBuf<'b>,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch<Vec<u8>> {
-        self.server.process_multiple(dgrams, now, max_datagrams)
+    ) -> OutputBatch<SendBuf<'b>> {
+        self.server
+            .process_multiple(dgrams, now, send_buf, max_datagrams)
     }
 
     fn process_events(&mut self, _now: Instant) {

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -306,7 +306,7 @@ pub trait HttpServer: Display {
         dgrams: D,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch;
+    ) -> OutputBatch<Vec<u8>>;
     fn process_events(&mut self, now: Instant);
     fn has_events(&self) -> bool;
     /// Enables an [`HttpServer`] to drive asynchronous operations.

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -45,7 +45,7 @@ use nss::{
 use thiserror::Error;
 use tokio::time::Sleep;
 
-use crate::{SharedArgs, now, send_data::SendData};
+use crate::{SendBuf, SharedArgs, now, send_data::SendData};
 
 const ANTI_REPLAY_WINDOW: Duration = Duration::from_secs(10);
 
@@ -301,12 +301,13 @@ pub(super) fn response_for_path(path: &str, is_qns_test: bool) -> Result<SendDat
 
 #[expect(clippy::module_name_repetitions, reason = "This is OK.")]
 pub trait HttpServer: Display {
-    fn process_multiple<'a, D: IntoIterator<Item = Datagram<&'a mut [u8]>>>(
+    fn process_multiple<'a, 'b, D: IntoIterator<Item = Datagram<&'a mut [u8]>>>(
         &mut self,
         dgrams: D,
         now: Instant,
+        send_buf: SendBuf<'b>,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch<Vec<u8>>;
+    ) -> OutputBatch<SendBuf<'b>>;
     fn process_events(&mut self, now: Instant);
     fn has_events(&self) -> bool;
     /// Enables an [`HttpServer`] to drive asynchronous operations.
@@ -326,6 +327,7 @@ pub struct Runner<S> {
     timeout: Option<Pin<Box<Sleep>>>,
     sockets: Vec<(SocketAddr, crate::udp::Socket)>,
     recv_buf: RecvBuf,
+    send_buf: Vec<u8>,
 }
 
 impl<S: HttpServer + Unpin> Runner<S> {
@@ -341,6 +343,7 @@ impl<S: HttpServer + Unpin> Runner<S> {
             timeout: None,
             sockets,
             recv_buf: RecvBuf::default(),
+            send_buf: vec![0; neqo_udp::SEND_BUF_SIZE],
         }
     }
 
@@ -371,6 +374,7 @@ impl<S: HttpServer + Unpin> Runner<S> {
         server: &mut S,
         timeout: &mut Option<Pin<Box<Sleep>>>,
         sockets: &mut [(SocketAddr, crate::udp::Socket)],
+        send_buf: &mut [u8],
         now: &dyn Fn() -> Instant,
         mut input_dgrams: Option<DatagramIter<'_>>,
     ) -> Result<(), io::Error> {
@@ -395,6 +399,7 @@ impl<S: HttpServer + Unpin> Runner<S> {
             match server.process_multiple(
                 input_dgrams.take().into_iter().flatten(),
                 now(),
+                SendBuf::new(&mut send_buf[..]),
                 smallest_max_gso_segments,
             ) {
                 OutputBatch::DatagramBatch(dgram) => {
@@ -466,6 +471,7 @@ impl<S: HttpServer + Unpin> Runner<S> {
                 &mut self.server,
                 &mut self.timeout,
                 &mut self.sockets,
+                &mut self.send_buf,
                 &self.now,
                 Some(input_dgrams),
             )
@@ -480,6 +486,7 @@ impl<S: HttpServer + Unpin> Runner<S> {
             &mut self.server,
             &mut self.timeout,
             &mut self.sockets,
+            &mut self.send_buf,
             &self.now,
             None,
         )
@@ -627,16 +634,17 @@ mod tests {
     }
 
     impl HttpServer for MockServer {
-        fn process_multiple<'a, D: IntoIterator<Item = Datagram<&'a mut [u8]>>>(
+        fn process_multiple<'a, 'b, D: IntoIterator<Item = Datagram<&'a mut [u8]>>>(
             &mut self,
             dgrams: D,
             _now: Instant,
+            send_buf: SendBuf<'b>,
             _max_datagrams: NonZeroUsize,
-        ) -> OutputBatch<Vec<u8>> {
+        ) -> OutputBatch<SendBuf<'b>> {
             self.received += dgrams.into_iter().count();
-            self.batches
-                .pop()
-                .map_or(OutputBatch::None, OutputBatch::DatagramBatch)
+            self.batches.pop().map_or(OutputBatch::None, |b| {
+                OutputBatch::DatagramBatch(b.copy_into(send_buf).unwrap())
+            })
         }
 
         fn process_events(&mut self, _now: Instant) {}

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -306,7 +306,7 @@ pub trait HttpServer: Display {
         dgrams: D,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch;
+    ) -> OutputBatch<Vec<u8>>;
     fn process_events(&mut self, now: Instant);
     fn has_events(&self) -> bool;
     /// Enables an [`HttpServer`] to drive asynchronous operations.
@@ -616,7 +616,7 @@ mod tests {
 
     #[derive(Default)]
     struct MockServer {
-        batches: Vec<datagram::Batch>,
+        batches: Vec<datagram::Batch<Vec<u8>>>,
         received: usize,
     }
 
@@ -632,7 +632,7 @@ mod tests {
             dgrams: D,
             _now: Instant,
             _max_datagrams: NonZeroUsize,
-        ) -> OutputBatch {
+        ) -> OutputBatch<Vec<u8>> {
             self.received += dgrams.into_iter().count();
             self.batches
                 .pop()

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -8,7 +8,7 @@
 
 use std::{io, net::SocketAddr};
 
-use neqo_common::{datagram, qdebug};
+use neqo_common::{Buffer, datagram, qdebug};
 use neqo_udp::{DatagramIter, RecvBuf};
 
 /// Ideally this would live in [`neqo_udp`]. [`neqo_udp`] is used in Firefox.
@@ -89,7 +89,7 @@ impl Socket {
     }
 
     /// Send a [`datagram::Batch`] on the given [`Socket`].
-    pub fn send(&self, d: &datagram::Batch) -> io::Result<()> {
+    pub fn send<B: Buffer>(&self, d: &datagram::Batch<B>) -> io::Result<()> {
         self.inner.try_io(tokio::io::Interest::WRITABLE, || {
             neqo_udp::send_inner(&self.state, (&self.inner).into(), d)
         })

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -237,6 +237,23 @@ impl<B: Buffer> PartialEq for Encoder<B> {
 impl<B: Buffer> Eq for Encoder<B> {}
 
 impl<B: Buffer> Encoder<B> {
+    // TODO cfg
+    // TODO hack
+    pub fn to_owned(&self) -> Encoder<Vec<u8>> {
+        dbg!(self.as_ref().len());
+        Encoder {
+            buf: self.as_ref().to_vec(),
+            start: 0,
+        }
+    }
+
+    // TODO: better name?
+    pub fn new_with_buffer(b: B) -> Self {
+        Self {
+            start: b.position(),
+            buf: b,
+        }
+    }
     /// Get the length of the [`Encoder`].
     ///
     /// Note that the length of the underlying buffer might be larger.
@@ -600,6 +617,36 @@ pub trait Buffer: io::Write {
     fn rotate_right(&mut self, start: usize, count: usize);
 }
 
+impl<B: Buffer> Buffer for &mut B {
+    fn position(&self) -> usize {
+        B::position(self)
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        B::as_slice(self)
+    }
+
+    fn as_mut(&mut self) -> &mut [u8] {
+        B::as_mut(self)
+    }
+
+    fn truncate(&mut self, len: usize) {
+        B::truncate(self, len)
+    }
+
+    fn pad_to(&mut self, n: usize, v: u8) {
+        B::pad_to(self, n, v)
+    }
+
+    fn write_at(&mut self, pos: usize, data: u8) {
+        B::write_at(self, pos, data)
+    }
+
+    fn rotate_right(&mut self, start: usize, count: usize) {
+        B::rotate_right(self, start, count)
+    }
+}
+
 impl Buffer for Vec<u8> {
     fn position(&self) -> usize {
         self.len()
@@ -615,36 +662,6 @@ impl Buffer for Vec<u8> {
 
     fn truncate(&mut self, len: usize) {
         Self::truncate(self, len);
-    }
-
-    fn pad_to(&mut self, n: usize, v: u8) {
-        self.resize(n, v);
-    }
-
-    fn write_at(&mut self, pos: usize, data: u8) {
-        self[pos] = data;
-    }
-
-    fn rotate_right(&mut self, start: usize, count: usize) {
-        self[start..].rotate_right(count);
-    }
-}
-
-impl Buffer for &mut Vec<u8> {
-    fn position(&self) -> usize {
-        Vec::len(self)
-    }
-
-    fn as_slice(&self) -> &[u8] {
-        self.as_ref()
-    }
-
-    fn as_mut(&mut self) -> &mut [u8] {
-        self.as_mut_slice()
-    }
-
-    fn truncate(&mut self, len: usize) {
-        Vec::truncate(self, len);
     }
 
     fn pad_to(&mut self, n: usize, v: u8) {

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -236,6 +236,23 @@ impl<B: Buffer> PartialEq for Encoder<B> {
 impl<B: Buffer> Eq for Encoder<B> {}
 
 impl<B: Buffer> Encoder<B> {
+    // TODO cfg
+    // TODO hack
+    pub fn to_owned(&self) -> Encoder<Vec<u8>> {
+        dbg!(self.as_ref().len());
+        Encoder {
+            buf: self.as_ref().to_vec(),
+            start: 0,
+        }
+    }
+
+    // TODO: better name?
+    pub fn new_with_buffer(b: B) -> Self {
+        Self {
+            start: b.position(),
+            buf: b,
+        }
+    }
     /// Get the length of the [`Encoder`].
     ///
     /// Note that the length of the underlying buffer might be larger.
@@ -599,6 +616,36 @@ pub trait Buffer: io::Write {
     fn rotate_right(&mut self, start: usize, count: usize);
 }
 
+impl<B: Buffer> Buffer for &mut B {
+    fn position(&self) -> usize {
+        B::position(self)
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        B::as_slice(self)
+    }
+
+    fn as_mut(&mut self) -> &mut [u8] {
+        B::as_mut(self)
+    }
+
+    fn truncate(&mut self, len: usize) {
+        B::truncate(self, len)
+    }
+
+    fn pad_to(&mut self, n: usize, v: u8) {
+        B::pad_to(self, n, v)
+    }
+
+    fn write_at(&mut self, pos: usize, data: u8) {
+        B::write_at(self, pos, data)
+    }
+
+    fn rotate_right(&mut self, start: usize, count: usize) {
+        B::rotate_right(self, start, count)
+    }
+}
+
 impl Buffer for Vec<u8> {
     fn position(&self) -> usize {
         self.len()
@@ -614,36 +661,6 @@ impl Buffer for Vec<u8> {
 
     fn truncate(&mut self, len: usize) {
         Self::truncate(self, len);
-    }
-
-    fn pad_to(&mut self, n: usize, v: u8) {
-        self.resize(n, v);
-    }
-
-    fn write_at(&mut self, pos: usize, data: u8) {
-        self[pos] = data;
-    }
-
-    fn rotate_right(&mut self, start: usize, count: usize) {
-        self[start..].rotate_right(count);
-    }
-}
-
-impl Buffer for &mut Vec<u8> {
-    fn position(&self) -> usize {
-        Vec::len(self)
-    }
-
-    fn as_slice(&self) -> &[u8] {
-        self.as_ref()
-    }
-
-    fn as_mut(&mut self) -> &mut [u8] {
-        self.as_mut_slice()
-    }
-
-    fn truncate(&mut self, len: usize) {
-        Vec::truncate(self, len);
     }
 
     fn pad_to(&mut self, n: usize, v: u8) {

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -236,23 +236,15 @@ impl<B: Buffer> PartialEq for Encoder<B> {
 impl<B: Buffer> Eq for Encoder<B> {}
 
 impl<B: Buffer> Encoder<B> {
-    // TODO cfg
-    // TODO hack
-    pub fn to_owned(&self) -> Encoder<Vec<u8>> {
-        dbg!(self.as_ref().len());
-        Encoder {
-            buf: self.as_ref().to_vec(),
-            start: 0,
-        }
-    }
-
-    // TODO: better name?
-    pub fn new_with_buffer(b: B) -> Self {
+    /// Append to `b`; [`Encoder::len`] counts only what this [`Encoder`] writes.
+    #[must_use]
+    pub fn new(b: B) -> Self {
         Self {
             start: b.position(),
             buf: b,
         }
     }
+
     /// Get the length of the [`Encoder`].
     ///
     /// Note that the length of the underlying buffer might be larger.
@@ -578,16 +570,6 @@ impl<'a> Encoder<Cursor<&'a mut [u8]>> {
     }
 }
 
-impl<'a> Encoder<&'a mut Vec<u8>> {
-    #[must_use]
-    pub fn new_borrowed_vec(buf: &'a mut Vec<u8>) -> Self {
-        Encoder {
-            start: buf.position(),
-            buf,
-        }
-    }
-}
-
 /// Extends a memory buffer with methods beyond [`std::io::Write`]. Needed for
 /// [`Encoder`].
 ///
@@ -599,6 +581,11 @@ pub trait Buffer: io::Write {
 
     fn is_empty(&self) -> bool {
         self.position() == 0
+    }
+
+    /// How many more bytes can be written, or [`None`] if the buffer grows.
+    fn available(&self) -> Option<usize> {
+        None
     }
 
     fn as_slice(&self) -> &[u8];
@@ -621,6 +608,10 @@ impl<B: Buffer> Buffer for &mut B {
         B::position(self)
     }
 
+    fn available(&self) -> Option<usize> {
+        B::available(self)
+    }
+
     fn as_slice(&self) -> &[u8] {
         B::as_slice(self)
     }
@@ -630,19 +621,19 @@ impl<B: Buffer> Buffer for &mut B {
     }
 
     fn truncate(&mut self, len: usize) {
-        B::truncate(self, len)
+        B::truncate(self, len);
     }
 
     fn pad_to(&mut self, n: usize, v: u8) {
-        B::pad_to(self, n, v)
+        B::pad_to(self, n, v);
     }
 
     fn write_at(&mut self, pos: usize, data: u8) {
-        B::write_at(self, pos, data)
+        B::write_at(self, pos, data);
     }
 
     fn rotate_right(&mut self, start: usize, count: usize) {
-        B::rotate_right(self, start, count)
+        B::rotate_right(self, start, count);
     }
 }
 
@@ -679,6 +670,10 @@ impl Buffer for Vec<u8> {
 impl Buffer for Cursor<&mut [u8]> {
     fn position(&self) -> usize {
         expect_usize(self.position())
+    }
+
+    fn available(&self) -> Option<usize> {
+        Some(self.get_ref().len() - Buffer::position(self))
     }
 
     fn as_slice(&self) -> &[u8] {
@@ -1251,7 +1246,7 @@ mod tests {
         check_as_mut(Encoder::default());
 
         let mut buf = Vec::<u8>::new();
-        check_as_mut(Encoder::new_borrowed_vec(&mut buf));
+        check_as_mut(Encoder::new(&mut buf));
 
         let mut buf = [0; 16];
         check_as_mut(Encoder::new_borrowed_slice(&mut buf[..]));
@@ -1264,7 +1259,7 @@ mod tests {
         let mut non_empty_vec = vec![1, 2, 3, 4];
         assert_eq!(non_empty_vec.len(), Buffer::position(&non_empty_vec));
 
-        let mut enc = Encoder::new_borrowed_vec(&mut non_empty_vec);
+        let mut enc = Encoder::new(&mut non_empty_vec);
         assert!(enc.is_empty());
         enc.encode_byte(5);
         assert!(!enc.is_empty());
@@ -1311,7 +1306,7 @@ mod tests {
     #[test]
     fn as_decoder_exposes_encoded_bytes_only_not_whole_buffer() {
         let mut buffer = vec![1, 2, 3, 4];
-        let mut enc = Encoder::new_borrowed_vec(&mut buffer);
+        let mut enc = Encoder::new(&mut buffer);
         enc.encode([5, 6, 7]);
 
         let decoder = enc.as_decoder();

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -11,7 +11,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use crate::{Bytes, Tos, hex_with_len};
+use crate::{Buffer, Bytes, Tos, hex_with_len};
 
 /// A UDP datagram.
 ///
@@ -24,10 +24,10 @@ pub struct Datagram<D = Vec<u8>> {
     d: D,
 }
 
-impl TryFrom<Batch> for Datagram {
+impl<B: Buffer> TryFrom<Batch<B>> for Datagram {
     type Error = ();
 
-    fn try_from(d: Batch) -> Result<Self, Self::Error> {
+    fn try_from(d: Batch<B>) -> Result<Self, Self::Error> {
         if d.num_datagrams() != 1 {
             return Err(());
         }
@@ -35,7 +35,8 @@ impl TryFrom<Batch> for Datagram {
             src: d.src,
             dst: d.dst,
             tos: d.tos,
-            d: d.d,
+            // TODO: Performance footgun?
+            d: d.d.as_slice().to_vec(),
         })
     }
 }
@@ -155,16 +156,18 @@ impl<D: AsRef<[u8]>> AsRef<[u8]> for Datagram<D> {
 ///
 /// Upholds Linux GSO requirement. That is, all but the last datagram in the
 /// batch have the same size. The last datagram may be equal or smaller.
+///
+/// TODO: pub fields good idea?
 #[derive(Clone, PartialEq, Eq)]
-pub struct Batch {
+pub struct Batch<B> {
     src: SocketAddr,
     dst: SocketAddr,
     tos: Tos,
     datagram_size: NonZeroUsize,
-    d: Vec<u8>,
+    d: B,
 }
 
-impl Debug for Batch {
+impl<B: Buffer> Debug for Batch<B> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
@@ -173,12 +176,12 @@ impl Debug for Batch {
             self.src,
             self.dst,
             self.datagram_size,
-            hex_with_len(&self.d)
+            hex_with_len(self.d.as_slice())
         )
     }
 }
 
-impl From<Datagram<Vec<u8>>> for Batch {
+impl From<Datagram<Vec<u8>>> for Batch<Vec<u8>> {
     fn from(d: Datagram<Vec<u8>>) -> Self {
         Self {
             src: d.src,
@@ -191,14 +194,25 @@ impl From<Datagram<Vec<u8>>> for Batch {
     }
 }
 
-impl Batch {
+impl<B: Buffer> Batch<B> {
+    /// Maximum [`Batch`] size in bytes.
+    ///
+    /// This value is set conservatively to ensure compatibility with batch IO
+    /// system calls across all supported platforms.
+    ///
+    /// See for example Linux limit in
+    /// <https://github.com/torvalds/linux/blob/fb4d33ab452ea254e2c319bac5703d1b56d895bf/include/linux/netdevice.h#L2402>.
+    pub const MAX: usize = 65535 // maximum UDP datagram size
+        - 40 // IPv6 header
+        - 8; // UDP header
+
     #[must_use]
     pub const fn new(
         src: SocketAddr,
         dst: SocketAddr,
         tos: Tos,
         datagram_size: NonZeroUsize,
-        d: Vec<u8>,
+        d: B,
     ) -> Self {
         Self {
             src,
@@ -235,16 +249,16 @@ impl Batch {
 
     #[must_use]
     pub fn data(&self) -> &[u8] {
-        &self.d
+        self.d.as_slice()
     }
 
     #[must_use]
-    pub const fn num_datagrams(&self) -> usize {
-        self.d.len().div_ceil(self.datagram_size.get())
+    pub fn num_datagrams(&self) -> usize {
+        self.d.position().div_ceil(self.datagram_size.get())
     }
 
     pub fn iter(&self) -> impl Iterator<Item = Datagram<&[u8]>> {
-        self.d.chunks(self.datagram_size.get()).map(|d| Datagram {
+        self.d.as_slice().chunks(self.datagram_size.get()).map(|d| Datagram {
             src: self.src,
             dst: self.dst,
             tos: self.tos,
@@ -253,12 +267,17 @@ impl Batch {
     }
 
     pub fn iter_mut(&mut self) -> impl Iterator<Item = Datagram<&mut [u8]>> {
+        let datagram_size = self.datagram_size.get();
+        let src = self.src;
+        let dst = self.dst;
+        let tos = self.tos;
         self.d
-            .chunks_mut(self.datagram_size.get())
-            .map(|d| Datagram {
-                src: self.src,
-                dst: self.dst,
-                tos: self.tos,
+            .as_mut()
+            .chunks_mut(datagram_size)
+            .map(move |d| Datagram {
+                src,
+                dst,
+                tos,
                 d,
             })
     }
@@ -308,6 +327,8 @@ mod tests {
         let src = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1234);
         let dst = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 5678);
         let tos = Tos::default();
+
+        // TODO: cleanup the &mut
 
         // 10 bytes, segment size 4 -> 3 datagrams (4+4+2)
         let batch =

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -6,6 +6,7 @@
 
 use std::{
     fmt::{self, Debug, Formatter},
+    io,
     net::SocketAddr,
     num::NonZeroUsize,
     ops::{Deref, DerefMut},
@@ -24,10 +25,11 @@ pub struct Datagram<D = Vec<u8>> {
     d: D,
 }
 
-impl<B: Buffer> TryFrom<Batch<B>> for Datagram {
+// Only for `Vec<u8>`, so that the buffer is moved rather than copied.
+impl TryFrom<Batch<Vec<u8>>> for Datagram {
     type Error = ();
 
-    fn try_from(d: Batch<B>) -> Result<Self, Self::Error> {
+    fn try_from(d: Batch<Vec<u8>>) -> Result<Self, Self::Error> {
         if d.num_datagrams() != 1 {
             return Err(());
         }
@@ -35,8 +37,7 @@ impl<B: Buffer> TryFrom<Batch<B>> for Datagram {
             src: d.src,
             dst: d.dst,
             tos: d.tos,
-            // TODO: Performance footgun?
-            d: d.d.as_slice().to_vec(),
+            d: d.d,
         })
     }
 }
@@ -156,8 +157,6 @@ impl<D: AsRef<[u8]>> AsRef<[u8]> for Datagram<D> {
 ///
 /// Upholds Linux GSO requirement. That is, all but the last datagram in the
 /// batch have the same size. The last datagram may be equal or smaller.
-///
-/// TODO: pub fields good idea?
 #[derive(Clone, PartialEq, Eq)]
 pub struct Batch<B> {
     src: SocketAddr,
@@ -195,17 +194,6 @@ impl From<Datagram<Vec<u8>>> for Batch<Vec<u8>> {
 }
 
 impl<B: Buffer> Batch<B> {
-    /// Maximum [`Batch`] size in bytes.
-    ///
-    /// This value is set conservatively to ensure compatibility with batch IO
-    /// system calls across all supported platforms.
-    ///
-    /// See for example Linux limit in
-    /// <https://github.com/torvalds/linux/blob/fb4d33ab452ea254e2c319bac5703d1b56d895bf/include/linux/netdevice.h#L2402>.
-    pub const MAX: usize = 65535 // maximum UDP datagram size
-        - 40 // IPv6 header
-        - 8; // UDP header
-
     #[must_use]
     pub const fn new(
         src: SocketAddr,
@@ -221,6 +209,28 @@ impl<B: Buffer> Batch<B> {
             datagram_size,
             d,
         }
+    }
+
+    /// Copy into `buffer`, which must be empty, returning a [`Batch`] over it.
+    ///
+    /// # Errors
+    /// When `buffer` cannot hold the contents.
+    pub fn copy_into<C: Buffer>(&self, mut buffer: C) -> Result<Batch<C>, io::Error> {
+        debug_assert!(buffer.is_empty());
+        // `write_all` writes what fits before failing, so undo a partial write.
+        // Back to the entry position, not 0, to not discard a caller's bytes.
+        let start = buffer.position();
+        if let Err(e) = buffer.write_all(self.data()) {
+            buffer.truncate(start);
+            return Err(e);
+        }
+        Ok(Batch {
+            src: self.src,
+            dst: self.dst,
+            tos: self.tos,
+            datagram_size: self.datagram_size,
+            d: buffer,
+        })
     }
 
     #[must_use]
@@ -285,13 +295,14 @@ impl<B: Buffer> Batch<B> {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::{
+        io::Cursor,
         net::{IpAddr, Ipv6Addr, SocketAddr},
         num::NonZeroUsize,
     };
 
     use test_fixture::{DEFAULT_ADDR, datagram};
 
-    use crate::{Datagram, Ecn, Tos, datagram};
+    use crate::{Buffer, Datagram, Ecn, Tos, datagram};
 
     #[test]
     fn fmt_datagram() {
@@ -326,8 +337,6 @@ mod tests {
         let dst = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 5678);
         let tos = Tos::default();
 
-        // TODO: cleanup the &mut
-
         // 10 bytes, segment size 4 -> 3 datagrams (4+4+2)
         let batch =
             datagram::Batch::new(src, dst, tos, NonZeroUsize::new(4).unwrap(), vec![0u8; 10]);
@@ -360,6 +369,46 @@ mod tests {
         );
         batch.set_tos(Ecn::Ce.into());
         assert_eq!(batch.tos(), Ecn::Ce.into());
+    }
+
+    #[test]
+    fn batch_copy_into() {
+        let src = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1234);
+        let dst = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 5678);
+        let batch = datagram::Batch::new(
+            src,
+            dst,
+            Ecn::Ce.into(),
+            NonZeroUsize::new(4).unwrap(),
+            vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+        );
+
+        let mut buf = [0; 16];
+        let copy = batch.copy_into(Cursor::new(&mut buf[..])).unwrap();
+        assert_eq!(copy.source(), src);
+        assert_eq!(copy.destination(), dst);
+        assert_eq!(copy.tos(), Ecn::Ce.into());
+        assert_eq!(copy.datagram_size(), batch.datagram_size());
+        assert_eq!(copy.data(), batch.data());
+        assert_eq!(copy.num_datagrams(), batch.num_datagrams());
+    }
+
+    #[test]
+    fn batch_copy_into_too_small() {
+        let addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1234);
+        let batch = datagram::Batch::new(
+            addr,
+            addr,
+            Tos::default(),
+            NonZeroUsize::new(4).unwrap(),
+            vec![0u8; 10],
+        );
+
+        let mut buf = [0; 4];
+        let mut cursor = Cursor::new(&mut buf[..]);
+        assert!(batch.copy_into(&mut cursor).is_err());
+        assert_eq!(Buffer::position(&cursor), 0);
+        assert_eq!(buf, [0; 4]);
     }
 
     #[test]

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -11,7 +11,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use crate::{Bytes, Tos, hex::HexWithLen};
+use crate::{Buffer, Bytes, Tos, hex::HexWithLen};
 
 /// A UDP datagram.
 ///
@@ -24,10 +24,10 @@ pub struct Datagram<D = Vec<u8>> {
     d: D,
 }
 
-impl TryFrom<Batch> for Datagram {
+impl<B: Buffer> TryFrom<Batch<B>> for Datagram {
     type Error = ();
 
-    fn try_from(d: Batch) -> Result<Self, Self::Error> {
+    fn try_from(d: Batch<B>) -> Result<Self, Self::Error> {
         if d.num_datagrams() != 1 {
             return Err(());
         }
@@ -35,7 +35,8 @@ impl TryFrom<Batch> for Datagram {
             src: d.src,
             dst: d.dst,
             tos: d.tos,
-            d: d.d,
+            // TODO: Performance footgun?
+            d: d.d.as_slice().to_vec(),
         })
     }
 }
@@ -155,16 +156,18 @@ impl<D: AsRef<[u8]>> AsRef<[u8]> for Datagram<D> {
 ///
 /// Upholds Linux GSO requirement. That is, all but the last datagram in the
 /// batch have the same size. The last datagram may be equal or smaller.
+///
+/// TODO: pub fields good idea?
 #[derive(Clone, PartialEq, Eq)]
-pub struct Batch {
+pub struct Batch<B> {
     src: SocketAddr,
     dst: SocketAddr,
     tos: Tos,
     datagram_size: NonZeroUsize,
-    d: Vec<u8>,
+    d: B,
 }
 
-impl Debug for Batch {
+impl<B: Buffer> Debug for Batch<B> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
@@ -173,12 +176,12 @@ impl Debug for Batch {
             self.src,
             self.dst,
             self.datagram_size,
-            HexWithLen::new(&self.d)
+            HexWithLen::new(self.d.as_slice())
         )
     }
 }
 
-impl From<Datagram<Vec<u8>>> for Batch {
+impl From<Datagram<Vec<u8>>> for Batch<Vec<u8>> {
     fn from(d: Datagram<Vec<u8>>) -> Self {
         Self {
             src: d.src,
@@ -191,14 +194,25 @@ impl From<Datagram<Vec<u8>>> for Batch {
     }
 }
 
-impl Batch {
+impl<B: Buffer> Batch<B> {
+    /// Maximum [`Batch`] size in bytes.
+    ///
+    /// This value is set conservatively to ensure compatibility with batch IO
+    /// system calls across all supported platforms.
+    ///
+    /// See for example Linux limit in
+    /// <https://github.com/torvalds/linux/blob/fb4d33ab452ea254e2c319bac5703d1b56d895bf/include/linux/netdevice.h#L2402>.
+    pub const MAX: usize = 65535 // maximum UDP datagram size
+        - 40 // IPv6 header
+        - 8; // UDP header
+
     #[must_use]
     pub const fn new(
         src: SocketAddr,
         dst: SocketAddr,
         tos: Tos,
         datagram_size: NonZeroUsize,
-        d: Vec<u8>,
+        d: B,
     ) -> Self {
         Self {
             src,
@@ -235,32 +249,35 @@ impl Batch {
 
     #[must_use]
     pub fn data(&self) -> &[u8] {
-        &self.d
+        self.d.as_slice()
     }
 
     #[must_use]
-    pub const fn num_datagrams(&self) -> usize {
-        self.d.len().div_ceil(self.datagram_size.get())
+    pub fn num_datagrams(&self) -> usize {
+        self.d.position().div_ceil(self.datagram_size.get())
     }
 
     pub fn iter(&self) -> impl Iterator<Item = Datagram<&[u8]>> {
-        self.d.chunks(self.datagram_size.get()).map(|d| Datagram {
-            src: self.src,
-            dst: self.dst,
-            tos: self.tos,
-            d,
-        })
-    }
-
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = Datagram<&mut [u8]>> {
         self.d
-            .chunks_mut(self.datagram_size.get())
+            .as_slice()
+            .chunks(self.datagram_size.get())
             .map(|d| Datagram {
                 src: self.src,
                 dst: self.dst,
                 tos: self.tos,
                 d,
             })
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = Datagram<&mut [u8]>> {
+        let datagram_size = self.datagram_size.get();
+        let src = self.src;
+        let dst = self.dst;
+        let tos = self.tos;
+        self.d
+            .as_mut()
+            .chunks_mut(datagram_size)
+            .map(move |d| Datagram { src, dst, tos, d })
     }
 }
 
@@ -308,6 +325,8 @@ mod tests {
         let src = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1234);
         let dst = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 5678);
         let tos = Tos::default();
+
+        // TODO: cleanup the &mut
 
         // 10 bytes, segment size 4 -> 3 datagrams (4+4+2)
         let batch =

--- a/neqo-http3/src/buffered_send_stream.rs
+++ b/neqo-http3/src/buffered_send_stream.rs
@@ -43,7 +43,7 @@ impl BufferedStream {
 
     pub fn encode_with<F: FnOnce(&mut Encoder<&mut Vec<u8>>)>(&mut self, f: F) {
         if let Self::Initialized { buf, .. } = self {
-            f(&mut Encoder::new_borrowed_vec(buf));
+            f(&mut Encoder::new(buf));
         } else {
             debug_assert!(false, "Do not encode data before the stream is initialized");
         }
@@ -135,7 +135,7 @@ impl BufferedStream {
         let Some((stream_id, buf)) = self.prepare_atomic_send(conn, now)? else {
             return Ok(false);
         };
-        f(&mut Encoder::new_borrowed_vec(buf));
+        f(&mut Encoder::new(buf));
         let len = buf.len();
         let res = conn.stream_send_atomic(stream_id, buf);
         buf.clear();

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -15,8 +15,8 @@ use std::{
 };
 
 use neqo_common::{
-    Datagram, Decoder, Encoder, Header, MessageType, Role, event::Provider as EventProvider, hex,
-    hex_with_len, qdebug, qinfo, qlog::Qlog, qtrace, qwarn,
+    Buffer, Datagram, Decoder, Encoder, Header, MessageType, Role, event::Provider as EventProvider,
+    hex, hex_with_len, qdebug, qinfo, qlog::Qlog, qtrace, qwarn,
 };
 use neqo_qpack::Stats as QpackStats;
 use neqo_transport::{
@@ -801,7 +801,8 @@ impl Http3Client {
     /// output datagram only.
     #[expect(clippy::missing_panics_doc, reason = "see expect()")]
     pub fn process_output(&mut self, now: Instant) -> Output {
-        self.process_multiple_output(now, 1.try_into().expect(">0"))
+        let send_buffer = vec![];
+        self.process_multiple_output(now, 1.try_into().expect(">0"), send_buffer)
             .try_into()
             .expect("max_datagrams is 1")
     }
@@ -833,17 +834,18 @@ impl Http3Client {
     /// [1]: ../neqo_transport/enum.Output.html
     /// [2]: ../neqo_transport/struct.ConnectionEvents.html
     /// [3]: ../neqo_transport/struct.Connection.html#method.process_output
-    pub fn process_multiple_output(
+    pub fn process_multiple_output<B: Buffer>(
         &mut self,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+        send_buffer: B,
+    ) -> OutputBatch<B> {
         qtrace!("[{self}] Process output");
 
         // Maybe send() stuff on http3-managed streams
         self.process_http3(now);
 
-        let out = self.conn.process_multiple_output(now, max_datagrams);
+        let out = self.conn.process_multiple_output(now, send_buffer, max_datagrams);
 
         // Update H3 for any transport state changes and events
         self.process_http3(now);

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -766,7 +766,7 @@ impl Http3Client {
     #[expect(clippy::missing_panics_doc, reason = "see expect()")]
     pub fn process_output(&mut self, now: Instant) -> Output {
         let send_buffer = vec![];
-        self.process_multiple_output(now, 1.try_into().expect(">0"), send_buffer)
+        self.process_multiple_output(now, send_buffer, NonZeroUsize::MIN)
             .try_into()
             .expect("max_datagrams is 1")
     }
@@ -798,11 +798,12 @@ impl Http3Client {
     /// [1]: ../neqo_transport/enum.Output.html
     /// [2]: ../neqo_transport/struct.ConnectionEvents.html
     /// [3]: ../neqo_transport/struct.Connection.html#method.process_output
+    /// `send_buffer` must be empty.
     pub fn process_multiple_output<B: Buffer>(
         &mut self,
         now: Instant,
-        max_datagrams: NonZeroUsize,
         send_buffer: B,
+        max_datagrams: NonZeroUsize,
     ) -> OutputBatch<B> {
         qtrace!("[{self}] Process output");
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use neqo_common::{
-    Datagram, Decoder, Encoder, Header, Role,
+    Buffer, Datagram, Decoder, Encoder, Header, Role,
     event::Provider as EventProvider,
     hex::{Hex, HexWithLen},
     qdebug, qinfo,
@@ -765,7 +765,8 @@ impl Http3Client {
     /// output datagram only.
     #[expect(clippy::missing_panics_doc, reason = "see expect()")]
     pub fn process_output(&mut self, now: Instant) -> Output {
-        self.process_multiple_output(now, 1.try_into().expect(">0"))
+        let send_buffer = vec![];
+        self.process_multiple_output(now, 1.try_into().expect(">0"), send_buffer)
             .try_into()
             .expect("max_datagrams is 1")
     }
@@ -797,17 +798,20 @@ impl Http3Client {
     /// [1]: ../neqo_transport/enum.Output.html
     /// [2]: ../neqo_transport/struct.ConnectionEvents.html
     /// [3]: ../neqo_transport/struct.Connection.html#method.process_output
-    pub fn process_multiple_output(
+    pub fn process_multiple_output<B: Buffer>(
         &mut self,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+        send_buffer: B,
+    ) -> OutputBatch<B> {
         qtrace!("[{self}] Process output");
 
         // Maybe send() stuff on http3-managed streams
         self.process_http3(now);
 
-        let out = self.conn.process_multiple_output(now, max_datagrams);
+        let out = self
+            .conn
+            .process_multiple_output(now, send_buffer, max_datagrams);
 
         // Update H3 for any transport state changes and events
         self.process_http3(now);

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -136,7 +136,7 @@ impl Http3Server {
         dgrams: I,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         qtrace!("[{self}] Process");
         let out = self.server.process_multiple_input(dgrams, now);
         self.process_http3(now);
@@ -146,9 +146,7 @@ impl Http3Server {
                 qtrace!("[{self}] Send packet: {d:?}");
                 OutputBatch::DatagramBatch(d)
             }
-            _ => self
-                .server
-                .process_multiple(Option::<Datagram>::None, now, max_datagrams),
+            _ => self.server.process_multiple(std::iter::empty::<Datagram<Vec<u8>>>(), now, max_datagrams),
         }
     }
 

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -13,7 +13,7 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{Datagram, qtrace};
+use neqo_common::{Buffer, Datagram, qtrace};
 use neqo_transport::{
     ConnectionIdGenerator, Output, OutputBatch,
     server::{ConnectionRef, Server, ValidateAddress},
@@ -126,29 +126,36 @@ impl Http3Server {
         dgrams: I,
         now: Instant,
     ) -> Output {
-        self.process_multiple(dgrams, now, 1.try_into().expect(">0"))
+        self.process_multiple(dgrams, now, Vec::new(), NonZeroUsize::MIN)
             .try_into()
             .expect("max_datagrams is 1")
     }
 
-    pub fn process_multiple<A: AsRef<[u8]> + AsMut<[u8]>, I: IntoIterator<Item = Datagram<A>>>(
+    /// `send_buffer` must be empty.
+    pub fn process_multiple<
+        A: AsRef<[u8]> + AsMut<[u8]>,
+        I: IntoIterator<Item = Datagram<A>>,
+        B: Buffer,
+    >(
         &mut self,
         dgrams: I,
         now: Instant,
+        send_buffer: B,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch<Vec<u8>> {
+    ) -> OutputBatch<B> {
         qtrace!("[{self}] Process");
         let out = self.server.process_multiple_input(dgrams, now);
         self.process_http3(now);
         // If we do not that a dgram already try again after process_http3.
         match out {
-            OutputBatch::DatagramBatch(d) => {
-                qtrace!("[{self}] Send packet: {d:?}");
-                OutputBatch::DatagramBatch(d)
+            o @ OutputBatch::DatagramBatch(_) => {
+                qtrace!("[{self}] Send packet: {o:?}");
+                self.server.copy_output_into(o, send_buffer)
             }
             _ => self.server.process_multiple(
                 std::iter::empty::<Datagram<Vec<u8>>>(),
                 now,
+                send_buffer,
                 max_datagrams,
             ),
         }

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -136,7 +136,7 @@ impl Http3Server {
         dgrams: I,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         qtrace!("[{self}] Process");
         let out = self.server.process_multiple_input(dgrams, now);
         self.process_http3(now);
@@ -146,9 +146,11 @@ impl Http3Server {
                 qtrace!("[{self}] Send packet: {d:?}");
                 OutputBatch::DatagramBatch(d)
             }
-            _ => self
-                .server
-                .process_multiple(Option::<Datagram>::None, now, max_datagrams),
+            _ => self.server.process_multiple(
+                std::iter::empty::<Datagram<Vec<u8>>>(),
+                now,
+                max_datagrams,
+            ),
         }
     }
 

--- a/neqo-http3/tests/connect_udp.rs
+++ b/neqo-http3/tests/connect_udp.rs
@@ -128,7 +128,7 @@ fn exchange_packets_through_proxy(
 
     qinfo!("Processing client_outer");
     let mut client_outer_dgrams = client_outer
-        .process_multiple_output(now(), 64.try_into().unwrap())
+        .process_multiple_output(now(), 64.try_into().unwrap(), Vec::new())
         .dgram()
         .unwrap();
 

--- a/neqo-http3/tests/connect_udp.rs
+++ b/neqo-http3/tests/connect_udp.rs
@@ -128,7 +128,7 @@ fn exchange_packets_through_proxy(
 
     qinfo!("Processing client_outer");
     let mut client_outer_dgrams = client_outer
-        .process_multiple_output(now(), 64.try_into().unwrap(), Vec::new())
+        .process_multiple_output(now(), Vec::new(), 64.try_into().unwrap())
         .dgram()
         .unwrap();
 
@@ -137,6 +137,7 @@ fn exchange_packets_through_proxy(
         .process_multiple(
             client_outer_dgrams.iter_mut(),
             now(),
+            Vec::new(),
             64.try_into().unwrap(),
         )
         .dgram();

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -105,10 +105,10 @@ pub enum Output {
     Callback(Duration),
 }
 
-impl TryFrom<OutputBatch> for Output {
+impl<B: Buffer> TryFrom<OutputBatch<B>> for Output {
     type Error = ();
 
-    fn try_from(value: OutputBatch) -> Result<Self, Self::Error> {
+    fn try_from(value: OutputBatch<B>) -> Result<Self, Self::Error> {
         match value {
             OutputBatch::None => Ok(Self::None),
             OutputBatch::DatagramBatch(dg) => Ok(Self::Datagram(dg.try_into()?)),
@@ -118,17 +118,17 @@ impl TryFrom<OutputBatch> for Output {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum OutputBatch {
+pub enum OutputBatch<B: Buffer> {
     /// Connection requires no action.
     None,
     /// Connection requires the datagram batch be sent.
-    DatagramBatch(datagram::Batch),
+    DatagramBatch(datagram::Batch<B>),
     /// Connection requires `process_input()` be called when the `Duration`
     /// elapses.
     Callback(Duration),
 }
 
-impl From<Output> for OutputBatch {
+impl From<Output> for OutputBatch<Vec<u8>> {
     fn from(value: Output) -> Self {
         match value {
             Output::None => Self::None,
@@ -138,10 +138,10 @@ impl From<Output> for OutputBatch {
     }
 }
 
-impl OutputBatch {
-    /// Convert into an [`Option<datagram::Batch>`].
+impl<B: Buffer> OutputBatch<B> {
+    /// Convert into an [`Option<datagram::Batch<B>>`].
     #[must_use]
-    pub fn dgram(self) -> Option<datagram::Batch> {
+    pub fn dgram(self) -> Option<datagram::Batch<B>> {
         match self {
             Self::DatagramBatch(dg) => Some(dg),
             _ => None,
@@ -185,14 +185,14 @@ impl From<Option<Datagram>> for Output {
 }
 
 /// Used by inner functions like `Connection::output`.
-enum SendOptionBatch {
+enum SendOptionBatch<B> {
     /// Yes, please send this datagram.
-    Yes(datagram::Batch),
+    Yes(datagram::Batch<B>),
     /// Don't send.  If this was blocked on the pacer (the arg is true).
     No(bool),
 }
 
-impl Default for SendOptionBatch {
+impl<B> Default for SendOptionBatch<B> {
     fn default() -> Self {
         Self::No(false)
     }
@@ -1214,7 +1214,8 @@ impl Connection {
     #[expect(clippy::missing_panics_doc, reason = "see expect()")]
     #[must_use = "Output of the process_output function must be handled"]
     pub fn process_output(&mut self, now: Instant) -> Output {
-        self.process_multiple_output(now, 1.try_into().expect(">0"))
+        let mut send_buffer = vec![];
+        self.process_multiple_output(now, &mut send_buffer, 1.try_into().expect(">0"))
             .try_into()
             .expect("max_datagrams is 1")
     }
@@ -1224,11 +1225,12 @@ impl Connection {
     /// Returns datagrams to send, and how long to wait before calling again
     /// even if no incoming packets.
     #[must_use = "OutputBatch of the process_multiple_output function must be handled"]
-    pub fn process_multiple_output(
+    pub fn process_multiple_output<B: Buffer>(
         &mut self,
         now: Instant,
+        send_buffer: B,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<B> {
         qtrace!("[{self}] process_output {:?} {now:?}", self.state);
 
         match (&self.state, self.role) {
@@ -1244,7 +1246,7 @@ impl Connection {
             }
         }
 
-        match self.output(now, max_datagrams) {
+        match self.output(now, send_buffer, max_datagrams) {
             SendOptionBatch::Yes(dgram) => OutputBatch::DatagramBatch(dgram),
             SendOptionBatch::No(paced) => match self.state {
                 State::Init | State::Closed(_) => OutputBatch::None,
@@ -1278,19 +1280,21 @@ impl Connection {
         dgram: Option<Datagram<A>>,
         now: Instant,
     ) -> Output {
-        self.process_multiple(dgram, now, 1.try_into().expect(">0"))
+        let mut send_buffer = vec![];
+        self.process_multiple(dgram, now,  &mut send_buffer, 1.try_into().expect(">0"),)
             .try_into()
             .expect("max_datagrams is 1")
     }
 
     /// Process input and generate output.
     #[must_use = "OutputBatch of the process_multiple function must be handled"]
-    pub fn process_multiple<A: AsRef<[u8]> + AsMut<[u8]>>(
+    pub fn process_multiple<A: AsRef<[u8]> + AsMut<[u8]>, B: Buffer>(
         &mut self,
         dgram: Option<Datagram<A>>,
         now: Instant,
+        send_buffer: B,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<B> {
         if let Some(d) = dgram {
             // Snapshot timer type before ACKs can alter loss state.
             if let Some(path) = self.paths.primary() {
@@ -1299,7 +1303,7 @@ impl Connection {
             self.input(d, now, now);
             self.process_saved(now);
         }
-        let output = self.process_multiple_output(now, max_datagrams);
+        let output = self.process_multiple_output(now, send_buffer, max_datagrams);
         #[cfg(feature = "build-fuzzing-corpus")]
         if self.test_frame_writer.is_none()
             && let OutputBatch::DatagramBatch(batch) = &output
@@ -2219,7 +2223,12 @@ impl Connection {
         }
     }
 
-    fn output(&mut self, now: Instant, max_datagrams: NonZeroUsize) -> SendOptionBatch {
+    fn output<B: Buffer>(
+        &mut self,
+        now: Instant,
+        send_buffer: B,
+        max_datagrams: NonZeroUsize,
+    ) -> SendOptionBatch<B> {
         qtrace!("[{self}] output {now:?}");
         let res = match &self.state {
             State::Init
@@ -2230,7 +2239,13 @@ impl Connection {
             | State::Confirmed => self.paths.select_path().map_or_else(
                 || Ok(SendOptionBatch::default()),
                 |path| {
-                    let res = self.output_dgram_batch_on_path(&path, now, None, max_datagrams);
+                    let res = self.output_dgram_batch_on_path(
+                        &path,
+                        now,
+                        None,
+                        send_buffer,
+                        max_datagrams,
+                    );
                     self.capture_error(Some(path), now, FrameType::Padding, res)
                 },
             ),
@@ -2251,6 +2266,7 @@ impl Connection {
                                 &path,
                                 now,
                                 Some(&details),
+                                send_buffer,
                                 max_datagrams,
                             )
                         };
@@ -2263,10 +2279,10 @@ impl Connection {
     }
 
     #[expect(clippy::too_many_arguments, reason = "no easy way to simplify")]
-    fn build_packet_header<'a>(
+    fn build_packet_header<B: Buffer>(
         path: &Path,
         epoch: Epoch,
-        encoder: Encoder<&'a mut Vec<u8>>,
+        encoder: Encoder<B>,
         tx: &CryptoDxState,
         address_validation: &AddressValidationInfo,
         version: Version,
@@ -2275,7 +2291,7 @@ impl Connection {
         largest_acknowledged: Option<packet::Number>,
     ) -> (
         packet::Type,
-        packet::Builder<&'a mut Vec<u8>>,
+        packet::Builder<B>,
         packet::Number,
     ) {
         let pt = packet::Type::from(epoch);
@@ -2328,10 +2344,10 @@ impl Connection {
 
     /// Write the frames that are exchanged in the application data space.
     /// The order of calls here determines the relative priority of frames.
-    fn write_appdata_frames(
+    fn write_appdata_frames<B: Buffer>(
         &mut self,
-        builder: &mut packet::Builder<&mut Vec<u8>>,
-        tokens: &mut recovery::Tokens,
+        builder: &mut packet::Builder<B>,
+        tokens: &mut Vec<recovery::Token>,
         now: Instant,
     ) {
         let rtt = self.paths.primary().map_or_else(
@@ -2470,12 +2486,12 @@ impl Connection {
     /// Write frames to the provided builder.  Returns a list of tokens used for
     /// tracking loss or acknowledgment, whether any frame was ACK eliciting, and
     /// whether the packet was padded.
-    fn write_frames(
+    fn write_frames<B: Buffer>(
         &mut self,
         path: &PathRef,
         space: PacketNumberSpace,
         profile: &SendProfile,
-        builder: &mut packet::Builder<&mut Vec<u8>>,
+        builder: &mut packet::Builder<B>,
         coalesced: bool, // Whether this packet is coalesced behind another one.
         now: Instant,
     ) -> (recovery::Tokens, bool, bool) {
@@ -2606,16 +2622,17 @@ impl Connection {
     }
 
     /// Build batch of datagrams to be sent on the provided path.
-    fn output_dgram_batch_on_path(
+    fn output_dgram_batch_on_path<B: Buffer>(
         &mut self,
         path: &PathRef,
         now: Instant,
         mut closing_frame: Option<&ClosingFrame>,
+        mut send_buffer: B,
         max_datagrams: NonZeroUsize,
-    ) -> Res<SendOptionBatch> {
+    ) -> Res<SendOptionBatch<B>> {
         let packet_tos = path.borrow().tos();
-        let mut send_buffer = Vec::new();
-        let mut max_datagram_size = None;
+
+        let mut datagram_size = None;
         let mut num_datagrams = 0;
         let mtu = path.borrow().plpmtu();
         let address_family_max_mtu = path.borrow().pmtud().address_family_max_mtu();
@@ -2633,22 +2650,22 @@ impl Connection {
                 break;
             }
 
-            let send_buffer_len_before = send_buffer.len();
+            let send_buffer_len_before = send_buffer.position();
 
             // Check if we can fit another PMTUD sized datagram into the batch.
-            if max_datagram_size.is_some_and(|datagram_size| {
+            if datagram_size.is_some_and(|ds| {
                 // GSO requires that all datagrams in a batch are of equal size.
                 // The last datagram can be smaller. The datagrams already in
-                // the batch are each `datagram_size` large. The next datagram
+                // the batch are each `ds` large. The next datagram
                 // can be up to `mtu` large. Break in case the next could be
                 // larger than the ones already in the batch.
-                datagram_size < mtu
+                ds < mtu
                 // GSO allows total datagram batch size up to the address family
                 // max MTU. If the next datagram could exceed that limit, break.
                 //
                 // See for example Linux kernel:
                 // https://github.com/torvalds/linux/blob/fb4d33ab452ea254e2c319bac5703d1b56d895bf/include/linux/netdevice.h#L2402
-                || address_family_max_mtu - send_buffer.len() < mtu
+                || address_family_max_mtu - send_buffer.position() < mtu
             }) {
                 break;
             }
@@ -2657,7 +2674,7 @@ impl Connection {
                 path,
                 now,
                 closing_frame.take(),
-                Encoder::new_borrowed_vec(&mut send_buffer),
+                Encoder::new_with_buffer(&mut send_buffer),
                 packet_tos,
             )? {
                 SendOption::Yes => {
@@ -2667,14 +2684,11 @@ impl Connection {
                         "MTU does not change within batch"
                     );
                     num_datagrams += 1;
-                    let datagram_size = send_buffer.len() - send_buffer_len_before;
-                    let max_datagram_size = *max_datagram_size.get_or_insert(datagram_size);
-
-                    // GSO requires that all datagrams in a batch are of equal
-                    // size. Only the last datagram can be smaller.
-                    debug_assert!(datagram_size <= max_datagram_size);
-                    if datagram_size < max_datagram_size {
-                        // This packet was smaller. Make sure it is the last by
+                    let ds = *datagram_size.get_or_insert(send_buffer.position() - send_buffer_len_before);
+                    if (send_buffer.position() % ds) > 0 {
+                        // GSO requires that all packets in a batch are of equal
+                        // size. Only the last packet can be smaller. This
+                        // packet was smaller. Make sure it was the last by
                         // breaking the loop.
                         break;
                     }
@@ -2694,7 +2708,7 @@ impl Connection {
             send_buffer,
             packet_tos,
             num_datagrams,
-            max_datagram_size.ok_or(Error::Internal)?,
+            datagram_size.ok_or(Error::Internal)?,
             &mut self.stats.borrow_mut(),
         );
 
@@ -2704,12 +2718,12 @@ impl Connection {
     /// Build a datagram, possibly from multiple packets (for different PN
     /// spaces) and each containing 1+ frames.
     #[expect(clippy::too_many_lines, reason = "Yeah, that's just the way it is.")]
-    fn output_dgram_on_path(
+    fn output_dgram_on_path<B: Buffer>(
         &mut self,
         path: &PathRef,
         now: Instant,
         closing_frame: Option<&ClosingFrame>,
-        mut encoder: Encoder<&mut Vec<u8>>,
+        mut encoder: Encoder<B>,
         packet_tos: Tos,
     ) -> Res<SendOption> {
         let mut initial_sent = None;
@@ -2891,9 +2905,9 @@ impl Connection {
         }
     }
 
-    fn pad_initial(
+    fn pad_initial<B: Buffer>(
         &self,
-        encoder: &mut Encoder<&mut Vec<u8>>,
+        encoder: &mut Encoder<B>,
         initial: &mut sent::Packet,
         profile: &SendProfile,
     ) {

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -110,10 +110,10 @@ pub enum Output {
     Callback(Duration),
 }
 
-impl<B: Buffer> TryFrom<OutputBatch<B>> for Output {
+impl TryFrom<OutputBatch<Vec<u8>>> for Output {
     type Error = ();
 
-    fn try_from(value: OutputBatch<B>) -> Result<Self, Self::Error> {
+    fn try_from(value: OutputBatch<Vec<u8>>) -> Result<Self, Self::Error> {
         match value {
             OutputBatch::None => Ok(Self::None),
             OutputBatch::DatagramBatch(dg) => Ok(Self::Datagram(dg.try_into()?)),
@@ -150,6 +150,24 @@ impl<B: Buffer> OutputBatch<B> {
         match self {
             Self::DatagramBatch(dg) => Some(dg),
             _ => None,
+        }
+    }
+
+    /// Re-back this batch with `buffer`, copying its contents.
+    ///
+    /// Drops a datagram that does not fit; loss recovery or the peer retries.
+    #[must_use]
+    pub fn copy_into<C: Buffer>(self, buffer: C) -> OutputBatch<C> {
+        match self {
+            Self::None => OutputBatch::None,
+            Self::Callback(t) => OutputBatch::Callback(t),
+            Self::DatagramBatch(b) => match b.copy_into(buffer) {
+                Ok(b) => OutputBatch::DatagramBatch(b),
+                Err(e) => {
+                    qerror!("Dropping {} byte datagram: {e}", b.data().len());
+                    OutputBatch::None
+                }
+            },
         }
     }
 }
@@ -1236,8 +1254,7 @@ impl Connection {
     #[expect(clippy::missing_panics_doc, reason = "see expect()")]
     #[must_use = "Output of the process_output function must be handled"]
     pub fn process_output(&mut self, now: Instant) -> Output {
-        let mut send_buffer = vec![];
-        self.process_multiple_output(now, &mut send_buffer, 1.try_into().expect(">0"))
+        self.process_multiple_output(now, Vec::new(), NonZeroUsize::MIN)
             .try_into()
             .expect("max_datagrams is 1")
     }
@@ -1246,6 +1263,11 @@ impl Connection {
     /// by the application.
     /// Returns datagrams to send, and how long to wait before calling again
     /// even if no incoming packets.
+    ///
+    /// `send_buffer` must be empty, as the batch is segmented from its start.
+    /// It is left empty when no batch is returned, so it can be reused as-is.
+    /// It also has to hold one maximum size datagram, which is a PMTUD probe
+    /// rather than the current PLPMTU, so `neqo_udp::SEND_BUF_SIZE` bytes.
     #[must_use = "OutputBatch of the process_multiple_output function must be handled"]
     pub fn process_multiple_output<B: Buffer>(
         &mut self,
@@ -1302,13 +1324,14 @@ impl Connection {
         dgram: Option<Datagram<A>>,
         now: Instant,
     ) -> Output {
-        let mut send_buffer = vec![];
-        self.process_multiple(dgram, now, &mut send_buffer, 1.try_into().expect(">0"))
+        self.process_multiple(dgram, now, Vec::new(), NonZeroUsize::MIN)
             .try_into()
             .expect("max_datagrams is 1")
     }
 
     /// Process input and generate output.
+    ///
+    /// `send_buffer` must be empty, see [`Connection::process_multiple_output`].
     #[must_use = "OutputBatch of the process_multiple function must be handled"]
     pub fn process_multiple<A: AsRef<[u8]> + AsMut<[u8]>, B: Buffer>(
         &mut self,
@@ -2389,7 +2412,7 @@ impl Connection {
     fn write_appdata_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut recovery::Tokens,
         now: Instant,
     ) {
         let rtt = self.paths.primary().map_or_else(
@@ -2604,7 +2627,10 @@ impl Connection {
             #[cfg(test)]
             if let Some(w) = &mut self.test_frame_writer {
                 assert!(!builder.is_full(), "test_frame_writer set on full packet");
-                w.write_frames(builder);
+                // `FrameWriter` is not generic over the buffer, so write via a copy.
+                let mut b = builder.copy_to_vec();
+                w.write_frames(&mut b);
+                builder.restore_from(b);
             }
         }
 
@@ -2672,12 +2698,22 @@ impl Connection {
         mut send_buffer: B,
         max_datagrams: NonZeroUsize,
     ) -> Res<SendOptionBatch<B>> {
+        // GSO segmentation and `Batch::num_datagrams` count from offset 0.
+        debug_assert!(send_buffer.is_empty());
         let packet_tos = path.borrow().tos();
 
         let mut datagram_size = None;
         let mut num_datagrams = 0;
         let mtu = path.borrow().plpmtu();
         let address_family_max_mtu = path.borrow().pmtud().address_family_max_mtu();
+        // A PMTUD probe is larger than the current PLPMTU, so it sets the
+        // minimum the buffer has to hold for the first datagram.
+        let first_datagram = if path.borrow().pmtud().needs_probe() {
+            path.borrow().pmtud().probe_size()
+        } else {
+            mtu
+        };
+        debug_assert!(send_buffer.available().is_none_or(|a| a >= first_datagram));
 
         loop {
             if max_datagrams.get() <= num_datagrams {
@@ -2708,17 +2744,22 @@ impl Connection {
                 // See for example Linux kernel:
                 // https://github.com/torvalds/linux/blob/fb4d33ab452ea254e2c319bac5703d1b56d895bf/include/linux/netdevice.h#L2402
                 || address_family_max_mtu - send_buffer.position() < mtu
+                // Whatever the caller's buffer can still hold.
+                || send_buffer.available().is_some_and(|a| a < mtu)
             }) {
                 break;
             }
 
-            match self.output_dgram_on_path(
+            let res = self.output_dgram_on_path(
                 path,
                 now,
                 closing_frame.take(),
-                Encoder::new_with_buffer(&mut send_buffer),
+                Encoder::new(&mut send_buffer),
                 packet_tos,
-            )? {
+            );
+            // Discard any bytes already written, so a reused buffer stays clean.
+            let res = res.inspect_err(|_| send_buffer.truncate(0))?;
+            match res {
                 SendOption::Yes => {
                     debug_assert_eq!(
                         mtu,
@@ -2726,9 +2767,11 @@ impl Connection {
                         "MTU does not change within batch"
                     );
                     num_datagrams += 1;
-                    let ds = *datagram_size
-                        .get_or_insert(send_buffer.position() - send_buffer_len_before);
-                    if (send_buffer.position() % ds) > 0 {
+                    let this_size = send_buffer.position() - send_buffer_len_before;
+                    let ds = *datagram_size.get_or_insert(this_size);
+                    // A larger one would slip past the multiple-of check below.
+                    debug_assert!(this_size <= ds);
+                    if !send_buffer.position().is_multiple_of(ds) {
                         // GSO requires that all packets in a batch are of equal
                         // size. Only the last packet can be smaller. This
                         // packet was smaller. Make sure it was the last by
@@ -2747,11 +2790,16 @@ impl Connection {
         }
 
         debug_assert!(!send_buffer.is_empty());
+        // Checked before moving `send_buffer`, so this path can still clear it.
+        let Some(datagram_size) = datagram_size else {
+            send_buffer.truncate(0);
+            return Err(Error::Internal);
+        };
         let batch = path.borrow_mut().datagram_batch(
             send_buffer,
             packet_tos,
             num_datagrams,
-            datagram_size.ok_or(Error::Internal)?,
+            datagram_size,
             &mut self.stats.borrow_mut(),
         );
 
@@ -4084,7 +4132,7 @@ impl Connection {
         let path = self.paths.primary().ok_or(Error::NotAvailable)?;
         let mtu = path.borrow().plpmtu();
         let mut buffer = Vec::new();
-        let encoder = Encoder::new_borrowed_vec(&mut buffer);
+        let encoder = Encoder::new(&mut buffer);
 
         let (_, builder, _) = Self::build_packet_header(
             &path.borrow(),

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -110,10 +110,10 @@ pub enum Output {
     Callback(Duration),
 }
 
-impl TryFrom<OutputBatch> for Output {
+impl<B: Buffer> TryFrom<OutputBatch<B>> for Output {
     type Error = ();
 
-    fn try_from(value: OutputBatch) -> Result<Self, Self::Error> {
+    fn try_from(value: OutputBatch<B>) -> Result<Self, Self::Error> {
         match value {
             OutputBatch::None => Ok(Self::None),
             OutputBatch::DatagramBatch(dg) => Ok(Self::Datagram(dg.try_into()?)),
@@ -123,17 +123,17 @@ impl TryFrom<OutputBatch> for Output {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum OutputBatch {
+pub enum OutputBatch<B: Buffer> {
     /// Connection requires no action.
     None,
     /// Connection requires the datagram batch be sent.
-    DatagramBatch(datagram::Batch),
+    DatagramBatch(datagram::Batch<B>),
     /// Connection requires `process_input()` be called when the `Duration`
     /// elapses.
     Callback(Duration),
 }
 
-impl From<Output> for OutputBatch {
+impl From<Output> for OutputBatch<Vec<u8>> {
     fn from(value: Output) -> Self {
         match value {
             Output::None => Self::None,
@@ -143,10 +143,10 @@ impl From<Output> for OutputBatch {
     }
 }
 
-impl OutputBatch {
-    /// Convert into an [`Option<datagram::Batch>`].
+impl<B: Buffer> OutputBatch<B> {
+    /// Convert into an [`Option<datagram::Batch<B>>`].
     #[must_use]
-    pub fn dgram(self) -> Option<datagram::Batch> {
+    pub fn dgram(self) -> Option<datagram::Batch<B>> {
         match self {
             Self::DatagramBatch(dg) => Some(dg),
             _ => None,
@@ -190,14 +190,14 @@ impl From<Option<Datagram>> for Output {
 }
 
 /// Used by inner functions like `Connection::output`.
-enum SendOptionBatch {
+enum SendOptionBatch<B> {
     /// Yes, please send this datagram.
-    Yes(datagram::Batch),
+    Yes(datagram::Batch<B>),
     /// Don't send.  If this was blocked on the pacer (the arg is true).
     No(bool),
 }
 
-impl Default for SendOptionBatch {
+impl<B> Default for SendOptionBatch<B> {
     fn default() -> Self {
         Self::No(false)
     }
@@ -1236,7 +1236,8 @@ impl Connection {
     #[expect(clippy::missing_panics_doc, reason = "see expect()")]
     #[must_use = "Output of the process_output function must be handled"]
     pub fn process_output(&mut self, now: Instant) -> Output {
-        self.process_multiple_output(now, 1.try_into().expect(">0"))
+        let mut send_buffer = vec![];
+        self.process_multiple_output(now, &mut send_buffer, 1.try_into().expect(">0"))
             .try_into()
             .expect("max_datagrams is 1")
     }
@@ -1246,11 +1247,12 @@ impl Connection {
     /// Returns datagrams to send, and how long to wait before calling again
     /// even if no incoming packets.
     #[must_use = "OutputBatch of the process_multiple_output function must be handled"]
-    pub fn process_multiple_output(
+    pub fn process_multiple_output<B: Buffer>(
         &mut self,
         now: Instant,
+        send_buffer: B,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<B> {
         qtrace!("[{self}] process_output {:?} {now:?}", self.state);
 
         match (&self.state, self.role) {
@@ -1266,7 +1268,7 @@ impl Connection {
             }
         }
 
-        match self.output(now, max_datagrams) {
+        match self.output(now, send_buffer, max_datagrams) {
             SendOptionBatch::Yes(dgram) => OutputBatch::DatagramBatch(dgram),
             SendOptionBatch::No(paced) => match self.state {
                 State::Init | State::Closed(_) => OutputBatch::None,
@@ -1300,19 +1302,21 @@ impl Connection {
         dgram: Option<Datagram<A>>,
         now: Instant,
     ) -> Output {
-        self.process_multiple(dgram, now, 1.try_into().expect(">0"))
+        let mut send_buffer = vec![];
+        self.process_multiple(dgram, now, &mut send_buffer, 1.try_into().expect(">0"))
             .try_into()
             .expect("max_datagrams is 1")
     }
 
     /// Process input and generate output.
     #[must_use = "OutputBatch of the process_multiple function must be handled"]
-    pub fn process_multiple<A: AsRef<[u8]> + AsMut<[u8]>>(
+    pub fn process_multiple<A: AsRef<[u8]> + AsMut<[u8]>, B: Buffer>(
         &mut self,
         dgram: Option<Datagram<A>>,
         now: Instant,
+        send_buffer: B,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<B> {
         if let Some(d) = dgram {
             // Snapshot timer type before ACKs can alter loss state.
             if let Some(path) = self.paths.primary() {
@@ -1321,7 +1325,7 @@ impl Connection {
             self.input(d, now, now);
             self.process_saved(now);
         }
-        let output = self.process_multiple_output(now, max_datagrams);
+        let output = self.process_multiple_output(now, send_buffer, max_datagrams);
         #[cfg(feature = "build-fuzzing-corpus")]
         if self.test_frame_writer.is_none()
             && let OutputBatch::DatagramBatch(batch) = &output
@@ -2265,7 +2269,12 @@ impl Connection {
         }
     }
 
-    fn output(&mut self, now: Instant, max_datagrams: NonZeroUsize) -> SendOptionBatch {
+    fn output<B: Buffer>(
+        &mut self,
+        now: Instant,
+        send_buffer: B,
+        max_datagrams: NonZeroUsize,
+    ) -> SendOptionBatch<B> {
         qtrace!("[{self}] output {now:?}");
         let res = match &self.state {
             State::Init
@@ -2276,7 +2285,13 @@ impl Connection {
             | State::Confirmed => self.paths.select_path().map_or_else(
                 || Ok(SendOptionBatch::default()),
                 |path| {
-                    let res = self.output_dgram_batch_on_path(&path, now, None, max_datagrams);
+                    let res = self.output_dgram_batch_on_path(
+                        &path,
+                        now,
+                        None,
+                        send_buffer,
+                        max_datagrams,
+                    );
                     self.capture_error(Some(path), now, FrameType::Padding, res)
                 },
             ),
@@ -2297,6 +2312,7 @@ impl Connection {
                                 &path,
                                 now,
                                 Some(&details),
+                                send_buffer,
                                 max_datagrams,
                             )
                         };
@@ -2309,21 +2325,17 @@ impl Connection {
     }
 
     #[expect(clippy::too_many_arguments, reason = "no easy way to simplify")]
-    fn build_packet_header<'a>(
+    fn build_packet_header<B: Buffer>(
         path: &Path,
         epoch: Epoch,
-        encoder: Encoder<&'a mut Vec<u8>>,
+        encoder: Encoder<B>,
         tx: &CryptoDxState,
         address_validation: &AddressValidationInfo,
         version: Version,
         grease_quic_bit: bool,
         limit: usize,
         largest_acknowledged: Option<packet::Number>,
-    ) -> (
-        packet::Type,
-        packet::Builder<&'a mut Vec<u8>>,
-        packet::Number,
-    ) {
+    ) -> (packet::Type, packet::Builder<B>, packet::Number) {
         let pt = packet::Type::from(epoch);
         let mut builder = if pt == packet::Type::Short {
             qdebug!("Building Short dcid {:?}", path.remote_cid());
@@ -2374,10 +2386,10 @@ impl Connection {
 
     /// Write the frames that are exchanged in the application data space.
     /// The order of calls here determines the relative priority of frames.
-    fn write_appdata_frames(
+    fn write_appdata_frames<B: Buffer>(
         &mut self,
-        builder: &mut packet::Builder<&mut Vec<u8>>,
-        tokens: &mut recovery::Tokens,
+        builder: &mut packet::Builder<B>,
+        tokens: &mut Vec<recovery::Token>,
         now: Instant,
     ) {
         let rtt = self.paths.primary().map_or_else(
@@ -2516,12 +2528,12 @@ impl Connection {
     /// Write frames to the provided builder.  Returns a list of tokens used for
     /// tracking loss or acknowledgment, whether any frame was ACK eliciting, and
     /// whether the packet was padded.
-    fn write_frames(
+    fn write_frames<B: Buffer>(
         &mut self,
         path: &PathRef,
         space: PacketNumberSpace,
         profile: &SendProfile,
-        builder: &mut packet::Builder<&mut Vec<u8>>,
+        builder: &mut packet::Builder<B>,
         coalesced: bool, // Whether this packet is coalesced behind another one.
         now: Instant,
     ) -> (recovery::Tokens, bool, bool) {
@@ -2652,16 +2664,17 @@ impl Connection {
     }
 
     /// Build batch of datagrams to be sent on the provided path.
-    fn output_dgram_batch_on_path(
+    fn output_dgram_batch_on_path<B: Buffer>(
         &mut self,
         path: &PathRef,
         now: Instant,
         mut closing_frame: Option<&ClosingFrame>,
+        mut send_buffer: B,
         max_datagrams: NonZeroUsize,
-    ) -> Res<SendOptionBatch> {
+    ) -> Res<SendOptionBatch<B>> {
         let packet_tos = path.borrow().tos();
-        let mut send_buffer = Vec::new();
-        let mut max_datagram_size = None;
+
+        let mut datagram_size = None;
         let mut num_datagrams = 0;
         let mtu = path.borrow().plpmtu();
         let address_family_max_mtu = path.borrow().pmtud().address_family_max_mtu();
@@ -2679,22 +2692,22 @@ impl Connection {
                 break;
             }
 
-            let send_buffer_len_before = send_buffer.len();
+            let send_buffer_len_before = send_buffer.position();
 
             // Check if we can fit another PMTUD sized datagram into the batch.
-            if max_datagram_size.is_some_and(|datagram_size| {
+            if datagram_size.is_some_and(|ds| {
                 // GSO requires that all datagrams in a batch are of equal size.
                 // The last datagram can be smaller. The datagrams already in
-                // the batch are each `datagram_size` large. The next datagram
+                // the batch are each `ds` large. The next datagram
                 // can be up to `mtu` large. Break in case the next could be
                 // larger than the ones already in the batch.
-                datagram_size < mtu
+                ds < mtu
                 // GSO allows total datagram batch size up to the address family
                 // max MTU. If the next datagram could exceed that limit, break.
                 //
                 // See for example Linux kernel:
                 // https://github.com/torvalds/linux/blob/fb4d33ab452ea254e2c319bac5703d1b56d895bf/include/linux/netdevice.h#L2402
-                || address_family_max_mtu - send_buffer.len() < mtu
+                || address_family_max_mtu - send_buffer.position() < mtu
             }) {
                 break;
             }
@@ -2703,7 +2716,7 @@ impl Connection {
                 path,
                 now,
                 closing_frame.take(),
-                Encoder::new_borrowed_vec(&mut send_buffer),
+                Encoder::new_with_buffer(&mut send_buffer),
                 packet_tos,
             )? {
                 SendOption::Yes => {
@@ -2713,14 +2726,12 @@ impl Connection {
                         "MTU does not change within batch"
                     );
                     num_datagrams += 1;
-                    let datagram_size = send_buffer.len() - send_buffer_len_before;
-                    let max_datagram_size = *max_datagram_size.get_or_insert(datagram_size);
-
-                    // GSO requires that all datagrams in a batch are of equal
-                    // size. Only the last datagram can be smaller.
-                    debug_assert!(datagram_size <= max_datagram_size);
-                    if datagram_size < max_datagram_size {
-                        // This packet was smaller. Make sure it is the last by
+                    let ds = *datagram_size
+                        .get_or_insert(send_buffer.position() - send_buffer_len_before);
+                    if (send_buffer.position() % ds) > 0 {
+                        // GSO requires that all packets in a batch are of equal
+                        // size. Only the last packet can be smaller. This
+                        // packet was smaller. Make sure it was the last by
                         // breaking the loop.
                         break;
                     }
@@ -2740,7 +2751,7 @@ impl Connection {
             send_buffer,
             packet_tos,
             num_datagrams,
-            max_datagram_size.ok_or(Error::Internal)?,
+            datagram_size.ok_or(Error::Internal)?,
             &mut self.stats.borrow_mut(),
         );
 
@@ -2750,12 +2761,12 @@ impl Connection {
     /// Build a datagram, possibly from multiple packets (for different PN
     /// spaces) and each containing 1+ frames.
     #[expect(clippy::too_many_lines, reason = "Yeah, that's just the way it is.")]
-    fn output_dgram_on_path(
+    fn output_dgram_on_path<B: Buffer>(
         &mut self,
         path: &PathRef,
         now: Instant,
         closing_frame: Option<&ClosingFrame>,
-        mut encoder: Encoder<&mut Vec<u8>>,
+        mut encoder: Encoder<B>,
         packet_tos: Tos,
     ) -> Res<SendOption> {
         let mut initial_sent = None;
@@ -2937,9 +2948,9 @@ impl Connection {
         }
     }
 
-    fn pad_initial(
+    fn pad_initial<B: Buffer>(
         &self,
-        encoder: &mut Encoder<&mut Vec<u8>>,
+        encoder: &mut Encoder<B>,
         initial: &mut sent::Packet,
         profile: &SendProfile,
     ) {

--- a/neqo-transport/src/connection/test_internal.rs
+++ b/neqo-transport/src/connection/test_internal.rs
@@ -9,5 +9,5 @@
 use crate::packet;
 
 pub trait FrameWriter {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>);
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>);
 }

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -48,7 +48,7 @@ struct InsertDatagram<'a> {
 }
 
 impl crate::connection::test_internal::FrameWriter for InsertDatagram<'_> {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         builder.encode_varint(FrameType::Datagram);
         builder.encode(self.data);
     }
@@ -596,13 +596,15 @@ fn datagram_overfill(client: &mut Connection, server: &mut Connection, gap: usiz
     /// This `FrameWriter` should not be invoked.
     struct PanickingFrameWriter {}
     impl crate::connection::test_internal::FrameWriter for PanickingFrameWriter {
-        fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+        fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
             panic!(
                 "builder invoked with {} bytes remaining",
                 builder.remaining()
             );
         }
     }
+
+
 
     // Work out how much space we have for a datagram.
     let space = {

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -48,7 +48,7 @@ struct InsertDatagram<'a> {
 }
 
 impl crate::connection::test_internal::FrameWriter for InsertDatagram<'_> {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         builder.encode_varint(FrameType::Datagram);
         builder.encode(self.data);
     }
@@ -57,7 +57,7 @@ impl crate::connection::test_internal::FrameWriter for InsertDatagram<'_> {
 struct InsertEmptyDatagram;
 
 impl crate::connection::test_internal::FrameWriter for InsertEmptyDatagram {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         builder.encode_varint(FrameType::DatagramWithLen);
         builder.encode_vvec(&[]);
     }
@@ -570,7 +570,7 @@ fn datagram_overfill(client: &mut Connection, server: &mut Connection, gap: usiz
     /// This `FrameWriter` should not be invoked.
     struct PanickingFrameWriter {}
     impl crate::connection::test_internal::FrameWriter for PanickingFrameWriter {
-        fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+        fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
             panic!(
                 "builder invoked with {} bytes remaining",
                 builder.remaining()
@@ -631,7 +631,7 @@ fn datagram_fill_gap4() {
         called: Rc<RefCell<bool>>,
     }
     impl crate::connection::test_internal::FrameWriter for TrackingFrameWriter {
-        fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+        fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
             assert_eq!(builder.remaining(), 2);
             *self.called.borrow_mut() = true;
         }

--- a/neqo-transport/src/connection/tests/keys.rs
+++ b/neqo-transport/src/connection/tests/keys.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::num::NonZeroUsize;
+
 use neqo_common::{Datagram, qdebug};
 use test_fixture::{
     assertions::{is_handshake, is_initial},
@@ -466,4 +468,25 @@ fn initial_handshake_pto_padding() {
         }
     }
     assert!(found_coalesced);
+}
+
+/// An error after frames are written must leave the send buffer empty.
+#[test]
+fn exhausted_write_keys_leave_send_buffer_empty() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+
+    overwrite_invocations(0);
+    let stream_id = client.stream_create(StreamType::UniDi).unwrap();
+    assert!(client.stream_send(stream_id, b"explode!").is_ok());
+
+    let mut send_buffer = Vec::new();
+    let out = client.process_multiple_output(now(), &mut send_buffer, NonZeroUsize::MIN);
+    assert!(out.dgram().is_none());
+    assert!(send_buffer.is_empty());
+    assert!(matches!(
+        client.state(),
+        State::Closed(CloseReason::Transport(Error::KeysExhausted))
+    ));
 }

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -1076,7 +1076,7 @@ struct RetireAll {
 }
 
 impl crate::connection::test_internal::FrameWriter for RetireAll {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         // Use a sequence number that is large enough that all existing values
         // will be lower (so they get retired).  As the code doesn't care about
         // gaps in sequence numbers, this is safe, even though the gap might
@@ -1238,7 +1238,7 @@ fn retire_prior_to_migration_success() {
 struct GarbageWriter {}
 
 impl crate::connection::test_internal::FrameWriter for GarbageWriter {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         // Not a valid frame type.
         builder.encode_varint(u32::MAX);
     }

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -1094,7 +1094,7 @@ impl NewConnectionIds {
 }
 
 impl crate::connection::test_internal::FrameWriter for NewConnectionIds {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         for i in 0..self.count {
             let seqno = Self::SEQNO + i;
             let cid = self.cid_gen.borrow_mut().generate_cid().unwrap();
@@ -1187,7 +1187,7 @@ fn retire_cid_queue_bounded() {
 struct RetireUnissued(u64);
 
 impl crate::connection::test_internal::FrameWriter for RetireUnissued {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         builder
             .encode_varint(FrameType::RetireConnectionId)
             .encode_varint(self.0);
@@ -1325,7 +1325,7 @@ fn retire_prior_to_migration_success() {
 struct GarbageWriter {}
 
 impl crate::connection::test_internal::FrameWriter for GarbageWriter {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         // Not a valid frame type.
         builder.encode_varint(u32::MAX);
     }

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -186,7 +186,7 @@ pub fn rttvar_after_n_updates(n: usize, rtt: Duration) -> Duration {
 struct PingWriter {}
 
 impl test_internal::FrameWriter for PingWriter {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         builder.encode_varint(FrameType::Ping);
     }
 }

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -802,3 +802,114 @@ fn server_receives_new_token() {
         }
     ));
 }
+
+/// A batch that does not fit the target buffer is dropped, not truncated.
+#[test]
+fn output_batch_copy_into_too_small() {
+    use std::{io::Cursor, num::NonZeroUsize};
+
+    use neqo_common::{Tos, datagram};
+
+    use super::OutputBatch;
+
+    let batch = datagram::Batch::new(
+        DEFAULT_ADDR,
+        DEFAULT_ADDR,
+        Tos::default(),
+        NonZeroUsize::new(4).unwrap(),
+        vec![0; 8],
+    );
+    let mut buf = [0; 4];
+    assert!(matches!(
+        OutputBatch::DatagramBatch(batch).copy_into(Cursor::new(&mut buf[..])),
+        OutputBatch::None
+    ));
+
+    let mut buf = [0; 4];
+    assert!(matches!(
+        OutputBatch::<Vec<u8>>::None.copy_into(Cursor::new(&mut buf[..])),
+        OutputBatch::None
+    ));
+    let mut buf = [0; 4];
+    assert!(matches!(
+        OutputBatch::<Vec<u8>>::Callback(Duration::from_millis(7))
+            .copy_into(Cursor::new(&mut buf[..])),
+        OutputBatch::Callback(d) if d == Duration::from_millis(7)
+    ));
+}
+
+/// One buffer shared across connections must yield only the later one's bytes.
+#[test]
+fn shared_send_buffer_across_connections() {
+    use std::num::NonZeroUsize;
+
+    let mut idle = default_client();
+    let mut idle_server = default_server();
+    connect_force_idle(&mut idle, &mut idle_server);
+
+    let mut client = default_client();
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+    let stream_id = client.stream_create(StreamType::UniDi).unwrap();
+    client.stream_send(stream_id, DEFAULT_STREAM_DATA).unwrap();
+    client.stream_close_send(stream_id).unwrap();
+
+    let mut buf = Vec::new();
+    assert!(
+        idle.process_multiple_output(now(), &mut buf, NonZeroUsize::MIN)
+            .dgram()
+            .is_none()
+    );
+    assert!(buf.is_empty());
+
+    let batch = client
+        .process_multiple_output(now(), &mut buf, NonZeroUsize::MIN)
+        .dgram()
+        .expect("a datagram");
+    assert_eq!(batch.num_datagrams(), 1);
+    assert_eq!(batch.data().len(), batch.datagram_size().get());
+
+    let d = Datagram::new(
+        batch.source(),
+        batch.destination(),
+        batch.tos(),
+        batch.data(),
+    );
+    server.process_input(d, now());
+    assert!(
+        server
+            .events()
+            .any(|e| matches!(e, ConnectionEvent::RecvStreamReadable { .. }))
+    );
+}
+
+/// A bounded send buffer limits the batch rather than overrunning.
+#[test]
+fn send_buffer_bounds_batch() {
+    use std::{io::Cursor, num::NonZeroUsize};
+
+    const MAX_DATAGRAMS: usize = 4;
+
+    let mut client = default_client();
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+    let stream_id = client.stream_create(StreamType::UniDi).unwrap();
+    fill_stream(&mut client, stream_id);
+
+    let max = NonZeroUsize::new(MAX_DATAGRAMS).unwrap();
+    let roomy = client
+        .process_multiple_output(now(), Vec::new(), max)
+        .dgram()
+        .expect("a datagram");
+    assert!(roomy.num_datagrams() > 2, "need a multi-datagram batch");
+    let ds = roomy.datagram_size().get();
+
+    // A buffer with room for two datagrams yields at most two.
+    let mut buf = vec![0; 2 * ds];
+    let bounded = client
+        .process_multiple_output(now(), Cursor::new(&mut buf[..]), max)
+        .dgram()
+        .expect("a datagram");
+    assert!(bounded.num_datagrams() <= 2);
+    assert!(bounded.data().len() <= 2 * ds);
+}

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -188,7 +188,7 @@ pub fn rttvar_after_n_updates(n: usize, rtt: Duration) -> Duration {
 struct PingWriter {}
 
 impl test_internal::FrameWriter for PingWriter {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         builder.encode_varint(FrameType::Ping);
     }
 }
@@ -775,7 +775,7 @@ fn server_receives_new_token() {
     struct NewTokenWriter {}
 
     impl test_internal::FrameWriter for NewTokenWriter {
-        fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+        fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
             builder.encode_varint(FrameType::NewToken);
             builder.encode_vvec(&[0; 4]);
         }

--- a/neqo-transport/src/connection/tests/pmtud.rs
+++ b/neqo-transport/src/connection/tests/pmtud.rs
@@ -191,3 +191,51 @@ fn vpn_migration_triggers_pmtud() {
     assert_eq!(server.plpmtu(), expected_vpn_mtu);
     assert_eq!(client.plpmtu(), expected_vpn_mtu);
 }
+
+/// A PMTUD probe is larger than the current PLPMTU, so a send buffer has to be
+/// sized for the probe, not the PLPMTU.
+#[test]
+fn send_buffer_holds_pmtud_probe() {
+    use std::{io::Cursor, num::NonZeroUsize};
+
+    fixture_init();
+    let mut client = new_client(
+        ConnectionParameters::default()
+            .pmtud(true)
+            .pmtud_iface_mtu(false),
+    );
+    let mut server = default_server();
+    connect(&mut client, &mut server);
+
+    let stream_id = client.stream_create(StreamType::UniDi).unwrap();
+    let needs_probe = |c: &Connection| c.paths.primary().unwrap().borrow().pmtud().needs_probe();
+
+    // Acknowledge probes until another one is pending, so that the next
+    // datagram is a probe larger than the current PLPMTU.
+    fill_stream(&mut client, stream_id);
+    while !needs_probe(&client) {
+        let mut pkts = client
+            .process_multiple_output(now(), Vec::new(), 2.try_into().unwrap())
+            .dgram()
+            .unwrap();
+        server.process_multiple_input(pkts.iter_mut(), now());
+        if let Some(ack) = server.process_output(now()).dgram() {
+            client.process_input(ack, now());
+        }
+        fill_stream(&mut client, stream_id);
+    }
+
+    let (plpmtu, probe) = {
+        let path = client.paths.primary().unwrap();
+        let p = path.borrow();
+        (p.pmtud().plpmtu(), p.pmtud().probe_size())
+    };
+    assert!(probe > plpmtu);
+
+    let mut buf = vec![0; probe];
+    let batch = client
+        .process_multiple_output(now(), Cursor::new(&mut buf[..]), NonZeroUsize::MIN)
+        .dgram()
+        .expect("a datagram");
+    assert_eq!(batch.datagram_size().get(), probe);
+}

--- a/neqo-transport/src/connection/tests/pmtud.rs
+++ b/neqo-transport/src/connection/tests/pmtud.rs
@@ -49,7 +49,7 @@ fn gso_with_max_mtu() {
     loop {
         fill_stream(&mut client, stream_id);
         let mut pkts = client
-            .process_multiple_output(now(), 2.try_into().unwrap())
+            .process_multiple_output(now(), Vec::new(), 2.try_into().unwrap())
             .dgram()
             .unwrap();
         if pkts.datagram_size().get() == 65507 {

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -921,7 +921,7 @@ fn ack_for_unsent() {
     struct AckforUnsentWriter {}
 
     impl FrameWriter for AckforUnsentWriter {
-        fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+        fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
             builder.encode_varint(FrameType::Ack);
             builder.encode_varint(666u16); // Largest ACKed
             builder.encode_varint(0u8); // ACK delay

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -1002,7 +1002,7 @@ fn ack_for_unsent() {
     struct AckforUnsentWriter {}
 
     impl FrameWriter for AckforUnsentWriter {
-        fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+        fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
             builder.encode_varint(FrameType::Ack);
             builder.encode_varint(666u16); // Largest ACKed
             builder.encode_varint(0u8); // ACK delay

--- a/neqo-transport/src/connection/tests/reset_stream_at.rs
+++ b/neqo-transport/src/connection/tests/reset_stream_at.rs
@@ -158,7 +158,7 @@ fn reliable_reset_emits_no_send_complete() {
 struct ResetStreamAtWriter(u64);
 
 impl FrameWriter for ResetStreamAtWriter {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         // type, stream_id, application_error_code, final_size, reliable_size
         builder.write_varint_frame(&[FrameType::ResetStreamAt.into(), self.0, 0, 0, 0]);
     }

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -531,7 +531,7 @@ fn do_not_accept_data_after_stop_sending() {
 struct Writer(Vec<u64>);
 
 impl crate::connection::test_internal::FrameWriter for Writer {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         builder.write_varint_frame(&self.0);
     }
 }

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -530,7 +530,7 @@ fn do_not_accept_data_after_stop_sending() {
 struct Writer(Vec<u64>);
 
 impl crate::connection::test_internal::FrameWriter for Writer {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         builder.write_varint_frame(&self.0);
     }
 }

--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -591,7 +591,7 @@ fn client_initial_versions() {
     pub struct CryptoWriter {}
 
     impl test_internal::FrameWriter for CryptoWriter {
-        fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+        fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
             // A first byte of 2 is the byte that indicates a ServerHello.
             builder.encode_varint(FrameType::Crypto);
             builder.encode_varint(0_u64); // Offset

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -115,6 +115,7 @@ impl From<Epoch> for Type {
     }
 }
 
+#[derive(Clone)]
 struct BuilderOffsets {
     /// The bits of the first octet that need masking.
     first_byte_mask: u8,
@@ -180,13 +181,14 @@ impl Builder<Vec<u8>> {
 
     /// Make a Version Negotiation packet.
     #[must_use]
-    pub fn version_negotiation(
+    pub fn version_negotiation<B: Buffer>(
         dcid: &[u8],
         scid: &[u8],
         client_version: u32,
         versions: &[Version],
-    ) -> Vec<u8> {
-        let mut encoder = Encoder::default();
+        send_buffer: B,
+    ) {
+        let mut encoder = Encoder::new_with_buffer(send_buffer);
         let mut grease = random::<4>();
         // This will not include the "QUIC bit" sometimes.  Intentionally.
         encoder.encode_byte(BIT_LONG | (grease[3] & 0x7f));
@@ -206,12 +208,55 @@ impl Builder<Vec<u8>> {
         // by making the last byte differ from the client initial.
         grease[3] = (client_version.wrapping_add(0x10) & 0xf0) as u8 | 0x0a;
         encoder.encode(&grease[..4]);
-
-        Vec::from(encoder)
     }
 }
 
 impl<B: Buffer> Builder<B> {
+    // TODO cfg
+    // TODO hack
+    pub fn x(&self) -> Builder<Vec<u8>> {
+        dbg!("x");
+        let Self {
+            encoder,
+            pn,
+            header,
+            offsets,
+            limit,
+            padding,
+        } = self;
+        dbg!(encoder.len());
+        let encoder = encoder.to_owned();
+
+        Builder {
+            encoder,
+            pn: *pn,
+            header: header.clone(),
+            offsets: (*offsets).clone(),
+            limit: *limit,
+            padding: *padding,
+        }
+    }
+
+    // TODO cfg
+    // TODO hack
+    pub fn y(&mut self, builder: Builder<Vec<u8>>) {
+        dbg!("y");
+        self.pn = builder.pn;
+        self.header = builder.header;
+        self.offsets = builder.offsets;
+        self.limit = builder.limit;
+        self.padding = builder.padding;
+
+        dbg!(self.encoder.len());
+
+        dbg!(builder.encoder.len());
+
+        self.encoder.encode(&builder.encoder.as_ref()[(self.encoder.len())..]);
+
+
+        dbg!(self.encoder.len());
+    }
+
     /// Start building a short header packet.
     ///
     /// This doesn't fail if there isn't enough space; instead it returns a builder that
@@ -1687,8 +1732,14 @@ mod tests {
     #[test]
     fn build_vn() {
         fixture_init();
-        let mut vn =
-            Builder::version_negotiation(SERVER_CID, CLIENT_CID, 0x0a0a_0a0a, &Version::all());
+        let mut vn = Vec::new();
+        Builder::version_negotiation(
+            SERVER_CID,
+            CLIENT_CID,
+            0x0a0a_0a0a,
+            &Version::all(),
+            &mut vn,
+        );
         // Erase randomness from greasing...
         assert_eq!(vn.len(), SAMPLE_VN.len());
         vn[0] &= 0x80;
@@ -1701,7 +1752,14 @@ mod tests {
     #[test]
     fn vn_do_not_repeat_client_grease() {
         fixture_init();
-        let vn = Builder::version_negotiation(SERVER_CID, CLIENT_CID, 0x0a0a_0a0a, &Version::all());
+        let mut vn = Vec::new();
+        Builder::version_negotiation(
+            SERVER_CID,
+            CLIENT_CID,
+            0x0a0a_0a0a,
+            &Version::all(),
+            &mut vn,
+        );
         assert_ne!(&vn[SAMPLE_VN.len() - 4..], &[0x0a, 0x0a, 0x0a, 0x0a]);
     }
 

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -119,6 +119,7 @@ impl From<Epoch> for Type {
     }
 }
 
+#[derive(Clone)]
 struct BuilderOffsets {
     /// The bits of the first octet that need masking.
     first_byte_mask: u8,
@@ -184,13 +185,14 @@ impl Builder<Vec<u8>> {
 
     /// Make a Version Negotiation packet.
     #[must_use]
-    pub fn version_negotiation(
+    pub fn version_negotiation<B: Buffer>(
         dcid: &[u8],
         scid: &[u8],
         client_version: u32,
         versions: &[Version],
-    ) -> Vec<u8> {
-        let mut encoder = Encoder::default();
+        send_buffer: B,
+    ) {
+        let mut encoder = Encoder::new_with_buffer(send_buffer);
         let mut grease = random::<4>();
         // This will not include the "QUIC bit" sometimes.  Intentionally.
         encoder.encode_byte(BIT_LONG | (grease[3] & 0x7f));
@@ -210,12 +212,55 @@ impl Builder<Vec<u8>> {
         // by making the last byte differ from the client initial.
         grease[3] = (client_version.wrapping_add(0x10) & 0xf0) as u8 | 0x0a;
         encoder.encode(&grease[..4]);
-
-        Vec::from(encoder)
     }
 }
 
 impl<B: Buffer> Builder<B> {
+    // TODO cfg
+    // TODO hack
+    pub fn x(&self) -> Builder<Vec<u8>> {
+        dbg!("x");
+        let Self {
+            encoder,
+            pn,
+            header,
+            offsets,
+            limit,
+            padding,
+        } = self;
+        dbg!(encoder.len());
+        let encoder = encoder.to_owned();
+
+        Builder {
+            encoder,
+            pn: *pn,
+            header: header.clone(),
+            offsets: (*offsets).clone(),
+            limit: *limit,
+            padding: *padding,
+        }
+    }
+
+    // TODO cfg
+    // TODO hack
+    pub fn y(&mut self, builder: Builder<Vec<u8>>) {
+        dbg!("y");
+        self.pn = builder.pn;
+        self.header = builder.header;
+        self.offsets = builder.offsets;
+        self.limit = builder.limit;
+        self.padding = builder.padding;
+
+        dbg!(self.encoder.len());
+
+        dbg!(builder.encoder.len());
+
+        self.encoder
+            .encode(&builder.encoder.as_ref()[(self.encoder.len())..]);
+
+        dbg!(self.encoder.len());
+    }
+
     /// Start building a short header packet.
     ///
     /// This doesn't fail if there isn't enough space; instead it returns a builder that
@@ -1764,8 +1809,14 @@ mod tests {
     #[test]
     fn build_vn() {
         fixture_init();
-        let mut vn =
-            Builder::version_negotiation(SERVER_CID, CLIENT_CID, 0x0a0a_0a0a, &Version::all());
+        let mut vn = Vec::new();
+        Builder::version_negotiation(
+            SERVER_CID,
+            CLIENT_CID,
+            0x0a0a_0a0a,
+            &Version::all(),
+            &mut vn,
+        );
         // Erase randomness from greasing...
         assert_eq!(vn.len(), SAMPLE_VN.len());
         vn[0] &= 0x80;
@@ -1778,7 +1829,14 @@ mod tests {
     #[test]
     fn vn_do_not_repeat_client_grease() {
         fixture_init();
-        let vn = Builder::version_negotiation(SERVER_CID, CLIENT_CID, 0x0a0a_0a0a, &Version::all());
+        let mut vn = Vec::new();
+        Builder::version_negotiation(
+            SERVER_CID,
+            CLIENT_CID,
+            0x0a0a_0a0a,
+            &Version::all(),
+            &mut vn,
+        );
         assert_ne!(&vn[SAMPLE_VN.len() - 4..], &[0x0a, 0x0a, 0x0a, 0x0a]);
     }
 

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -183,8 +183,10 @@ impl Builder<Vec<u8>> {
         Ok(complete.split_off(start))
     }
 
-    /// Make a Version Negotiation packet.
-    #[must_use]
+    /// Write a Version Negotiation packet into `send_buffer`.
+    ///
+    /// # Panics
+    /// When `send_buffer` cannot grow to hold the packet.
     pub fn version_negotiation<B: Buffer>(
         dcid: &[u8],
         scid: &[u8],
@@ -192,7 +194,7 @@ impl Builder<Vec<u8>> {
         versions: &[Version],
         send_buffer: B,
     ) {
-        let mut encoder = Encoder::new_with_buffer(send_buffer);
+        let mut encoder = Encoder::new(send_buffer);
         let mut grease = random::<4>();
         // This will not include the "QUIC bit" sometimes.  Intentionally.
         encoder.encode_byte(BIT_LONG | (grease[3] & 0x7f));
@@ -216,10 +218,10 @@ impl Builder<Vec<u8>> {
 }
 
 impl<B: Buffer> Builder<B> {
-    // TODO cfg
-    // TODO hack
-    pub fn x(&self) -> Builder<Vec<u8>> {
-        dbg!("x");
+    /// Copy into a [`Vec`]-backed builder, for callers that cannot be generic
+    /// over the buffer. Fold the result back with [`Builder::restore_from`].
+    #[cfg(test)]
+    pub(crate) fn copy_to_vec(&self) -> Builder<Vec<u8>> {
         let Self {
             encoder,
             pn,
@@ -228,11 +230,9 @@ impl<B: Buffer> Builder<B> {
             limit,
             padding,
         } = self;
-        dbg!(encoder.len());
-        let encoder = encoder.to_owned();
 
         Builder {
-            encoder,
+            encoder: Encoder::from(encoder.as_ref()),
             pn: *pn,
             header: header.clone(),
             offsets: (*offsets).clone(),
@@ -241,24 +241,18 @@ impl<B: Buffer> Builder<B> {
         }
     }
 
-    // TODO cfg
-    // TODO hack
-    pub fn y(&mut self, builder: Builder<Vec<u8>>) {
-        dbg!("y");
+    /// Adopt `builder`'s state and append what it wrote. It must have come
+    /// from [`Builder::copy_to_vec`] on `self`.
+    #[cfg(test)]
+    pub(crate) fn restore_from(&mut self, builder: Builder<Vec<u8>>) {
         self.pn = builder.pn;
         self.header = builder.header;
         self.offsets = builder.offsets;
         self.limit = builder.limit;
         self.padding = builder.padding;
 
-        dbg!(self.encoder.len());
-
-        dbg!(builder.encoder.len());
-
         self.encoder
             .encode(&builder.encoder.as_ref()[(self.encoder.len())..]);
-
-        dbg!(self.encoder.len());
     }
 
     /// Start building a short header packet.
@@ -1806,8 +1800,7 @@ mod tests {
         0x01, 0xff, 0x00, 0x00, 0x1d, 0x0a, 0x0a, 0x0a, 0x0a,
     ];
 
-    #[test]
-    fn build_vn() {
+    fn build_sample_vn() -> Vec<u8> {
         fixture_init();
         let mut vn = Vec::new();
         Builder::version_negotiation(
@@ -1817,6 +1810,12 @@ mod tests {
             &Version::all(),
             &mut vn,
         );
+        vn
+    }
+
+    #[test]
+    fn build_vn() {
+        let mut vn = build_sample_vn();
         // Erase randomness from greasing...
         assert_eq!(vn.len(), SAMPLE_VN.len());
         vn[0] &= 0x80;
@@ -1828,15 +1827,7 @@ mod tests {
 
     #[test]
     fn vn_do_not_repeat_client_grease() {
-        fixture_init();
-        let mut vn = Vec::new();
-        Builder::version_negotiation(
-            SERVER_CID,
-            CLIENT_CID,
-            0x0a0a_0a0a,
-            &Version::all(),
-            &mut vn,
-        );
+        let vn = build_sample_vn();
         assert_ne!(&vn[SAMPLE_VN.len() - 4..], &[0x0a, 0x0a, 0x0a, 0x0a]);
     }
 

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -751,14 +751,14 @@ impl Path {
     }
 
     /// Make a datagram.
-    pub fn datagram_batch(
+    pub fn datagram_batch<B: Buffer>(
         &mut self,
-        payload: Vec<u8>,
+        payload: B,
         tos: Tos,
         num_datagrams: usize,
         datagram_size: usize,
         stats: &mut Stats,
-    ) -> datagram::Batch {
+    ) -> datagram::Batch<B> {
         // Make sure to use the TOS value from before calling ecn::Info::on_packet_sent, which may
         // update the ECN state and can hence change it - this packet should still be sent
         // with the current value.

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -759,14 +759,14 @@ impl Path {
     }
 
     /// Make a datagram.
-    pub fn datagram_batch(
+    pub fn datagram_batch<B: Buffer>(
         &mut self,
-        payload: Vec<u8>,
+        payload: B,
         tos: Tos,
         num_datagrams: usize,
         datagram_size: usize,
         stats: &mut Stats,
-    ) -> datagram::Batch {
+    ) -> datagram::Batch<B> {
         // Make sure to use the TOS value from before calling ecn::Info::on_packet_sent, which may
         // update the ECN state and can hence change it - this packet should still be sent
         // with the current value.

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -19,8 +19,8 @@ use std::{
 };
 
 use neqo_common::{
-    Datagram, Role, Tos, event::Provider as _, hex, qdebug, qerror, qinfo, qlog::Qlog, qtrace,
-    qwarn,
+    Datagram, Role, Tos, event::Provider as _, hex, qdebug, qerror, qinfo,
+    qlog::Qlog, qtrace, qwarn,
 };
 use nss::{
     AntiReplay, Cipher, PrivateKey, PublicKey, ZeroRttCheckResult, ZeroRttChecker,
@@ -232,6 +232,7 @@ impl Server {
         now: Instant,
     ) -> Output {
         qdebug!("[{self}] Handle initial");
+        qdebug!("[{self}] Handle initial");
         #[cfg(feature = "build-fuzzing-corpus")]
         Self::write_addr_valid_corpus(dgram.source(), &initial.token);
         let res = self
@@ -406,7 +407,7 @@ impl Server {
         &mut self,
         dgrams: I,
         now: Instant,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         // Process input datagrams from previous call.
         while let Some(SavedDatagram { d, t }) = self.saved_datagrams.pop_front() {
             if let OutputBatch::DatagramBatch(b) = self.process_input(std::iter::once(d), t) {
@@ -432,7 +433,7 @@ impl Server {
         &mut self,
         dgrams: I,
         now: Instant,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         let mut dgrams = dgrams.into_iter();
         while let Some(mut dgram) = dgrams.next() {
             qtrace!("Process datagram: {}", hex(&dgram[..]));
@@ -479,11 +480,13 @@ impl Server {
                 }
 
                 qdebug!("[{self}] Unsupported version: {:x}", packet.wire_version());
-                let vn = packet::Builder::version_negotiation(
+                let mut vn = Vec::new();
+                packet::Builder::version_negotiation(
                     &packet.scid()[..],
                     &packet.dcid()[..],
                     packet.wire_version(),
                     self.conn_params.get_versions().all(),
+                    &mut vn,
                 );
                 qdebug!(
                     "[{self}] type={:?} path:{} {destination}->{source} {:?} len {}",
@@ -545,7 +548,7 @@ impl Server {
 
     /// Iterate through the pending connections looking for any that might want
     /// to send a datagram.  Stop at the first one that does.
-    fn process_next_output(&mut self, now: Instant, max_datagrams: NonZeroUsize) -> OutputBatch {
+    fn process_next_output(&mut self, now: Instant, max_datagrams: NonZeroUsize) -> OutputBatch<Vec<u8>> {
         assert!(
             self.saved_datagrams.is_empty(),
             "Always process all inbound datagrams first."
@@ -553,9 +556,10 @@ impl Server {
         let mut callback = None;
 
         for connection in &mut self.connections {
+            let send_buffer = Vec::new();
             match connection
                 .borrow_mut()
-                .process_multiple_output(now, max_datagrams)
+                .process_multiple_output(now, send_buffer, max_datagrams)
             {
                 OutputBatch::None => {}
                 d @ OutputBatch::DatagramBatch(_) => return d,
@@ -594,7 +598,7 @@ impl Server {
         dgrams: I,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         if let o @ OutputBatch::DatagramBatch(_) = self.process_multiple_input(dgrams, now) {
             // Return immediately. Do any maintenance on next call.
             return o;

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -15,12 +15,12 @@ use std::{
     ops::{Deref, DerefMut},
     path::PathBuf,
     rc::Rc,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use neqo_common::{
-    Datagram, Role, Tos, event::Provider as _, hex::Hex, qdebug, qerror, qinfo, qlog::Qlog, qtrace,
-    qwarn,
+    Buffer, Datagram, Role, Tos, datagram, event::Provider as _, hex::Hex, qdebug, qerror, qinfo,
+    qlog::Qlog, qtrace, qwarn,
 };
 use nss::{
     AntiReplay, Cipher, PrivateKey, PublicKey, ZeroRttCheckResult, ZeroRttChecker,
@@ -231,7 +231,6 @@ impl Server {
         dgram: Datagram<impl AsRef<[u8]> + AsMut<[u8]>>,
         now: Instant,
     ) -> Output {
-        qdebug!("[{self}] Handle initial");
         qdebug!("[{self}] Handle initial");
         #[cfg(feature = "build-fuzzing-corpus")]
         Self::write_addr_valid_corpus(dgram.source(), &initial.token);
@@ -546,32 +545,62 @@ impl Server {
         OutputBatch::None
     }
 
+    /// Re-back an owned batch, as Version Negotiation, Retry and the handshake
+    /// build, with the caller's buffer.
+    ///
+    /// Asks to be called again if the datagram had to be dropped while saved
+    /// input is still pending, so that the input is not left undrained.
+    #[must_use]
+    pub fn copy_output_into<B: Buffer>(
+        &self,
+        batch: OutputBatch<Vec<u8>>,
+        send_buffer: B,
+    ) -> OutputBatch<B> {
+        match batch.copy_into(send_buffer) {
+            OutputBatch::None if !self.saved_datagrams.is_empty() => {
+                OutputBatch::Callback(Duration::ZERO)
+            }
+            o => o,
+        }
+    }
+
     /// Iterate through the pending connections looking for any that might want
     /// to send a datagram.  Stop at the first one that does.
-    fn process_next_output(
+    fn process_next_output<B: Buffer>(
         &mut self,
         now: Instant,
+        mut send_buffer: B,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch<Vec<u8>> {
+    ) -> OutputBatch<B> {
         assert!(
             self.saved_datagrams.is_empty(),
             "Always process all inbound datagrams first."
         );
         let mut callback = None;
 
+        // Reused across connections; no output leaves the buffer empty.
         for connection in &mut self.connections {
-            let send_buffer = Vec::new();
-            match connection
+            let (src, dst, tos, datagram_size) = match connection
                 .borrow_mut()
-                .process_multiple_output(now, send_buffer, max_datagrams)
+                .process_multiple_output(now, &mut send_buffer, max_datagrams)
             {
-                OutputBatch::None => {}
-                d @ OutputBatch::DatagramBatch(_) => return d,
-                OutputBatch::Callback(next) => match callback {
-                    Some(previous) => callback = Some(min(previous, next)),
-                    None => callback = Some(next),
-                },
-            }
+                OutputBatch::DatagramBatch(b) => {
+                    (b.source(), b.destination(), b.tos(), b.datagram_size())
+                }
+                OutputBatch::None => continue,
+                OutputBatch::Callback(next) => {
+                    callback = Some(callback.map_or(next, |previous| min(previous, next)));
+                    continue;
+                }
+            };
+            // Only metadata outlives the match, so `send_buffer` is free to move.
+            return OutputBatch::DatagramBatch(datagram::Batch::new(
+                src,
+                dst,
+                tos,
+                datagram_size,
+                send_buffer,
+            ));
         }
 
         callback.map_or(OutputBatch::None, OutputBatch::Callback)
@@ -592,24 +621,31 @@ impl Server {
         dgrams: I,
         now: Instant,
     ) -> Output {
-        self.process_multiple(dgrams, now, 1.try_into().expect(">0"))
+        self.process_multiple(dgrams, now, Vec::new(), NonZeroUsize::MIN)
             .try_into()
             .expect("max_datagrams is 1")
     }
 
-    pub fn process_multiple<A: AsRef<[u8]> + AsMut<[u8]>, I: IntoIterator<Item = Datagram<A>>>(
+    /// `send_buffer` must be empty, see [`Connection::process_multiple_output`].
+    pub fn process_multiple<
+        A: AsRef<[u8]> + AsMut<[u8]>,
+        I: IntoIterator<Item = Datagram<A>>,
+        B: Buffer,
+    >(
         &mut self,
         dgrams: I,
         now: Instant,
+        send_buffer: B,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch<Vec<u8>> {
-        if let o @ OutputBatch::DatagramBatch(_) = self.process_multiple_input(dgrams, now) {
+    ) -> OutputBatch<B> {
+        let input = self.process_multiple_input(dgrams, now);
+        if matches!(input, OutputBatch::DatagramBatch(_)) {
             // Return immediately. Do any maintenance on next call.
-            return o;
+            return self.copy_output_into(input, send_buffer);
         }
 
         // Process output datagrams.
-        let maybe_callback = match self.process_next_output(now, max_datagrams) {
+        let maybe_callback = match self.process_next_output(now, send_buffer, max_datagrams) {
             // Return immediately. Do any maintenance on next call.
             o @ OutputBatch::DatagramBatch(_) => return o,
             o @ (OutputBatch::Callback(_) | OutputBatch::None) => o,

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -232,6 +232,7 @@ impl Server {
         now: Instant,
     ) -> Output {
         qdebug!("[{self}] Handle initial");
+        qdebug!("[{self}] Handle initial");
         #[cfg(feature = "build-fuzzing-corpus")]
         Self::write_addr_valid_corpus(dgram.source(), &initial.token);
         let res = self
@@ -406,7 +407,7 @@ impl Server {
         &mut self,
         dgrams: I,
         now: Instant,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         // Process input datagrams from previous call.
         while let Some(SavedDatagram { d, t }) = self.saved_datagrams.pop_front() {
             if let OutputBatch::DatagramBatch(b) = self.process_input(std::iter::once(d), t) {
@@ -432,7 +433,7 @@ impl Server {
         &mut self,
         dgrams: I,
         now: Instant,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         let mut dgrams = dgrams.into_iter();
         while let Some(mut dgram) = dgrams.next() {
             qtrace!("Process datagram: {}", Hex::new(&dgram[..]));
@@ -479,11 +480,13 @@ impl Server {
                 }
 
                 qdebug!("[{self}] Unsupported version: {:x}", packet.wire_version());
-                let vn = packet::Builder::version_negotiation(
+                let mut vn = Vec::new();
+                packet::Builder::version_negotiation(
                     &packet.scid()[..],
                     &packet.dcid()[..],
                     packet.wire_version(),
                     self.conn_params.get_versions().all(),
+                    &mut vn,
                 );
                 qdebug!(
                     "[{self}] type={:?} path:{} {destination}->{source} {:?} len {}",
@@ -545,7 +548,11 @@ impl Server {
 
     /// Iterate through the pending connections looking for any that might want
     /// to send a datagram.  Stop at the first one that does.
-    fn process_next_output(&mut self, now: Instant, max_datagrams: NonZeroUsize) -> OutputBatch {
+    fn process_next_output(
+        &mut self,
+        now: Instant,
+        max_datagrams: NonZeroUsize,
+    ) -> OutputBatch<Vec<u8>> {
         assert!(
             self.saved_datagrams.is_empty(),
             "Always process all inbound datagrams first."
@@ -553,9 +560,10 @@ impl Server {
         let mut callback = None;
 
         for connection in &mut self.connections {
+            let send_buffer = Vec::new();
             match connection
                 .borrow_mut()
-                .process_multiple_output(now, max_datagrams)
+                .process_multiple_output(now, send_buffer, max_datagrams)
             {
                 OutputBatch::None => {}
                 d @ OutputBatch::DatagramBatch(_) => return d,
@@ -594,7 +602,7 @@ impl Server {
         dgrams: I,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         if let o @ OutputBatch::DatagramBatch(_) = self.process_multiple_input(dgrams, now) {
             // Return immediately. Do any maintenance on next call.
             return o;

--- a/neqo-transport/tests/connection.rs
+++ b/neqo-transport/tests/connection.rs
@@ -32,8 +32,9 @@ fn gso() {
     client.stream_send(stream_id2, &[42; 2048]).unwrap();
     client.stream_close_send(stream_id2).unwrap();
 
+    let send_buffer = vec![];
     let out = client
-        .process_multiple_output(now(), 64.try_into().expect(">0"))
+        .process_multiple_output(now(),send_buffer, 64.try_into().expect(">0"))
         .dgram()
         .unwrap();
 

--- a/neqo-transport/tests/connection.rs
+++ b/neqo-transport/tests/connection.rs
@@ -32,8 +32,9 @@ fn gso() {
     client.stream_send(stream_id2, &[42; 2048]).unwrap();
     client.stream_close_send(stream_id2).unwrap();
 
+    let send_buffer = vec![];
     let out = client
-        .process_multiple_output(now(), 64.try_into().expect(">0"))
+        .process_multiple_output(now(), send_buffer, 64.try_into().expect(">0"))
         .dgram()
         .unwrap();
 

--- a/neqo-transport/tests/connection.rs
+++ b/neqo-transport/tests/connection.rs
@@ -175,7 +175,7 @@ fn set_payload(server_packet: Option<&Datagram>, client_dcid: &[u8], payload: &[
     let pn_len = usize::from(header[0] & 0b0000_0011) + 1;
     let len_pos = header.len() - pn_len - Encoder::varint_len(to_u64(pn_len + orig_payload.len()));
     header.truncate(len_pos);
-    let mut enc = Encoder::new_borrowed_vec(&mut header);
+    let mut enc = Encoder::new(&mut header);
     enc.encode_len(4 + payload.len() + aead.expansion());
     enc.encode_uint(4, pn);
     header[0] = header[0] & 0xfc | 0b0000_0011; // Set the packet number length to 4.

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -6,13 +6,13 @@
 
 mod common;
 
-use std::{cell::RefCell, net::SocketAddr, rc::Rc, time::Duration};
+use std::{cell::RefCell, io::Cursor, net::SocketAddr, num::NonZeroUsize, rc::Rc, time::Duration};
 
 use common::{connect, connected_server, default_server, find_ticket, generate_ticket, new_server};
 use neqo_common::{Datagram, Decoder, Encoder, Role, qtrace};
 use neqo_transport::{
-    CloseReason, Connection, ConnectionParameters, Error, MIN_INITIAL_PACKET_SIZE, Output, State,
-    StreamType, Version,
+    CloseReason, Connection, ConnectionParameters, Error, MIN_INITIAL_PACKET_SIZE, Output,
+    OutputBatch, State, StreamType, Version,
     server::{ConnectionRef, Server, ValidateAddress},
     version,
 };
@@ -944,7 +944,8 @@ fn saved_datagrams() {
         .process_multiple(
             vec![invalid_dgram(), valid_dgram, invalid_dgram()],
             now(),
-            1.try_into().expect("1>0"),
+            Vec::new(),
+            NonZeroUsize::MIN,
         )
         .dgram()
         .expect("first packet triggers first vn");
@@ -954,13 +955,45 @@ fn saved_datagrams() {
     // which does require an immediate response. It thereby has to save the
     // fourth (new) datagram for the next call.
     server
-        .process_multiple(Some(invalid_dgram()), now(), 1.try_into().expect("1>0"))
+        .process_multiple(Some(invalid_dgram()), now(), Vec::new(), NonZeroUsize::MIN)
         .dgram()
         .expect("third packet triggers second vn");
 
     // Server processes the fourth datagram.
     server
-        .process_multiple(Vec::<Datagram>::new(), now(), 1.try_into().expect("1>0"))
+        .process_multiple(Vec::<Datagram>::new(), now(), Vec::new(), NonZeroUsize::MIN)
         .dgram()
         .expect("fourth packet triggers third vn");
+}
+
+/// A send buffer too small for a Version Negotiation packet drops it, but must
+/// still ask to be called again to drain the saved input.
+#[test]
+fn saved_datagrams_with_undersized_send_buffer() {
+    let mut server = default_server();
+
+    let invalid_dgram = || {
+        let mut client = default_client();
+        let dgram = client.process_output(now()).dgram().expect("a datagram");
+        let mut input = dgram.to_vec();
+        input[1] ^= 0x12;
+        Datagram::new(dgram.source(), dgram.destination(), dgram.tos(), input)
+    };
+
+    // Two datagrams each need an immediate Version Negotiation response, so the
+    // second is saved while the first is answered.
+    let mut small = [0; 4];
+    let out = server.process_multiple(
+        vec![invalid_dgram(), invalid_dgram()],
+        now(),
+        Cursor::new(&mut small[..]),
+        NonZeroUsize::MIN,
+    );
+    assert!(matches!(out, OutputBatch::Callback(_)));
+
+    // A roomy buffer then drains what was saved.
+    server
+        .process_multiple(Vec::<Datagram>::new(), now(), Vec::new(), NonZeroUsize::MIN)
+        .dgram()
+        .expect("saved datagram triggers a vn");
 }

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use log::{Level, log_enabled};
-use neqo_common::{Datagram, Tos, datagram, qdebug, qtrace};
+use neqo_common::{Buffer, Datagram, Tos, datagram, qdebug, qtrace};
 use quinn_udp::{EcnCodepoint, RecvMeta, Transmit, UdpSocketState};
 #[cfg(windows)]
 use windows::Win32::Networking::WinSock;
@@ -29,6 +29,9 @@ use windows::Win32::Networking::WinSock;
 /// Fits a maximum size UDP datagram, or, on platforms with segmentation
 /// offloading, multiple smaller datagrams.
 const RECV_BUF_SIZE: usize = u16::MAX as usize;
+
+/// Send buffer size
+pub const SEND_BUF_SIZE: usize = u16::MAX as usize;
 
 /// The number of buffers to pass to the OS on [`Socket::recv`].
 ///
@@ -49,6 +52,8 @@ const NUM_BUFS: usize = 1;
 const NUM_BUFS: usize = 16;
 
 /// A UDP receive buffer.
+//
+// TODO: Is a Box<[u8]> better?
 pub struct RecvBuf(Vec<Vec<u8>>);
 
 impl Default for RecvBuf {
@@ -57,10 +62,10 @@ impl Default for RecvBuf {
     }
 }
 
-pub fn send_inner(
+pub fn send_inner<B: Buffer>(
     state: &UdpSocketState,
     socket: quinn_udp::UdpSockRef<'_>,
-    d: &datagram::Batch,
+    d: &datagram::Batch<B>,
 ) -> io::Result<()> {
     let transmit = Transmit {
         destination: d.destination(),
@@ -269,7 +274,7 @@ impl<S: SocketRef> Socket<S> {
     }
 
     /// Send a [`datagram::Batch`] on the given [`Socket`].
-    pub fn send(&self, d: &datagram::Batch) -> io::Result<()> {
+    pub fn send<B: Buffer>(&self, d: &datagram::Batch<B>) -> io::Result<()> {
         send_inner(&self.state, (&self.inner).into(), d)
     }
 
@@ -341,7 +346,7 @@ mod tests {
         let receiver = socket()?;
         let receiver_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-        let datagram: datagram::Batch = Datagram::new(
+        let datagram: datagram::Batch<Vec<u8>> = Datagram::new(
             sender.inner.local_addr()?,
             receiver.inner.local_addr()?,
             Tos::from((Dscp::Le, Ecn::Ect1)),

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
     io::{self, IoSliceMut},
     iter,
     net::SocketAddr,
-    slice::{self, ChunksMut},
+    slice::ChunksMut,
 };
 
 use log::{Level, log_enabled};
@@ -24,13 +24,19 @@ use quinn_udp::{EcnCodepoint, RecvMeta, Transmit, UdpSocketState};
 #[cfg(windows)]
 use windows::Win32::Networking::WinSock;
 
-/// Receive buffer size
+/// Receive buffer size, per slot in [`RecvBuf`].
 ///
 /// Fits a maximum size UDP datagram, or, on platforms with segmentation
 /// offloading, multiple smaller datagrams.
-const RECV_BUF_SIZE: usize = u16::MAX as usize;
+///
+/// Rounded up to a page-aligned stride: where [`NUM_BUFS`] exceeds one, 65535
+/// doubles the pages a datagram makes resident. The payload maximum is 65527.
+const RECV_BUF_SIZE: usize = u16::MAX as usize + 1;
 
 /// Send buffer size
+///
+/// Has to hold the largest PMTUD probe, which reaches the top of
+/// `neqo-transport`'s search table, so it cannot be shrunk to an MTU.
 pub const SEND_BUF_SIZE: usize = u16::MAX as usize;
 
 /// The number of buffers to pass to the OS on [`Socket::recv`].
@@ -52,13 +58,15 @@ const NUM_BUFS: usize = 1;
 const NUM_BUFS: usize = 16;
 
 /// A UDP receive buffer.
-//
-// TODO: Is a Box<[u8]> better?
-pub struct RecvBuf(Vec<Vec<u8>>);
+///
+/// One contiguous zeroed allocation of `NUM_BUFS` slots. Where the allocator
+/// serves that as zero-filled pages, resident memory tracks what is received.
+pub struct RecvBuf(Box<[u8]>);
 
 impl Default for RecvBuf {
     fn default() -> Self {
-        Self(vec![vec![0; RECV_BUF_SIZE]; NUM_BUFS])
+        // `into_boxed_slice` does not reallocate, as capacity matches length.
+        Self(vec![0; RECV_BUF_SIZE * NUM_BUFS].into_boxed_slice())
     }
 }
 
@@ -156,7 +164,7 @@ pub fn recv_inner<'a, S: SocketRef>(
 ) -> Result<DatagramIter<'a>, io::Error> {
     let mut metas = [RecvMeta::default(); NUM_BUFS];
     let mut iovs: [IoSliceMut; NUM_BUFS] = {
-        let mut bufs = recv_buf.0.iter_mut().map(|b| IoSliceMut::new(b));
+        let mut bufs = recv_buf.0.chunks_mut(RECV_BUF_SIZE).map(IoSliceMut::new);
         array::from_fn(|_| bufs.next().expect("NUM_BUFS elements"))
     };
 
@@ -180,7 +188,10 @@ pub fn recv_inner<'a, S: SocketRef>(
 
     Ok(DatagramIter {
         current_buffer: None,
-        remaining_buffers: metas.into_iter().zip(recv_buf.0.iter_mut()).take(n),
+        remaining_buffers: metas
+            .into_iter()
+            .zip(recv_buf.0.chunks_mut(RECV_BUF_SIZE))
+            .take(n),
         local_address,
     })
 }
@@ -192,7 +203,7 @@ pub struct DatagramIter<'a> {
     /// Remaining buffers, each containing zero or more datagrams, one
     /// [`RecvMeta`] per buffer.
     remaining_buffers:
-        iter::Take<iter::Zip<array::IntoIter<RecvMeta, NUM_BUFS>, slice::IterMut<'a, Vec<u8>>>>,
+        iter::Take<iter::Zip<array::IntoIter<RecvMeta, NUM_BUFS>, ChunksMut<'a, u8>>>,
     /// The local address of the UDP socket used to receive the datagrams.
     local_address: SocketAddr,
 }


### PR DESCRIPTION
Maintain a long-lived send buffer. When producing outbound UDP datagrams
write them into the buffer. Then pass the buffer to the OS to be sent
out on the network.

In other words, don't heap-allocate in the UDP send path.

---

Corresponding past patch for the receive path https://github.com/mozilla/neqo/pull/2184
Fixes https://github.com/mozilla/neqo/issues/2670