### PR TITLE
chore(Cargo.toml): prepare for version 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "enum-map",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "enumset",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "log",
  "neqo-common",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "enum-map",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.17.0"
+version = "0.18.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
[https://github.com/mozilla/neqo/pull/3069 fixes a bug seen in [normal Firefox web surfing](https://bugzilla.mozilla.org/show_bug.cgi?id=1992919). Thus I would like to prioritize getting it into Firefox.

Any objections?
