### PR TITLE
chore: improve `IncrementalDecoder` test coverage

### DIFF
--- a/neqo-common/src/incrdecoder.rs
+++ b/neqo-common/src/incrdecoder.rs
@@ -263,4 +263,19 @@ mod tests {
             assert!(res);
         }
     }
+
+    #[test]
+    fn decoding_in_progress() {
+        let mut dec = IncrementalDecoderUint::default();
+        assert!(!dec.decoding_in_progress());
+        let mut dv = Decoder::new(&[0x40]); // Start of 2-byte varint
+        assert!(dec.consume(&mut dv).is_none());
+        assert!(dec.decoding_in_progress());
+    }
+
+    #[test]
+    fn buffer_min_remaining() {
+        let dec = IncrementalDecoderBuffer::new(5);
+        assert_eq!(dec.min_remaining(), 5);
+    }
 }


### PR DESCRIPTION
Add tests to eliminate missed mutants in `neqo-common/src/incrdecoder.rs`:
- `decoding_in_progress`: test both false (initial) and true (mid-decode) states
- `buffer_min_remaining`: test `min_remaining()` returns expected value