### PR TITLE
fix(transport/frame): prevent potential overflow in padding decode

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -847,6 +847,7 @@ mod tests {
         let mut dec = enc.as_decoder();
         dec.skip_vvec();
     }
+
     #[test]
     fn skip_while() {
         let enc = Encoder::from_hex("000001020202");

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -1085,4 +1085,14 @@ mod tests {
 
         just_dec(&f, "4030010203");
     }
+
+    /// See bug in <https://github.com/mozilla/neqo/issues/2838>.
+    #[test]
+    fn padding_frame_u16_overflow() {
+        let mut e = Encoder::new();
+        e.encode_varint(FrameType::Padding);
+        // `Frame::Padding` uses u16 to store length. Try to overflow length.
+        e.pad_to(u16::MAX as usize + 1, 0);
+        assert_eq!(Frame::decode(&mut e.as_decoder()), Err(Error::TooMuchData));
+    }
 }


### PR DESCRIPTION
Previously `neqo-transport` would use a `u16` to count the number of padding frames, i.e. `0`s. If an attacker sends more than `u16::MAX` `0`s, the counter would overflow.

This commit returns a `Error::TooMuchData` instead.

Note that the maximum UDP size is `u16::MAX`, thus in the real world, an attacker can not send more than `u16::MAX` padding frames.

---

Fixes https://github.com/mozilla/neqo/issues/2838.