### PR TITLE
chore: Run less CI on merge to `main`

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: ["main"]
     paths: [".github/**"]
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,7 +3,6 @@ on:
   workflow_call:
   pull_request:
     branches: ["main"]
-  merge_group:
   workflow_dispatch:
     inputs:
       bencher:

--- a/.github/workflows/check-mtu.yml
+++ b/.github/workflows/check-mtu.yml
@@ -3,7 +3,6 @@ on:
   workflow_dispatch:
   pull_request:
     branches: ["main"]
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -15,7 +14,6 @@ permissions:
 jobs:
   check-android:
     name: Check Android
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -32,7 +30,6 @@ jobs:
 
   check-vm:
     name: Run checks for VM-only platforms
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -198,7 +198,6 @@ jobs:
 
   check-android:
     name: Check Android
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -217,7 +216,6 @@ jobs:
 
   check-vm:
     name: Run checks for VM-only platforms
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -4,7 +4,6 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-  merge_group:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -3,7 +3,6 @@ on:
   workflow_call:
   pull_request:
     branches: ["main"]
-  merge_group:
   workflow_dispatch:
     inputs:
       bencher:

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -26,7 +26,6 @@ env:
 jobs:
   docker-image:
     name: Build Docker image
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-24.04
     outputs:
       imageID: ${{ steps.docker_build_and_push.outputs.imageID }}

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -3,7 +3,6 @@ on:
   workflow_dispatch:
   pull_request:
     branches: ["main"]
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -4,7 +4,6 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-  merge_group:
   workflow_dispatch:
 env:
   DUMP_SIMULATION_SEEDS: /tmp/simulation-seeds
@@ -23,7 +22,6 @@ defaults:
 jobs:
   sanitize:
     name: Sanitize
-    if: github.actor != 'dependabot[bot]'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -3,7 +3,6 @@ on:
   workflow_dispatch:
   pull_request:
     branches: ["main"]
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Run only those workflows that are either required checks or that create `main`-branch cached state for others.

Especially skipping benchmarking should help reduce load on the self-hosted runners.

Also run a fuller set of CI on Dependabot updates, to catch more issues.