### PR TITLE
ci: Unpin `bencherdev/bencher`

### DIFF
--- a/.github/workflows/bencher-archive.yml
+++ b/.github/workflows/bencher-archive.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - uses: bencherdev/bencher@e0bb2f0dcd5ae8446994d15536c902b289eeda17 # v0.5.4
+      - uses: bencherdev/bencher@v0.5.4 # zizmor: ignore[unpinned-uses]
       - run: bencher archive --branch "$GITHUB_HEAD_REF"

--- a/.github/workflows/bencher-upload.yml
+++ b/.github/workflows/bencher-upload.yml
@@ -43,7 +43,7 @@ jobs:
           name: ${{ github.event.repository.name }}-${{ github.event.workflow_run.referenced_workflows[0].sha }}-bench-perf
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: bencherdev/bencher@e0bb2f0dcd5ae8446994d15536c902b289eeda17 # v0.5.4
+      - uses: bencherdev/bencher@v0.5.4 # zizmor: ignore[unpinned-uses]
 
       - name: Upload main-branch results to bencher.dev
         run: |


### PR DESCRIPTION
Because allowlisted is only `bencherdev/bencher@v0.5.*`.

Broken in #2911