### PR TITLE
feat(transport/server): add process_multiple_input 

### DIFF
--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -138,7 +138,7 @@ impl Http3Server {
         max_datagrams: NonZeroUsize,
     ) -> OutputBatch {
         qtrace!("[{self}] Process");
-        let out = self.server.process_multiple(dgrams, now, max_datagrams);
+        let out = self.server.process_multiple_input(dgrams, now);
         self.process_http3(now);
         // If we do not that a dgram already try again after process_http3.
         match out {
@@ -352,7 +352,7 @@ mod tests {
     };
 
     use neqo_common::{event::Provider as _, Encoder};
-    use neqo_crypto::{AuthenticationStatus, ZeroRttCheckResult, ZeroRttChecker};
+    use neqo_crypto::{AuthenticationStatus, ResumptionToken, ZeroRttCheckResult, ZeroRttChecker};
     use neqo_qpack as qpack;
     use neqo_transport::{
         CloseReason, Connection, ConnectionEvent, State, StreamId, StreamType, ZeroRttState,
@@ -462,18 +462,22 @@ mod tests {
         };
         assert!(client.state().connected());
         let s4 = server.process(c3.dgram(), now());
+        assert_eq!(server.process_output(now()).dgram(), None);
         assert_connected(server);
-        _ = client.process(s4.dgram(), now());
+        assert_eq!(client.process(s4.dgram(), now()).dgram(), None);
     }
 
     // Start a client/server and check setting frame.
-    fn connect_and_receive_settings_with_server(server: &mut Http3Server) -> Connection {
-        const CONTROL_STREAM_DATA: &[u8] = &[0x0, 0x4, 0x6, 0x1, 0x40, 0x64, 0x7, 0x40, 0x64];
+    fn connect_and_receive_settings_with_server(
+        server: &mut Http3Server,
+    ) -> (Connection, ResumptionToken) {
+        const CONTROL_STREAM_DATA: &[u8] = &[0x0, 0x4, 0x12, 0x1, 0x40, 0x64, 0x7, 0x40, 0x64];
 
         let mut client = default_client();
         connect_transport(server, &mut client, false);
 
         let mut connected = false;
+        let mut token = None;
         while let Some(e) = client.next_event() {
             match e {
                 ConnectionEvent::NewStream { stream_id } => {
@@ -490,10 +494,9 @@ mod tests {
                     {
                         // the control stream
                         let mut buf = [0_u8; 100];
-                        let (amount, fin) = client.stream_recv(stream_id, &mut buf).unwrap();
+                        let (_, fin) = client.stream_recv(stream_id, &mut buf).unwrap();
                         assert!(!fin);
-                        assert_eq!(amount, CONTROL_STREAM_DATA.len());
-                        assert_eq!(&buf[..9], CONTROL_STREAM_DATA);
+                        assert_eq!(&buf[..CONTROL_STREAM_DATA.len()], CONTROL_STREAM_DATA);
                     } else if stream_id == CLIENT_SIDE_ENCODER_STREAM_ID
                         || stream_id == SERVER_SIDE_ENCODER_STREAM_ID
                     {
@@ -522,15 +525,16 @@ mod tests {
                     );
                 }
                 ConnectionEvent::StateChange(State::Connected) => connected = true,
+                ConnectionEvent::ResumptionToken(t) => token = Some(t),
                 ConnectionEvent::StateChange(_) | ConnectionEvent::SendStreamCreatable { .. } => (),
-                _ => panic!("unexpected event"),
+                e => panic!("unexpected event: {e:?}"),
             }
         }
         assert!(connected);
-        client
+        (client, token.unwrap())
     }
 
-    fn connect_and_receive_settings() -> (Http3Server, Connection) {
+    fn connect_and_receive_settings() -> (Http3Server, Connection, ResumptionToken) {
         // Create a server and connect it to a client.
         // We will have a http3 server on one side and a neqo_transport
         // connection on the other side so that we can check what the http3
@@ -538,8 +542,8 @@ mod tests {
         // client.
 
         let mut server = default_server();
-        let client = connect_and_receive_settings_with_server(&mut server);
-        (server, client)
+        let (client, token) = connect_and_receive_settings_with_server(&mut server);
+        (server, client, token)
     }
 
     // Test http3 connection initialization.
@@ -576,8 +580,8 @@ mod tests {
     }
 
     // Connect transport, send and receive settings.
-    fn connect_to(server: &mut Http3Server) -> PeerConnection {
-        let mut neqo_trans_conn = connect_and_receive_settings_with_server(server);
+    fn connect_to(server: &mut Http3Server) -> (PeerConnection, ResumptionToken) {
+        let (mut neqo_trans_conn, token) = connect_and_receive_settings_with_server(server);
         let control_stream = neqo_trans_conn.stream_create(StreamType::UniDi).unwrap();
         let mut sent = neqo_trans_conn.stream_send(
             control_stream,
@@ -604,16 +608,24 @@ mod tests {
         // assert no error occurred.
         assert_not_closed(server);
 
-        PeerConnection {
-            conn: neqo_trans_conn,
-            control_stream_id: control_stream,
-        }
+        (
+            PeerConnection {
+                conn: neqo_trans_conn,
+                control_stream_id: control_stream,
+            },
+            token,
+        )
     }
 
     fn connect() -> (Http3Server, PeerConnection) {
-        let mut server = default_server();
-        let client = connect_to(&mut server);
+        let (server, client, _token) = connect_with_token();
         (server, client)
+    }
+
+    fn connect_with_token() -> (Http3Server, PeerConnection, ResumptionToken) {
+        let mut server = default_server();
+        let (client, token) = connect_to(&mut server);
+        (server, client, token)
     }
 
     // Server: Test receiving a new control stream and a SETTINGS frame.
@@ -638,7 +650,7 @@ mod tests {
     // (the first frame sent is a MAX_PUSH_ID frame).
     #[test]
     fn server_missing_settings() {
-        let (mut hconn, mut neqo_trans_conn) = connect_and_receive_settings();
+        let (mut hconn, mut neqo_trans_conn, _token) = connect_and_receive_settings();
         // Create client control stream.
         let control_stream = neqo_trans_conn.stream_create(StreamType::UniDi).unwrap();
         // Send a MAX_PUSH_ID frame instead.
@@ -788,7 +800,7 @@ mod tests {
     /// Test reading of a slowly streamed frame. bytes are received one by one
     #[test]
     fn server_frame_reading() {
-        let (mut hconn, mut peer_conn) = connect_and_receive_settings();
+        let (mut hconn, mut peer_conn, _token) = connect_and_receive_settings();
 
         // create a control stream.
         let control_stream = peer_conn.stream_create(StreamType::UniDi).unwrap();
@@ -874,7 +886,7 @@ mod tests {
 
     // Test reading of a slowly streamed frame. bytes are received one by one
     fn test_incomplete_frame(res: &[u8]) {
-        let (mut hconn, mut peer_conn) = connect_and_receive_settings();
+        let (mut hconn, mut peer_conn, _token) = connect_and_receive_settings();
 
         // send an incomplete request.
         let stream_id = peer_conn.stream_create(StreamType::BiDi).unwrap();
@@ -1194,19 +1206,11 @@ mod tests {
     /// Perform a handshake, then another with the token from the first.
     /// The second should always resume, but it might not always accept early data.
     fn zero_rtt_with_settings(conn_params: Http3Parameters, zero_rtt: ZeroRttState) {
-        let (_, mut client) = connect();
-        let token = client.events().find_map(|e| {
-            if let ConnectionEvent::ResumptionToken(token) = e {
-                Some(token)
-            } else {
-                None
-            }
-        });
-        assert!(token.is_some());
+        let (_, _, token) = connect_with_token();
 
         let mut server = create_server(conn_params);
         let mut client = default_client();
-        client.enable_resumption(now(), token.unwrap()).unwrap();
+        client.enable_resumption(now(), token).unwrap();
 
         connect_transport(&mut server, &mut client, true);
         assert!(client.tls_info().unwrap().resumed());
@@ -1339,18 +1343,10 @@ mod tests {
             Some(Box::<RejectZeroRtt>::default()),
         )
         .expect("create a server");
-        let mut client = connect_to(&mut server);
-        let token = client.events().find_map(|e| {
-            if let ConnectionEvent::ResumptionToken(token) = e {
-                Some(token)
-            } else {
-                None
-            }
-        });
-        assert!(token.is_some());
+        let (_, token) = connect_to(&mut server);
 
         let mut client = default_client();
-        client.enable_resumption(now(), token.unwrap()).unwrap();
+        client.enable_resumption(now(), token).unwrap();
 
         connect_transport(&mut server, &mut client, true);
         assert!(client.tls_info().unwrap().resumed());

--- a/neqo-http3/tests/classic_connect.rs
+++ b/neqo-http3/tests/classic_connect.rs
@@ -16,8 +16,7 @@ fn classic_connect() {
     let mut client = default_http3_client();
     let mut server = default_http3_server();
     let out = test_fixture::connect_peers(&mut client, &mut server);
-    let out = server.process(out, now()).dgram().unwrap();
-    client.process_input(out, now());
+    assert_eq!(server.process(out, now()).dgram(), None);
 
     // Ignore all events so far.
     drop(server.events());
@@ -101,8 +100,7 @@ fn classic_connect_via_fetch_panics_in_debug() {
     let mut client = default_http3_client();
     let mut server = default_http3_server();
     let out = test_fixture::connect_peers(&mut client, &mut server);
-    let out = server.process(out, now()).dgram().unwrap();
-    client.process_input(out, now());
+    assert_eq!(server.process(out, now()).dgram(), None);
 
     let res = client.fetch(
         now(),

--- a/neqo-http3/tests/send_message.rs
+++ b/neqo-http3/tests/send_message.rs
@@ -127,7 +127,6 @@ fn process_client_events_no_data(conn: &mut Http3Client) {
 }
 
 fn connect() -> (Http3Client, Http3Server) {
-
     let mut hconn_c = default_http3_client();
     let mut hconn_s = default_http3_server();
 
@@ -138,10 +137,12 @@ fn connect() -> (Http3Client, Http3Server) {
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
 
     (hconn_c, hconn_s)
-
 }
 
-fn send_and_receive_request(hconn_c: &mut Http3Client, hconn_s: &mut Http3Server) -> Http3OrWebTransportStream {
+fn send_and_receive_request(
+    hconn_c: &mut Http3Client,
+    hconn_s: &mut Http3Server,
+) -> Http3OrWebTransportStream {
     let req = hconn_c
         .fetch(
             now(),
@@ -340,7 +341,7 @@ fn server_send_single_udp_datagram() {
 
     // Request 1 has no pending data. This call goes straight to the QUIC layer.
     request_1.stream_close_send().unwrap();
-    // This adds pending data to request 1 on the HTTP/3 layer.
+    // This adds pending data to request 2 on the HTTP/3 layer.
     send_headers(&request_2).unwrap();
 
     // Expect server to pack request 1 close frame and request 2 data frame into


### PR DESCRIPTION
Given a connection between client and server, take the following scenario:

1. Client opens two streams to server.
2. Server closes the first and sends data on the second.

Previously this would result in the HTTP/3 server to send two UDP datagrams, one
with the close frame for the first stream, one with the data frame for the
second stream. A close is forwarded right away from the Neqo HTTP/3 layer to the
Neqo QUIC layer. Data is buffered at the HTTP/3 layer.

The HTTP/3 server first processes any outbound data on the QUIC layer, and only
then, if nothing is to be send, does it flush down any pending data from the
HTTP/3 layer to the QUIC layer.

https://github.com/mozilla/neqo/blob/c5d1fc5a4f4ba28b043c811eef50174ee26a63cd/neqo-http3/src/server.rs#L134-L153

This commit introduces a `process_multiple_input` function on the QUIC server
layer. The HTTP/3 server layer can now first pass any incoming datagrams down to
the QUIC layer, then flush any outbound data from the HTTP/3 layer to the QUIC
layer, then produce outbound UDP datagrams at the UDP layer. That way, UDP
datagrams are more efficiently packed. E.g. in the above scenario, both the
close frame and the data frame end up in the same UDP datagram.

Relevant for https://github.com/mozilla/neqo/pull/2979.