### PR TITLE
chore: add tests for `neqo-common/src/lib.rs`

### DIFF
--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -106,3 +106,32 @@ pub enum MessageType {
     Request,
     Response,
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_output() {
+        assert_eq!(hex([]), "");
+        assert_eq!(hex([0xab, 0xcd]), "abcd");
+    }
+
+    #[test]
+    fn const_minmax() {
+        for (a, b, min, max) in [(2, 5, 2, 5), (5, 2, 2, 5), (3, 3, 3, 3)] {
+            assert_eq!(const_min(a, b), min);
+            assert_eq!(const_max(a, b), max);
+        }
+    }
+
+    #[test]
+    fn hex_snip_middle_boundary() {
+        let short: Vec<u8> = (0..16).collect();
+        assert!(hex_snip_middle(&short).ends_with("0e0f"));
+        let long: Vec<u8> = (0..20).collect();
+        let s = hex_snip_middle(&long);
+        assert!(s.starts_with("[20]: 00") && s.contains("..") && s.ends_with("1213"));
+    }
+}


### PR DESCRIPTION
Add tests to eliminate missed mutants in `neqo-common/src/lib.rs`:
- `hex_output`: verifies empty and non-empty hex encoding
- `const_minmax`: tests min/max with a>b, a<b, a==b cases
- `hex_snip_middle_boundary`: tests 16-byte boundary and longer inputs