### PR TITLE
fix(common/codec): have as_decoder expose encoded bytes only 

### DIFF
--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -239,7 +239,7 @@ impl<B: Buffer> Encoder<B> {
     /// Note: for a view of a slice, use `Decoder::new(&enc[s..e])`
     #[must_use]
     pub fn as_decoder(&self) -> Decoder<'_> {
-        Decoder::new(self.buf.as_slice())
+        Decoder::new(self.as_ref())
     }
 
     /// Generic encode routine for arbitrary data.
@@ -1195,7 +1195,8 @@ mod tests {
         assert_eq!(Buffer::position(&buf), 0);
     }
 
-    /// [`Encoder::as_decoder`] should only expose the bytes actively encoded through this [`Encoder`], not all bytes of the underlying [`Buffer`].
+    /// [`Encoder::as_decoder`] should only expose the bytes actively encoded through this
+    /// [`Encoder`], not all bytes of the underlying [`Buffer`].
     #[test]
     fn as_decoder_exposes_encoded_bytes_only_not_whole_buffer() {
         let mut buffer = vec![1, 2, 3, 4];


### PR DESCRIPTION
Previously `Encoder::as_decoder` exposed the entire underlying buffer as a `Decoder`, not just the bytes encoded through that particular `Encoder` instance.

This commit changes `Encoder::as_decoder` to only expose the bytes actively encoded through that `Encoder`, which is the expected behavior.

---

Note that `Encoder::as_decoder` is currently used in test code only, thus does not affect Firefox.

Regression introduced in https://github.com/mozilla/neqo/pull/2677.

Fixes https://github.com/mozilla/neqo/issues/3055.