### PR TITLE
feat(common): use NonZeroUsize for DatagramBatch::datagram_size

### DIFF
--- a/neqo-transport/src/connection/tests/pmtud.rs
+++ b/neqo-transport/src/connection/tests/pmtud.rs
@@ -44,11 +44,11 @@ fn gso_with_max_mtu() {
             .process_multiple_output(now(), 2.try_into().unwrap())
             .dgram()
             .unwrap();
-        if pkts.datagram_size() == 65507 {
+        if pkts.datagram_size().get() == 65507 {
             // Success. It reached the maximum IPv4 UDP MTU.
             break;
         }
-        assert!(pkts.datagram_size() < 65507);
+        assert!(pkts.datagram_size().get() < 65507);
 
         server.process_multiple_input(pkts.iter_mut(), now());
         let ack = server.process_output(now()).dgram();

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -8,6 +8,7 @@ use std::{
     cell::RefCell,
     fmt::{self, Display},
     net::SocketAddr,
+    num::NonZeroUsize,
     rc::Rc,
     time::{Duration, Instant},
 };
@@ -707,7 +708,13 @@ impl Path {
         // update the ECN state and can hence change it - this packet should still be sent
         // with the current value.
         self.ecn_info.on_packet_sent(num_datagrams, stats);
-        DatagramBatch::new(self.local, self.remote, tos, datagram_size, payload)
+        DatagramBatch::new(
+            self.local,
+            self.remote,
+            tos,
+            NonZeroUsize::new(datagram_size).expect("datagram size cannot be zero"),
+            payload,
+        )
     }
 
     /// Get local address as `SocketAddr`

--- a/neqo-transport/tests/connection.rs
+++ b/neqo-transport/tests/connection.rs
@@ -37,8 +37,8 @@ fn gso() {
         .dgram()
         .unwrap();
 
-    assert_eq!(out.datagram_size(), 1232);
-    assert!(out.data().len() > out.datagram_size());
+    assert_eq!(out.datagram_size().get(), 1232);
+    assert!(out.data().len() > out.datagram_size().get());
 }
 
 #[test]

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -64,7 +64,7 @@ pub fn send_inner(
         destination: d.destination(),
         ecn: EcnCodepoint::from_bits(Into::<u8>::into(d.tos())),
         contents: d.data(),
-        segment_size: Some(d.datagram_size()),
+        segment_size: Some(d.datagram_size().get()),
         src_ip: None,
     };
 
@@ -75,7 +75,7 @@ pub fn send_inner(
                 "Failed to send datagram of size {} bytes, in {} segments, each {} bytes, from {} to {}. PMTUD probe? Ignoring error: {}",
                 d.data().len(),
                 d.num_datagrams(),
-                d.datagram_size(),
+                d.datagram_size().get(),
                 d.source(),
                 d.destination(),
                 e
@@ -89,7 +89,7 @@ pub fn send_inner(
         "sent {} bytes, in {} segments, each {} bytes, from {} to {} ",
         d.data().len(),
         d.num_datagrams(),
-        d.datagram_size(),
+        d.datagram_size().get(),
         d.source(),
         d.destination(),
     );
@@ -356,6 +356,8 @@ mod tests {
         ignore = "GRO not available"
     )]
     fn many_datagrams_through_gso_gro() -> Result<(), io::Error> {
+        use std::num::NonZeroUsize;
+
         const SEGMENT_SIZE: usize = 128;
 
         let sender = socket()?;
@@ -368,7 +370,7 @@ mod tests {
             sender.inner.local_addr()?,
             receiver.inner.local_addr()?,
             Tos::from((Dscp::Le, Ecn::Ect0)),
-            SEGMENT_SIZE,
+            NonZeroUsize::new(SEGMENT_SIZE).expect("SEGMENT_SIZE cannot be zero"),
             msg,
         );
 


### PR DESCRIPTION
- Encode invariant that `datagram_size` is always > 0 to prevent misuse.
- Update constructor and getter to take/return `NonZeroUsize`.
- Adapt all call sites in `neqo-udp` and `neqo-transport`, adjust tests accordingly.
- No behavioral change intended, improves type safety and clarity.

BREAKING CHANGE: `DatagramBatch::new(...)` and `datagram_size()` now use `NonZeroUsize` in the public API (`neqo-common`).

Related issue: #2768