### PR TITLE
fix: Off-by-one error in QPACK table size calc

### DIFF
--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -134,7 +134,7 @@ impl HeaderTable {
     /// `HeaderLookup` if the index does not exist in the static table.
     pub fn get_static(index: u64) -> Res<&'static StaticTableEntry> {
         let inx = usize::try_from(index).or(Err(Error::HeaderLookup))?;
-        if inx > HEADER_STATIC_TABLE.len() {
+        if inx >= HEADER_STATIC_TABLE.len() {
             return Err(Error::HeaderLookup);
         }
         Ok(&HEADER_STATIC_TABLE[inx])


### PR DESCRIPTION
Broken out of and found by #3160.