### PR TITLE
agent: Accommodate upcoming bindgen 0.73.

### DIFF
--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -1270,7 +1270,7 @@ impl Server {
                 return Err(Error::CertificateLoading);
             };
             secstatus_to_res(unsafe {
-                ssl::SSL_ConfigServerCert(agent.fd, *cert, *key, null(), 0)
+                ssl::SSL_ConfigServerCert(agent.fd, (*cert).cast(), (*key).cast(), null(), 0)
             })?;
         }
 


### PR DESCRIPTION
I'm fixing a long-standing issue with bindgen type layouts (https://github.com/rust-lang/rust-bindgen/issues/3279), and this code will stop compiling because it's mixing (compatible) types from two bindgen invocations (in particular, opaque arrays from the p11:: bindings into ssl:: bindings).

Cast the pointer so that it works with current bindgen and newer bindgen too.