### PR TITLE
fix: Fix nightly Rust clippy warnings in #3133

### DIFF
--- a/neqo-http3/tests/non_ascii_headers.rs
+++ b/neqo-http3/tests/non_ascii_headers.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![expect(clippy::unwrap_used, reason = "OK in test code.")]
+
 use neqo_common::{event::Provider as _, header::HeadersExt as _};
 use neqo_http3::{Header, Http3ClientEvent, Http3ServerEvent, Priority};
 use test_fixture::{default_http3_client, default_http3_server, exchange_packets, now};
@@ -40,9 +42,7 @@ fn echo_header(request_header_name: &str, response_header_name: &str, test_data:
     let mut received_headers = None;
     while let Some(event) = server.next_event() {
         if let Http3ServerEvent::Headers {
-            stream,
-            headers,
-            fin: _,
+            stream, headers, ..
         } = event
         {
             received_stream = Some(stream);


### PR DESCRIPTION
@valenting the remaining one is
```
warning: call to `std::mem::drop` with a value that does not implement `Drop`. Dropping such a type only extends its contained lifetimes
  --> neqo-http3/tests/non_ascii_headers.rs:22:5
   |
22 |     drop(client.events());
   |     ^^^^^^^^^^^^^^^^^^^^^
   |
note: argument has type `neqo_common::event::Iter<'_, neqo_http3::Http3Client, neqo_http3::Http3ClientEvent>`
  --> neqo-http3/tests/non_ascii_headers.rs:22:10
   |
22 |     drop(client.events());
   |          ^^^^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#drop_non_drop
   = note: `#[warn(clippy::drop_non_drop)]` on by default
```