### PR TITLE
chore: prepare v0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enumset",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "log",
  "neqo-common",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.22.2"
+version = "0.23.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I would like to cut a new release. Most notable changes:

- e002fd1f feat(transport): respect peer's max_udp_payload_size tp (#3414)
- 918a5210 fix: Don't prime the handshake PTO w/o keys (#3411)
- f79e40f9 chore: Sync deps with Gecko (#3413)
- a3fe34a3 fix: Allow Initial CRYPTO retransmission during Handshake PTO (#3350)
- 04513e02 chore(transport/stats): expose cwnd stats (#3386)
- df250d3d chore: Transition to Rust 2024 edition (#3320)

Any objections?