### PR TITLE
refactor(cc): split up `CongestionEvent` enum

### DIFF
--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -18,7 +18,7 @@ use rustc_hash::FxHashMap as HashMap;
 use super::CongestionController;
 use crate::{
     Pmtud,
-    cc::CongestionEvent,
+    cc::CongestionTrigger::{self, Ecn, Loss},
     packet, qlog,
     recovery::sent,
     rtt::RttEstimate,
@@ -98,7 +98,7 @@ pub trait WindowAdjustment: Display + Debug {
         curr_cwnd: usize,
         acked_bytes: usize,
         max_datagram_size: usize,
-        congestion_event: CongestionEvent,
+        congestion_trigger: CongestionTrigger,
         cc_stats: &mut CongestionControlStats,
     ) -> (usize, usize);
     /// Cubic needs this signal to reset its epoch.
@@ -485,8 +485,7 @@ where
             return false;
         };
 
-        let congestion =
-            self.on_congestion_event(last_lost_packet, CongestionEvent::Loss, now, cc_stats);
+        let congestion = self.on_congestion_event(last_lost_packet, Loss, now, cc_stats);
         // Persistent congestion checks still need to see lost packets that are not in-flight for
         // continuity checks. That is why only the closure to filter out lost PMTUD probes is used.
         let persistent_congestion = self.detect_persistent_congestion(
@@ -516,7 +515,7 @@ where
         now: Instant,
         cc_stats: &mut CongestionControlStats,
     ) -> bool {
-        self.on_congestion_event(largest_acked_pkt, CongestionEvent::Ecn, now, cc_stats)
+        self.on_congestion_event(largest_acked_pkt, Ecn, now, cc_stats)
     }
 
     fn discard(&mut self, pkt: &sent::Packet, now: Instant) {
@@ -732,7 +731,7 @@ where
                 stored.congestion_window,
                 self.current.congestion_window
             );
-            cc_stats.congestion_events[CongestionEvent::Spurious] += 1;
+            cc_stats.congestion_events.spurious += 1;
             return;
         }
         self.congestion_control.restore_undo_state(cc_stats);
@@ -749,7 +748,7 @@ where
             cc_stats.slow_start_exit_reason = None;
         }
         qinfo!("[{self}] Spurious cong event -> RESTORED;");
-        cc_stats.congestion_events[CongestionEvent::Spurious] += 1;
+        cc_stats.congestion_events.spurious += 1;
     }
 
     fn detect_persistent_congestion<'a>(
@@ -845,7 +844,7 @@ where
     fn on_congestion_event(
         &mut self,
         last_packet: &sent::Packet,
-        congestion_event: CongestionEvent,
+        congestion_trigger: CongestionTrigger,
         now: Instant,
         cc_stats: &mut CongestionControlStats,
     ) -> bool {
@@ -860,7 +859,7 @@ where
             return false;
         }
 
-        if congestion_event != CongestionEvent::Ecn {
+        if congestion_trigger != Ecn {
             self.stored = Some(self.current.clone());
             self.congestion_control.save_undo_state();
         }
@@ -869,7 +868,7 @@ where
             self.current.congestion_window,
             self.current.acked_bytes,
             self.max_datagram_size(),
-            congestion_event,
+            congestion_trigger,
             cc_stats,
         );
         self.current.congestion_window = max(cwnd, self.cwnd_min());
@@ -881,7 +880,10 @@ where
             self.current.ssthresh
         );
 
-        cc_stats.congestion_events[congestion_event] += 1;
+        match congestion_trigger {
+            Loss => cc_stats.congestion_events.loss += 1,
+            Ecn => cc_stats.congestion_events.ecn += 1,
+        }
         cc_stats.cwnd = Some(self.current.congestion_window);
         // If we were in slow start when `on_congestion_event` was called we will exit slow start
         // and should record the exit congestion window.
@@ -898,8 +900,7 @@ where
             ],
             now,
         );
-        let trigger =
-            (congestion_event == CongestionEvent::Ecn).then_some(qlog::CongestionStateTrigger::Ecn);
+        let trigger = (congestion_trigger == Ecn).then_some(qlog::CongestionStateTrigger::Ecn);
         self.set_phase(Phase::RecoveryStart, trigger, now);
         true
     }
@@ -933,7 +934,8 @@ mod tests {
     use crate::{
         MIN_INITIAL_PACKET_SIZE,
         cc::{
-            CWND_INITIAL_PKTS, ClassicSlowStart, CongestionController, CongestionEvent,
+            CWND_INITIAL_PKTS, ClassicSlowStart, CongestionController,
+            CongestionTrigger::{self, Ecn, Loss},
             classic_cc::Phase,
             cubic::Cubic,
             new_reno::NewReno,
@@ -1593,14 +1595,14 @@ mod tests {
         assert_eq!(cc.cwnd(), cc.cwnd_initial());
         assert_eq!(cc.ssthresh(), usize::MAX);
         assert_eq!(cc.current.phase, Phase::SlowStart);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Ecn], 0);
+        assert_eq!(cc_stats.congestion_events.ecn, 0);
 
         // Signal congestion (ECN CE) and thus change phase to recovery start.
         cc.on_ecn_ce_received(&p_ce, now, &mut cc_stats);
         assert_eq!(cc.cwnd(), cc.cwnd_initial() * 85 / 100);
         assert_eq!(cc.ssthresh(), cc.cwnd_initial() * 85 / 100);
         assert_eq!(cc.current.phase, Phase::RecoveryStart);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Ecn], 1);
+        assert_eq!(cc_stats.congestion_events.ecn, 1);
     }
 
     /// This tests spurious congestion event detection, stat counting and the recovery mechanism.
@@ -1625,8 +1627,8 @@ mod tests {
         cc.on_packet_sent(&pkt1, now);
         cc.on_packet_sent(&pkt2, now);
         assert_eq!(cc.current.phase, Phase::SlowStart);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 0);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Spurious], 0);
+        assert_eq!(cc_stats.congestion_events.loss, 0);
+        assert_eq!(cc_stats.congestion_events.spurious, 0);
 
         // 2. Lose packets (1, 2) --> `RecoveryStart`, 1 event, reduced cwnd
         let cwnd_before_loss = cc.cwnd();
@@ -1649,7 +1651,7 @@ mod tests {
             cc_stats.slow_start_exit_reason,
             Some(SlowStartExitReason::CongestionEvent)
         );
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 1);
+        assert_eq!(cc_stats.congestion_events.loss, 1);
         #[expect(
             clippy::cast_sign_loss,
             clippy::cast_possible_truncation,
@@ -1666,7 +1668,7 @@ mod tests {
         let pkt3 = sent::make_packet(3, now, 1000);
         cc.on_packet_sent(&pkt3, now);
         assert_eq!(cc.current.phase, Phase::Recovery);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 1);
+        assert_eq!(cc_stats.congestion_events.loss, 1);
 
         // 4. Ack packet (3)      --> `CongestionAvoidance`, 1 event
         cc.on_packets_acked(
@@ -1676,7 +1678,7 @@ mod tests {
             &mut cc_stats,
         );
         assert_eq!(cc.current.phase, Phase::CongestionAvoidance);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 1);
+        assert_eq!(cc_stats.congestion_events.loss, 1);
 
         // 5. Ack packet (1)      --> `CongestionAvoidance`, 1 event, not a spurious event as not
         //    all lost packets were recovered
@@ -1687,8 +1689,8 @@ mod tests {
             &mut cc_stats,
         );
         assert_eq!(cc.current.phase, Phase::CongestionAvoidance);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 1);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Spurious], 0);
+        assert_eq!(cc_stats.congestion_events.loss, 1);
+        assert_eq!(cc_stats.congestion_events.spurious, 0);
 
         // 6. Ack packet (2)      --> all lost packets have been recovered so now we've detected a
         //    spurious congestion event and reset to previous state
@@ -1701,8 +1703,8 @@ mod tests {
         assert_eq!(cc.current.phase, Phase::SlowStart);
         assert_eq!(cc_stats.slow_start_exit_cwnd, None);
         assert_eq!(cc_stats.slow_start_exit_reason, None);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 1);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Spurious], 1);
+        assert_eq!(cc_stats.congestion_events.loss, 1);
+        assert_eq!(cc_stats.congestion_events.spurious, 1);
         assert_eq!(cc.cwnd(), cc.cwnd_initial());
         assert_eq!(cc_stats.w_max, None);
     }
@@ -1760,7 +1762,7 @@ mod tests {
         // Detects the spurious congestion event but should NOT restore old params because cwnd has
         // recovered naturally.
         assert_eq!(cc.cwnd(), cwnd_recovered, "cwnd should not be restored");
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Spurious], 1);
+        assert_eq!(cc_stats.congestion_events.spurious, 1);
     }
 
     /// Test that losses during recovery don't cause double-counting of spurious events.
@@ -1792,8 +1794,8 @@ mod tests {
         cc.on_packet_sent(&pkt2, now);
 
         assert_eq!(cc.current.phase, Phase::SlowStart);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 0);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Spurious], 0);
+        assert_eq!(cc_stats.congestion_events.loss, 0);
+        assert_eq!(cc_stats.congestion_events.spurious, 0);
 
         let mut lost_pkt1 = pkt1.clone();
         lost_pkt1.declare_lost(now, sent::LossTrigger::TimeThreshold);
@@ -1809,8 +1811,8 @@ mod tests {
         );
 
         assert_eq!(cc.current.phase, Phase::RecoveryStart);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 1);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Spurious], 0);
+        assert_eq!(cc_stats.congestion_events.loss, 1);
+        assert_eq!(cc_stats.congestion_events.spurious, 0);
 
         // Step 3: Send packet 3 → enter Recovery phase
         let pkt3 = sent::make_packet(3, now, 1000);
@@ -1820,8 +1822,8 @@ mod tests {
         // Step 4: Ack packet 1 → spurious event #1 detected
         cc.on_packets_acked(&[pkt1], &rtt_estimate, now, &mut cc_stats);
 
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 1);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Spurious], 1);
+        assert_eq!(cc_stats.congestion_events.loss, 1);
+        assert_eq!(cc_stats.congestion_events.spurious, 1);
 
         let mut lost_pkt2 = pkt2.clone();
         lost_pkt2.declare_lost(now, sent::LossTrigger::TimeThreshold);
@@ -1838,16 +1840,16 @@ mod tests {
         );
 
         // Still only 1 spurious event (but a new loss event)
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 2);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Spurious], 1);
+        assert_eq!(cc_stats.congestion_events.loss, 2);
+        assert_eq!(cc_stats.congestion_events.spurious, 1);
 
         // 6. Ack packet 2 → should trigger spurious event #2 because we left recovery when
         //    recovering from spurious event #1
         cc.on_packets_acked(&[pkt2], &rtt_estimate, now, &mut cc_stats);
 
         // Should now be 2 loss events and 2 spurious events, no double counting occured
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 2);
-        assert_eq!(cc_stats.congestion_events[CongestionEvent::Spurious], 2,);
+        assert_eq!(cc_stats.congestion_events.loss, 2);
+        assert_eq!(cc_stats.congestion_events.spurious, 2,);
     }
 
     #[test]
@@ -1896,7 +1898,7 @@ mod tests {
         assert!(cc.maybe_lost_packets.is_empty());
     }
 
-    fn slow_start_exit_stats(congestion_event: CongestionEvent) {
+    fn slow_start_exit_stats(congestion_trigger: CongestionTrigger) {
         let mut cc = make_cc_newreno();
         let now = now();
         let mut cc_stats = CongestionControlStats::default();
@@ -1909,11 +1911,11 @@ mod tests {
         let pkt1 = sent::make_packet(1, now, 1000);
         cc.on_packet_sent(&pkt1, now);
 
-        match congestion_event {
-            CongestionEvent::Ecn => {
+        match congestion_trigger {
+            Ecn => {
                 cc.on_ecn_ce_received(&pkt1, now, &mut cc_stats);
             }
-            CongestionEvent::Loss => {
+            Loss => {
                 cc.on_packets_lost(
                     Some(now),
                     None,
@@ -1923,7 +1925,6 @@ mod tests {
                     &mut cc_stats,
                 );
             }
-            CongestionEvent::Spurious => panic!("unsupported congestion event"),
         }
 
         // Should have exited slow start with cwnd captured AFTER reduction.
@@ -1935,7 +1936,7 @@ mod tests {
         );
 
         // For loss, test that a spurious congestion event resets the stats.
-        if congestion_event == CongestionEvent::Loss {
+        if congestion_trigger == Loss {
             // Send recovery packet and ack it to exit recovery.
             let pkt2 = sent::make_packet(2, now, 1000);
             cc.on_packet_sent(&pkt2, now);
@@ -1952,12 +1953,12 @@ mod tests {
 
     #[test]
     fn slow_start_exit_stats_loss() {
-        slow_start_exit_stats(CongestionEvent::Loss);
+        slow_start_exit_stats(Loss);
     }
 
     #[test]
     fn slow_start_exit_stats_ecn_ce() {
-        slow_start_exit_stats(CongestionEvent::Ecn);
+        slow_start_exit_stats(Ecn);
     }
 
     #[test]

--- a/neqo-transport/src/cc/cubic.rs
+++ b/neqo-transport/src/cc/cubic.rs
@@ -14,7 +14,10 @@ use std::{
 use neqo_common::{qdebug, qtrace};
 
 use crate::{
-    cc::{CongestionEvent, classic_cc::WindowAdjustment},
+    cc::{
+        CongestionTrigger::{self, Ecn},
+        classic_cc::WindowAdjustment,
+    },
     stats::CongestionControlStats,
 };
 
@@ -420,7 +423,7 @@ impl WindowAdjustment for Cubic {
         curr_cwnd: usize,
         acked_bytes: usize,
         max_datagram_size: usize,
-        congestion_event: CongestionEvent,
+        congestion_trigger: CongestionTrigger,
         cc_stats: &mut CongestionControlStats,
     ) -> (usize, usize) {
         let curr_cwnd_f64 = convert_to_f64(curr_cwnd);
@@ -455,7 +458,7 @@ impl WindowAdjustment for Cubic {
 
         // Reducing the congestion window and resetting time
         self.current.t_epoch = None;
-        let beta_dividend = if congestion_event == CongestionEvent::Ecn {
+        let beta_dividend = if congestion_trigger == Ecn {
             Self::BETA_USIZE_DIVIDEND_ECN
         } else {
             Self::BETA_USIZE_DIVIDEND

--- a/neqo-transport/src/cc/mod.rs
+++ b/neqo-transport/src/cc/mod.rs
@@ -11,7 +11,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use enum_map::Enum;
 use neqo_common::qlog::Qlog;
 
 use crate::{Pmtud, recovery::sent, rtt::RttEstimate, stats::CongestionControlStats};
@@ -28,11 +27,10 @@ pub use cubic::Cubic;
 pub use hystart::{HyStart, HyStartCssBaseline};
 pub use new_reno::NewReno;
 
-#[derive(Clone, Copy, PartialEq, Eq, Enum, Debug)]
-pub enum CongestionEvent {
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CongestionTrigger {
     Loss,
     Ecn,
-    Spurious,
 }
 
 pub trait CongestionController: Display + Debug {

--- a/neqo-transport/src/cc/new_reno.rs
+++ b/neqo-transport/src/cc/new_reno.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use crate::{
-    cc::{CongestionEvent, classic_cc::WindowAdjustment},
+    cc::{CongestionTrigger, classic_cc::WindowAdjustment},
     stats::CongestionControlStats,
 };
 
@@ -33,7 +33,6 @@ impl WindowAdjustment for NewReno {
         _new_acked_bytes: usize,
         _min_rtt: Duration,
         _max_datagram_size: usize,
-
         _now: Instant,
     ) -> usize {
         curr_cwnd
@@ -44,7 +43,7 @@ impl WindowAdjustment for NewReno {
         curr_cwnd: usize,
         acked_bytes: usize,
         _max_datagram_size: usize,
-        _congestion_event: CongestionEvent,
+        _congestion_trigger: CongestionTrigger,
         _cc_stats: &mut CongestionControlStats,
     ) -> (usize, usize) {
         (curr_cwnd / 2, acked_bytes / 2)
@@ -66,7 +65,7 @@ mod tests {
 
     use super::NewReno;
     use crate::{
-        cc::{CongestionEvent, classic_cc::WindowAdjustment as _},
+        cc::{CongestionTrigger, classic_cc::WindowAdjustment as _},
         stats::CongestionControlStats,
     };
 
@@ -77,7 +76,7 @@ mod tests {
             1000,
             200,
             1500,
-            CongestionEvent::Loss,
+            CongestionTrigger::Loss,
             &mut CongestionControlStats::default(),
         );
         assert_eq!(cwnd, 500);

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -20,7 +20,7 @@ use test_fixture::now;
 use super::{RTT, make_cc_cubic};
 use crate::{
     cc::{
-        ClassicSlowStart, CongestionController as _, CongestionEvent,
+        ClassicSlowStart, CongestionController as _,
         classic_cc::ClassicCongestionController,
         cubic::{Cubic, convert_to_f64},
     },
@@ -312,7 +312,7 @@ fn congestion_event_slow_start() {
         cubic.cwnd(),
         cwnd_after_loss_slow_start(cubic.cwnd_initial(), cubic.max_datagram_size())
     );
-    assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 1);
+    assert_eq!(cc_stats.congestion_events.loss, 1);
 }
 
 #[test]
@@ -331,7 +331,7 @@ fn congestion_event_congestion_avoidance() {
         f64::EPSILON,
     );
     assert_eq!(cubic.cwnd(), cwnd_after_loss(cubic.cwnd_initial()));
-    assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 1);
+    assert_eq!(cc_stats.congestion_events.loss, 1);
 }
 
 /// Verify that `acked_bytes` is correctly reduced on a congestion event.
@@ -401,7 +401,7 @@ fn congestion_event_congestion_avoidance_fast_convergence() {
         f64::EPSILON,
     );
     assert_eq!(cubic.cwnd(), cwnd_after_loss(cubic.cwnd_initial()));
-    assert_eq!(cc_stats.congestion_events[CongestionEvent::Loss], 1);
+    assert_eq!(cc_stats.congestion_events.loss, 1);
 }
 
 #[test]

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -55,7 +55,7 @@ mod tracking;
 pub mod version;
 
 pub use self::{
-    cc::{CongestionControl, CongestionEvent, HyStartCssBaseline, SlowStart},
+    cc::{CongestionControl, CongestionTrigger, HyStartCssBaseline, SlowStart},
     cid::{
         ConnectionId, ConnectionIdDecoder, ConnectionIdGenerator, ConnectionIdRef,
         EmptyConnectionIdGenerator, RandomConnectionIdGenerator,

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -18,7 +18,7 @@ use enum_map::EnumMap;
 use neqo_common::{Dscp, Ecn, qdebug};
 use strum::IntoEnumIterator as _;
 
-use crate::{cc::CongestionEvent, ecn, packet};
+use crate::{ecn, packet};
 
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct FrameStats {
@@ -142,16 +142,27 @@ pub enum SlowStartExitReason {
     Heuristic,
 }
 
+/// Congestion event counters.
+///
+/// `loss` and `ecn` are mutually exclusive triggers (their sum equals the total number of
+/// congestion events). `spurious` is an orthogonal category that applies to a subset of
+/// loss-triggered congestion events.
+#[derive(Default, Clone, PartialEq, Eq)]
+pub struct CongestionEventStats {
+    /// Congestion events triggered by packet loss.
+    pub loss: usize,
+    /// Congestion events triggered by ECN-CE marks.
+    pub ecn: usize,
+    /// Congestion events later found to be spurious, due to packets which were initially
+    /// considered lost but later got acknowledged.
+    pub spurious: usize,
+}
+
 /// Congestion Control stats
 #[derive(Default, Clone, PartialEq)]
 pub struct CongestionControlStats {
-    /// Total number of congestion events caused by packet loss, total number of
-    /// congestion events caused by ECN-CE marked packets, and number of
-    /// spurious congestion events, where congestion was incorrectly inferred
-    /// due to packets initially considered lost but subsequently acknowledged.
-    /// The latter indicates instances where the congestion control algorithm
-    /// overreacted to perceived losses.
-    pub congestion_events: EnumMap<CongestionEvent, usize>,
+    /// Congestion event counters. Includes trigger type and other qualifier flags.
+    pub congestion_events: CongestionEventStats,
     /// The congestion window size (in bytes) when we exited slow start.
     /// None if we haven't exited slow start or if we re-entered after spurious congestion.
     /// When exiting via congestion event, this is the cwnd AFTER the reduction.
@@ -416,9 +427,9 @@ impl Debug for Stats {
         writeln!(
             f,
             "    ce_loss {} ce_ecn {} ce_spurious {}",
-            self.cc.congestion_events[CongestionEvent::Loss],
-            self.cc.congestion_events[CongestionEvent::Ecn],
-            self.cc.congestion_events[CongestionEvent::Spurious],
+            self.cc.congestion_events.loss,
+            self.cc.congestion_events.ecn,
+            self.cc.congestion_events.spurious,
         )?;
         writeln!(
             f,


### PR DESCRIPTION
- into mutually exclusive `CongestionTrigger` enum for control flow and `CongestionEventStats` struct that includes orthogonal categories for stat recording

As discussed in https://github.com/mozilla/neqo/pull/3527#issuecomment-4205870835 (see below), but only the refactor without the new metric that exists in that PR.

> [...] How about the following middle ground:
> 
> Keeping the enum change, so we have the mutually exclusive `Loss` and `Ecn` used in control flow:
> 
> ```rust
> pub enum CongestionTrigger { Loss, Ecn }
> ```
> 
> And then simplify the stat side:
> 
> ```rust
> pub struct CongestionEventStats {
>     /// Congestion events triggered by packet loss.
>     pub loss: usize,
>     /// Congestion events triggered by ECN-CE marks.
>     pub ecn: usize,
>     /// Events later found spurious (subset of loss+ecn total).
>     pub spurious: usize,
>     /// Events while underutilized (subset of loss+ecn total).
>     pub underutilized: usize,
>   }
> ```
> 
> This way we wouldn't have those `cc_stats.congestion_events.by_trigger[CongestionTrigger::Loss]` calls anymore (which is I think part of your concern in added complexity?) but still have the type-safety in actual control flow with `CongestionTrigger`.
> 
> Alternatively I could just add `Underutilized` to the existing `CongestionEvent` enum, but then the problems (see below) I outlined remain. I'm not a big fan of those.
> 
> > I think we shouldn't mix triggers (ecn, loss) with categories for stats (triggered by ecn/loss, spurious, underutilized) in a single enum. Right no we e.g. use CongestionEvent for on_congestion_event calls where we only expect Loss or Ecn to be passed in. I think it would be good to actually codify that expectation by having an extra enum for CongestionTriggers, especially so if we add more categories like we do in this patch.
> 
> > I also think it is slightly confusing to have a congestion_events EnumMap where the total sum of all entries doesn't equal the total sum of all congestion events (which it doesn't because a congestion event can be both triggered by loss, spurious and triggered while underutilized). But maybe that's a problem on my intuition about enums.

This would obviously need changes to glue code on the Firefox side since it restructures stat fields consumed by Gecko.