### PR TITLE
feat: Make `Encoder::encoder` take an `AsRef[u8]`

### DIFF
--- a/neqo-crypto/src/selfencrypt.rs
+++ b/neqo-crypto/src/selfencrypt.rs
@@ -90,7 +90,7 @@ impl SelfEncrypt {
         let mut enc = Encoder::with_capacity(encoded_len);
         enc.encode_byte(Self::VERSION);
         enc.encode_byte(self.key_id);
-        enc.encode(&salt);
+        enc.encode(salt);
 
         let mut extended_aad = enc.clone();
         extended_aad.encode(aad);

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -4132,7 +4132,7 @@ mod tests {
         hframe.encode(&mut d);
         let d_frame = HFrame::Data { len: 3 };
         d_frame.encode(&mut d);
-        d.encode(&[0x61, 0x62, 0x63]);
+        d.encode([0x61, 0x62, 0x63]);
         server_send_response_and_exchange_packet(
             &mut client,
             &mut server,
@@ -5134,7 +5134,7 @@ mod tests {
         hframe.encode(&mut d);
         let d_frame = HFrame::Data { len: 3 };
         d_frame.encode(&mut d);
-        d.encode(&[0x61, 0x62, 0x63]);
+        d.encode([0x61, 0x62, 0x63]);
         _ = server
             .conn
             .stream_send(request_stream_id, d.as_ref())

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -85,11 +85,11 @@ impl AddressValidation {
         match peer_address.ip() {
             IpAddr::V4(a) => {
                 aad.encode_byte(4);
-                aad.encode(&a.octets());
+                aad.encode(a.octets());
             }
             IpAddr::V6(a) => {
                 aad.encode_byte(6);
-                aad.encode(&a.octets());
+                aad.encode(a.octets());
             }
         }
         if retry {

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -312,7 +312,7 @@ impl ConnectionIdEntry<[u8; 16]> {
         builder.encode_varint(self.seqno);
         builder.encode_varint(0u64);
         builder.encode_vec(1, &self.cid);
-        builder.encode(&self.srt);
+        builder.encode(self.srt);
         stats.new_connection_id += 1;
         true
     }

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -1059,7 +1059,7 @@ impl crate::connection::test_internal::FrameWriter for RetireAll {
             .encode_varint(SEQNO)
             .encode_varint(SEQNO) // Retire Prior To
             .encode_vec(1, &cid)
-            .encode(&[0x7f; 16]);
+            .encode([0x7f; 16]);
     }
 }
 

--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -75,7 +75,7 @@ fn create_vn(initial_pkt: &[u8], versions: &[u32]) -> Vec<u8> {
 
     let mut encoder = Encoder::default();
     encoder.encode_byte(PACKET_BIT_LONG);
-    encoder.encode(&[0; 4]); // Zero version == VN.
+    encoder.encode([0; 4]); // Zero version == VN.
     encoder.encode_vec(1, src_cid);
     encoder.encode_vec(1, dst_cid);
 

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -188,7 +188,7 @@ impl Builder<Vec<u8>> {
         let mut grease = random::<4>();
         // This will not include the "QUIC bit" sometimes.  Intentionally.
         encoder.encode_byte(PACKET_BIT_LONG | (grease[3] & 0x7f));
-        encoder.encode(&[0; 4]); // Zero version == VN.
+        encoder.encode([0; 4]); // Zero version == VN.
         encoder.encode_vec(1, dcid);
         encoder.encode_vec(1, scid);
 
@@ -400,7 +400,7 @@ impl<B: Buffer> Builder<B> {
             }
 
             self.offsets.len = self.encoder.len();
-            self.encoder.encode(&[0; LONG_PACKET_LENGTH_LEN]);
+            self.encoder.encode([0; LONG_PACKET_LENGTH_LEN]);
         }
 
         // This allows the input to be >4, which is absurd, but we can eat that.
@@ -1073,7 +1073,7 @@ mod tests {
         enc.encode_uint(4, Version::default().wire_version());
         enc.encode_vec(1, &[0x00; MAX_CONNECTION_ID_LEN + 1]);
         enc.encode_vec(1, &[]);
-        enc.encode(&[0xff; 40]); // junk
+        enc.encode([0xff; 40]); // junk
 
         assert!(Public::decode(enc.as_mut(), &cid_mgr()).is_err());
     }
@@ -1085,7 +1085,7 @@ mod tests {
         enc.encode_uint(4, Version::default().wire_version());
         enc.encode_vec(1, &[]);
         enc.encode_vec(1, &[0x00; MAX_CONNECTION_ID_LEN + 2]);
-        enc.encode(&[0xff; 40]); // junk
+        enc.encode([0xff; 40]); // junk
 
         assert!(Public::decode(enc.as_mut(), &cid_mgr()).is_err());
     }
@@ -1194,7 +1194,7 @@ mod tests {
             PACKET_LIMIT,
         );
         builder.pn(0, 1);
-        builder.encode(&[0; 3]);
+        builder.encode([0; 3]);
         let encoder = builder.build(&mut prot).expect("build");
         assert_eq!(encoder.len(), 45);
         let first = encoder.clone();
@@ -1206,7 +1206,7 @@ mod tests {
             PACKET_LIMIT,
         );
         builder.pn(1, 3);
-        builder.encode(&[0]); // Minimal size (packet number is big enough).
+        builder.encode([0]); // Minimal size (packet number is big enough).
         let encoder = builder.build(&mut prot).expect("build");
         assert_eq!(
             first.as_ref(),
@@ -1234,7 +1234,7 @@ mod tests {
             PACKET_LIMIT,
         );
         builder.pn(0, 1);
-        builder.encode(&[1, 2, 3]);
+        builder.encode([1, 2, 3]);
         let packet = builder.build(&mut CryptoDxState::test_default()).unwrap();
         assert_eq!(packet.as_ref(), EXPECTED);
     }

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -819,7 +819,7 @@ impl Path {
             qtrace!("[{self}] Initiating path challenge {probe_count}");
             let data = random::<8>();
             builder.encode_varint(FrameType::PathChallenge);
-            builder.encode(&data);
+            builder.encode(data);
 
             // As above, no recovery token.
             stats.path_challenge += 1;

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -176,13 +176,13 @@ impl TransportParameter {
                         enc_inner.encode(&v4.ip().octets()[..]);
                         enc_inner.encode_uint(2, v4.port());
                     } else {
-                        enc_inner.encode(&[0; 6]);
+                        enc_inner.encode([0; 6]);
                     }
                     if let Some(v6) = v6 {
                         enc_inner.encode(&v6.ip().octets()[..]);
                         enc_inner.encode_uint(2, v6.port());
                     } else {
-                        enc_inner.encode(&[0; 18]);
+                        enc_inner.encode([0; 18]);
                     }
                     enc_inner.encode_vec(1, &cid[..]);
                     enc_inner.encode(&srt[..]);

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -413,7 +413,7 @@ fn vn_after_retry() {
 
     let mut encoder = Encoder::default();
     encoder.encode_byte(0x80);
-    encoder.encode(&[0; 4]); // Zero version == VN.
+    encoder.encode([0; 4]); // Zero version == VN.
     encoder.encode_vec(1, &client.odcid().unwrap()[..]);
     encoder.encode_vec(1, &[]);
     encoder.encode_uint(4, 0x5a5a_6a6a_u64);

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -449,7 +449,7 @@ fn bad_client_initial() {
         .unwrap();
 
     let mut payload_enc = Encoder::from(plaintext);
-    payload_enc.encode(&[0x08, 0x02, 0x00, 0x00]); // Add a stream frame.
+    payload_enc.encode([0x08, 0x02, 0x00, 0x00]); // Add a stream frame.
 
     // Make a new header with a 1 byte packet number length.
     let mut header_enc = Encoder::new();
@@ -541,7 +541,7 @@ fn bad_client_initial_connection_close() {
     let (_, pn) = header_protection::remove(&hp, header, payload);
 
     let mut payload_enc = Encoder::with_capacity(MIN_INITIAL_PACKET_SIZE);
-    payload_enc.encode(&[0x1c, 0x01, 0x00, 0x00]); // Add a CONNECTION_CLOSE frame.
+    payload_enc.encode([0x1c, 0x01, 0x00, 0x00]); // Add a CONNECTION_CLOSE frame.
 
     // Make a new header with a 1 byte packet number length.
     let mut header_enc = Encoder::new();


### PR DESCRIPTION
And deal with the fallout.

Fixes #3135