### PR TITLE
Reapply "bench(transport/transfer): measure both wallclock and simulated time"

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -132,8 +132,9 @@ jobs:
           for BENCH in $BENCHES; do
             cp "$BENCH" ../binaries/neqo/
             # shellcheck disable=SC2086
+            # --baseline-lenient allows us to add new benchmarks in pull requests.
             nice -n -20 setarch --addr-no-randomize cset proc --set=cpu23 --exec \
-              $BENCH -- --bench --baseline main | { grep -v '^cset' || test $? = 1; } | tee -a ../results.txt
+              $BENCH -- --bench --baseline-lenient main | { grep -v '^cset' || test $? = 1; } | tee -a ../results.txt
           done
           for BENCH in $BENCHES; do
             NAME=$(basename "$BENCH" | cut -d- -f1)

--- a/neqo-transport/benches/transfer.rs
+++ b/neqo-transport/benches/transfer.rs
@@ -13,7 +13,7 @@ use test_fixture::{
     sim::{
         connection::{Node, ReachState, ReceiveData, SendData},
         network::{RandomDelay, TailDrop},
-        ReadySimulator, Simulator,
+        Simulator,
     },
 };
 
@@ -27,45 +27,68 @@ const TRANSFER_AMOUNT: usize = 1 << 22; // 4Mbyte
 )]
 fn benchmark_transfer(c: &mut Criterion, label: &str, seed: Option<impl AsRef<str>>) {
     for pacing in [false, true] {
-        let mut group = c.benchmark_group(format!("transfer/pacing-{pacing}"));
-        // Don't let criterion calculate throughput, as that's based on wall-clock time, not
-        // simulator time.
+        let setup = || {
+            let nodes = boxed![
+                Node::new_client(
+                    ConnectionParameters::default()
+                        .pmtud(true)
+                        .pacing(pacing)
+                        .mlkem(false),
+                    boxed![ReachState::new(State::Confirmed)],
+                    boxed![SendData::new(TRANSFER_AMOUNT)]
+                ),
+                TailDrop::dsl_uplink(),
+                RandomDelay::new(ZERO..JITTER),
+                Node::new_server(
+                    ConnectionParameters::default()
+                        .pmtud(true)
+                        .pacing(pacing)
+                        .mlkem(false),
+                    boxed![ReachState::new(State::Confirmed)],
+                    boxed![ReceiveData::new(TRANSFER_AMOUNT)]
+                ),
+                TailDrop::dsl_downlink(),
+                RandomDelay::new(ZERO..JITTER),
+            ];
+            let mut sim = Simulator::new(label, nodes);
+            if let Some(seed) = &seed {
+                sim.seed_str(seed);
+            }
+            sim.setup()
+        };
+
+        let mut group = c.benchmark_group(format!("transfer/pacing-{pacing}/{label}"));
         group.noise_threshold(0.03);
-        group.bench_function(label, |b| {
+
+        // Benchmark with wallclock time, i.e. measure the compute efficiency.
+        group.bench_function("wallclock-time", |b| {
             b.iter_batched(
-                || {
-                    let nodes = boxed![
-                        Node::new_client(
-                            ConnectionParameters::default()
-                                .pmtud(true)
-                                .pacing(pacing)
-                                .mlkem(false),
-                            boxed![ReachState::new(State::Confirmed)],
-                            boxed![SendData::new(TRANSFER_AMOUNT)]
-                        ),
-                        TailDrop::dsl_uplink(),
-                        RandomDelay::new(ZERO..JITTER),
-                        Node::new_server(
-                            ConnectionParameters::default()
-                                .pmtud(true)
-                                .pacing(pacing)
-                                .mlkem(false),
-                            boxed![ReachState::new(State::Confirmed)],
-                            boxed![ReceiveData::new(TRANSFER_AMOUNT)]
-                        ),
-                        TailDrop::dsl_downlink(),
-                        RandomDelay::new(ZERO..JITTER),
-                    ];
-                    let mut sim = Simulator::new(label, nodes);
-                    if let Some(seed) = &seed {
-                        sim.seed_str(seed);
-                    }
-                    sim.setup()
+                setup,
+                |s| {
+                    black_box(s.run());
                 },
-                black_box(ReadySimulator::run),
                 SmallInput,
             );
         });
+
+        // Benchmark with simulated time, i.e. measure the network protocol
+        // efficiency.
+        //
+        // Note: Given that this is using simulated time, we can measure actual
+        // throughput.
+        group.throughput(criterion::Throughput::Bytes(TRANSFER_AMOUNT as u64));
+        group.bench_function("simulated-time", |b| {
+            b.iter_custom(|iters| {
+                let mut d_sum = Duration::ZERO;
+                for _i in 0..iters {
+                    // run() returns the simulated time, excluding setup time.
+                    // No need for black_box(), because this doesn't measure compute.
+                    d_sum += setup().run();
+                }
+                d_sum
+            });
+        });
+
         group.finish();
     }
 }

--- a/neqo-transport/benches/transfer.rs
+++ b/neqo-transport/benches/transfer.rs
@@ -57,39 +57,41 @@ fn benchmark_transfer(c: &mut Criterion, label: &str, seed: Option<impl AsRef<st
             sim.setup()
         };
 
-        let mut group = c.benchmark_group(format!("transfer/pacing-{pacing}/{label}"));
-        group.noise_threshold(0.03);
-
         // Benchmark with wallclock time, i.e. measure the compute efficiency.
-        group.bench_function("wallclock-time", |b| {
-            b.iter_batched(
-                setup,
-                |s| {
-                    black_box(s.run());
-                },
-                SmallInput,
-            );
-        });
+        {
+            let mut group = c.benchmark_group(format!("transfer/pacing-{pacing}/{label}"));
+            group.noise_threshold(0.03);
+            group.bench_function("wallclock-time", |b| {
+                b.iter_batched(
+                    setup,
+                    |s| {
+                        black_box(s.run());
+                    },
+                    SmallInput,
+                );
+            });
+        }
 
         // Benchmark with simulated time, i.e. measure the network protocol
         // efficiency.
         //
         // Note: Given that this is using simulated time, we can measure actual
         // throughput.
-        group.throughput(criterion::Throughput::Bytes(TRANSFER_AMOUNT as u64));
-        group.bench_function("simulated-time", |b| {
-            b.iter_custom(|iters| {
-                let mut d_sum = Duration::ZERO;
-                for _i in 0..iters {
-                    // run() returns the simulated time, excluding setup time.
-                    // No need for black_box(), because this doesn't measure compute.
-                    d_sum += setup().run();
-                }
-                d_sum
+        {
+            let mut group = c.benchmark_group(format!("transfer/pacing-{pacing}/{label}"));
+            group.throughput(criterion::Throughput::Bytes(TRANSFER_AMOUNT as u64));
+            group.bench_function("simulated-time", |b| {
+                b.iter_custom(|iters| {
+                    let mut d_sum = Duration::ZERO;
+                    for _i in 0..iters {
+                        // run() returns the simulated time, excluding setup time.
+                        // No need for black_box(), because this doesn't measure compute.
+                        d_sum += setup().run();
+                    }
+                    d_sum
+                });
             });
-        });
-
-        group.finish();
+        }
     }
 }
 


### PR DESCRIPTION
Got reverted in https://github.com/mozilla/neqo/pull/2908 due to https://github.com/mozilla/neqo/pull/2885#issuecomment-3223885666.

This pull request adds a fix in the second commit:

```
fix(transport/bench): use new group for each benchmark

We parse the criterion benchmark output, alter it, then post it as a
GitHub comment.

https://github.com/mozilla/neqo/blob/8ce7f9bcdef89fa5a1eb37db6a2375db9a4531ea/.github/workflows/bench.yml#L163-L187

We want to split by benchmark. The easiest way to do so is through a
newline. Criterion only inserts a newline for each benchmark group. Thus
split the existing group into two, one per benchmark function (i.e.
wallclock-time and simulated-time).

Issue raised in https://github.com/mozilla/neqo/pull/2885#issuecomment-3223885666
```