### PR TITLE
chore: Use `strum` and `enum-map` for `StreamId`

### DIFF
--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -677,17 +677,17 @@ impl RemoteStreamLimits {
     }
 }
 
-impl Deref for RemoteStreamLimits {
-    type Target = EnumMap<StreamType, RemoteStreamLimit>;
+impl Index<StreamType> for RemoteStreamLimits {
+    type Output = RemoteStreamLimit;
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    fn index(&self, index: StreamType) -> &Self::Output {
+        &self.0[index]
     }
 }
 
-impl DerefMut for RemoteStreamLimits {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+impl IndexMut<StreamType> for RemoteStreamLimits {
+    fn index_mut(&mut self, index: StreamType) -> &mut Self::Output {
+        &mut self.0[index]
     }
 }
 

--- a/neqo-transport/src/stream_id.rs
+++ b/neqo-transport/src/stream_id.rs
@@ -10,11 +10,10 @@ use std::fmt::{self, Display, Formatter};
 
 use enum_map::Enum;
 use neqo_common::Role;
-use strum::FromRepr;
 
 /// The type of stream, either Bi-Directional or Uni-Directional.
 /// The discriminant values match the QUIC stream type bits.
-#[derive(PartialEq, Debug, Copy, Clone, PartialOrd, Eq, Ord, Hash, Enum, FromRepr)]
+#[derive(PartialEq, Debug, Copy, Clone, PartialOrd, Eq, Ord, Hash, Enum)]
 #[repr(u64)]
 pub enum StreamType {
     BiDi = 0,


### PR DESCRIPTION
And related functionality. Maybe a bit shorter? Am on the fence.