### PR TITLE
refactor(http3): replace (Vec<Header>, bool, bool) with named struct

### DIFF
--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -109,16 +109,22 @@ impl ExtendedConnectFeature {
 }
 
 #[derive(Debug, Default)]
+struct HeaderInfo {
+    interim: bool,
+    fin: bool,
+}
+
+#[derive(Debug, Default)]
 struct Listener {
-    headers: Option<(Vec<Header>, bool, bool)>,
+    headers: Option<(Vec<Header>, HeaderInfo)>,
 }
 
 impl Listener {
     fn set_headers(&mut self, headers: Vec<Header>, interim: bool, fin: bool) {
-        self.headers = Some((headers, interim, fin));
+        self.headers = Some((headers, HeaderInfo { interim, fin }));
     }
 
-    pub fn get_headers(&mut self) -> Option<(Vec<Header>, bool, bool)> {
+    pub fn get_headers(&mut self) -> Option<(Vec<Header>, HeaderInfo)> {
         mem::take(&mut self.headers)
     }
 }

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -15,7 +15,9 @@ use neqo_common::{qdebug, qtrace, Encoder, Header, MessageType, Role};
 use neqo_transport::{AppError, Connection, DatagramTracking, StreamId};
 
 use crate::{
-    features::extended_connect::{ExtendedConnectEvents, ExtendedConnectType, Listener},
+    features::extended_connect::{
+        ExtendedConnectEvents, ExtendedConnectType, HeaderInfo, Listener,
+    },
     frames::HFrame,
     priority::PriorityHandler,
     recv_message::{RecvMessage, RecvMessageInfo},
@@ -228,7 +230,8 @@ impl Session {
             return Ok(());
         }
 
-        if let Some((headers, interim, fin)) = self.stream_event_listener.borrow_mut().get_headers()
+        if let Some((headers, HeaderInfo { interim, fin })) =
+            self.stream_event_listener.borrow_mut().get_headers()
         {
             qtrace!("ExtendedConnect response headers {headers:?}, fin={fin}");
 


### PR DESCRIPTION
Minor follow-up to Lars' comment in https://github.com/mozilla/neqo/pull/2796#discussion_r2325101347.