### PR TITLE
feat(transport): implement RESET_STREAM_AT frame

### DIFF
--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -507,6 +507,8 @@ impl ConnectionParameters {
         }
         tps.local_mut()
             .set_integer(MaxDatagramFrameSize, self.datagram_size);
+        tps.local_mut()
+            .set_empty(TransportParameterId::ResetStreamAt);
         Ok(tps)
     }
 }

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -431,6 +431,21 @@ impl From<Frame<'_>> for QuicFrame {
                 length: None,
                 payload_length: None,
             },
+            Frame::ResetStreamAt {
+                stream_id,
+                application_error_code,
+                final_size,
+                reliable_size: _,
+            } => {
+                // TODO: Add definition to qlog crate.
+                Self::ResetStream {
+                    stream_id: stream_id.as_u64(),
+                    error_code: application_error_code,
+                    final_size,
+                    length: None,
+                    payload_length: None,
+                }
+            }
             Frame::StopSending {
                 stream_id,
                 application_error_code,

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1006,6 +1006,7 @@ impl SendStream {
         tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) -> bool {
+        // TODO: Always use ResetStreamAt.
         if let State::ResetSent {
             final_size,
             err,

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -30,6 +30,7 @@ pub struct FrameStats {
     pub crypto: usize,
     pub stream: usize,
     pub reset_stream: usize,
+    pub reset_stream_at: usize,
     pub stop_sending: usize,
 
     pub ping: usize,
@@ -70,8 +71,8 @@ impl Debug for FrameStats {
         )?;
         writeln!(
             f,
-            "    stream {} reset {} stop {}",
-            self.stream, self.reset_stream, self.stop_sending,
+            "    stream {} reset {} reset_at {} stop {}",
+            self.stream, self.reset_stream, self.reset_stream_at, self.stop_sending,
         )?;
         writeln!(
             f,
@@ -103,6 +104,7 @@ impl FrameStats {
             + self.crypto
             + self.stream
             + self.reset_stream
+            + self.reset_stream_at
             + self.stop_sending
             + self.ping
             + self.padding

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -121,7 +121,18 @@ impl Streams {
             } => {
                 stats.reset_stream += 1;
                 if let (_, Some(rs)) = self.obtain_stream(*stream_id)? {
-                    rs.reset(*application_error_code, *final_size)?;
+                    rs.reset(*application_error_code, *final_size, None)?;
+                }
+            }
+            Frame::ResetStreamAt {
+                stream_id,
+                application_error_code,
+                final_size,
+                reliable_size,
+            } => {
+                stats.reset_stream_at += 1;
+                if let (_, Some(rs)) = self.obtain_stream(*stream_id)? {
+                    rs.reset(*application_error_code, *final_size, Some(*reliable_size))?;
                 }
             }
             Frame::StopSending {

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -6,6 +6,11 @@
 
 // Transport parameters. See -transport section 7.3.
 
+// TODO: When using 0-RTT, both endpoints MUST remember the value of this
+// transport parameter. This allows use of this extension in 0-RTT packets. When
+// the server accepts 0-RTT data, the server MUST NOT disable this extension on
+// the resumed connection.
+
 use std::{
     cell::RefCell,
     fmt::{self, Display, Formatter},
@@ -54,6 +59,7 @@ pub enum TransportParameterId {
     GreaseQuicBit = 0x2ab2,
     MinAckDelay = 0xff02_de1a,
     MaxDatagramFrameSize = 0x0020,
+    ResetStreamAt = 0x17f7586d2cb571,
     #[cfg(test)]
     TestTransportParameter = 0xce16,
 }
@@ -324,6 +330,7 @@ impl TransportParameter {
                 _ => return Err(Error::TransportParameter),
             },
             TransportParameterId::VersionInformation => Self::decode_versions(&mut d)?,
+            TransportParameterId::ResetStreamAt => Self::Empty,
             #[cfg(test)]
             TransportParameterId::TestTransportParameter => {
                 Self::Bytes(d.decode_remainder().to_vec())


### PR DESCRIPTION
Implementation of https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/.

---

Draft only for now.