### PR TITLE
perf: don't allocate in client UDP send path

### DIFF
--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -13,7 +13,7 @@ use std::{
     collections::VecDeque,
     fmt::Display,
     fs::File,
-    io::{BufWriter, Write as _},
+    io::{BufWriter, Cursor, Write as _},
     net::SocketAddr,
     num::NonZeroUsize,
     path::PathBuf,
@@ -192,12 +192,13 @@ impl TryFrom<&State> for CloseState {
 }
 
 impl super::Client for Connection {
-    fn process_multiple_output(
+    fn process_multiple_output<'a>(
         &mut self,
         now: Instant,
+        send_buffer: Cursor<&'a mut [u8]>,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
-        self.process_multiple_output(now, max_datagrams)
+    ) -> OutputBatch<Cursor<&'a mut [u8]>> {
+        self.process_multiple_output(now, send_buffer, max_datagrams)
     }
 
     fn process_multiple_input<'a>(

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -13,7 +13,7 @@ use std::{
     collections::VecDeque,
     fmt::Display,
     fs::File,
-    io::{BufWriter, Write as _},
+    io::{BufWriter, Cursor, Write as _},
     net::SocketAddr,
     num::NonZeroUsize,
     path::PathBuf,
@@ -135,12 +135,13 @@ impl super::Client for Http3Client {
         self.state().try_into()
     }
 
-    fn process_multiple_output(
+    fn process_multiple_output<'a>(
         &mut self,
         now: Instant,
+        send_buf: Cursor<&'a mut [u8]>,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
-        self.process_multiple_output(now, max_datagrams)
+    ) -> OutputBatch<Cursor<&'a mut [u8]>> {
+        self.process_multiple_output(now,  max_datagrams, send_buf,)
     }
 
     fn process_multiple_input<'a>(

--- a/neqo-bin/src/server/http09.rs
+++ b/neqo-bin/src/server/http09.rs
@@ -214,7 +214,7 @@ impl super::HttpServer for HttpServer {
         dgrams: impl IntoIterator<Item = Datagram<&'a mut [u8]>>,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         self.server.process_multiple(dgrams, now, max_datagrams)
     }
 

--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -96,7 +96,7 @@ impl super::HttpServer for HttpServer {
         dgrams: impl IntoIterator<Item = Datagram<&'a mut [u8]>>,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         self.server.process_multiple(dgrams, now, max_datagrams)
     }
 

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -259,7 +259,7 @@ pub trait HttpServer: Display {
         dgrams: impl IntoIterator<Item = Datagram<&'a mut [u8]>>,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch;
+    ) -> OutputBatch<Vec<u8>>;
     fn process_events(&mut self, now: Instant);
     fn has_events(&self) -> bool;
 }

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -8,7 +8,7 @@
 
 use std::{io, net::SocketAddr};
 
-use neqo_common::{qdebug, DatagramBatch};
+use neqo_common::{qdebug, Buffer, DatagramBatch};
 use neqo_udp::{DatagramIter, RecvBuf};
 
 /// Ideally this would live in [`neqo-udp`]. [`neqo-udp`] is used in Firefox.
@@ -80,7 +80,8 @@ impl Socket {
     }
 
     /// Send a [`DatagramBatch`] on the given [`Socket`].
-    pub fn send(&self, d: &DatagramBatch) -> io::Result<()> {
+    /// TODO: Do we need to be generic over B? Why not concrete Vec<u8>?
+    pub fn send<B: Buffer>(&self, d: &DatagramBatch<B>) -> io::Result<()> {
         self.inner.try_io(tokio::io::Interest::WRITABLE, || {
             neqo_udp::send_inner(&self.state, (&self.inner).into(), d)
         })

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -222,6 +222,23 @@ pub struct Encoder<B = Vec<u8>> {
 }
 
 impl<B: Buffer> Encoder<B> {
+    // TODO cfg
+    // TODO hack
+    pub fn to_owned(&self) -> Encoder<Vec<u8>> {
+        dbg!(self.as_ref().len());
+        Encoder {
+            buf: self.as_ref().to_vec(),
+            start: 0,
+        }
+    }
+
+    // TODO: better name?
+    pub fn new_with_buffer(b: B) -> Self {
+        Self {
+            start: b.position(),
+            buf: b,
+        }
+    }
     /// Get the length of the [`Encoder`].
     ///
     /// Note that the length of the underlying buffer might be larger.
@@ -581,6 +598,36 @@ pub trait Buffer: io::Write {
     fn rotate_right(&mut self, start: usize, count: usize);
 }
 
+impl<B: Buffer> Buffer for &mut B {
+    fn position(&self) -> usize {
+        B::position(self)
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        B::as_slice(self)
+    }
+
+    fn as_mut(&mut self) -> &mut [u8] {
+        B::as_mut(self)
+    }
+
+    fn truncate(&mut self, len: usize) {
+        B::truncate(self, len)
+    }
+
+    fn pad_to(&mut self, n: usize, v: u8) {
+        B::pad_to(self, n, v)
+    }
+
+    fn write_at(&mut self, pos: usize, data: u8) {
+        B::write_at(self, pos, data)
+    }
+
+    fn rotate_right(&mut self, start: usize, count: usize) {
+        B::rotate_right(self, start, count)
+    }
+}
+
 impl Buffer for Vec<u8> {
     fn position(&self) -> usize {
         self.len()
@@ -596,36 +643,6 @@ impl Buffer for Vec<u8> {
 
     fn truncate(&mut self, len: usize) {
         Self::truncate(self, len);
-    }
-
-    fn pad_to(&mut self, n: usize, v: u8) {
-        self.resize(n, v);
-    }
-
-    fn write_at(&mut self, pos: usize, data: u8) {
-        self[pos] = data;
-    }
-
-    fn rotate_right(&mut self, start: usize, count: usize) {
-        self[start..].rotate_right(count);
-    }
-}
-
-impl Buffer for &mut Vec<u8> {
-    fn position(&self) -> usize {
-        Vec::len(self)
-    }
-
-    fn as_slice(&self) -> &[u8] {
-        self.as_ref()
-    }
-
-    fn as_mut(&mut self) -> &mut [u8] {
-        self.as_mut_slice()
-    }
-
-    fn truncate(&mut self, len: usize) {
-        Vec::truncate(self, len);
     }
 
     fn pad_to(&mut self, n: usize, v: u8) {

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -10,7 +10,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use crate::{hex_with_len, Tos};
+use crate::{hex_with_len, Buffer, Tos};
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct Datagram<D = Vec<u8>> {
@@ -20,10 +20,10 @@ pub struct Datagram<D = Vec<u8>> {
     d: D,
 }
 
-impl TryFrom<DatagramBatch> for Datagram {
+impl<B: Buffer> TryFrom<DatagramBatch<B>> for Datagram {
     type Error = ();
 
-    fn try_from(d: DatagramBatch) -> Result<Self, Self::Error> {
+    fn try_from(d: DatagramBatch<B>) -> Result<Self, Self::Error> {
         if d.num_datagrams() != 1 {
             return Err(());
         }
@@ -31,7 +31,8 @@ impl TryFrom<DatagramBatch> for Datagram {
             src: d.src,
             dst: d.dst,
             tos: d.tos,
-            d: d.d,
+            // TODO: Performance footgun?
+            d: d.d.as_slice().to_vec(),
         })
     }
 }
@@ -137,16 +138,19 @@ impl<D: AsRef<[u8]>> AsRef<[u8]> for Datagram<D> {
 ///
 /// Upholds Linux GSO requirement. That is, all but the last datagram in the
 /// batch have the same size. The last datagram may be equal or smaller.
+///
+/// TODO: pub fields good idea?
 #[derive(Clone, PartialEq, Eq)]
-pub struct DatagramBatch {
-    src: SocketAddr,
-    dst: SocketAddr,
-    tos: Tos,
-    datagram_size: usize,
-    d: Vec<u8>,
+pub struct DatagramBatch<B> {
+    // TODO: No pub
+    pub src: SocketAddr,
+    pub dst: SocketAddr,
+    pub tos: Tos,
+    pub datagram_size: usize,
+    pub d: B,
 }
 
-impl Debug for DatagramBatch {
+impl<B: Buffer> Debug for DatagramBatch<B> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
@@ -155,12 +159,12 @@ impl Debug for DatagramBatch {
             self.src,
             self.dst,
             self.datagram_size,
-            hex_with_len(&self.d)
+            hex_with_len(&self.d.as_slice())
         )
     }
 }
 
-impl From<Datagram<Vec<u8>>> for DatagramBatch {
+impl From<Datagram<Vec<u8>>> for DatagramBatch<Vec<u8>> {
     fn from(d: Datagram<Vec<u8>>) -> Self {
         Self {
             src: d.src,
@@ -172,7 +176,7 @@ impl From<Datagram<Vec<u8>>> for DatagramBatch {
     }
 }
 
-impl DatagramBatch {
+impl<B: Buffer> DatagramBatch<B> {
     /// Maximum [`DatagramBatch`] size in bytes.
     ///
     /// This value is set conservatively to ensure compatibility with batch IO
@@ -190,8 +194,9 @@ impl DatagramBatch {
         dst: SocketAddr,
         tos: Tos,
         datagram_size: usize,
-        d: Vec<u8>,
+        d: B,
     ) -> Self {
+        assert!(datagram_size != 0);
         Self {
             src,
             dst,
@@ -227,12 +232,12 @@ impl DatagramBatch {
 
     #[must_use]
     pub fn data(&self) -> &[u8] {
-        &self.d
+        &self.d.as_slice()
     }
 
     #[must_use]
     pub fn num_datagrams(&self) -> usize {
-        self.d.len().div_ceil(self.datagram_size)
+        self.d.position().div_ceil(self.datagram_size)
     }
 
     #[cfg(feature = "build-fuzzing-corpus")]
@@ -271,20 +276,26 @@ mod tests {
         let dst = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 5678);
         let tos = Tos::default();
 
+        // TODO: cleanup the &mut
+
         // 10 bytes, segment size 4 -> 3 datagrams (4+4+2)
-        let batch = DatagramBatch::new(src, dst, tos, 4, vec![0u8; 10]);
+        let mut data =vec![0u8; 10];
+        let batch = DatagramBatch::new(src, dst, tos, 4, &mut data);
         assert_eq!(batch.num_datagrams(), 3);
 
         // 8 bytes, segment size 4 -> 2 datagrams (4+4)
-        let batch = DatagramBatch::new(src, dst, tos, 4, vec![0u8; 8]);
+        let mut data =vec![0u8; 8];
+        let batch = DatagramBatch::new(src, dst, tos, 4, &mut data);
         assert_eq!(batch.num_datagrams(), 2);
 
         // 5 bytes, segment size 5 -> 1 datagram
-        let batch = DatagramBatch::new(src, dst, tos, 5, vec![0u8; 5]);
+        let mut data = vec![0u8; 5];
+        let batch = DatagramBatch::new(src, dst, tos, 5, &mut data);
         assert_eq!(batch.num_datagrams(), 1);
 
         // 6 bytes, segment size 5 -> 2 datagrams (5+1)
-        let batch = DatagramBatch::new(src, dst, tos, 5, vec![0u8; 6]);
+        let mut data = vec![0u8; 6];
+        let batch = DatagramBatch::new(src, dst, tos, 5, &mut data);
         assert_eq!(batch.num_datagrams(), 2);
     }
 

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -136,7 +136,7 @@ impl Http3Server {
         dgrams: I,
         now: Instant,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<Vec<u8>> {
         qtrace!("[{self}] Process");
         let out = self.server.process_multiple(dgrams, now, max_datagrams);
         self.process_http3(now);

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -108,10 +108,10 @@ pub enum Output {
     Callback(Duration),
 }
 
-impl TryFrom<OutputBatch> for Output {
+impl<B: Buffer> TryFrom<OutputBatch<B>> for Output {
     type Error = ();
 
-    fn try_from(value: OutputBatch) -> Result<Self, Self::Error> {
+    fn try_from(value: OutputBatch<B>) -> Result<Self, Self::Error> {
         match value {
             OutputBatch::None => Ok(Self::None),
             OutputBatch::DatagramBatch(dg) => Ok(Self::Datagram(dg.try_into()?)),
@@ -121,30 +121,30 @@ impl TryFrom<OutputBatch> for Output {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum OutputBatch {
+pub enum OutputBatch<B: Buffer> {
     /// Connection requires no action.
     None,
     /// Connection requires the datagram batch be sent.
-    DatagramBatch(DatagramBatch),
+    DatagramBatch(DatagramBatch<B>),
     /// Connection requires `process_input()` be called when the `Duration`
     /// elapses.
     Callback(Duration),
 }
 
-impl From<Output> for OutputBatch {
-    fn from(value: Output) -> Self {
-        match value {
-            Output::None => Self::None,
-            Output::Datagram(dg) => Self::DatagramBatch(DatagramBatch::from(dg)),
-            Output::Callback(t) => Self::Callback(t),
-        }
-    }
-}
+impl From<Output> for OutputBatch<Vec<u8>> {
+     fn from(value: Output) -> Self {
+         match value {
+             Output::None => Self::None,
+             Output::Datagram(dg) => Self::DatagramBatch(DatagramBatch::from(dg)),
+             Output::Callback(t) => Self::Callback(t),
+         }
+     }
+ }
 
-impl OutputBatch {
+impl<B: Buffer> OutputBatch<B> {
     /// Convert into an [`Option<DatagramBatch>`].
     #[must_use]
-    pub fn dgram(self) -> Option<DatagramBatch> {
+    pub fn dgram(self) -> Option<DatagramBatch<B>> {
         match self {
             Self::DatagramBatch(dg) => Some(dg),
             _ => None,
@@ -210,14 +210,14 @@ impl From<Option<Datagram>> for Output {
 }
 
 /// Used by inner functions like `Connection::output`.
-enum SendOptionBatch {
+enum SendOptionBatch<B> {
     /// Yes, please send this datagram.
-    Yes(DatagramBatch),
+    Yes(DatagramBatch<B>),
     /// Don't send.  If this was blocked on the pacer (the arg is true).
     No(bool),
 }
 
-impl Default for SendOptionBatch {
+impl<B> Default for SendOptionBatch<B> {
     fn default() -> Self {
         Self::No(false)
     }
@@ -1205,7 +1205,8 @@ impl Connection {
     #[expect(clippy::missing_panics_doc, reason = "see expect()")]
     #[must_use = "Output of the process_output function must be handled"]
     pub fn process_output(&mut self, now: Instant) -> Output {
-        self.process_multiple_output(now, 1.try_into().expect(">0"))
+        let mut send_buffer = vec![];
+        self.process_multiple_output(now, &mut send_buffer, 1.try_into().expect(">0"))
             .try_into()
             .expect("max_datagrams is 1")
     }
@@ -1215,11 +1216,12 @@ impl Connection {
     /// Returns datagrams to send, and how long to wait before calling again
     /// even if no incoming packets.
     #[must_use = "OutputBatch of the process_multiple_output function must be handled"]
-    pub fn process_multiple_output(
+    pub fn process_multiple_output<B: Buffer>(
         &mut self,
         now: Instant,
+        send_buffer: B,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<B> {
         qtrace!("[{self}] process_output {:?} {now:?}", self.state);
 
         match (&self.state, self.role) {
@@ -1235,7 +1237,7 @@ impl Connection {
             }
         }
 
-        match self.output(now, max_datagrams) {
+        match self.output(now, send_buffer, max_datagrams) {
             SendOptionBatch::Yes(dgram) => OutputBatch::DatagramBatch(dgram),
             SendOptionBatch::No(paced) => match self.state {
                 State::Init | State::Closed(_) => OutputBatch::None,
@@ -1269,24 +1271,26 @@ impl Connection {
         dgram: Option<Datagram<A>>,
         now: Instant,
     ) -> Output {
-        self.process_multiple(dgram, now, 1.try_into().expect(">0"))
+        let mut send_buffer = vec![];
+        self.process_multiple(dgram, now,  &mut send_buffer, 1.try_into().expect(">0"),)
             .try_into()
             .expect("max_datagrams is 1")
     }
 
     /// Process input and generate output.
     #[must_use = "OutputBatch of the process_multiple function must be handled"]
-    pub fn process_multiple(
+    pub fn process_multiple<B: Buffer>(
         &mut self,
         dgram: Option<Datagram<impl AsRef<[u8]> + AsMut<[u8]>>>,
         now: Instant,
+        send_buffer: B,
         max_datagrams: NonZeroUsize,
-    ) -> OutputBatch {
+    ) -> OutputBatch<B> {
         if let Some(d) = dgram {
             self.input(d, now, now);
             self.process_saved(now);
         }
-        let output = self.process_multiple_output(now, max_datagrams);
+        let output = self.process_multiple_output(now, send_buffer, max_datagrams);
         #[cfg(all(feature = "build-fuzzing-corpus", test))]
         if self.test_frame_writer.is_none() {
             if let OutputBatch::DatagramBatch(batch) = &output {
@@ -2174,7 +2178,12 @@ impl Connection {
         }
     }
 
-    fn output(&mut self, now: Instant, max_datagrams: NonZeroUsize) -> SendOptionBatch {
+    fn output<B: Buffer>(
+        &mut self,
+        now: Instant,
+        send_buffer: B,
+        max_datagrams: NonZeroUsize,
+    ) -> SendOptionBatch<B> {
         qtrace!("[{self}] output {now:?}");
         let res = match &self.state {
             State::Init
@@ -2185,7 +2194,13 @@ impl Connection {
             | State::Confirmed => self.paths.select_path().map_or_else(
                 || Ok(SendOptionBatch::default()),
                 |path| {
-                    let res = self.output_dgram_batch_on_path(&path, now, None, max_datagrams);
+                    let res = self.output_dgram_batch_on_path(
+                        &path,
+                        now,
+                        None,
+                        send_buffer,
+                        max_datagrams,
+                    );
                     self.capture_error(Some(path), now, FrameType::Padding, res)
                 },
             ),
@@ -2206,6 +2221,7 @@ impl Connection {
                                 &path,
                                 now,
                                 Some(&details),
+                                send_buffer,
                                 max_datagrams,
                             )
                         };
@@ -2218,16 +2234,16 @@ impl Connection {
     }
 
     #[expect(clippy::too_many_arguments, reason = "no easy way to simplify")]
-    fn build_packet_header<'a>(
+    fn build_packet_header<B: Buffer>(
         path: &Path,
         epoch: Epoch,
-        encoder: Encoder<&'a mut Vec<u8>>,
+        encoder: Encoder<B>,
         tx: &CryptoDxState,
         address_validation: &AddressValidationInfo,
         version: Version,
         grease_quic_bit: bool,
         limit: usize,
-    ) -> (packet::Type, packet::Builder<&'a mut Vec<u8>>) {
+    ) -> (packet::Type, packet::Builder<B>) {
         let pt = packet::Type::from(epoch);
         let mut builder = if pt == packet::Type::Short {
             qdebug!("Building Short dcid {:?}", path.remote_cid());
@@ -2258,8 +2274,8 @@ impl Connection {
     }
 
     #[must_use]
-    fn add_packet_number(
-        builder: &mut packet::Builder<&mut Vec<u8>>,
+    fn add_packet_number<B: Buffer>(
+        builder: &mut packet::Builder<B>,
         tx: &CryptoDxState,
         largest_acknowledged: Option<packet::Number>,
     ) -> packet::Number {
@@ -2291,10 +2307,10 @@ impl Connection {
 
     /// Write the frames that are exchanged in the application data space.
     /// The order of calls here determines the relative priority of frames.
-    fn write_appdata_frames(
+    fn write_appdata_frames<B: Buffer>(
         &mut self,
-        builder: &mut packet::Builder<&mut Vec<u8>>,
-        tokens: &mut recovery::Tokens,
+        builder: &mut packet::Builder<B>,
+        tokens: &mut Vec<recovery::Token>,
         now: Instant,
     ) {
         let rtt = self.paths.primary().map_or_else(
@@ -2382,7 +2398,9 @@ impl Connection {
 
         #[cfg(test)]
         if let Some(w) = &mut self.test_frame_writer {
-            w.write_frames(builder);
+            let mut tmp_builder =  builder.x();
+            w.write_frames(&mut tmp_builder);
+            builder.y(tmp_builder);
         }
     }
 
@@ -2438,12 +2456,12 @@ impl Connection {
     /// Write frames to the provided builder.  Returns a list of tokens used for
     /// tracking loss or acknowledgment, whether any frame was ACK eliciting, and
     /// whether the packet was padded.
-    fn write_frames(
+    fn write_frames<B: Buffer>(
         &mut self,
         path: &PathRef,
         space: PacketNumberSpace,
         profile: &SendProfile,
-        builder: &mut packet::Builder<&mut Vec<u8>>,
+        builder: &mut packet::Builder<B>,
         coalesced: bool, // Whether this packet is coalesced behind another one.
         now: Instant,
     ) -> (recovery::Tokens, bool, bool) {
@@ -2570,15 +2588,15 @@ impl Connection {
         clippy::unwrap_in_result,
         reason = "expect() used on internal invariants"
     )]
-    fn output_dgram_batch_on_path(
+    fn output_dgram_batch_on_path<B: Buffer>(
         &mut self,
         path: &PathRef,
         now: Instant,
         mut closing_frame: Option<&ClosingFrame>,
+        mut send_buffer: B,
         max_datagrams: NonZeroUsize,
-    ) -> Res<SendOptionBatch> {
+    ) -> Res<SendOptionBatch<B>> {
         let packet_tos = path.borrow().tos();
-        let mut send_buffer = Vec::new();
 
         let mut datagram_size = None;
         let mut num_datagrams = 0;
@@ -2590,7 +2608,8 @@ impl Connection {
 
             // Check if we can fit another PMTUD sized datagram into the batch.
             if datagram_size.is_some_and(|datagram_size| {
-                min(datagram_size, DatagramBatch::MAX - send_buffer.len()) < path.borrow().plpmtu()
+                min(datagram_size, DatagramBatch::<B>::MAX - send_buffer.position())
+                    < path.borrow().plpmtu()
             }) {
                 break;
             }
@@ -2604,13 +2623,13 @@ impl Connection {
                 now,
                 closing_frame.take(),
                 &profile,
-                Encoder::new_borrowed_vec(&mut send_buffer),
+                Encoder::new_with_buffer(&mut send_buffer),
                 packet_tos,
             )? {
                 SendOption::Yes => {
                     num_datagrams += 1;
-                    let datagram_size = *datagram_size.get_or_insert(send_buffer.len());
-                    if ((send_buffer.len()) % datagram_size) > 0 {
+                    let datagram_size = *datagram_size.get_or_insert(send_buffer.position());
+                    if ((send_buffer.position()) % datagram_size) > 0 {
                         // GSO requires that all packets in a batch are of equal
                         // size. Only the last packet can be smaller. This
                         // packet was smaller. Make sure it was the last by
@@ -2643,13 +2662,13 @@ impl Connection {
     /// Build a datagram, possibly from multiple packets (for different PN
     /// spaces) and each containing 1+ frames.
     #[expect(clippy::too_many_lines, reason = "Yeah, that's just the way it is.")]
-    fn output_dgram_on_path(
+    fn output_dgram_on_path<B: Buffer>(
         &mut self,
         path: &PathRef,
         now: Instant,
         closing_frame: Option<&ClosingFrame>,
         profile: &SendProfile,
-        mut encoder: Encoder<&mut Vec<u8>>,
+        mut encoder: Encoder<B>,
         packet_tos: Tos,
     ) -> Res<SendOption> {
         let mut initial_sent = None;

--- a/neqo-transport/src/connection/test_internal.rs
+++ b/neqo-transport/src/connection/test_internal.rs
@@ -9,5 +9,5 @@
 use crate::packet;
 
 pub trait FrameWriter {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>);
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>);
 }

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -43,7 +43,7 @@ struct InsertDatagram<'a> {
 }
 
 impl crate::connection::test_internal::FrameWriter for InsertDatagram<'_> {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         builder.encode_varint(FrameType::Datagram);
         builder.encode(self.data);
     }
@@ -605,7 +605,7 @@ fn multiple_quic_datagrams_in_one_packet() {
 fn datagram_fill() {
     struct PanickingFrameWriter {}
     impl crate::connection::test_internal::FrameWriter for PanickingFrameWriter {
-        fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+        fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
             panic!(
                 "builder invoked with {} bytes remaining",
                 builder.remaining()
@@ -616,7 +616,7 @@ fn datagram_fill() {
         called: Rc<RefCell<bool>>,
     }
     impl crate::connection::test_internal::FrameWriter for TrackingFrameWriter {
-        fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+        fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
             assert_eq!(builder.remaining(), 2);
             *self.called.borrow_mut() = true;
         }

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -1041,7 +1041,7 @@ struct RetireAll {
 }
 
 impl crate::connection::test_internal::FrameWriter for RetireAll {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         // Use a sequence number that is large enough that all existing values
         // will be lower (so they get retired).  As the code doesn't care about
         // gaps in sequence numbers, this is safe, even though the gap might
@@ -1203,7 +1203,7 @@ fn retire_prior_to_migration_success() {
 struct GarbageWriter {}
 
 impl crate::connection::test_internal::FrameWriter for GarbageWriter {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         // Not a valid frame type.
         builder.encode_varint(u32::MAX);
     }

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -181,7 +181,7 @@ pub fn rttvar_after_n_updates(n: usize, rtt: Duration) -> Duration {
 struct PingWriter {}
 
 impl test_internal::FrameWriter for PingWriter {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         builder.encode_varint(FrameType::Ping);
     }
 }

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -908,7 +908,7 @@ fn ack_for_unsent() {
     struct AckforUnsentWriter {}
 
     impl FrameWriter for AckforUnsentWriter {
-        fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+        fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
             builder.encode_varint(FrameType::Ack);
             builder.encode_varint(666u16); // Largest ACKed
             builder.encode_varint(0u8); // ACK delay

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -532,7 +532,7 @@ fn do_not_accept_data_after_stop_sending() {
 struct Writer(Vec<u64>);
 
 impl crate::connection::test_internal::FrameWriter for Writer {
-    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+    fn write_frames(&mut self, builder: &mut packet::Builder<Vec<u8>>) {
         builder.write_varint_frame(&self.0);
     }
 }

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -120,6 +120,7 @@ impl From<PacketNumberSpace> for Type {
     }
 }
 
+#[derive(Clone)]
 struct BuilderOffsets {
     /// The bits of the first octet that need masking.
     first_byte_mask: u8,
@@ -184,14 +185,14 @@ impl Builder<Vec<u8>> {
     }
 
     /// Make a Version Negotiation packet.
-    #[must_use]
-    pub fn version_negotiation(
+    pub fn version_negotiation<B: Buffer>(
         dcid: &[u8],
         scid: &[u8],
         client_version: u32,
         versions: &[Version],
-    ) -> Vec<u8> {
-        let mut encoder = Encoder::default();
+        send_buffer: B,
+    ) {
+        let mut encoder = Encoder::new_with_buffer(send_buffer);
         let mut grease = random::<4>();
         // This will not include the "QUIC bit" sometimes.  Intentionally.
         encoder.encode_byte(PACKET_BIT_LONG | (grease[3] & 0x7f));
@@ -211,12 +212,55 @@ impl Builder<Vec<u8>> {
         // by making the last byte differ from the client initial.
         grease[3] = (client_version.wrapping_add(0x10) & 0xf0) as u8 | 0x0a;
         encoder.encode(&grease[..4]);
-
-        Vec::from(encoder)
     }
 }
 
 impl<B: Buffer> Builder<B> {
+    // TODO cfg
+    // TODO hack
+    pub fn x(&self) -> Builder<Vec<u8>> {
+        dbg!("x");
+        let Self {
+            encoder,
+            pn,
+            header,
+            offsets,
+            limit,
+            padding,
+        } = self;
+        dbg!(encoder.len());
+        let encoder = encoder.to_owned();
+
+        Builder {
+            encoder,
+            pn: *pn,
+            header: header.clone(),
+            offsets: (*offsets).clone(),
+            limit: *limit,
+            padding: *padding,
+        }
+    }
+
+    // TODO cfg
+    // TODO hack
+    pub fn y(&mut self, builder: Builder<Vec<u8>>) {
+        dbg!("y");
+        self.pn = builder.pn;
+        self.header = builder.header;
+        self.offsets = builder.offsets;
+        self.limit = builder.limit;
+        self.padding = builder.padding;
+
+        dbg!(self.encoder.len());
+
+        dbg!(builder.encoder.len());
+
+        self.encoder.encode(&builder.encoder.as_ref()[(self.encoder.len())..]);
+
+
+        dbg!(self.encoder.len());
+    }
+
     /// Start building a short header packet.
     ///
     /// This doesn't fail if there isn't enough space; instead it returns a builder that
@@ -1445,8 +1489,14 @@ mod tests {
     #[test]
     fn build_vn() {
         fixture_init();
-        let mut vn =
-            Builder::version_negotiation(SERVER_CID, CLIENT_CID, 0x0a0a_0a0a, &Version::all());
+        let mut vn = Vec::new();
+        Builder::version_negotiation(
+            SERVER_CID,
+            CLIENT_CID,
+            0x0a0a_0a0a,
+            &Version::all(),
+            &mut vn,
+        );
         // Erase randomness from greasing...
         assert_eq!(vn.len(), SAMPLE_VN.len());
         vn[0] &= 0x80;
@@ -1459,7 +1509,14 @@ mod tests {
     #[test]
     fn vn_do_not_repeat_client_grease() {
         fixture_init();
-        let vn = Builder::version_negotiation(SERVER_CID, CLIENT_CID, 0x0a0a_0a0a, &Version::all());
+        let mut vn = Vec::new();
+        Builder::version_negotiation(
+            SERVER_CID,
+            CLIENT_CID,
+            0x0a0a_0a0a,
+            &Version::all(),
+            &mut vn,
+        );
         assert_ne!(&vn[SAMPLE_VN.len() - 4..], &[0x0a, 0x0a, 0x0a, 0x0a]);
     }
 

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -695,14 +695,14 @@ impl Path {
     }
 
     /// Make a datagram.
-    pub fn datagram_batch(
+    pub fn datagram_batch<B: Buffer>(
         &mut self,
-        payload: Vec<u8>,
+        payload: B,
         tos: Tos,
         num_datagrams: usize,
         datagram_size: usize,
         stats: &mut Stats,
-    ) -> DatagramBatch {
+    ) -> DatagramBatch<B> {
         // Make sure to use the TOS value from before calling ecn::Info::on_packet_sent, which may
         // update the ECN state and can hence change it - this packet should still be sent
         // with the current value.

--- a/neqo-transport/tests/connection.rs
+++ b/neqo-transport/tests/connection.rs
@@ -32,8 +32,9 @@ fn gso() {
     client.stream_send(stream_id2, &[42; 2048]).unwrap();
     client.stream_close_send(stream_id2).unwrap();
 
+    let send_buffer = vec![];
     let out = client
-        .process_multiple_output(now(), 64.try_into().expect(">0"))
+        .process_multiple_output(now(),send_buffer, 64.try_into().expect(">0"))
         .dgram()
         .unwrap();
 


### PR DESCRIPTION
Have client maintain a long-lived send buffer. When producing outbound UDP datagrams write them into the buffer. Then pass the buffer to the OS to be sent out on the network.

In other words, don't heap-allocate in the client UDP send path.

---

Corresponding past patch for the receive path https://github.com/mozilla/neqo/pull/2184

Fixes https://github.com/mozilla/neqo/issues/2670

Subset of https://github.com/mozilla/neqo/pull/2747