### PR TITLE
feat(transport/quic_datagrams): expose send queue capacity

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -820,6 +820,8 @@ impl Http3Client {
 
     /// Send `WebTransport` datagram.
     ///
+    /// Consider calling [`Http3Client::datagram_send_queue_capacity`] before.
+    ///
     /// # Errors
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
@@ -838,6 +840,8 @@ impl Http3Client {
 
     /// Send `ConnectUdp` datagram.
     ///
+    /// Consider calling [`Http3Client::datagram_send_queue_capacity`] before.
+    ///
     /// # Errors
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
@@ -852,6 +856,13 @@ impl Http3Client {
         qtrace!("connect_udp_send_datagram session:{session_id:?}");
         self.base_handler
             .connect_udp_send_datagram(session_id, &mut self.conn, buf, id)
+    }
+
+    /// Returns the number of QUIC datagrams that can still be queued for
+    /// sending before the queue is full.
+    #[must_use]
+    pub fn datagram_send_queue_capacity(&self) -> usize {
+        self.conn.datagram_send_queue_capacity()
     }
 
     /// Returns the current max size of a datagram that can fit into a packet.

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -3868,6 +3868,13 @@ impl Connection {
             .add_datagram(buf, id.into(), &mut self.stats.borrow_mut())
     }
 
+    /// Returns the number of QUIC datagrams that can still be queued for
+    /// sending before the queue is full.
+    #[must_use]
+    pub fn datagram_send_queue_capacity(&self) -> usize {
+        self.quic_datagrams.send_queue_capacity()
+    }
+
     /// Return the PLMTU of the primary path.
     ///
     /// # Panics

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -186,6 +186,12 @@ impl QuicDatagrams {
         Ok(())
     }
 
+    /// Returns the number of QUIC datagrams that can still be queued for
+    /// sending before the queue is full.
+    pub fn send_queue_capacity(&self) -> usize {
+        self.max_queued_outgoing_datagrams - self.datagrams.len()
+    }
+
     pub fn handle_datagram(&self, data: &[u8], stats: &mut Stats) -> Res<()> {
         if self.local_datagram_size < u64::try_from(data.len())? {
             return Err(Error::ProtocolViolation);


### PR DESCRIPTION
Add function `datagram_send_queue_capacity` to `Connection` and `Http3Client`. Before sending a WebTransport or MASQUE connect-udp datagram, users can check how many datagrams can still be queued for sending, thus avoiding datagrams being dropped due to a full send queue.

Enables https://github.com/mozilla/neqo/issues/2852.