### PR TITLE
fix: Run zizmor on push to main

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,5 +1,8 @@
 name: Lint GitHub Actions workflows
 on:
+  push:
+    branches: ["main"]
+    paths: [".github/**"]
   pull_request:
     paths: [".github/**"]
   merge_group:


### PR DESCRIPTION
Without this trigger, GitHub marks the zizmor code scanning configuration as stale since zizmor only ran on PR branches, not on main.