### PR TITLE
ci: Don't generate and upload `junit.xml` to CodeCov anymore

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           version: ${{ matrix.rust-toolchain }}
           components: ${{ matrix.rust-toolchain == 'stable' && 'llvm-tools' || '' }}
-          tools: ${{ matrix.rust-toolchain == 'stable' && 'cargo-llvm-cov, ' || '' }} junit-test
+          tools: ${{ matrix.rust-toolchain == 'stable' && 'cargo-llvm-cov' || '' }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - id: nss-version
@@ -130,8 +130,6 @@ jobs:
           else
             cargo test $BUILD_TYPE --locked --features ci
           fi
-          # shellcheck disable=SC2086
-          junit-test $BUILD_TYPE
 
       - name: Run client/server transfer
         run: |
@@ -166,14 +164,6 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: matrix.type == 'debug' && matrix.rust-toolchain == 'stable'
-
-      - uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
-        if: ${{ always() }}
-        with:
-          files: junit.xml
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
 
       - name: Save simulation seeds artifact
         if: ${{ always() }}


### PR DESCRIPTION
`nextest` was producing `junit.xml` as a side effect, and so uploading it for [CodeCov's "flaky tests" dashboard](https://app.codecov.io/gh/mozilla/neqo/tests) was simple. When we stopped using `nextest` in #2679, I switched us to `junit-test` which I thought was converting the existing `cargo test` output to produce a `junit.xml` for upload.

Turns out what it is actually doing is compiling and running the entire `cargo test` suite again, which takes minutes in CI.

We're not really getting much use out of the CodeCov tests feature, so let's just stop feeding it data.