### PR TITLE
chore: prepare for v0.22.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "codspeed-criterion-compat",
  "derive_more",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "bindgen",
  "derive_more",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "codspeed-criterion-compat",
  "derive_more",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "derive_more",
  "log",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "codspeed-criterion-compat",
  "derive_more",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "derive_more",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.21.0"
+version = "0.22.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Most notable changes:

- 8fc67fb7 fix(transport/fc): prevent auto-tuning to decrease max_active (#3314)
- fb213872 feat(transport/cc): spurious congestion event recovery (#3298)
- 66cd2960 fix: integer overflow when parsing QPACK headers (#3287)
