### PR TITLE
chore: `binstall` & `rust-cache` again for CI

### DIFF
--- a/.github/actions/check-vm/action.yml
+++ b/.github/actions/check-vm/action.yml
@@ -108,35 +108,31 @@ runs:
       uses: vmactions/freebsd-vm@a9c0dcaf5ed572d89ea1a59fe2217d3b3da4fd23 # v1.3.7
       with:
         usesh: true
-        disable-cache: true
         envs: ${{ steps.prep.outputs.envs }}
         prepare: ${{ steps.prep.outputs.prepare }}
         run: ${{ steps.prep.outputs.run }}
 
     - if: ${{ inputs.platform == 'openbsd' }}
-      uses: vmactions/openbsd-vm@f5b9bc1261c3d4eed9639fcae0cf5dcc5374ca0c # v1.3.2
+      uses: vmactions/openbsd-vm@00753f2835e62704570734312de6f212069dfef7 # v1.3.1
       with:
         usesh: true
-        disable-cache: true
         envs: ${{ steps.prep.outputs.envs }}
         prepare: ${{ steps.prep.outputs.prepare }}
         run: ${{ steps.prep.outputs.run }}
 
     - if: ${{ inputs.platform == 'netbsd' }}
-      uses: vmactions/netbsd-vm@37b614756f0b44b02f5dab4fd9ecb27545d1785e # v1.3.2
+      uses: vmactions/netbsd-vm@2ba9902c77c2ebdb7501e5e9308dea03f0f251c4 # v1.3.1
       with:
         usesh: true
-        disable-cache: true
         envs: ${{ steps.prep.outputs.envs }}
         prepare: ${{ steps.prep.outputs.prepare }}
         run: ${{ steps.prep.outputs.run }}
 
     - if: ${{ inputs.platform == 'solaris' }}
-      uses: vmactions/solaris-vm@37d40b6627e80434541454b42841caa4cc77d0cf # v1.2.7
+      uses: vmactions/solaris-vm@61030aaba6acacac59cf375214a9668f46e94445 # v1.2.6
       with:
         release: "11.4-gcc"
         usesh: true
-        disable-cache: true
         envs: ${{ steps.prep.outputs.envs }}
         prepare: ${{ steps.prep.outputs.prepare }}
         run: ${{ steps.prep.outputs.run }}


### PR DESCRIPTION
`binstall` was previously disabled due to: (1) binstall MSRV was too high, and (2) macOS issues. Both resolved: binstall MSRV is now 1.79.0 (below our 1.87.0), and macOS issues were fixed in late 2024/2025 (cargo-bins/cargo-binstall #1953, #2049).

`rust-cache` has a new config that should significantly reduce cache pressure.