### PR TITLE
fix(transport): expose CongestionEvent

### DIFF
--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -61,7 +61,7 @@ mod tracking;
 pub mod version;
 
 pub use self::{
-    cc::CongestionControlAlgorithm,
+    cc::{CongestionControlAlgorithm, CongestionEvent},
     cid::{
         ConnectionId, ConnectionIdDecoder, ConnectionIdGenerator, ConnectionIdRef,
         EmptyConnectionIdGenerator, RandomConnectionIdGenerator,


### PR DESCRIPTION
With https://github.com/mozilla/neqo/pull/3233 congestion control stats are now index by `CongestionEvent`. In order to read the stats in `neqo_glue` one needs to access `CongestionEvent`.