### PR TITLE
chore: prepare v0.21.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enumset",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "log",
  "neqo-common",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.20.0"
+version = "0.21.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I would like to cut a new Neqo release.

Downstream testing with latest Neqo `main`:
- https://bugzilla.mozilla.org/show_bug.cgi?id=2006102
- https://phabricator.services.mozilla.com/D276469
- https://treeherder.mozilla.org/jobs?repo=try&revision=ed7daf4b20299dc72f4ffb2fd977f4e20faa8404

Notable changes for Firefox:

- cf390b0f fix(transport): expose CongestionEvent (#3268)
- edbdeec1 fix(common/qlog): disable qlog on error on inner (shared) option (#3267)
- d47e84fc feat(transport/cc): lower cwnd reduction on ECN-CE vs loss (#3233)
- bece9bfc chore: remove `Qlog::add_event_with_instant` (#3253)
- 81c80ad7 chore: Use `Vec::with_capacity` where we can (#3050)
- 393e250d fix: prevent TP caching from affecting greasing behavior (#3095)
- 105d9212 fix: Replace `qpack::Data` with trait (#3013)
- 5530576d perf(qlog): introduce outer `Option` (#3129)
- 8842dcd4 feat: `send_atomic_with` to avoid `Encoder` alloc (#3238)
- f9cbd20e fix: `remove` once in `send_stream_complete` (#3240)
- 042e684f refactor(transport): move profile creation into output_dgram_on_path (#3230)
- d5201924 fix: Stop loss monitoring for PMTUD triggering (#3200)
- 18306622 chore(transport/fc): add debug_assert to catch underflow (#3209)
- 1c9cbd45 feat: Use tokens to identify PMTUD probes (#3199)
- a94d62f3 fix: Make `PublicPacket::decrypt` take non-`mut` `self` (#2989)
- 162ca33a Don't collect when decoding a header block (#3197)
- be1e755e fix: qpack idiomization (#3181)
- f7c629b8 feat: Simplify some in-place crypto API things (#3139)
