### PR TITLE
fix(.clippy.toml): fully qualify std::dbg macro

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -2,7 +2,7 @@ disallowed-methods = [
     { path = "std::slice::from_raw_parts", reason = "see null_safe_slice" }
 ]
 disallowed-macros = [
-    { path = "dbg!" }
+    { path = "std::dbg" }
 ]
 allow-mixed-uninlined-format-args = false
 allow-unwrap-in-tests = true


### PR DESCRIPTION
Macros in `disallowed-macros` need to be fully qualified. Instead of `dbg`, disallow `std::dbg`.

---

Fixes https://github.com/mozilla/neqo/issues/2778.