### PR TITLE
chore: `macos-13` CI runners now unsupported

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -76,7 +76,7 @@ jobs:
           # - os: ubuntu-22.04
           #   rust-toolchain: stable
           #   type: debug
-          - os: macos-13
+          - os: macos-14
             rust-toolchain: stable
             type: debug
           - os: windows-2022


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

Switch to `macos-14`.