### PR TITLE
refactor(crypto): replace dynamic expansion() calls with AEAD_EXPANSION_SIZE

### DIFF
--- a/neqo-crypto/src/lib.rs
+++ b/neqo-crypto/src/lib.rs
@@ -39,7 +39,7 @@ pub use self::aead::RealAead;
 #[cfg(feature = "disable-encryption")]
 pub use self::aead_null::AeadNull as Aead;
 pub use self::{
-    aead::Aead as AeadTrait,
+    aead::{Aead as AeadTrait, AEAD_EXPANSION_SIZE},
     agent::{
         Agent, AllowZeroRtt, Client, HandshakeState, Record, RecordList, ResumptionToken,
         SecretAgent, SecretAgentInfo, SecretAgentPreInfo, Server, ZeroRttCheckResult,

--- a/neqo-crypto/src/selfencrypt.rs
+++ b/neqo-crypto/src/selfencrypt.rs
@@ -14,7 +14,7 @@ use crate::{
     err::{Error, Res},
     hkdf,
     p11::{random, SymKey},
-    Aead,
+    Aead, AEAD_EXPANSION_SIZE,
 };
 
 #[derive(Debug)]
@@ -85,7 +85,7 @@ impl SelfEncrypt {
         // AAD covers the entire header, plus the value of the AAD parameter that is provided.
         let salt = random::<{ Self::SALT_LENGTH }>();
         let cipher = self.make_aead(&self.key, &salt)?;
-        let encoded_len = 2 + salt.len() + plaintext.len() + cipher.expansion();
+        let encoded_len = 2 + salt.len() + plaintext.len() + AEAD_EXPANSION_SIZE;
 
         let mut enc = Encoder::with_capacity(encoded_len);
         enc.encode_byte(Self::VERSION);

--- a/neqo-crypto/tests/aead.rs
+++ b/neqo-crypto/tests/aead.rs
@@ -9,7 +9,7 @@
 
 use neqo_crypto::{
     constants::{Cipher, TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
-    hkdf, Aead, AeadTrait as _,
+    hkdf, Aead, AeadTrait as _, AEAD_EXPANSION_SIZE,
 };
 use test_fixture::fixture_init;
 
@@ -126,7 +126,7 @@ fn aead_encrypt_in_place_too_small_buffer() {
     let aead = make_aead(TLS_AES_128_GCM_SHA256);
 
     // Create a buffer that's smaller than the expansion size
-    let mut small_buffer = vec![0u8; aead.expansion() - 1];
+    let mut small_buffer = vec![0u8; AEAD_EXPANSION_SIZE - 1];
 
     let result = aead.encrypt_in_place(1, AAD, &mut small_buffer);
     assert!(result.is_err());

--- a/neqo-transport/src/packet/retry.rs
+++ b/neqo-transport/src/packet/retry.rs
@@ -47,9 +47,3 @@ where
         Error::Internal
     })?
 }
-
-/// Determine how large the expansion is for a given key.
-pub fn expansion(version: Version) -> usize {
-    use_aead(version, |aead| Ok(aead.expansion()))
-        .unwrap_or_else(|_| panic!("Unable to access Retry AEAD"))
-}

--- a/neqo-transport/tests/connection.rs
+++ b/neqo-transport/tests/connection.rs
@@ -7,7 +7,7 @@
 mod common;
 use common::assert_dscp;
 use neqo_common::{Datagram, Decoder, Encoder, Role};
-use neqo_crypto::AeadTrait as _;
+use neqo_crypto::{AeadTrait as _, AEAD_EXPANSION_SIZE};
 use neqo_transport::{
     CloseReason, ConnectionParameters, Error, State, StreamType, Version, MIN_INITIAL_PACKET_SIZE,
 };
@@ -161,6 +161,8 @@ fn reorder_server_initial() {
 
 #[cfg(test)]
 fn set_payload(server_packet: Option<&Datagram>, client_dcid: &[u8], payload: &[u8]) -> Datagram {
+    use neqo_crypto::AEAD_EXPANSION_SIZE;
+
     let (server_initial, _server_hs) = split_datagram(server_packet.as_ref().unwrap());
     let (protected_header, _, _, orig_payload) =
         decode_initial_header(&server_initial, Role::Server).unwrap();
@@ -176,13 +178,13 @@ fn set_payload(server_packet: Option<&Datagram>, client_dcid: &[u8], payload: &[
         - Encoder::varint_len(u64::try_from(pn_len + orig_payload.len()).unwrap());
     header.truncate(len_pos);
     let mut enc = Encoder::new_borrowed_vec(&mut header);
-    enc.encode_varint(u64::try_from(4 + payload.len() + aead.expansion()).unwrap());
+    enc.encode_varint(u64::try_from(4 + payload.len() + AEAD_EXPANSION_SIZE).unwrap());
     enc.encode_uint(4, pn);
     header[0] = header[0] & 0xfc | 0b0000_0011; // Set the packet number length to 4.
 
     // And build a packet containing the given payload.
     let mut packet = header.clone();
-    packet.resize(header.len() + payload.len() + aead.expansion(), 0);
+    packet.resize(header.len() + payload.len() + AEAD_EXPANSION_SIZE, 0);
     aead.encrypt(pn, &header, payload, &mut packet[header.len()..])
         .unwrap();
     header_protection::apply(&hp, &mut packet, protected_header.len()..header.len());
@@ -277,13 +279,13 @@ fn overflow_crypto() {
             .encode_vec(1, server_dcid)
             .encode_vec(1, server_scid)
             .encode_vvec(&[]) // token
-            .encode_varint(u64::try_from(2 + payload.len() + aead.expansion()).unwrap()); // length
+            .encode_varint(u64::try_from(2 + payload.len() + AEAD_EXPANSION_SIZE).unwrap()); // length
         let pn_offset = packet.len();
         packet.encode_uint(2, pn);
 
         let mut packet = Vec::from(packet);
         let header = packet.clone();
-        packet.resize(header.len() + payload.len() + aead.expansion(), 0);
+        packet.resize(header.len() + payload.len() + AEAD_EXPANSION_SIZE, 0);
         aead.encrypt(pn, &header, payload.as_ref(), &mut packet[header.len()..])
             .unwrap();
         header_protection::apply(&hp, &mut packet, pn_offset..(pn_offset + 2));


### PR DESCRIPTION
This commit replaces all dynamic calls to `expansion()` method on AEAD instances with a static `AEAD_EXPANSION_SIZE` constant set to 16. The expansion size for all AEAD ciphers used in QUIC is consistently 16 bytes. A constant makes this explicit and simplifies downstream code in `neqo-transport/src/connection/mod.rs`.

---

Do we expect an expansion size of 16 in the near future? If not, do you consider this a simplification?