### PR TITLE
ci: Fix cirun.io integration

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -5,6 +5,6 @@ runners:
     machine_image: "ubuntu-2404-lts-amd64"
     preemptible: false
     labels:
-      - "gcp-cirun-bencher"
+      - "cirun-gcp-bencher"
     extra_config:
       project_id: "moz-fx-dev-leggert-cirun"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   bench:
     name: cargo bench
-    runs-on: ${{ inputs.bencher == 'on-prem' && fromJson('["self-hosted", "moonshot"]') || format('gcp-cirun-bencher--{0}', github.run_id) }}
+    runs-on: ${{ inputs.bencher == 'on-prem' && fromJson('["self-hosted", "moonshot"]') || format('cirun-gcp-bencher--{0}', github.run_id) }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   perfcompare:
     name: Performance comparison
-    runs-on: ${{ inputs.bencher == 'on-prem' && fromJson('["self-hosted", "moonshot"]') || format('gcp-cirun-bencher--{0}', github.run_id) }}
+    runs-on: ${{ inputs.bencher == 'on-prem' && fromJson('["self-hosted", "moonshot"]') || format('cirun-gcp-bencher--{0}', github.run_id) }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Label needs to start with `cirun-`, see https://docs.cirun.io/reference/yaml#labels-labels.