### PR TITLE
fix(common/qlog): disable qlog on error on inner (shared) option

### DIFF
--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -123,13 +123,15 @@ impl Qlog {
 
         let Some(shared_streamer) = borrow.as_mut() else {
             drop(borrow);
+            // Set the outer Option to None to prevent future dereferences.
             self.inner = None;
             return;
         };
 
         if let Err(e) = f(&mut shared_streamer.streamer) {
             log::error!("Qlog event generation failed with error {e}; closing qlog.");
-
+            // Set the inner Option to None to disable future logging for other references.
+            *borrow = None;
             // Explicitly drop the RefCell borrow to release the mutable borrow.
             drop(borrow);
             // Set the outer Option to None to prevent future dereferences.


### PR DESCRIPTION
Without setting the inner Option to None, other references will attempt to write logs to a previously errored qlog stream. By setting the inner Option to None on error, the current reference notifies all other references that an error occured.

See conversation in https://github.com/mozilla/neqo/pull/3129#discussion_r2607855548.