### PR TITLE
feat: Use `jemalloc` as allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "url",
 ]
@@ -843,6 +844,7 @@ dependencies = [
  "strum",
  "test-fixture",
  "thiserror",
+ "tikv-jemallocator",
  "windows",
 ]
 
@@ -882,6 +884,7 @@ dependencies = [
  "strum",
  "test-fixture",
  "thiserror",
+ "tikv-jemallocator",
  "url",
 ]
 
@@ -919,6 +922,7 @@ dependencies = [
  "strum",
  "test-fixture",
  "thiserror",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -1318,6 +1322,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/neqo-bin/Cargo.toml
+++ b/neqo-bin/Cargo.toml
@@ -44,6 +44,9 @@ thiserror = { workspace = true }
 tokio = { version = "1", default-features = false, features = ["net", "time", "macros", "rt"] }
 url = { workspace = true }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6", default-features = false }
+
 [dev-dependencies]
 criterion = { version = "0.6", default-features = false, features = ["async_tokio", "cargo_bench_support"] }
 neqo-bin = { path = ".", features = ["draft-29"] }

--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -10,7 +10,13 @@ use std::{env, hint::black_box, net::SocketAddr, path::PathBuf, str::FromStr as 
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 use neqo_bin::{client, server};
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
 use tokio::runtime::Builder;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 struct Benchmark {
     name: String,

--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -12,12 +12,12 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughpu
 use neqo_bin::{client, server};
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
-use tokio::runtime::Builder;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
+use tokio::runtime::Builder;
 struct Benchmark {
     name: String,
     num_requests: usize,

--- a/neqo-bin/src/bin/client.rs
+++ b/neqo-bin/src/bin/client.rs
@@ -5,6 +5,12 @@
 // except according to those terms.
 
 use clap::Parser as _;
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[tokio::main(flavor = "current_thread")]
 #[allow(

--- a/neqo-bin/src/bin/server.rs
+++ b/neqo-bin/src/bin/server.rs
@@ -6,6 +6,12 @@
 
 use clap::Parser as _;
 use neqo_bin::server::Res;
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[tokio::main(flavor = "current_thread")]
 #[allow(

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -24,6 +24,9 @@ qlog = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6", default-features = false }
+
 [target."cfg(windows)".dependencies]
 windows = { workspace = true , features = ["Win32_Media"] }
 

--- a/neqo-common/benches/decoder.rs
+++ b/neqo-common/benches/decoder.rs
@@ -11,6 +11,12 @@ use std::hint::black_box;
 use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_common::Decoder;
 use neqo_crypto::{init, randomize};
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 fn randomize_buffer(n: usize, mask: u8) -> Vec<u8> {
     let mut buf = vec![0; n];

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -32,6 +32,9 @@ strum = { workspace = true}
 thiserror = { workspace = true}
 url = { workspace = true }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6", default-features = false }
+
 [dev-dependencies]
 criterion = { version = "0.6", default-features = false, features = ["cargo_bench_support"] }
 neqo-http3 = { path = ".", features = ["draft-29"] }

--- a/neqo-http3/benches/streams.rs
+++ b/neqo-http3/benches/streams.rs
@@ -15,6 +15,12 @@ use test_fixture::{
         ReadySimulator, Simulator,
     },
 };
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 const ZERO: Duration = Duration::from_millis(0);
 const JITTER: Duration = Duration::from_millis(10);

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -16,7 +16,6 @@ readme.workspace = true
 workspace = true
 
 [dependencies]
-# Checked against https://searchfox.org/mozilla-central/source/Cargo.lock 2024-11-11
 enum-map = { workspace = true }
 enumset = { workspace = true }
 indexmap = { version = "2.2", default-features = false } # See https://github.com/mozilla/neqo/issues/1858
@@ -30,6 +29,9 @@ smallvec = { version = "1.13", default-features = false, features = ["union", "c
 static_assertions = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.6", default-features = false, features = ["cargo_bench_support"] }

--- a/neqo-transport/benches/min_bandwidth.rs
+++ b/neqo-transport/benches/min_bandwidth.rs
@@ -24,6 +24,12 @@ use test_fixture::{
         Simulator,
     },
 };
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 /// Run a transfer of a gigabyte over a gigabit link.
 /// Check to see that the achieved transfer rate matches expectations.

--- a/neqo-transport/benches/range_tracker.rs
+++ b/neqo-transport/benches/range_tracker.rs
@@ -8,6 +8,12 @@ use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_transport::send_stream::RangeTracker;
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 const CHUNK: u64 = 1000;
 const END: u64 = 100_000;

--- a/neqo-transport/benches/rx_stream_orderer.rs
+++ b/neqo-transport/benches/rx_stream_orderer.rs
@@ -8,6 +8,12 @@ use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use neqo_transport::recv_stream::RxStreamOrderer;
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 fn rx_stream_orderer() {
     let mut rx = RxStreamOrderer::new();

--- a/neqo-transport/benches/sent_packets.rs
+++ b/neqo-transport/benches/sent_packets.rs
@@ -11,6 +11,12 @@ use neqo_transport::{
     self, packet,
     recovery::{self, sent},
 };
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 fn sent_packets() -> sent::Packets {
     let mut pkts = sent::Packets::default();

--- a/neqo-transport/benches/transfer.rs
+++ b/neqo-transport/benches/transfer.rs
@@ -16,6 +16,12 @@ use test_fixture::{
         Simulator,
     },
 };
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 const ZERO: Duration = Duration::from_millis(0);
 const JITTER: Duration = Duration::from_millis(10);


### PR DESCRIPTION
Gecko uses (it's own flavor of) `jemalloc`, including for Rust. The intent here is to get the standalone demo client and server, and the benchmarks, closer to Gecko.

As discussed with @valenting.

TODO: Is there a way to put this behind a feature or something, so that the `tikv-jemallocator` crate doesn't become part of the Gecko deps when vendored in?