### PR TITLE
fix: Don't serve h09 requests before stream FIN

### DIFF
--- a/neqo-bin/src/server/http09.rs
+++ b/neqo-bin/src/server/http09.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 use std::{
-    borrow::Cow,
     cell::RefCell,
     fmt::{self, Display, Formatter},
     num::NonZeroUsize,
@@ -14,16 +13,16 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{Datagram, event::Provider as _, hex, qdebug, qerror, qinfo, qwarn};
-use neqo_crypto::{AllowZeroRtt, AntiReplay, generate_ech_keys, random};
+use neqo_common::{Datagram, event::Provider as _, qdebug, qwarn};
+use neqo_crypto::{AllowZeroRtt, AntiReplay};
 use neqo_http3::Error;
 use neqo_transport::{
     ConnectionEvent, ConnectionIdGenerator, OutputBatch, State, StreamId,
-    server::{ConnectionRef, Server, ValidateAddress},
+    server::{ConnectionRef, Server},
 };
 use rustc_hash::FxHashMap as HashMap;
 
-use super::{Args, qns_read_response};
+use super::Args;
 use crate::{
     STREAM_IO_BUFFER_SIZE,
     send_data::{SendData, SendResult},
@@ -59,18 +58,7 @@ impl HttpServer {
             args.shared.quic_parameters.get(&args.shared.alpn),
         )?;
 
-        server.set_ciphers(args.get_ciphers());
-        server.set_qlog_dir(args.shared.qlog_dir.clone());
-        if args.retry {
-            server.set_validation(ValidateAddress::Always);
-        }
-        if args.ech {
-            let (sk, pk) = generate_ech_keys().map_err(|_| Error::Internal)?;
-            server
-                .enable_ech(random::<1>()[0], "public.example", &sk, &pk)
-                .map_err(|_| Error::Internal)?;
-            qinfo!("ECHConfigList: {}", hex(server.ech_config()));
-        }
+        super::configure_server(&mut server, args);
 
         Ok(Self {
             server,
@@ -82,19 +70,12 @@ impl HttpServer {
     }
 
     fn save_partial(&mut self, stream_id: StreamId, partial: Vec<u8>, conn: &ConnectionRef) {
+        let url = String::from_utf8_lossy(&partial);
         if partial.len() < 4096 {
-            qdebug!(
-                "Saving partial URL: {}",
-                String::from_utf8(partial.clone())
-                    .unwrap_or_else(|_| format!("<invalid UTF-8: {}>", hex(&partial)))
-            );
+            qdebug!("Saving partial URL: {url}");
             self.read_state.insert(stream_id, partial);
         } else {
-            qdebug!(
-                "Giving up on partial URL {}",
-                String::from_utf8(partial.clone())
-                    .unwrap_or_else(|_| format!("<invalid UTF-8: {}>", hex(&partial)))
-            );
+            qdebug!("Giving up on partial URL {url}");
             _ = conn.borrow_mut().stream_stop_sending(stream_id, 0); // Stream may be closed; ignore errors.
         }
     }
@@ -115,18 +96,21 @@ impl HttpServer {
             }
             return;
         }
-        let read_buffer = &self.read_buffer[..sz];
+        let read_data = &self.read_buffer[..sz];
+        let mut buf = self.read_state.remove(&stream_id).unwrap_or_default();
+        buf.extend_from_slice(read_data);
 
-        let buf = self.read_state.remove(&stream_id).map_or(
-            Cow::Borrowed(read_buffer),
-            |mut existing| {
-                existing.extend_from_slice(read_buffer);
-                Cow::Owned(existing)
-            },
-        );
+        // HQ requests are terminated by stream FIN. Never process a request
+        // before FIN: partial data could look like a valid truncated path,
+        // causing the server to serve the wrong (or non-existent) file.
+        if !fin {
+            self.save_partial(stream_id, buf, conn);
+            return;
+        }
 
-        let Ok(msg) = str::from_utf8(&buf[..]) else {
-            self.save_partial(stream_id, buf.to_vec(), conn);
+        // FIN is set: the request is complete. Non-UTF-8 or unrecognised format
+        // cannot be recovered by waiting for more data; just drop and return.
+        let Ok(msg) = str::from_utf8(&buf) else {
             return;
         };
 
@@ -142,44 +126,22 @@ impl HttpServer {
                 }
             })
         else {
-            self.save_partial(stream_id, buf.to_vec(), conn);
             return;
         };
 
-        let resp: SendData = {
-            qdebug!("Path = '{path}'");
-            if self.is_qns_test {
-                match qns_read_response(path) {
-                    Ok(data) => data.into(),
-                    Err(e) => {
-                        qerror!("Failed to read {path}: {e}");
-                        b"404".to_vec().into()
-                    }
-                }
-            } else {
-                let count = path.parse().unwrap();
-                SendData::zeroes(count)
-            }
-        };
+        qdebug!("Path = '{path}'");
+        let resp = super::response_for_path(path, self.is_qns_test)
+            .unwrap_or_else(|()| b"404".as_slice().into());
 
-        if let Some(stream_state) = self.write_state.get_mut(&stream_id) {
-            match stream_state.data_to_send {
-                None => stream_state.data_to_send = Some(resp),
-                Some(_) => {
-                    qdebug!("Data already set, doing nothing");
-                }
-            }
-            if stream_state.writable {
-                self.stream_writable(stream_id, conn);
-            }
+        let stream_state = self.write_state.entry(stream_id).or_default();
+        if stream_state.data_to_send.is_none() {
+            stream_state.data_to_send = Some(resp);
         } else {
-            self.write_state.insert(
-                stream_id,
-                HttpStreamState {
-                    writable: false,
-                    data_to_send: Some(resp),
-                },
-            );
+            qdebug!("Data already set, doing nothing");
+        }
+        let writable = stream_state.writable;
+        if writable {
+            self.stream_writable(stream_id, conn);
         }
     }
 
@@ -190,20 +152,26 @@ impl HttpServer {
         };
 
         stream_state.writable = true;
-        if let Some(resp) = &mut stream_state.data_to_send {
+        let remove = if let Some(resp) = &mut stream_state.data_to_send {
             match resp.send(|chunk| conn.borrow_mut().stream_send(stream_id, chunk)) {
                 SendResult::StreamClosed => {
                     qwarn!("Stream {stream_id} closed by peer, stopping send");
-                    self.write_state.remove(&stream_id);
+                    true
                 }
                 SendResult::Done => {
                     _ = conn.borrow_mut().stream_close_send(stream_id); // Stream may be closed; ignore errors.
-                    self.write_state.remove(&stream_id);
+                    true
                 }
                 SendResult::MoreData => {
                     stream_state.writable = false;
+                    false
                 }
             }
+        } else {
+            false
+        };
+        if remove {
+            self.write_state.remove(&stream_id);
         }
     }
 }
@@ -235,8 +203,7 @@ impl super::HttpServer for HttpServer {
                 };
                 match event {
                     ConnectionEvent::NewStream { stream_id } => {
-                        self.write_state
-                            .insert(stream_id, HttpStreamState::default());
+                        self.write_state.entry(stream_id).or_default();
                     }
                     ConnectionEvent::RecvStreamReadable { stream_id } => {
                         self.stream_readable(stream_id, &acr);

--- a/neqo-bin/src/server/http09.rs
+++ b/neqo-bin/src/server/http09.rs
@@ -70,14 +70,33 @@ impl HttpServer {
     }
 
     fn save_partial(&mut self, stream_id: StreamId, partial: Vec<u8>, conn: &ConnectionRef) {
-        let url = String::from_utf8_lossy(&partial);
         if partial.len() < 4096 {
-            qdebug!("Saving partial URL: {url}");
+            qdebug!("Saving partial URL: {}", String::from_utf8_lossy(&partial));
             self.read_state.insert(stream_id, partial);
         } else {
-            qdebug!("Giving up on partial URL {url}");
+            qdebug!(
+                "Giving up on partial URL {}",
+                String::from_utf8_lossy(&partial)
+            );
             _ = conn.borrow_mut().stream_stop_sending(stream_id, 0); // Stream may be closed; ignore errors.
         }
+    }
+
+    /// Parse a complete HQ request buffer and return the path component.
+    ///
+    /// Returns `None` on non-UTF-8 input, missing `GET /` prefix, or a path
+    /// that doesn't pass the filter for the current mode (QNS vs. non-QNS).
+    fn parse_path(buf: &[u8], is_qns_test: bool) -> Option<&str> {
+        let msg = str::from_utf8(buf).ok()?;
+        msg.strip_prefix("GET /")
+            .and_then(|s| s.lines().next())
+            .filter(|p| {
+                if is_qns_test {
+                    !p.chars().any(char::is_whitespace)
+                } else {
+                    p.chars().all(|c| c.is_ascii_digit())
+                }
+            })
     }
 
     fn stream_readable(&mut self, stream_id: StreamId, conn: &ConnectionRef) {
@@ -90,15 +109,15 @@ impl HttpServer {
             .stream_recv(stream_id, &mut self.read_buffer)
             .expect("Read should succeed");
 
-        if sz == 0 {
-            if !fin {
-                qdebug!("size 0 but !fin");
-            }
+        // A zero-length read with no FIN is unexpected but harmless; leave any
+        // buffered partial data untouched and wait for more.
+        if sz == 0 && !fin {
+            qdebug!("size 0 but !fin");
             return;
         }
-        let read_data = &self.read_buffer[..sz];
+
         let mut buf = self.read_state.remove(&stream_id).unwrap_or_default();
-        buf.extend_from_slice(read_data);
+        buf.extend_from_slice(&self.read_buffer[..sz]);
 
         // HQ requests are terminated by stream FIN. Never process a request
         // before FIN: partial data could look like a valid truncated path,
@@ -108,24 +127,18 @@ impl HttpServer {
             return;
         }
 
-        // FIN is set: the request is complete. Non-UTF-8 or unrecognised format
-        // cannot be recovered by waiting for more data; just drop and return.
-        let Ok(msg) = str::from_utf8(&buf) else {
+        // FIN is set: the request is complete. If no data was received (either
+        // now or buffered from a prior read), there is nothing to serve.
+        if buf.is_empty() {
+            self.write_state.remove(&stream_id);
             return;
-        };
+        }
 
-        // Parse "GET /path\n" or "GET /path\r\n"
-        let Some(path) = msg
-            .strip_prefix("GET /")
-            .and_then(|s| s.lines().next())
-            .filter(|p| {
-                if self.is_qns_test {
-                    !p.chars().any(char::is_whitespace)
-                } else {
-                    p.chars().all(|c| c.is_ascii_digit())
-                }
-            })
-        else {
+        // Non-UTF-8 or unrecognised format cannot be recovered by waiting for
+        // more data; reset the stream so the client gets a clean signal.
+        let Some(path) = Self::parse_path(&buf, self.is_qns_test) else {
+            _ = conn.borrow_mut().stream_reset_send(stream_id, 0);
+            self.write_state.remove(&stream_id);
             return;
         };
 
@@ -234,5 +247,38 @@ impl super::HttpServer for HttpServer {
 impl Display for HttpServer {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Http 0.9 server ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HttpServer;
+
+    // Issue 1 (FIN-only frame after buffered partial data) is exercised by
+    // the QNS zerortt interop test end-to-end; unit testing it would require
+    // a real neqo_transport::server::ConnectionRef.
+
+    #[test]
+    fn parse_path_valid() {
+        assert_eq!(HttpServer::parse_path(b"GET /1000\n", false), Some("1000"));
+        assert_eq!(HttpServer::parse_path(b"GET /42\r\n", false), Some("42"));
+        assert_eq!(
+            HttpServer::parse_path(b"GET /index.html\n", true),
+            Some("index.html")
+        );
+    }
+
+    #[test]
+    fn parse_path_invalid() {
+        // Non-UTF-8 input must return None so the caller can reset the stream.
+        assert_eq!(HttpServer::parse_path(b"\xff\xfe", false), None);
+        // Wrong verb.
+        assert_eq!(HttpServer::parse_path(b"HEAD /1000\n", false), None);
+        // Non-digit in non-QNS mode.
+        assert_eq!(HttpServer::parse_path(b"GET /foo\n", false), None);
+        // Whitespace in QNS path.
+        assert_eq!(HttpServer::parse_path(b"GET /foo bar\n", true), None);
+        // Empty buffer: a FIN-only frame with no prior buffered data.
+        assert_eq!(HttpServer::parse_path(b"", false), None);
     }
 }

--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -13,15 +13,15 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{Datagram, Header, header::HeadersExt as _, hex, qdebug, qerror, qinfo};
-use neqo_crypto::{AntiReplay, generate_ech_keys, random};
+use neqo_common::{Datagram, Header, header::HeadersExt as _, qdebug, qerror};
+use neqo_crypto::AntiReplay;
 use neqo_http3::{
     Http3OrWebTransportStream, Http3Parameters, Http3Server, Http3ServerEvent, StreamId,
 };
-use neqo_transport::{ConnectionIdGenerator, OutputBatch, server::ValidateAddress};
+use neqo_transport::{ConnectionIdGenerator, OutputBatch};
 use rustc_hash::FxHashMap as HashMap;
 
-use super::{Args, qns_read_response};
+use super::Args;
 use crate::{
     now,
     send_data::{SendData, SendResult},
@@ -102,18 +102,7 @@ impl HttpServer {
         )
         .expect("We cannot make a server!");
 
-        server.set_ciphers(args.get_ciphers());
-        server.set_qlog_dir(args.shared.qlog_dir.clone());
-        if args.retry {
-            server.set_validation(ValidateAddress::Always);
-        }
-        if args.ech {
-            let (sk, pk) = generate_ech_keys().expect("should create ECH keys");
-            server
-                .enable_ech(random::<1>()[0], "public.example", &sk, &pk)
-                .unwrap();
-            qinfo!("ECHConfigList: {}", hex(server.ech_config()));
-        }
+        super::configure_server(&mut server, args);
         Self {
             server,
             remaining_data: HashMap::default(),
@@ -169,30 +158,31 @@ impl super::HttpServer for HttpServer {
 
                     let response = if self.is_qns_test {
                         let path_str = path.value_utf8().unwrap_or("/");
-                        match qns_read_response(path_str) {
-                            Ok(data) => SendData::from(data),
-                            Err(e) => {
-                                qerror!("Failed to read {path_str}: {e}");
-                                // Stream may be closed; ignore errors.
-                                if stream
-                                    .send_headers(&[Header::new(":status", "404")])
-                                    .is_ok()
-                                {
-                                    _ = stream.stream_close_send(now);
-                                } else {
-                                    _ = stream
-                                        .stream_reset_send(neqo_http3::Error::HttpNone.code());
-                                }
-                                continue;
+                        let Ok(data) = super::response_for_path(path_str, true) else {
+                            // Stream may be closed; ignore errors.
+                            if stream
+                                .send_headers(&[Header::new(":status", "404")])
+                                .is_ok()
+                            {
+                                _ = stream.stream_close_send(now);
+                            } else {
+                                _ = stream.stream_reset_send(neqo_http3::Error::HttpNone.code());
                             }
-                        }
-                    } else if let Ok(path_str) = path.value_utf8() {
-                        path_str
-                            .trim_matches(|p| p == '/')
-                            .parse::<usize>()
-                            .map_or_else(|_| SendData::from(path.value()), SendData::zeroes)
+                            continue;
+                        };
+                        data
                     } else {
-                        SendData::from(path.value())
+                        // Non-QNS: path is a byte count; fall back to raw bytes for
+                        // non-numeric or non-UTF-8 paths.
+                        path.value_utf8()
+                            .ok()
+                            .and_then(|s| {
+                                s.trim_matches('/')
+                                    .parse::<usize>()
+                                    .ok()
+                                    .map(SendData::zeroes)
+                            })
+                            .unwrap_or_else(|| SendData::from(path.value()))
                     };
 
                     self.send_response(&stream, response, now);

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -33,18 +33,19 @@ use futures::{
     FutureExt as _,
     future::{Either, select, select_all},
 };
-use neqo_common::{Datagram, qdebug, qerror, qinfo, qwarn};
+use neqo_common::{Datagram, hex, qdebug, qerror, qinfo, qwarn};
 use neqo_crypto::{
-    AntiReplay, Cipher,
+    AntiReplay, Cipher, PrivateKey, PublicKey,
     constants::{TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256},
-    init_db,
+    generate_ech_keys, init_db, random,
 };
-use neqo_transport::{OutputBatch, RandomConnectionIdGenerator, Version};
+use neqo_http3::Http3Server;
+use neqo_transport::{OutputBatch, RandomConnectionIdGenerator, Version, server::ValidateAddress};
 use neqo_udp::{DatagramIter, RecvBuf};
 use thiserror::Error;
 use tokio::time::Sleep;
 
-use crate::{SharedArgs, now};
+use crate::{SharedArgs, now, send_data::SendData};
 
 const ANTI_REPLAY_WINDOW: Duration = Duration::from_secs(10);
 
@@ -211,11 +212,86 @@ impl Args {
     }
 }
 
-fn qns_read_response(filename: &str) -> Result<Vec<u8>, io::Error> {
-    let path: PathBuf = ["/www", filename.trim_matches(|p| p == '/')]
-        .iter()
-        .collect();
-    fs::read(path)
+/// Abstracts the common configuration methods shared by [`neqo_transport::server::Server`]
+/// and [`Http3Server`], enabling [`configure_server`] to work with both.
+pub(super) trait ServerConfig {
+    fn set_ciphers(&mut self, ciphers: &[Cipher]);
+    fn set_qlog_dir(&mut self, dir: Option<PathBuf>);
+    fn set_validation(&self, v: ValidateAddress);
+    fn enable_ech(&mut self, config: u8, public_name: &str, sk: &PrivateKey, pk: &PublicKey);
+    fn ech_config(&self) -> &[u8];
+}
+
+impl ServerConfig for neqo_transport::server::Server {
+    fn set_ciphers(&mut self, ciphers: &[Cipher]) {
+        self.set_ciphers(ciphers);
+    }
+    fn set_qlog_dir(&mut self, dir: Option<PathBuf>) {
+        self.set_qlog_dir(dir);
+    }
+    fn set_validation(&self, v: ValidateAddress) {
+        self.set_validation(v);
+    }
+    fn enable_ech(&mut self, config: u8, public_name: &str, sk: &PrivateKey, pk: &PublicKey) {
+        self.enable_ech(config, public_name, sk, pk)
+            .expect("ECH configuration failed");
+    }
+    fn ech_config(&self) -> &[u8] {
+        self.ech_config()
+    }
+}
+
+impl ServerConfig for Http3Server {
+    fn set_ciphers(&mut self, ciphers: &[Cipher]) {
+        self.set_ciphers(ciphers);
+    }
+    fn set_qlog_dir(&mut self, dir: Option<PathBuf>) {
+        self.set_qlog_dir(dir);
+    }
+    fn set_validation(&self, v: ValidateAddress) {
+        self.set_validation(v);
+    }
+    fn enable_ech(&mut self, config: u8, public_name: &str, sk: &PrivateKey, pk: &PublicKey) {
+        self.enable_ech(config, public_name, sk, pk)
+            .expect("ECH configuration failed");
+    }
+    fn ech_config(&self) -> &[u8] {
+        self.ech_config()
+    }
+}
+
+/// Apply common [`Args`]-driven configuration to any server that implements [`ServerConfig`].
+pub(super) fn configure_server(server: &mut impl ServerConfig, args: &Args) {
+    server.set_ciphers(&args.get_ciphers());
+    server.set_qlog_dir(args.shared.qlog_dir.clone());
+    if args.retry {
+        server.set_validation(ValidateAddress::Always);
+    }
+    if args.ech {
+        let (sk, pk) = generate_ech_keys().expect("should create ECH keys");
+        server.enable_ech(random::<1>()[0], "public.example", &sk, &pk);
+        qinfo!("ECHConfigList: {}", hex(server.ech_config()));
+    }
+}
+
+/// Generate a response [`SendData`] for a given request path.
+///
+/// In QNS test mode, reads the corresponding file from `/www/`. Returns `Err`
+/// if the file cannot be read (caller sends a 404).
+/// In non-QNS mode, parses the path as a byte count and generates that many
+/// zero bytes.
+pub(super) fn response_for_path(path: &str, is_qns_test: bool) -> Result<SendData, ()> {
+    if is_qns_test {
+        let file_path: PathBuf = ["/www", path.trim_matches('/')].iter().collect();
+        fs::read(file_path).map(SendData::from).map_err(|e| {
+            qerror!("Failed to read {path}: {e}");
+        })
+    } else {
+        Ok(path
+            .trim_matches('/')
+            .parse::<usize>()
+            .map_or_else(|_| path.into(), SendData::zeroes))
+    }
 }
 
 #[expect(clippy::module_name_repetitions, reason = "This is OK.")]
@@ -500,5 +576,30 @@ pub fn run(
         );
         let local_addrs = runner.local_addresses();
         Ok((Box::pin(runner.run()), local_addrs))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::response_for_path;
+
+    #[test]
+    fn response_for_path_qns_not_found() {
+        // Non-existent file should return Err.
+        let result = response_for_path("/no_such_file_xyz", true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn response_for_path_non_qns_count() {
+        let data = response_for_path("/1000", false).expect("should succeed");
+        assert_eq!(data.len(), 1000);
+    }
+
+    #[test]
+    fn response_for_path_non_qns_non_numeric_sends_path_bytes() {
+        // Non-numeric path falls back to sending the path bytes themselves.
+        let data = response_for_path("/hello", false).expect("should succeed");
+        assert_eq!(data.len(), "/hello".len());
     }
 }

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -277,11 +277,17 @@ pub(super) fn configure_server(server: &mut impl ServerConfig, args: &Args) {
 /// Generate a response [`SendData`] for a given request path.
 ///
 /// In QNS test mode, reads the corresponding file from `/www/`. Returns `Err`
-/// if the file cannot be read (caller sends a 404).
-/// In non-QNS mode, parses the path as a byte count and generates that many
-/// zero bytes.
+/// if the file cannot be read (caller sends a 404) or if the path contains
+/// `..` components.
+/// In non-QNS mode, trims `/` from the path, parses the remainder as a byte
+/// count, and generates that many zero bytes. If parsing fails, sends the
+/// path bytes instead.
 pub(super) fn response_for_path(path: &str, is_qns_test: bool) -> Result<SendData, ()> {
     if is_qns_test {
+        if path.split('/').any(|segment| segment == "..") {
+            qerror!("Rejecting path with '..' component: {path}");
+            return Err(());
+        }
         let file_path: PathBuf = ["/www", path.trim_matches('/')].iter().collect();
         fs::read(file_path).map(SendData::from).map_err(|e| {
             qerror!("Failed to read {path}: {e}");
@@ -601,5 +607,14 @@ mod tests {
         // Non-numeric path falls back to sending the path bytes themselves.
         let data = response_for_path("/hello", false).expect("should succeed");
         assert_eq!(data.len(), "/hello".len());
+    }
+
+    #[test]
+    fn response_for_path_qns_dotdot_rejected() {
+        // Paths with ".." components must be rejected in QNS mode to prevent
+        // directory traversal outside /www/.
+        for path in ["/../etc/passwd", "/foo/../etc/passwd", "/.."] {
+            assert!(response_for_path(path, true).is_err(), "path: {path}");
+        }
     }
 }

--- a/test/test.sh
+++ b/test/test.sh
@@ -35,7 +35,7 @@ tcpdump -U -i "$iface" -w "$tmp/test.pcap" host $addr and port $port >/dev/null 
 tcpdump_pid=$!
 trap 'kill $tcpdump_pid; rm -rf "$tmp"' EXIT
 
-tmux -CC \
+tmux \
         set-option -g default-shell "$(which bash)" \; \
         new-session "$client; kill -USR2 $tcpdump_pid; touch $tmp/done" \; \
         split-window -h "$server" \; \


### PR DESCRIPTION
The h09 server was processing requests as soon as any stream data arrived, without waiting for the stream FIN. During 0-RTT, stream data for a single request is often split across multiple packets, so the server would see a partial URL, fail to find the corresponding file, and respond with a 3-byte "404" — causing the zerortt interop test to fail. Fix by buffering incoming data until FIN is received before attempting to parse and serve the request. Also factor out the shared QNS file-lookup logic into response_for_path() and the common server setup into configure_server(), and add tests.