### PR TITLE
fix: Don't condition `neqo_common::log::init` on `cfg(test)`

### DIFF
--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -52,6 +52,12 @@ pub fn init(level_filter: Option<log::LevelFilter>) {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qerror {
     ($($arg:tt)*) => ( {
+<<<<<<< Updated upstream
+||||||| Stash base
+        #[cfg(any(test, feature = "bench"))]
+=======
+        #[cfg(debug_assertions)]
+>>>>>>> Stashed changes
         ::neqo_common::log::init(None);
         ::log::error!($($arg)*);
     } );
@@ -60,6 +66,12 @@ macro_rules! qerror {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qwarn {
     ($($arg:tt)*) => ( {
+<<<<<<< Updated upstream
+||||||| Stash base
+        #[cfg(any(test, feature = "bench"))]
+=======
+        #[cfg(debug_assertions)]
+>>>>>>> Stashed changes
         ::neqo_common::log::init(None);
         ::log::warn!($($arg)*);
     } );
@@ -68,6 +80,12 @@ macro_rules! qwarn {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qinfo {
     ($($arg:tt)*) => ( {
+<<<<<<< Updated upstream
+||||||| Stash base
+        #[cfg(any(test, feature = "bench"))]
+=======
+        #[cfg(debug_assertions)]
+>>>>>>> Stashed changes
         ::neqo_common::log::init(None);
         ::log::info!($($arg)*);
     } );
@@ -76,6 +94,12 @@ macro_rules! qinfo {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qdebug {
     ($($arg:tt)*) => ( {
+<<<<<<< Updated upstream
+||||||| Stash base
+        #[cfg(any(test, feature = "bench"))]
+=======
+        #[cfg(debug_assertions)]
+>>>>>>> Stashed changes
         ::neqo_common::log::init(None);
         ::log::debug!($($arg)*);
     } );
@@ -84,6 +108,12 @@ macro_rules! qdebug {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qtrace {
     ($($arg:tt)*) => ( {
+<<<<<<< Updated upstream
+||||||| Stash base
+        #[cfg(any(test, feature = "bench"))]
+=======
+        #[cfg(debug_assertions)]
+>>>>>>> Stashed changes
         ::neqo_common::log::init(None);
         ::log::trace!($($arg)*);
     } );

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -52,39 +52,39 @@ pub fn init(level_filter: Option<log::LevelFilter>) {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qerror {
     ($($arg:tt)*) => ( {
-        ::neqo_common::log::init(None);
-        ::log::error!($($arg)*);
+        // ::neqo_common::log::init(None);
+        // ::log::error!($($arg)*);
     } );
 }
 #[macro_export]
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qwarn {
     ($($arg:tt)*) => ( {
-        ::neqo_common::log::init(None);
-        ::log::warn!($($arg)*);
+        // ::neqo_common::log::init(None);
+        // ::log::warn!($($arg)*);
     } );
 }
 #[macro_export]
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qinfo {
     ($($arg:tt)*) => ( {
-        ::neqo_common::log::init(None);
-        ::log::info!($($arg)*);
+        // ::neqo_common::log::init(None);
+        // ::log::info!($($arg)*);
     } );
 }
 #[macro_export]
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qdebug {
     ($($arg:tt)*) => ( {
-        ::neqo_common::log::init(None);
-        ::log::debug!($($arg)*);
+        // ::neqo_common::log::init(None);
+        // ::log::debug!($($arg)*);
     } );
 }
 #[macro_export]
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qtrace {
     ($($arg:tt)*) => ( {
-        ::neqo_common::log::init(None);
-        ::log::trace!($($arg)*);
+        // ::neqo_common::log::init(None);
+        // ::log::trace!($($arg)*);
     } );
 }

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -52,12 +52,7 @@ pub fn init(level_filter: Option<log::LevelFilter>) {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qerror {
     ($($arg:tt)*) => ( {
-<<<<<<< Updated upstream
-||||||| Stash base
-        #[cfg(any(test, feature = "bench"))]
-=======
         #[cfg(debug_assertions)]
->>>>>>> Stashed changes
         ::neqo_common::log::init(None);
         ::log::error!($($arg)*);
     } );
@@ -66,12 +61,7 @@ macro_rules! qerror {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qwarn {
     ($($arg:tt)*) => ( {
-<<<<<<< Updated upstream
-||||||| Stash base
-        #[cfg(any(test, feature = "bench"))]
-=======
         #[cfg(debug_assertions)]
->>>>>>> Stashed changes
         ::neqo_common::log::init(None);
         ::log::warn!($($arg)*);
     } );
@@ -80,12 +70,7 @@ macro_rules! qwarn {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qinfo {
     ($($arg:tt)*) => ( {
-<<<<<<< Updated upstream
-||||||| Stash base
-        #[cfg(any(test, feature = "bench"))]
-=======
         #[cfg(debug_assertions)]
->>>>>>> Stashed changes
         ::neqo_common::log::init(None);
         ::log::info!($($arg)*);
     } );
@@ -94,12 +79,7 @@ macro_rules! qinfo {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qdebug {
     ($($arg:tt)*) => ( {
-<<<<<<< Updated upstream
-||||||| Stash base
-        #[cfg(any(test, feature = "bench"))]
-=======
         #[cfg(debug_assertions)]
->>>>>>> Stashed changes
         ::neqo_common::log::init(None);
         ::log::debug!($($arg)*);
     } );
@@ -108,12 +88,7 @@ macro_rules! qdebug {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qtrace {
     ($($arg:tt)*) => ( {
-<<<<<<< Updated upstream
-||||||| Stash base
-        #[cfg(any(test, feature = "bench"))]
-=======
         #[cfg(debug_assertions)]
->>>>>>> Stashed changes
         ::neqo_common::log::init(None);
         ::log::trace!($($arg)*);
     } );

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -52,7 +52,6 @@ pub fn init(level_filter: Option<log::LevelFilter>) {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qerror {
     ($($arg:tt)*) => ( {
-        #[cfg(any(test, feature = "bench"))]
         ::neqo_common::log::init(None);
         ::log::error!($($arg)*);
     } );
@@ -61,7 +60,6 @@ macro_rules! qerror {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qwarn {
     ($($arg:tt)*) => ( {
-        #[cfg(any(test, feature = "bench"))]
         ::neqo_common::log::init(None);
         ::log::warn!($($arg)*);
     } );
@@ -70,7 +68,6 @@ macro_rules! qwarn {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qinfo {
     ($($arg:tt)*) => ( {
-        #[cfg(any(test, feature = "bench"))]
         ::neqo_common::log::init(None);
         ::log::info!($($arg)*);
     } );
@@ -79,7 +76,6 @@ macro_rules! qinfo {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qdebug {
     ($($arg:tt)*) => ( {
-        #[cfg(any(test, feature = "bench"))]
         ::neqo_common::log::init(None);
         ::log::debug!($($arg)*);
     } );
@@ -88,7 +84,6 @@ macro_rules! qdebug {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qtrace {
     ($($arg:tt)*) => ( {
-        #[cfg(any(test, feature = "bench"))]
         ::neqo_common::log::init(None);
         ::log::trace!($($arg)*);
     } );

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -52,39 +52,39 @@ pub fn init(level_filter: Option<log::LevelFilter>) {
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qerror {
     ($($arg:tt)*) => ( {
-        // ::neqo_common::log::init(None);
-        // ::log::error!($($arg)*);
+        ::neqo_common::log::init(None);
+        ::log::error!($($arg)*);
     } );
 }
 #[macro_export]
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qwarn {
     ($($arg:tt)*) => ( {
-        // ::neqo_common::log::init(None);
-        // ::log::warn!($($arg)*);
+        ::neqo_common::log::init(None);
+        ::log::warn!($($arg)*);
     } );
 }
 #[macro_export]
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qinfo {
     ($($arg:tt)*) => ( {
-        // ::neqo_common::log::init(None);
-        // ::log::info!($($arg)*);
+        ::neqo_common::log::init(None);
+        ::log::info!($($arg)*);
     } );
 }
 #[macro_export]
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qdebug {
     ($($arg:tt)*) => ( {
-        // ::neqo_common::log::init(None);
-        // ::log::debug!($($arg)*);
+        ::neqo_common::log::init(None);
+        ::log::debug!($($arg)*);
     } );
 }
 #[macro_export]
 // TODO: Enable `#[clippy::format_args]` once our MSRV is >= 1.84
 macro_rules! qtrace {
     ($($arg:tt)*) => ( {
-        // ::neqo_common::log::init(None);
-        // ::log::trace!($($arg)*);
+        ::neqo_common::log::init(None);
+        ::log::trace!($($arg)*);
     } );
 }


### PR DESCRIPTION
Turns out we cannot make the initialization conditioned on `cfg(test)`, because before a test uses one of the logging macros, the log init won't happen and there will no output :-(

Fixes #2368