### PR TITLE
fix(http3): resurrect Http3StreamInfo::is_http

### DIFF
--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -500,6 +500,11 @@ impl Http3StreamInfo {
             None
         }
     }
+
+    #[must_use]
+    pub fn is_http(&self) -> bool {
+        self.stream_type == Http3StreamType::Http
+    }
 }
 
 trait RecvStreamEvents: Debug {


### PR DESCRIPTION
Used in https://github.com/mozilla-firefox/firefox/blob/2560b9e4645c84c00c70e997cee1b13a6500f994/netwerk/test/http3server/src/main.rs#L666