### PR TITLE
fix(common): add DatagramBatch::set_tos

### DIFF
--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -247,7 +247,7 @@ mod tests {
 
     use test_fixture::datagram;
 
-    use crate::{DatagramBatch, Tos};
+    use crate::{DatagramBatch, Ecn, Tos};
 
     #[test]
     fn fmt_datagram() {
@@ -286,5 +286,18 @@ mod tests {
         // 6 bytes, segment size 5 -> 2 datagrams (5+1)
         let batch = DatagramBatch::new(src, dst, tos, 5, vec![0u8; 6]);
         assert_eq!(batch.num_datagrams(), 2);
+    }
+
+    #[test]
+    fn batch_tos() {
+        let mut batch = DatagramBatch::new(
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1234),
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 5678),
+            Tos::default(),
+            4,
+            vec![0u8; 10],
+        );
+        batch.set_tos(Ecn::Ce.into());
+        assert_eq!(batch.tos(), Ecn::Ce.into());
     }
 }


### PR DESCRIPTION
See analogue `Datagram::set_tos`.

Needed for Firefox's `neqo_glue`.