### PR TITLE
fix(build): NSS now builds when NSS_PREBUILT is unset or zero

### DIFF
--- a/neqo-crypto/build.rs
+++ b/neqo-crypto/build.rs
@@ -335,6 +335,7 @@ fn setup_standalone(nss: &str) -> Vec<String> {
     setup_clang();
 
     println!("cargo:rerun-if-env-changed=NSS_DIR");
+    println!("cargo:rerun-if-env-changed=NSS_PREBUILT");
     let nss = PathBuf::from(nss);
     assert!(
         !nss.is_relative(),


### PR DESCRIPTION
Previously we only rebuilt NSS if the env var was unset, but I think suggesting to set it to `1` after having built NSS in the README implies being able to set it to `0`, too.

*(I just had a very fun time debugging local build failures after updating NSS/NSPR)*