### PR TITLE
cubic: reno region updates

### DIFF
--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -100,10 +100,6 @@ pub trait WindowAdjustment: Display + Debug {
     ) -> (usize, usize);
     /// Cubic needs this signal to reset its epoch.
     fn on_app_limited(&mut self);
-    #[cfg(test)]
-    fn last_max_cwnd(&self) -> f64;
-    #[cfg(test)]
-    fn set_last_max_cwnd(&mut self, last_max_cwnd: f64);
 }
 
 #[derive(Debug)]
@@ -434,14 +430,18 @@ impl<T: WindowAdjustment> ClassicCongestionControl<T> {
         self.ssthresh = v;
     }
 
+    /// Accessor for [`ClassicCongestionControl::cc_algorithm`]. Is used to call Cubic getters in
+    /// tests.
     #[cfg(test)]
-    pub fn last_max_cwnd(&self) -> f64 {
-        self.cc_algorithm.last_max_cwnd()
+    pub const fn cc_algorithm(&self) -> &T {
+        &self.cc_algorithm
     }
 
+    /// Mutable accessor for [`ClassicCongestionControl::cc_algorithm`]. Is used to call Cubic
+    /// setters in tests.
     #[cfg(test)]
-    pub fn set_last_max_cwnd(&mut self, last_max_cwnd: f64) {
-        self.cc_algorithm.set_last_max_cwnd(last_max_cwnd);
+    pub fn cc_algorithm_mut(&mut self) -> &mut T {
+        &mut self.cc_algorithm
     }
 
     #[cfg(test)]

--- a/neqo-transport/src/cc/cubic.rs
+++ b/neqo-transport/src/cc/cubic.rs
@@ -165,6 +165,16 @@ impl Cubic {
         }
         qtrace!("[{self}] New epoch");
     }
+
+    #[cfg(test)]
+    pub const fn last_max_cwnd(&self) -> f64 {
+        self.last_max_cwnd
+    }
+
+    #[cfg(test)]
+    pub fn set_last_max_cwnd(&mut self, last_max_cwnd: f64) {
+        self.last_max_cwnd = last_max_cwnd;
+    }
 }
 
 impl WindowAdjustment for Cubic {
@@ -277,15 +287,5 @@ impl WindowAdjustment for Cubic {
         // Reset ca_epoch_start. Let it start again when the congestion controller
         // exits the app-limited period.
         self.ca_epoch_start = None;
-    }
-
-    #[cfg(test)]
-    fn last_max_cwnd(&self) -> f64 {
-        self.last_max_cwnd
-    }
-
-    #[cfg(test)]
-    fn set_last_max_cwnd(&mut self, last_max_cwnd: f64) {
-        self.last_max_cwnd = last_max_cwnd;
     }
 }

--- a/neqo-transport/src/cc/cubic.rs
+++ b/neqo-transport/src/cc/cubic.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! CUBIC congestion control
+//! CUBIC congestion control (RFC 9438)
 
 use std::{
     fmt::{self, Display},
@@ -24,11 +24,22 @@ use crate::cc::classic_cc::WindowAdjustment;
 ///
 /// <https://datatracker.ietf.org/doc/html/rfc8312#section-5.1>
 pub const CUBIC_C: f64 = 0.4;
-/// TCP-friendly region additive factor
+/// > CUBIC additive increase factor used in the Reno-friendly region \[to achieve approximately the
+/// > same average congestion window size as Reno\].
 ///
-/// <https://datatracker.ietf.org/doc/html/rfc8312#section-4.2>
-pub const CUBIC_ALPHA: f64 = 3.0 * (1.0 - 0.7) / (1.0 + 0.7);
-
+/// <https://datatracker.ietf.org/doc/html/rfc9438#name-constants-of-interest>
+///
+/// > The model used to calculate CUBIC_ALPHA is not absolutely precise,
+/// > but analysis and simulation \[...\], as well as over a decade of experience with
+/// > CUBIC in the public Internet, show that this approach produces acceptable
+/// > levels of rate fairness between CUBIC and Reno flows.
+///
+/// Formula:
+///
+/// `CUBIC_ALPHA = 3.0 * (1.0 - CUBIC_BETA) / (1.0 + CUBIC_BETA)`
+///
+/// <https://datatracker.ietf.org/doc/html/rfc9438#name-reno-friendly-region>
+pub const CUBIC_ALPHA: f64 = 3.0 * (1.0 - 0.7) / (1.0 + 0.7); // with CUBIC_BETA = 0.7
 /// `CUBIC_BETA` = 0.7;
 ///
 /// > Principle 4: To balance between the scalability and convergence speed,
@@ -79,16 +90,17 @@ pub struct Cubic {
     ///
     /// <https://datatracker.ietf.org/doc/html/rfc8312#section-4.6>
     last_max_cwnd: f64,
-    /// Estimate of Standard TCP congestion window for Cubic's TCP-friendly
-    /// Region.
+    /// > An estimate for the congestion window \[...\] in the Reno-friendly region -- that
+    /// > is, an estimate for the congestion window of Reno.
     ///
-    /// > Standard TCP performs well in certain types of networks, for example,
-    /// > under short RTT and small bandwidth (or small BDP) networks.  In
-    /// > these networks, we use the TCP-friendly region to ensure that CUBIC
-    /// > achieves at least the same throughput as Standard TCP.
+    /// <https://datatracker.ietf.org/doc/html/rfc9438#name-variables-of-interest>
     ///
-    /// <https://datatracker.ietf.org/doc/html/rfc8312#section-4.2>
-    estimated_tcp_cwnd: f64,
+    /// > Reno performs well in certain types of networks -- for example, under short RTTs and
+    /// > small bandwidths (or small BDPs). In these networks, CUBIC remains in the Reno-friendly
+    /// > region to achieve at least the same throughput as Reno.
+    ///
+    /// <https://datatracker.ietf.org/doc/html/rfc9438#name-reno-friendly-region>
+    w_est: f64,
     /// > K is the time period that the above function takes to increase the
     /// > current window size to W_max if there are no further congestion events
     ///
@@ -104,8 +116,6 @@ pub struct Cubic {
     ///
     /// <https://datatracker.ietf.org/doc/html/rfc8312#section-4.1>
     ca_epoch_start: Option<Instant>,
-    /// Number of bytes acked since the last Standard TCP congestion window increase.
-    tcp_acked_bytes: f64,
 }
 
 impl Display for Cubic {
@@ -144,18 +154,23 @@ impl Cubic {
     fn w_cubic(&self, t: f64, max_datagram_size: usize) -> f64 {
         (CUBIC_C * (t - self.k).powi(3)).mul_add(convert_to_f64(max_datagram_size), self.w_max)
     }
-
-    fn start_epoch(
-        &mut self,
-        curr_cwnd_f64: f64,
-        new_acked_f64: f64,
-        max_datagram_size: usize,
-        now: Instant,
-    ) {
+    /// Resets all relevant parameters at the start of a new epoch (new congestion
+    /// avoidance stage) according to RFC 9438. The `w_max` variable is set in `reduce_cwnd()`. Also
+    /// initializes `k` and `w_max` if we start an epoch without having ever had a congestion
+    /// event, which can happen upon exiting slow start.
+    ///
+    /// > `w_est` is set equal to `cwnd_epoch` at the start of the congestion avoidance stage.
+    ///
+    /// <https://datatracker.ietf.org/doc/html/rfc9438#section-4.3-9>
+    fn start_epoch(&mut self, curr_cwnd_f64: f64, max_datagram_size: usize, now: Instant) {
         self.ca_epoch_start = Some(now);
-        // reset tcp_acked_bytes and estimated_tcp_cwnd;
-        self.tcp_acked_bytes = new_acked_f64;
-        self.estimated_tcp_cwnd = curr_cwnd_f64;
+        self.w_est = curr_cwnd_f64;
+        // If `w_max < cwnd_epoch` we take the cubic root from a negative value in `calc_k()`. That
+        // could only happen if somehow `cwnd` get's increased between calling `reduce_cwnd()` and
+        // `start_epoch()`, which is only possible after persistent congestion or an app limited
+        // period. It could also happen if we never had a congestion event, so never called
+        // `reduce_cwnd()` thus `w_max` was never set (so is still it's default `0.0`
+        // value). In any case we reset/initialize `w_max`, `cwnd_prior` and `k` here.
         if self.last_max_cwnd <= curr_cwnd_f64 {
             self.w_max = curr_cwnd_f64;
             self.k = 0.0;
@@ -192,14 +207,11 @@ impl WindowAdjustment for Cubic {
         now: Instant,
     ) -> usize {
         let curr_cwnd_f64 = convert_to_f64(curr_cwnd);
-        let new_acked_f64 = convert_to_f64(new_acked_bytes);
+        let max_datagram_size_f64 = convert_to_f64(max_datagram_size);
         if self.ca_epoch_start.is_none() {
             // This is a start of a new congestion avoidance phase.
-            self.start_epoch(curr_cwnd_f64, new_acked_f64, max_datagram_size, now);
-        } else {
-            self.tcp_acked_bytes += new_acked_f64;
+            self.start_epoch(curr_cwnd_f64, max_datagram_size, now);
         }
-
         // Cubic concave or convex region
         //
         // <https://datatracker.ietf.org/doc/html/rfc8312#section-4.3>
@@ -218,16 +230,18 @@ impl WindowAdjustment for Cubic {
             .as_secs_f64();
         let target_cubic = self.w_cubic(time_ca, max_datagram_size);
 
-        // Cubic TCP-friendly region
+        // Calculate w_est for the Reno-friendly region with a slightly adjusted formula per the
+        // below:
         //
-        //  <https://datatracker.ietf.org/doc/html/rfc8312#section-4.2>
-        let max_datagram_size = convert_to_f64(max_datagram_size);
-        let tcp_cnt = self.estimated_tcp_cwnd / CUBIC_ALPHA;
-        let incr = (self.tcp_acked_bytes / tcp_cnt).floor();
-        if incr > 0.0 {
-            self.tcp_acked_bytes -= incr * tcp_cnt;
-            self.estimated_tcp_cwnd += incr * max_datagram_size;
-        }
+        // > Note that this equation uses segments_acked and cwnd is measured in segments. An
+        // > implementation that measures cwnd in bytes should adjust the equation accordingly
+        // > using the number of acknowledged bytes and the SMSS.
+        //
+        // Formula: w_est = w_est + alpha * (bytes_acked / cwnd) * SMSS
+        //
+        // <https://datatracker.ietf.org/doc/html/rfc9438#section-4.3-9>
+        self.w_est +=
+            CUBIC_ALPHA * (convert_to_f64(new_acked_bytes) / curr_cwnd_f64) * max_datagram_size_f64;
 
         // Take the larger cwnd of Cubic concave or convex and Cubic
         // TCP-friendly region.
@@ -238,7 +252,7 @@ impl WindowAdjustment for Cubic {
         // > cwnd SHOULD be set to W_est(t) at each reception of an ACK.
         //
         // <https://datatracker.ietf.org/doc/html/rfc8312#section-4.2>
-        let target_cwnd = target_cubic.max(self.estimated_tcp_cwnd);
+        let target_cwnd = target_cubic.max(self.w_est);
 
         // Calculate the number of bytes that would need to be acknowledged for an increase
         // of `max_datagram_size` to match the increase of `target - cwnd / cwnd` as defined
@@ -247,11 +261,12 @@ impl WindowAdjustment for Cubic {
         // If the target is not significantly higher than the congestion window, require a very
         // large amount of acknowledged data (effectively block increases).
         let mut acked_to_increase =
-            max_datagram_size * curr_cwnd_f64 / (target_cwnd - curr_cwnd_f64).max(1.0);
+            max_datagram_size_f64 * curr_cwnd_f64 / (target_cwnd - curr_cwnd_f64).max(1.0);
 
         // Limit increase to max 1 MSS per EXPONENTIAL_GROWTH_REDUCTION ack packets.
         // This effectively limits target_cwnd to (1 + 1 / EXPONENTIAL_GROWTH_REDUCTION) cwnd.
-        acked_to_increase = acked_to_increase.max(EXPONENTIAL_GROWTH_REDUCTION * max_datagram_size);
+        acked_to_increase =
+            acked_to_increase.max(EXPONENTIAL_GROWTH_REDUCTION * max_datagram_size_f64);
         acked_to_increase as usize
     }
 

--- a/neqo-transport/src/cc/new_reno.rs
+++ b/neqo-transport/src/cc/new_reno.rs
@@ -46,12 +46,4 @@ impl WindowAdjustment for NewReno {
     }
 
     fn on_app_limited(&mut self) {}
-
-    #[cfg(test)]
-    fn last_max_cwnd(&self) -> f64 {
-        0.0
-    }
-
-    #[cfg(test)]
-    fn set_last_max_cwnd(&mut self, _last_max_cwnd: f64) {}
 }

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -193,7 +193,7 @@ fn tcp_phase() {
     // num_acks is very close to the calculated value. The exact value is hard to calculate
     // because the proportional increase (i.e. curr_cwnd_f64 / (target - curr_cwnd_f64) *
     // MAX_DATAGRAM_SIZE_F64) and the byte counting.
-    assert_eq!(num_acks2, expected_ack_cubic_increase + 2);
+    assert_eq!(num_acks2, expected_ack_cubic_increase + 3);
 }
 
 #[test]

--- a/neqo-transport/src/connection/tests/cc.rs
+++ b/neqo-transport/src/connection/tests/cc.rs
@@ -246,7 +246,7 @@ fn cc_cong_avoidance_recovery_period_to_cong_avoidance(cc_algorithm: CongestionC
     assert!(cwnd_before_loss > cwnd_after_loss);
     qinfo!("moving to congestion avoidance {}", cwnd(&client));
 
-    for i in 0..6 {
+    for i in 0..7 {
         qinfo!("iteration {i}");
 
         let (c_tx_dgrams, next_now) = fill_cwnd(&mut client, stream_id, now);
@@ -261,7 +261,16 @@ fn cc_cong_avoidance_recovery_period_to_cong_avoidance(cc_algorithm: CongestionC
         client.process_input(s_ack, now);
     }
 
-    assert!(cwnd_before_loss < cwnd(&client));
+    qinfo!(
+        "cwnd_before_loss = {cwnd_before_loss} cwnd(&client) = {}",
+        cwnd(&client)
+    );
+
+    assert!(
+        cwnd_before_loss < cwnd(&client),
+        "cwnd_before_loss = {cwnd_before_loss} cwnd(&client) = {}",
+        cwnd(&client)
+    );
 }
 
 #[test]


### PR DESCRIPTION
Keeping as a draft until https://github.com/mozilla/neqo/pull/2968 is merged.

Changes the following:

- renaming to match RFC 9438
- new formula for `w_est` (see [RFC](https://datatracker.ietf.org/doc/html/rfc9438#section-4.3-10.1.1))
- removing the tracking of `new_acked_bytes` across acks (see https://github.com/mozilla/neqo/pull/2535#discussion_r2315913966 for discussion)
- comments and docs
- making tests pass (see [`33cc7c8` (#2535)](https://github.com/mozilla/neqo/pull/2535/commits/33cc7c8a2da93113388a0d72298874d7c8d8e522#r2281629718) for discussion)


Split off of https://github.com/mozilla/neqo/pull/2535.
Part of https://github.com/mozilla/neqo/issues/2967.
Depends on https://github.com/mozilla/neqo/pull/2968.