### PR TITLE
refactor(qpack): don't collect when decoding a header block

### DIFF
--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -221,17 +221,13 @@ impl Decoder {
                 if self.blocked_streams.len() > self.max_blocked_streams {
                     Err(Error::Decompression)
                 } else {
-                    let r = self
+                    let found = self
                         .blocked_streams
                         .iter()
-                        .filter_map(|(id, req)| (*id == stream_id).then_some(*req))
-                        .collect::<Vec<_>>();
-                    if !r.is_empty() {
-                        debug_assert!(r.len() == 1);
-                        debug_assert!(r[0] == req_insert_cnt);
-                        return Ok(None);
+                        .any(|(id, _req)| *id == stream_id);
+                    if !found {
+                        self.blocked_streams.push((stream_id, req_insert_cnt));
                     }
-                    self.blocked_streams.push((stream_id, req_insert_cnt));
                     Ok(None)
                 }
             }


### PR DESCRIPTION
The code here used `collect()` just to check if the result was empty.

I've removed the debug assertions; I think we're good for that given the age and stability of this code.  Happy to restore the check that the required insert count matches, but there's no point in iterating over the entire collection to determine if there are duplicates.  This code is the only place that adds and there is no way we'll get duplicates.