### PR TITLE
refactor(http3): simplify RequestTarget

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -6,7 +6,7 @@
 
 use std::{
     cell::RefCell,
-    fmt::{self, Debug, Display, Formatter},
+    fmt::{self, Display, Formatter},
     iter,
     net::SocketAddr,
     num::NonZeroUsize,
@@ -32,7 +32,7 @@ use crate::{
     frames::HFrame,
     push_controller::{PushController, RecvPushEvents},
     recv_message::{RecvMessage, RecvMessageInfo},
-    request_target::AsRequestTarget,
+    request_target::RequestTarget,
     settings::HSettings,
     Error, Http3Parameters, Http3StreamType, NewStreamType, Priority, PriorityHandler, PushId,
     ReceiveOutput, Res,
@@ -483,16 +483,16 @@ impl Http3Client {
     /// # Panics
     ///
     /// `SendMessage` implements `http_stream` so it will not panic.
-    pub fn fetch<'x, 't: 'x, T>(
+    pub fn fetch<'t, T>(
         &mut self,
         now: Instant,
         method: &'t str,
-        target: &'t T,
+        target: T,
         headers: &'t [Header],
         priority: Priority,
     ) -> Res<StreamId>
     where
-        T: AsRequestTarget<'x> + ?Sized + Debug,
+        T: RequestTarget,
     {
         let output = self.base_handler.fetch(
             &mut self.conn,
@@ -656,14 +656,14 @@ impl Http3Client {
     ///
     /// If `WebTransport` cannot be created, e.g. the `WebTransport` support is
     /// not negotiated or the HTTP/3 connection is closed.
-    pub fn webtransport_create_session<'x, 't: 'x, T>(
+    pub fn webtransport_create_session<T>(
         &mut self,
         now: Instant,
-        target: &'t T,
-        headers: &'t [Header],
+        target: T,
+        headers: &[Header],
     ) -> Res<StreamId>
     where
-        T: AsRequestTarget<'x> + ?Sized + Debug,
+        T: RequestTarget,
     {
         let output = self.base_handler.webtransport_create_session(
             &mut self.conn,
@@ -1265,6 +1265,7 @@ mod tests {
         CountingConnectionIdGenerator, DEFAULT_ADDR, DEFAULT_ALPN_H3, DEFAULT_KEYS,
         DEFAULT_SERVER_NAME,
     };
+    use url::Url;
 
     use super::{
         AuthenticationStatus, Connection, Error, HSettings, Header, Http3Client, Http3ClientEvent,
@@ -1707,7 +1708,7 @@ mod tests {
             .fetch(
                 now(),
                 "GET",
-                "https://something.com/",
+                &Url::parse("https://something.com/").unwrap(),
                 headers,
                 Priority::default(),
             )
@@ -3416,7 +3417,7 @@ mod tests {
             client.fetch(
                 now(),
                 "GET",
-                &("https", "something.com", "/"),
+                ("https", "something.com", "/"),
                 &[],
                 Priority::default()
             ),
@@ -4229,7 +4230,7 @@ mod tests {
             .fetch(
                 now(),
                 "GET",
-                &("https", "something.com", "/"),
+                ("https", "something.com", "/"),
                 &[],
                 Priority::default()
             )

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -148,7 +148,7 @@ impl WtTest {
     ) -> (StreamId, Option<WebTransportRequest>) {
         let wt_session_id = self
             .client
-            .webtransport_create_session(now(), &("https", "something.com", "/"), &[])
+            .webtransport_create_session(now(), ("https", "something.com", "/"), &[])
             .unwrap();
         self.exchange_packets();
 

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -121,7 +121,7 @@ fn wt_session_response_with_1xx() {
 
     let wt_session_id = wt
         .client
-        .webtransport_create_session(now(), &("https", "something.com", "/"), &[])
+        .webtransport_create_session(now(), ("https", "something.com", "/"), &[])
         .unwrap();
     wt.exchange_packets();
 
@@ -190,7 +190,7 @@ fn wt_session_respone_200_with_fin() {
 
     let wt_session_id = wt
         .client
-        .webtransport_create_session(now(), &("https", "something.com", "/"), &[])
+        .webtransport_create_session(now(), ("https", "something.com", "/"), &[])
         .unwrap();
     wt.exchange_packets();
     let mut wt_server_session = None;
@@ -384,7 +384,7 @@ fn wt_close_session_cannot_be_sent_at_once() {
         .fetch(
             now(),
             "GET",
-            &("https", "something.com", "/"),
+            ("https", "something.com", "/"),
             &[],
             Priority::default(),
         )

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -178,7 +178,7 @@ fn fetch() {
         .fetch(
             now(),
             "GET",
-            &("https", "something.com", "/"),
+            ("https", "something.com", "/"),
             &[],
             Priority::default(),
         )
@@ -207,7 +207,7 @@ fn response_103() {
         .fetch(
             now(),
             "GET",
-            &("https", "something.com", "/"),
+            ("https", "something.com", "/"),
             &[],
             Priority::default(),
         )
@@ -261,7 +261,7 @@ fn data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::Error>
     let stream_id = hconn_c.fetch(
         now(),
         "GET",
-        &("https", "something.com", "/"),
+        ("https", "something.com", "/"),
         &[],
         Priority::default(),
     )?;
@@ -336,7 +336,7 @@ fn data_writable_events() {
         .fetch(
             now(),
             "GET",
-            &("https", "something.com", "/"),
+            ("https", "something.com", "/"),
             &[],
             Priority::default(),
         )
@@ -440,7 +440,7 @@ fn zerortt() {
         .fetch(
             now(),
             "GET",
-            &("https", "something.com", "/"),
+            ("https", "something.com", "/"),
             &[],
             Priority::default(),
         )
@@ -510,7 +510,7 @@ fn fetch_noresponse_will_idletimeout() {
         .fetch(
             now,
             "GET",
-            &("https", "something.com", "/"),
+            ("https", "something.com", "/"),
             &[],
             Priority::default(),
         )

--- a/neqo-http3/tests/priority.rs
+++ b/neqo-http3/tests/priority.rs
@@ -57,7 +57,7 @@ fn priority_update() {
         .fetch(
             now(),
             "GET",
-            &("https", "something.com", "/"),
+            ("https", "something.com", "/"),
             &[Header::new("priority", "u=4,i")],
             Priority::new(4, true),
         )
@@ -114,7 +114,7 @@ fn priority_update_dont_send_for_cancelled_stream() {
         .fetch(
             now(),
             "GET",
-            &("https", "something.com", "/"),
+            ("https", "something.com", "/"),
             &[Header::new("priority", "u=5")],
             Priority::new(5, false),
         )

--- a/neqo-http3/tests/send_message.rs
+++ b/neqo-http3/tests/send_message.rs
@@ -140,7 +140,7 @@ fn connect_send_and_receive_request() -> (Http3Client, Http3Server, Http3OrWebTr
         .fetch(
             now(),
             "GET",
-            &("https", "something.com", "/"),
+            ("https", "something.com", "/"),
             &[],
             Priority::default(),
         )

--- a/neqo-http3/tests/webtransport.rs
+++ b/neqo-http3/tests/webtransport.rs
@@ -79,7 +79,7 @@ fn connect() -> (Http3Client, Http3Server) {
 
 fn create_wt_session(client: &mut Http3Client, server: &mut Http3Server) -> WebTransportRequest {
     let wt_session_id = client
-        .webtransport_create_session(now(), &("https", "something.com", "/"), &[])
+        .webtransport_create_session(now(), ("https", "something.com", "/"), &[])
         .unwrap();
     exchange_packets(client, server, false, None);
 

--- a/test-fixture/src/sim/http3_connection.rs
+++ b/test-fixture/src/sim/http3_connection.rs
@@ -280,7 +280,7 @@ impl Requests {
             let stream_id = match c.fetch(
                 now(),
                 "POST",
-                &("https", "something.com", "/"),
+                ("https", "something.com", "/"),
                 &[],
                 Priority::default(),
             ) {


### PR DESCRIPTION
Previously to specify a request target we used the following types:

- trait `RequestTarget` for gettters
- struct `RefRequestTarget` as base representation of `RequestTarget`
- trait `AsRequestTarget` to convert other types into something that implements `RequestTarget`
- struct `UrlRequestTarget` implementing `RequestTarget` to convert a `str` potentially fallible

This commit reduces the mechanism to a single trait, i.e. `RequestTarget`.

Only downside is that one can no longer directly pass a `&str` to functions like `fetch`. That said, we did this in a single place only, `neqo-bin`. Now, it requires a single conversion step to a `Url` before. Additional upside is that the caller handles the error on invalid request targets.

---

Follow-up to https://github.com/mozilla/neqo/pull/2886#discussion_r2331761769.