### PR TITLE
feat: Remove use of `add_event_data_now`

### DIFF
--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -114,27 +114,6 @@ impl Qlog {
         });
     }
 
-    /// If logging enabled, closure may generate an event to be logged.
-    ///
-    /// This function is similar to [`Qlog::add_event_data_with_instant`],
-    /// but it does not take `now: Instant` as an input parameter. Instead, it
-    /// internally calls [`std::time::Instant::now`]. Prefer calling
-    /// [`Qlog::add_event_data_with_instant`] when `now` is available, as it
-    /// ensures consistency with the current time, which might differ from
-    /// [`std::time::Instant::now`] (e.g., when using simulated time instead of
-    /// real time).
-    pub fn add_event_data_now<F>(&self, f: F)
-    where
-        F: FnOnce() -> Option<qlog::events::EventData>,
-    {
-        self.add_event_with_stream(|s| {
-            if let Some(ev_data) = f() {
-                s.add_event_data_now(ev_data)?;
-            }
-            Ok(())
-        });
-    }
-
     /// If logging enabled, closure is given the Qlog stream to write events and
     /// frames to.
     pub fn add_event_with_stream<F>(&self, f: F)

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -9,6 +9,7 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
     mem,
     rc::Rc,
+    time::Instant,
 };
 
 use neqo_common::{qdebug, qerror, qinfo, qtrace, qwarn, Decoder, Header, MessageType, Role};
@@ -394,7 +395,7 @@ impl Http3Connection {
     /// has data to send it will be added to the `streams_with_pending_data` list.
     ///
     /// Control and QPACK streams are handled differently and are never added to the list.
-    fn send_non_control_streams(&mut self, conn: &mut Connection) -> Res<()> {
+    fn send_non_control_streams(&mut self, conn: &mut Connection, now: Instant) -> Res<()> {
         let to_send = mem::take(&mut self.streams_with_pending_data);
         #[expect(
             clippy::iter_over_hash_type,
@@ -402,7 +403,7 @@ impl Http3Connection {
         )]
         for stream_id in to_send {
             let done = if let Some(s) = &mut self.send_streams.get_mut(&stream_id) {
-                s.send(conn)?;
+                s.send(conn, now)?;
                 if s.has_data_to_send() {
                     self.streams_with_pending_data.insert(stream_id);
                 }
@@ -419,12 +420,12 @@ impl Http3Connection {
 
     /// Call `send` for all streams that need to send data. See explanation for the main structure
     /// for more details.
-    pub(crate) fn process_sending(&mut self, conn: &mut Connection) -> Res<()> {
+    pub(crate) fn process_sending(&mut self, conn: &mut Connection, now: Instant) -> Res<()> {
         // check if control stream has data to send.
         self.control_stream_local
-            .send(conn, &mut self.recv_streams)?;
+            .send(conn, &mut self.recv_streams, now)?;
 
-        self.send_non_control_streams(conn)?;
+        self.send_non_control_streams(conn, now)?;
 
         self.qpack_decoder.borrow_mut().send(conn)?;
         match self.qpack_encoder.borrow_mut().send_encoder_updates(conn) {
@@ -472,11 +473,16 @@ impl Http3Connection {
     /// The function calls [`RecvStream::receive`] for a stream. It also deals
     /// with the outcome of a read by calling
     /// [`Http3Connection::handle_stream_manipulation_output`].
-    fn stream_receive(&mut self, conn: &mut Connection, stream_id: StreamId) -> Res<ReceiveOutput> {
+    fn stream_receive(
+        &mut self,
+        conn: &mut Connection,
+        stream_id: StreamId,
+        now: Instant,
+    ) -> Res<ReceiveOutput> {
         qtrace!("[{self}] Readable stream {stream_id}");
 
         if let Some(recv_stream) = self.recv_streams.get_mut(&stream_id) {
-            let res = recv_stream.receive(conn);
+            let res = recv_stream.receive(conn, now);
             return self
                 .handle_stream_manipulation_output(res, stream_id, conn)
                 .map(|(output, _)| output);
@@ -488,6 +494,7 @@ impl Http3Connection {
         &mut self,
         unblocked_streams: Vec<StreamId>,
         conn: &mut Connection,
+        now: Instant,
     ) -> Res<()> {
         for stream_id in unblocked_streams {
             qdebug!("[{self}] Stream {stream_id} is unblocked");
@@ -495,7 +502,7 @@ impl Http3Connection {
                 let res = r
                     .http_stream()
                     .ok_or(Error::HttpInternal(10))?
-                    .header_unblocked(conn);
+                    .header_unblocked(conn, now);
                 let res = self.handle_stream_manipulation_output(res, stream_id, conn)?;
                 debug_assert!(matches!(res, (ReceiveOutput::NoOutput, _)));
             }
@@ -515,16 +522,17 @@ impl Http3Connection {
         &mut self,
         conn: &mut Connection,
         stream_id: StreamId,
+        now: Instant,
     ) -> Res<ReceiveOutput> {
-        let mut output = self.stream_receive(conn, stream_id)?;
+        let mut output = self.stream_receive(conn, stream_id, now)?;
 
         if let ReceiveOutput::NewStream(stream_type) = output {
-            output = self.handle_new_stream(conn, stream_type, stream_id)?;
+            output = self.handle_new_stream(conn, stream_type, stream_id, now)?;
         }
 
         match output {
             ReceiveOutput::UnblockedStreams(unblocked_streams) => {
-                self.handle_unblocked_streams(unblocked_streams, conn)?;
+                self.handle_unblocked_streams(unblocked_streams, conn, now)?;
                 Ok(ReceiveOutput::NoOutput)
             }
             ReceiveOutput::ControlFrames(control_frames) => {
@@ -688,6 +696,7 @@ impl Http3Connection {
         conn: &mut Connection,
         stream_type: NewStreamType,
         stream_id: StreamId,
+        now: Instant,
     ) -> Res<ReceiveOutput> {
         match stream_type {
             NewStreamType::Control => {
@@ -748,7 +757,7 @@ impl Http3Connection {
 
         match stream_type {
             NewStreamType::Control | NewStreamType::Decoder | NewStreamType::Encoder => {
-                self.stream_receive(conn, stream_id)
+                self.stream_receive(conn, stream_id, now)
             }
             NewStreamType::Push(_)
             | NewStreamType::Http(_)
@@ -869,6 +878,7 @@ impl Http3Connection {
         recv_events: Box<dyn HttpRecvStreamEvents>,
         push_handler: Option<Rc<RefCell<PushController>>>,
         request: &RequestDescription<T>,
+        now: Instant,
     ) -> Res<StreamId>
     where
         T: RequestTarget,
@@ -879,7 +889,15 @@ impl Http3Connection {
             request.target,
         );
         let id = self.create_bidi_transport_stream(conn)?;
-        self.request_with_stream(id, conn, send_events, recv_events, push_handler, request)?;
+        self.request_with_stream(
+            id,
+            conn,
+            send_events,
+            recv_events,
+            push_handler,
+            request,
+            now,
+        )?;
         Ok(id)
     }
 
@@ -901,6 +919,7 @@ impl Http3Connection {
         Ok(id)
     }
 
+    #[expect(clippy::too_many_arguments, reason = "Yes, but they are needed.")]
     fn request_with_stream<T>(
         &mut self,
         stream_id: StreamId,
@@ -909,6 +928,7 @@ impl Http3Connection {
         recv_events: Box<dyn HttpRecvStreamEvents>,
         push_handler: Option<Rc<RefCell<PushController>>>,
         request: &RequestDescription<T>,
+        now: Instant,
     ) -> Res<()>
     where
         T: RequestTarget,
@@ -957,7 +977,7 @@ impl Http3Connection {
         self.send_streams
             .get_mut(&stream_id)
             .ok_or(Error::InvalidStreamId)?
-            .send(conn)?;
+            .send(conn, now)?;
         Ok(())
     }
 
@@ -973,13 +993,14 @@ impl Http3Connection {
         conn: &mut Connection,
         stream_id: StreamId,
         buf: &mut [u8],
+        now: Instant,
     ) -> Res<(usize, bool)> {
         qdebug!("[{self}] read_data from stream {stream_id}");
         let res = self
             .recv_streams
             .get_mut(&stream_id)
             .ok_or(Error::InvalidStreamId)?
-            .read_data(conn, buf);
+            .read_data(conn, buf, now);
         self.handle_stream_manipulation_output(res, stream_id, conn)
     }
 
@@ -1102,7 +1123,12 @@ impl Http3Connection {
     }
 
     /// This is called when an application wants to close the sending side of a stream.
-    pub fn stream_close_send(&mut self, conn: &mut Connection, stream_id: StreamId) -> Res<()> {
+    pub fn stream_close_send(
+        &mut self,
+        conn: &mut Connection,
+        stream_id: StreamId,
+        now: Instant,
+    ) -> Res<()> {
         qdebug!("[{self}] Close the sending side for stream {stream_id}");
         debug_assert!(self.state.active());
         let send_stream = self
@@ -1111,7 +1137,7 @@ impl Http3Connection {
             .ok_or(Error::InvalidStreamId)?;
         // The following function may return InvalidStreamId from the transport layer if the stream
         // has been closed already. It is ok to ignore it here.
-        drop(send_stream.close(conn));
+        drop(send_stream.close(conn, now));
         if send_stream.done() {
             self.remove_send_stream(stream_id, conn);
         } else if send_stream.has_data_to_send() {
@@ -1213,6 +1239,7 @@ impl Http3Connection {
         stream_id: StreamId,
         events: Box<dyn ExtendedConnectEvents>,
         accept_res: &SessionAcceptAction,
+        now: Instant,
     ) -> Res<()> {
         qtrace!("Respond to WebTransport session with accept={accept_res}");
         if !self.webtransport_enabled() {
@@ -1224,6 +1251,7 @@ impl Http3Connection {
             events,
             accept_res,
             ExtendedConnectType::WebTransport,
+            now,
         )
     }
 
@@ -1233,6 +1261,7 @@ impl Http3Connection {
         stream_id: StreamId,
         events: Box<dyn ExtendedConnectEvents>,
         accept_res: &SessionAcceptAction,
+        now: Instant,
     ) -> Res<()> {
         qtrace!("Respond to ConnectUdp session with accept={accept_res}");
         if !self.connect_udp_enabled() {
@@ -1244,6 +1273,7 @@ impl Http3Connection {
             events,
             accept_res,
             ExtendedConnectType::ConnectUdp,
+            now,
         )
     }
 
@@ -1254,6 +1284,7 @@ impl Http3Connection {
         events: Box<dyn ExtendedConnectEvents>,
         accept_res: &SessionAcceptAction,
         connect_type: ExtendedConnectType,
+        now: Instant,
     ) -> Res<()> {
         let mut recv_stream = self.recv_streams.get_mut(&stream_id);
         if let Some(r) = &mut recv_stream {
@@ -1282,7 +1313,7 @@ impl Http3Connection {
                     .send_headers(headers, conn)
                     .is_ok()
                 {
-                    drop(self.stream_close_send(conn, stream_id));
+                    drop(self.stream_close_send(conn, stream_id, now));
                     // TODO issue 1294: add a timer to clean up the recv_stream if the peer does not
                     // do that in a short time.
                     self.streams_with_pending_data.insert(stream_id);
@@ -1332,9 +1363,10 @@ impl Http3Connection {
         session_id: StreamId,
         error: u32,
         message: &str,
+        now: Instant,
     ) -> Res<()> {
         qtrace!("Close WebTransport session {session_id:?}");
-        self.extended_connect_close_session(conn, session_id, error, message)
+        self.extended_connect_close_session(conn, session_id, error, message, now)
     }
 
     pub(crate) fn connect_udp_close_session(
@@ -1343,9 +1375,10 @@ impl Http3Connection {
         session_id: StreamId,
         error: u32,
         message: &str,
+        now: Instant,
     ) -> Res<()> {
         qtrace!("Close ConnectUdp session {session_id:?}");
-        self.extended_connect_close_session(conn, session_id, error, message)
+        self.extended_connect_close_session(conn, session_id, error, message, now)
     }
 
     fn extended_connect_close_session(
@@ -1354,6 +1387,7 @@ impl Http3Connection {
         session_id: StreamId,
         error: u32,
         message: &str,
+        now: Instant,
     ) -> Res<()> {
         let send_stream = self
             .send_streams
@@ -1361,7 +1395,7 @@ impl Http3Connection {
             .filter(|s| s.stream_type() == Http3StreamType::ExtendedConnect)
             .ok_or(Error::InvalidStreamId)?;
 
-        send_stream.close_with_message(conn, error, message)?;
+        send_stream.close_with_message(conn, error, message, now)?;
         if send_stream.done() {
             self.remove_send_stream(session_id, conn);
         } else if send_stream.has_data_to_send() {

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -508,6 +508,7 @@ impl Http3Client {
                 headers,
                 priority,
             },
+            now,
         );
         if let Err(e) = &output {
             if e.connection_error() {
@@ -549,6 +550,7 @@ impl Http3Client {
                 headers,
                 priority,
             },
+            now,
         );
         if let Err(e) = &output {
             if e.connection_error() {
@@ -587,10 +589,10 @@ impl Http3Client {
     /// # Errors
     ///
     /// An error will be return if stream does not exist.
-    pub fn stream_close_send(&mut self, stream_id: StreamId) -> Res<()> {
+    pub fn stream_close_send(&mut self, stream_id: StreamId, now: Instant) -> Res<()> {
         qdebug!("[{self}] Close sending side stream={stream_id}");
         self.base_handler
-            .stream_close_send(&mut self.conn, stream_id)
+            .stream_close_send(&mut self.conn, stream_id, now)
     }
 
     /// # Errors
@@ -623,7 +625,7 @@ impl Http3Client {
     /// `process_output` has not been called when needed, and HTTP3 layer has not picked up the
     /// info that the stream has been closed.) `InvalidInput` if an empty buffer has been
     /// supplied.
-    pub fn send_data(&mut self, stream_id: StreamId, buf: &[u8]) -> Res<usize> {
+    pub fn send_data(&mut self, stream_id: StreamId, buf: &[u8], now: Instant) -> Res<usize> {
         qinfo!(
             "[{self}] end_data from stream {stream_id} sending {} bytes",
             buf.len()
@@ -632,7 +634,7 @@ impl Http3Client {
             .send_streams_mut()
             .get_mut(&stream_id)
             .ok_or(Error::InvalidStreamId)?
-            .send_data(&mut self.conn, buf)
+            .send_data(&mut self.conn, buf, now)
     }
 
     /// Response data are read directly into a buffer supplied as a parameter of this function to
@@ -649,7 +651,9 @@ impl Http3Client {
         buf: &mut [u8],
     ) -> Res<(usize, bool)> {
         qdebug!("[{self}] read_data from stream {stream_id}");
-        let res = self.base_handler.read_data(&mut self.conn, stream_id, buf);
+        let res = self
+            .base_handler
+            .read_data(&mut self.conn, stream_id, buf, now);
         if let Err(e) = &res {
             if e.connection_error() {
                 self.close(now, e.code(), "");
@@ -765,9 +769,15 @@ impl Http3Client {
         session_id: StreamId,
         error: u32,
         message: &str,
+        now: Instant,
     ) -> Res<()> {
-        self.base_handler
-            .webtransport_close_session(&mut self.conn, session_id, error, message)
+        self.base_handler.webtransport_close_session(
+            &mut self.conn,
+            session_id,
+            error,
+            message,
+            now,
+        )
     }
 
     /// Close `ConnectUdp` cleanly
@@ -784,9 +794,10 @@ impl Http3Client {
         session_id: StreamId,
         error: u32,
         message: &str,
+        now: Instant,
     ) -> Res<()> {
         self.base_handler
-            .connect_udp_close_session(&mut self.conn, session_id, error, message)
+            .connect_udp_close_session(&mut self.conn, session_id, error, message, now)
     }
 
     /// # Errors
@@ -975,19 +986,19 @@ impl Http3Client {
         qtrace!("[{self}] Process http3 internal");
         match self.base_handler.state() {
             Http3State::ZeroRtt | Http3State::Connected | Http3State::GoingAway(..) => {
-                let res = self.check_connection_events();
+                let res = self.check_connection_events(now);
                 if self.check_result(now, &res) {
                     return;
                 }
                 self.push_handler
                     .borrow_mut()
                     .maybe_send_max_push_id_frame(&mut self.base_handler);
-                let res = self.base_handler.process_sending(&mut self.conn);
+                let res = self.base_handler.process_sending(&mut self.conn, now);
                 self.check_result(now, &res);
             }
             Http3State::Closed { .. } => {}
             _ => {
-                let res = self.check_connection_events();
+                let res = self.check_connection_events(now);
                 _ = self.check_result(now, &res);
             }
         }
@@ -1083,7 +1094,7 @@ impl Http3Client {
     /// [1]: https://github.com/mozilla/neqo/blob/main/neqo-http3/src/connection.rs
     /// [2]: ../neqo_transport/enum.ConnectionEvent.html
     /// [3]: ../neqo_transport/enum.ConnectionEvent.html#variant.RecvStreamReadable
-    fn check_connection_events(&mut self) -> Res<()> {
+    fn check_connection_events(&mut self, now: Instant) -> Res<()> {
         qtrace!("[{self}] Check connection events");
         while let Some(e) = self.conn.next_event() {
             qdebug!("[{self}] check_connection_events - event {e:?}");
@@ -1102,7 +1113,7 @@ impl Http3Client {
                     }
                 }
                 ConnectionEvent::RecvStreamReadable { stream_id } => {
-                    self.handle_stream_readable(stream_id)?;
+                    self.handle_stream_readable(stream_id, now)?;
                 }
                 ConnectionEvent::RecvStreamReset {
                     stream_id,
@@ -1175,13 +1186,13 @@ impl Http3Client {
     ///       specification.
     ///
     /// [1]: https://github.com/mozilla/neqo/blob/main/neqo-http3/src/connection.rs
-    fn handle_stream_readable(&mut self, stream_id: StreamId) -> Res<()> {
+    fn handle_stream_readable(&mut self, stream_id: StreamId, now: Instant) -> Res<()> {
         match self
             .base_handler
-            .handle_stream_readable(&mut self.conn, stream_id)?
+            .handle_stream_readable(&mut self.conn, stream_id, now)?
         {
             ReceiveOutput::NewStream(NewStreamType::Push(push_id)) => {
-                self.handle_new_push_stream(stream_id, push_id)
+                self.handle_new_push_stream(stream_id, push_id, now)
             }
             ReceiveOutput::NewStream(NewStreamType::Http(_)) => Err(Error::HttpStreamCreation),
             ReceiveOutput::NewStream(NewStreamType::WebTransportStream(session_id)) => {
@@ -1191,9 +1202,9 @@ impl Http3Client {
                     Box::new(self.events.clone()),
                     Box::new(self.events.clone()),
                 )?;
-                let res = self
-                    .base_handler
-                    .handle_stream_readable(&mut self.conn, stream_id)?;
+                let res =
+                    self.base_handler
+                        .handle_stream_readable(&mut self.conn, stream_id, now)?;
                 debug_assert!(matches!(res, ReceiveOutput::NoOutput));
                 Ok(())
             }
@@ -1221,7 +1232,12 @@ impl Http3Client {
         }
     }
 
-    fn handle_new_push_stream(&mut self, stream_id: StreamId, push_id: PushId) -> Res<()> {
+    fn handle_new_push_stream(
+        &mut self,
+        stream_id: StreamId,
+        push_id: PushId,
+        now: Instant,
+    ) -> Res<()> {
         if !self.push_handler.borrow().can_receive_push() {
             return Err(Error::HttpId);
         }
@@ -1262,7 +1278,7 @@ impl Http3Client {
         );
         let res = self
             .base_handler
-            .handle_stream_readable(&mut self.conn, stream_id)?;
+            .handle_stream_readable(&mut self.conn, stream_id, now)?;
         debug_assert!(matches!(res, ReceiveOutput::NoOutput));
         Ok(())
     }
@@ -1825,7 +1841,7 @@ mod tests {
             )
             .unwrap();
         if close_sending_side {
-            client.stream_close_send(request_stream_id).unwrap();
+            client.stream_close_send(request_stream_id, now()).unwrap();
         }
         request_stream_id
     }
@@ -2764,9 +2780,11 @@ mod tests {
         // Get DataWritable for the request stream so that we can write the request body.
         let data_writable = |e| matches!(e, Http3ClientEvent::DataWritable { .. });
         assert!(client.events().any(data_writable));
-        let sent = client.send_data(request_stream_id, REQUEST_BODY).unwrap();
+        let sent = client
+            .send_data(request_stream_id, REQUEST_BODY, now())
+            .unwrap();
         assert_eq!(sent, REQUEST_BODY.len());
-        client.stream_close_send(request_stream_id).unwrap();
+        client.stream_close_send(request_stream_id, now()).unwrap();
 
         let out = client.process_output(now());
         drop(server.conn.process(out.dgram(), now()));
@@ -2810,11 +2828,11 @@ mod tests {
         // Get DataWritable for the request stream so that we can write the request body.
         let data_writable = |e| matches!(e, Http3ClientEvent::DataWritable { .. });
         assert!(client.events().any(data_writable));
-        let sent = client.send_data(request_stream_id, request_body);
+        let sent = client.send_data(request_stream_id, request_body, now());
         assert_eq!(sent, Ok(request_body.len()));
 
         // Close stream.
-        client.stream_close_send(request_stream_id).unwrap();
+        client.stream_close_send(request_stream_id, now()).unwrap();
 
         // We need to loop a bit until all data has been sent.
         let mut out = client.process_output(now());
@@ -2898,15 +2916,19 @@ mod tests {
         assert!(client.events().any(data_writable));
 
         // Send the first frame.
-        let sent = client.send_data(request_stream_id, first_frame);
+        let sent = client.send_data(request_stream_id, first_frame, now());
         assert_eq!(sent, Ok(first_frame.len()));
 
         // The second frame cannot fit.
-        let sent = client.send_data(request_stream_id, &vec![0_u8; INITIAL_RECV_WINDOW_SIZE]);
+        let sent = client.send_data(
+            request_stream_id,
+            &vec![0_u8; INITIAL_RECV_WINDOW_SIZE],
+            now(),
+        );
         assert_eq!(sent, Ok(expected_second_data_frame.len()));
 
         // Close stream.
-        client.stream_close_send(request_stream_id).unwrap();
+        client.stream_close_send(request_stream_id, now()).unwrap();
 
         let mut out = client.process_output(now());
         // We need to loop a bit until all data has been sent. Once for every 1K
@@ -3067,7 +3089,7 @@ mod tests {
                     // assert that we cannot send any more request data.
                     assert_eq!(
                         Err(Error::InvalidStreamId),
-                        client.send_data(request_stream_id, &[0_u8; 10])
+                        client.send_data(request_stream_id, &[0_u8; 10], now())
                     );
                     stop_sending = true;
                 }
@@ -4405,7 +4427,7 @@ mod tests {
         assert!(client.events().any(recvd_0rtt_reject));
 
         // ...and the client stream should be gone.
-        let res = client.stream_close_send(request_stream_id);
+        let res = client.stream_close_send(request_stream_id, now());
         assert!(res.is_err());
         assert_eq!(res.unwrap_err(), Error::InvalidStreamId);
 
@@ -6579,7 +6601,7 @@ mod tests {
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
         let out = client.process_output(now());
         drop(server.conn.process(out.dgram(), now()));
-        drop(server.encoder_receiver.receive(&mut server.conn));
+        drop(server.encoder_receiver.receive(&mut server.conn, now()));
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 1);
     }
 
@@ -6628,7 +6650,7 @@ mod tests {
         let out = server.conn.process_output(now());
         let out = client.process(out.dgram(), now());
         drop(server.conn.process(out.dgram(), now()));
-        drop(server.encoder_receiver.receive(&mut server.conn));
+        drop(server.encoder_receiver.receive(&mut server.conn, now()));
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 1);
     }
 
@@ -6664,7 +6686,12 @@ mod tests {
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
         let out = client.process_output(now());
         drop(server.conn.process(out.dgram(), now()));
-        drop(server.encoder_receiver.receive(&mut server.conn).unwrap());
+        drop(
+            server
+                .encoder_receiver
+                .receive(&mut server.conn, now())
+                .unwrap(),
+        );
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 1);
     }
 
@@ -6701,7 +6728,12 @@ mod tests {
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
         let out = client.process_output(now());
         drop(server.conn.process(out.dgram(), now()));
-        drop(server.encoder_receiver.receive(&mut server.conn).unwrap());
+        drop(
+            server
+                .encoder_receiver
+                .receive(&mut server.conn, now())
+                .unwrap(),
+        );
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
     }
 
@@ -6762,7 +6794,12 @@ mod tests {
 
         let out = client.process_output(now());
         drop(server.conn.process(out.dgram(), now()));
-        drop(server.encoder_receiver.receive(&mut server.conn).unwrap());
+        drop(
+            server
+                .encoder_receiver
+                .receive(&mut server.conn, now())
+                .unwrap(),
+        );
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 1);
     }
 
@@ -6776,7 +6813,12 @@ mod tests {
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
         let out = client.process_output(now());
         drop(server.conn.process(out.dgram(), now()));
-        drop(server.encoder_receiver.receive(&mut server.conn).unwrap());
+        drop(
+            server
+                .encoder_receiver
+                .receive(&mut server.conn, now())
+                .unwrap(),
+        );
         assert_eq!(server.encoder.borrow_mut().stats().stream_cancelled_recv, 0);
     }
 
@@ -7352,12 +7394,12 @@ mod tests {
             Error::InvalidStreamId
         );
         assert_eq!(
-            client.stream_close_send(stream_id).unwrap_err(),
+            client.stream_close_send(stream_id, now()).unwrap_err(),
             Error::InvalidStreamId
         );
         let mut buf = [0; 2];
         assert_eq!(
-            client.send_data(stream_id, &buf).unwrap_err(),
+            client.send_data(stream_id, &buf, now()).unwrap_err(),
             Error::InvalidStreamId
         );
         assert_eq!(
@@ -7409,7 +7451,9 @@ mod tests {
         let data_writable = |e| matches!(e, Http3ClientEvent::DataWritable { .. });
         assert!(client.events().any(data_writable));
         // Send a lot of data to reach the flow control limit
-        client.send_data(request_stream_id, &[0; 2000]).unwrap();
+        client
+            .send_data(request_stream_id, &[0; 2000], now())
+            .unwrap();
 
         // now queue a priority_update packet for that stream
         assert!(client

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -67,13 +67,14 @@ impl Http3ServerHandler {
         stream_id: StreamId,
         data: &[u8],
         conn: &mut Connection,
+        now: Instant,
     ) -> Res<usize> {
         let n = self
             .base_handler
             .send_streams_mut()
             .get_mut(&stream_id)
             .ok_or(Error::InvalidStreamId)?
-            .send_data(conn, data)?;
+            .send_data(conn, data, now)?;
         if n > 0 {
             self.base_handler.stream_has_pending_data(stream_id);
         }
@@ -105,9 +106,14 @@ impl Http3ServerHandler {
     /// # Errors
     ///
     /// An error will be returned if stream does not exist.
-    pub fn stream_close_send(&mut self, stream_id: StreamId, conn: &mut Connection) -> Res<()> {
+    pub fn stream_close_send(
+        &mut self,
+        stream_id: StreamId,
+        conn: &mut Connection,
+        now: Instant,
+    ) -> Res<()> {
         qdebug!("[{self}] Close sending side stream={stream_id}");
-        self.base_handler.stream_close_send(conn, stream_id)?;
+        self.base_handler.stream_close_send(conn, stream_id, now)?;
         self.needs_processing = true;
         Ok(())
     }
@@ -158,6 +164,7 @@ impl Http3ServerHandler {
         conn: &mut Connection,
         stream_id: StreamId,
         accept: &SessionAcceptAction,
+        now: Instant,
     ) -> Res<()> {
         self.needs_processing = true;
         self.base_handler.webtransport_session_accept(
@@ -165,6 +172,7 @@ impl Http3ServerHandler {
             stream_id,
             Box::new(self.events.clone()),
             accept,
+            now,
         )
     }
 
@@ -174,6 +182,7 @@ impl Http3ServerHandler {
         conn: &mut Connection,
         stream_id: StreamId,
         accept: &SessionAcceptAction,
+        now: Instant,
     ) -> Res<()> {
         self.needs_processing = true;
         self.base_handler.connect_udp_session_accept(
@@ -181,6 +190,7 @@ impl Http3ServerHandler {
             stream_id,
             Box::new(self.events.clone()),
             accept,
+            now,
         )
     }
 
@@ -199,10 +209,11 @@ impl Http3ServerHandler {
         session_id: StreamId,
         error: u32,
         message: &str,
+        now: Instant,
     ) -> Res<()> {
         self.needs_processing = true;
         self.base_handler
-            .webtransport_close_session(conn, session_id, error, message)
+            .webtransport_close_session(conn, session_id, error, message, now)
     }
 
     /// Close `ConnectUdp` cleanly
@@ -220,10 +231,11 @@ impl Http3ServerHandler {
         session_id: StreamId,
         error: u32,
         message: &str,
+        now: Instant,
     ) -> Res<()> {
         self.needs_processing = true;
         self.base_handler
-            .connect_udp_close_session(conn, session_id, error, message)
+            .connect_udp_close_session(conn, session_id, error, message, now)
     }
 
     pub fn webtransport_create_stream(
@@ -275,7 +287,7 @@ impl Http3ServerHandler {
 
         let res = self.check_connection_events(conn, now);
         if !self.check_result(conn, now, &res) && self.base_handler.state().active() {
-            let res = self.base_handler.process_sending(conn);
+            let res = self.base_handler.process_sending(conn, now);
             self.check_result(conn, now, &res);
         }
     }
@@ -324,7 +336,7 @@ impl Http3ServerHandler {
                     self.base_handler.add_new_stream(stream_id);
                 }
                 ConnectionEvent::RecvStreamReadable { stream_id } => {
-                    self.handle_stream_readable(conn, stream_id)?;
+                    self.handle_stream_readable(conn, stream_id, now)?;
                 }
                 ConnectionEvent::RecvStreamReset {
                     stream_id,
@@ -368,8 +380,16 @@ impl Http3ServerHandler {
         Ok(())
     }
 
-    fn handle_stream_readable(&mut self, conn: &mut Connection, stream_id: StreamId) -> Res<()> {
-        match self.base_handler.handle_stream_readable(conn, stream_id)? {
+    fn handle_stream_readable(
+        &mut self,
+        conn: &mut Connection,
+        stream_id: StreamId,
+        now: Instant,
+    ) -> Res<()> {
+        match self
+            .base_handler
+            .handle_stream_readable(conn, stream_id, now)?
+        {
             ReceiveOutput::NewStream(NewStreamType::Push(_)) => Err(Error::HttpStreamCreation),
             ReceiveOutput::NewStream(NewStreamType::Http(first_frame_type)) => {
                 self.base_handler.add_streams(
@@ -394,7 +414,9 @@ impl Http3ServerHandler {
                         PriorityHandler::new(false, Priority::default()),
                     )),
                 );
-                let res = self.base_handler.handle_stream_readable(conn, stream_id)?;
+                let res = self
+                    .base_handler
+                    .handle_stream_readable(conn, stream_id, now)?;
                 assert_eq!(ReceiveOutput::NoOutput, res);
                 Ok(())
             }
@@ -405,7 +427,9 @@ impl Http3ServerHandler {
                     Box::new(self.events.clone()),
                     Box::new(self.events.clone()),
                 )?;
-                let res = self.base_handler.handle_stream_readable(conn, stream_id)?;
+                let res = self
+                    .base_handler
+                    .handle_stream_readable(conn, stream_id, now)?;
                 assert_eq!(ReceiveOutput::NoOutput, res);
                 Ok(())
             }
@@ -465,7 +489,7 @@ impl Http3ServerHandler {
         buf: &mut [u8],
     ) -> Res<(usize, bool)> {
         qdebug!("[{self}] read_data from stream {stream_id}");
-        let res = self.base_handler.read_data(conn, stream_id, buf);
+        let res = self.base_handler.read_data(conn, stream_id, buf, now);
         if let Err(e) = &res {
             if e.connection_error() {
                 self.close(conn, now, e);

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -7,6 +7,7 @@
 use std::{
     collections::VecDeque,
     fmt::{self, Display, Formatter},
+    time::Instant,
 };
 
 use neqo_common::{qtrace, Encoder};
@@ -53,15 +54,17 @@ impl ControlStreamLocal {
         &mut self,
         conn: &mut Connection,
         recv_conn: &mut HashMap<StreamId, Box<dyn RecvStream>>,
+        now: Instant,
     ) -> Res<()> {
-        self.stream.send_buffer(conn)?;
-        self.send_priority_update(conn, recv_conn)
+        self.stream.send_buffer(conn, now)?;
+        self.send_priority_update(conn, recv_conn, now)
     }
 
     fn send_priority_update(
         &mut self,
         conn: &mut Connection,
         recv_conn: &mut HashMap<StreamId, Box<dyn RecvStream>>,
+        now: Instant,
     ) -> Res<()> {
         // send all necessary priority updates
         while let Some(update_id) = self.outstanding_priority_update.pop_front() {
@@ -81,7 +84,7 @@ impl ControlStreamLocal {
             if let Some(hframe) = stream.priority_update_frame() {
                 let mut enc = Encoder::new();
                 hframe.encode(&mut enc);
-                if self.stream.send_atomic(conn, enc.as_ref())? {
+                if self.stream.send_atomic(conn, enc.as_ref(), now)? {
                     stream.priority_update_sent()?;
                 } else {
                     self.outstanding_priority_update.push_front(update_id);

--- a/neqo-http3/src/features/extended_connect/connect_udp_session.rs
+++ b/neqo-http3/src/features/extended_connect/connect_udp_session.rs
@@ -4,7 +4,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::{self, Display, Formatter};
+use std::{
+    fmt::{self, Display, Formatter},
+    time::Instant,
+};
 
 use neqo_common::Encoder;
 use neqo_transport::{Connection, StreamId};
@@ -50,13 +53,14 @@ impl Protocol for Session {
         conn: &mut Connection,
         events: &mut Box<dyn ExtendedConnectEvents>,
         control_stream_recv: &mut Box<dyn RecvStream>,
+        now: Instant,
     ) -> Res<Option<State>> {
         let (f, fin) = self
             .frame_reader
-            .receive::<ConnectUdpFrame>(&mut StreamReaderRecvStreamWrapper::new(
-                conn,
-                control_stream_recv,
-            ))
+            .receive::<ConnectUdpFrame>(
+                &mut StreamReaderRecvStreamWrapper::new(conn, control_stream_recv),
+                now,
+            )
             .map_err(|_| Error::HttpGeneralProtocolStream)?;
 
         if let Some(f) = f {

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -159,7 +159,7 @@ impl WtTest {
                     headers,
                 }) => {
                     assert_wt(&headers);
-                    session.response(accept).unwrap();
+                    session.response(accept, now()).unwrap();
                     wt_server_session = Some(session);
                 }
                 Http3ServerEvent::Data { .. } => {
@@ -307,7 +307,7 @@ impl WtTest {
 
     fn send_data_client(&mut self, wt_stream_id: StreamId, data: &[u8]) {
         assert_eq!(
-            self.client.send_data(wt_stream_id, data).unwrap(),
+            self.client.send_data(wt_stream_id, data, now()).unwrap(),
             data.len()
         );
         self.exchange_packets();
@@ -355,7 +355,7 @@ impl WtTest {
     }
 
     fn close_stream_sending_client(&mut self, wt_stream_id: StreamId) {
-        self.client.stream_close_send(wt_stream_id).unwrap();
+        self.client.stream_close_send(wt_stream_id, now()).unwrap();
         self.exchange_packets();
     }
 
@@ -455,7 +455,7 @@ impl WtTest {
     }
 
     fn send_data_server(&mut self, wt_stream: &Http3OrWebTransportStream, data: &[u8]) {
-        assert_eq!(wt_stream.send_data(data).unwrap(), data.len());
+        assert_eq!(wt_stream.send_data(data, now()).unwrap(), data.len());
         self.exchange_packets();
     }
 
@@ -499,7 +499,7 @@ impl WtTest {
     }
 
     fn close_stream_sending_server(&mut self, wt_stream: &Http3OrWebTransportStream) {
-        wt_stream.stream_close_send().unwrap();
+        wt_stream.stream_close_send(now()).unwrap();
         self.exchange_packets();
     }
 
@@ -587,12 +587,12 @@ impl WtTest {
 
     pub fn session_close_frame_client(&mut self, session_id: StreamId, error: u32, message: &str) {
         self.client
-            .webtransport_close_session(session_id, error, message)
+            .webtransport_close_session(session_id, error, message, now())
             .unwrap();
     }
 
     pub fn session_close_frame_server(wt_session: &WebTransportRequest, error: u32, message: &str) {
-        wt_session.close_session(error, message).unwrap();
+        wt_session.close_session(error, message, now()).unwrap();
     }
 
     fn max_datagram_size(&self, stream_id: StreamId) -> Result<u64, Error> {

--- a/neqo-http3/src/frames/tests/mod.rs
+++ b/neqo-http3/src/frames/tests/mod.rs
@@ -44,10 +44,10 @@ pub fn enc_dec<T: FrameDecoder<T>>(d: &Encoder, st: &str, remaining: usize) -> T
     drop(conn_c.process(out.dgram(), now()));
 
     let (frame, fin) = fr
-        .receive::<T>(&mut StreamReaderConnectionWrapper::new(
-            &mut conn_c,
-            stream_id,
-        ))
+        .receive::<T>(
+            &mut StreamReaderConnectionWrapper::new(&mut conn_c, stream_id),
+            now(),
+        )
         .unwrap();
     assert!(!fin);
     assert!(frame.is_some());

--- a/neqo-http3/src/frames/tests/reader.rs
+++ b/neqo-http3/src/frames/tests/reader.rs
@@ -43,10 +43,10 @@ impl FrameReaderTest {
         drop(self.conn_c.process(out.dgram(), now()));
         let (frame, fin) = self
             .fr
-            .receive::<T>(&mut StreamReaderConnectionWrapper::new(
-                &mut self.conn_c,
-                self.stream_id,
-            ))
+            .receive::<T>(
+                &mut StreamReaderConnectionWrapper::new(&mut self.conn_c, self.stream_id),
+                now(),
+            )
             .ok()?;
         assert!(!fin);
         frame
@@ -247,10 +247,10 @@ fn test_reading_frame<T: FrameDecoder<T> + PartialEq + Debug>(
         drop(fr.conn_c.process(out.dgram(), now()));
     }
 
-    let rv = fr.fr.receive::<T>(&mut StreamReaderConnectionWrapper::new(
-        &mut fr.conn_c,
-        fr.stream_id,
-    ));
+    let rv = fr.fr.receive::<T>(
+        &mut StreamReaderConnectionWrapper::new(&mut fr.conn_c, fr.stream_id),
+        now(),
+    );
 
     match expected_result {
         FrameReadingTestExpect::Error => assert_eq!(Err(Error::HttpFrame), rv),
@@ -498,11 +498,10 @@ fn frame_reading_when_stream_is_closed_before_sending_data() {
     drop(fr.conn_s.process(out.dgram(), now()));
     assert_eq!(
         Ok((None, true)),
-        fr.fr
-            .receive::<HFrame>(&mut StreamReaderConnectionWrapper::new(
-                &mut fr.conn_s,
-                fr.stream_id
-            ))
+        fr.fr.receive::<HFrame>(
+            &mut StreamReaderConnectionWrapper::new(&mut fr.conn_s, fr.stream_id),
+            now()
+        )
     );
 }
 
@@ -521,10 +520,9 @@ fn wt_frame_reading_when_stream_is_closed_before_sending_data() {
     drop(fr.conn_s.process(out.dgram(), now()));
     assert_eq!(
         Ok((None, true)),
-        fr.fr
-            .receive::<WebTransportFrame>(&mut StreamReaderConnectionWrapper::new(
-                &mut fr.conn_s,
-                fr.stream_id
-            ))
+        fr.fr.receive::<WebTransportFrame>(
+            &mut StreamReaderConnectionWrapper::new(&mut fr.conn_s, fr.stream_id),
+            now()
+        )
     );
 }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -158,7 +158,7 @@ mod server_events;
 mod settings;
 mod stream_type_reader;
 
-use std::{cell::RefCell, fmt::Debug, rc::Rc};
+use std::{cell::RefCell, fmt::Debug, rc::Rc, time::Instant};
 
 use buffered_send_stream::BufferedStream;
 pub use client_events::{ConnectUdpEvent, Http3ClientEvent, WebTransportEvent};
@@ -437,7 +437,7 @@ trait RecvStream: Stream {
     /// # Errors
     ///
     /// An error may happen while reading a stream, e.g. early close, protocol error, etc.
-    fn receive(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)>;
+    fn receive(&mut self, conn: &mut Connection, now: Instant) -> Res<(ReceiveOutput, bool)>;
 
     /// # Errors
     ///
@@ -451,7 +451,12 @@ trait RecvStream: Stream {
     /// # Errors
     ///
     /// An error may happen while reading a stream, e.g. early close, protocol error, etc.
-    fn read_data(&mut self, _conn: &mut Connection, _buf: &mut [u8]) -> Res<(usize, bool)> {
+    fn read_data(
+        &mut self,
+        _conn: &mut Connection,
+        _buf: &mut [u8],
+        _now: Instant,
+    ) -> Res<(usize, bool)> {
         Err(Error::InvalidStreamId)
     }
 
@@ -477,7 +482,11 @@ trait HttpRecvStream: RecvStream {
     /// # Errors
     ///
     /// An error may happen while reading a stream, e.g. early close, protocol error, etc.
-    fn header_unblocked(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)>;
+    fn header_unblocked(
+        &mut self,
+        conn: &mut Connection,
+        now: Instant,
+    ) -> Res<(ReceiveOutput, bool)>;
 
     fn maybe_update_priority(&mut self, priority: Priority) -> Res<bool>;
     fn priority_update_frame(&mut self) -> Option<HFrame>;
@@ -544,7 +553,7 @@ trait SendStream: Stream {
     /// # Errors
     ///
     /// Error may occur during sending data, e.g. protocol error, etc.
-    fn send(&mut self, conn: &mut Connection) -> Res<()>;
+    fn send(&mut self, conn: &mut Connection, now: Instant) -> Res<()>;
     fn has_data_to_send(&self) -> bool;
     fn stream_writable(&self);
     fn done(&self) -> bool;
@@ -552,12 +561,12 @@ trait SendStream: Stream {
     /// # Errors
     ///
     /// Error may occur during sending data, e.g. protocol error, etc.
-    fn send_data(&mut self, _conn: &mut Connection, _buf: &[u8]) -> Res<usize>;
+    fn send_data(&mut self, _conn: &mut Connection, _buf: &[u8], now: Instant) -> Res<usize>;
 
     /// # Errors
     ///
     /// It may happen that the transport stream is already closed. This is unlikely.
-    fn close(&mut self, conn: &mut Connection) -> Res<()>;
+    fn close(&mut self, conn: &mut Connection, now: Instant) -> Res<()>;
 
     /// # Errors
     ///
@@ -567,6 +576,7 @@ trait SendStream: Stream {
         _conn: &mut Connection,
         _error: u32,
         _message: &str,
+        _now: Instant,
     ) -> Res<()> {
         Err(Error::InvalidStreamId)
     }
@@ -581,7 +591,7 @@ trait SendStream: Stream {
     /// # Errors
     ///
     /// It may happen that the transport stream is already closed. This is unlikely.
-    fn send_data_atomic(&mut self, _conn: &mut Connection, _buf: &[u8]) -> Res<()> {
+    fn send_data_atomic(&mut self, _conn: &mut Connection, _buf: &[u8], _now: Instant) -> Res<()> {
         Err(Error::InvalidStreamId)
     }
 

--- a/neqo-http3/src/qlog.rs
+++ b/neqo-http3/src/qlog.rs
@@ -6,42 +6,44 @@
 
 // Functions that handle capturing QLOG traces.
 
+use std::time::Instant;
+
 use neqo_common::qlog::Qlog;
 use neqo_transport::StreamId;
 use qlog::events::{DataRecipient, EventData};
 
-/// Uses [`Qlog::add_event_data_now`] instead of
-/// [`Qlog::add_event_data_with_instant`], given that `now` is not available
-/// on call-site. See docs on [`Qlog::add_event_data_now`] for details.
-pub fn h3_data_moved_up(qlog: &Qlog, stream_id: StreamId, amount: usize) {
-    qlog.add_event_data_now(|| {
-        let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
-            stream_id: Some(stream_id.as_u64()),
-            offset: None,
-            length: Some(u64::try_from(amount).expect("usize fits in u64")),
-            from: Some(DataRecipient::Transport),
-            to: Some(DataRecipient::Application),
-            raw: None,
-        });
+pub fn h3_data_moved_up(qlog: &Qlog, stream_id: StreamId, amount: usize, now: Instant) {
+    qlog.add_event_data_with_instant(
+        || {
+            let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
+                stream_id: Some(stream_id.as_u64()),
+                offset: None,
+                length: Some(u64::try_from(amount).expect("usize fits in u64")),
+                from: Some(DataRecipient::Transport),
+                to: Some(DataRecipient::Application),
+                raw: None,
+            });
 
-        Some(ev_data)
-    });
+            Some(ev_data)
+        },
+        now,
+    );
 }
 
-/// Uses [`Qlog::add_event_data_now`] instead of
-/// [`Qlog::add_event_data_with_instant`], given that `now` is not available
-/// on call-site. See docs on [`Qlog::add_event_data_now`] for details.
-pub fn h3_data_moved_down(qlog: &Qlog, stream_id: StreamId, amount: usize) {
-    qlog.add_event_data_now(|| {
-        let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
-            stream_id: Some(stream_id.as_u64()),
-            offset: None,
-            length: Some(u64::try_from(amount).expect("usize fits in u64")),
-            from: Some(DataRecipient::Application),
-            to: Some(DataRecipient::Transport),
-            raw: None,
-        });
+pub fn h3_data_moved_down(qlog: &Qlog, stream_id: StreamId, amount: usize, now: Instant) {
+    qlog.add_event_data_with_instant(
+        || {
+            let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
+                stream_id: Some(stream_id.as_u64()),
+                offset: None,
+                length: Some(u64::try_from(amount).expect("usize fits in u64")),
+                from: Some(DataRecipient::Application),
+                to: Some(DataRecipient::Transport),
+                raw: None,
+            });
 
-        Some(ev_data)
-    });
+            Some(ev_data)
+        },
+        now,
+    );
 }

--- a/neqo-http3/src/qpack_decoder_receiver.rs
+++ b/neqo-http3/src/qpack_decoder_receiver.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::Rc, time::Instant};
 
 use neqo_qpack as qpack;
 use neqo_transport::{Connection, StreamId};
@@ -34,7 +34,7 @@ impl RecvStream for DecoderRecvStream {
         Err(Error::HttpClosedCriticalStream)
     }
 
-    fn receive(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)> {
+    fn receive(&mut self, conn: &mut Connection, _now: Instant) -> Res<(ReceiveOutput, bool)> {
         Ok((
             ReceiveOutput::UnblockedStreams(
                 self.decoder.borrow_mut().receive(conn, self.stream_id)?,

--- a/neqo-http3/src/qpack_encoder_receiver.rs
+++ b/neqo-http3/src/qpack_encoder_receiver.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::Rc, time::Instant};
 
 use neqo_qpack as qpack;
 use neqo_transport::{Connection, StreamId};
@@ -34,8 +34,10 @@ impl RecvStream for EncoderRecvStream {
         Err(Error::HttpClosedCriticalStream)
     }
 
-    fn receive(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)> {
-        self.encoder.borrow_mut().receive(conn, self.stream_id)?;
+    fn receive(&mut self, conn: &mut Connection, now: Instant) -> Res<(ReceiveOutput, bool)> {
+        self.encoder
+            .borrow_mut()
+            .receive(conn, self.stream_id, now)?;
         Ok((ReceiveOutput::NoOutput, false))
     }
 }

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -10,6 +10,7 @@ use std::{
     collections::VecDeque,
     fmt::{self, Debug, Display, Formatter},
     rc::Rc,
+    time::Instant,
 };
 
 use neqo_common::{header::HeadersExt as _, qdebug, qinfo, qtrace, Header};
@@ -259,7 +260,12 @@ impl RecvMessage {
         Ok(())
     }
 
-    fn receive_internal(&mut self, conn: &mut Connection, post_readable_event: bool) -> Res<()> {
+    fn receive_internal(
+        &mut self,
+        conn: &mut Connection,
+        post_readable_event: bool,
+        now: Instant,
+    ) -> Res<()> {
         loop {
             qdebug!("[{self}] state={:?}", self.state);
             match &mut self.state {
@@ -267,10 +273,10 @@ impl RecvMessage {
                 RecvMessageState::WaitingForResponseHeaders { frame_reader }
                 | RecvMessageState::WaitingForData { frame_reader }
                 | RecvMessageState::WaitingForFinAfterTrailers { frame_reader } => {
-                    match frame_reader.receive(&mut StreamReaderConnectionWrapper::new(
-                        conn,
-                        self.stream_id,
-                    ))? {
+                    match frame_reader.receive(
+                        &mut StreamReaderConnectionWrapper::new(conn, self.stream_id),
+                        now,
+                    )? {
                         (None, true) => {
                             break self.set_state_to_close_pending(post_readable_event);
                         }
@@ -375,8 +381,8 @@ impl Stream for RecvMessage {
 }
 
 impl RecvStream for RecvMessage {
-    fn receive(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)> {
-        self.receive_internal(conn, true)?;
+    fn receive(&mut self, conn: &mut Connection, now: Instant) -> Res<(ReceiveOutput, bool)> {
+        self.receive_internal(conn, true, now)?;
         Ok((
             ReceiveOutput::NoOutput,
             matches!(self.state, RecvMessageState::Closed),
@@ -394,7 +400,12 @@ impl RecvStream for RecvMessage {
         Ok(())
     }
 
-    fn read_data(&mut self, conn: &mut Connection, buf: &mut [u8]) -> Res<(usize, bool)> {
+    fn read_data(
+        &mut self,
+        conn: &mut Connection,
+        buf: &mut [u8],
+        now: Instant,
+    ) -> Res<(usize, bool)> {
         let mut written = 0;
         loop {
             match self.state {
@@ -405,7 +416,7 @@ impl RecvStream for RecvMessage {
                     let (amount, fin) = conn
                         .stream_recv(self.stream_id, &mut buf[written..written + to_read])
                         .map_err(|e| Error::map_stream_recv_errors(&Error::from(e)))?;
-                    qlog::h3_data_moved_up(conn.qlog_mut(), self.stream_id, amount);
+                    qlog::h3_data_moved_up(conn.qlog_mut(), self.stream_id, amount, now);
 
                     debug_assert!(amount <= to_read);
                     *remaining_data_len -= amount;
@@ -421,7 +432,7 @@ impl RecvStream for RecvMessage {
                         self.state = RecvMessageState::WaitingForData {
                             frame_reader: FrameReader::new(),
                         };
-                        self.receive_internal(conn, false)?;
+                        self.receive_internal(conn, false, now)?;
                     } else {
                         break Ok((written, false));
                     }
@@ -441,7 +452,11 @@ impl RecvStream for RecvMessage {
 }
 
 impl HttpRecvStream for RecvMessage {
-    fn header_unblocked(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)> {
+    fn header_unblocked(
+        &mut self,
+        conn: &mut Connection,
+        now: Instant,
+    ) -> Res<(ReceiveOutput, bool)> {
         while let Some(p) = self.blocked_push_promise.front() {
             if let Some(headers) = self
                 .qpack_decoder
@@ -459,7 +474,7 @@ impl HttpRecvStream for RecvMessage {
             }
         }
 
-        self.receive(conn)
+        self.receive(conn, now)
     }
 
     fn maybe_update_priority(&mut self, priority: Priority) -> Res<bool> {

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -10,6 +10,7 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
     num::NonZeroUsize,
     rc::Rc,
+    time::Instant,
 };
 
 use neqo_common::{qdebug, qtrace, Buffer, Encoder, Header, MessageType};
@@ -168,12 +169,12 @@ impl Stream for SendMessage {
     }
 }
 impl SendStream for SendMessage {
-    fn send_data(&mut self, conn: &mut Connection, buf: &[u8]) -> Res<usize> {
+    fn send_data(&mut self, conn: &mut Connection, buf: &[u8], now: Instant) -> Res<usize> {
         qtrace!("[{self}] send_body: len={}", buf.len());
 
         self.state.new_data()?;
 
-        self.stream.send_buffer(conn)?;
+        self.stream.send_buffer(conn, now)?;
         if self.stream.has_buffered_data() {
             return Ok(0);
         }
@@ -212,13 +213,13 @@ impl SendStream for SendMessage {
         data_frame.encode(&mut enc);
         let sent_fh = self
             .stream
-            .send_atomic(conn, enc.as_ref())
+            .send_atomic(conn, enc.as_ref(), now)
             .map_err(|e| Error::map_stream_send_errors(&e))?;
         debug_assert!(sent_fh);
 
         let sent = self
             .stream
-            .send_atomic(conn, &buf[..to_send])
+            .send_atomic(conn, &buf[..to_send], now)
             .map_err(|e| Error::map_stream_send_errors(&e))?;
         debug_assert!(sent);
         Ok(to_send)
@@ -245,8 +246,8 @@ impl SendStream for SendMessage {
     /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if
     /// `process_output` has not been called when needed, and HTTP3 layer has not picked up the
     /// info that the stream has been closed.)
-    fn send(&mut self, conn: &mut Connection) -> Res<()> {
-        let sent = Error::map_error(self.stream.send_buffer(conn), Error::HttpInternal(5))?;
+    fn send(&mut self, conn: &mut Connection, now: Instant) -> Res<()> {
+        let sent = Error::map_error(self.stream.send_buffer(conn, now), Error::HttpInternal(5))?;
 
         qtrace!("[{self}] {sent} bytes sent");
         if !self.stream.has_buffered_data() {
@@ -273,7 +274,7 @@ impl SendStream for SendMessage {
         self.stream.has_buffered_data()
     }
 
-    fn close(&mut self, conn: &mut Connection) -> Res<()> {
+    fn close(&mut self, conn: &mut Connection, _now: Instant) -> Res<()> {
         self.state.fin()?;
         if !self.stream.has_buffered_data() {
             conn.stream_close_send(self.stream_id())?;
@@ -294,13 +295,13 @@ impl SendStream for SendMessage {
         Some(self)
     }
 
-    fn send_data_atomic(&mut self, conn: &mut Connection, buf: &[u8]) -> Res<()> {
+    fn send_data_atomic(&mut self, conn: &mut Connection, buf: &[u8], now: Instant) -> Res<()> {
         let data_frame = HFrame::Data {
             len: buf.len() as u64,
         };
         self.stream.encode_with(|e| data_frame.encode(e));
         self.stream.buffer(buf);
-        _ = self.stream.send_buffer(conn)?;
+        _ = self.stream.send_buffer(conn, now)?;
         Ok(())
     }
 }

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -1003,7 +1003,7 @@ mod tests {
                             Header::new("content-length", "3"),
                         ])
                         .unwrap();
-                    stream.send_data(RESPONSE_BODY).unwrap();
+                    stream.send_data(RESPONSE_BODY, now()).unwrap();
                     data_received += 1;
                 }
                 Http3ServerEvent::DataWritable { .. }
@@ -1051,7 +1051,7 @@ mod tests {
                             Header::new("content-length", "3"),
                         ])
                         .unwrap();
-                    stream.send_data(RESPONSE_BODY).unwrap();
+                    stream.send_data(RESPONSE_BODY, now()).unwrap();
                 }
                 Http3ServerEvent::Data { .. } => {
                     panic!("We should not have a Data event");

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::cmp::min;
+use std::{cmp::min, time::Instant};
 
 use neqo_common::{qtrace, Decoder, IncrementalDecoderUint, Role};
 use neqo_qpack::{decoder::QPACK_UNI_STREAM_TYPE_DECODER, encoder::QPACK_UNI_STREAM_TYPE_ENCODER};
@@ -230,7 +230,7 @@ impl RecvStream for NewStreamHeadReader {
         Ok(())
     }
 
-    fn receive(&mut self, conn: &mut Connection) -> Res<(ReceiveOutput, bool)> {
+    fn receive(&mut self, conn: &mut Connection, _now: Instant) -> Res<(ReceiveOutput, bool)> {
         let t = self.get_type(conn)?;
         Ok((
             t.map_or(ReceiveOutput::NoOutput, ReceiveOutput::NewStream),
@@ -296,7 +296,7 @@ mod tests {
                 let out = self.conn_s.process_output(now());
                 drop(self.conn_c.process(out.dgram(), now()));
                 assert_eq!(
-                    self.decoder.receive(&mut self.conn_c).unwrap(),
+                    self.decoder.receive(&mut self.conn_c, now()).unwrap(),
                     (ReceiveOutput::NoOutput, false)
                 );
                 assert!(!self.decoder.done());
@@ -309,7 +309,7 @@ mod tests {
             }
             let out = self.conn_s.process_output(now());
             drop(self.conn_c.process(out.dgram(), now()));
-            assert_eq!(&self.decoder.receive(&mut self.conn_c), outcome);
+            assert_eq!(&self.decoder.receive(&mut self.conn_c, now()), outcome);
             assert_eq!(self.decoder.done(), done);
         }
 

--- a/neqo-http3/tests/classic_connect.rs
+++ b/neqo-http3/tests/classic_connect.rs
@@ -26,7 +26,7 @@ fn classic_connect() {
     let stream_id = client
         .connect(now(), AUTHORITY, &[], Priority::default())
         .unwrap();
-    client.send_data(stream_id, b"ping").unwrap();
+    client.send_data(stream_id, b"ping", now()).unwrap();
     exchange_packets(&mut client, &mut server, false, None);
 
     let Some(Http3ServerEvent::Headers { headers, .. }) = server.next_event() else {
@@ -56,7 +56,7 @@ fn classic_connect() {
     stream
         .send_headers(&[Header::new(":status", "200")])
         .unwrap();
-    stream.send_data(b"pong").unwrap();
+    stream.send_data(b"pong", now()).unwrap();
     exchange_packets(&mut client, &mut server, false, None);
 
     // Ignore some client events.

--- a/neqo-http3/tests/connect_udp.rs
+++ b/neqo-http3/tests/connect_udp.rs
@@ -84,7 +84,9 @@ fn establish_new_session() -> (
                         && headers.contains_header(":protocol", "connect-udp")
                 );
 
-                session.response(&SessionAcceptAction::Accept).unwrap();
+                session
+                    .response(&SessionAcceptAction::Accept, now())
+                    .unwrap();
                 Some(session)
             } else {
                 None
@@ -244,7 +246,7 @@ fn session_lifecycle(client_closes: bool) {
 
     if client_closes {
         client
-            .connect_udp_close_session(session_id, 0, "kthxbye")
+            .connect_udp_close_session(session_id, 0, "kthxbye", now())
             .unwrap();
 
         exchange_packets(&mut client, &mut proxy, false, None);
@@ -262,7 +264,7 @@ fn session_lifecycle(client_closes: bool) {
             })
             .unwrap();
     } else {
-        proxy_session.close_session(0, "kthxbye").unwrap();
+        proxy_session.close_session(0, "kthxbye", now()).unwrap();
 
         exchange_packets(&mut client, &mut proxy, false, None);
 
@@ -387,7 +389,7 @@ fn server_datagram_before_accept() {
             })
             .unwrap();
         proxy_session
-            .response(&SessionAcceptAction::Accept)
+            .response(&SessionAcceptAction::Accept, now())
             .unwrap();
         let proxy_accept = proxy.process_output(now()).dgram().unwrap();
         assert!(proxy.process_output(now()).dgram().is_none());
@@ -487,7 +489,7 @@ fn connect_udp_operation_on_fetch_stream() {
     );
 
     assert_eq!(
-        client.connect_udp_close_session(fetch_stream, 0, "kthxbye"),
+        client.connect_udp_close_session(fetch_stream, 0, "kthxbye", now()),
         Err(Error::InvalidStreamId)
     );
 }

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -44,20 +44,20 @@ fn receive_request(server: &Http3Server) -> Option<Http3OrWebTransportStream> {
     None
 }
 
-fn set_response(request: &Http3OrWebTransportStream) {
+fn set_response(request: &Http3OrWebTransportStream, now: Instant) {
     request
         .send_headers(&[
             Header::new(":status", "200"),
             Header::new("content-length", "3"),
         ])
         .unwrap();
-    request.send_data(RESPONSE_DATA).unwrap();
-    request.stream_close_send().unwrap();
+    request.send_data(RESPONSE_DATA, now).unwrap();
+    request.stream_close_send(now).unwrap();
 }
 
-fn process_server_events(server: &Http3Server) {
+fn process_server_events(server: &Http3Server, now: Instant) {
     let request = receive_request(server).unwrap();
-    set_response(&request);
+    set_response(&request, now);
 }
 
 fn process_client_events(conn: &mut Http3Client) {
@@ -159,12 +159,12 @@ fn fetch() {
         )
         .unwrap();
     assert_eq!(req, 0);
-    hconn_c.stream_close_send(req).unwrap();
+    hconn_c.stream_close_send(req, now()).unwrap();
     let out = hconn_c.process(dgram, now());
     qtrace!("-----server");
     let out = hconn_s.process(out.dgram(), now());
     drop(hconn_c.process(out.dgram(), now()));
-    process_server_events(&hconn_s);
+    process_server_events(&hconn_s, now());
     let out = hconn_s.process(None::<Datagram>, now());
 
     qtrace!("-----client");
@@ -188,7 +188,7 @@ fn response_103() {
         )
         .unwrap();
     assert_eq!(req, 0);
-    hconn_c.stream_close_send(req).unwrap();
+    hconn_c.stream_close_send(req, now()).unwrap();
     let out = hconn_c.process(dgram, now());
 
     let out = hconn_s.process(out.dgram(), now());
@@ -211,7 +211,7 @@ fn response_103() {
     };
     assert!(hconn_c.events().any(info_headers_event));
 
-    set_response(&request);
+    set_response(&request, now());
     let out = hconn_s.process(None::<Datagram>, now());
     drop(hconn_c.process(out.dgram(), now()));
     process_client_events(&mut hconn_c);
@@ -240,7 +240,7 @@ fn data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::Error>
         &[],
         Priority::default(),
     )?;
-    hconn_c.stream_close_send(stream_id)?;
+    hconn_c.stream_close_send(stream_id, now())?;
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
 
     // Server receives GET and responds with headers.
@@ -263,7 +263,7 @@ fn data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::Error>
     // Have server fill entire send buffer minus 1 byte.
     let all_but_one = request.available()? - DATA_FRAME_HEADER_SIZE - 1;
     let buf = vec![1; all_but_one];
-    let sent = request.send_data(&buf)?;
+    let sent = request.send_data(&buf, now())?;
     assert_eq!(sent, all_but_one);
     assert_eq!(request.available()?, 1);
 
@@ -275,7 +275,7 @@ fn data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::Error>
     // Sending more fails, given that each data frame needs to be preceded by a
     // header, i.e. needs more than 1 byte of send space to send 1 byte payload.
     assert_eq!(request.available()?, 1);
-    assert_eq!(request.send_data(&buf)?, 0);
+    assert_eq!(request.send_data(&buf, now())?, 0);
 
     // Have the client read all the pending data.
     let mut recv_buf = vec![0_u8; all_but_one];
@@ -316,7 +316,7 @@ fn data_writable_events() {
             Priority::default(),
         )
         .unwrap();
-    hconn_c.stream_close_send(req).unwrap();
+    hconn_c.stream_close_send(req, now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
 
     let request = receive_request(&hconn_s).unwrap();
@@ -330,7 +330,7 @@ fn data_writable_events() {
 
     // Send a lot of data
     let buf = &[1; DATA_AMOUNT];
-    let mut sent = request.send_data(buf).unwrap();
+    let mut sent = request.send_data(buf, now()).unwrap();
     assert!(sent < DATA_AMOUNT);
 
     // Exchange packets and read the data on the client side.
@@ -352,7 +352,7 @@ fn data_writable_events() {
     // Make sure we have a DataWritable event.
     assert!(hconn_s.events().any(data_writable));
     // Data can be sent again.
-    let s = request.send_data(&buf[sent..]).unwrap();
+    let s = request.send_data(&buf[sent..], now()).unwrap();
     assert!(s > 0);
     sent += s;
 
@@ -368,7 +368,7 @@ fn data_writable_events() {
     // One more DataWritable event.
     assert!(hconn_s.events().any(data_writable));
     // Send more data.
-    let s = request.send_data(&buf[sent..]).unwrap();
+    let s = request.send_data(&buf[sent..], now()).unwrap();
     assert!(s > 0);
     sent += s;
     assert_eq!(sent, DATA_AMOUNT);
@@ -420,7 +420,7 @@ fn zerortt() {
             Priority::default(),
         )
         .unwrap();
-    hconn_c.stream_close_send(req).unwrap();
+    hconn_c.stream_close_send(req, now()).unwrap();
 
     let out = hconn_c.process(dgram, now());
     let out2 = hconn_c.process_output(now());
@@ -463,7 +463,7 @@ fn zerortt() {
     let request_stream = request_stream.unwrap();
 
     // Send a response
-    set_response(&request_stream);
+    set_response(&request_stream, now());
 
     // Receive the response
     exchange_packets(&mut hconn_c, &mut hconn_s, false, out.dgram());
@@ -491,7 +491,7 @@ fn fetch_noresponse_will_idletimeout() {
         )
         .unwrap();
     assert_eq!(req, 0);
-    hconn_c.stream_close_send(req).unwrap();
+    hconn_c.stream_close_send(req, now).unwrap();
     let _out = hconn_c.process(dgram, now);
     qtrace!("-----server");
 

--- a/neqo-http3/tests/send_message.rs
+++ b/neqo-http3/tests/send_message.rs
@@ -152,7 +152,7 @@ fn send_and_receive_request(
             Priority::default(),
         )
         .unwrap();
-    hconn_c.stream_close_send(req).unwrap();
+    hconn_c.stream_close_send(req, now()).unwrap();
     exchange_packets(hconn_c, hconn_s, false, None);
 
     receive_request(hconn_s).unwrap()
@@ -168,9 +168,9 @@ fn connect_send_and_receive_request() -> (Http3Client, Http3Server, Http3OrWebTr
 fn response_trailers1() {
     let (mut hconn_c, mut hconn_s, request) = connect_send_and_receive_request();
     send_headers(&request).unwrap();
-    request.send_data(RESPONSE_DATA).unwrap();
+    request.send_data(RESPONSE_DATA, now()).unwrap();
     send_trailers(&request).unwrap();
-    request.stream_close_send().unwrap();
+    request.stream_close_send(now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     process_client_events(&mut hconn_c);
 }
@@ -179,10 +179,10 @@ fn response_trailers1() {
 fn response_trailers2() {
     let (mut hconn_c, mut hconn_s, request) = connect_send_and_receive_request();
     send_headers(&request).unwrap();
-    request.send_data(RESPONSE_DATA).unwrap();
+    request.send_data(RESPONSE_DATA, now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     send_trailers(&request).unwrap();
-    request.stream_close_send().unwrap();
+    request.stream_close_send(now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     process_client_events(&mut hconn_c);
 }
@@ -191,11 +191,11 @@ fn response_trailers2() {
 fn response_trailers3() {
     let (mut hconn_c, mut hconn_s, request) = connect_send_and_receive_request();
     send_headers(&request).unwrap();
-    request.send_data(RESPONSE_DATA).unwrap();
+    request.send_data(RESPONSE_DATA, now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     send_trailers(&request).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
-    request.stream_close_send().unwrap();
+    request.stream_close_send(now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     process_client_events(&mut hconn_c);
 }
@@ -207,7 +207,7 @@ fn response_trailers_no_data() {
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     send_trailers(&request).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
-    request.stream_close_send().unwrap();
+    request.stream_close_send(now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     process_client_events_no_data(&mut hconn_c);
 }
@@ -216,14 +216,14 @@ fn response_trailers_no_data() {
 fn multiple_response_trailers() {
     let (mut hconn_c, mut hconn_s, request) = connect_send_and_receive_request();
     send_headers(&request).unwrap();
-    request.send_data(RESPONSE_DATA).unwrap();
+    request.send_data(RESPONSE_DATA, now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     send_trailers(&request).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
 
     assert_eq!(send_trailers(&request), Err(Error::InvalidInput));
 
-    request.stream_close_send().unwrap();
+    request.stream_close_send(now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     process_client_events(&mut hconn_c);
 }
@@ -232,14 +232,17 @@ fn multiple_response_trailers() {
 fn data_after_trailer() {
     let (mut hconn_c, mut hconn_s, request) = connect_send_and_receive_request();
     send_headers(&request).unwrap();
-    request.send_data(RESPONSE_DATA).unwrap();
+    request.send_data(RESPONSE_DATA, now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     send_trailers(&request).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
 
-    assert_eq!(request.send_data(RESPONSE_DATA), Err(Error::InvalidInput));
+    assert_eq!(
+        request.send_data(RESPONSE_DATA, now()),
+        Err(Error::InvalidInput)
+    );
 
-    request.stream_close_send().unwrap();
+    request.stream_close_send(now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     process_client_events(&mut hconn_c);
 }
@@ -248,8 +251,8 @@ fn data_after_trailer() {
 fn trailers_after_close() {
     let (mut hconn_c, mut hconn_s, request) = connect_send_and_receive_request();
     send_headers(&request).unwrap();
-    request.send_data(RESPONSE_DATA).unwrap();
-    request.stream_close_send().unwrap();
+    request.send_data(RESPONSE_DATA, now()).unwrap();
+    request.stream_close_send(now()).unwrap();
 
     assert_eq!(send_trailers(&request), Err(Error::InvalidStreamId));
 
@@ -267,7 +270,7 @@ fn multiple_response_headers() {
         Err(Error::InvalidHeader)
     );
 
-    request.stream_close_send().unwrap();
+    request.stream_close_send(now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     process_client_events_no_data(&mut hconn_c);
 }
@@ -282,7 +285,7 @@ fn informational_after_response_headers() {
         Err(Error::InvalidHeader)
     );
 
-    request.stream_close_send().unwrap();
+    request.stream_close_send(now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     process_client_events_no_data(&mut hconn_c);
 }
@@ -292,11 +295,14 @@ fn data_after_informational() {
     let (mut hconn_c, mut hconn_s, request) = connect_send_and_receive_request();
     send_informational_headers(&request).unwrap();
 
-    assert_eq!(request.send_data(RESPONSE_DATA), Err(Error::InvalidInput));
+    assert_eq!(
+        request.send_data(RESPONSE_DATA, now()),
+        Err(Error::InvalidInput)
+    );
 
     send_headers(&request).unwrap();
-    request.send_data(RESPONSE_DATA).unwrap();
-    request.stream_close_send().unwrap();
+    request.send_data(RESPONSE_DATA, now()).unwrap();
+    request.stream_close_send(now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     process_client_events(&mut hconn_c);
 }
@@ -305,7 +311,7 @@ fn data_after_informational() {
 fn non_trailers_headers_after_data() {
     let (mut hconn_c, mut hconn_s, request) = connect_send_and_receive_request();
     send_headers(&request).unwrap();
-    request.send_data(RESPONSE_DATA).unwrap();
+    request.send_data(RESPONSE_DATA, now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
 
     assert_eq!(
@@ -313,7 +319,7 @@ fn non_trailers_headers_after_data() {
         Err(Error::InvalidHeader)
     );
 
-    request.stream_close_send().unwrap();
+    request.stream_close_send(now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     process_client_events(&mut hconn_c);
 }
@@ -321,11 +327,14 @@ fn non_trailers_headers_after_data() {
 #[test]
 fn data_before_headers() {
     let (mut hconn_c, mut hconn_s, request) = connect_send_and_receive_request();
-    assert_eq!(request.send_data(RESPONSE_DATA), Err(Error::InvalidInput));
+    assert_eq!(
+        request.send_data(RESPONSE_DATA, now()),
+        Err(Error::InvalidInput)
+    );
 
     send_headers(&request).unwrap();
-    request.send_data(RESPONSE_DATA).unwrap();
-    request.stream_close_send().unwrap();
+    request.send_data(RESPONSE_DATA, now()).unwrap();
+    request.stream_close_send(now()).unwrap();
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
     process_client_events(&mut hconn_c);
 }
@@ -335,12 +344,12 @@ fn server_send_single_udp_datagram() {
     let (mut hconn_c, mut hconn_s, request_1) = connect_send_and_receive_request();
 
     send_headers(&request_1).unwrap();
-    request_1.send_data(RESPONSE_DATA).unwrap();
+    request_1.send_data(RESPONSE_DATA, now()).unwrap();
 
     let request_2 = send_and_receive_request(&mut hconn_c, &mut hconn_s);
 
     // Request 1 has no pending data. This call goes straight to the QUIC layer.
-    request_1.stream_close_send().unwrap();
+    request_1.stream_close_send(now()).unwrap();
     // This adds pending data to request 2 on the HTTP/3 layer.
     send_headers(&request_2).unwrap();
 

--- a/neqo-http3/tests/webtransport.rs
+++ b/neqo-http3/tests/webtransport.rs
@@ -94,7 +94,9 @@ fn create_wt_session(client: &mut Http3Client, server: &mut Http3Server) -> WebT
                     headers.contains_header(":method", "CONNECT")
                         && headers.contains_header(":protocol", "webtransport")
                 );
-                session.response(&SessionAcceptAction::Accept).unwrap();
+                session
+                    .response(&SessionAcceptAction::Accept, now())
+                    .unwrap();
                 wt_server_session = Some(session);
             }
             Http3ServerEvent::Data { .. } => {
@@ -133,7 +135,10 @@ fn send_data_client(
     wt_stream_id: StreamId,
     data: &[u8],
 ) {
-    assert_eq!(client.send_data(wt_stream_id, data).unwrap(), data.len());
+    assert_eq!(
+        client.send_data(wt_stream_id, data, now()).unwrap(),
+        data.len()
+    );
     exchange_packets(client, server, false, None);
 }
 
@@ -143,7 +148,7 @@ fn send_data_server(
     wt_stream: &Http3OrWebTransportStream,
     data: &[u8],
 ) {
-    assert_eq!(wt_stream.send_data(data).unwrap(), data.len());
+    assert_eq!(wt_stream.send_data(data, now()).unwrap(), data.len());
     exchange_packets(client, server, false, None);
 }
 
@@ -356,7 +361,7 @@ fn wt_race_condition_server_stream_before_confirmation() {
             })
             .expect("Should receive WebTransport session request");
         wt_server_session
-            .response(&SessionAcceptAction::Accept)
+            .response(&SessionAcceptAction::Accept, now)
             .unwrap();
         let server_accept_dgram = server
             .process_output(now)
@@ -366,7 +371,7 @@ fn wt_race_condition_server_stream_before_confirmation() {
 
         // Server creates a stream, but hold back the UDP datagram.
         let wt_server_stream = wt_server_session.create_stream(StreamType::UniDi).unwrap();
-        assert_eq!(wt_server_stream.send_data(&[42]).unwrap(), 1);
+        assert_eq!(wt_server_stream.send_data(&[42], now).unwrap(), 1);
         let server_stream_dgram = server
             .process_output(now)
             .dgram()
@@ -459,7 +464,7 @@ fn wt_session_ok_and_wt_datagram_in_same_udp_datagram() {
         })
         .expect("Should receive WebTransport session request");
     wt_server_session
-        .response(&SessionAcceptAction::Accept)
+        .response(&SessionAcceptAction::Accept, now)
         .unwrap();
     wt_server_session.send_datagram(b"PING", None).unwrap();
     let accept_and_wt_datagram = server

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -8,6 +8,7 @@ use std::{
     cmp::min,
     collections::VecDeque,
     fmt::{self, Display, Formatter},
+    time::Instant,
 };
 
 use neqo_common::{qdebug, qerror, qlog::Qlog, qtrace, Header};
@@ -126,17 +127,22 @@ impl Encoder {
     ///
     /// May return: `ClosedCriticalStream` if stream has been closed or `DecoderStream`
     /// in case of any other transport error.
-    pub fn receive(&mut self, conn: &mut Connection, stream_id: StreamId) -> Res<()> {
-        self.read_instructions(conn, stream_id)
+    pub fn receive(&mut self, conn: &mut Connection, stream_id: StreamId, now: Instant) -> Res<()> {
+        self.read_instructions(conn, stream_id, now)
             .map_err(|e| map_error(&e))
     }
 
-    fn read_instructions(&mut self, conn: &mut Connection, stream_id: StreamId) -> Res<()> {
+    fn read_instructions(
+        &mut self,
+        conn: &mut Connection,
+        stream_id: StreamId,
+        now: Instant,
+    ) -> Res<()> {
         qdebug!("[{self}] read a new instruction");
         loop {
             let mut recv = ReceiverConnWrapper::new(conn, stream_id);
             match self.instruction_reader.read_instructions(&mut recv) {
-                Ok(instruction) => self.call_instruction(instruction, conn.qlog_mut())?,
+                Ok(instruction) => self.call_instruction(instruction, conn.qlog_mut(), now)?,
                 Err(Error::NeedMoreData) => break Ok(()),
                 Err(e) => break Err(e),
             }
@@ -216,7 +222,12 @@ impl Encoder {
         }
     }
 
-    fn call_instruction(&mut self, instruction: DecoderInstruction, qlog: &Qlog) -> Res<()> {
+    fn call_instruction(
+        &mut self,
+        instruction: DecoderInstruction,
+        qlog: &Qlog,
+        now: Instant,
+    ) -> Res<()> {
         qdebug!("[{self}] call instruction {instruction:?}");
         match instruction {
             DecoderInstruction::InsertCountIncrement { increment } => {
@@ -224,6 +235,7 @@ impl Encoder {
                     qlog,
                     increment,
                     &increment.to_be_bytes(),
+                    now,
                 );
 
                 self.insert_count_instruction(increment)
@@ -538,6 +550,8 @@ fn map_stream_send_atomic_error(err: &TransportError) -> Error {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use neqo_transport::{ConnectionParameters, StreamId, StreamType};
     use test_fixture::{
         default_client, default_server, handshake, new_server, now, CountingConnectionIdGenerator,
@@ -643,16 +657,16 @@ mod tests {
         connect_generic(true, Some(max_data))
     }
 
-    fn recv_instruction(encoder: &mut TestEncoder, decoder_instruction: &[u8]) {
+    fn recv_instruction(encoder: &mut TestEncoder, decoder_instruction: &[u8], now: Instant) {
         encoder
             .peer_conn
             .stream_send(encoder.recv_stream_id, decoder_instruction)
             .unwrap();
-        let out = encoder.peer_conn.process_output(now());
-        drop(encoder.conn.process(out.dgram(), now()));
+        let out = encoder.peer_conn.process_output(now);
+        drop(encoder.conn.process(out.dgram(), now));
         assert!(encoder
             .encoder
-            .read_instructions(&mut encoder.conn, encoder.recv_stream_id)
+            .read_instructions(&mut encoder.conn, encoder.recv_stream_id, now)
             .is_ok());
     }
 
@@ -912,7 +926,7 @@ mod tests {
         encoder.send_instructions(&[]);
 
         // receive an insert count increment.
-        recv_instruction(&mut encoder, &[0x01]);
+        recv_instruction(&mut encoder, &[0x01], now());
 
         // insert "content-length: 12345 again it will succeed.
         let res =
@@ -943,7 +957,7 @@ mod tests {
         encoder.send_instructions(HEADER_CONTENT_LENGTH_VALUE_1_NAME_LITERAL);
 
         // receive an insert count increment.
-        recv_instruction(&mut encoder, &[0x01]);
+        recv_instruction(&mut encoder, &[0x01], now());
 
         // send a header block
         let buf = encoder.encoder.encode_header_block(
@@ -965,10 +979,10 @@ mod tests {
 
         if wait == 0 {
             // receive a header_ack.
-            recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_1);
+            recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_1, now());
         } else {
             // receive a stream canceled
-            recv_instruction(&mut encoder, STREAM_CANCELED_ID_1);
+            recv_instruction(&mut encoder, STREAM_CANCELED_ID_1, now());
         }
 
         // insert "content-length: 12345 again it will succeed.
@@ -1189,7 +1203,7 @@ mod tests {
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 1);
 
         // receive a header_ack for the first header block.
-        recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_1);
+        recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_1, now());
 
         // The stream is still blocking because the second header block is not acked.
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 1);
@@ -1229,7 +1243,7 @@ mod tests {
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 1);
 
         // receive a header_ack for the first header block.
-        recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_1);
+        recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_1, now());
 
         // The stream is not blocking anymore because header ack also ACKs the instruction.
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 0);
@@ -1269,7 +1283,7 @@ mod tests {
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 2);
 
         // receive a header_ack for the second header block. This will ack the first as well
-        recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_2);
+        recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_2, now());
 
         // The stream is not blocking anymore because header ack also ACKs the instruction.
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 0);
@@ -1311,7 +1325,7 @@ mod tests {
         // receive a stream cancel for the first stream.
         // This will remove the first stream as blocking but it will not mark the instruction as
         // acked. and the second steam will still be blocking.
-        recv_instruction(&mut encoder, STREAM_CANCELED_ID_1);
+        recv_instruction(&mut encoder, STREAM_CANCELED_ID_1, now());
 
         // The stream is not blocking anymore because header ack also ACKs the instruction.
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 1);
@@ -1363,7 +1377,7 @@ mod tests {
         // stream 1 is block on entries 1 and 2; stream 2 is block only on 1.
         // receive an Insert Count Increment for the first entry.
         // After that only stream 1 will be blocking.
-        recv_instruction(&mut encoder, &[0x01]);
+        recv_instruction(&mut encoder, &[0x01], now());
 
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 1);
     }
@@ -1400,13 +1414,13 @@ mod tests {
         assert!(encoder.change_capacity(10).is_err());
 
         // receive an Insert Count Increment for the entry.
-        recv_instruction(&mut encoder, &[0x01]);
+        recv_instruction(&mut encoder, &[0x01], now());
 
         // trying to evict the entry will failed. The stream is still referring to it.
         assert!(encoder.change_capacity(10).is_err());
 
         // receive a header_ack for the header block.
-        recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_1);
+        recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_1, now());
 
         // now entry can be evicted.
         assert!(encoder.change_capacity(10).is_ok());
@@ -1444,13 +1458,13 @@ mod tests {
         assert!(encoder.change_capacity(10).is_err());
 
         // receive an Insert Count Increment for the entry.
-        recv_instruction(&mut encoder, &[0x01]);
+        recv_instruction(&mut encoder, &[0x01], now());
 
         // trying to evict the entry will failed. The stream is still referring to it.
         assert!(encoder.change_capacity(10).is_err());
 
         // receive a stream cancelled.
-        recv_instruction(&mut encoder, STREAM_CANCELED_ID_1);
+        recv_instruction(&mut encoder, STREAM_CANCELED_ID_1, now());
 
         // now entry can be evicted.
         assert!(encoder.change_capacity(10).is_ok());
@@ -1480,7 +1494,7 @@ mod tests {
         assert!(encoder.change_capacity(10).is_err());
 
         // receive an Insert Count Increment for the entry.
-        recv_instruction(&mut encoder, &[0x01]);
+        recv_instruction(&mut encoder, &[0x01], now());
 
         // now entry can be evicted.
         assert!(encoder.change_capacity(10).is_ok());
@@ -1519,7 +1533,7 @@ mod tests {
         assert!(encoder.change_capacity(10).is_err());
 
         // receive a header_ack for the header block. This will also ack the instruction.
-        recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_1);
+        recv_instruction(&mut encoder, HEADER_ACK_STREAM_ID_1, now());
 
         // now entry can be evicted.
         assert!(encoder.change_capacity(10).is_ok());
@@ -1628,7 +1642,7 @@ mod tests {
         let out = encoder.conn.process_output(now());
         drop(encoder.peer_conn.process(out.dgram(), now()));
         // receive an insert count increment.
-        recv_instruction(&mut encoder, &[0x01]);
+        recv_instruction(&mut encoder, &[0x01], now());
 
         // The first header will use the table entry and the second will use the literal
         // encoding because the first entry is referred to and cannot be evicted.
@@ -1677,8 +1691,8 @@ mod tests {
         );
 
         // receive a stream canceled instruction.
-        recv_instruction(&mut encoder, STREAM_CANCELED_ID_1);
+        recv_instruction(&mut encoder, STREAM_CANCELED_ID_1, now());
 
-        recv_instruction(&mut encoder, &[0x01]);
+        recv_instruction(&mut encoder, &[0x01], now());
     }
 }

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -6,30 +6,37 @@
 
 // Functions that handle capturing QLOG traces.
 
+use std::time::Instant;
+
 use neqo_common::{hex, qlog::Qlog};
 use qlog::events::{
     qpack::{QPackInstruction, QpackInstructionParsed, QpackInstructionTypeName},
     EventData, RawInfo,
 };
 
-/// Uses [`Qlog::add_event_data_now`] instead of
-/// [`Qlog::add_event_data_with_instant`], given that `now` is not available
-/// on call-site. See docs on [`Qlog::add_event_data_now`] for details.
-pub fn qpack_read_insert_count_increment_instruction(qlog: &Qlog, increment: u64, data: &[u8]) {
-    qlog.add_event_data_now(|| {
-        let raw = RawInfo {
-            length: Some(8),
-            payload_length: None,
-            data: Some(hex(data)),
-        };
-        let ev_data = EventData::QpackInstructionParsed(QpackInstructionParsed {
-            instruction: QPackInstruction::InsertCountIncrementInstruction {
-                instruction_type: QpackInstructionTypeName::InsertCountIncrementInstruction,
-                increment,
-            },
-            raw: Some(raw),
-        });
+pub fn qpack_read_insert_count_increment_instruction(
+    qlog: &Qlog,
+    increment: u64,
+    data: &[u8],
+    now: Instant,
+) {
+    qlog.add_event_data_with_instant(
+        || {
+            let raw = RawInfo {
+                length: Some(8),
+                payload_length: None,
+                data: Some(hex(data)),
+            };
+            let ev_data = EventData::QpackInstructionParsed(QpackInstructionParsed {
+                instruction: QPackInstruction::InsertCountIncrementInstruction {
+                    instruction_type: QpackInstructionTypeName::InsertCountIncrementInstruction,
+                    increment,
+                },
+                raw: Some(raw),
+            });
 
-        Some(ev_data)
-    });
+            Some(ev_data)
+        },
+        now,
+    );
 }

--- a/test-fixture/src/sim/http3_connection.rs
+++ b/test-fixture/src/sim/http3_connection.rs
@@ -276,9 +276,9 @@ impl Requests {
             if self.amount == 0 {
                 return;
             }
-
+            let now = now();
             let stream_id = match c.fetch(
-                now(),
+                now,
                 "POST",
                 ("https", "something.com", "/"),
                 &[],
@@ -293,17 +293,17 @@ impl Requests {
             qdebug!("[{c}] made stream {stream_id} for sending");
             self.remaining.insert(stream_id, self.send_per_request);
             self.amount -= 1;
-            self.send(c, stream_id);
+            self.send(c, stream_id, now);
         }
     }
 
-    fn send(&mut self, c: &mut Http3Client, stream_id: StreamId) -> GoalStatus {
+    fn send(&mut self, c: &mut Http3Client, stream_id: StreamId, now: Instant) -> GoalStatus {
         const DATA: &[u8] = &[0; 4096];
         let mut status = GoalStatus::Waiting;
         loop {
             let remaining = self.remaining.get_mut(&stream_id).unwrap();
             let end = min(*remaining, DATA.len());
-            let sent = c.send_data(stream_id, &DATA[..end]).unwrap();
+            let sent = c.send_data(stream_id, &DATA[..end], now).unwrap();
             if sent == 0 {
                 return status;
             }
@@ -311,7 +311,7 @@ impl Requests {
             *remaining -= sent;
             qtrace!("sent {sent} remaining {}", remaining);
             if *remaining == 0 {
-                c.stream_close_send(stream_id).unwrap();
+                c.stream_close_send(stream_id, now).unwrap();
                 self.remaining.remove(&stream_id);
                 return status;
             }
@@ -340,7 +340,7 @@ impl Goal for Requests {
         GoalStatus::Waiting
     }
 
-    fn handle_event(&mut self, c: &mut Endpoint, e: &Event, _now: Instant) -> GoalStatus {
+    fn handle_event(&mut self, c: &mut Endpoint, e: &Event, now: Instant) -> GoalStatus {
         let e = match e {
             Event::Client(http3_client_event) => http3_client_event,
             Event::Server(_) => unreachable!("only client can make a request"),
@@ -354,7 +354,7 @@ impl Goal for Requests {
                 self.fetch(c);
                 GoalStatus::Active
             }
-            Http3ClientEvent::DataWritable { stream_id } => self.send(c, *stream_id),
+            Http3ClientEvent::DataWritable { stream_id } => self.send(c, *stream_id, now),
 
             // If we sent data in 0-RTT, then we didn't track how much we should
             // have sent.  This is trivial to fix if 0-RTT testing is ever needed.
@@ -388,7 +388,7 @@ impl Responses {
 }
 
 impl Goal for Responses {
-    fn handle_event(&mut self, _c: &mut Endpoint, e: &Event, _now: Instant) -> GoalStatus {
+    fn handle_event(&mut self, _c: &mut Endpoint, e: &Event, now: Instant) -> GoalStatus {
         let e = match e {
             Event::Client(_) => unreachable!("only server can send a response"),
             Event::Server(http3_server_event) => http3_server_event,
@@ -417,7 +417,7 @@ impl Goal for Responses {
                     stream
                         .send_headers(&[Header::new(":status", "200")])
                         .unwrap();
-                    stream.stream_close_send().unwrap();
+                    stream.stream_close_send(now).unwrap();
                     self.remaining.remove(&stream_id);
                 }
 


### PR DESCRIPTION
So `qlog` always logs the time we maintain. Broken out of #3005.