### PR TITLE
ci: Use implicit `$HOME` home directory

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Set PATH and environment
         run: |
-          echo "/home/bench/.cargo/bin" >> "${GITHUB_PATH}"
+          echo "~/.cargo/bin" >> "${GITHUB_PATH}"
 
       - name: Install Rust
         uses: ./neqo/.github/actions/rust

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Set PATH and environment
         run: |
-          echo "~/.cargo/bin" >> "${GITHUB_PATH}"
+          echo "$HOME/.cargo/bin" >> "${GITHUB_PATH}"
 
       - name: Install Rust
         uses: ./neqo/.github/actions/rust

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Set PATH and environment
         run: |
-          echo "~/.cargo/bin" >> "${GITHUB_PATH}"
+          echo "$HOME/.cargo/bin" >> "${GITHUB_PATH}"
 
       - name: Install Rust
         uses: ./neqo/.github/actions/rust
@@ -151,7 +151,7 @@ jobs:
       - name: Build google/quiche
         run: |
           cd google-quiche
-          bazel-7.0.0 build -c opt --copt=-fno-omit-frame-pointer --copt=-g --strip=never --sandbox_writable_path=~/.cache/sccache quiche:quic_server quiche:quic_client
+          bazel-7.0.0 build -c opt --copt=-fno-omit-frame-pointer --copt=-g --strip=never --sandbox_writable_path=$HOME/.cache/sccache quiche:quic_server quiche:quic_client
           bazel-7.0.0 shutdown
 
       - name: Build cloudflare/quiche

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Build google/quiche
         run: |
           cd google-quiche
-          bazel-7.0.0 build -c opt --copt=-fno-omit-frame-pointer --copt=-g --strip=never --sandbox_writable_path=$HOME/.cache/sccache quiche:quic_server quiche:quic_client
+          bazel-7.0.0 build -c opt --copt=-fno-omit-frame-pointer --copt=-g --strip=never --sandbox_writable_path="$HOME/.cache/sccache" quiche:quic_server quiche:quic_client
           bazel-7.0.0 shutdown
 
       - name: Build cloudflare/quiche

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Set PATH and environment
         run: |
-          echo "/home/bench/.cargo/bin" >> "${GITHUB_PATH}"
+          echo "~/.cargo/bin" >> "${GITHUB_PATH}"
 
       - name: Install Rust
         uses: ./neqo/.github/actions/rust
@@ -151,7 +151,7 @@ jobs:
       - name: Build google/quiche
         run: |
           cd google-quiche
-          bazel-7.0.0 build -c opt --copt=-fno-omit-frame-pointer --copt=-g --strip=never --sandbox_writable_path=/home/bench/.cache/sccache quiche:quic_server quiche:quic_client
+          bazel-7.0.0 build -c opt --copt=-fno-omit-frame-pointer --copt=-g --strip=never --sandbox_writable_path=~/.cache/sccache quiche:quic_server quiche:quic_client
           bazel-7.0.0 shutdown
 
       - name: Build cloudflare/quiche


### PR DESCRIPTION
Instead of hardcoding it, which breaks on GCP w/cirun.io.