### PR TITLE
fix: Remove trailing newline from REQUESTS URLs

### DIFF
--- a/qns/interop.sh
+++ b/qns/interop.sh
@@ -14,7 +14,7 @@ client)
   /wait-for-it.sh sim:57832 -s -t 30
   OPTIONS=(--cc cubic --qns-test "$TESTCASE" --qlog-dir "$QLOGDIR" --output-dir /downloads)
   if [ "$REQUESTS" ]; then
-    mapfile -d ' ' -t URLS <<<"$REQUESTS"
+    read -ra URLS <<<"$REQUESTS"
     OPTIONS+=("${URLS[@]}")
   fi
   RUST_LOG=debug RUST_BACKTRACE=1 neqo-client "${OPTIONS[@]}" 2> >(tee -i -a "/logs/$ROLE.log" >&2)


### PR DESCRIPTION
## Description

### Problem

The interop test runner passes URLs via the `$REQUESTS` environment variable.
When parsing this in `qns/interop.sh`, we use:

```bash
mapfile -d ' ' -t URLS <<<"$REQUESTS"
```

However, bash's here-string (`<<<`) appends a trailing newline to the input.
This causes the last URL to contain a newline character, resulting in:

```
error: invalid value 'https://server46:443/some-file
' for '[URLS]...': invalid uri character
```

This breaks specific interop tests (e.g.,   connectionmigration).

### Solution

Replace `mapfile` with `read -ra` which doesn't have this issue:

```bash
read -ra URLS <<<"$REQUESTS"
```

### Why this works

- `read -ra`: Splits on IFS (whitespace by default). The trailing newline from here-string is consumed as a delimiter.
- `mapfile -d ' '`: Splits only on space. The trailing newline remains attached to the last element.

### Testing

Tested with quic-interop-runner against hibana server:
- Before: `error: invalid value ... invalid uri character`
- After: Test runs successfully