### PR TITLE
 fix(crypto): do not filter transport parameters on invalid ECH conf 

### DIFF
--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -1155,7 +1155,8 @@ impl Client {
                     config.as_ptr(),
                     c_uint::try_from(config.len())?,
                 )?;
-                // Allow writing of different transport parameters to the inner and outer
+                // If the ECH configuration is valid, and only then,
+                // allow writing of different transport parameters to the inner and outer
                 // ClientHello. Avoid setting this otherwise, as the transport
                 // parameter extension handler filters out essential values from the
                 // outer ClientHello. Under normal operation, NSS reports to

--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -1150,18 +1150,18 @@ impl Client {
             unsafe { ech::SSL_EnableTls13GreaseEch(self.agent.fd, PRBool::from(true)) }
         } else {
             unsafe {
+                ech::SSL_SetClientEchConfigs(
+                    self.agent.fd,
+                    config.as_ptr(),
+                    c_uint::try_from(config.len())?,
+                )?;
                 // Allow writing of different transport parameters to the inner and outer
                 // ClientHello. Avoid setting this otherwise, as the transport
                 // parameter extension handler filters out essential values from the
                 // outer ClientHello. Under normal operation, NSS reports to
                 // extension writers that an ordinary, non-ECH ClientHello is an
                 // outer ClientHello, resulting in unwanted filtering.
-                SSL_CallExtensionWriterOnEchInner(self.fd, PRBool::from(true))?;
-                ech::SSL_SetClientEchConfigs(
-                    self.agent.fd,
-                    config.as_ptr(),
-                    c_uint::try_from(config.len())?,
-                )
+                SSL_CallExtensionWriterOnEchInner(self.fd, PRBool::from(true))
             }
         }
     }


### PR DESCRIPTION
Previously `enable_ech` would first call `SSL_CallExtensionWriterOnEchInner`, i.e. enable the transport parameter
filtering on the outer client hello and then `ech::SSL_SetClientEchConfigs`. Given an invalid ECH config, the first
would succeed and the second fail, resulting in a non-ECH client hello with filtered transport parameters. One such transport parameter is `InitialMaxStreamsBidi`, thus preventing the serverl to open streams to
the client after the handshake.

This commit reverses the order, thus no longer filtering transport parameters after an invalid ECH config.

---

Bug now surfacing with https://github.com/mozilla/neqo/pull/2666. Note that https://github.com/mozilla/neqo/pull/2666/ did not introduce the bug.

Discovered through [mozilla-central Neqo v0.14.0 upgrade](https://bugzilla.mozilla.org/show_bug.cgi?id=1975873), more specifically the [`test_trr_https_fallback.js`](https://github.com/mozilla-firefox/firefox/blob/main/netwerk/test/unit/test_trr_https_fallback.js#L141) test that accidentally uses an invalid ECH config.

I plan to change [`neqo_glue` to fail on an invalid ECH config](https://github.com/mozilla-firefox/firefox/blob/44b433258df6ae4ad83c0d88d0bff2e347d34133/netwerk/socket/neqo_glue/src/lib.rs#L1809-L1814) and update the [`test_trr_https_fallback.js`](https://github.com/mozilla-firefox/firefox/blob/main/netwerk/test/unit/test_trr_https_fallback.js#L141) unit test to no longer use an invalid ECH config.

Shout out to @KershawChang who pointed me to the invalid ECH config in [`test_trr_https_fallback.js`](https://github.com/mozilla-firefox/firefox/blob/main/netwerk/test/unit/test_trr_https_fallback.js#L141).