### PR TITLE
feat: Optimize neqo-common

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -98,15 +98,47 @@ impl<'a> Decoder<'a> {
         if self.remaining() < n {
             return None;
         }
-        Some(if n == 1 {
-            let v = u64::from(self.buf[self.offset]);
-            self.offset += 1;
-            v
-        } else {
-            let mut buf = [0; 8];
-            buf[8 - n..].copy_from_slice(&self.buf[self.offset..self.offset + n]);
-            self.offset += n;
-            u64::from_be_bytes(buf)
+        Some(match n {
+            1 => {
+                let v = u64::from(self.buf[self.offset]);
+                self.offset += 1;
+                v
+            }
+            2 => {
+                let bytes = [self.buf[self.offset], self.buf[self.offset + 1]];
+                self.offset += 2;
+                u64::from(u16::from_be_bytes(bytes))
+            }
+            4 => {
+                let bytes = [
+                    self.buf[self.offset],
+                    self.buf[self.offset + 1],
+                    self.buf[self.offset + 2],
+                    self.buf[self.offset + 3],
+                ];
+                self.offset += 4;
+                u64::from(u32::from_be_bytes(bytes))
+            }
+            8 => {
+                let bytes = [
+                    self.buf[self.offset],
+                    self.buf[self.offset + 1],
+                    self.buf[self.offset + 2],
+                    self.buf[self.offset + 3],
+                    self.buf[self.offset + 4],
+                    self.buf[self.offset + 5],
+                    self.buf[self.offset + 6],
+                    self.buf[self.offset + 7],
+                ];
+                self.offset += 8;
+                u64::from_be_bytes(bytes)
+            }
+            _ => {
+                let mut buf = [0; 8];
+                buf[8 - n..].copy_from_slice(&self.buf[self.offset..self.offset + n]);
+                self.offset += n;
+                u64::from_be_bytes(buf)
+            }
         })
     }
 

--- a/neqo-common/src/incrdecoder.rs
+++ b/neqo-common/src/incrdecoder.rs
@@ -70,9 +70,9 @@ pub struct IncrementalDecoderBuffer {
 
 impl IncrementalDecoderBuffer {
     #[must_use]
-    pub const fn new(n: usize) -> Self {
+    pub fn new(n: usize) -> Self {
         Self {
-            v: Vec::new(),
+            v: Vec::with_capacity(n),
             remaining: n,
         }
     }


### PR DESCRIPTION
I'm playing around with Claude and asked it
> Check the neqo_common crate for any avoidable memory copies, and eliminate them.

This is what it came up with. Let's see what the benches say...