### PR TITLE
test(min_bandwidth): reduce expected utilization

### DIFF
--- a/neqo-transport/benches/min_bandwidth.rs
+++ b/neqo-transport/benches/min_bandwidth.rs
@@ -43,7 +43,7 @@ fn gbit_bandwidth(ecn: bool) {
     /// How much of the theoretical bandwidth we will expect to deliver.
     /// Because we're not transferring a whole lot relative to the bandwidth,
     /// this ratio is relatively low.
-    const MINIMUM_EXPECTED_UTILIZATION: f64 = 0.6;
+    const MINIMUM_EXPECTED_UTILIZATION: f64 = 0.4;
 
     let gbit_link = || {
         let rate_byte = LINK_BANDWIDTH / 8;


### PR DESCRIPTION
https://github.com/mozilla/neqo/pull/3117 and https://github.com/mozilla/neqo/pull/3125 improved raw byte throughput significantly, especially on the simulator. Thus the latter bumped the expected utilization value. We seem to have been to optimistic, thus lowering it a bit again (still above first value). Needs further investigation.

---

My bad. Suggested by me in https://github.com/mozilla/neqo/pull/3125#pullrequestreview-3496634490.