### PR TITLE
chore: Split QNS workflows

### DIFF
--- a/.github/workflows/qns-pr.yml
+++ b/.github/workflows/qns-pr.yml
@@ -1,3 +1,6 @@
+# Run QNS (QUIC Network Simulator) on PRs to test interop between the
+# changes in the PR and the main branch.
+
 name: QNS PR
 on:
   pull_request:

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -1,4 +1,7 @@
-name: QNS
+# Publish a Docker image for QNS (QUIC Network Simulator) to GitHub Container Registry.
+# https://interop.seemann.io/ uses this image to run interop tests.
+
+name: Publish QNS Docker Image
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Into one generating a Docker image for the interop runner, and one running on PRs. The old file had both, and they had zero overlap.