### PR TITLE
chore: Update other QUIC stacks for `perfcompare`

### DIFF
--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: google/quiche
-          ref: 37de4454d92b9b0aeb4be5fcd6c49cd3d622f0c7 # Google doesn't tag release, just update the hash occasionally
+          ref: f9f012c06eeabf39ccfbaaf6ea4bf5bda932d25b # Google doesn't tag release, just update the hash occasionally
           path: google-quiche
           submodules: 'recursive'
           persist-credentials: false


### PR DESCRIPTION
And also give `msquic` some flags to maybe make it faster.