### PR TITLE
ci: `recreate` PR comments

### DIFF
--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
   mode:
     description: 'Mode of operation (upsert/recreate/delete).'
-    default: 'upsert'
+    default: 'recreate'
   token:
     description: 'A Github PAT'
     required: true


### PR DESCRIPTION
Switch from `upsert`. This _should_ make updated bench and other comments appear at the current place in the comment timeline, so no more scrolling. Downside is that one can't diff against earlier runs for the same PR.