### PR TITLE
chore: prepare v0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "criterion",
  "enum-map",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "criterion",
  "enumset",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "log",
  "neqo-common",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "criterion",
  "enum-map",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.16.1"
+version = "0.17.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I would like to get @omansfeld Cubic changes into Firefox. 

In addition, most relevant changes:
- b90ded6f refactor(transport): move UDP datagram limit calc outside loop (#3045)
- 791fd40f perf(http3): eliminate allocations with zero-copy `Bytes` (#3010)
- 58b6e72b feat(udp): expose quinn-udp may_fragment (#3035)
- 47961539 fix(transport/ecn): downgrade validation result from warn to info (#3033)
- 9c920d0f cubic: reno region updates (#2973)
- 3a429ef8 feat: Remove use of `add_event_data_now` (#3006)
- a75f3b58 refactor(transport/cubic): use `saturating_duration_since` for t (#2997)
- 07bd508e chore(transport/pmtud): improve logging (#3016)
- 9dbd0cb6 fix(http3/connect-udp): parse context id as varint (#3018)
- f6821b39 fix: Implement a trait for `Aead` (#3014)
- d46f3f4a fix: Don't call `Instant::now()` in `neqo-common/src/qlog.rs` (#3008)
- 836046b2 feat(transport/cubic): multiplicative decrease updates (#2970)
- b285077e refactor(transport/recovery): improve log message (#3004)
- 8b7d4408 refactor(http3): replace (bool, bool) with named struct (#3002)
- 7d9cfc19 perf(codec): optimize encode functions for modern CPUs (#2990)
