### PR TITLE
fix: ConnectionClose error code, NewToken type, LH fields

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1761,7 +1761,7 @@ impl Connection {
                     let pn = payload.pn();
                     self.idle_timeout.on_packet_received(now);
                     self.log_packet(
-                        packet::MetaData::new_in(path, tos, packet_len, &payload),
+                        packet::MetaData::new_in(path, tos, packet_len, &payload, self.version),
                         now,
                     );
 
@@ -2743,6 +2743,7 @@ impl Connection {
                     builder.len() + aead_expansion,
                     &builder.as_ref()[payload_start..],
                     packet_tos,
+                    self.version,
                 ),
                 now,
             );

--- a/neqo-transport/src/packet/metadata.rs
+++ b/neqo-transport/src/packet/metadata.rs
@@ -13,7 +13,7 @@ use neqo_common::Tos;
 use qlog::events::quic::PacketHeader;
 use strum::Display;
 
-use crate::{packet, path::PathRef};
+use crate::{packet, path::PathRef, version::Version};
 
 #[derive(Clone, Copy, Display)]
 pub enum Direction {
@@ -28,6 +28,7 @@ pub struct MetaData<'a> {
     direction: Direction,
     packet_type: packet::Type,
     packet_number: packet::Number,
+    version: Version,
     tos: Tos,
     len: usize,
     payload: &'a [u8],
@@ -39,12 +40,14 @@ impl MetaData<'_> {
         tos: Tos,
         len: usize,
         decrypted: &'a packet::Decrypted,
+        version: Version,
     ) -> MetaData<'a> {
         MetaData {
             path,
             direction: Direction::Rx,
             packet_type: decrypted.packet_type(),
             packet_number: decrypted.pn(),
+            version,
             tos,
             len,
             payload: decrypted,
@@ -58,12 +61,14 @@ impl MetaData<'_> {
         length: usize,
         payload: &'a [u8],
         tos: Tos,
+        version: Version,
     ) -> MetaData<'a> {
         MetaData {
             path,
             direction: Direction::Tx,
             packet_type,
             packet_number,
+            version,
             tos,
             len: length,
             payload,
@@ -88,12 +93,25 @@ impl MetaData<'_> {
 
 impl From<MetaData<'_>> for PacketHeader {
     fn from(val: MetaData<'_>) -> Self {
+        let path = val.path.borrow();
+        // For long-header packets, scid/dcid reflect who sent the packet:
+        // on TX we are the source; on RX the peer is the source.
+        let (scid, dcid) = match val.direction {
+            Direction::Tx => (
+                path.local_cid().map(AsRef::as_ref),
+                path.remote_cid().map(AsRef::as_ref),
+            ),
+            Direction::Rx => (
+                path.remote_cid().map(AsRef::as_ref),
+                path.local_cid().map(AsRef::as_ref),
+            ),
+        };
         Self::with_type(
             val.packet_type.into(),
             Some(val.packet_number),
-            None,
-            None,
-            None,
+            Some(val.version.wire_version()),
+            scid,
+            dcid,
         )
     }
 }

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -478,7 +478,7 @@ impl From<Frame<'_>> for QuicFrame {
             },
             Frame::NewToken { token } => Self::NewToken {
                 token: qlog::Token {
-                    ty: Some(qlog::TokenType::Retry),
+                    ty: None,
                     details: None,
                     raw: Some(RawInfo {
                         data: Some(hex(token)),
@@ -569,7 +569,7 @@ impl From<Frame<'_>> for QuicFrame {
                     CloseError::Application(_) => Some(ErrorSpace::ApplicationError),
                 },
                 error_code: Some(error_code.code()),
-                error_code_value: Some(0),
+                error_code_value: Some(error_code.code()),
                 reason: Some(reason_phrase),
                 trigger_frame_type: Some(frame_type),
             },


### PR DESCRIPTION
`ConnectionClose` hardcoded `error_code_value` as 0; `NewToken` set token type to `retry`; long header packets omitted version/scid/dcid.