### PR TITLE
Flip equality for const_min/const_max

### DIFF
--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -73,11 +73,11 @@ pub fn hex_with_len<A: AsRef<[u8]>>(buf: A) -> String {
 
 #[must_use]
 pub const fn const_max(a: usize, b: usize) -> usize {
-    [a, b][(a < b) as usize]
+    [a, b][(a <= b) as usize]
 }
 #[must_use]
 pub const fn const_min(a: usize, b: usize) -> usize {
-    [a, b][(a >= b) as usize]
+    [a, b][(a > b) as usize]
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Enum, Display)]


### PR DESCRIPTION
The specification for max() and min() when the arguments are equal has min() take the first argument and max() take the second.  Our code does the opposite.  Flip them.

This has no effect, other than to avoid propagating a logical error.