### PR TITLE
fix: Enable keepalive for h09 client streams

### DIFF
--- a/neqo-bin/src/client/http09.rs
+++ b/neqo-bin/src/client/http09.rs
@@ -268,6 +268,9 @@ impl<'b> Handler<'b> {
         match client.stream_create(StreamType::BiDi) {
             Ok(client_stream_id) => {
                 qinfo!("Created stream {client_stream_id} for {url}");
+                client
+                    .stream_keep_alive(client_stream_id, true)
+                    .expect("keep-alive on new stream");
                 let req = format!("GET {}\r\n", url.path());
                 if client
                     .stream_send(client_stream_id, req.as_bytes())


### PR DESCRIPTION
The HTTP/0.9 (hq-interop) client was not calling stream_keep_alive() after creating a request stream, unlike the HTTP/3 client which does this in create_bidi_transport_stream(). Without keepalive, the connection's next scheduled wakeup after the last ACK is the full 30-second idle timeout, rather than the keepalive timer at idle_timeout / 2 (15 s).

This causes the rebind-port interop test to fail. In that scenario the client is a pure receiver mid-transfer: it sends ACKs (not ack-eliciting) and then has nothing to send for ~30 s. If a NAT rebind occurs during that window, the server keeps sending to the stale port, the client never sends a packet from the new port, and both sides time out.

With stream_keep_alive() set, the client sends a PING at ~15 s, which (a) travels through the new NAT mapping and (b) lets the server discover the new client port and resume the transfer.