### PR TITLE
chore: Use local context `.` for QNS docker

### DIFF
--- a/.github/workflows/qns-pr.yml
+++ b/.github/workflows/qns-pr.yml
@@ -47,6 +47,7 @@ jobs:
 
       - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
+          context: .
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           file: qns/Dockerfile

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -53,6 +53,7 @@ jobs:
 
       - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
+          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           file: qns/Dockerfile


### PR DESCRIPTION
To avoid spurious failures when force-merging early.