### PR TITLE
ci: Remove`--bindgen` from `cargo ndk`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -237,7 +237,7 @@ jobs:
 
       - env:
           MATRIX_TARGET: ${{ matrix.target }}
-        run: cargo ndk --bindgen --platform "$API_LEVEL" --target "$MATRIX_TARGET" test --no-run
+        run: cargo ndk --platform "$API_LEVEL" --target "$MATRIX_TARGET" test --no-run
 
       - env:
           TARGET: ${{ matrix.target }}


### PR DESCRIPTION
It's now on by default in `cargo ndk`@4.
https://github.com/bbqsrc/cargo-ndk/commit/de4dcba8e3d545b87b55bd7c37ff3098717cec39