### PR TITLE
refactor(crypto): improve `ResumptionToken` `Debug` impl

### DIFF
--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -986,10 +986,19 @@ impl Display for SecretAgent {
     }
 }
 
-#[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone)]
+#[derive(PartialOrd, Ord, PartialEq, Eq, Clone)]
 pub struct ResumptionToken {
     token: Vec<u8>,
     expiration_time: Instant,
+}
+
+impl Debug for ResumptionToken {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResumptionToken")
+            .field("token", &hex_snip_middle(&self.token))
+            .field("expiration_time", &self.expiration_time)
+            .finish()
+    }
 }
 
 impl AsRef<[u8]> for ResumptionToken {


### PR DESCRIPTION
Use `hex_snip_middle` to print token.

See similar change in https://github.com/mozilla/neqo/pull/2815.