### PR TITLE
feat(transport/cc): expose whether connection exited slow start as stat

### DIFF
--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -218,7 +218,7 @@ fn debug() {
   rx: 0 drop 0 dup 0 saved 0
   tx: 0 lost 0 lateack 0 ptoack 0 unackdrop 0
   cc: ce_loss 0 ce_ecn 0 ce_spurious 0
-  ss_exited: false
+  ss_exit: false
   pmtud: 0 sent 0 acked 0 lost 0 change 0 iface_mtu 0 pmtu
   resumed: false
   frames rx:

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -392,7 +392,7 @@ impl Debug for Stats {
             self.cc.congestion_events_ecn,
             self.cc.congestion_events_spurious,
         )?;
-        writeln!(f, "  ss_exited: {}", self.cc.slow_start_exited)?;
+        writeln!(f, "  ss_exit: {}", self.cc.slow_start_exited)?;
         writeln!(
             f,
             "  pmtud: {} sent {} acked {} lost {} change {} iface_mtu {} pmtu",


### PR DESCRIPTION
A first PR exposing the simplest stat discussed in #3112. Other stats like exit reason or approximations as to how close a heuristic was to the ideal exit point don't really apply as long as we only exit through loss/ecn and haven't implemented any heuristics.

But this is pretty useful already and would allow us to get some insight into how many connections actually exit slow start.

I hope with #3086 just merged we can also get this simple patch in quickly and then make a release so I can integrate both into Firefox glean metrics.

In addition to the unit tests below I also manually tested the changes using the `min_bandwidth` simulation with very small transfer amounts.