### PR TITLE
ci: Add `docker-build-qns` action

### DIFF
--- a/.github/actions/docker-build-qns/action.yml
+++ b/.github/actions/docker-build-qns/action.yml
@@ -1,0 +1,67 @@
+name: 'Build QNS Docker Image'
+description: 'Build a Docker image for QNS testing'
+author: 'neqo'
+
+inputs:
+  ref:
+    description: 'Git ref to checkout (SHA, branch, tag)'
+    required: false
+    default: github.ref
+  tag:
+    description: 'Tag for the image'
+    required: false
+    default: ''
+  push:
+    description: 'Whether to push the image to registry'
+    required: false
+    default: 'false'
+  platforms:
+    description: 'Platforms to build for'
+    required: false
+    default: 'linux/amd64'
+
+outputs:
+  image-id:
+    description: 'The ID of the built Docker image'
+    value: ${{ steps.docker_build.outputs.imageID }}
+  artifact-name:
+    description: 'The name of the uploaded artifact'
+    value: ${{ upload.outputs.artifact-name }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        ref: inputs.ref
+        persist-credentials: false
+
+    - uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
+      id: meta
+      with:
+        images: ghcr.io/${{ github.repository }}-qns${{ inputs.tag }}
+        tags: |
+          # default
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=tag
+          type=ref,event=pr
+          # set latest tag for default branch
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      id: docker_build
+      with:
+        push: ${{ inputs.push }}
+        tags: ${{ steps.meta.outputs.tags }}
+        file: qns/Dockerfile
+        build-args: RUST_VERSION=stable
+        platforms: ${{ inputs.platforms }}
+        outputs: type=docker,dest=/tmp/${{ format('{0}.tar', inputs.tag }}
+
+    - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      id: upload
+      if: ${{ inputs.push == 'false' }}
+      with:
+        name: ${{ format('{0} Docker image ', inputs.tag) }}
+        path: /tmp/${{ format('{0}.tar', inputs.tag }}


### PR DESCRIPTION
Needed for #3123. Will be a no-op until called from there, hence committing.