### PR TITLE
test(udp): set emsgsize test socket to blocking

### DIFF
--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -380,6 +380,7 @@ mod tests {
         let receiver = Socket::new(std::net::UdpSocket::bind("127.0.0.1:0")?)?;
         let receiver_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
+        // Send oversized datagram and expect `EMSGSIZE` error to be ignored.
         let oversized_datagram = Datagram::new(
             sender.inner.local_addr()?,
             receiver.inner.local_addr()?,
@@ -395,7 +396,6 @@ mod tests {
         }
 
         // Now send a normal datagram to ensure that the socket is still usable.
-
         let normal_datagram = Datagram::new(
             sender.inner.local_addr()?,
             receiver.inner.local_addr()?,
@@ -405,6 +405,8 @@ mod tests {
         sender.send(&normal_datagram)?;
 
         let mut recv_buf = RecvBuf::new();
+        // Block until "Hello World!" is received.
+        receiver.inner.set_nonblocking(false)?;
         let mut received_datagram = receiver.recv(receiver_addr, &mut recv_buf)?;
         assert_eq!(
             received_datagram.next().unwrap().as_ref(),


### PR DESCRIPTION
The `send_ignore_emsgsize` unit test first sends an oversized datagram, expecting it to be ignored, then sends a normal datagram, expecting it to be received.

In the second check, to avoid race conditions, set the receiving socket to blocking before the call to `receiver.recv`.

Fixes https://github.com/mozilla/neqo/issues/2752