### PR TITLE
cubic: streamline test value setters/getters

### DIFF
--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -100,10 +100,6 @@ pub trait WindowAdjustment: Display + Debug {
     ) -> (usize, usize);
     /// Cubic needs this signal to reset its epoch.
     fn on_app_limited(&mut self);
-    #[cfg(test)]
-    fn last_max_cwnd(&self) -> f64;
-    #[cfg(test)]
-    fn set_last_max_cwnd(&mut self, last_max_cwnd: f64);
 }
 
 #[derive(Debug)]
@@ -434,14 +430,18 @@ impl<T: WindowAdjustment> ClassicCongestionControl<T> {
         self.ssthresh = v;
     }
 
+    /// Accessor for [`ClassicCongestionControl::cc_algorithm`]. Is used to call Cubic getters in
+    /// tests.
     #[cfg(test)]
-    pub fn last_max_cwnd(&self) -> f64 {
-        self.cc_algorithm.last_max_cwnd()
+    pub const fn cc_algorithm(&self) -> &T {
+        &self.cc_algorithm
     }
 
+    /// Mutable accessor for [`ClassicCongestionControl::cc_algorithm`]. Is used to call Cubic
+    /// setters in tests.
     #[cfg(test)]
-    pub fn set_last_max_cwnd(&mut self, last_max_cwnd: f64) {
-        self.cc_algorithm.set_last_max_cwnd(last_max_cwnd);
+    pub fn cc_algorithm_mut(&mut self) -> &mut T {
+        &mut self.cc_algorithm
     }
 
     #[cfg(test)]

--- a/neqo-transport/src/cc/cubic.rs
+++ b/neqo-transport/src/cc/cubic.rs
@@ -165,6 +165,16 @@ impl Cubic {
         }
         qtrace!("[{self}] New epoch");
     }
+
+    #[cfg(test)]
+    pub const fn last_max_cwnd(&self) -> f64 {
+        self.last_max_cwnd
+    }
+
+    #[cfg(test)]
+    pub fn set_last_max_cwnd(&mut self, last_max_cwnd: f64) {
+        self.last_max_cwnd = last_max_cwnd;
+    }
 }
 
 impl WindowAdjustment for Cubic {
@@ -277,15 +287,5 @@ impl WindowAdjustment for Cubic {
         // Reset ca_epoch_start. Let it start again when the congestion controller
         // exits the app-limited period.
         self.ca_epoch_start = None;
-    }
-
-    #[cfg(test)]
-    fn last_max_cwnd(&self) -> f64 {
-        self.last_max_cwnd
-    }
-
-    #[cfg(test)]
-    fn set_last_max_cwnd(&mut self, last_max_cwnd: f64) {
-        self.last_max_cwnd = last_max_cwnd;
     }
 }

--- a/neqo-transport/src/cc/new_reno.rs
+++ b/neqo-transport/src/cc/new_reno.rs
@@ -46,12 +46,4 @@ impl WindowAdjustment for NewReno {
     }
 
     fn on_app_limited(&mut self) {}
-
-    #[cfg(test)]
-    fn last_max_cwnd(&self) -> f64 {
-        0.0
-    }
-
-    #[cfg(test)]
-    fn set_last_max_cwnd(&mut self, _last_max_cwnd: f64) {}
 }


### PR DESCRIPTION
I will add some new getters/setters in later CUBIC PRs. 

With the old code structure you'd have to add each getter or setter function in 3 different places:
- the signature to the `WindowAdjustment` trait in `classic_cc.rs`
- the function to the `WindowAdjustment` implementation in `classic_cc.rs` with `!unreachable()` or some default value
- the actual implementation in `impl WindowAdjustment for Cubic` in `cubic.rs`

Now they can just be added to the `Cubic` struct implementation in `cubic.rs` and then accessed through the two new functions in `classic_cc.rs`

Part of #2967. All other following PRs will depend on this one.