### PR TITLE
fix: Define all DSCP values

### DIFF
--- a/neqo-common/src/tos.rs
+++ b/neqo-common/src/tos.rs
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn u8_into_dscp_all() {
-        for i in 0..u8::MAX {
+        for i in 0..=u8::MAX {
             _ = Dscp::from(i);
         }
     }


### PR DESCRIPTION
And add tests for all `u8` values for DSCP and ECN conversion confirming no panics.

Fixes #2818