### PR TITLE
fix(fuzz): fix renamed header_protection::*

### DIFF
--- a/fuzz/fuzz_targets/client_initial.rs
+++ b/fuzz/fuzz_targets/client_initial.rs
@@ -9,10 +9,7 @@ fuzz_target!(|data: &[u8]| {
     use neqo_crypto::Aead;
     use neqo_transport::{packet::MIN_INITIAL_PACKET_SIZE, ConnectionParameters, Version};
     use test_fixture::{
-        header_protection::{
-            apply_header_protection, decode_initial_header, initial_aead_and_hp,
-            remove_header_protection,
-        },
+        header_protection::{self, decode_initial_header, initial_aead_and_hp},
         new_client, new_server, now, DEFAULT_ALPN,
     };
 
@@ -22,7 +19,7 @@ fuzz_target!(|data: &[u8]| {
         return;
     };
     let (aead, hp) = initial_aead_and_hp(d_cid, Role::Client);
-    let (_, pn) = remove_header_protection(&hp, header, payload);
+    let (_, pn) = header_protection::remove(&hp, header, payload);
 
     let mut payload_enc = Encoder::with_capacity(MIN_INITIAL_PACKET_SIZE);
     payload_enc.encode(data); // Add fuzzed data.
@@ -52,7 +49,7 @@ fuzz_target!(|data: &[u8]| {
     // Pad with zero to get up to MIN_INITIAL_PACKET_SIZE.
     ciphertext.resize(MIN_INITIAL_PACKET_SIZE, 0);
 
-    apply_header_protection(
+    header_protection::apply(
         &hp,
         &mut ciphertext,
         (header_enc.len() - 1)..header_enc.len(),

--- a/fuzz/fuzz_targets/packet.rs
+++ b/fuzz/fuzz_targets/packet.rs
@@ -7,14 +7,14 @@ use libfuzzer_sys::fuzz_target;
 fuzz_target!(|data: &[u8]| {
     use std::sync::OnceLock;
 
-    use neqo_transport::{packet::PublicPacket, RandomConnectionIdGenerator};
+    use neqo_transport::{packet, RandomConnectionIdGenerator};
 
     static DECODER: OnceLock<RandomConnectionIdGenerator> = OnceLock::new();
     let decoder = DECODER.get_or_init(|| RandomConnectionIdGenerator::new(20));
     neqo_crypto::init().unwrap();
 
     // Run the fuzzer
-    _ = PublicPacket::decode(&mut data.to_vec(), decoder);
+    _ = packet::Public::decode(&mut data.to_vec(), decoder);
 });
 
 #[cfg(any(not(fuzzing), windows))]


### PR DESCRIPTION
See test failure in e.g. https://github.com/mozilla/neqo/actions/runs/15845790074/job/44667546909?pr=2755

Follow-up to https://github.com/mozilla/neqo/pull/2753