### PR TITLE
test(transport): loosen min_bandwidth test tolerance

### DIFF
--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -1234,7 +1234,7 @@ mod test {
         /// Allow auto-tuning algorithm to be off from actual bandwidth-delay
         /// product by up to 1KiB.
         const TOLERANCE: u64 = 1024;
-        const BW_TOLERANCE: f64 = 0.8;
+        const BW_TOLERANCE: f64 = 0.6;
 
         test_fixture::fixture_init();
 


### PR DESCRIPTION
https://github.com/mozilla/neqo/pull/3125 improved the flow control auto-tuning algorithm and added a test that asserts an 80% bandwidth usage. That limit seems to be too tight, as we spuriously see failures.

Setting to 60% for now.