### PR TITLE
fix: Turn off more TLS randomization with `disable-random`

### DIFF
--- a/neqo-crypto/src/agent.rs
+++ b/neqo-crypto/src/agent.rs
@@ -560,11 +560,7 @@ impl SecretAgent {
         self.set_option(ssl::Opt::OcspStapling, true)?;
         self.set_option(
             ssl::Opt::Grease,
-            if cfg!(not(feature = "disable-random")) {
-                grease
-            } else {
-                false
-            },
+            cfg!(not(feature = "disable-random")) && grease,
         )?;
         self.set_option(
             ssl::Opt::EnableChExtensionPermutation,


### PR DESCRIPTION
Might address some of #2855.