### PR TITLE
feat(bin/client): add --proxy to proxy HTTP/3 connection

### DIFF
--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -79,7 +79,7 @@ fn transfer(c: &mut Criterion) {
                     },
                     |(server_handle, client)| {
                         black_box(async move {
-                            client.await.unwrap();
+                            Box::pin(client).await.unwrap();
                             // Tell server to shut down.
                             server_handle.send(()).unwrap();
                         })

--- a/neqo-bin/src/bin/client.rs
+++ b/neqo-bin/src/bin/client.rs
@@ -14,6 +14,5 @@ use clap::Parser as _;
 )]
 async fn main() -> Result<(), neqo_bin::client::Error> {
     let args = neqo_bin::client::Args::parse();
-
-    neqo_bin::client::client(args).await
+    Box::pin(neqo_bin::client::client(args)).await
 }

--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![expect(clippy::unwrap_used, reason = "This is example code.")]
-
 //! An [HTTP 0.9](https://www.w3.org/Protocols/HTTP/AsImplemented.html) client implementation.
 
 use std::{

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![expect(clippy::unwrap_used, reason = "This is example code.")]
-
 //! An HTTP 3 client implementation.
 
 use std::{
@@ -83,7 +81,7 @@ pub fn create_client(
         cid_generator,
         local_addr,
         remote_addr,
-        args.shared.quic_parameters.get(args.shared.alpn.as_str()),
+        args.shared.quic_parameters.get(args.shared.alpn.as_str()).pmtud(false),
         Instant::now(),
     )?;
     let ciphers = args.get_ciphers();

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![expect(clippy::unwrap_used, reason = "This is example code.")]
-
 use std::{
     collections::VecDeque,
     fmt::Display,
@@ -37,10 +35,11 @@ use thiserror::Error;
 use tokio::time::Sleep;
 use url::{Host, Origin, Url};
 
-use crate::SharedArgs;
+use crate::{udp, SharedArgs};
 
 mod http09;
 mod http3;
+mod proxied_http3;
 
 const BUFWRITER_BUFFER_SIZE: usize = 64 * 1024;
 
@@ -179,6 +178,10 @@ pub struct Args {
     #[arg(name = "cid-length", short = 'l', long, default_value = "0",
           value_parser = clap::value_parser!(u8).range(..=20))]
     cid_len: u8,
+
+    /// Use a MASQUE connect-udp proxy server at the given URL.
+    #[arg(name = "proxy", long)]
+    proxy: Option<Url>,
 }
 
 impl Args {
@@ -220,6 +223,7 @@ impl Args {
             upload_size,
             stats: false,
             cid_len: 0,
+            proxy: None,
         }
     }
 
@@ -368,7 +372,7 @@ enum Ready {
 
 // Wait for the socket to be readable or the timeout to fire.
 async fn ready(
-    socket: &crate::udp::Socket,
+    socket: &udp::Socket,
     mut timeout: Option<&mut Pin<Box<Sleep>>>,
 ) -> Result<Ready, io::Error> {
     let socket_ready = Box::pin(socket.readable()).map_ok(|()| Ready::Socket);
@@ -387,6 +391,7 @@ trait Handler {
     fn take_token(&mut self) -> Option<ResumptionToken>;
 }
 
+#[derive(Debug)]
 enum CloseState {
     NotClosing,
     Closing,
@@ -412,7 +417,7 @@ trait Client {
 
 struct Runner<'a, H: Handler> {
     local_addr: SocketAddr,
-    socket: &'a mut crate::udp::Socket,
+    socket: &'a mut udp::Socket,
     client: H::Client,
     handler: H,
     timeout: Option<Pin<Box<Sleep>>>,
@@ -423,7 +428,7 @@ struct Runner<'a, H: Handler> {
 impl<'a, H: Handler> Runner<'a, H> {
     fn new(
         local_addr: SocketAddr,
-        socket: &'a mut crate::udp::Socket,
+        socket: &'a mut udp::Socket,
         client: H::Client,
         handler: H,
         args: &'a Args,
@@ -587,7 +592,6 @@ fn urls_by_origin(urls: &[Url]) -> impl Iterator<Item = ((Host, u16), VecDeque<U
 
 #[expect(
     clippy::future_not_send,
-    clippy::missing_panics_doc,
     clippy::missing_errors_doc,
     reason = "This is example code."
 )]
@@ -604,67 +608,120 @@ pub async fn client(mut args: Args) -> Res<()> {
 
     init()?;
 
-    for ((host, port), mut urls) in urls_by_origin(&args.urls) {
-        if args.resume && urls.len() < 2 {
-            qerror!("Resumption to {host} cannot work without at least 2 URLs");
-            exit(127);
-        }
-
-        let remote_addr = format!("{host}:{port}").to_socket_addrs()?.find(|addr| {
-            !matches!(
-                (addr, args.ipv4_only, args.ipv6_only),
-                (SocketAddr::V4(..), false, true) | (SocketAddr::V6(..), true, false)
-            )
-        });
-        let Some(remote_addr) = remote_addr else {
-            qerror!("No compatible address found for: {host}");
-            exit(1);
-        };
-        let mut socket = crate::udp::Socket::bind(local_addr_for(&remote_addr, 0))?;
-        if socket.may_fragment() {
-            qinfo!("Datagrams may be fragmented by the IP layer. Disabling PMTUD.");
-            args.shared.quic_parameters.no_pmtud = true;
-        }
-        let real_local = socket.local_addr().unwrap();
-        qinfo!(
-            "{} Client connecting: {real_local:?} -> {remote_addr:?}",
-            args.shared.alpn
-        );
-
-        let hostname = format!("{host}");
-        let mut token: Option<ResumptionToken> = None;
-        let mut first = true;
-        while !urls.is_empty() {
-            let to_request = if (args.resume && first) || args.download_in_series {
-                urls.pop_front().into_iter().collect()
-            } else {
-                std::mem::take(&mut urls)
-            };
-
-            first = false;
-
-            token = if args.shared.alpn == "h3" {
-                let client = http3::create_client(&args, real_local, remote_addr, &hostname, token)
-                    .expect("failed to create client");
-
-                let handler = http3::Handler::new(to_request, args.clone());
-
-                Runner::new(real_local, &mut socket, client, handler, &args)
-                    .run()
-                    .await?
-            } else {
-                let client =
-                    http09::create_client(&args, real_local, remote_addr, &hostname, token)
-                        .expect("failed to create client");
-
-                let handler = http09::Handler::new(to_request, &args);
-
-                Runner::new(real_local, &mut socket, client, handler, &args)
-                    .run()
-                    .await?
-            };
-        }
+    for ((host, port), urls) in urls_by_origin(&args.urls) {
+        client_for_origin(host, port, urls, &args).await?;
     }
 
+    Ok(())
+}
+
+#[expect(clippy::future_not_send, reason = "This is example code.")]
+async fn client_for_origin(host: Host, port: u16, mut urls: VecDeque<Url>, args: &Args) -> Res<()> {
+    if args.resume && urls.len() < 2 {
+        qerror!("Resumption to {host} cannot work without at least 2 URLs");
+        exit(127);
+    }
+
+    let Some(origin_addr) = format!("{host}:{port}").to_socket_addrs()?.find(|addr| {
+        !matches!(
+            (addr, args.ipv4_only, args.ipv6_only),
+            (SocketAddr::V4(..), false, true) | (SocketAddr::V6(..), true, false)
+        )
+    }) else {
+        qerror!("No compatible address found for: {host}");
+        exit(1);
+    };
+
+    let proxy_addr = args.proxy.as_ref().map(|proxy_url| {
+        let Origin::Tuple(_scheme, proxy_host, proxy_port) = proxy_url.origin() else {
+            panic!();
+        };
+        let Some(proxy_addr) = format!("{proxy_host}:{proxy_port}")
+            .to_socket_addrs()
+            .unwrap()
+            .find(|addr| {
+                !matches!(
+                    (addr, args.ipv4_only, args.ipv6_only),
+                    (SocketAddr::V4(..), false, true) | (SocketAddr::V6(..), true, false)
+                )
+            })
+        else {
+            qerror!("No compatible address found for: {proxy_host}");
+            exit(1);
+        };
+        (proxy_host, proxy_addr)
+    });
+
+    let mut socket = udp::Socket::bind(local_addr_for(
+        &proxy_addr.as_ref().map_or(origin_addr, |p| p.1),
+        0,
+    ))?;
+    let real_local = socket.local_addr().unwrap();
+    qinfo!(
+        "{} Client connecting: {real_local:?} -> {origin_addr:?}",
+        args.shared.alpn
+    );
+
+    let hostname = format!("{host}");
+    let mut token: Option<ResumptionToken> = None;
+    let mut first = true;
+    while !urls.is_empty() {
+        let to_request = if (args.resume && first) || args.download_in_series {
+            urls.pop_front().into_iter().collect()
+        } else {
+            std::mem::take(&mut urls)
+        };
+
+        first = false;
+
+        token = if args.shared.alpn == "h3" {
+            let mut client_args = args.clone();
+            // Don't forward proxy authorization to origin.
+            client_args.headers.retain(|h| {
+                let name_lower = h.name().to_ascii_lowercase();
+                name_lower != "authorization" && name_lower != "proxy-authorization"
+            });
+            let client =
+                http3::create_client(&client_args, real_local, origin_addr, &hostname, token)
+                    .expect("failed to create client");
+            let client_handler = http3::Handler::new(to_request, client_args.clone());
+
+            if let Some((proxy_host, proxy_addr)) = &proxy_addr {
+                let proxy = proxied_http3::ProxiedHttp3::new(
+                    client,
+                    client_handler,
+                    args.proxy.clone().unwrap(),
+                    args.headers.clone(),
+                    &format!("{proxy_host}"),
+                    real_local,
+                    *proxy_addr,
+                )?;
+                Box::pin(
+                    Runner::new(
+                        real_local,
+                        &mut socket,
+                        proxy,
+                        proxied_http3::Handler::default(),
+                        args,
+                    )
+                    .run(),
+                )
+                .await?
+            } else {
+                Runner::new(real_local, &mut socket, client, client_handler, args)
+                    .run()
+                    .await?
+            }
+        } else {
+            let client = http09::create_client(args, real_local, origin_addr, &hostname, token)
+                .expect("failed to create client");
+
+            let handler = http09::Handler::new(to_request, args);
+
+            Runner::new(real_local, &mut socket, client, handler, args)
+                .run()
+                .await?
+        };
+    }
     Ok(())
 }

--- a/neqo-bin/src/client/proxied_http3.rs
+++ b/neqo-bin/src/client/proxied_http3.rs
@@ -1,0 +1,243 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! An HTTP/3 MASQUE connect-udp proxy client.
+//!
+//! Wraps an [`Http3Client`] and [`super::http3::Handler`] and proxies their UDP
+//! datagrams via an HTTP/3 MASQUE connect-udp proxy.
+
+use std::{
+    cell::RefCell, cmp::min, fmt::Display, net::SocketAddr, num::NonZeroUsize, rc::Rc,
+    time::Instant,
+};
+
+use neqo_common::{event::Provider, Datagram, Tos};
+use neqo_crypto::{AuthenticationStatus, ResumptionToken};
+use neqo_http3::{
+    ConnectUdpEvent, Header, Http3Client, Http3ClientEvent, Http3Parameters, Http3State,
+};
+use neqo_transport::{
+    AppError, CloseReason, ConnectionParameters, DatagramTracking, EmptyConnectionIdGenerator,
+    OutputBatch, StreamId,
+};
+use url::Url;
+
+use super::{Client, CloseState, Res};
+
+#[derive(Default)]
+pub struct Handler {}
+
+impl super::Handler for Handler {
+    type Client = ProxiedHttp3;
+
+    fn handle(&mut self, client: &mut ProxiedHttp3) -> Res<bool> {
+        let done = client.handler.handle(&mut client.inner_conn)?;
+
+        if matches!(client.inner_conn.is_closed()?, CloseState::Closed) {
+            if let Some(stream_id) = client.session_id.take() {
+                client
+                    .outer_conn
+                    .connect_udp_close_session(stream_id, 0, "kthxbye!", Instant::now())?;
+                client.outer_conn.close(Instant::now(), 0, "kthxbye!");
+            }
+
+            return Ok(true);
+        }
+
+        if client.session_id.is_none() {
+            return Ok(false);
+        }
+
+        Ok(done)
+    }
+
+    fn take_token(&mut self) -> Option<ResumptionToken> {
+        None
+    }
+}
+
+pub struct ProxiedHttp3 {
+    /// HTTP/3 connection to the origin, proxied through
+    /// [`ProxiedHttp3::proxy_conn`].
+    inner_conn: Http3Client,
+    handler: super::http3::Handler,
+    /// HTTP/3 connection to the proxy server, providing a MASQUE connect-udp
+    /// session.
+    outer_conn: Http3Client,
+    url: Url,
+    /// The MASQUE connect-udp session ID, i.e., the HTTP EXTENDED CONNECT stream ID.
+    session_id: Option<StreamId>,
+    local: Option<SocketAddr>,
+    remote: Option<SocketAddr>,
+    headers: Vec<Header>,
+}
+
+impl ProxiedHttp3 {
+    pub(crate) fn new(
+        proxied_conn: Http3Client,
+        handler: super::http3::Handler,
+        url: Url,
+        headers: Vec<Header>,
+        hostname: &str,
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+    ) -> Res<Self> {
+        let proxy_conn = Http3Client::new(
+            hostname,
+            Rc::new(RefCell::new(EmptyConnectionIdGenerator::default())),
+            local_addr,
+            remote_addr,
+            Http3Parameters::default()
+                .connection_parameters(
+                    ConnectionParameters::default()
+                        .datagram_size(1500)
+                        .pmtud(true),
+                )
+                .connect(true)
+                .http3_datagram(true),
+            Instant::now(),
+        )?;
+        Ok(Self {
+            inner_conn: proxied_conn,
+            handler,
+            outer_conn: proxy_conn,
+            url,
+            session_id: None,
+            local: None,
+            remote: None,
+            headers,
+        })
+    }
+}
+
+impl Client for ProxiedHttp3 {
+    fn process_multiple_output(
+        &mut self,
+        now: Instant,
+        max_datagrams: NonZeroUsize,
+    ) -> OutputBatch {
+        // First, if the proxy session is established already, service the proxied connection first.
+        let maybe_proxied_conn_callback = loop {
+            let Some(stream_id) = self.session_id else {
+                // If we don't have a stream ID, the proxy session isn't
+                // established yet, and we can't send anything.
+                break None;
+            };
+            match self.inner_conn.process_output(now) {
+                neqo_http3::Output::None => break None,
+                neqo_http3::Output::Callback(duration) => break Some(duration),
+                neqo_http3::Output::Datagram(datagram) => {
+                    self.local = Some(datagram.source());
+                    self.remote = Some(datagram.destination());
+                    self.outer_conn
+                        .connect_udp_send_datagram(
+                            stream_id,
+                            datagram.as_ref(),
+                            DatagramTracking::None,
+                        )
+                        .unwrap();
+                }
+            }
+        };
+
+        // Second, service the proxy connection.
+        let maybe_proxy_conn_callback =
+            match self.outer_conn.process_multiple_output(now, max_datagrams) {
+                OutputBatch::None => None,
+                o @ OutputBatch::DatagramBatch(_) => return o,
+                OutputBatch::Callback(duration) => Some(duration),
+            };
+
+        // No datagram to send. Return the earlier callback, if any.
+        match (maybe_proxied_conn_callback, maybe_proxy_conn_callback) {
+            (None, None) => OutputBatch::None,
+            (Some(duration), None) | (None, Some(duration)) => OutputBatch::Callback(duration),
+            (Some(d1), Some(d2)) => OutputBatch::Callback(min(d1, d2)),
+        }
+    }
+
+    fn process_multiple_input<'a>(
+        &mut self,
+        dgrams: impl IntoIterator<Item = Datagram<&'a mut [u8]>>,
+        now: Instant,
+    ) {
+        // Process the input datagrams.
+        self.outer_conn.process_multiple_input(dgrams, now);
+
+        // See whether as a result we have any datagrams for the proxied connection.
+        while let Some(event) = self.outer_conn.next_event() {
+            match event {
+                Http3ClientEvent::AuthenticationNeeded => {
+                    self.outer_conn
+                        .authenticated(AuthenticationStatus::Ok, Instant::now());
+                }
+                Http3ClientEvent::ConnectUdp(event) => match event {
+                    ConnectUdpEvent::Negotiated(success) => {
+                        assert!(success);
+                        assert!(self.outer_conn.state().active());
+                        self.outer_conn
+                            .connect_udp_create_session(Instant::now(), &self.url, &self.headers)
+                            .unwrap();
+                    }
+                    ConnectUdpEvent::NewSession { stream_id, .. } => {
+                        self.session_id = Some(stream_id);
+                    }
+                    ConnectUdpEvent::Datagram {
+                        session_id,
+                        datagram,
+                    } => {
+                        assert_eq!(session_id, self.session_id.unwrap());
+                        let tos = Tos::default();
+                        let datagram = Datagram::new(
+                            *self.remote.as_ref().unwrap(),
+                            *self.local.as_ref().unwrap(),
+                            tos,
+                            // TODO
+                            datagram.as_ref().to_vec(),
+                        );
+                        self.inner_conn.process_input(datagram, now);
+                    }
+                    ConnectUdpEvent::SessionClosed { .. } => {}
+                },
+                Http3ClientEvent::RequestsCreatable
+                | Http3ClientEvent::StateChange(Http3State::Connected)
+                | Http3ClientEvent::ResumptionToken(_) => {}
+                _ => {
+                    panic!("Unhandled event {event:?}");
+                }
+            }
+        }
+    }
+
+    fn close<S>(&mut self, now: Instant, app_error: AppError, msg: S)
+    where
+        S: AsRef<str> + Display,
+    {
+        self.inner_conn
+            .close(now, app_error, msg.as_ref().to_string());
+    }
+
+    fn is_closed(&self) -> Result<CloseState, CloseReason> {
+        match self.inner_conn.is_closed()? {
+            CloseState::NotClosing => return Ok(CloseState::NotClosing),
+            CloseState::Closing => return Ok(CloseState::Closing),
+            CloseState::Closed => {}
+        }
+
+        match self.outer_conn.is_closed()? {
+            CloseState::Closed => Ok(CloseState::Closed),
+            CloseState::NotClosing | CloseState::Closing => Ok(CloseState::Closing),
+        }
+    }
+
+    fn stats(&self) -> neqo_transport::Stats {
+        self.inner_conn.transport_stats()
+    }
+
+    fn has_events(&self) -> bool {
+        Provider::has_events(&self.inner_conn)
+    }
+}

--- a/neqo-bin/src/server/http09.rs
+++ b/neqo-bin/src/server/http09.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![expect(clippy::unwrap_used, reason = "This is example code.")]
-
 use std::{
     borrow::Cow,
     cell::RefCell,

--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![expect(clippy::unwrap_used, reason = "This is example code.")]
-
 use std::{
     cell::RefCell,
     fmt::{self, Display},

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 #![expect(
-    clippy::unwrap_used,
     clippy::future_not_send,
     clippy::missing_errors_doc,
     clippy::missing_panics_doc,


### PR DESCRIPTION
This commit enables the `neqo-client` to proxy an HTTP/3 connection through a MASQUE CONNECT-UDP proxy.

Example:

```
cargo run --bin neqo-client -- --stats --output-read-data --header "authorization: $TOKEN" --proxy "https://$PROXY_URL/.well-known/masque/udp/www.cnn.com/443/" "https://www.cnn.com/favicon.ico"
```