### PR TITLE
feat: emit event on QUIC datagram sent

### DIFF
--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -8,7 +8,7 @@ use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
 use neqo_common::{event::Provider as EventProvider, qtrace, Bytes, Header};
 use neqo_crypto::ResumptionToken;
-use neqo_transport::{AppError, StreamId, StreamType};
+use neqo_transport::{AppError, OutgoingDatagramOutcome, StreamId, StreamType};
 
 use crate::{
     connection::Http3State,
@@ -130,6 +130,8 @@ pub enum Http3ClientEvent {
     WebTransport(WebTransportEvent),
     /// `ConnectUdp` events
     ConnectUdp(ConnectUdpEvent),
+    /// Outcome of an outgoing datagram.
+    OutgoingDatagramOutcome { outcome: OutgoingDatagramOutcome },
 }
 
 #[derive(Debug, Default, Clone)]

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -1159,8 +1159,12 @@ impl Http3Client {
                 ConnectionEvent::Datagram(dgram) => {
                     self.base_handler.handle_datagram(dgram);
                 }
+                ConnectionEvent::OutgoingDatagramOutcome { outcome, .. } => {
+                    // TODO: Move into events?
+                    self.events
+                        .insert(Http3ClientEvent::OutgoingDatagramOutcome { outcome });
+                }
                 ConnectionEvent::SendStreamComplete { .. }
-                | ConnectionEvent::OutgoingDatagramOutcome { .. }
                 | ConnectionEvent::IncomingDatagramDropped => {}
             }
         }

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -18,10 +18,11 @@ use crate::{
     AppError, Stats,
 };
 
-#[derive(Debug, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone)]
 pub enum OutgoingDatagramOutcome {
     DroppedTooBig,
     DroppedQueueFull,
+    Sent,
     Lost,
     Acked,
 }

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -73,7 +73,7 @@ pub use self::{
         },
         Connection, Output, OutputBatch, State, ZeroRttState,
     },
-    events::{ConnectionEvent, ConnectionEvents},
+    events::{ConnectionEvent, ConnectionEvents, OutgoingDatagramOutcome},
     frame::CloseError,
     packet::MIN_INITIAL_PACKET_SIZE,
     pmtud::Pmtud,

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -132,6 +132,8 @@ impl QuicDatagrams {
                 debug_assert!(builder.len() <= builder.limit());
                 stats.frame_tx.datagram += 1;
                 tokens.push(recovery::Token::Datagram(*dgram.tracking()));
+                self.conn_events
+                    .datagram_outcome(dgram.tracking(), OutgoingDatagramOutcome::Sent);
             } else if tokens.is_empty() {
                 // If the packet is empty, except packet headers, and the
                 // datagram cannot fit, drop it.


### PR DESCRIPTION
Work-in-progress

Needed for MASQUE to notify inner connection that it can add more datagrams to the outer connection QUIC datagram queue.