### PR TITLE
docs: add comprehensive documentation for logging API

### DIFF
--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -53,6 +53,10 @@ pub fn init(level_filter: Option<log::LevelFilter>) {
     });
 }
 
+/// Log an error message using the neqo logging framework.
+///
+/// Automatically initializes logging in test/bench builds before logging.
+/// Equivalent to `log::error!` but with automatic initialization.
 #[macro_export]
 #[clippy::format_args]
 macro_rules! qerror {
@@ -62,6 +66,11 @@ macro_rules! qerror {
         ::log::error!($($arg)*);
     } );
 }
+
+/// Log a warning message using the neqo logging framework.
+///
+/// Automatically initializes logging in test/bench builds before logging.
+/// Equivalent to `log::warn!` but with automatic initialization.
 #[macro_export]
 #[clippy::format_args]
 macro_rules! qwarn {
@@ -71,6 +80,11 @@ macro_rules! qwarn {
         ::log::warn!($($arg)*);
     } );
 }
+
+/// Log an informational message using the neqo logging framework.
+///
+/// Automatically initializes logging in test/bench builds before logging.
+/// Equivalent to `log::info!` but with automatic initialization.
 #[macro_export]
 #[clippy::format_args]
 macro_rules! qinfo {
@@ -80,6 +94,11 @@ macro_rules! qinfo {
         ::log::info!($($arg)*);
     } );
 }
+
+/// Log a debug message using the neqo logging framework.
+///
+/// Automatically initializes logging in test/bench builds before logging.
+/// Equivalent to `log::debug!` but with automatic initialization.
 #[macro_export]
 #[clippy::format_args]
 macro_rules! qdebug {
@@ -89,6 +108,11 @@ macro_rules! qdebug {
         ::log::debug!($($arg)*);
     } );
 }
+
+/// Log a trace message using the neqo logging framework.
+///
+/// Automatically initializes logging in test/bench builds before logging.
+/// Equivalent to `log::trace!` but with automatic initialization.
 #[macro_export]
 #[clippy::format_args]
 macro_rules! qtrace {

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -20,7 +20,7 @@ fn since_start() -> Duration {
 
 /// Initialize the logging system with optional level filtering.
 ///
-/// This function sets up the env_logger with a custom format that includes
+/// This function sets up the `env_logger` with a custom format that includes
 /// elapsed time since initialization. It can be called multiple times safely.
 pub fn init(level_filter: Option<log::LevelFilter>) {
     static INIT_ONCE: Once = Once::new();

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -18,6 +18,10 @@ fn since_start() -> Duration {
     START_TIME.get_or_init(Instant::now).elapsed()
 }
 
+/// Initialize the logging system with optional level filtering.
+///
+/// This function sets up the env_logger with a custom format that includes
+/// elapsed time since initialization. It can be called multiple times safely.
 pub fn init(level_filter: Option<log::LevelFilter>) {
     static INIT_ONCE: Once = Once::new();
 


### PR DESCRIPTION
This PR adds missing documentation for the neqo-common logging module.

## Changes

- Document the public `init()` function with parameter details and behavior
- Add doc comments for all exported logging macros (`qerror!`, `qwarn!`, `qinfo!`, `qdebug!`, `qtrace!`)
- Explain automatic initialization in test/bench builds
- Clarify equivalence to standard `log` crate macros

## Motivation

These are public API items that lacked documentation. This improves discoverability and helps users understand the automatic initialization behavior of the logging macros.

All macros follow the same pattern - they wrap the standard log macros but ensure logging is initialized in test/bench contexts.