### PR TITLE
chore: Use `Vec::with_capacity` where we can

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2547,7 +2547,7 @@ impl Connection {
         max_datagrams: NonZeroUsize,
     ) -> Res<SendOptionBatch> {
         let packet_tos = path.borrow().tos();
-        let mut send_buffer = Vec::new(); // TODO: Investigate is `with_capacity` is beneficial here.
+        let mut send_buffer = Vec::new();
         let mut max_datagram_size = None;
         let mut num_datagrams = 0;
         let mtu = path.borrow().plpmtu();


### PR DESCRIPTION
Use `Vec::with_capacity` where we know a minimum size for the vector exists.