### PR TITLE
feat: Optimize more

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Ctarget-cpu=native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,9 @@ opt-level = 1
 
 [profile.release]
 lto = "fat"
+# TODO: Benchmark this separately.
+#codegen-units = 1
+#panic = "abort"
 
 [profile.bench]
 # Inherits from the "release" profile, so just provide overrides here:


### PR DESCRIPTION
There is currrently a discussion whether it is worth raising the minimal supported x86 hardware requirements for Gecko. (Chrome seems to want to require AVX2 in the near future.) For Gecko speedometer 3, it only seems to get us 1%, but that doesn't include any networking...

Turn the dial to 11 here to see if there is an effect on our benches. Our benchmark CPUs are somewhat dated, so running this on them might roughly correspond to what we'd see if we moderately raised the hardware requirements.