### PR TITLE
fix(transport/fc): prevent auto-tuning to decrease max_active

### DIFF
--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -425,7 +425,7 @@ where
 
         self.max_active = new_max_active;
         qdebug!(
-            "Increasing max {subject} receive window by {increase} B, \
+            "Increasing max {subject} receive window by {} B, \
                 previous max_active: {} MiB, \
                 new max_active: {} MiB, \
                 last update: {:?}, \


### PR DESCRIPTION
A user can configure the initial receive window size. Given a user that sets the initial receive window size to a value larger than the maximum auto-tuning value, the auto-tuning logic should not decrease `max_active` below the user-configured value.

Note that Firefox currently sets a larger initial receive window size than the maximum auto-tuning value. (As an aside, effectively disabling auto-tuning.)

``` yaml
# Stream-level flow control limit
- name: network.http.http3.max_stream_data
  type: RelaxedAtomicUint32
  value: 12582912
  mirror: always
```

https://github.com/mozilla-firefox/firefox/blob/e1eada69e2ddd86a398ccb141dcbf772254162eb/modules/libpref/init/StaticPrefList.yaml#L15423-L15427

https://github.com/mozilla/neqo/blob/0798e0ac28b31d6a18e3f43801336abeeca195c7/neqo-transport/src/connection/params.rs#L80

While a bug in Firefox release, it is minor only, reducing the receive window from 12 MB to 10 MB.

I will consider removing the initial window override in Firefox as a next step.

---

Fixes #3208

Thanks to @mb for the help with Pernosco and @tysmith for the report via site scout.