### PR TITLE
feat: Use `SmallVec` for `recovery::Token`

### DIFF
--- a/neqo-transport/src/pmtud.rs
+++ b/neqo-transport/src/pmtud.rs
@@ -362,7 +362,7 @@ mod tests {
         Some(u16::MAX as usize),
     ];
 
-    const fn make_sent_packet(pn: u64, now: Instant, len: usize) -> sent::Packet {
+    fn make_sent_packet(pn: u64, now: Instant, len: usize) -> sent::Packet {
         sent::Packet::new(
             packet::Type::Short,
             pn,

--- a/neqo-transport/src/recovery/token.rs
+++ b/neqo-transport/src/recovery/token.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use smallvec::SmallVec;
+
 use crate::{
     ackrate::AckRate,
     cid::ConnectionIdEntry,
@@ -14,7 +16,7 @@ use crate::{
     tracking::AckToken,
 };
 
-pub type Tokens = Vec<Token>;
+pub type Tokens = SmallVec<[Token; 16]>;
 
 #[derive(Debug, Clone)]
 pub enum StreamRecoveryToken {


### PR DESCRIPTION
With size 16, just to see if it matters. Alternative to #1657.