### PR TITLE
fix: Fix wrong results in CodSpeed reports

### DIFF
--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -58,15 +58,16 @@ fn transfer(c: &mut Criterion) {
             download_size: 0,
         },
     ] {
-        let formatted_name = mtu_suffix.as_ref().map(|suffix| format!("{name}{suffix}"));
-        let name = formatted_name.as_deref().unwrap_or(name);
-        let mut group = c.benchmark_group(name);
+        let bench_name = mtu_suffix
+            .as_ref()
+            .map_or_else(|| name.to_string(), |suffix| format!("{name}{suffix}"));
+        let mut group = c.benchmark_group("transfer");
         group.throughput(if num_requests == 1 {
             Throughput::Bytes((upload_size + download_size) as u64)
         } else {
             Throughput::Elements(num_requests as u64)
         });
-        group.bench_function(name, |b| {
+        group.bench_function(&bench_name, |b| {
             b.to_async(Builder::new_current_thread().enable_all().build().unwrap())
                 .iter_batched(
                     || {

--- a/neqo-http3/benches/common.rs
+++ b/neqo-http3/benches/common.rs
@@ -37,18 +37,17 @@ pub fn setup(streams: usize, data_size: usize) -> ReadySimulator {
 
 /// Runs benchmarks for all parameter combinations.
 ///
-/// The closure receives the benchmark group, group name, and parameters, allowing each
+/// The closure receives the benchmark group and parameters, allowing each
 /// benchmark to define its own measurement approach.
 pub fn benchmark<M>(c: &mut Criterion, mut measure: M)
 where
-    M: FnMut(&mut BenchmarkGroup<'_, criterion::measurement::WallTime>, &str, usize, usize),
+    M: FnMut(&mut BenchmarkGroup<'_, criterion::measurement::WallTime>, usize, usize),
 {
     fixture_init();
 
+    let mut group = c.benchmark_group("streams");
     for (streams, data_size) in BENCHMARK_PARAMS {
-        let name = format!("{streams}-streams/each-{data_size}-bytes");
-        let mut group = c.benchmark_group(&name);
-        measure(&mut group, &name, streams, data_size);
-        group.finish();
+        measure(&mut group, streams, data_size);
     }
+    group.finish();
 }

--- a/neqo-http3/benches/streams_simulated.rs
+++ b/neqo-http3/benches/streams_simulated.rs
@@ -21,9 +21,10 @@ use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 mod common;
 
 fn benchmark(c: &mut Criterion) {
-    common::benchmark(c, |group, name, streams, data_size| {
+    common::benchmark(c, |group, streams, data_size| {
+        let bench_name = format!("simulated/{streams}-streams/each-{data_size}-bytes");
         group.throughput(Throughput::Bytes((streams * data_size) as u64));
-        group.bench_function(name, |b| {
+        group.bench_function(&bench_name, |b| {
             b.iter_custom(|iters| {
                 let mut d_sum = Duration::ZERO;
                 for _i in 0..iters {

--- a/neqo-http3/benches/streams_walltime.rs
+++ b/neqo-http3/benches/streams_walltime.rs
@@ -19,8 +19,9 @@ use criterion::{criterion_group, criterion_main, Criterion};
 mod common;
 
 fn benchmark(c: &mut Criterion) {
-    common::benchmark(c, |group, name, streams, data_size| {
-        group.bench_function(name, |b| {
+    common::benchmark(c, |group, streams, data_size| {
+        let bench_name = format!("walltime/{streams}-streams/each-{data_size}-bytes");
+        group.bench_function(&bench_name, |b| {
             b.iter_batched(
                 || common::setup(streams, data_size),
                 |sim| black_box(sim.run()),

--- a/neqo-transport/benches/transfer_common.rs
+++ b/neqo-transport/benches/transfer_common.rs
@@ -56,17 +56,11 @@ pub fn setup(label: &str, seed: Option<&str>, pacing: bool) -> ReadySimulator {
 
 /// Runs transfer benchmarks for all configurations.
 ///
-/// The closure receives the benchmark group, group name, label, seed, and pacing flag,
+/// The closure receives the benchmark group, label, seed, and pacing flag,
 /// allowing each benchmark to define its own measurement approach.
 pub fn benchmark<M>(c: &mut Criterion, mut measure: M)
 where
-    M: FnMut(
-        &mut BenchmarkGroup<'_, criterion::measurement::WallTime>,
-        &str,
-        &str,
-        Option<&str>,
-        bool,
-    ),
+    M: FnMut(&mut BenchmarkGroup<'_, criterion::measurement::WallTime>, &str, Option<&str>, bool),
 {
     // Handle SIMULATION_SEED environment variable for varying-seeds config
     let env_seed = std::env::var("SIMULATION_SEED").ok();
@@ -75,15 +69,14 @@ where
         ("same-seed", Some(FIXED_SEED)),
     ];
 
+    let mut group = c.benchmark_group("transfer");
+    group.noise_threshold(0.03);
     for (label, seed) in configs {
         for pacing in [false, true] {
-            let name = format!("transfer/pacing-{pacing}/{label}");
-            let mut group = c.benchmark_group(&name);
-            group.noise_threshold(0.03);
-            measure(&mut group, &name, label, seed, pacing);
-            group.finish();
+            measure(&mut group, label, seed, pacing);
         }
     }
+    group.finish();
 }
 
 /// Returns the criterion configuration for transfer benchmarks.

--- a/neqo-transport/benches/transfer_simulated.rs
+++ b/neqo-transport/benches/transfer_simulated.rs
@@ -21,9 +21,10 @@ use criterion::{criterion_group, criterion_main, Throughput};
 mod common;
 
 fn benchmark(c: &mut criterion::Criterion) {
-    common::benchmark(c, |group, name, label, seed, pacing| {
+    common::benchmark(c, |group, label, seed, pacing| {
+        let bench_name = format!("simulated/pacing-{pacing}/{label}");
         group.throughput(Throughput::Bytes(common::TRANSFER_AMOUNT as u64));
-        group.bench_function(name, |b| {
+        group.bench_function(&bench_name, |b| {
             b.iter_custom(|iters| {
                 let mut d_sum = Duration::ZERO;
                 for _i in 0..iters {

--- a/neqo-transport/benches/transfer_walltime.rs
+++ b/neqo-transport/benches/transfer_walltime.rs
@@ -19,8 +19,9 @@ use criterion::{criterion_group, criterion_main, BatchSize::SmallInput};
 mod common;
 
 fn benchmark(c: &mut criterion::Criterion) {
-    common::benchmark(c, |group, name, label, seed, pacing| {
-        group.bench_function(name, |b| {
+    common::benchmark(c, |group, label, seed, pacing| {
+        let bench_name = format!("walltime/pacing-{pacing}/{label}");
+        group.bench_function(&bench_name, |b| {
             b.iter_batched(
                 || common::setup(label, seed, pacing),
                 |sim| black_box(sim.run()),


### PR DESCRIPTION
PR #3340 attempted to show meaningful benchmark names in CodSpeed's PR comments. However, since Criterion constructs full benchmark IDs as `group_name/function_name`, and both were set to the same value, this resulted in duplicated names like: `transfer/pacing-false/varying-seeds/transfer/pacing-false/varying-seeds`. CodSpeed interpreted these as new benchmarks, causing false regression reports of ~100,000%.

The fix restructures benchmark naming:
- Use a simple category for the group name (`transfer`, `streams`)
- Use the full descriptive identifier for the function name