### PR TITLE
feat(transport): implement connection level flow control

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -1383,7 +1383,7 @@ mod tests {
     use neqo_qpack as qpack;
     use neqo_transport::{
         CloseReason, ConnectionEvent, ConnectionParameters, Output, State, StreamId, StreamType,
-        Version, INITIAL_RECV_WINDOW_SIZE, MIN_INITIAL_PACKET_SIZE,
+        Version, INITIAL_STREAM_RECV_WINDOW_SIZE, MIN_INITIAL_PACKET_SIZE,
     };
     use test_fixture::{
         anti_replay, default_server_h3, fixture_init, new_server, now,
@@ -2848,7 +2848,7 @@ mod tests {
             if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
                 if stream_id == request_stream_id {
                     // Read the DATA frame.
-                    let mut buf = vec![1_u8; INITIAL_RECV_WINDOW_SIZE];
+                    let mut buf = vec![1_u8; INITIAL_STREAM_RECV_WINDOW_SIZE];
                     let (amount, fin) = server.conn.stream_recv(stream_id, &mut buf).unwrap();
                     assert!(fin);
                     assert_eq!(
@@ -2923,7 +2923,7 @@ mod tests {
         // The second frame cannot fit.
         let sent = client.send_data(
             request_stream_id,
-            &vec![0_u8; INITIAL_RECV_WINDOW_SIZE],
+            &vec![0_u8; INITIAL_STREAM_RECV_WINDOW_SIZE],
             now(),
         );
         assert_eq!(sent, Ok(expected_second_data_frame.len()));
@@ -2934,7 +2934,7 @@ mod tests {
         let mut out = client.process_output(now());
         // We need to loop a bit until all data has been sent. Once for every 1K
         // of data.
-        for _i in 0..INITIAL_RECV_WINDOW_SIZE / 1000 {
+        for _i in 0..INITIAL_STREAM_RECV_WINDOW_SIZE / 1000 {
             out = server.conn.process(out.dgram(), now());
             out = client.process(out.dgram(), now());
         }
@@ -2944,7 +2944,7 @@ mod tests {
             if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
                 if stream_id == request_stream_id {
                     // Read DATA frames.
-                    let mut buf = vec![1_u8; INITIAL_RECV_WINDOW_SIZE];
+                    let mut buf = vec![1_u8; INITIAL_STREAM_RECV_WINDOW_SIZE];
                     let (amount, fin) = server.conn.stream_recv(stream_id, &mut buf).unwrap();
                     assert!(fin);
                     assert_eq!(
@@ -2997,7 +2997,7 @@ mod tests {
     // After the first frame there is exactly 63+2 bytes left in the send buffer.
     #[test]
     fn fetch_two_data_frame_second_63bytes() {
-        let (buf, hdr) = alloc_buffer(INITIAL_RECV_WINDOW_SIZE - 88);
+        let (buf, hdr) = alloc_buffer(INITIAL_STREAM_RECV_WINDOW_SIZE - 88);
         fetch_with_two_data_frames(&buf, &hdr, &[0x0, 0x3f], &[0_u8; 63]);
     }
 
@@ -3006,7 +3006,7 @@ mod tests {
     // but we can only send 63 bytes.
     #[test]
     fn fetch_two_data_frame_second_63bytes_place_for_66() {
-        let (buf, hdr) = alloc_buffer(INITIAL_RECV_WINDOW_SIZE - 89);
+        let (buf, hdr) = alloc_buffer(INITIAL_STREAM_RECV_WINDOW_SIZE - 89);
         fetch_with_two_data_frames(&buf, &hdr, &[0x0, 0x3f], &[0_u8; 63]);
     }
 
@@ -3015,7 +3015,7 @@ mod tests {
     // but we can only send 64 bytes.
     #[test]
     fn fetch_two_data_frame_second_64bytes_place_for_67() {
-        let (buf, hdr) = alloc_buffer(INITIAL_RECV_WINDOW_SIZE - 90);
+        let (buf, hdr) = alloc_buffer(INITIAL_STREAM_RECV_WINDOW_SIZE - 90);
         fetch_with_two_data_frames(&buf, &hdr, &[0x0, 0x40, 0x40], &[0_u8; 64]);
     }
 
@@ -3023,7 +3023,7 @@ mod tests {
     // After the first frame there is exactly 16383+3 bytes left in the send buffer.
     #[test]
     fn fetch_two_data_frame_second_16383bytes() {
-        let (buf, hdr) = alloc_buffer(INITIAL_RECV_WINDOW_SIZE - 16409);
+        let (buf, hdr) = alloc_buffer(INITIAL_STREAM_RECV_WINDOW_SIZE - 16409);
         fetch_with_two_data_frames(&buf, &hdr, &[0x0, 0x7f, 0xff], &[0_u8; 16383]);
     }
 
@@ -3032,7 +3032,7 @@ mod tests {
     // send 16383 bytes.
     #[test]
     fn fetch_two_data_frame_second_16383bytes_place_for_16387() {
-        let (buf, hdr) = alloc_buffer(INITIAL_RECV_WINDOW_SIZE - 16410);
+        let (buf, hdr) = alloc_buffer(INITIAL_STREAM_RECV_WINDOW_SIZE - 16410);
         fetch_with_two_data_frames(&buf, &hdr, &[0x0, 0x7f, 0xff], &[0_u8; 16383]);
     }
 
@@ -3041,7 +3041,7 @@ mod tests {
     // send 16383 bytes.
     #[test]
     fn fetch_two_data_frame_second_16383bytes_place_for_16388() {
-        let (buf, hdr) = alloc_buffer(INITIAL_RECV_WINDOW_SIZE - 16411);
+        let (buf, hdr) = alloc_buffer(INITIAL_STREAM_RECV_WINDOW_SIZE - 16411);
         fetch_with_two_data_frames(&buf, &hdr, &[0x0, 0x7f, 0xff], &[0_u8; 16383]);
     }
 
@@ -3050,7 +3050,7 @@ mod tests {
     // 16384 bytes.
     #[test]
     fn fetch_two_data_frame_second_16384bytes_place_for_16389() {
-        let (buf, hdr) = alloc_buffer(INITIAL_RECV_WINDOW_SIZE - 16412);
+        let (buf, hdr) = alloc_buffer(INITIAL_STREAM_RECV_WINDOW_SIZE - 16412);
         fetch_with_two_data_frames(&buf, &hdr, &[0x0, 0x80, 0x0, 0x40, 0x0], &[0_u8; 16384]);
     }
 

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -18,7 +18,7 @@ use crate::{
     events::ConnectionEvent,
     frame::FrameType,
     packet,
-    recv_stream::INITIAL_RECV_WINDOW_SIZE,
+    recv_stream::INITIAL_STREAM_RECV_WINDOW_SIZE,
     send_stream::{self, OrderGroup},
     streams::{SendOrder, StreamOrder},
     tparams::{TransportParameter, TransportParameterId::*},
@@ -438,7 +438,7 @@ fn max_data() {
     client.streams.handle_max_data(100_000_000);
     assert_eq!(
         client.stream_avail_send_space(stream_id).unwrap(),
-        INITIAL_RECV_WINDOW_SIZE - SMALL_MAX_DATA
+        INITIAL_STREAM_RECV_WINDOW_SIZE - SMALL_MAX_DATA
     );
 
     let evts = client.events().collect::<Vec<_>>();
@@ -885,7 +885,7 @@ fn stream_data_blocked_generates_max_stream_data() {
         }
         written += amount;
     }
-    assert_eq!(written, INITIAL_RECV_WINDOW_SIZE);
+    assert_eq!(written, INITIAL_STREAM_RECV_WINDOW_SIZE);
 }
 
 /// See <https://github.com/mozilla/neqo/issues/871>

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -9,7 +9,7 @@
 
 use std::{
     cmp::min,
-    fmt::Debug,
+    fmt::{Debug, Display},
     num::NonZeroU64,
     ops::{Deref, DerefMut, Index, IndexMut},
     time::{Duration, Instant},
@@ -21,7 +21,7 @@ use crate::{
     frame::FrameType,
     packet,
     recovery::{self, StreamRecoveryToken},
-    recv_stream::MAX_RECV_WINDOW_SIZE,
+    recv_stream::{MAX_CONN_RECV_WINDOW_SIZE, MAX_RECV_WINDOW_SIZE},
     stats::FrameStats,
     stream_id::{StreamId, StreamType},
     Error, Res,
@@ -43,6 +43,23 @@ pub const WINDOW_UPDATE_FRACTION: u64 = 4;
 /// Note that the flow control window should grow at least as fast as the
 /// congestion control window, in order to not unnecessarily limit throughput.
 const WINDOW_INCREASE_MULTIPLIER: u64 = 4;
+
+/// Subject for flow control auto-tuning, used to avoid heap allocations
+/// when logging.
+#[derive(Debug, Clone, Copy)]
+enum AutoTuneSubject {
+    Connection,
+    Stream(StreamId),
+}
+
+impl Display for AutoTuneSubject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connection => write!(f, "connection"),
+            Self::Stream(id) => write!(f, "stream {id}"),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct SenderFlowControl<T>
@@ -225,8 +242,10 @@ where
     max_allowed: u64,
     /// Last time a flow control update was sent.
     ///
-    /// Only used in [`ReceiverFlowControl<StreamId>`] implementation for
-    /// receive window auto-tuning.
+    /// Used by auto-tuning logic to estimate sending rate between updates.
+    /// This is active for both stream-level
+    /// ([`ReceiverFlowControl<StreamId>`]) and connection-level
+    /// ([`ReceiverFlowControl<()>`]) flow control.
     last_update: Option<Instant>,
     /// Item received, but not retired yet.
     /// This will be used for byte flow control: each stream will remember its largest byte
@@ -322,6 +341,70 @@ where
     pub const fn consumed(&self) -> u64 {
         self.consumed
     }
+
+    /// Core auto-tuning logic for adjusting the maximum flow control window.
+    ///
+    /// This method is called by both connection-level and stream-level
+    /// implementations. It increases `max_active` when the sending rate exceeds
+    /// what the current window and RTT would allow, capping at `max_window`.
+    fn auto_tune_inner(
+        &mut self,
+        now: Instant,
+        rtt: Duration,
+        max_window: u64,
+        subject: AutoTuneSubject,
+    ) {
+        let Some(max_allowed_sent_at) = self.last_update else {
+            return;
+        };
+
+        let Ok(elapsed): Result<u64, _> = now
+            .duration_since(max_allowed_sent_at)
+            .as_micros()
+            .try_into()
+        else {
+            return;
+        };
+
+        let Ok(rtt): Result<NonZeroU64, _> = rtt
+            .as_micros()
+            .try_into()
+            .and_then(|rtt: u64| NonZeroU64::try_from(rtt))
+        else {
+            // RTT is zero, no need for tuning.
+            return;
+        };
+
+        // Compute the amount of bytes we have received in excess
+        // of what `max_active` might allow.
+        let window_bytes_expected = self.max_active * elapsed / rtt;
+        let window_bytes_used = self.max_active - (self.max_allowed - self.retired);
+        let Some(excess) = window_bytes_used.checked_sub(window_bytes_expected) else {
+            // Used below expected. No auto-tuning needed.
+            return;
+        };
+
+        let prev_max_active = self.max_active;
+        self.max_active = min(
+            self.max_active + excess * WINDOW_INCREASE_MULTIPLIER,
+            max_window,
+        );
+
+        let increase = self.max_active - prev_max_active;
+        if increase > 0 {
+            qdebug!(
+                "Increasing max {subject} receive window by {} B, \
+                previous max_active: {} MiB, \
+                new max_active: {} MiB, \
+                last update: {:?}, \
+                rtt: {rtt:?}",
+                increase,
+                prev_max_active / 1024 / 1024,
+                self.max_active / 1024 / 1024,
+                now - max_allowed_sent_at,
+            );
+        }
+    }
 }
 
 impl ReceiverFlowControl<()> {
@@ -330,10 +413,15 @@ impl ReceiverFlowControl<()> {
         builder: &mut packet::Builder<B>,
         tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
+        now: Instant,
+        rtt: Duration,
     ) {
         if !self.frame_needed() {
             return;
         }
+
+        self.auto_tune(now, rtt);
+
         let max_allowed = self.next_limit();
         if builder.write_varint_frame(&[FrameType::MaxData.into(), max_allowed]) {
             stats.max_data += 1;
@@ -341,7 +429,24 @@ impl ReceiverFlowControl<()> {
                 max_allowed,
             )));
             self.frame_sent(max_allowed);
+            self.last_update = Some(now);
         }
+    }
+
+    /// Auto-tune [`ReceiverFlowControl::max_active`], i.e. the connection flow
+    /// control window.
+    ///
+    /// If the sending rate (`window_bytes_used`) exceeds the rate allowed by
+    /// the maximum flow control window and the current rtt
+    /// (`window_bytes_expected`), try to increase the maximum flow control
+    /// window ([`ReceiverFlowControl::max_active`]).
+    fn auto_tune(&mut self, now: Instant, rtt: Duration) {
+        self.auto_tune_inner(
+            now,
+            rtt,
+            MAX_CONN_RECV_WINDOW_SIZE,
+            AutoTuneSubject::Connection,
+        );
     }
 
     pub fn add_retired(&mut self, count: u64) {
@@ -407,53 +512,11 @@ impl ReceiverFlowControl<StreamId> {
     /// (`window_bytes_expected`), try to increase the maximum flow control
     /// window ([`ReceiverFlowControl::max_active`]).
     fn auto_tune(&mut self, now: Instant, rtt: Duration) {
-        let Some(max_allowed_sent_at) = self.last_update else {
-            return;
-        };
-
-        let Ok(elapsed): Result<u64, _> = now
-            .duration_since(max_allowed_sent_at)
-            .as_micros()
-            .try_into()
-        else {
-            return;
-        };
-
-        let Ok(rtt): Result<NonZeroU64, _> = rtt
-            .as_micros()
-            .try_into()
-            .and_then(|rtt: u64| NonZeroU64::try_from(rtt))
-        else {
-            // RTT is zero, no need for tuning.
-            return;
-        };
-
-        // Compute the amount of bytes we have received in excess
-        // of what `max_active` might allow.
-        let window_bytes_expected = self.max_active * elapsed / rtt;
-        let window_bytes_used = self.max_active - (self.max_allowed - self.retired);
-        let Some(excess) = window_bytes_used.checked_sub(window_bytes_expected) else {
-            // Used below expected. No auto-tuning needed.
-            return;
-        };
-
-        let prev_max_active = self.max_active;
-        self.max_active = min(
-            self.max_active + excess * WINDOW_INCREASE_MULTIPLIER,
+        self.auto_tune_inner(
+            now,
+            rtt,
             MAX_RECV_WINDOW_SIZE,
-        );
-        qdebug!(
-            "Increasing max stream receive window by {} B, \
-            previous max_active: {} MiB, \
-            new max_active: {} MiB, \
-            last update: {:?}, \
-            rtt: {rtt:?}, \
-            stream_id: {}",
-            self.max_active - prev_max_active,
-            prev_max_active / 1024 / 1024,
-            self.max_active / 1024 / 1024,
-            now - max_allowed_sent_at,
-            self.subject,
+            AutoTuneSubject::Stream(self.subject),
         );
     }
 
@@ -671,7 +734,7 @@ mod test {
         time::{Duration, Instant},
     };
 
-    use neqo_common::{qdebug, Encoder, Role, MAX_VARINT};
+    use neqo_common::{qdebug, Encoder, Role};
     use neqo_crypto::random;
 
     use super::{LocalStreamLimits, ReceiverFlowControl, RemoteStreamLimits, SenderFlowControl};
@@ -679,10 +742,10 @@ mod test {
         fc::WINDOW_UPDATE_FRACTION,
         packet::{self, PACKET_LIMIT},
         recovery,
-        recv_stream::MAX_RECV_WINDOW_SIZE,
+        recv_stream::{MAX_CONN_RECV_WINDOW_SIZE, MAX_RECV_WINDOW_SIZE},
         stats::FrameStats,
         stream_id::{StreamId, StreamType},
-        ConnectionParameters, Error, Res, INITIAL_RECV_WINDOW_SIZE,
+        ConnectionParameters, Error, Res, INITIAL_STREAM_RECV_WINDOW_SIZE,
     };
 
     #[test]
@@ -1046,9 +1109,10 @@ mod test {
     fn trigger_factor() -> Res<()> {
         let rtt = Duration::from_millis(40);
         let now = test_fixture::now();
-        let mut fc = ReceiverFlowControl::new(StreamId::new(0), INITIAL_RECV_WINDOW_SIZE as u64);
+        let mut fc =
+            ReceiverFlowControl::new(StreamId::new(0), INITIAL_STREAM_RECV_WINDOW_SIZE as u64);
 
-        let fraction = INITIAL_RECV_WINDOW_SIZE as u64 / WINDOW_UPDATE_FRACTION;
+        let fraction = INITIAL_STREAM_RECV_WINDOW_SIZE as u64 / WINDOW_UPDATE_FRACTION;
 
         let consumed = fc.set_consumed(fraction)?;
         fc.add_retired(consumed);
@@ -1067,7 +1131,8 @@ mod test {
     fn auto_tuning_increase_no_decrease() -> Res<()> {
         let rtt = Duration::from_millis(40);
         let mut now = test_fixture::now();
-        let mut fc = ReceiverFlowControl::new(StreamId::new(0), INITIAL_RECV_WINDOW_SIZE as u64);
+        let mut fc =
+            ReceiverFlowControl::new(StreamId::new(0), INITIAL_STREAM_RECV_WINDOW_SIZE as u64);
         let initial_max_active = fc.max_active();
 
         // Consume and retire multiple receive windows without increasing time.
@@ -1102,7 +1167,8 @@ mod test {
     fn stream_data_blocked_triggers_auto_tuning() -> Res<()> {
         let rtt = Duration::from_millis(40);
         let now = test_fixture::now();
-        let mut fc = ReceiverFlowControl::new(StreamId::new(0), INITIAL_RECV_WINDOW_SIZE as u64);
+        let mut fc =
+            ReceiverFlowControl::new(StreamId::new(0), INITIAL_STREAM_RECV_WINDOW_SIZE as u64);
 
         // Send first window update to give auto-tuning algorithm a baseline.
         let consumed = fc.set_consumed(fc.next_limit())?;
@@ -1158,12 +1224,12 @@ mod test {
             let mut send_to_recv = VecDeque::new();
             let mut recv_to_send = VecDeque::new();
 
-            let mut last_max_active = INITIAL_RECV_WINDOW_SIZE as u64;
+            let mut last_max_active = INITIAL_STREAM_RECV_WINDOW_SIZE as u64;
             let mut last_max_active_changed = now;
 
-            let mut sender_window = INITIAL_RECV_WINDOW_SIZE as u64;
+            let mut sender_window = INITIAL_STREAM_RECV_WINDOW_SIZE as u64;
             let mut fc =
-                ReceiverFlowControl::new(StreamId::new(0), INITIAL_RECV_WINDOW_SIZE as u64);
+                ReceiverFlowControl::new(StreamId::new(0), INITIAL_STREAM_RECV_WINDOW_SIZE as u64);
 
             loop {
                 // Sender receives window updates.
@@ -1231,7 +1297,7 @@ mod test {
             );
             assert!(
                 fc.max_active - TOLERANCE <= bdp
-                    || fc.max_active == INITIAL_RECV_WINDOW_SIZE as u64,
+                    || fc.max_active == INITIAL_STREAM_RECV_WINDOW_SIZE as u64,
                 "{summary} Receive window is larger than the bdp."
             );
 
@@ -1242,24 +1308,107 @@ mod test {
     }
 
     #[test]
-    fn max_active_larger_max_varint() {
-        // Instead of doing proper connection flow control, Neqo simply sets
-        // the largest connection flow control limit possible.
+    fn connection_flow_control_initial_window() {
+        // Connection flow control starts with a reasonable initial window
+        // (16x the stream window to accommodate 16 concurrent streams).
         let max_data = ConnectionParameters::default().get_max_data();
-        assert_eq!(max_data, MAX_VARINT);
-        let mut fc = ReceiverFlowControl::new((), max_data);
+        assert_eq!(max_data, (INITIAL_STREAM_RECV_WINDOW_SIZE * 16) as u64);
+    }
 
-        // Say that the remote consumes 1 byte of that connection flow control
-        // limit and then requests a connection flow control update.
-        fc.consume(1).unwrap();
-        fc.add_retired(1);
-        fc.send_flowc_update();
+    #[test]
+    fn connection_flow_control_auto_tune() -> Res<()> {
+        let rtt = Duration::from_millis(40);
+        let now = test_fixture::now();
+        let initial_window = (INITIAL_STREAM_RECV_WINDOW_SIZE * 16) as u64;
+        let mut fc = ReceiverFlowControl::new((), initial_window);
+        let initial_max_active = fc.max_active();
 
-        // Neqo should never attempt writing a connection flow control update
-        // larger than the largest possible QUIC varint value.
-        let mut builder =
-            packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
-        let mut tokens = recovery::Tokens::new();
-        fc.write_frames(&mut builder, &mut tokens, &mut FrameStats::default());
+        // Helper to write frames
+        let write_conn_frames = |fc: &mut ReceiverFlowControl<()>, now: Instant| {
+            let mut builder =
+                packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
+            let mut tokens = recovery::Tokens::new();
+            fc.write_frames(
+                &mut builder,
+                &mut tokens,
+                &mut FrameStats::default(),
+                now,
+                rtt,
+            );
+            tokens.len()
+        };
+
+        // Consume and retire multiple windows to trigger auto-tuning.
+        // Each iteration: consume a full window, retire it, send update.
+        for _ in 1..11 {
+            let to_consume = fc.max_active();
+            fc.consume(to_consume)?;
+            fc.add_retired(to_consume);
+            write_conn_frames(&mut fc, now);
+        }
+        let increased_max_active = fc.max_active();
+
+        assert!(
+            initial_max_active < increased_max_active,
+            "expect connection-level receive window auto-tuning to increase max_active on full utilization"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn connection_flow_control_respects_max_window() -> Res<()> {
+        let rtt = Duration::from_millis(40);
+        let now = test_fixture::now();
+        let initial_window = (INITIAL_STREAM_RECV_WINDOW_SIZE * 16) as u64;
+        let mut fc = ReceiverFlowControl::new((), initial_window);
+
+        // Helper to write frames
+        let write_conn_frames = |fc: &mut ReceiverFlowControl<()>| {
+            let mut builder =
+                packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
+            let mut tokens = recovery::Tokens::new();
+            fc.write_frames(
+                &mut builder,
+                &mut tokens,
+                &mut FrameStats::default(),
+                now,
+                rtt,
+            );
+            tokens.len()
+        };
+
+        // Consume and retire many full windows to push window to the limit.
+        // Keep consuming without advancing time to create maximum pressure.
+        for _ in 0..1000 {
+            let prev_max = fc.max_active();
+            let to_consume = fc.max_active();
+            fc.consume(to_consume)?;
+            fc.add_retired(to_consume);
+            write_conn_frames(&mut fc);
+
+            // Stop if we've reached the maximum and it's not growing anymore
+            if fc.max_active() == MAX_CONN_RECV_WINDOW_SIZE && fc.max_active() == prev_max {
+                qdebug!(
+                    "Reached and stabilized at max window: {} MiB",
+                    fc.max_active() / 1024 / 1024
+                );
+                break;
+            }
+        }
+
+        assert_eq!(
+            fc.max_active(),
+            MAX_CONN_RECV_WINDOW_SIZE,
+            "expect connection-level receive window to cap at MAX_CONN_RECV_WINDOW_SIZE (100 MiB), got {} MiB",
+            fc.max_active() / 1024 / 1024
+        );
+
+        qdebug!(
+            "Connection flow control window reached max: {} MiB",
+            fc.max_active() / 1024 / 1024
+        );
+
+        Ok(())
     }
 }

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -70,7 +70,7 @@ pub use self::{
     packet::MIN_INITIAL_PACKET_SIZE,
     pmtud::Pmtud,
     quic_datagrams::DatagramTracking,
-    recv_stream::INITIAL_RECV_WINDOW_SIZE,
+    recv_stream::INITIAL_STREAM_RECV_WINDOW_SIZE,
     rtt::DEFAULT_INITIAL_RTT,
     sni::find_sni,
     stats::Stats,

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -33,7 +33,7 @@ use crate::{
     AppError, Error, Res,
 };
 
-pub const INITIAL_RECV_WINDOW_SIZE: usize = 1024 * 1024;
+pub const INITIAL_STREAM_RECV_WINDOW_SIZE: usize = 1024 * 1024;
 
 /// Limit for the maximum amount of bytes active on a single stream, i.e. limit
 /// for the size of the stream receive window.
@@ -47,6 +47,17 @@ pub const INITIAL_RECV_WINDOW_SIZE: usize = 1024 * 1024;
 ///
 /// Keep in sync with [`crate::send_stream::MAX_SEND_BUFFER_SIZE`].
 pub const MAX_RECV_WINDOW_SIZE: u64 = 10 * 1024 * 1024;
+
+/// Limit for the maximum amount of bytes active on the connection, i.e. limit
+/// for the size of the connection-level receive window.
+///
+/// A value of 100 MiB allows for:
+///
+/// - 10 streams at max window (10 MiB each)
+/// - 10ms rtt and 80 GBit/s
+/// - 50ms rtt and 16 GBit/s
+/// - 100ms rtt and 8 GBit/s
+pub const MAX_CONN_RECV_WINDOW_SIZE: u64 = 100 * 1024 * 1024;
 
 #[derive(Debug, Default)]
 pub struct RecvStreams {
@@ -1009,7 +1020,7 @@ mod tests {
         recovery,
         recv_stream::RxStreamOrderer,
         stats::FrameStats,
-        ConnectionEvents, Error, StreamId, INITIAL_RECV_WINDOW_SIZE,
+        ConnectionEvents, Error, StreamId, INITIAL_STREAM_RECV_WINDOW_SIZE,
     };
 
     const SESSION_WINDOW: usize = 1024;
@@ -1459,14 +1470,17 @@ mod tests {
 
     #[test]
     fn stream_flowc_update() {
-        let mut s = create_stream(1024 * INITIAL_RECV_WINDOW_SIZE as u64);
-        let mut buf = vec![0u8; INITIAL_RECV_WINDOW_SIZE + 100]; // Make it overlarge
+        let mut s = create_stream(1024 * INITIAL_STREAM_RECV_WINDOW_SIZE as u64);
+        let mut buf = vec![0u8; INITIAL_STREAM_RECV_WINDOW_SIZE + 100]; // Make it overlarge
 
         assert!(!s.has_frames_to_write());
-        let big_buf = vec![0; INITIAL_RECV_WINDOW_SIZE];
+        let big_buf = vec![0; INITIAL_STREAM_RECV_WINDOW_SIZE];
         s.inbound_stream_frame(false, 0, &big_buf).unwrap();
         assert!(!s.has_frames_to_write());
-        assert_eq!(s.read(&mut buf).unwrap(), (INITIAL_RECV_WINDOW_SIZE, false));
+        assert_eq!(
+            s.read(&mut buf).unwrap(),
+            (INITIAL_STREAM_RECV_WINDOW_SIZE, false)
+        );
         assert!(!s.data_ready());
 
         // flow msg generated!
@@ -1492,7 +1506,7 @@ mod tests {
         let conn_events = ConnectionEvents::default();
         RecvStream::new(
             StreamId::from(67),
-            INITIAL_RECV_WINDOW_SIZE as u64,
+            INITIAL_STREAM_RECV_WINDOW_SIZE as u64,
             Rc::new(RefCell::new(ReceiverFlowControl::new((), session_fc))),
             conn_events,
         )
@@ -1500,11 +1514,11 @@ mod tests {
 
     #[test]
     fn stream_max_stream_data() {
-        let mut s = create_stream(1024 * INITIAL_RECV_WINDOW_SIZE as u64);
+        let mut s = create_stream(1024 * INITIAL_STREAM_RECV_WINDOW_SIZE as u64);
         assert!(!s.has_frames_to_write());
-        let big_buf = vec![0; INITIAL_RECV_WINDOW_SIZE];
+        let big_buf = vec![0; INITIAL_STREAM_RECV_WINDOW_SIZE];
         s.inbound_stream_frame(false, 0, &big_buf).unwrap();
-        s.inbound_stream_frame(false, INITIAL_RECV_WINDOW_SIZE as u64, &[1; 1])
+        s.inbound_stream_frame(false, INITIAL_STREAM_RECV_WINDOW_SIZE as u64, &[1; 1])
             .unwrap_err();
     }
 
@@ -1545,14 +1559,14 @@ mod tests {
 
     #[test]
     fn no_stream_flowc_event_after_exiting_recv() {
-        let mut s = create_stream(1024 * INITIAL_RECV_WINDOW_SIZE as u64);
-        let mut buf = vec![0; INITIAL_RECV_WINDOW_SIZE];
+        let mut s = create_stream(1024 * INITIAL_STREAM_RECV_WINDOW_SIZE as u64);
+        let mut buf = vec![0; INITIAL_STREAM_RECV_WINDOW_SIZE];
         // Write from buf at first.
         s.inbound_stream_frame(false, 0, &buf).unwrap();
         // Then read into it.
         s.read(&mut buf).unwrap();
         assert!(s.has_frames_to_write());
-        s.inbound_stream_frame(true, INITIAL_RECV_WINDOW_SIZE as u64, &[])
+        s.inbound_stream_frame(true, INITIAL_STREAM_RECV_WINDOW_SIZE as u64, &[])
             .unwrap();
         assert!(!s.has_frames_to_write());
     }
@@ -1570,13 +1584,16 @@ mod tests {
     }
 
     fn create_stream_session_flow_control() -> (RecvStream, Rc<RefCell<ReceiverFlowControl<()>>>) {
-        static_assertions::const_assert!(INITIAL_RECV_WINDOW_SIZE > SESSION_WINDOW);
+        static_assertions::const_assert!(INITIAL_STREAM_RECV_WINDOW_SIZE > SESSION_WINDOW);
         let session_fc = Rc::new(RefCell::new(ReceiverFlowControl::new(
             (),
             u64::try_from(SESSION_WINDOW).unwrap(),
         )));
         (
-            create_stream_with_fc(Rc::clone(&session_fc), INITIAL_RECV_WINDOW_SIZE as u64),
+            create_stream_with_fc(
+                Rc::clone(&session_fc),
+                INITIAL_STREAM_RECV_WINDOW_SIZE as u64,
+            ),
             session_fc,
         )
     }
@@ -1597,9 +1614,13 @@ mod tests {
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
         let mut token = recovery::Tokens::new();
-        session_fc
-            .borrow_mut()
-            .write_frames(&mut builder, &mut token, &mut FrameStats::default());
+        session_fc.borrow_mut().write_frames(
+            &mut builder,
+            &mut token,
+            &mut FrameStats::default(),
+            Instant::now(),
+            Duration::from_millis(100),
+        );
 
         // Switch to SizeKnown state
         s.inbound_stream_frame(true, 2 * u64::try_from(SESSION_WINDOW).unwrap() - 1, &[0])
@@ -1619,9 +1640,13 @@ mod tests {
         let mut builder =
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
         let mut token = recovery::Tokens::new();
-        session_fc
-            .borrow_mut()
-            .write_frames(&mut builder, &mut token, &mut FrameStats::default());
+        session_fc.borrow_mut().write_frames(
+            &mut builder,
+            &mut token,
+            &mut FrameStats::default(),
+            Instant::now(),
+            Duration::from_millis(100),
+        );
 
         // Test DataRecvd state
         let session_fc = Rc::new(RefCell::new(ReceiverFlowControl::new(
@@ -1630,7 +1655,7 @@ mod tests {
         )));
         let mut s = RecvStream::new(
             StreamId::from(567),
-            INITIAL_RECV_WINDOW_SIZE as u64,
+            INITIAL_STREAM_RECV_WINDOW_SIZE as u64,
             Rc::clone(&session_fc),
             ConnectionEvents::default(),
         );
@@ -1925,8 +1950,13 @@ mod tests {
             packet::Builder::short(Encoder::new(), false, None::<&[u8]>, PACKET_LIMIT);
         let mut token = recovery::Tokens::new();
         let mut stats = FrameStats::default();
-        fc.borrow_mut()
-            .write_frames(&mut builder, &mut token, &mut stats);
+        fc.borrow_mut().write_frames(
+            &mut builder,
+            &mut token,
+            &mut stats,
+            Instant::now(),
+            Duration::from_millis(100),
+        );
         assert_eq!(stats.max_data, 0);
         s.write_frame(
             &mut builder,
@@ -1953,8 +1983,13 @@ mod tests {
         );
         assert!(fc.borrow().frame_needed());
         assert!(!s.fc().unwrap().frame_needed());
-        fc.borrow_mut()
-            .write_frames(&mut builder, &mut token, &mut stats);
+        fc.borrow_mut().write_frames(
+            &mut builder,
+            &mut token,
+            &mut stats,
+            Instant::now(),
+            Duration::from_millis(100),
+        );
         assert_eq!(stats.max_data, 1);
         s.write_frame(
             &mut builder,

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1792,7 +1792,7 @@ mod tests {
             MAX_SEND_BUFFER_SIZE,
         },
         stats::FrameStats,
-        ConnectionEvents, StreamId, INITIAL_RECV_WINDOW_SIZE,
+        ConnectionEvents, StreamId, INITIAL_STREAM_RECV_WINDOW_SIZE,
     };
 
     fn connection_fc(limit: u64) -> Rc<RefCell<SenderFlowControl<()>>> {
@@ -2260,14 +2260,14 @@ mod tests {
         let mut txb = TxBuffer::new();
 
         // Fill the buffer
-        let big_buf = vec![1; INITIAL_RECV_WINDOW_SIZE];
-        assert_eq!(txb.send(&big_buf), INITIAL_RECV_WINDOW_SIZE);
+        let big_buf = vec![1; INITIAL_STREAM_RECV_WINDOW_SIZE];
+        assert_eq!(txb.send(&big_buf), INITIAL_STREAM_RECV_WINDOW_SIZE);
         assert!(matches!(txb.next_bytes(),
-                         Some((0, x)) if x.len() == INITIAL_RECV_WINDOW_SIZE
+                         Some((0, x)) if x.len() == INITIAL_STREAM_RECV_WINDOW_SIZE
                          && x.iter().all(|ch| *ch == 1)));
 
         // Mark almost all as sent. Get what's left
-        let one_byte_from_end = INITIAL_RECV_WINDOW_SIZE as u64 - 1;
+        let one_byte_from_end = INITIAL_STREAM_RECV_WINDOW_SIZE as u64 - 1;
         txb.mark_as_sent(0, usize::try_from(one_byte_from_end).unwrap());
         assert!(matches!(txb.next_bytes(),
                          Some((start, x)) if x.len() == 1
@@ -2275,7 +2275,7 @@ mod tests {
                          && x.iter().all(|ch| *ch == 1)));
 
         // Mark all as sent. Get nothing
-        txb.mark_as_sent(0, INITIAL_RECV_WINDOW_SIZE);
+        txb.mark_as_sent(0, INITIAL_STREAM_RECV_WINDOW_SIZE);
         assert!(txb.next_bytes().is_none());
 
         // Mark as lost. Get it again
@@ -2287,7 +2287,7 @@ mod tests {
 
         // Mark a larger range lost, including beyond what's in the buffer even.
         // Get a little more
-        let five_bytes_from_end = INITIAL_RECV_WINDOW_SIZE as u64 - 5;
+        let five_bytes_from_end = INITIAL_STREAM_RECV_WINDOW_SIZE as u64 - 5;
         txb.mark_as_lost(five_bytes_from_end, 100);
         assert!(matches!(txb.next_bytes(),
                          Some((start, x)) if x.len() == 5
@@ -2312,7 +2312,7 @@ mod tests {
         txb.mark_as_sent(five_bytes_from_end, 5);
         assert!(matches!(txb.next_bytes(),
                          Some((start, x)) if x.len() == 30
-                         && start == INITIAL_RECV_WINDOW_SIZE as u64
+                         && start == INITIAL_STREAM_RECV_WINDOW_SIZE as u64
                          && x.iter().all(|ch| *ch == 2)));
     }
 
@@ -2321,14 +2321,14 @@ mod tests {
         let mut txb = TxBuffer::new();
 
         // Fill the buffer
-        let big_buf = vec![1; INITIAL_RECV_WINDOW_SIZE];
-        assert_eq!(txb.send(&big_buf), INITIAL_RECV_WINDOW_SIZE);
+        let big_buf = vec![1; INITIAL_STREAM_RECV_WINDOW_SIZE];
+        assert_eq!(txb.send(&big_buf), INITIAL_STREAM_RECV_WINDOW_SIZE);
         assert!(matches!(txb.next_bytes(),
-                         Some((0, x)) if x.len()==INITIAL_RECV_WINDOW_SIZE
+                         Some((0, x)) if x.len()==INITIAL_STREAM_RECV_WINDOW_SIZE
                          && x.iter().all(|ch| *ch == 1)));
 
         // As above
-        let forty_bytes_from_end = INITIAL_RECV_WINDOW_SIZE as u64 - 40;
+        let forty_bytes_from_end = INITIAL_STREAM_RECV_WINDOW_SIZE as u64 - 40;
 
         txb.mark_as_acked(0, usize::try_from(forty_bytes_from_end).unwrap());
         assert!(matches!(txb.next_bytes(),
@@ -2348,7 +2348,7 @@ mod tests {
                          && x.iter().all(|ch| *ch == 1)));
 
         // Mark a range 'A' in second slice as sent. Should still return the same
-        let range_a_start = INITIAL_RECV_WINDOW_SIZE as u64 + 30;
+        let range_a_start = INITIAL_STREAM_RECV_WINDOW_SIZE as u64 + 30;
         let range_a_end = range_a_start + 10;
         txb.mark_as_sent(range_a_start, 10);
         assert!(matches!(txb.next_bytes(),
@@ -2357,7 +2357,7 @@ mod tests {
                          && x.iter().all(|ch| *ch == 1)));
 
         // Ack entire first slice and into second slice
-        let ten_bytes_past_end = INITIAL_RECV_WINDOW_SIZE as u64 + 10;
+        let ten_bytes_past_end = INITIAL_STREAM_RECV_WINDOW_SIZE as u64 + 10;
         txb.mark_as_acked(0, usize::try_from(ten_bytes_past_end).unwrap());
 
         // Get up to marked range A
@@ -2396,24 +2396,26 @@ mod tests {
         }
 
         // Should hit stream flow control limit before filling up send buffer
-        let big_buf = vec![4; INITIAL_RECV_WINDOW_SIZE + 100];
-        let res = s.send(&big_buf[..INITIAL_RECV_WINDOW_SIZE]).unwrap();
+        let big_buf = vec![4; INITIAL_STREAM_RECV_WINDOW_SIZE + 100];
+        let res = s.send(&big_buf[..INITIAL_STREAM_RECV_WINDOW_SIZE]).unwrap();
         assert_eq!(res, 1024 - 100);
 
         // should do nothing, max stream data already 1024
         s.set_max_stream_data(1024);
-        let res = s.send(&big_buf[..INITIAL_RECV_WINDOW_SIZE]).unwrap();
+        let res = s.send(&big_buf[..INITIAL_STREAM_RECV_WINDOW_SIZE]).unwrap();
         assert_eq!(res, 0);
 
         // should now hit the conn flow control (4096)
         s.set_max_stream_data(1_048_576);
-        let res = s.send(&big_buf[..INITIAL_RECV_WINDOW_SIZE]).unwrap();
+        let res = s.send(&big_buf[..INITIAL_STREAM_RECV_WINDOW_SIZE]).unwrap();
         assert_eq!(res, 3072);
 
         // should now hit the tx buffer size
-        conn_fc.borrow_mut().update(INITIAL_RECV_WINDOW_SIZE as u64);
+        conn_fc
+            .borrow_mut()
+            .update(INITIAL_STREAM_RECV_WINDOW_SIZE as u64);
         let res = s.send(&big_buf).unwrap();
-        assert_eq!(res, INITIAL_RECV_WINDOW_SIZE - 4096);
+        assert_eq!(res, INITIAL_STREAM_RECV_WINDOW_SIZE - 4096);
 
         // TODO(agrover@mozilla.com): test ooo acks somehow
         s.mark_as_acked(0, 40, false);
@@ -2479,8 +2481,8 @@ mod tests {
         conn_fc.borrow_mut().update(1_000_000_000);
         assert_eq!(conn_events.events().count(), 0);
 
-        let big_buf = vec![b'a'; INITIAL_RECV_WINDOW_SIZE];
-        assert_eq!(s.send(&big_buf).unwrap(), INITIAL_RECV_WINDOW_SIZE);
+        let big_buf = vec![b'a'; INITIAL_STREAM_RECV_WINDOW_SIZE];
+        assert_eq!(s.send(&big_buf).unwrap(), INITIAL_STREAM_RECV_WINDOW_SIZE);
     }
 
     #[test]

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -220,7 +220,7 @@ impl Streams {
         // Send `MAX_DATA` as necessary.
         self.receiver_fc
             .borrow_mut()
-            .write_frames(builder, tokens, stats);
+            .write_frames(builder, tokens, stats, now, rtt);
         if builder.is_full() {
             return;
         }


### PR DESCRIPTION
- Replace unlimited `LOCAL_MAX_DATA` with a safe initial window (`INITIAL_STREAM_RECV_WINDOW_SIZE` * `LOCAL_STREAM_LIMIT_BIDI`) and add runtime auto-tuning for connection-level FC by reusing the existing stream auto-tune algorithm.
- Cap connection receive window at 100 MiB (`MAX_CONN_RECV_WINDOW_SIZE`). Keep per-stream caps unchanged.
- `ReceiverFlowControl<()>` now writes `MAX_DATA` with (now, rtt), wiring added in `streams.rs`.
- Rename the constant `INITIAL_RECV_WINDOW_SIZE` to `INITIAL_STREAM_RECV_WINDOW_SIZE` and update the location where it is called
- Extract the shared method of `auto_tune_inner`
- Tests updated; related tests pass; clippy clean.

Related issue: #2544 