### PR TITLE
chore: prepare v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "enum-map",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "enumset",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "log",
  "neqo-common",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "enum-map",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.15.0"
+version = "0.16.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Most notable changes, relevant for downstream users:

- 387b2294 feat: implement MASQUE connect-udp (#2796)
- 47a7593d  fix(http3/webtransport): buffer new stream before session acceptance  (#2806)
- afbfba89 feat(bin/server): add `HttpServer::poll` (#2974)
- 3435dce4 feat(http3): support classic HTTP CONNECT (#2886)
- 8d039214 feat(transport,http3): enable SETTINGS_H3_DATAGRAM and max_datagram_frame_size (#2972)
- 2e1d656f feat: Put tokens into `Rc` (#2780)
- e5c5e773 refactor: replace all manual impl std::error::Error with thiserror (#2912)
- 6ba87a0e chore: improve QUIC datagram logging (#2919)
- bf80acf5 chore(transport): assert GSO requirements and break on PMTUD probe (#2918)
- ea6cde43 agent: Accommodate upcoming bindgen 0.73. (#2913)
- 7e58040e feat(transport): randomize the first packet number (#2885)
- b6dca075 feat: start using thiserror (#2889)