### PR TITLE
ci: Remove last traces of `mold`

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -42,6 +42,13 @@ runs:
       if: ${{ env.SCCACHE_ENABLED != '1' && runner.environment != 'github-hosted' }}
       uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
 
+    - name: Install dependencies (MacOS)
+      shell: bash
+      if: ${{ runner.os == 'MacOS' && runner.environment == 'github-hosted' && inputs.target == '' }}
+      run: |
+        [ "$BREW_UPDATED" ] || brew update && echo "BREW_UPDATED=1" >> "$GITHUB_ENV"
+        brew install lld
+
     # See https://corrode.dev/blog/tips-for-faster-ci-builds/
     - name: Set up build environment
       shell: bash

--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -45,19 +45,10 @@ runs:
     # See https://corrode.dev/blog/tips-for-faster-ci-builds/
     - name: Set up build environment
       shell: bash
-      env:
-        TARGETS: ${{ inputs.targets }}
-        RUNNER_OS: ${{ runner.os }}
       run: |
         {
           echo "CARGO_PROFILE_RELEASE_LTO=true"
           echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1"
-          if [[ "$RUNNER_OS" == "Linux" && "$TARGETS" == "" && "$(command -v mold)" ]]; then
-            echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=mold $RUSTFLAGS"
-          elif [[ "$RUNNER_OS" == "Windows" ]]; then
-            echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld $RUSTFLAGS"
-          fi
-          echo "RUNNER_OS=$(uname -srm)"
         } >> "$GITHUB_ENV"
 
     - name: Enable sscache
@@ -77,7 +68,7 @@ runs:
       with:
         cache-bin: ${{ runner.environment != 'github-hosted' }}
         cache-all-crates: true
-        key: ${{ inputs.targets }}-${{ env.RUNNER_OS }}
+        key: ${{ inputs.targets != '' && format('{0}-', inputs.targets) || ''}}${{ runner.os }}
         workspaces: ${{ inputs.workspaces }}
          # Only create the cache when we push to `main` (also via a merge group).
         save-if: ${{ github.ref == 'refs/heads/main' || github.event.merge_group.base_ref == 'refs/heads/main' }}

--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -42,21 +42,16 @@ runs:
       if: ${{ env.SCCACHE_ENABLED != '1' && runner.environment != 'github-hosted' }}
       uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
 
-    - name: Install dependencies (MacOS)
-      shell: bash
-      if: ${{ runner.os == 'MacOS' && runner.environment == 'github-hosted' && inputs.target == '' }}
-      run: |
-        [ "$BREW_UPDATED" ] || brew update && echo "BREW_UPDATED=1" >> "$GITHUB_ENV"
-        brew install lld
-
     # See https://corrode.dev/blog/tips-for-faster-ci-builds/
     - name: Set up build environment
       shell: bash
+      env:
+        RUNNER_OS: ${{ runner.os }}
       run: |
         {
           echo "CARGO_PROFILE_RELEASE_LTO=true"
           echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1"
-          if [[ "$RUNNER_OS" != "Windows" ]]; then
+          if "$RUNNER_OS" == "Linux" && "$TARGETS" == "" ]]; then
             echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=lld $RUSTFLAGS"
           fi
 

--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -74,7 +74,7 @@ runs:
       with:
         cache-bin: ${{ runner.environment != 'github-hosted' }}
         cache-all-crates: true
-        key: ${{ inputs.targets != '' && format('{0}-', inputs.targets) || ''}}${{ runner.os }}
+        key: ${{ inputs.targets != '' && format('{0}-', inputs.targets) || '' }}${{ runner.os }}
         workspaces: ${{ inputs.workspaces }}
          # Only create the cache when we push to `main` (also via a merge group).
         save-if: ${{ github.ref == 'refs/heads/main' || github.event.merge_group.base_ref == 'refs/heads/main' }}

--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -49,6 +49,10 @@ runs:
         {
           echo "CARGO_PROFILE_RELEASE_LTO=true"
           echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1"
+          if [[ "$RUNNER_OS" != "Windows" ]]; then
+            echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld $RUSTFLAGS"
+          fi
+
         } >> "$GITHUB_ENV"
 
     - name: Enable sscache

--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -50,7 +50,7 @@ runs:
           echo "CARGO_PROFILE_RELEASE_LTO=true"
           echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1"
           if [[ "$RUNNER_OS" != "Windows" ]]; then
-            echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld $RUSTFLAGS"
+            echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=lld $RUSTFLAGS"
           fi
 
         } >> "$GITHUB_ENV"


### PR DESCRIPTION
We killed `mold` in #2857.

Also make our cache key a bit prettier while I'm here.