### PR TITLE
Add ECN to the simulator

### DIFF
--- a/neqo-transport/benches/min_bandwidth.rs
+++ b/neqo-transport/benches/min_bandwidth.rs
@@ -39,9 +39,9 @@ pub fn main() {
 
     let gbit_link = || {
         let rate_byte = LINK_BANDWIDTH / 8;
-        // Router buffer set to bandwidth-delay product.
-        let capacity_byte = rate_byte * LINK_RTT_MS / 1_000;
-        TailDrop::new(rate_byte, capacity_byte, Duration::ZERO)
+        // BDP here is 5MB = 1e9 * 0.04 / 8: buffer an entire BDP here.
+        let capacity_byte = LINK_BANDWIDTH * LINK_RTT_MS / 1000;
+        TailDrop::new(rate_byte, capacity_byte, capacity_byte, Duration::ZERO)
     };
 
     let simulated_time = Simulator::new(

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -16,7 +16,7 @@ use std::{
 use enum_map::{Enum, EnumMap};
 use enumset::{EnumSet, EnumSetType};
 use log::{log_enabled, Level};
-use neqo_common::{qdebug, qinfo, qtrace, qwarn, Buffer, Ecn, MAX_VARINT};
+use neqo_common::{qdebug, qtrace, qwarn, Buffer, Ecn, MAX_VARINT};
 use neqo_crypto::Epoch;
 use smallvec::SmallVec;
 use strum::{Display, EnumIter};
@@ -136,7 +136,7 @@ impl PacketRange {
 
     /// Maybe merge a higher-numbered range into this.
     fn merge_larger(&mut self, other: &Self) {
-        qinfo!("[{self}] Merging {other}");
+        qdebug!("[{self}] Merging {other}");
         // This only works if they are immediately adjacent.
         assert_eq!(self.largest + 1, other.smallest);
 

--- a/neqo-transport/tests/network.rs
+++ b/neqo-transport/tests/network.rs
@@ -182,6 +182,16 @@ simulate!(
     ],
 );
 
+simulate!(
+    transfer_taildrop_ecn,
+    [
+        Node::default_client(boxed![SendData::new(TRANSFER_AMOUNT)]),
+        TailDrop::new(1_000_000, 65_536, 32_768, Duration::from_millis(50)),
+        Node::default_server(boxed![ReceiveData::new(TRANSFER_AMOUNT)]),
+        TailDrop::new(200_000, 16_384, 8_192, Duration::from_millis(50))
+    ],
+);
+
 /// This test is a nasty piece of work.  Delays are anything from 0 to 50ms and 1% of
 /// packets get dropped.
 #[test]

--- a/test-fixture/src/sim/mod.rs
+++ b/test-fixture/src/sim/mod.rs
@@ -239,7 +239,7 @@ impl Simulator {
             if dgram.is_none() {
                 let next = self.next_time(now);
                 if next > now {
-                    qinfo!(
+                    qdebug!(
                         "[{}] advancing time by {:?} to {:?}",
                         self.name,
                         next - now,


### PR DESCRIPTION
This is still pretty crude, but it seems to approximate something
sensible now.

There was a big bug in the simulator where the TailDrop node wasn't
asking to be serviced when removing things from its queue.  So it was
only removing things from the queue when packets left the link.  That
meant that the only sensible way to use it was to have zero delay (as it
was being used).

This fixes that and adds ECN marking at a chosen threshold.  My
observation is that the marking threshold has a small impact on
performance (the output below shows that moving from marking at 0.7 to
marking at 0.8 improves throughput a little.  The first two were run at
0.7. Obviously, this comes at the cost of extra latency.  I have no real
idea what buffers make sense, this is just a synthetic test that sets
out some guard rails for things like CC and flow control under very,
very clean conditions.

This is still not ideal.  The min_bandwidth test should probably get a
higher throughput than it does.  Occasionally, this gets as high as
870Mbps.  But mostly it is 760Mbps or thereabouts.  I have no idea what
makes those occasional runs so much faster.

```
# while RUST_LOG=info cargo test --release -p neqo-transport --bench min_bandwidth -F bench |& grep Achieved; do :; done
5.384 INFO Achieved 756.5999835520076 Mb/s bandwidth (link rate 1000)
5.411 INFO Achieved 759.7709198759945 Mb/s bandwidth (link rate 1000)
5.536 INFO Achieved 769.6899939983132 Mb/s bandwidth (link rate 1000)
5.358 INFO Achieved 771.442097560842 Mb/s bandwidth (link rate 1000)
5.423 INFO Achieved 768.9489036615845 Mb/s bandwidth (link rate 1000)
5.551 INFO Achieved 870.1786336328342 Mb/s bandwidth (link rate 1000)
5.504 INFO Achieved 768.9484584413776 Mb/s bandwidth (link rate 1000)
5.380 INFO Achieved 768.9018540063886 Mb/s bandwidth (link rate 1000)
5.412 INFO Achieved 768.9489036615845 Mb/s bandwidth (link rate 1000)
5.492 INFO Achieved 768.9481621100322 Mb/s bandwidth (link rate 1000)
5.418 INFO Achieved 872.2894963620984 Mb/s bandwidth (link rate 1000)
5.423 INFO Achieved 768.9489036615845 Mb/s bandwidth (link rate 1000)
5.377 INFO Achieved 872.2894966278358 Mb/s bandwidth (link rate 1000)
5.488 INFO Achieved 768.9024512780954 Mb/s bandwidth (link rate 1000)
5.439 INFO Achieved 767.510863851431 Mb/s bandwidth (link rate 1000)
5.487 INFO Achieved 768.9489038680874 Mb/s bandwidth (link rate 1000)
```