### PR TITLE
chore(Cargo.toml): prepare for version 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enumset",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "log",
  "neqo-common",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.18.0"
+version = "0.19.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The main change that I'm interested in is the non-ascii header value support needed for [bug 1999659](https://bugzilla.mozilla.org/show_bug.cgi?id=1999659)