### PR TITLE
fix(http3/connect-udp): parse context id as varint

### DIFF
--- a/neqo-http3/src/features/extended_connect/connect_udp_session.rs
+++ b/neqo-http3/src/features/extended_connect/connect_udp_session.rs
@@ -97,3 +97,26 @@ impl Protocol for Session {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use neqo_transport::StreamId;
+
+    use super::Session;
+    use crate::features::extended_connect::session::Protocol as _;
+
+    #[test]
+    fn varint_0_context_id() {
+        let session = Session::new(StreamId::new(42));
+        // Varint [0x00] is 0, i.e. a supported connect-udp context ID.
+        assert_eq!(
+            session.dgram_context_id(&[0x00, 0x00, 0x00]).unwrap(),
+            &[0x00, 0x00]
+        );
+        // Varint [0x40 0x00] is 0 as well, thus a supported connect-udp context ID, too.
+        assert_eq!(
+            session.dgram_context_id(&[0x40, 0x00, 0x00, 0x00]).unwrap(),
+            &[0x00, 0x00]
+        );
+    }
+}

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -551,5 +551,5 @@ pub(crate) enum DgramContextIdError {
     #[error("Missing context identifier")]
     MissingIdentifier,
     #[error("Unknown context identifier: {0}")]
-    UnknownIdentifier(u8),
+    UnknownIdentifier(u64),
 }


### PR DESCRIPTION
MASQUE connect-udp prefixes each proxied UDP datagram payload with a context ID. A context ID is a varint.

> Context IDs are 62-bit integers (0 to 262-1). Context IDs are encoded as variable-length integers; see Section 16 of [QUIC].

https://www.rfc-editor.org/rfc/rfc9298.html#section-4

Previously the code would parse the first byte only, checking whether it is 0x00. But 0x00 is not the only varint encoding of 0. Another e.g. is 0x40 0x00.

This commit properly parses the context ID as a varint.

---

Fixes https://github.com/mozilla/neqo/issues/3017