### PR TITLE
refactor(http3): remove module_name_repetition lint

### DIFF
--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -25,7 +25,7 @@ use crate::{
     control_stream_local::ControlStreamLocal,
     control_stream_remote::ControlStreamRemote,
     features::extended_connect::{
-        webtransport_session::WebTransportSession,
+        webtransport_session,
         webtransport_streams::{WebTransportRecvStream, WebTransportSendStream},
         ExtendedConnectEvents, ExtendedConnectFeature, ExtendedConnectType,
     },
@@ -1057,7 +1057,7 @@ impl Http3Connection {
 
         let id = self.create_bidi_transport_stream(conn)?;
 
-        let extended_conn = Rc::new(RefCell::new(WebTransportSession::new(
+        let extended_conn = Rc::new(RefCell::new(webtransport_session::Session::new(
             id,
             events,
             self.role,
@@ -1137,8 +1137,8 @@ impl Http3Connection {
                     .send_headers(&[Header::new(":status", "200")], conn)
                     .is_ok()
                 {
-                    let extended_conn =
-                        Rc::new(RefCell::new(WebTransportSession::new_with_http_streams(
+                    let extended_conn = Rc::new(RefCell::new(
+                        webtransport_session::Session::new_with_http_streams(
                             stream_id,
                             events,
                             self.role,
@@ -1148,7 +1148,8 @@ impl Http3Connection {
                             self.send_streams
                                 .remove(&stream_id)
                                 .ok_or(Error::Internal)?,
-                        )?));
+                        )?,
+                    ));
                     self.add_streams(
                         stream_id,
                         Box::new(Rc::clone(&extended_conn)),
@@ -1255,7 +1256,7 @@ impl Http3Connection {
 
     fn webtransport_create_stream_internal(
         &mut self,
-        webtransport_session: Rc<RefCell<WebTransportSession>>,
+        webtransport_session: Rc<RefCell<webtransport_session::Session>>,
         stream_id: StreamId,
         session_id: StreamId,
         send_events: Box<dyn SendStreamEvents>,
@@ -1496,7 +1497,7 @@ impl Http3Connection {
 
     fn remove_extended_connect(
         &mut self,
-        wt: &Rc<RefCell<WebTransportSession>>,
+        wt: &Rc<RefCell<webtransport_session::Session>>,
         conn: &mut Connection,
     ) {
         let (recv, send) = wt.borrow_mut().take_sub_streams();

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -11,7 +11,6 @@ use std::fmt::Debug;
 
 use neqo_common::Header;
 use neqo_transport::{AppError, StreamId};
-pub(crate) use webtransport_session::WebTransportSession;
 
 use crate::{
     client_events::Http3ClientEvents,

--- a/neqo-http3/src/features/extended_connect/webtransport_streams.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_streams.rs
@@ -9,7 +9,7 @@ use std::{cell::RefCell, rc::Rc};
 use neqo_common::Encoder;
 use neqo_transport::{recv_stream, send_stream, Connection, StreamId};
 
-use super::WebTransportSession;
+use super::webtransport_session;
 use crate::{
     CloseType, Http3StreamInfo, Http3StreamType, ReceiveOutput, RecvStream, RecvStreamEvents, Res,
     SendStream, SendStreamEvents, Stream,
@@ -23,7 +23,7 @@ pub struct WebTransportRecvStream {
     stream_id: StreamId,
     stream_info: Http3StreamInfo,
     events: Box<dyn RecvStreamEvents>,
-    session: Rc<RefCell<WebTransportSession>>,
+    session: Rc<RefCell<webtransport_session::Session>>,
     session_id: StreamId,
     fin: bool,
 }
@@ -33,7 +33,7 @@ impl WebTransportRecvStream {
         stream_id: StreamId,
         session_id: StreamId,
         events: Box<dyn RecvStreamEvents>,
-        session: Rc<RefCell<WebTransportSession>>,
+        session: Rc<RefCell<webtransport_session::Session>>,
     ) -> Self {
         Self {
             stream_id,
@@ -118,7 +118,7 @@ pub struct WebTransportSendStream {
     stream_info: Http3StreamInfo,
     state: WebTransportSenderStreamState,
     events: Box<dyn SendStreamEvents>,
-    session: Rc<RefCell<WebTransportSession>>,
+    session: Rc<RefCell<webtransport_session::Session>>,
     session_id: StreamId,
 }
 
@@ -127,7 +127,7 @@ impl WebTransportSendStream {
         stream_id: StreamId,
         session_id: StreamId,
         events: Box<dyn SendStreamEvents>,
-        session: Rc<RefCell<WebTransportSession>>,
+        session: Rc<RefCell<webtransport_session::Session>>,
         local: bool,
     ) -> Self {
         Self {

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -169,7 +169,7 @@ pub use client_events::{Http3ClientEvent, WebTransportEvent};
 pub use conn_params::Http3Parameters;
 pub use connection::{Http3State, WebTransportSessionAcceptAction};
 pub use connection_client::Http3Client;
-use features::extended_connect::WebTransportSession;
+use features::extended_connect::webtransport_session;
 use frames::HFrame;
 pub use neqo_common::Header;
 use neqo_common::MessageType;
@@ -476,7 +476,7 @@ trait RecvStream: Stream {
         None
     }
 
-    fn webtransport(&self) -> Option<Rc<RefCell<WebTransportSession>>> {
+    fn webtransport(&self) -> Option<Rc<RefCell<webtransport_session::Session>>> {
         None
     }
 


### PR DESCRIPTION
Also to stay consistent with upcoming MASQUE connect-udp implementation. See Martin's comment in
https://github.com/mozilla/neqo/pull/2796#discussion_r2241913893.