### PR TITLE
refactor(transport): replace magic number with MAX_PACKET_NUMBER_LEN

### DIFF
--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -383,7 +383,7 @@ impl<B: Buffer> Builder<B> {
     ///
     /// This will panic if the packet number length is too large.
     pub fn pn(&mut self, pn: Number, pn_len: usize) {
-        if self.remaining() < 4 {
+        if self.remaining() < MAX_PACKET_NUMBER_LEN {
             self.limit = 0;
             return;
         }


### PR DESCRIPTION
As far as I can tell, `4` here represents the maximum packet number length.

https://github.com/mozilla/neqo/blob/be98b44a6cf8b798e1e6fd15a1524dce3605639b/neqo-transport/src/packet/mod.rs#L44