### PR TITLE
PTO across packet number spaces better

### DIFF
--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -535,11 +535,13 @@ fn reorder_handshake() {
     now += RTT / 2;
     client.process_input(s_handshake_2, now);
     assert_eq!(client.stats().saved_datagrams, 2);
-    assert_eq!(client.stats().packets_rx, 0);
+    // There's a chance that the second datagram contained a little bit of an Initial packet.
+    // That will have been processed by the client.
+    assert!((0..=1).contains(&client.stats().packets_rx));
 
     client.process_input(s_initial_2, now);
     // Each saved packet should now be "received" again.
-    assert_eq!(client.stats().packets_rx, 3);
+    assert!((3..=5).contains(&client.stats().packets_rx));
     maybe_authenticate(&mut client);
     let c3 = client.process_output(now).dgram();
     assert!(c3.is_some());

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -71,7 +71,7 @@ impl SendProfile {
         Self {
             limit: max(ACK_ONLY_SIZE_LIMIT - 1, limit),
             pto: None,
-            probe: PacketNumberSpaceSet::default(),
+            probe: PacketNumberSpaceSet::empty(),
             paced: false,
         }
     }
@@ -82,7 +82,7 @@ impl SendProfile {
         Self {
             limit: ACK_ONLY_SIZE_LIMIT - 1,
             pto: None,
-            probe: PacketNumberSpaceSet::default(),
+            probe: PacketNumberSpaceSet::empty(),
             paced: true,
         }
     }
@@ -90,7 +90,6 @@ impl SendProfile {
     #[must_use]
     pub fn new_pto(pn_space: PacketNumberSpace, mtu: usize, probe: PacketNumberSpaceSet) -> Self {
         debug_assert!(mtu > ACK_ONLY_SIZE_LIMIT);
-        debug_assert!(probe.contains(pn_space));
         Self {
             limit: mtu,
             pto: Some(pn_space),
@@ -425,35 +424,22 @@ struct PtoState {
 }
 
 impl PtoState {
-    /// The number of packets we send on a PTO.
-    fn pto_packet_count(space: PacketNumberSpace) -> usize {
-        if space == PacketNumberSpace::ApplicationData {
-            MAX_PTO_PACKET_COUNT
-        } else {
-            // For the Initial and Handshake spaces, we only send one packet on PTO. This avoids
-            // sending useless PING-only packets when only a single packet was lost, which is the
-            // common case. These PINGs use cwnd and amplification window space, and sending them
-            // hence makes the handshake more brittle.
-            1
-        }
-    }
-
     pub fn new(space: PacketNumberSpace, probe: PacketNumberSpaceSet) -> Self {
         debug_assert!(probe.contains(space));
         Self {
             space,
             count: 1,
-            packets: Self::pto_packet_count(space),
+            packets: MAX_PTO_PACKET_COUNT,
             probe,
         }
     }
 
     pub fn pto(&mut self, space: PacketNumberSpace, probe: PacketNumberSpaceSet) {
         debug_assert!(probe.contains(space));
-        self.space = space;
+        self.space = min(space, self.space);
         self.count += 1;
-        self.packets = Self::pto_packet_count(space);
-        self.probe = probe;
+        self.packets = MAX_PTO_PACKET_COUNT;
+        self.probe |= probe;
     }
 
     pub const fn count(&self) -> usize {
@@ -468,10 +454,20 @@ impl PtoState {
     /// This takes a packet from the supply if one remains, or returns `None`.
     pub fn send_profile(&mut self, mtu: usize) -> Option<SendProfile> {
         (self.packets > 0).then(|| {
-            // This is a PTO, so ignore the limit.
             self.packets -= 1;
+            // This is a PTO, so ignore the limit.
             SendProfile::new_pto(self.space, mtu, self.probe)
         })
+    }
+
+    pub fn pto_sent(&mut self, space: PacketNumberSpace) {
+        // For Initial and Handshake packets, don't force probes after the first packet.
+        // Probing forces the inclusion of frames, even when there is nothing to send.
+        // We do want to send subsequent packets if there is something there,
+        // but, if we force a probe, we end up sending useless packets with just PING.
+        if self.packets < MAX_PTO_PACKET_COUNT && space != PacketNumberSpace::ApplicationData {
+            self.probe -= space;
+        }
     }
 }
 
@@ -530,6 +526,9 @@ impl Loss {
     pub fn on_packet_sent(&mut self, path: &PathRef, mut sent_packet: sent::Packet, now: Instant) {
         let pn_space = PacketNumberSpace::from(sent_packet.packet_type());
         qtrace!("[{self}] packet {pn_space}-{} sent", sent_packet.pn());
+        if let Some(pto) = self.pto_state.as_mut() {
+            pto.pto_sent(pn_space);
+        }
         if let Some(space) = self.spaces.get_mut(pn_space) {
             path.borrow_mut().packet_sent(&mut sent_packet, now);
             space.on_packet_sent(sent_packet);
@@ -963,7 +962,7 @@ mod tests {
         cid::{ConnectionId, ConnectionIdEntry},
         ecn, packet,
         path::{Path, PathRef},
-        recovery::{self, sent},
+        recovery::{self, sent, MAX_PTO_PACKET_COUNT},
         stats::{Stats, StatsCell},
         ConnectionParameters,
     };
@@ -1564,7 +1563,7 @@ mod tests {
                 recovery::Tokens::new(),
                 ON_SENT_SIZE,
             ),
-            Instant::now(),
+            now(),
         );
 
         let handshake_pto = lr.path.borrow().rtt().pto(false);
@@ -1576,5 +1575,159 @@ mod tests {
         assert!(!profile.should_probe(PacketNumberSpace::Initial));
         assert!(!profile.should_probe(PacketNumberSpace::Handshake));
         assert!(!profile.should_probe(PacketNumberSpace::ApplicationData));
+    }
+
+    /// Confirm that a PTO in two spaces leads to probes in both.
+    #[test]
+    fn pto_two_spaces() {
+        let mut lr = Fixture::default();
+        let now = now();
+        lr.on_packet_sent(
+            sent::Packet::new(
+                packet::Type::Initial,
+                0,
+                now,
+                true,
+                recovery::Tokens::new(),
+                ON_SENT_SIZE,
+            ),
+            now,
+        );
+        lr.on_packet_sent(
+            sent::Packet::new(
+                packet::Type::Handshake,
+                0,
+                now,
+                true,
+                recovery::Tokens::new(),
+                ON_SENT_SIZE,
+            ),
+            now,
+        );
+
+        let handshake_pto = lr.path.borrow().rtt().pto(false);
+        let expected_pto = now + handshake_pto;
+        assert_eq!(lr.pto_time(PacketNumberSpace::Initial), Some(expected_pto));
+        assert_eq!(
+            lr.pto_time(PacketNumberSpace::Handshake),
+            Some(expected_pto)
+        );
+
+        // After a PTO, sent packet should be marked "lost" (not really)
+        // so that they can be sent again.
+        let now = expected_pto;
+        let lost = lr.timeout(now);
+        assert_eq!(2, lost.len());
+        assert!(lost
+            .iter()
+            .any(|x| x.packet_type() == packet::Type::Initial));
+        assert!(lost
+            .iter()
+            .any(|x| x.packet_type() == packet::Type::Handshake));
+
+        // The resulting send profile should probe spaces where packets were "lost".
+        let profile = lr.send_profile(now);
+        assert!(profile.pto.is_some());
+        assert!(profile.should_probe(PacketNumberSpace::Initial));
+        assert!(profile.should_probe(PacketNumberSpace::Handshake));
+        assert!(!profile.should_probe(PacketNumberSpace::ApplicationData));
+
+        // Sending a packet clears the probe bit for that space.
+        lr.on_packet_sent(
+            sent::Packet::new(
+                packet::Type::Handshake,
+                0,
+                now,
+                true,
+                recovery::Tokens::new(),
+                ON_SENT_SIZE,
+            ),
+            now,
+        );
+        let profile = lr.send_profile(now);
+        assert!(profile.pto.is_some());
+        assert!(profile.should_probe(PacketNumberSpace::Initial));
+        assert!(!profile.should_probe(PacketNumberSpace::Handshake)); // changed
+        assert!(!profile.should_probe(PacketNumberSpace::ApplicationData));
+
+        assert_eq!(2, MAX_PTO_PACKET_COUNT); // because we're relying on that...
+        let profile = lr.send_profile(now);
+        assert!(profile.pto.is_none());
+    }
+
+    /// Confirm that a PTO in two spaces leads to probes in both, staggered.
+    #[test]
+    fn pto_two_spaces_staggered() {
+        let mut lr = Fixture::default();
+        let start_time = now();
+        let now = start_time;
+        lr.on_packet_sent(
+            sent::Packet::new(
+                packet::Type::Initial,
+                0,
+                now,
+                true,
+                recovery::Tokens::new(),
+                ON_SENT_SIZE,
+            ),
+            now,
+        );
+
+        let initial_pto = now + lr.path.borrow().rtt().pto(false);
+        assert_eq!(lr.pto_time(PacketNumberSpace::Initial), Some(initial_pto));
+        assert!(lr.pto_time(PacketNumberSpace::ApplicationData).is_none());
+
+        // A PTO results in the profile including Initial.
+        let now = initial_pto;
+        let _lost = lr.timeout(now);
+        let profile = lr.send_profile(now);
+        assert!(profile.pto.is_some());
+        assert!(profile.should_probe(PacketNumberSpace::Initial));
+        assert!(!profile.should_probe(PacketNumberSpace::Handshake));
+        assert!(!profile.should_probe(PacketNumberSpace::ApplicationData));
+
+        // Sending and timing out a short header packet...
+        lr.on_packet_sent(
+            sent::Packet::new(
+                packet::Type::Short,
+                0,
+                now,
+                true,
+                recovery::Tokens::new(),
+                ON_SENT_SIZE,
+            ),
+            now,
+        );
+
+        // The PTO time is doubled.  But the app PTO is relative to its send time.
+        let two_pto = 2 * lr.path.borrow().rtt().pto(false);
+        let initial_pto2 = start_time + two_pto;
+        let app_pto = now + two_pto;
+        assert_eq!(lr.pto_time(PacketNumberSpace::Initial), Some(initial_pto2));
+        assert_eq!(
+            lr.pto_time(PacketNumberSpace::ApplicationData),
+            Some(app_pto)
+        );
+
+        // A second PTO resets the count.
+        let now = app_pto;
+        let _lost = lr.timeout(now);
+        let profile = lr.send_profile(now);
+        assert!(profile.pto.is_some());
+        assert!(profile.should_probe(PacketNumberSpace::Initial));
+        assert!(!profile.should_probe(PacketNumberSpace::Handshake));
+        assert!(profile.should_probe(PacketNumberSpace::ApplicationData));
+
+        // This is the second and the Initial space still hasn't been probed.
+        let profile = lr.send_profile(now);
+        assert!(profile.pto.is_some());
+        assert!(profile.should_probe(PacketNumberSpace::Initial));
+        assert!(!profile.should_probe(PacketNumberSpace::Handshake));
+        assert!(profile.should_probe(PacketNumberSpace::ApplicationData));
+
+        // The PTO is now done.
+        assert_eq!(2, MAX_PTO_PACKET_COUNT); // because we're relying on that...
+        let profile = lr.send_profile(now);
+        assert!(profile.pto.is_none());
     }
 }


### PR DESCRIPTION
This tweaks the change that @larseggert made to reduce the number of pointless handshake packets (Initial and Handshake both).  Rather than cap the number of probes we send on a PTO, this keeps the limit of two packets, but disables the probing we do with PING frames once we have sent a packet of the indicated type.

This merges the spaces that we probe when a PTO occurs.  So we don't
just probe the last space that fired the PTO timer.   Because we time
out Initial and Handshake packets at the same time often, that results
in only probing the Handshake space.  That's probably OK in most cases,
but it can mean stalling Handshake if there is stuff to send at that
level at a server.

Because this allows more than one packet to be sent in Initial and Handshake packet number spaces, there are some tests that do precise counting and need to be adjusted.