### PR TITLE
refactor(bin/server): simplify `run()` removing need for `HttpServer::new`

### DIFF
--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -95,21 +95,17 @@ fn spawn_server() -> (tokio::sync::oneshot::Sender<()>, SocketAddr) {
 
         let mut args = server::Args::default();
         args.set_hosts(vec!["[::]:0".to_string()]);
-        let server =
-            runtime.block_on(async { server::server::<server::http3::HttpServer>(args).unwrap() });
+        // `server.run` calls tokio's `UdpSocket::from_std` which requires a
+        // Tokio runtime. Ensure one is available by running it in
+        // `runtime.block_on`.
+        let (server, local_addrs) = runtime.block_on(async { server::run(args).unwrap() });
 
         addr_sender
-            .send(
-                server
-                    .local_addresses()
-                    .into_iter()
-                    .find(SocketAddr::is_ipv6)
-                    .unwrap(),
-            )
+            .send(local_addrs.into_iter().find(SocketAddr::is_ipv6).unwrap())
             .unwrap();
 
         runtime.block_on(async {
-            let mut server = Box::pin(server.run());
+            let mut server = Box::pin(server);
             tokio::select! {
                 _ = &mut done_receiver => {}
                 res = &mut server  => panic!("expect server not to terminate: {res:?}"),

--- a/neqo-bin/src/bin/server.rs
+++ b/neqo-bin/src/bin/server.rs
@@ -5,21 +5,11 @@
 // except according to those terms.
 
 use clap::Parser as _;
-use neqo_bin::server::{http09, http3, Res};
+use neqo_bin::server::Res;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Res<()> {
-    let mut args = neqo_bin::server::Args::parse();
+    let args = neqo_bin::server::Args::parse();
 
-    args.update_for_tests();
-
-    if args.get_shared().get_alpn() == "h3" {
-        neqo_bin::server::server::<http3::HttpServer>(args)?
-            .run()
-            .await
-    } else {
-        neqo_bin::server::server::<http09::HttpServer>(args)?
-            .run()
-            .await
-    }
+    neqo_bin::server::run(args)?.0.await
 }

--- a/neqo-bin/src/lib.rs
+++ b/neqo-bin/src/lib.rs
@@ -328,11 +328,7 @@ mod tests {
         server_args.set_qlog_dir(temp_dir.path());
 
         let client = client::client(client_args);
-        let server = Box::pin(
-            server::server::<server::http3::HttpServer>(server_args)
-                .unwrap()
-                .run(),
-        );
+        let (server, _local_addrs) = server::run(server_args).unwrap();
         tokio::select! {
             _ = client => {}
             res = server  => panic!("expect server not to terminate: {res:?}"),

--- a/neqo-bin/src/server/http09.rs
+++ b/neqo-bin/src/server/http09.rs
@@ -201,14 +201,6 @@ impl HttpServer {
 }
 
 impl super::HttpServer for HttpServer {
-    fn new(
-        args: &Args,
-        anti_replay: AntiReplay,
-        cid_mgr: Rc<RefCell<dyn ConnectionIdGenerator>>,
-    ) -> Self {
-        Self::new(args, anti_replay, cid_mgr).expect("We cannot make a server!")
-    }
-
     fn process_multiple<'a>(
         &mut self,
         dgrams: impl IntoIterator<Item = Datagram<&'a mut [u8]>>,

--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -83,14 +83,6 @@ impl Display for HttpServer {
 }
 
 impl super::HttpServer for HttpServer {
-    fn new(
-        args: &Args,
-        anti_replay: AntiReplay,
-        cid_mgr: Rc<RefCell<dyn ConnectionIdGenerator>>,
-    ) -> Self {
-        Self::new(args, anti_replay, cid_mgr)
-    }
-
     fn process_multiple<'a>(
         &mut self,
         dgrams: impl IntoIterator<Item = Datagram<&'a mut [u8]>>,


### PR DESCRIPTION
https://github.com/mozilla/neqo/pull/2734 introduced a trait parameter into the `HTTPServer::process_multiple` trait function, thus making `HttpServer` no longer object safe. That required a couple of minor changes, solved via a new `HttpServer::new` function.

`HttpServer` is consumed by `neqo-bin`, but also `http3server` in mozilla-firefox/firefox. The latter does not use `HttpServer::new`, but the trait requires implementing it anyways.

This commit removes the need for `HttpServer::new`.