### PR TITLE
refactor(bin): derive Clone for Args

### DIFF
--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -34,16 +34,17 @@ use url::Url;
 use super::{get_output_file, qlog_new, Args, CloseState, Res};
 use crate::{send_data::SendData, STREAM_IO_BUFFER_SIZE};
 
-pub struct Handler<'a> {
+pub struct Handler {
     #[expect(clippy::struct_field_names, reason = "This name is more descriptive.")]
-    url_handler: UrlHandler<'a>,
+    url_handler: UrlHandler,
     token: Option<ResumptionToken>,
     output_read_data: bool,
     read_buffer: Vec<u8>,
 }
 
-impl<'a> Handler<'a> {
-    pub(crate) fn new(url_queue: VecDeque<Url>, args: &'a Args) -> Self {
+impl Handler {
+    pub(crate) fn new(url_queue: VecDeque<Url>, args: Args) -> Self {
+        let output_read_data = args.output_read_data;
         let url_handler = UrlHandler {
             url_queue,
             handled_urls: Vec::new(),
@@ -55,9 +56,17 @@ impl<'a> Handler<'a> {
         Self {
             url_handler,
             token: None,
-            output_read_data: args.output_read_data,
+            output_read_data,
             read_buffer: vec![0; STREAM_IO_BUFFER_SIZE],
         }
+    }
+
+    fn reinit(&mut self) {
+        for url in self.url_handler.handled_urls.drain(..) {
+            self.url_handler.url_queue.push_front(url);
+        }
+        self.url_handler.stream_handlers.clear();
+        self.url_handler.all_paths.clear();
     }
 }
 
@@ -167,17 +176,7 @@ impl super::Client for Http3Client {
     }
 }
 
-impl Handler<'_> {
-    fn reinit(&mut self) {
-        for url in self.url_handler.handled_urls.drain(..) {
-            self.url_handler.url_queue.push_front(url);
-        }
-        self.url_handler.stream_handlers.clear();
-        self.url_handler.all_paths.clear();
-    }
-}
-
-impl super::Handler for Handler<'_> {
+impl super::Handler for Handler {
     type Client = Http3Client;
 
     fn handle(&mut self, client: &mut Http3Client) -> Res<bool> {
@@ -363,15 +362,15 @@ impl StreamHandler for UploadStreamHandler {
     }
 }
 
-struct UrlHandler<'a> {
+struct UrlHandler {
     url_queue: VecDeque<Url>,
     handled_urls: Vec<Url>,
     stream_handlers: HashMap<StreamId, Box<dyn StreamHandler>>,
     all_paths: Vec<PathBuf>,
-    args: &'a Args,
+    args: Args,
 }
 
-impl UrlHandler<'_> {
+impl UrlHandler {
     fn stream_handler(&mut self, stream_id: StreamId) -> Option<&mut Box<dyn StreamHandler>> {
         self.stream_handlers.get_mut(&stream_id)
     }

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -104,7 +104,7 @@ impl std::error::Error for Error {}
 
 type Res<T> = Result<T, Error>;
 
-#[derive(Debug, Parser)]
+#[derive(Clone, Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 #[expect(
     clippy::struct_excessive_bools,
@@ -636,7 +636,7 @@ pub async fn client(mut args: Args) -> Res<()> {
                 let client = http3::create_client(&args, real_local, remote_addr, &hostname, token)
                     .expect("failed to create client");
 
-                let handler = http3::Handler::new(to_request, &args);
+                let handler = http3::Handler::new(to_request, args.clone());
 
                 Runner::new(real_local, &mut socket, client, handler, &args)
                     .run()

--- a/neqo-bin/src/lib.rs
+++ b/neqo-bin/src/lib.rs
@@ -27,7 +27,7 @@ pub mod udp;
 /// See `network.buffer.cache.size` pref <https://searchfox.org/mozilla-central/rev/f6e3b81aac49e602f06c204f9278da30993cdc8a/modules/libpref/init/all.js#3212>
 const STREAM_IO_BUFFER_SIZE: usize = 32 * 1024;
 
-#[derive(Debug, Parser)]
+#[derive(Clone, Debug, Parser)]
 pub struct SharedArgs {
     #[command(flatten)]
     verbose: Option<clap_verbosity_flag::Verbosity>,
@@ -88,7 +88,7 @@ impl SharedArgs {
     }
 }
 
-#[derive(Debug, Parser)]
+#[derive(Clone, Debug, Parser)]
 pub struct QuicParameters {
     #[arg(
         short = 'Q',


### PR DESCRIPTION
Previousy `Args` would not implement `Clone`, thus requiring lifetime parameters for `Args` references in various places in `neqo-bin`.

This commit derives `Clone` for `Args`, thus simplifying the code.

Needed in and pulled out of https://github.com/mozilla/neqo/pull/2796/.