### PR TITLE
tests(transport): reduce iterations to reduce test runtime

### DIFF
--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -1138,7 +1138,7 @@ mod test {
         test_fixture::fixture_init();
 
         // Run multiple iterations with randomized bandwidth and rtt.
-        for _ in 0..1_000 {
+        for _ in 0..100 {
             // Random bandwidth between 1 Mbit/s and 1 Gbit/s.
             let bandwidth =
                 u64::from(u16::from_be_bytes(random::<2>()) % 1_000 + 1) * 1_000 * 1_000;


### PR DESCRIPTION
The `auto_tuning_approximates_bandwidth_delay_product` runs multiple iterations with randomized inputs. Previously it would execute 1_000 iterations. To reduce test runtime, run only 100 iterations.

Fixes https://github.com/mozilla/neqo/issues/2813