### PR TITLE
feat(common): enforce non-zero length for Datagram

### DIFF
--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -274,9 +274,9 @@ impl DatagramBatch {
 mod tests {
     use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 
-    use test_fixture::datagram;
+    use test_fixture::{datagram, DEFAULT_ADDR};
 
-    use crate::{DatagramBatch, Ecn, Tos};
+    use crate::{Datagram, DatagramBatch, Ecn, Tos};
 
     #[test]
     fn fmt_datagram() {
@@ -289,8 +289,20 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "Datagram data cannot be empty")]
-    fn is_empty() {
-        let _d = datagram(vec![]);
+    fn new_empty() {
+        let _d = Datagram::new(DEFAULT_ADDR, DEFAULT_ADDR, Ecn::Ect0.into(), vec![]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Datagram data cannot be empty")]
+    fn from_slice_empty() {
+        let _d = Datagram::from_slice(DEFAULT_ADDR, DEFAULT_ADDR, Ecn::Ect0.into(), &mut []);
+    }
+
+    #[test]
+    #[should_panic(expected = "Datagram data cannot be empty")]
+    fn from_bytes_empty() {
+        let _d = Datagram::from_bytes(DEFAULT_ADDR, DEFAULT_ADDR, Ecn::Ect0.into(), vec![].into());
     }
 
     #[test]


### PR DESCRIPTION
Enforce that `Datagram` data is always non-empty by adding assertions in all construction methods (`new()`, `from_slice()`, `from_bytes()`).

This change establishes a type-level invariant that prevents empty datagrams from being created, which aligns with the protocol's requirements and simplifies downstream code.

### Testing

- All existing tests pass (in neqo-common)
- Updated test case that tested empty datagram creation
- No call sites in the codebase create empty datagrams

### Breaking Changes

1. **`Datagram::from_bytes()` is no longer const fn**

**Reason**: The `Bytes::is_empty()` method is not const, preventing compile-time evaluation of the assertion

2. **All construction functions now panic on empty data**


### Related

- Part of #2768
- Prerequisite for #3068 