### PR TITLE
Introduce a `recovery::Tokens` type

### DIFF
--- a/neqo-transport/benches/sent_packets.rs
+++ b/neqo-transport/benches/sent_packets.rs
@@ -7,7 +7,10 @@
 use std::{hint::black_box, time::Instant};
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use neqo_transport::{self, packet, recovery::sent};
+use neqo_transport::{
+    self, packet,
+    recovery::{sent, RecoveryTokenVec},
+};
 
 fn sent_packets() -> sent::Packets {
     let mut pkts = sent::Packets::default();
@@ -19,7 +22,7 @@ fn sent_packets() -> sent::Packets {
             packet::Number::from(i),
             now,
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             100,
         ));
     }

--- a/neqo-transport/benches/sent_packets.rs
+++ b/neqo-transport/benches/sent_packets.rs
@@ -9,7 +9,7 @@ use std::{hint::black_box, time::Instant};
 use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_transport::{
     self, packet,
-    recovery::{sent, RecoveryTokenVec},
+    recovery::{recovery::Tokens, sent},
 };
 
 fn sent_packets() -> sent::Packets {
@@ -22,7 +22,7 @@ fn sent_packets() -> sent::Packets {
             packet::Number::from(i),
             now,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             100,
         ));
     }

--- a/neqo-transport/benches/sent_packets.rs
+++ b/neqo-transport/benches/sent_packets.rs
@@ -9,7 +9,7 @@ use std::{hint::black_box, time::Instant};
 use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_transport::{
     self, packet,
-    recovery::{recovery::Tokens, sent},
+    recovery::{self, sent},
 };
 
 fn sent_packets() -> sent::Packets {

--- a/neqo-transport/src/ackrate.rs
+++ b/neqo-transport/src/ackrate.rs
@@ -11,7 +11,11 @@ use std::{cmp::max, time::Duration};
 use neqo_common::{qtrace, Buffer};
 
 use crate::{
-    connection::params::ACK_RATIO_SCALE, frame::FrameType, packet, recovery, stats::FrameStats,
+    connection::params::ACK_RATIO_SCALE,
+    frame::FrameType,
+    packet,
+    recovery::{self, RecoveryTokenVec},
+    stats::FrameStats,
     tracking::DEFAULT_REMOTE_ACK_DELAY,
 };
 
@@ -100,7 +104,7 @@ impl FlexibleAckRate {
     fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         if !self.frame_outstanding
@@ -166,7 +170,7 @@ impl PeerAckDelay {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         if let Self::Flexible(rate) = self {

--- a/neqo-transport/src/ackrate.rs
+++ b/neqo-transport/src/ackrate.rs
@@ -14,7 +14,7 @@ use crate::{
     connection::params::ACK_RATIO_SCALE,
     frame::FrameType,
     packet,
-    recovery::{self, RecoveryTokenVec},
+    recovery::{self},
     stats::FrameStats,
     tracking::DEFAULT_REMOTE_ACK_DELAY,
 };
@@ -104,7 +104,7 @@ impl FlexibleAckRate {
     fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         if !self.frame_outstanding
@@ -170,7 +170,7 @@ impl PeerAckDelay {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         if let Self::Flexible(rate) = self {

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -18,7 +18,14 @@ use neqo_crypto::{
 };
 use smallvec::SmallVec;
 
-use crate::{cid::ConnectionId, frame::FrameType, packet, recovery, stats::FrameStats, Res};
+use crate::{
+    cid::ConnectionId,
+    frame::FrameType,
+    packet,
+    recovery::{self, RecoveryTokenVec},
+    stats::FrameStats,
+    Res,
+};
 
 /// A prefix we add to Retry tokens to distinguish them from `NEW_TOKEN` tokens.
 const TOKEN_IDENTIFIER_RETRY: &[u8] = &[0x52, 0x65, 0x74, 0x72, 0x79];
@@ -338,7 +345,7 @@ impl NewTokenState {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         if let Self::Server(ref mut sender) = self {
@@ -412,7 +419,7 @@ impl NewTokenSender {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         for t in &mut self.tokens {

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -18,14 +18,7 @@ use neqo_crypto::{
 };
 use smallvec::SmallVec;
 
-use crate::{
-    cid::ConnectionId,
-    frame::FrameType,
-    packet,
-    recovery::{self, RecoveryTokenVec},
-    stats::FrameStats,
-    Res,
-};
+use crate::{cid::ConnectionId, frame::FrameType, packet, recovery, stats::FrameStats, Res};
 
 /// A prefix we add to Retry tokens to distinguish them from `NEW_TOKEN` tokens.
 const TOKEN_IDENTIFIER_RETRY: &[u8] = &[0x52, 0x65, 0x74, 0x72, 0x79];
@@ -345,7 +338,7 @@ impl NewTokenState {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         if let Self::Server(ref mut sender) = self {
@@ -419,7 +412,7 @@ impl NewTokenSender {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         for t in &mut self.tokens {

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -613,8 +613,8 @@ mod tests {
         },
         packet,
         recovery::{
+            self,
             sent::{self},
-            RecoveryTokenVec,
         },
         rtt::RttEstimate,
         Pmtud,
@@ -646,7 +646,7 @@ mod tests {
             pn,
             now() + t,
             ack_eliciting,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             100,
         )
     }
@@ -860,7 +860,7 @@ mod tests {
                     u64::try_from(i).unwrap(),
                     by_pto(t),
                     true,
-                    RecoveryTokenVec::new(),
+                    recovery::Tokens::new(),
                     1000,
                 )
             })
@@ -1082,7 +1082,7 @@ mod tests {
                     next_pn,
                     now,
                     true,
-                    RecoveryTokenVec::new(),
+                    recovery::Tokens::new(),
                     cc.max_datagram_size(),
                 );
                 next_pn += 1;
@@ -1109,7 +1109,7 @@ mod tests {
                 next_pn,
                 now,
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 cc.max_datagram_size(),
             );
             next_pn += 1;
@@ -1159,7 +1159,7 @@ mod tests {
             1,
             now,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             cc.max_datagram_size(),
         );
         cc.on_packet_sent(&p_lost, now);
@@ -1172,7 +1172,7 @@ mod tests {
             2,
             now,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             cc.max_datagram_size(),
         );
         cc.on_packet_sent(&p_not_lost, now);
@@ -1195,7 +1195,7 @@ mod tests {
                     next_pn,
                     now,
                     true,
-                    RecoveryTokenVec::new(),
+                    recovery::Tokens::new(),
                     cc.max_datagram_size(),
                 );
                 next_pn += 1;
@@ -1228,7 +1228,7 @@ mod tests {
                 next_pn,
                 now,
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 cc.max_datagram_size(),
             );
             next_pn += 1;
@@ -1267,7 +1267,7 @@ mod tests {
             1,
             now,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             cc.max_datagram_size(),
         );
         cc.on_packet_sent(&p_ce, now);

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -612,7 +612,10 @@ mod tests {
             CongestionControl, CongestionControlAlgorithm, CWND_INITIAL_PKTS,
         },
         packet,
-        recovery::sent::{self},
+        recovery::{
+            sent::{self},
+            RecoveryTokenVec,
+        },
         rtt::RttEstimate,
         Pmtud,
     };
@@ -643,7 +646,7 @@ mod tests {
             pn,
             now() + t,
             ack_eliciting,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             100,
         )
     }
@@ -857,7 +860,7 @@ mod tests {
                     u64::try_from(i).unwrap(),
                     by_pto(t),
                     true,
-                    Vec::new(),
+                    RecoveryTokenVec::new(),
                     1000,
                 )
             })
@@ -978,7 +981,7 @@ mod tests {
             lost[0].pn(),
             lost[0].time_sent(),
             false,
-            lost[0].tokens().to_vec(),
+            lost[0].tokens().clone(),
             lost[0].len(),
         );
         assert!(!persistent_congestion_by_pto(
@@ -1079,7 +1082,7 @@ mod tests {
                     next_pn,
                     now,
                     true,
-                    Vec::new(),
+                    RecoveryTokenVec::new(),
                     cc.max_datagram_size(),
                 );
                 next_pn += 1;
@@ -1106,7 +1109,7 @@ mod tests {
                 next_pn,
                 now,
                 true,
-                Vec::new(),
+                RecoveryTokenVec::new(),
                 cc.max_datagram_size(),
             );
             next_pn += 1;
@@ -1156,7 +1159,7 @@ mod tests {
             1,
             now,
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             cc.max_datagram_size(),
         );
         cc.on_packet_sent(&p_lost, now);
@@ -1169,7 +1172,7 @@ mod tests {
             2,
             now,
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             cc.max_datagram_size(),
         );
         cc.on_packet_sent(&p_not_lost, now);
@@ -1192,7 +1195,7 @@ mod tests {
                     next_pn,
                     now,
                     true,
-                    Vec::new(),
+                    RecoveryTokenVec::new(),
                     cc.max_datagram_size(),
                 );
                 next_pn += 1;
@@ -1225,7 +1228,7 @@ mod tests {
                 next_pn,
                 now,
                 true,
-                Vec::new(),
+                RecoveryTokenVec::new(),
                 cc.max_datagram_size(),
             );
             next_pn += 1;
@@ -1264,7 +1267,7 @@ mod tests {
             1,
             now,
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             cc.max_datagram_size(),
         );
         cc.on_packet_sent(&p_ce, now);

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -29,7 +29,7 @@ use crate::{
     },
     packet,
     pmtud::Pmtud,
-    recovery::sent,
+    recovery::{sent, RecoveryTokenVec},
     rtt::RttEstimate,
 };
 
@@ -48,7 +48,7 @@ fn fill_cwnd(cc: &mut ClassicCongestionControl<Cubic>, mut next_pn: u64, now: In
             next_pn,
             now,
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             cc.max_datagram_size(),
         );
         cc.on_packet_sent(&sent, now);
@@ -63,7 +63,7 @@ fn ack_packet(cc: &mut ClassicCongestionControl<Cubic>, pn: u64, now: Instant) {
         pn,
         now,
         true,
-        Vec::new(),
+        RecoveryTokenVec::new(),
         cc.max_datagram_size(),
     );
     cc.on_packets_acked(&[acked], &RttEstimate::from_duration(RTT), now);
@@ -76,7 +76,7 @@ fn packet_lost(cc: &mut ClassicCongestionControl<Cubic>, pn: u64) {
         pn,
         now(),
         true,
-        Vec::new(),
+        RecoveryTokenVec::new(),
         cc.max_datagram_size(),
     );
     cc.on_packets_lost(None, None, PTO, &[p_lost], now());

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -29,7 +29,7 @@ use crate::{
     },
     packet,
     pmtud::Pmtud,
-    recovery::{sent, RecoveryTokenVec},
+    recovery::{self, sent},
     rtt::RttEstimate,
 };
 
@@ -48,7 +48,7 @@ fn fill_cwnd(cc: &mut ClassicCongestionControl<Cubic>, mut next_pn: u64, now: In
             next_pn,
             now,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             cc.max_datagram_size(),
         );
         cc.on_packet_sent(&sent, now);
@@ -63,7 +63,7 @@ fn ack_packet(cc: &mut ClassicCongestionControl<Cubic>, pn: u64, now: Instant) {
         pn,
         now,
         true,
-        RecoveryTokenVec::new(),
+        recovery::Tokens::new(),
         cc.max_datagram_size(),
     );
     cc.on_packets_acked(&[acked], &RttEstimate::from_duration(RTT), now);
@@ -76,7 +76,7 @@ fn packet_lost(cc: &mut ClassicCongestionControl<Cubic>, pn: u64) {
         pn,
         now(),
         true,
-        RecoveryTokenVec::new(),
+        recovery::Tokens::new(),
         cc.max_datagram_size(),
     );
     cc.on_packets_lost(None, None, PTO, &[p_lost], now());

--- a/neqo-transport/src/cc/tests/new_reno.rs
+++ b/neqo-transport/src/cc/tests/new_reno.rs
@@ -15,7 +15,7 @@ use crate::{
     cc::{new_reno::NewReno, ClassicCongestionControl, CongestionControl as _},
     packet,
     pmtud::Pmtud,
-    recovery::sent,
+    recovery::{sent, RecoveryTokenVec},
     rtt::RttEstimate,
 };
 
@@ -44,7 +44,7 @@ fn issue_876() {
             1,
             before,
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             cc.max_datagram_size() - 1,
         ),
         sent::Packet::new(
@@ -52,7 +52,7 @@ fn issue_876() {
             2,
             before,
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             cc.max_datagram_size() - 2,
         ),
         sent::Packet::new(
@@ -60,7 +60,7 @@ fn issue_876() {
             3,
             before,
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             cc.max_datagram_size(),
         ),
         sent::Packet::new(
@@ -68,7 +68,7 @@ fn issue_876() {
             4,
             before,
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             cc.max_datagram_size(),
         ),
         sent::Packet::new(
@@ -76,7 +76,7 @@ fn issue_876() {
             5,
             before,
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             cc.max_datagram_size(),
         ),
         sent::Packet::new(
@@ -84,7 +84,7 @@ fn issue_876() {
             6,
             before,
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             cc.max_datagram_size(),
         ),
         sent::Packet::new(
@@ -92,7 +92,7 @@ fn issue_876() {
             7,
             after,
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             cc.max_datagram_size() - 3,
         ),
     ];
@@ -147,7 +147,7 @@ fn issue_1465() {
             pn,
             now,
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             max_datagram_size,
         );
         pn += 1;

--- a/neqo-transport/src/cc/tests/new_reno.rs
+++ b/neqo-transport/src/cc/tests/new_reno.rs
@@ -15,7 +15,7 @@ use crate::{
     cc::{new_reno::NewReno, ClassicCongestionControl, CongestionControl as _},
     packet,
     pmtud::Pmtud,
-    recovery::{sent, RecoveryTokenVec},
+    recovery::{self, sent},
     rtt::RttEstimate,
 };
 
@@ -44,7 +44,7 @@ fn issue_876() {
             1,
             before,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             cc.max_datagram_size() - 1,
         ),
         sent::Packet::new(
@@ -52,7 +52,7 @@ fn issue_876() {
             2,
             before,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             cc.max_datagram_size() - 2,
         ),
         sent::Packet::new(
@@ -60,7 +60,7 @@ fn issue_876() {
             3,
             before,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             cc.max_datagram_size(),
         ),
         sent::Packet::new(
@@ -68,7 +68,7 @@ fn issue_876() {
             4,
             before,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             cc.max_datagram_size(),
         ),
         sent::Packet::new(
@@ -76,7 +76,7 @@ fn issue_876() {
             5,
             before,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             cc.max_datagram_size(),
         ),
         sent::Packet::new(
@@ -84,7 +84,7 @@ fn issue_876() {
             6,
             before,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             cc.max_datagram_size(),
         ),
         sent::Packet::new(
@@ -92,7 +92,7 @@ fn issue_876() {
             7,
             after,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             cc.max_datagram_size() - 3,
         ),
     ];
@@ -147,7 +147,7 @@ fn issue_1465() {
             pn,
             now,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             max_datagram_size,
         );
         pn += 1;

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -19,13 +19,7 @@ use neqo_common::{hex, hex_with_len, qdebug, qinfo, Buffer, Decoder, Encoder};
 use neqo_crypto::{random, randomize};
 use smallvec::{smallvec, SmallVec};
 
-use crate::{
-    frame::FrameType,
-    packet,
-    recovery::{self, RecoveryTokenVec},
-    stats::FrameStats,
-    Error, Res,
-};
+use crate::{frame::FrameType, packet, recovery, stats::FrameStats, Error, Res};
 
 pub const MAX_CONNECTION_ID_LEN: usize = 20;
 pub const LOCAL_ACTIVE_CID_LIMIT: usize = 8;
@@ -561,7 +555,7 @@ impl ConnectionIdManager {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         if self.generator.deref().borrow().generates_empty_cids() {

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -19,7 +19,13 @@ use neqo_common::{hex, hex_with_len, qdebug, qinfo, Buffer, Decoder, Encoder};
 use neqo_crypto::{random, randomize};
 use smallvec::{smallvec, SmallVec};
 
-use crate::{frame::FrameType, packet, recovery, stats::FrameStats, Error, Res};
+use crate::{
+    frame::FrameType,
+    packet,
+    recovery::{self, RecoveryTokenVec},
+    stats::FrameStats,
+    Error, Res,
+};
 
 pub const MAX_CONNECTION_ID_LEN: usize = 20;
 pub const LOCAL_ACTIVE_CID_LIMIT: usize = 8;
@@ -555,7 +561,7 @@ impl ConnectionIdManager {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         if self.generator.deref().borrow().generates_empty_cids() {

--- a/neqo-transport/src/connection/idle.rs
+++ b/neqo-transport/src/connection/idle.rs
@@ -11,7 +11,7 @@ use std::{
 
 use neqo_common::qtrace;
 
-use crate::recovery::{self, RecoveryTokenVec};
+use crate::recovery;
 
 #[derive(Debug, Clone)]
 /// There's a little bit of different behavior for resetting idle timeout. See
@@ -122,7 +122,7 @@ impl IdleTimeout {
         &mut self,
         now: Instant,
         pto: Duration,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
     ) -> bool {
         if !self.keep_alive_outstanding && now >= self.keep_alive_timeout(now, pto) {
             self.keep_alive_outstanding = true;

--- a/neqo-transport/src/connection/idle.rs
+++ b/neqo-transport/src/connection/idle.rs
@@ -11,7 +11,7 @@ use std::{
 
 use neqo_common::qtrace;
 
-use crate::recovery;
+use crate::recovery::{self, RecoveryTokenVec};
 
 #[derive(Debug, Clone)]
 /// There's a little bit of different behavior for resetting idle timeout. See
@@ -122,7 +122,7 @@ impl IdleTimeout {
         &mut self,
         now: Instant,
         pto: Duration,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
     ) -> bool {
         if !self.keep_alive_outstanding && now >= self.keep_alive_timeout(now, pto) {
             self.keep_alive_outstanding = true;

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -43,7 +43,7 @@ use crate::{
     path::{Path, PathRef, Paths},
     qlog,
     quic_datagrams::{DatagramTracking, QuicDatagrams},
-    recovery::{self, sent, SendProfile},
+    recovery::{self, sent, RecoveryTokenVec, SendProfile},
     recv_stream,
     rtt::{RttEstimate, GRANULARITY, INITIAL_RTT},
     send_stream::{self, SendStream},
@@ -2286,7 +2286,7 @@ impl Connection {
     fn write_appdata_frames(
         &mut self,
         builder: &mut packet::Builder<&mut Vec<u8>>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         now: Instant,
     ) {
         let rtt = self.paths.primary().map_or_else(
@@ -2385,7 +2385,7 @@ impl Connection {
         force_probe: bool,
         builder: &mut packet::Builder<B>,
         ack_end: usize,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         now: Instant,
     ) -> bool {
         let untracked = self.received_untracked && !self.state.connected();
@@ -2438,8 +2438,8 @@ impl Connection {
         builder: &mut packet::Builder<&mut Vec<u8>>,
         coalesced: bool, // Whether this packet is coalesced behind another one.
         now: Instant,
-    ) -> (Vec<recovery::Token>, bool, bool) {
-        let mut tokens = Vec::new();
+    ) -> (RecoveryTokenVec, bool, bool) {
+        let mut tokens = RecoveryTokenVec::new();
         let primary = path.borrow().is_primary();
         let mut ack_eliciting = false;
 
@@ -2530,7 +2530,7 @@ impl Connection {
         space: PacketNumberSpace,
         now: Instant,
         path: &PathRef,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
     ) {
         if builder.remaining() > ClosingFrame::MIN_LENGTH + RecvdPackets::USEFUL_ACK_LEN {
             // Include an ACK frame with the CONNECTION_CLOSE.
@@ -2699,7 +2699,8 @@ impl Connection {
 
             // Add frames to the packet.
             let payload_start = builder.len();
-            let (mut tokens, mut ack_eliciting, mut padded) = (Vec::new(), false, false);
+            let (mut tokens, mut ack_eliciting, mut padded) =
+                (RecoveryTokenVec::new(), false, false);
             if let Some(close) = closing_frame {
                 self.write_closing_frames(close, &mut builder, space, now, path, &mut tokens);
             } else {

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::{
     packet::{self, PACKET_LIMIT},
-    recovery::RecoveryTokenVec,
+    recovery,
     stats::FrameStats,
     stream_id::{StreamId, StreamType},
     tparams::{TransportParameter, TransportParameterId},
@@ -309,7 +309,7 @@ fn idle_caching() {
     // Now let the server process the RTX'ed client Initial.  This causes the server
     // to send CRYPTO frames again, so manually extract and discard those.
     server.process_input(dgram.unwrap(), middle);
-    let mut tokens = RecoveryTokenVec::new();
+    let mut tokens = recovery::Tokens::new();
     server.crypto.streams_mut().write_frame(
         PacketNumberSpace::Initial,
         server.conn_params.sni_slicing_enabled(),

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -17,6 +17,7 @@ use super::{
 };
 use crate::{
     packet::{self, PACKET_LIMIT},
+    recovery::RecoveryTokenVec,
     stats::FrameStats,
     stream_id::{StreamId, StreamType},
     tparams::{TransportParameter, TransportParameterId},
@@ -308,7 +309,7 @@ fn idle_caching() {
     // Now let the server process the RTX'ed client Initial.  This causes the server
     // to send CRYPTO frames again, so manually extract and discard those.
     server.process_input(dgram.unwrap(), middle);
-    let mut tokens = Vec::new();
+    let mut tokens = RecoveryTokenVec::new();
     server.crypto.streams_mut().write_frame(
         PacketNumberSpace::Initial,
         server.conn_params.sni_slicing_enabled(),

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -29,7 +29,7 @@ use crate::{
     cid::ConnectionIdRef,
     frame::FrameType,
     packet::{self},
-    recovery,
+    recovery::{self, RecoveryTokenVec},
     recv_stream::RxStreamOrderer,
     send_stream::TxBuffer,
     sni::find_sni,
@@ -319,7 +319,7 @@ impl Crypto {
         space: PacketNumberSpace,
         sni_slicing: bool,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         self.streams
@@ -1511,7 +1511,7 @@ impl CryptoStreams {
         space: PacketNumberSpace,
         sni_slicing: bool,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         fn write_chunk<B: Buffer>(
@@ -1543,7 +1543,7 @@ impl CryptoStreams {
         fn mark_as_sent(
             cs: &mut CryptoStream,
             space: PacketNumberSpace,
-            tokens: &mut Vec<recovery::Token>,
+            tokens: &mut RecoveryTokenVec,
             offset: u64,
             len: usize,
             stats: &mut FrameStats,

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -29,7 +29,7 @@ use crate::{
     cid::ConnectionIdRef,
     frame::FrameType,
     packet::{self},
-    recovery::{self, RecoveryTokenVec},
+    recovery,
     recv_stream::RxStreamOrderer,
     send_stream::TxBuffer,
     sni::find_sni,
@@ -319,7 +319,7 @@ impl Crypto {
         space: PacketNumberSpace,
         sni_slicing: bool,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         self.streams
@@ -1511,7 +1511,7 @@ impl CryptoStreams {
         space: PacketNumberSpace,
         sni_slicing: bool,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         fn write_chunk<B: Buffer>(
@@ -1543,7 +1543,7 @@ impl CryptoStreams {
         fn mark_as_sent(
             cs: &mut CryptoStream,
             space: PacketNumberSpace,
-            tokens: &mut RecoveryTokenVec,
+            tokens: &mut recovery::Tokens,
             offset: u64,
             len: usize,
             stats: &mut FrameStats,

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -20,7 +20,7 @@ use neqo_common::{qdebug, qtrace, Buffer, Role, MAX_VARINT};
 use crate::{
     frame::FrameType,
     packet,
-    recovery::{self, RecoveryTokenVec, StreamRecoveryToken},
+    recovery::{self, StreamRecoveryToken},
     recv_stream::MAX_RECV_WINDOW_SIZE,
     stats::FrameStats,
     stream_id::{StreamId, StreamType},
@@ -145,7 +145,7 @@ impl SenderFlowControl<()> {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         if let Some(limit) = self.blocked_needed() {
@@ -164,7 +164,7 @@ impl SenderFlowControl<StreamId> {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         if let Some(limit) = self.blocked_needed() {
@@ -190,7 +190,7 @@ impl SenderFlowControl<StreamType> {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         if let Some(limit) = self.blocked_needed() {
@@ -328,7 +328,7 @@ impl ReceiverFlowControl<()> {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         if !self.frame_needed() {
@@ -370,7 +370,7 @@ impl ReceiverFlowControl<StreamId> {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
         now: Instant,
         rtt: Duration,
@@ -484,7 +484,7 @@ impl ReceiverFlowControl<StreamType> {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         if !self.frame_needed() {
@@ -671,7 +671,7 @@ mod test {
     use crate::{
         fc::WINDOW_UPDATE_FRACTION,
         packet::{self, PACKET_LIMIT},
-        recovery::RecoveryTokenVec,
+        recovery,
         recv_stream::MAX_RECV_WINDOW_SIZE,
         stats::FrameStats,
         stream_id::{StreamId, StreamType},
@@ -916,7 +916,7 @@ mod test {
         // consume the frame
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut tokens = RecoveryTokenVec::new();
+        let mut tokens = recovery::Tokens::new();
         fc[StreamType::BiDi].write_frames(&mut builder, &mut tokens, &mut FrameStats::default());
         assert_eq!(tokens.len(), 1);
 
@@ -1024,7 +1024,7 @@ mod test {
     fn write_frames(fc: &mut ReceiverFlowControl<StreamId>, rtt: Duration, now: Instant) -> usize {
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut tokens = RecoveryTokenVec::new();
+        let mut tokens = recovery::Tokens::new();
         fc.write_frames(
             &mut builder,
             &mut tokens,
@@ -1252,7 +1252,7 @@ mod test {
         // larger than the largest possible QUIC varint value.
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut tokens = RecoveryTokenVec::new();
+        let mut tokens = recovery::Tokens::new();
         fc.write_frames(&mut builder, &mut tokens, &mut FrameStats::default());
     }
 }

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -20,7 +20,7 @@ use neqo_common::{qdebug, qtrace, Buffer, Role, MAX_VARINT};
 use crate::{
     frame::FrameType,
     packet,
-    recovery::{self, StreamRecoveryToken},
+    recovery::{self, RecoveryTokenVec, StreamRecoveryToken},
     recv_stream::MAX_RECV_WINDOW_SIZE,
     stats::FrameStats,
     stream_id::{StreamId, StreamType},
@@ -145,7 +145,7 @@ impl SenderFlowControl<()> {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         if let Some(limit) = self.blocked_needed() {
@@ -164,7 +164,7 @@ impl SenderFlowControl<StreamId> {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         if let Some(limit) = self.blocked_needed() {
@@ -190,7 +190,7 @@ impl SenderFlowControl<StreamType> {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         if let Some(limit) = self.blocked_needed() {
@@ -328,7 +328,7 @@ impl ReceiverFlowControl<()> {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         if !self.frame_needed() {
@@ -370,7 +370,7 @@ impl ReceiverFlowControl<StreamId> {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
         now: Instant,
         rtt: Duration,
@@ -484,7 +484,7 @@ impl ReceiverFlowControl<StreamType> {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         if !self.frame_needed() {
@@ -671,6 +671,7 @@ mod test {
     use crate::{
         fc::WINDOW_UPDATE_FRACTION,
         packet::{self, PACKET_LIMIT},
+        recovery::RecoveryTokenVec,
         recv_stream::MAX_RECV_WINDOW_SIZE,
         stats::FrameStats,
         stream_id::{StreamId, StreamType},
@@ -915,7 +916,7 @@ mod test {
         // consume the frame
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut tokens = Vec::new();
+        let mut tokens = RecoveryTokenVec::new();
         fc[StreamType::BiDi].write_frames(&mut builder, &mut tokens, &mut FrameStats::default());
         assert_eq!(tokens.len(), 1);
 
@@ -1023,7 +1024,7 @@ mod test {
     fn write_frames(fc: &mut ReceiverFlowControl<StreamId>, rtt: Duration, now: Instant) -> usize {
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut tokens = Vec::new();
+        let mut tokens = RecoveryTokenVec::new();
         fc.write_frames(
             &mut builder,
             &mut tokens,
@@ -1251,7 +1252,7 @@ mod test {
         // larger than the largest possible QUIC varint value.
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut tokens = Vec::new();
+        let mut tokens = RecoveryTokenVec::new();
         fc.write_frames(&mut builder, &mut tokens, &mut FrameStats::default());
     }
 }

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -24,7 +24,7 @@ use crate::{
     frame::FrameType,
     packet,
     pmtud::Pmtud,
-    recovery::{self, sent},
+    recovery::{self, sent, RecoveryTokenVec},
     rtt::{RttEstimate, RttSource},
     sender::PacketSender,
     stats::FrameStats,
@@ -370,7 +370,7 @@ impl Paths {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         while let Some(seqno) = self.to_retire.pop() {
@@ -826,7 +826,7 @@ impl Path {
     pub fn write_cc_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         self.rtt.write_frames(builder, tokens, stats);

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -24,7 +24,7 @@ use crate::{
     frame::FrameType,
     packet,
     pmtud::Pmtud,
-    recovery::{self, sent, RecoveryTokenVec},
+    recovery::{self, sent},
     rtt::{RttEstimate, RttSource},
     sender::PacketSender,
     stats::FrameStats,
@@ -370,7 +370,7 @@ impl Paths {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         while let Some(seqno) = self.to_retire.pop() {
@@ -826,7 +826,7 @@ impl Path {
     pub fn write_cc_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         self.rtt.write_frames(builder, tokens, stats);

--- a/neqo-transport/src/pmtud.rs
+++ b/neqo-transport/src/pmtud.rs
@@ -348,7 +348,7 @@ mod tests {
         crypto::CryptoDxState,
         packet,
         pmtud::{Probe, PMTU_RAISE_TIMER, SEARCH_TABLE_LEN},
-        recovery::{sent, SendProfile},
+        recovery::{sent, RecoveryTokenVec, SendProfile},
         Pmtud, Stats,
     };
 
@@ -362,8 +362,15 @@ mod tests {
         Some(u16::MAX as usize),
     ];
 
-    const fn make_sent_packet(pn: u64, now: Instant, len: usize) -> sent::Packet {
-        sent::Packet::new(packet::Type::Short, pn, now, true, Vec::new(), len)
+    fn make_sent_packet(pn: u64, now: Instant, len: usize) -> sent::Packet {
+        sent::Packet::new(
+            packet::Type::Short,
+            pn,
+            now,
+            true,
+            RecoveryTokenVec::new(),
+            len,
+        )
     }
 
     /// Asserts that the PMTUD process has stopped at the given MTU.

--- a/neqo-transport/src/pmtud.rs
+++ b/neqo-transport/src/pmtud.rs
@@ -362,7 +362,7 @@ mod tests {
         Some(u16::MAX as usize),
     ];
 
-    fn make_sent_packet(pn: u64, now: Instant, len: usize) -> sent::Packet {
+    const fn make_sent_packet(pn: u64, now: Instant, len: usize) -> sent::Packet {
         sent::Packet::new(
             packet::Type::Short,
             pn,

--- a/neqo-transport/src/pmtud.rs
+++ b/neqo-transport/src/pmtud.rs
@@ -348,7 +348,7 @@ mod tests {
         crypto::CryptoDxState,
         packet,
         pmtud::{Probe, PMTU_RAISE_TIMER, SEARCH_TABLE_LEN},
-        recovery::{sent, RecoveryTokenVec, SendProfile},
+        recovery::{self, sent, SendProfile},
         Pmtud, Stats,
     };
 
@@ -368,7 +368,7 @@ mod tests {
             pn,
             now,
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             len,
         )
     }

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -11,8 +11,11 @@ use std::{cmp::min, collections::VecDeque};
 use neqo_common::{Buffer, Encoder};
 
 use crate::{
-    events::OutgoingDatagramOutcome, frame::FrameType, packet, recovery, ConnectionEvents, Error,
-    Res, Stats,
+    events::OutgoingDatagramOutcome,
+    frame::FrameType,
+    packet,
+    recovery::{self, RecoveryTokenVec},
+    ConnectionEvents, Error, Res, Stats,
 };
 
 pub const MAX_QUIC_DATAGRAM: u64 = 65535;
@@ -100,7 +103,7 @@ impl QuicDatagrams {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut Stats,
     ) {
         while let Some(dgram) = self.datagrams.pop_front() {

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -11,11 +11,8 @@ use std::{cmp::min, collections::VecDeque};
 use neqo_common::{Buffer, Encoder};
 
 use crate::{
-    events::OutgoingDatagramOutcome,
-    frame::FrameType,
-    packet,
-    recovery::{self, RecoveryTokenVec},
-    ConnectionEvents, Error, Res, Stats,
+    events::OutgoingDatagramOutcome, frame::FrameType, packet, recovery, ConnectionEvents, Error,
+    Res, Stats,
 };
 
 pub const MAX_QUIC_DATAGRAM: u64 = 65535;
@@ -103,7 +100,7 @@ impl QuicDatagrams {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut Stats,
     ) {
         while let Some(dgram) = self.datagrams.pop_front() {

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -23,7 +23,7 @@ use enum_map::EnumMap;
 use enumset::enum_set;
 use neqo_common::{qdebug, qinfo, qlog::Qlog, qtrace, qwarn};
 use strum::IntoEnumIterator as _;
-pub use token::{StreamRecoveryToken, Token};
+pub use token::{RecoveryTokenVec, StreamRecoveryToken, Token};
 
 use crate::{
     ecn, packet,
@@ -963,7 +963,7 @@ mod tests {
         cid::{ConnectionId, ConnectionIdEntry},
         ecn, packet,
         path::{Path, PathRef},
-        recovery::{self, sent},
+        recovery::{self, sent, RecoveryTokenVec},
         stats::{Stats, StatsCell},
         ConnectionParameters,
     };
@@ -1136,7 +1136,7 @@ mod tests {
                     pn,
                     pn_time(pn),
                     true,
-                    Vec::new(),
+                    RecoveryTokenVec::new(),
                     ON_SENT_SIZE,
                 ),
                 Instant::now(),
@@ -1163,7 +1163,7 @@ mod tests {
                 pn,
                 pn_time(pn),
                 true,
-                Vec::new(),
+                RecoveryTokenVec::new(),
                 ON_SENT_SIZE,
             ));
         }
@@ -1287,7 +1287,7 @@ mod tests {
                 0,
                 pn_time(0),
                 true,
-                Vec::new(),
+                RecoveryTokenVec::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1298,7 +1298,7 @@ mod tests {
                 1,
                 pn_time(0) + TEST_RTT / 4,
                 true,
-                Vec::new(),
+                RecoveryTokenVec::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1396,7 +1396,7 @@ mod tests {
                 0,
                 pn_time(0),
                 true,
-                Vec::new(),
+                RecoveryTokenVec::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1407,7 +1407,7 @@ mod tests {
                 0,
                 pn_time(1),
                 true,
-                Vec::new(),
+                RecoveryTokenVec::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1418,7 +1418,7 @@ mod tests {
                 0,
                 pn_time(2),
                 true,
-                Vec::new(),
+                RecoveryTokenVec::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1430,7 +1430,14 @@ mod tests {
             packet::Type::Handshake,
             packet::Type::Short,
         ] {
-            let sent_pkt = sent::Packet::new(*sp, 1, pn_time(3), true, Vec::new(), ON_SENT_SIZE);
+            let sent_pkt = sent::Packet::new(
+                *sp,
+                1,
+                pn_time(3),
+                true,
+                RecoveryTokenVec::new(),
+                ON_SENT_SIZE,
+            );
             let pn_space = PacketNumberSpace::from(sent_pkt.packet_type());
             lr.on_packet_sent(sent_pkt, Instant::now());
             lr.on_ack_received(
@@ -1464,7 +1471,7 @@ mod tests {
                 0,
                 pn_time(3),
                 true,
-                Vec::new(),
+                RecoveryTokenVec::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1481,7 +1488,7 @@ mod tests {
                 0,
                 now(),
                 true,
-                Vec::new(),
+                RecoveryTokenVec::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1503,7 +1510,7 @@ mod tests {
                 0,
                 now(),
                 true,
-                Vec::new(),
+                RecoveryTokenVec::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1514,7 +1521,7 @@ mod tests {
                 0,
                 now(),
                 true,
-                Vec::new(),
+                RecoveryTokenVec::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1554,7 +1561,7 @@ mod tests {
                 0,
                 now(),
                 true,
-                Vec::new(),
+                RecoveryTokenVec::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -23,7 +23,7 @@ use enum_map::EnumMap;
 use enumset::enum_set;
 use neqo_common::{qdebug, qinfo, qlog::Qlog, qtrace, qwarn};
 use strum::IntoEnumIterator as _;
-pub use token::{RecoveryTokenVec, StreamRecoveryToken, Token};
+pub use token::{StreamRecoveryToken, Token, Tokens};
 
 use crate::{
     ecn, packet,
@@ -963,7 +963,7 @@ mod tests {
         cid::{ConnectionId, ConnectionIdEntry},
         ecn, packet,
         path::{Path, PathRef},
-        recovery::{self, sent, RecoveryTokenVec},
+        recovery::{self, sent},
         stats::{Stats, StatsCell},
         ConnectionParameters,
     };
@@ -1136,7 +1136,7 @@ mod tests {
                     pn,
                     pn_time(pn),
                     true,
-                    RecoveryTokenVec::new(),
+                    recovery::Tokens::new(),
                     ON_SENT_SIZE,
                 ),
                 Instant::now(),
@@ -1163,7 +1163,7 @@ mod tests {
                 pn,
                 pn_time(pn),
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 ON_SENT_SIZE,
             ));
         }
@@ -1287,7 +1287,7 @@ mod tests {
                 0,
                 pn_time(0),
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1298,7 +1298,7 @@ mod tests {
                 1,
                 pn_time(0) + TEST_RTT / 4,
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1396,7 +1396,7 @@ mod tests {
                 0,
                 pn_time(0),
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1407,7 +1407,7 @@ mod tests {
                 0,
                 pn_time(1),
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1418,7 +1418,7 @@ mod tests {
                 0,
                 pn_time(2),
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1435,7 +1435,7 @@ mod tests {
                 1,
                 pn_time(3),
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 ON_SENT_SIZE,
             );
             let pn_space = PacketNumberSpace::from(sent_pkt.packet_type());
@@ -1471,7 +1471,7 @@ mod tests {
                 0,
                 pn_time(3),
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1488,7 +1488,7 @@ mod tests {
                 0,
                 now(),
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1510,7 +1510,7 @@ mod tests {
                 0,
                 now(),
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1521,7 +1521,7 @@ mod tests {
                 0,
                 now(),
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),
@@ -1561,7 +1561,7 @@ mod tests {
                 0,
                 now(),
                 true,
-                RecoveryTokenVec::new(),
+                recovery::Tokens::new(),
                 ON_SENT_SIZE,
             ),
             Instant::now(),

--- a/neqo-transport/src/recovery/sent.rs
+++ b/neqo-transport/src/recovery/sent.rs
@@ -12,7 +12,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{packet, recovery};
+use crate::{
+    packet,
+    recovery::{self, RecoveryTokenVec},
+};
 
 #[derive(Debug, Clone)]
 pub struct Packet {
@@ -21,7 +24,7 @@ pub struct Packet {
     ack_eliciting: bool,
     time_sent: Instant,
     primary_path: bool,
-    tokens: Vec<recovery::Token>,
+    tokens: RecoveryTokenVec,
 
     time_declared_lost: Option<Instant>,
     /// After a PTO, this is true when the packet has been released.
@@ -37,7 +40,7 @@ impl Packet {
         pn: packet::Number,
         time_sent: Instant,
         ack_eliciting: bool,
-        tokens: Vec<recovery::Token>,
+        tokens: RecoveryTokenVec,
         len: usize,
     ) -> Self {
         Self {
@@ -104,7 +107,7 @@ impl Packet {
 
     /// Access the recovery tokens that this holds.
     #[must_use]
-    pub fn tokens(&self) -> &[recovery::Token] {
+    pub const fn tokens(&self) -> &RecoveryTokenVec {
         &self.tokens
     }
 
@@ -311,7 +314,7 @@ mod tests {
     };
 
     use super::{Packet, Packets};
-    use crate::packet;
+    use crate::{packet, recovery::RecoveryTokenVec};
 
     const PACKET_GAP: Duration = Duration::from_secs(1);
     fn start_time() -> Instant {
@@ -325,7 +328,7 @@ mod tests {
             packet::Number::from(n),
             start_time() + (PACKET_GAP * n),
             true,
-            Vec::new(),
+            RecoveryTokenVec::new(),
             100,
         )
     }

--- a/neqo-transport/src/recovery/sent.rs
+++ b/neqo-transport/src/recovery/sent.rs
@@ -12,10 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{
-    packet,
-    recovery::{self, RecoveryTokenVec},
-};
+use crate::{packet, recovery};
 
 #[derive(Debug, Clone)]
 pub struct Packet {
@@ -24,7 +21,7 @@ pub struct Packet {
     ack_eliciting: bool,
     time_sent: Instant,
     primary_path: bool,
-    tokens: RecoveryTokenVec,
+    tokens: recovery::Tokens,
 
     time_declared_lost: Option<Instant>,
     /// After a PTO, this is true when the packet has been released.
@@ -40,7 +37,7 @@ impl Packet {
         pn: packet::Number,
         time_sent: Instant,
         ack_eliciting: bool,
-        tokens: RecoveryTokenVec,
+        tokens: recovery::Tokens,
         len: usize,
     ) -> Self {
         Self {
@@ -107,7 +104,7 @@ impl Packet {
 
     /// Access the recovery tokens that this holds.
     #[must_use]
-    pub const fn tokens(&self) -> &RecoveryTokenVec {
+    pub const fn tokens(&self) -> &recovery::Tokens {
         &self.tokens
     }
 
@@ -314,7 +311,7 @@ mod tests {
     };
 
     use super::{Packet, Packets};
-    use crate::{packet, recovery::RecoveryTokenVec};
+    use crate::{packet, recovery};
 
     const PACKET_GAP: Duration = Duration::from_secs(1);
     fn start_time() -> Instant {
@@ -328,7 +325,7 @@ mod tests {
             packet::Number::from(n),
             start_time() + (PACKET_GAP * n),
             true,
-            RecoveryTokenVec::new(),
+            recovery::Tokens::new(),
             100,
         )
     }

--- a/neqo-transport/src/recovery/token.rs
+++ b/neqo-transport/src/recovery/token.rs
@@ -16,7 +16,7 @@ use crate::{
     tracking::AckToken,
 };
 
-pub type RecoveryTokenVec = SmallVec<[Token; 8]>;
+pub type Tokens = SmallVec<[Token; 8]>;
 
 #[derive(Debug, Clone)]
 pub enum StreamRecoveryToken {

--- a/neqo-transport/src/recovery/token.rs
+++ b/neqo-transport/src/recovery/token.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use smallvec::SmallVec;
+
 use crate::{
     ackrate::AckRate,
     cid::ConnectionIdEntry,
@@ -13,6 +15,8 @@ use crate::{
     stream_id::{StreamId, StreamType},
     tracking::AckToken,
 };
+
+pub type RecoveryTokenVec = SmallVec<[Token; 8]>;
 
 #[derive(Debug, Clone)]
 pub enum StreamRecoveryToken {

--- a/neqo-transport/src/recovery/token.rs
+++ b/neqo-transport/src/recovery/token.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use smallvec::SmallVec;
-
 use crate::{
     ackrate::AckRate,
     cid::ConnectionIdEntry,
@@ -16,7 +14,7 @@ use crate::{
     tracking::AckToken,
 };
 
-pub type Tokens = SmallVec<[Token; 8]>;
+pub type Tokens = Vec<Token>;
 
 #[derive(Debug, Clone)]
 pub enum StreamRecoveryToken {

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -26,7 +26,7 @@ use crate::{
     fc::ReceiverFlowControl,
     frame::FrameType,
     packet,
-    recovery::{self, RecoveryTokenVec, StreamRecoveryToken},
+    recovery::{self, StreamRecoveryToken},
     send_stream::SendStreams,
     stats::FrameStats,
     stream_id::StreamId,
@@ -58,7 +58,7 @@ impl RecvStreams {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
         now: Instant,
         rtt: Duration,
@@ -891,7 +891,7 @@ impl RecvStream {
     pub fn write_frame<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
         now: Instant,
         rtt: Duration,
@@ -1005,7 +1005,7 @@ mod tests {
     use crate::{
         fc::{ReceiverFlowControl, WINDOW_UPDATE_FRACTION},
         packet::{self, PACKET_LIMIT},
-        recovery::RecoveryTokenVec,
+        recovery,
         recv_stream::RxStreamOrderer,
         stats::FrameStats,
         ConnectionEvents, Error, StreamId, INITIAL_RECV_WINDOW_SIZE,
@@ -1474,7 +1474,7 @@ mod tests {
         // consume it
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut token = RecoveryTokenVec::new();
+        let mut token = recovery::Tokens::new();
         s.write_frame(
             &mut builder,
             &mut token,
@@ -1595,7 +1595,7 @@ mod tests {
         // consume it
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut token = RecoveryTokenVec::new();
+        let mut token = recovery::Tokens::new();
         session_fc
             .borrow_mut()
             .write_frames(&mut builder, &mut token, &mut FrameStats::default());
@@ -1617,7 +1617,7 @@ mod tests {
         // consume it
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut token = RecoveryTokenVec::new();
+        let mut token = recovery::Tokens::new();
         session_fc
             .borrow_mut()
             .write_frames(&mut builder, &mut token, &mut FrameStats::default());
@@ -1922,7 +1922,7 @@ mod tests {
         // Write the fc update frame
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut token = RecoveryTokenVec::new();
+        let mut token = recovery::Tokens::new();
         let mut stats = FrameStats::default();
         fc.borrow_mut()
             .write_frames(&mut builder, &mut token, &mut stats);

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -26,7 +26,7 @@ use crate::{
     fc::ReceiverFlowControl,
     frame::FrameType,
     packet,
-    recovery::{self, StreamRecoveryToken},
+    recovery::{self, RecoveryTokenVec, StreamRecoveryToken},
     send_stream::SendStreams,
     stats::FrameStats,
     stream_id::StreamId,
@@ -58,7 +58,7 @@ impl RecvStreams {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
         now: Instant,
         rtt: Duration,
@@ -891,7 +891,7 @@ impl RecvStream {
     pub fn write_frame<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
         now: Instant,
         rtt: Duration,
@@ -1005,6 +1005,7 @@ mod tests {
     use crate::{
         fc::{ReceiverFlowControl, WINDOW_UPDATE_FRACTION},
         packet::{self, PACKET_LIMIT},
+        recovery::RecoveryTokenVec,
         recv_stream::RxStreamOrderer,
         stats::FrameStats,
         ConnectionEvents, Error, StreamId, INITIAL_RECV_WINDOW_SIZE,
@@ -1473,7 +1474,7 @@ mod tests {
         // consume it
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut token = Vec::new();
+        let mut token = RecoveryTokenVec::new();
         s.write_frame(
             &mut builder,
             &mut token,
@@ -1594,7 +1595,7 @@ mod tests {
         // consume it
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut token = Vec::new();
+        let mut token = RecoveryTokenVec::new();
         session_fc
             .borrow_mut()
             .write_frames(&mut builder, &mut token, &mut FrameStats::default());
@@ -1616,7 +1617,7 @@ mod tests {
         // consume it
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut token = Vec::new();
+        let mut token = RecoveryTokenVec::new();
         session_fc
             .borrow_mut()
             .write_frames(&mut builder, &mut token, &mut FrameStats::default());
@@ -1921,7 +1922,7 @@ mod tests {
         // Write the fc update frame
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut token = Vec::new();
+        let mut token = RecoveryTokenVec::new();
         let mut stats = FrameStats::default();
         fc.borrow_mut()
             .write_frames(&mut builder, &mut token, &mut stats);

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -17,7 +17,7 @@ use crate::{
     ackrate::{AckRate, PeerAckDelay},
     packet,
     qlog::{self, QlogMetric},
-    recovery::RecoveryTokenVec,
+    recovery,
     stats::FrameStats,
 };
 
@@ -196,7 +196,7 @@ impl RttEstimate {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         self.ack_delay.write_frames(builder, tokens, stats);

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -17,7 +17,7 @@ use crate::{
     ackrate::{AckRate, PeerAckDelay},
     packet,
     qlog::{self, QlogMetric},
-    recovery,
+    recovery::RecoveryTokenVec,
     stats::FrameStats,
 };
 
@@ -196,7 +196,7 @@ impl RttEstimate {
     pub fn write_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         self.ack_delay.write_frames(builder, tokens, stats);

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -26,7 +26,7 @@ use crate::{
     fc::SenderFlowControl,
     frame::{Frame, FrameType},
     packet,
-    recovery::{self, RecoveryTokenVec, StreamRecoveryToken},
+    recovery::{self, StreamRecoveryToken},
     stats::FrameStats,
     stream_id::StreamId,
     streams::SendOrder,
@@ -726,7 +726,7 @@ impl SendStream {
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         qtrace!("write STREAM frames at priority {priority:?}");
@@ -741,7 +741,7 @@ impl SendStream {
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) -> bool {
         if !self.write_reset_frame(priority, builder, tokens, stats) {
@@ -919,7 +919,7 @@ impl SendStream {
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         let retransmission = if priority == self.priority {
@@ -1017,7 +1017,7 @@ impl SendStream {
         &mut self,
         p: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) -> bool {
         if let State::ResetSent {
@@ -1063,7 +1063,7 @@ impl SendStream {
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         // Send STREAM_DATA_BLOCKED at normal priority always.
@@ -1681,7 +1681,7 @@ impl SendStreams {
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         qtrace!("write STREAM frames at priority {priority:?}");
@@ -1800,7 +1800,7 @@ mod tests {
         events::ConnectionEvent,
         fc::SenderFlowControl,
         packet::{self, PACKET_LIMIT},
-        recovery::{self, RecoveryTokenVec, StreamRecoveryToken},
+        recovery::{self, StreamRecoveryToken},
         send_stream::{
             RangeState, RangeTracker, SendStream, SendStreams, State, TxBuffer,
             MAX_SEND_BUFFER_SIZE,
@@ -2582,7 +2582,7 @@ mod tests {
         let mut ss = SendStreams::default();
         ss.insert(StreamId::from(0), s);
 
-        let mut tokens = RecoveryTokenVec::new();
+        let mut tokens = recovery::Tokens::new();
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
 
@@ -2671,7 +2671,7 @@ mod tests {
         let mut ss = SendStreams::default();
         ss.insert(StreamId::from(0), s);
 
-        let mut tokens = RecoveryTokenVec::new();
+        let mut tokens = recovery::Tokens::new();
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
         ss.write_frames(
@@ -2753,7 +2753,7 @@ mod tests {
         // This doesn't report blocking yet.
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut tokens = RecoveryTokenVec::new();
+        let mut tokens = recovery::Tokens::new();
         let mut stats = FrameStats::default();
         s.write_blocked_frame(
             TransmissionPriority::default(),
@@ -2820,7 +2820,7 @@ mod tests {
         // Assert that STREAM_DATA_BLOCKED is sent.
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut tokens = RecoveryTokenVec::new();
+        let mut tokens = recovery::Tokens::new();
         let mut stats = FrameStats::default();
         s.write_blocked_frame(
             TransmissionPriority::default(),
@@ -2908,7 +2908,7 @@ mod tests {
         // No frame should be sent here.
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut tokens = RecoveryTokenVec::new();
+        let mut tokens = recovery::Tokens::new();
         let mut stats = FrameStats::default();
         s.write_stream_frame(
             TransmissionPriority::default(),
@@ -2963,7 +2963,7 @@ mod tests {
         let header_len = builder.len();
         builder.set_limit(header_len + space);
 
-        let mut tokens = RecoveryTokenVec::new();
+        let mut tokens = recovery::Tokens::new();
         let mut stats = FrameStats::default();
         s.write_stream_frame(
             TransmissionPriority::default(),
@@ -3065,7 +3065,7 @@ mod tests {
             let header_len = builder.len();
             // Add 2 for the frame type and stream ID, then add the extra.
             builder.set_limit(header_len + data.len() + 2 + extra);
-            let mut tokens = RecoveryTokenVec::new();
+            let mut tokens = recovery::Tokens::new();
             let mut stats = FrameStats::default();
             s.write_stream_frame(
                 TransmissionPriority::default(),

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -26,7 +26,7 @@ use crate::{
     fc::SenderFlowControl,
     frame::{Frame, FrameType},
     packet,
-    recovery::{self, StreamRecoveryToken},
+    recovery::{self, RecoveryTokenVec, StreamRecoveryToken},
     stats::FrameStats,
     stream_id::StreamId,
     streams::SendOrder,
@@ -726,7 +726,7 @@ impl SendStream {
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         qtrace!("write STREAM frames at priority {priority:?}");
@@ -741,7 +741,7 @@ impl SendStream {
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) -> bool {
         if !self.write_reset_frame(priority, builder, tokens, stats) {
@@ -919,7 +919,7 @@ impl SendStream {
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         let retransmission = if priority == self.priority {
@@ -1017,7 +1017,7 @@ impl SendStream {
         &mut self,
         p: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) -> bool {
         if let State::ResetSent {
@@ -1063,7 +1063,7 @@ impl SendStream {
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         // Send STREAM_DATA_BLOCKED at normal priority always.
@@ -1681,7 +1681,7 @@ impl SendStreams {
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         qtrace!("write STREAM frames at priority {priority:?}");
@@ -1800,7 +1800,7 @@ mod tests {
         events::ConnectionEvent,
         fc::SenderFlowControl,
         packet::{self, PACKET_LIMIT},
-        recovery::{self, StreamRecoveryToken},
+        recovery::{self, RecoveryTokenVec, StreamRecoveryToken},
         send_stream::{
             RangeState, RangeTracker, SendStream, SendStreams, State, TxBuffer,
             MAX_SEND_BUFFER_SIZE,
@@ -2582,7 +2582,7 @@ mod tests {
         let mut ss = SendStreams::default();
         ss.insert(StreamId::from(0), s);
 
-        let mut tokens = Vec::new();
+        let mut tokens = RecoveryTokenVec::new();
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
 
@@ -2671,7 +2671,7 @@ mod tests {
         let mut ss = SendStreams::default();
         ss.insert(StreamId::from(0), s);
 
-        let mut tokens = Vec::new();
+        let mut tokens = RecoveryTokenVec::new();
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
         ss.write_frames(
@@ -2753,7 +2753,7 @@ mod tests {
         // This doesn't report blocking yet.
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut tokens = Vec::new();
+        let mut tokens = RecoveryTokenVec::new();
         let mut stats = FrameStats::default();
         s.write_blocked_frame(
             TransmissionPriority::default(),
@@ -2820,7 +2820,7 @@ mod tests {
         // Assert that STREAM_DATA_BLOCKED is sent.
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut tokens = Vec::new();
+        let mut tokens = RecoveryTokenVec::new();
         let mut stats = FrameStats::default();
         s.write_blocked_frame(
             TransmissionPriority::default(),
@@ -2908,7 +2908,7 @@ mod tests {
         // No frame should be sent here.
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut tokens = Vec::new();
+        let mut tokens = RecoveryTokenVec::new();
         let mut stats = FrameStats::default();
         s.write_stream_frame(
             TransmissionPriority::default(),
@@ -2963,7 +2963,7 @@ mod tests {
         let header_len = builder.len();
         builder.set_limit(header_len + space);
 
-        let mut tokens = Vec::new();
+        let mut tokens = RecoveryTokenVec::new();
         let mut stats = FrameStats::default();
         s.write_stream_frame(
             TransmissionPriority::default(),
@@ -3065,7 +3065,7 @@ mod tests {
             let header_len = builder.len();
             // Add 2 for the frame type and stream ID, then add the extra.
             builder.set_limit(header_len + data.len() + 2 + extra);
-            let mut tokens = Vec::new();
+            let mut tokens = RecoveryTokenVec::new();
             let mut stats = FrameStats::default();
             s.write_stream_frame(
                 TransmissionPriority::default(),

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -18,7 +18,7 @@ use crate::{
     fc::{LocalStreamLimits, ReceiverFlowControl, RemoteStreamLimits, SenderFlowControl},
     frame::Frame,
     packet,
-    recovery::{RecoveryTokenVec, StreamRecoveryToken},
+    recovery::{self, StreamRecoveryToken},
     recv_stream::{RecvStream, RecvStreams},
     send_stream::{SendStream, SendStreams, TransmissionPriority},
     stats::FrameStats,
@@ -212,7 +212,7 @@ impl Streams {
     pub fn write_maintenance_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
         now: Instant,
         rtt: Duration,
@@ -256,7 +256,7 @@ impl Streams {
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         self.send.write_frames(priority, builder, tokens, stats);

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -18,7 +18,7 @@ use crate::{
     fc::{LocalStreamLimits, ReceiverFlowControl, RemoteStreamLimits, SenderFlowControl},
     frame::Frame,
     packet,
-    recovery::{self, StreamRecoveryToken},
+    recovery::{RecoveryTokenVec, StreamRecoveryToken},
     recv_stream::{RecvStream, RecvStreams},
     send_stream::{SendStream, SendStreams, TransmissionPriority},
     stats::FrameStats,
@@ -212,7 +212,7 @@ impl Streams {
     pub fn write_maintenance_frames<B: Buffer>(
         &mut self,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
         now: Instant,
         rtt: Duration,
@@ -256,7 +256,7 @@ impl Streams {
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         self.send.write_frames(priority, builder, tokens, stats);

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -25,7 +25,7 @@ use crate::{
     ecn,
     frame::FrameType,
     packet,
-    recovery::{self, RecoveryTokenVec},
+    recovery::{self},
     stats::FrameStats,
     Error, Res, Stats,
 };
@@ -424,7 +424,7 @@ impl RecvdPackets {
         now: Instant,
         rtt: Duration,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         // Check that we aren't delaying ACKs.
@@ -597,7 +597,7 @@ impl AckTracker {
         now: Instant,
         rtt: Duration,
         builder: &mut packet::Builder<B>,
-        tokens: &mut RecoveryTokenVec,
+        tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) {
         if let Some(space) = self.get_mut(pn_space) {
@@ -631,7 +631,7 @@ mod tests {
     use crate::{
         frame::Frame,
         packet::{self, PACKET_LIMIT},
-        recovery::{self, RecoveryTokenVec},
+        recovery::{self},
         stats::FrameStats,
         Stats,
     };
@@ -771,7 +771,7 @@ mod tests {
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
         let mut stats = FrameStats::default();
-        let mut tokens = RecoveryTokenVec::new();
+        let mut tokens = recovery::Tokens::new();
         rp.write_frame(now, RTT, &mut builder, &mut tokens, &mut stats);
         assert!(!tokens.is_empty());
         assert_eq!(stats.ack, 1);
@@ -940,7 +940,7 @@ mod tests {
             .ack_time(now().checked_sub(Duration::from_millis(1)).unwrap())
             .is_some());
 
-        let mut tokens = RecoveryTokenVec::new();
+        let mut tokens = recovery::Tokens::new();
         let mut frame_stats = FrameStats::default();
         tracker.write_frame(
             PacketNumberSpace::Initial,
@@ -1007,7 +1007,7 @@ mod tests {
             now(),
             RTT,
             &mut builder,
-            &mut RecoveryTokenVec::new(),
+            &mut recovery::Tokens::new(),
             &mut stats,
         );
         assert_eq!(stats.ack, 0);
@@ -1044,7 +1044,7 @@ mod tests {
             now(),
             RTT,
             &mut builder,
-            &mut RecoveryTokenVec::new(),
+            &mut recovery::Tokens::new(),
             &mut stats,
         );
         assert_eq!(stats.ack, 1);

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -21,7 +21,14 @@ use neqo_crypto::Epoch;
 use smallvec::SmallVec;
 use strum::{Display, EnumIter};
 
-use crate::{ecn, frame::FrameType, packet, recovery, stats::FrameStats, Error, Res, Stats};
+use crate::{
+    ecn,
+    frame::FrameType,
+    packet,
+    recovery::{self, RecoveryTokenVec},
+    stats::FrameStats,
+    Error, Res, Stats,
+};
 
 #[derive(Debug, PartialOrd, Ord, EnumSetType, Enum, EnumIter, Display)]
 pub enum PacketNumberSpace {
@@ -417,7 +424,7 @@ impl RecvdPackets {
         now: Instant,
         rtt: Duration,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         // Check that we aren't delaying ACKs.
@@ -590,7 +597,7 @@ impl AckTracker {
         now: Instant,
         rtt: Duration,
         builder: &mut packet::Builder<B>,
-        tokens: &mut Vec<recovery::Token>,
+        tokens: &mut RecoveryTokenVec,
         stats: &mut FrameStats,
     ) {
         if let Some(space) = self.get_mut(pn_space) {
@@ -624,7 +631,7 @@ mod tests {
     use crate::{
         frame::Frame,
         packet::{self, PACKET_LIMIT},
-        recovery,
+        recovery::{self, RecoveryTokenVec},
         stats::FrameStats,
         Stats,
     };
@@ -764,7 +771,7 @@ mod tests {
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
         let mut stats = FrameStats::default();
-        let mut tokens = Vec::new();
+        let mut tokens = RecoveryTokenVec::new();
         rp.write_frame(now, RTT, &mut builder, &mut tokens, &mut stats);
         assert!(!tokens.is_empty());
         assert_eq!(stats.ack, 1);
@@ -933,7 +940,7 @@ mod tests {
             .ack_time(now().checked_sub(Duration::from_millis(1)).unwrap())
             .is_some());
 
-        let mut tokens = Vec::new();
+        let mut tokens = RecoveryTokenVec::new();
         let mut frame_stats = FrameStats::default();
         tracker.write_frame(
             PacketNumberSpace::Initial,
@@ -1000,7 +1007,7 @@ mod tests {
             now(),
             RTT,
             &mut builder,
-            &mut Vec::new(),
+            &mut RecoveryTokenVec::new(),
             &mut stats,
         );
         assert_eq!(stats.ack, 0);
@@ -1037,7 +1044,7 @@ mod tests {
             now(),
             RTT,
             &mut builder,
-            &mut Vec::new(),
+            &mut RecoveryTokenVec::new(),
             &mut stats,
         );
         assert_eq!(stats.ack, 1);


### PR DESCRIPTION
~~For some reason, I wasn't allowed to push a rebase straight to #1657. So this is a new PR. Wanted to check if all the perf work we did in the meantime changes things here, and to get perf traces.~~

This PR now just introduces the `recovery::Tokens` type, which is still based on a `Vec`.