### PR TITLE
feat(transport/cubic): cubic region RFC9438 updates

### DIFF
--- a/neqo-transport/src/cc/cubic.rs
+++ b/neqo-transport/src/cc/cubic.rs
@@ -310,16 +310,6 @@ impl WindowAdjustment for Cubic {
             // `reno_acked_bytes` but have to calculate the actual bytes used.
             let acked_bytes_used = increase * curr_cwnd / CUBIC_ALPHA;
             self.reno_acked_bytes -= acked_bytes_used;
-
-            // Enforce assumption that Reno adheres to the bounds in the RFC:
-            // <https://datatracker.ietf.org/doc/html/rfc9438#section-4.2-10>
-            //
-            // On very small `curr_cwnd` values it can happen that an increase by just `1 *
-            // max_datagram_size` would violate the bounds. To avoid asserting in that case the
-            // additional `|| max_datagram_size > curr_cwnd * 0.5` predicate was added.
-            debug_assert!(self.w_est <= curr_cwnd * 1.5 || max_datagram_size > curr_cwnd * 0.5,
-               "expect w_est to increase slower than slow start, curr_cwnd: {curr_cwnd}, w_est: {}, acked_bytes_used: {acked_bytes_used}, max_datagram_size: {max_datagram_size}",
-               self.w_est);
         }
 
         // > When receiving a new ACK in congestion avoidance (where cwnd could be greater than


### PR DESCRIPTION
- comments and docs
- ~~using max_datagram_size_f64 across functions~~
  - (this was already merged in #2994)
- ~~using `saturating_duration_since` to get time since epoch start~~
  - (this was merged in #2997)
- new `target` formula clamping to min and max value (cwnd<=target<=cwnd*1.5)
- removing `EXPONENTIAL_GROWTH_REDUCTION` since it's use is now covered by the max value mentioned above

Split off of #2535.
Part of #2967.

EDIT 2025-10-13:

I rebased after parts of this have already landed (see above checklist). This PR now contains the last updates to the cubic region and should be ready for review.

In the old code we'd also apply the clamping to `1.5 * curr_cwnd` to the reno region, since it was applied to the return value, not to the cubic region calculation result. Since this clamping is supposed to prevent exponential growth ("less than the increase rate of slow start" - [RFC9438](https://datatracker.ietf.org/doc/html/rfc9438#section-4.2-10)) it doesn't need to be applied to the reno region, which is growing additively per design.