### PR TITLE
Revert "bench(transport/transfer): measure both wallclock and simulated time"

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -132,9 +132,8 @@ jobs:
           for BENCH in $BENCHES; do
             cp "$BENCH" ../binaries/neqo/
             # shellcheck disable=SC2086
-            # --baseline-lenient allows us to add new benchmarks in pull requests.
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
-              $BENCH -- --bench --baseline-lenient main | { grep -v '^cset' || test $? = 1; } | tee -a ../results.txt
+              $BENCH -- --bench --baseline main | { grep -v '^cset' || test $? = 1; } | tee -a ../results.txt
           done
           for BENCH in $BENCHES; do
             NAME=$(basename "$BENCH" | cut -d- -f1)

--- a/neqo-transport/benches/transfer.rs
+++ b/neqo-transport/benches/transfer.rs
@@ -13,7 +13,7 @@ use test_fixture::{
     sim::{
         connection::{Node, ReachState, ReceiveData, SendData},
         network::{RandomDelay, TailDrop},
-        Simulator,
+        ReadySimulator, Simulator,
     },
 };
 
@@ -27,68 +27,45 @@ const TRANSFER_AMOUNT: usize = 1 << 22; // 4Mbyte
 )]
 fn benchmark_transfer(c: &mut Criterion, label: &str, seed: Option<impl AsRef<str>>) {
     for pacing in [false, true] {
-        let setup = || {
-            let nodes = boxed![
-                Node::new_client(
-                    ConnectionParameters::default()
-                        .pmtud(true)
-                        .pacing(pacing)
-                        .mlkem(false),
-                    boxed![ReachState::new(State::Confirmed)],
-                    boxed![SendData::new(TRANSFER_AMOUNT)]
-                ),
-                TailDrop::dsl_uplink(),
-                RandomDelay::new(ZERO..JITTER),
-                Node::new_server(
-                    ConnectionParameters::default()
-                        .pmtud(true)
-                        .pacing(pacing)
-                        .mlkem(false),
-                    boxed![ReachState::new(State::Confirmed)],
-                    boxed![ReceiveData::new(TRANSFER_AMOUNT)]
-                ),
-                TailDrop::dsl_downlink(),
-                RandomDelay::new(ZERO..JITTER),
-            ];
-            let mut sim = Simulator::new(label, nodes);
-            if let Some(seed) = &seed {
-                sim.seed_str(seed);
-            }
-            sim.setup()
-        };
-
-        let mut group = c.benchmark_group(format!("transfer/pacing-{pacing}/{label}"));
+        let mut group = c.benchmark_group(format!("transfer/pacing-{pacing}"));
+        // Don't let criterion calculate throughput, as that's based on wall-clock time, not
+        // simulator time.
         group.noise_threshold(0.03);
-
-        // Benchmark with wallclock time, i.e. measure the compute efficiency.
-        group.bench_function("wallclock-time", |b| {
+        group.bench_function(label, |b| {
             b.iter_batched(
-                setup,
-                |s| {
-                    black_box(s.run());
+                || {
+                    let nodes = boxed![
+                        Node::new_client(
+                            ConnectionParameters::default()
+                                .pmtud(true)
+                                .pacing(pacing)
+                                .mlkem(false),
+                            boxed![ReachState::new(State::Confirmed)],
+                            boxed![SendData::new(TRANSFER_AMOUNT)]
+                        ),
+                        TailDrop::dsl_uplink(),
+                        RandomDelay::new(ZERO..JITTER),
+                        Node::new_server(
+                            ConnectionParameters::default()
+                                .pmtud(true)
+                                .pacing(pacing)
+                                .mlkem(false),
+                            boxed![ReachState::new(State::Confirmed)],
+                            boxed![ReceiveData::new(TRANSFER_AMOUNT)]
+                        ),
+                        TailDrop::dsl_downlink(),
+                        RandomDelay::new(ZERO..JITTER),
+                    ];
+                    let mut sim = Simulator::new(label, nodes);
+                    if let Some(seed) = &seed {
+                        sim.seed_str(seed);
+                    }
+                    sim.setup()
                 },
+                black_box(ReadySimulator::run),
                 SmallInput,
             );
         });
-
-        // Benchmark with simulated time, i.e. measure the network protocol
-        // efficiency.
-        //
-        // Note: Given that this is using simulated time, we can measure actual
-        // throughput.
-        group.throughput(criterion::Throughput::Bytes(TRANSFER_AMOUNT as u64));
-        group.bench_function("simulated-time", |b| {
-            b.iter_custom(|iters| {
-                let mut d_sum = Duration::ZERO;
-                for _i in 0..iters {
-                    // run() returns the simulated time, excluding setup time.
-                    // No need for black_box(), because this doesn't measure compute.
-                    d_sum += setup().run();
-                }
-                d_sum
-            });
-        });
-
         group.finish();
     }
 }


### PR DESCRIPTION
Reverts mozilla/neqo#2891

The pull request messed up our Github benchmark comment formatting. Let's revert for now.

Details: https://github.com/mozilla/neqo/pull/2885#issuecomment-3223885666