### PR TITLE
chore: No `merge_group` trigger for Codspeed

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -4,7 +4,8 @@ on:
     branches: ["main"] # To generate a performance baseline.
   pull_request:
     branches: ["main"]
-  merge_group:
+  # `workflow_dispatch` allows CodSpeed to trigger backtest
+  # performance analysis in order to generate initial data.
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Hoperfully fixes
```
Error: unknown variant `merge_group`, expected one of `push`, `pull_request`, `workflow_dispatch`, `schedule`, `local` at line 1 column 13
```
in https://github.com/mozilla/neqo/actions/runs/21163502018/job/60862778551#step:7:181