### PR TITLE
chore: Disable the `uv` cache

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -46,6 +46,8 @@ jobs:
           persist-credentials: false
 
       - uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        with:
+          enable-cache: false
 
       - run: uvx zizmor --persona auditor --format sarif . > results.sarif
         env:


### PR DESCRIPTION
Only useful if we were a Python project and causes a false warning.