### PR TITLE
feat(udp): expose quinn-udp may_fragment

### DIFF
--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -614,6 +614,10 @@ pub async fn client(mut args: Args) -> Res<()> {
             exit(1);
         };
         let mut socket = crate::udp::Socket::bind(local_addr_for(&remote_addr, 0))?;
+        if socket.may_fragment() {
+            qinfo!("Datagrams may be fragmented by the IP layer. Disabling PMTUD.");
+            args.shared.quic_parameters.no_pmtud = true;
+        }
         let real_local = socket.local_addr().unwrap();
         qinfo!(
             "{} Client connecting: {real_local:?} -> {remote_addr:?}",

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -110,4 +110,11 @@ impl Socket {
     pub fn max_gso_segments(&self) -> usize {
         self.state.max_gso_segments()
     }
+
+    /// Whether transmitted datagrams might get fragmented by the IP layer
+    ///
+    /// Returns `false` on targets which employ e.g. the `IPV6_DONTFRAG` socket option.
+    pub fn may_fragment(&self) -> bool {
+        self.state.may_fragment()
+    }
 }

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -255,6 +255,13 @@ impl<S: SocketRef> Socket<S> {
     ) -> Result<DatagramIter<'a>, io::Error> {
         recv_inner(local_address, &self.state, &self.inner, recv_buf)
     }
+
+    /// Whether transmitted datagrams might get fragmented by the IP layer
+    ///
+    /// Returns `false` on targets which employ e.g. the `IPV6_DONTFRAG` socket option.
+    pub fn may_fragment(&self) -> bool {
+        self.state.may_fragment()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
quinn-udp exposes `fn may_fragment`:

``` rust
    /// Whether transmitted datagrams might get fragmented by the IP layer
    ///
    /// Returns `false` on targets which employ e.g. the `IPV6_DONTFRAG` socket option.
    #[inline]
    pub fn may_fragment(&self) -> bool {
```

This commit exposes this function through neqo-udp to be used in Firefox. When the socket `may_fragment`, Firefox should disable PMTUD.

In addition, this commit updates neqo-bin to disable PMTUD on `may_fragment`, too.