### PR TITLE
chore: preapre v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "enum-map",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "enumset",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "log",
  "neqo-common",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "enum-map",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.14.1"
+version = "0.15.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Got [Firefox CI all green](https://treeherder.mozilla.org/jobs?repo=try&revision=b62b5f5f766240be4aaef1fcabf5665b94beddf3) with latest Neqo `main`, thus ready to cut a release.