### PR TITLE
chore: prepare v0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enumset",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "log",
  "neqo-common",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.19.0"
+version = "0.20.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Want to get the stats for congestion control into Firefox to expose in Glean.

- 5d10d28d fix: Off-by-one error in QPACK table size calc (#3174)
- c2caaa23 fix(transport/fc): account for WINDOW_UPDATE_FRACTION when auto-tuning (#3125)
- 340f4f1a feat(transport/cc): expose whether connection exited slow start as stat (#3165)
- 51652818 feat(transport/cc): spurious congestion event detection (#3086)