### PR TITLE
feat(transport): Use tokens to identify PMTUD probes

### DIFF
--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -333,10 +333,9 @@ impl<T: WindowAdjustment> CongestionControl for ClassicCongestionControl<T> {
             now,
         );
 
-        let is_pmtud_probe = self.pmtud.is_probe_filter();
         let mut lost_packets = lost_packets
             .iter()
-            .filter(|pkt| !is_pmtud_probe(pkt))
+            .filter(|pkt| !pkt.is_pmtud_probe())
             .rev()
             .peekable();
 

--- a/neqo-transport/src/recovery/sent.rs
+++ b/neqo-transport/src/recovery/sent.rs
@@ -74,6 +74,14 @@ impl Packet {
             .any(|t| matches!(t, recovery::Token::EcnEct0))
     }
 
+    /// Returns `true` if this packet is a PMTUD probe.
+    #[must_use]
+    pub fn is_pmtud_probe(&self) -> bool {
+        self.tokens
+            .iter()
+            .any(|t| matches!(t, recovery::Token::PmtudProbe))
+    }
+
     /// The time that this packet was sent.
     #[must_use]
     pub const fn time_sent(&self) -> Instant {

--- a/neqo-transport/src/recovery/token.rs
+++ b/neqo-transport/src/recovery/token.rs
@@ -67,4 +67,6 @@ pub enum Token {
     Datagram(DatagramTracking),
     /// A packet marked with [`neqo_common::Ecn::Ect0`].
     EcnEct0,
+    /// A PMTUD probe packet.
+    PmtudProbe,
 }


### PR DESCRIPTION
Rather than doind it based on size. This is possible now that we do PMTUD after the handshake, where coalescing can't happen.

Suggestion by @mxinden.