### PR TITLE
Revert "ci: Remove last traces of `mold`"

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -46,15 +46,18 @@ runs:
     - name: Set up build environment
       shell: bash
       env:
+        TARGETS: ${{ inputs.targets }}
         RUNNER_OS: ${{ runner.os }}
       run: |
         {
           echo "CARGO_PROFILE_RELEASE_LTO=true"
           echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1"
-          if "$RUNNER_OS" == "Linux" && "$TARGETS" == "" ]]; then
-            echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=lld $RUSTFLAGS"
+          if [[ "$RUNNER_OS" == "Linux" && "$TARGETS" == "" && "$(command -v mold)" ]]; then
+            echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=mold $RUSTFLAGS"
+          elif [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld $RUSTFLAGS"
           fi
-
+          echo "RUNNER_OS=$(uname -srm)"
         } >> "$GITHUB_ENV"
 
     - name: Enable sscache
@@ -74,7 +77,7 @@ runs:
       with:
         cache-bin: ${{ runner.environment != 'github-hosted' }}
         cache-all-crates: true
-        key: ${{ inputs.targets != '' && format('{0}-', inputs.targets) || '' }}${{ runner.os }}
+        key: ${{ inputs.targets }}-${{ env.RUNNER_OS }}
         workspaces: ${{ inputs.workspaces }}
          # Only create the cache when we push to `main` (also via a merge group).
         save-if: ${{ github.ref == 'refs/heads/main' || github.event.merge_group.base_ref == 'refs/heads/main' }}


### PR DESCRIPTION
Reverts mozilla/neqo#2939

Testing whether https://github.com/mozilla/neqo/pull/2939 is the source of the new `cargo bench` failure:

```
 error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "-m64" "/tmp/rustc85mDwy/symbols.o" "<2 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,libcfg_if-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustc85mDwy/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/opt/actions-runner/_work/neqo/neqo/neqo/target/release/build/bindgen-77d0643b92e491a7/build_script_build-77d0643b92e491a7" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs" "-Wl,--no-rosegment,"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: /usr/bin/ld: unrecognized option '--no-rosegment'
          /usr/bin/ld: use the --help option for usage information
          collect2: error: ld returned 1 exit status
```