### PR TITLE
chore: Improve Codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,17 @@ ignore:
   - "neqo-bin"
   - "test-fixture"
 
+# Coverage flags for each platform. Carryforward reuses cached coverage if an upload fails.
+flags:
+  linux:
+    carryforward: true
+  macos:
+    carryforward: true
+  windows:
+    carryforward: true
+  freebsd:
+    carryforward: true
+
 # Add any new components to the list below.
 component_management:
   individual_components:
@@ -40,6 +51,13 @@ comment:
 
 coverage:
   status:
+    # Only post coverage status on pull requests, not on merge queue commits.
+    # This prevents PRs from failing in the merge queue due to coverage changes
+    # introduced by other recently-merged PRs.
     project:
       default:
         threshold: 0.05%
+        only_pulls: true
+    patch:
+      default:
+        only_pulls: true

--- a/.github/actions/check-vm/action.yml
+++ b/.github/actions/check-vm/action.yml
@@ -137,10 +137,18 @@ runs:
         prepare: ${{ steps.prep.outputs.prepare }}
         run: ${{ steps.prep.outputs.run }}
 
-    - if: ${{ inputs.codecov-token != '' }}
+    - id: check-coverage
+      shell: bash
+      env:
+        WORKING_DIR: ${{ inputs.working-directory }}
+      run: test -f "$WORKING_DIR/codecov.json" && echo "exists=true" >> "$GITHUB_OUTPUT" || true
+
+    - if: ${{ steps.check-coverage.outputs.exists == 'true' }}
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
       with:
         files: codecov.json
+        working-directory: ${{ inputs.working-directory }}
         fail_ci_if_error: false
         token: ${{ inputs.codecov-token }}
         verbose: true
+        flags: ${{ inputs.platform }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -148,6 +148,7 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+          flags: ${{ startsWith(matrix.os, 'ubuntu') && 'linux' || startsWith(matrix.os, 'macos') && 'macos' || 'windows' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: matrix.type == 'debug' && matrix.rust-toolchain == 'stable'


### PR DESCRIPTION
**Disable coverage checks in merge queue**: Add `only_pulls: true` to both `project` and `patch` coverage status checks. This prevents PRs from failing in the merge queue due to coverage changes introduced by other recently-merged PRs (the "coverage inheritance" problem).

**Add per-platform coverage flags**: Configure coverage flags for `linux`, `macos`, `windows`, and `freebsd` with `carryforward: true`. This segments coverage reports by platform and reuses cached coverage data if an upload fails, improving reliability.

**Pass flags in CI workflows**: Update `check.yml` and `check-vm/action.yml` to pass the appropriate platform flag to the Codecov action.
