### PR TITLE
chore(.github/check.yaml): remove obsolete run_benchmarks input

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,12 +6,6 @@ on:
     branches: ["main"]
   merge_group:
   workflow_dispatch:
-    inputs:
-      run_benchmarks:
-        description: 'Run benchmarks'
-        type: boolean
-        required: false
-        default: false
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
https://github.com/mozilla/neqo/pull/2773 removed the benchmark trigger from `check.yml`. Thus the input is no longer needed.