### PR TITLE
refactor(webtransport): rename WebTransportEvent::Session to NewSession

### DIFF
--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -21,7 +21,7 @@ use crate::{
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum WebTransportEvent {
     Negotiated(bool),
-    Session {
+    NewSession {
         stream_id: StreamId,
         status: u16,
         headers: Vec<Header>,
@@ -189,11 +189,13 @@ impl ExtendedConnectEvents for Http3ClientEvents {
         headers: Vec<Header>,
     ) {
         if connect_type == ExtendedConnectType::WebTransport {
-            self.insert(Http3ClientEvent::WebTransport(WebTransportEvent::Session {
-                stream_id,
-                status,
-                headers,
-            }));
+            self.insert(Http3ClientEvent::WebTransport(
+                WebTransportEvent::NewSession {
+                    stream_id,
+                    status,
+                    headers,
+                },
+            ));
         } else {
             unreachable!("There is only ExtendedConnectType::WebTransport");
         }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -175,7 +175,7 @@ const fn alpn_from_quic_version(version: Version) -> &'static str {
 ///
 ///     while let Some(event) = client.next_event() {
 ///         match event {
-///             Http3ClientEvent::WebTransport(WebTransportEvent::Session{
+///             Http3ClientEvent::WebTransport(WebTransportEvent::NewSession{
 ///                 stream_id,
 ///                 status,
 ///                 ..

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -180,7 +180,7 @@ impl WtTest {
         let wt_session_negotiated_event = |e| {
             matches!(
                 e,
-                Http3ClientEvent::WebTransport(WebTransportEvent::Session{
+                Http3ClientEvent::WebTransport(WebTransportEvent::NewSession{
                     stream_id,
                     status,
                     headers,

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -152,7 +152,7 @@ fn wt_session_response_with_1xx() {
     let wt_session_negotiated_event = |e| {
         matches!(
             e,
-            Http3ClientEvent::WebTransport(WebTransportEvent::Session{
+            Http3ClientEvent::WebTransport(WebTransportEvent::NewSession{
                 stream_id,
                 status,
                 headers,

--- a/neqo-http3/tests/webtransport.rs
+++ b/neqo-http3/tests/webtransport.rs
@@ -122,7 +122,7 @@ fn create_wt_session(client: &mut Http3Client, server: &mut Http3Server) -> WebT
     let wt_session_negotiated_event = |e| {
         matches!(
             e,
-            Http3ClientEvent::WebTransport(WebTransportEvent::Session{
+            Http3ClientEvent::WebTransport(WebTransportEvent::NewSession{
                 stream_id,
                 status,
                 headers,


### PR DESCRIPTION
On a new WebTransport session a client emits
`neqo_http3::client_events::WebTransportEvent::Session` and a server emits  `neqo_http3::server_events::WebTransportServerEvent::NewSession`. For the sake of consistency, rename the former to `NewSession`. Also consistent with `neqo_http3:client_event::WebTransportEvent::NewStream`.