### PR TITLE
ci: Create cache on `merge_group` trigger

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -90,7 +90,8 @@ runs:
         cache-all-crates: true
         key: ${{ inputs.targets }}-${{ env.RUNNER_OS }}
         workspaces: ${{ inputs.workspaces }}
-        save-if: ${{ github.ref == 'refs/heads/main' || github.event.merge_group.base_ref == 'refs/heads/main' }} # Only cache runs from `main`.
+         # Only create the cache when we push to `main` (also via a merge group).
+        save-if: ${{ github.ref == 'refs/heads/main' || github.event.merge_group.base_ref == 'refs/heads/main' }}
 
     - name: Set up MSVC (Windows)
       if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
Rust caches are currently only being created for workflows that have an `on push` trigger, which some don't (e.g., `bench.yml` and `perfcompare.yml`. Make it so that Rust caches are also generated for these.