### PR TITLE
Fix: guard against invalid state in http09 client

### DIFF
--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -287,7 +287,9 @@ impl<'b> Handler<'b> {
                 false
             }
             Err(e) => {
-                return Err(e.into());
+                qwarn!("Unexpected error creating stream {e:?}");
+                self.url_queue.push_front(url);
+                false
             }
         }
     }


### PR DESCRIPTION
This change adds a guard to prevent an invalid HTTP/0.9 client state during request handling.

This avoids unexpected behavior when the client encounters an unsupported or empty response.
