### PR TITLE
docs(transport/datagrams): remove outdated fn return docs

### DIFF
--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -137,7 +137,7 @@ impl QuicDatagrams {
         }
     }
 
-    /// Returns true if there was an unsent datagram that has been dismissed.
+    /// Add a datagram to the send queue.
     ///
     /// # Error
     ///


### PR DESCRIPTION
`fn` doesn't return a `bool` (`-> Res<()>`).