### PR TITLE
fix: `reno` -> `newreno`

### DIFF
--- a/.github/scripts/perfcompare.py
+++ b/.github/scripts/perfcompare.py
@@ -299,8 +299,8 @@ def run(cfg, tmp):
 
             if client == "neqo" and server == "neqo":
                 opts = [
-                    ("reno", True),
-                    ("reno", False),
+                    ("newreno", True),
+                    ("newreno", False),
                     ("cubic", True),
                     ("cubic", False),
                 ]


### PR DESCRIPTION
#3277 broke this, and it's surprisingly hard to make `clap` and `strum` cooperate here. This is easier and unbreaks CI.