### PR TITLE
chore(transport/fc): add debug_assert to catch underflow

### DIFF
--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -423,6 +423,12 @@ where
             max_window,
         );
 
+        // Debug <https://github.com/mozilla/neqo/issues/3208>.
+        debug_assert!(
+            self.max_active >= prev_max_active,
+            "expect no decrease, self: {self:?}, now: {now:?}, rtt: {rtt:?}, max_window: {max_window}, subject: {subject}"
+        );
+
         let increase = self.max_active - prev_max_active;
         if increase > 0 {
             qdebug!(


### PR DESCRIPTION
Needed for https://github.com/mozilla/neqo/issues/3208.