### PR TITLE
chore: `QlogMetric` -> `qlog::Metric`

### DIFF
--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -16,14 +16,7 @@ use ::qlog::events::{quic::CongestionStateUpdated, EventData};
 use neqo_common::{const_max, const_min, qdebug, qinfo, qlog::Qlog, qtrace};
 
 use super::CongestionControl;
-use crate::{
-    packet,
-    qlog::{self, QlogMetric},
-    recovery::sent,
-    rtt::RttEstimate,
-    sender::PACING_BURST_SIZE,
-    Pmtud,
-};
+use crate::{packet, qlog, recovery::sent, rtt::RttEstimate, sender::PACING_BURST_SIZE, Pmtud};
 
 pub const CWND_INITIAL_PKTS: usize = 10;
 const PERSISTENT_CONG_THRESH: u32 = 3;
@@ -210,7 +203,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
 
             if self.state.in_recovery() {
                 self.set_state(State::CongestionAvoidance, now);
-                qlog::metrics_updated(&self.qlog, &[QlogMetric::InRecovery(false)], now);
+                qlog::metrics_updated(&self.qlog, &[qlog::Metric::InRecovery(false)], now);
             }
 
             new_acked += pkt.len();
@@ -266,8 +259,8 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
         qlog::metrics_updated(
             &self.qlog,
             &[
-                QlogMetric::CongestionWindow(self.congestion_window),
-                QlogMetric::BytesInFlight(self.bytes_in_flight),
+                qlog::Metric::CongestionWindow(self.congestion_window),
+                qlog::Metric::BytesInFlight(self.bytes_in_flight),
             ],
             now,
         );
@@ -299,7 +292,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
         }
         qlog::metrics_updated(
             &self.qlog,
-            &[QlogMetric::BytesInFlight(self.bytes_in_flight)],
+            &[qlog::Metric::BytesInFlight(self.bytes_in_flight)],
             now,
         );
 
@@ -346,7 +339,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
             self.bytes_in_flight -= pkt.len();
             qlog::metrics_updated(
                 &self.qlog,
-                &[QlogMetric::BytesInFlight(self.bytes_in_flight)],
+                &[qlog::Metric::BytesInFlight(self.bytes_in_flight)],
                 now,
             );
             qtrace!("[{self}] Ignore pkt with size {}", pkt.len());
@@ -357,7 +350,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
         self.bytes_in_flight = 0;
         qlog::metrics_updated(
             &self.qlog,
-            &[QlogMetric::BytesInFlight(self.bytes_in_flight)],
+            &[qlog::Metric::BytesInFlight(self.bytes_in_flight)],
             now,
         );
     }
@@ -388,7 +381,7 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
         );
         qlog::metrics_updated(
             &self.qlog,
-            &[QlogMetric::BytesInFlight(self.bytes_in_flight)],
+            &[qlog::Metric::BytesInFlight(self.bytes_in_flight)],
             now,
         );
     }
@@ -520,7 +513,7 @@ impl<T: WindowAdjustment> ClassicCongestionControl<T> {
                     self.set_state(State::PersistentCongestion, now);
                     qlog::metrics_updated(
                         &self.qlog,
-                        &[QlogMetric::CongestionWindow(self.congestion_window)],
+                        &[qlog::Metric::CongestionWindow(self.congestion_window)],
                         now,
                     );
                     return true;
@@ -568,9 +561,9 @@ impl<T: WindowAdjustment> ClassicCongestionControl<T> {
         qlog::metrics_updated(
             &self.qlog,
             &[
-                QlogMetric::CongestionWindow(self.congestion_window),
-                QlogMetric::SsThresh(self.ssthresh),
-                QlogMetric::InRecovery(true),
+                qlog::Metric::CongestionWindow(self.congestion_window),
+                qlog::Metric::SsThresh(self.ssthresh),
+                qlog::Metric::InRecovery(true),
             ],
             now,
         );

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -298,7 +298,7 @@ pub fn packets_lost(qlog: &Qlog, pkts: &[sent::Packet], now: Instant) {
 }
 
 #[expect(dead_code, reason = "TODO: Construct all variants.")]
-pub enum QlogMetric {
+pub enum Metric {
     MinRtt(Duration),
     SmoothedRtt(Duration),
     LatestRtt(Duration),
@@ -313,7 +313,7 @@ pub enum QlogMetric {
     PacingRate(u64),
 }
 
-pub fn metrics_updated(qlog: &Qlog, updated_metrics: &[QlogMetric], now: Instant) {
+pub fn metrics_updated(qlog: &Qlog, updated_metrics: &[Metric], now: Instant) {
     debug_assert!(!updated_metrics.is_empty());
 
     qlog.add_event_data_with_instant(
@@ -331,24 +331,24 @@ pub fn metrics_updated(qlog: &Qlog, updated_metrics: &[QlogMetric], now: Instant
 
             for metric in updated_metrics {
                 match metric {
-                    QlogMetric::MinRtt(v) => min_rtt = Some(v.as_secs_f32() * 1000.0),
-                    QlogMetric::SmoothedRtt(v) => smoothed_rtt = Some(v.as_secs_f32() * 1000.0),
-                    QlogMetric::LatestRtt(v) => latest_rtt = Some(v.as_secs_f32() * 1000.0),
-                    QlogMetric::RttVariance(v) => rtt_variance = Some(v.as_secs_f32() * 1000.0),
-                    QlogMetric::PtoCount(v) => {
+                    Metric::MinRtt(v) => min_rtt = Some(v.as_secs_f32() * 1000.0),
+                    Metric::SmoothedRtt(v) => smoothed_rtt = Some(v.as_secs_f32() * 1000.0),
+                    Metric::LatestRtt(v) => latest_rtt = Some(v.as_secs_f32() * 1000.0),
+                    Metric::RttVariance(v) => rtt_variance = Some(v.as_secs_f32() * 1000.0),
+                    Metric::PtoCount(v) => {
                         pto_count = Some(u16::try_from(*v).expect("fits in u16"));
                     }
-                    QlogMetric::CongestionWindow(v) => {
+                    Metric::CongestionWindow(v) => {
                         congestion_window = Some(u64::try_from(*v).expect("fits in u64"));
                     }
-                    QlogMetric::BytesInFlight(v) => {
+                    Metric::BytesInFlight(v) => {
                         bytes_in_flight = Some(u64::try_from(*v).expect("fits in u64"));
                     }
-                    QlogMetric::SsThresh(v) => {
+                    Metric::SsThresh(v) => {
                         ssthresh = Some(u64::try_from(*v).expect("fits in u64"));
                     }
-                    QlogMetric::PacketsInFlight(v) => packets_in_flight = Some(*v),
-                    QlogMetric::PacingRate(v) => pacing_rate = Some(*v),
+                    Metric::PacketsInFlight(v) => packets_in_flight = Some(*v),
+                    Metric::PacingRate(v) => pacing_rate = Some(*v),
                     _ => (),
                 }
             }

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -28,7 +28,7 @@ pub use token::{StreamRecoveryToken, Token, Tokens};
 use crate::{
     ecn, packet,
     path::{Path, PathRef},
-    qlog::{self, QlogMetric},
+    qlog,
     rtt::{RttEstimate, RttSource},
     stats::{Stats, StatsCell},
     tracking::{PacketNumberSpace, PacketNumberSpaceSet},
@@ -808,7 +808,7 @@ impl Loss {
 
         if let Some(st) = &mut self.pto_state {
             st.count_pto(&mut self.stats.borrow_mut());
-            qlog::metrics_updated(&self.qlog, &[QlogMetric::PtoCount(st.count())], now);
+            qlog::metrics_updated(&self.qlog, &[qlog::Metric::PtoCount(st.count())], now);
         }
     }
 

--- a/neqo-transport/src/rtt.rs
+++ b/neqo-transport/src/rtt.rs
@@ -15,9 +15,7 @@ use neqo_common::{qlog::Qlog, qtrace, Buffer};
 
 use crate::{
     ackrate::{AckRate, PeerAckDelay},
-    packet,
-    qlog::{self, QlogMetric},
-    recovery,
+    packet, qlog, recovery,
     stats::FrameStats,
 };
 
@@ -143,10 +141,10 @@ impl RttEstimate {
         qlog::metrics_updated(
             qlog,
             &[
-                QlogMetric::LatestRtt(self.latest_rtt),
-                QlogMetric::MinRtt(self.min_rtt),
-                QlogMetric::SmoothedRtt(self.smoothed_rtt),
-                QlogMetric::RttVariance(self.rttvar),
+                qlog::Metric::LatestRtt(self.latest_rtt),
+                qlog::Metric::MinRtt(self.min_rtt),
+                qlog::Metric::SmoothedRtt(self.smoothed_rtt),
+                qlog::Metric::RttVariance(self.rttvar),
             ],
             now,
         );


### PR DESCRIPTION
Broken out of #3005.