### PR TITLE
chore(clippy): remove expect for needless_match

### DIFF
--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -550,7 +550,6 @@ impl Server {
             return o;
         }
 
-        #[expect(clippy::needless_match, reason = "false positive")]
         let maybe_callback = match self.process_next_output(now, max_datagrams) {
             // Return immediately. Do any maintenance on next call.
             o @ OutputBatch::DatagramBatch(_) => return o,


### PR DESCRIPTION
Fixes failures like https://github.com/mozilla/neqo/actions/runs/16823368835/job/47654527842?pr=2833

False positive seems to have been resolved in latest Clippy.