### PR TITLE
ci: Don't delay the start of CI benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,11 @@
 name: cargo bench
 on:
+  workflow_dispatch:
   workflow_call:
+  pull_request:
+    branches: ["main"]
+  merge_group:
+
 env:
   CARGO_PROFILE_BENCH_BUILD_OVERRIDE_DEBUG: true
   CARGO_PROFILE_RELEASE_DEBUG: true
@@ -12,6 +17,10 @@ env:
   CFLAGS: -fno-omit-frame-pointer
   CXXFLAGS: -fno-omit-frame-pointer
   WORKSPACE: ${{ github.workspace}}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -201,7 +210,7 @@ jobs:
       - name: Export PR comment data
         uses: ./neqo/.github/actions/pr-comment-data-export
         with:
-          name: ${{ github.workflow }}-bench
+          name: ${{ github.workflow }}
           contents: results.md
           log-md: ${{ format('[Download data for `profiler.firefox.com`]({0}) or [download performance comparison data]({1}).', steps.export_samply.outputs.artifact-url, steps.export_perf.outputs.artifact-url) }}
 

--- a/.github/workflows/bencher-upload.yml
+++ b/.github/workflows/bencher-upload.yml
@@ -2,7 +2,7 @@ name: bencher.dev Upload
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["cargo bench", "Performance comparison"]
     # SAFETY: We are not running any code from the triggering PR, so this is safe.
     types: [completed] # zizmor: ignore[dangerous-triggers]
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -184,16 +184,6 @@ jobs:
           persist-credentials: false
       - run: cargo update -w --locked
 
-  bench:
-    needs: [check]
-    if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || github.event.inputs.run_benchmarks) && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
-    uses: ./.github/workflows/bench.yml
-
-  perfcompare:
-    needs: [check]
-    if: ${{ !cancelled() && (github.event_name != 'workflow_dispatch' || github.event.inputs.run_benchmarks) && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
-    uses: ./.github/workflows/perfcompare.yml
-
   check-android:
     name: Check Android
     runs-on: ubuntu-24.04

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -1,6 +1,11 @@
 name: Performance comparison
 on:
+  workflow_dispatch:
   workflow_call:
+  pull_request:
+    branches: ["main"]
+  merge_group:
+
 env:
   CARGO_PROFILE_BENCH_BUILD_OVERRIDE_DEBUG: true
   CARGO_PROFILE_RELEASE_DEBUG: true
@@ -12,6 +17,10 @@ env:
   CFLAGS: -fno-omit-frame-pointer
   CXXFLAGS: -fno-omit-frame-pointer
   WORKSPACE: ${{ github.workspace}}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -482,7 +491,7 @@ jobs:
       - name: Export PR comment data
         uses: ./neqo/.github/actions/pr-comment-data-export
         with:
-          name: ${{ github.workflow }}-perfcompare
+          name: ${{ github.workflow }}
           contents: results.md
           log-md: ${{ format('[Download data for `profiler.firefox.com`]({0}) or [download performance comparison data]({1}).', steps.export_samply.outputs.artifact-url, steps.export_perf.outputs.artifact-url) }}
 

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -8,7 +8,7 @@ name: PR Comment
 
 on:
   workflow_run:
-    workflows: ["QNS", "CI", "Firefox"]
+    workflows: ["QNS", "cargo bench", "Performance comparison", "Firefox"]
     types:
       - completed # zizmor: ignore[dangerous-triggers]
 
@@ -29,20 +29,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - if: ${{ github.event.workflow_run.name != 'CI' }}
-        uses: ./.github/actions/pr-comment
+      - uses: ./.github/actions/pr-comment
         with:
           name: ${{ github.event.workflow_run.name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - if: ${{ github.event.workflow_run.name == 'CI' }}
-        uses: ./.github/actions/pr-comment
-        with:
-          name: ${{ github.event.workflow_run.name }}-bench
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - if: ${{ github.event.workflow_run.name == 'CI' }}
-        uses: ./.github/actions/pr-comment
-        with:
-          name: ${{ github.event.workflow_run.name }}-perfcompare
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Now that we have multiple runners, we don't need to be so careful to avoid wasting runtime there, and can instead trade for earlier completion.