### PR TITLE
fix(transport): head-drop QUIC datagram on limit

### DIFF
--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -536,11 +536,11 @@ fn too_many_datagram_events() {
     // Datagram with FIRST_DATAGRAM data will be dropped.
     assert!(matches!(
         client.next_event().unwrap(),
-        ConnectionEvent::Datagram(data) if data == SECOND_DATAGRAM
+        ConnectionEvent::IncomingDatagramDropped
     ));
     assert!(matches!(
         client.next_event().unwrap(),
-        ConnectionEvent::IncomingDatagramDropped
+        ConnectionEvent::Datagram(data) if data == SECOND_DATAGRAM
     ));
     assert!(matches!(
         client.next_event().unwrap(),

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -169,7 +169,7 @@ impl QuicDatagrams {
             return Err(Error::TooMuchData);
         }
         if self.datagrams.len() == self.max_queued_outgoing_datagrams {
-            qdebug!("QUIC datagram queue full, dropping first datagram in queue.");
+            qdebug!("QUIC datagram queue full, dropping first datagram in queue (head-drop).");
             self.conn_events.datagram_outcome(
                 self.datagrams
                     .pop_front()


### PR DESCRIPTION
Previously `check_datagram_queued`:

- Would drop at the tail, even though the doc comment was describing a
  head-drop.
- Would drop at the wrong index, e.g. remove an entirely unrelated event.
- Would add the `IncomingDatagramDropped` event at the end.

This commit:

- Implements true head-drop.
- Drops at the correct index.
- Adds the `IncomingDatagramDropped` at the position of the dropped datagram,
  thus informing the consumer about the loss much earlier.

---

Continuation of https://github.com/mozilla/neqo/pull/3096.

Initial author is @MegaManSec, see git commit.