### PR TITLE
feat(http3): optimize stream sending to avoid blocked streams

### DIFF
--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -75,7 +75,7 @@ impl Http3ServerHandler {
             .ok_or(Error::InvalidStreamId)?
             .send_data(conn, data)?;
         if n > 0 {
-            self.base_handler.stream_has_pending_data(stream_id);
+            self.base_handler.mark_stream_for_sending(stream_id);
         }
         self.needs_processing = true;
         Ok(n)
@@ -95,7 +95,7 @@ impl Http3ServerHandler {
             .http_stream()
             .ok_or(Error::InvalidStreamId)?
             .send_headers(headers, conn)?;
-        self.base_handler.stream_has_pending_data(stream_id);
+        self.base_handler.mark_stream_for_sending(stream_id);
         self.needs_processing = true;
         Ok(())
     }


### PR DESCRIPTION
Implements optimizations to address wasteful attempts to send data on flow-control blocked streams and fixes iteration patterns that could lose streams during re-addition.

Key improvements:
- Add blocked_streams HashSet to track flow-control blocked streams separately
- Modify stream_has_pending_data() to skip adding blocked streams to pending queue
- Add check_blocked_streams() method to automatically move unblocked streams back

Benefits:
- Reduces CPU usage by eliminating repeated attempts on blocked streams
- Improves responsiveness by automatically detecting when streams become unblocked

Closes #261