### PR TITLE
ci: Skip bench regression check on `main`

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -225,7 +225,7 @@ jobs:
 
       - name: Fail on regression
         # Don't check for regressions when running on main.
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.event.merge_group.base_ref != 'refs/heads/main'
         run: |
           if grep -q "Performance has regressed." results.txt; then
             echo "Performance regression detected."

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -505,7 +505,7 @@ jobs:
 
       - name: Fail on regression
         # Don't check for regressions when running on main.
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.event.merge_group.base_ref != 'refs/heads/main'
         run: |
           if grep -q "Performance has regressed." results.txt; then
             echo "Performance regression detected."


### PR DESCRIPTION
We usually merge to `main` via the merge queue, which needs another condition to check for it.