### PR TITLE
feat(http3): support classic HTTP CONNECT

### DIFF
--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -758,6 +758,7 @@ impl Http3Connection {
         output
     }
 
+    // TODO: Rename?
     fn create_fetch_headers<'b, 't, T>(request: &RequestDescription<'b, 't, T>) -> Res<Vec<Header>>
     where
         T: AsRequestTarget<'t> + ?Sized + Debug,
@@ -770,10 +771,21 @@ impl Http3Connection {
         // Transform pseudo-header fields
         let mut final_headers = vec![
             Header::new(":method", request.method),
-            Header::new(":scheme", target.scheme()),
             Header::new(":authority", target.authority()),
-            Header::new(":path", target.path()),
         ];
+        let is_classic_connect = request.connect_type.is_none()
+            && request
+                .headers
+                .iter()
+                .any(|h| h.name() == ":method" && h.value() == "CONNECT");
+        if is_classic_connect {
+            // > The :scheme and :path pseudo-header fields are omitted
+            //
+            // <https://datatracker.ietf.org/doc/html/rfc9114#section-4.4>
+        } else {
+            final_headers.push(Header::new(":scheme", target.scheme()));
+            final_headers.push(Header::new(":path", target.path()));
+        }
         if let Some(conn_type) = request.connect_type {
             final_headers.push(Header::new(":protocol", conn_type.string()));
         }
@@ -835,6 +847,7 @@ impl Http3Connection {
     {
         let final_headers = Self::create_fetch_headers(request)?;
 
+        // TODO: Why is this here? WebTransport goes a different route, no?
         let stream_type = if request.connect_type.is_some() {
             Http3StreamType::ExtendedConnect
         } else {


### PR DESCRIPTION
For now, just a hack, to unblock @KershawChang on the Firefox side.

Will need more work. Probably, as @KershawChang suggested, a new function on `Http3Client`, as HTTP CONNECT strictly speaking isn't part of _fetch_.