### PR TITLE
chore: No Dependabot for `taskcluster`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,13 +39,3 @@ updates:
       # semver-major-days: 20
       # semver-minor-days: 10
       # semver-patch-days: 5
-  - package-ecosystem: docker
-    directory: /taskcluster/docker/linux
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 10
-      # "semver" not supported for docker; see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#configuration-of-cooldown
-      # semver-major-days: 20
-      # semver-minor-days: 10
-      # semver-patch-days: 5


### PR DESCRIPTION
Since we dropped trying out `taskcluster` long ago; forgot this.