### PR TITLE
chore: remove `Qlog::add_event_with_instant`

### DIFF
--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -56,8 +56,7 @@ impl Qlog {
             // As a server, the original DCID is chosen by the client. Using
             // create_new() prevents attackers from overwriting existing logs.
             .create_new(true)
-            .open(&qlog_path)
-            .map_err(qlog::Error::IoError)?;
+            .open(&qlog_path)?;
 
         let streamer = QlogStreamer::new(
             qlog::QLOG_VERSION.to_string(),
@@ -98,7 +97,7 @@ impl Qlog {
     }
 
     /// If logging enabled, closure may generate an event to be logged.
-    pub fn add_event_data_with_instant<F>(&mut self, f: F, now: Instant)
+    pub fn add_event_at<F>(&mut self, f: F, now: Instant)
     where
         F: FnOnce() -> Option<qlog::events::EventData>,
     {
@@ -206,9 +205,9 @@ mod test {
     }
 
     #[test]
-    fn add_event_data_with_instant() {
+    fn add_event_at() {
         let (mut log, contents) = test_fixture::new_neqo_qlog();
-        log.add_event_data_with_instant(|| Some(EV_DATA), test_fixture::now());
+        log.add_event_at(|| Some(EV_DATA), test_fixture::now());
         assert_eq!(
             Regex::new("\"time\":[0-9]+.[0-9]+,")
                 .unwrap()

--- a/neqo-http3/src/qlog.rs
+++ b/neqo-http3/src/qlog.rs
@@ -13,7 +13,7 @@ use neqo_transport::StreamId;
 use qlog::events::{DataRecipient, EventData};
 
 pub fn h3_data_moved_up(qlog: &mut Qlog, stream_id: StreamId, amount: usize, now: Instant) {
-    qlog.add_event_data_with_instant(
+    qlog.add_event_at(
         || {
             let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
                 stream_id: Some(stream_id.as_u64()),
@@ -31,7 +31,7 @@ pub fn h3_data_moved_up(qlog: &mut Qlog, stream_id: StreamId, amount: usize, now
 }
 
 pub fn h3_data_moved_down(qlog: &mut Qlog, stream_id: StreamId, amount: usize, now: Instant) {
-    qlog.add_event_data_with_instant(
+    qlog.add_event_at(
         || {
             let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
                 stream_id: Some(stream_id.as_u64()),

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -20,7 +20,7 @@ pub fn qpack_read_insert_count_increment_instruction(
     data: &[u8],
     now: Instant,
 ) {
-    qlog.add_event_data_with_instant(
+    qlog.add_event_at(
         || {
             let raw = RawInfo {
                 length: Some(8),

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -488,7 +488,7 @@ impl<T: WindowAdjustment> ClassicCongestionControl<T> {
         if self.state != state {
             qdebug!("[{self}] state -> {state:?}");
             let old_state = self.state;
-            self.qlog.add_event_data_with_instant(
+            self.qlog.add_event_at(
                 || {
                     // No need to tell qlog about exit from transient states.
                     if old_state.transient() {

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -42,7 +42,7 @@ use crate::{
 };
 
 pub fn connection_tparams_set(qlog: &mut Qlog, tph: &TransportParametersHandler, now: Instant) {
-    qlog.add_event_data_with_instant(
+    qlog.add_event_at(
         || {
             let remote = tph.remote();
             #[expect(clippy::cast_possible_truncation, reason = "These are OK.")]
@@ -98,7 +98,7 @@ pub fn client_connection_started(qlog: &mut Qlog, path: &PathRef, now: Instant) 
 }
 
 fn connection_started(qlog: &mut Qlog, path: &PathRef, now: Instant) {
-    qlog.add_event_data_with_instant(
+    qlog.add_event_at(
         || {
             let p = path.deref().borrow();
             let ev_data = EventData::ConnectionStarted(ConnectionStarted {
@@ -128,7 +128,7 @@ fn connection_started(qlog: &mut Qlog, path: &PathRef, now: Instant) {
     reason = "FIXME: 'new and now are similar' hits on MSRV <1.91."
 )]
 pub fn connection_state_updated(qlog: &mut Qlog, new: &State, now: Instant) {
-    qlog.add_event_data_with_instant(
+    qlog.add_event_at(
         || {
             let ev_data = EventData::ConnectionStateUpdated(ConnectionStateUpdated {
                 old: None,
@@ -154,7 +154,7 @@ pub fn client_version_information_initiated(
     version_config: &version::Config,
     now: Instant,
 ) {
-    qlog.add_event_data_with_instant(
+    qlog.add_event_at(
         || {
             Some(EventData::VersionInformation(VersionInformation {
                 client_versions: Some(
@@ -179,7 +179,7 @@ pub fn client_version_information_negotiated(
     chosen: Version,
     now: Instant,
 ) {
-    qlog.add_event_data_with_instant(
+    qlog.add_event_at(
         || {
             Some(EventData::VersionInformation(VersionInformation {
                 client_versions: Some(
@@ -202,7 +202,7 @@ pub fn server_version_information_failed(
     client: version::Wire,
     now: Instant,
 ) {
-    qlog.add_event_data_with_instant(
+    qlog.add_event_at(
         || {
             Some(EventData::VersionInformation(VersionInformation {
                 client_versions: Some(vec![format!("{client:02x}")]),
@@ -220,7 +220,7 @@ pub fn server_version_information_failed(
 }
 
 pub fn packet_io(qlog: &mut Qlog, meta: packet::MetaData, now: Instant) {
-    qlog.add_event_data_with_instant(
+    qlog.add_event_at(
         || {
             let mut d = Decoder::from(meta.payload());
             let raw = RawInfo {
@@ -258,7 +258,7 @@ pub fn packet_io(qlog: &mut Qlog, meta: packet::MetaData, now: Instant) {
     );
 }
 pub fn packet_dropped(qlog: &mut Qlog, decrypt_err: &packet::DecryptionError, now: Instant) {
-    qlog.add_event_data_with_instant(
+    qlog.add_event_at(
         || {
             let header =
                 PacketHeader::with_type(decrypt_err.packet_type().into(), None, None, None, None);
@@ -315,7 +315,7 @@ pub enum Metric {
 pub fn metrics_updated(qlog: &mut Qlog, updated_metrics: &[Metric], now: Instant) {
     debug_assert!(!updated_metrics.is_empty());
 
-    qlog.add_event_data_with_instant(
+    qlog.add_event_at(
         || {
             let mut min_rtt: Option<f32> = None;
             let mut smoothed_rtt: Option<f32> = None;


### PR DESCRIPTION
Remove dead code `add_event_with_instant` which was only used in its own test. Update the test to use `add_event_data_with_instant` instead, which is the function actually used throughout the codebase (14 call sites).

This also fixes a missed mutant for `add_event_data_with_instant`.