### PR TITLE
Make discarded_initial_keys more robust

### DIFF
--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -7,10 +7,7 @@
 use std::time::Duration;
 
 use neqo_common::{event::Provider as _, Decoder, Dscp, Encoder};
-use test_fixture::{
-    assertions::{self},
-    datagram, now,
-};
+use test_fixture::{assertions, datagram, now};
 
 use super::{
     super::{CloseReason, ConnectionEvent, Output, State, ZeroRttState},


### PR DESCRIPTION
Use split_datagram to make the dropping/dup counting more robust. Rename some variables to make them more obvious.

I discovered a bug in the reformatter today:

`use foo::{bar}` and `use foo::{bar::{self}}` are combined into `use foo::{bar, bar::{self}}`, which is not something the compiler likes.