### PR TITLE
feat(cc): add parameter to disable spurious congestion recovery

### DIFF
--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -1744,7 +1744,7 @@ mod tests {
         cc.on_packet_sent(&pkt2, now);
         assert_eq!(cc.current.phase, Phase::SlowStart);
 
-        // 2. Lose packets (1, 2) --> `RecoveryStart`, reduced cwnd, but no state saved
+        // 2. Lose packets (1, 2) --> `RecoveryStart` and reduced cwnd
         let mut lost_pkt1 = pkt1.clone();
         let mut lost_pkt2 = pkt2.clone();
         lost_pkt1.declare_lost(now, sent::LossTrigger::TimeThreshold);

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -726,12 +726,6 @@ where
     }
 
     fn on_spurious_congestion_event(&mut self, cc_stats: &mut CongestionControlStats) {
-        if !self.spurious_recovery {
-            cc_stats.congestion_events.spurious += 1;
-            qinfo!("[{self}] Spurious cong event detected -> recovery disabled;");
-            return;
-        }
-
         let Some(stored) = self.stored.take() else {
             qdebug!(
                 "[{self}] Spurious cong event -> ABORT, no stored params to restore available."
@@ -739,17 +733,24 @@ where
             return;
         };
 
+        // The stat is recorded for all cases below.
+        cc_stats.congestion_events.spurious += 1;
+
         if stored.congestion_window <= self.current.congestion_window {
             qinfo!(
                 "[{self}] Spurious cong event -> IGNORED because stored.cwnd {} < self.cwnd {};",
                 stored.congestion_window,
                 self.current.congestion_window
             );
-            cc_stats.congestion_events.spurious += 1;
             return;
         }
-        self.congestion_control.restore_undo_state(cc_stats);
 
+        if !self.spurious_recovery {
+            qinfo!("[{self}] Spurious cong event detected -> recovery disabled;");
+            return;
+        }
+
+        self.congestion_control.restore_undo_state(cc_stats);
         qdebug!(
             "Spurious cong event: recovering cc params from {} to {stored}",
             self.current
@@ -762,7 +763,6 @@ where
             cc_stats.slow_start_exit_reason = None;
         }
         qinfo!("[{self}] Spurious cong event -> RESTORED;");
-        cc_stats.congestion_events.spurious += 1;
     }
 
     fn detect_persistent_congestion<'a>(
@@ -873,7 +873,7 @@ where
             return false;
         }
 
-        if congestion_trigger != Ecn && self.spurious_recovery {
+        if congestion_trigger != Ecn {
             self.stored = Some(self.current.clone());
             self.congestion_control.save_undo_state();
         }
@@ -1724,10 +1724,10 @@ mod tests {
     }
 
     /// Same scenario as `spurious_congestion_event_detection_and_undo` but with recovery disabled.
-    /// Detection still fires and the spurious counter is incremented, but cwnd is not restored and
-    /// the prior state is never saved.
+    /// Detection still fires and the spurious counter is incremented, but cc parameters are not
+    /// restored.
     #[test]
-    fn spurious_congestion_event_detection_without_recovery() {
+    fn spurious_congestion_event_detection_recovery_disabled() {
         let mut cc = ClassicCongestionController::new(
             ClassicSlowStart::default(),
             Cubic::default(),
@@ -1761,7 +1761,6 @@ mod tests {
         assert_eq!(cc_stats.congestion_events.loss, 1);
         let cwnd_after_loss = cc.cwnd();
         assert!(cc_stats.slow_start_exit_cwnd.is_some());
-        assert!(cc.stored.is_none());
 
         // 3. Send packet (3) --> `Recovery`
         let pkt3 = sent::make_packet(3, now, 1000);
@@ -1787,7 +1786,7 @@ mod tests {
         assert_eq!(cc_stats.congestion_events.spurious, 0);
 
         // 6. Ack packet (2) --> spurious event detected, counter incremented, but NO recovery
-        //    because pref is turned off
+        //    because pref is turned off. Assert that nothing is reset.
         cc.on_packets_acked(
             &[pkt2],
             &RttEstimate::new(crate::DEFAULT_INITIAL_RTT),
@@ -1798,6 +1797,8 @@ mod tests {
         assert_eq!(cc.cwnd(), cwnd_after_loss);
         assert_eq!(cc.current.phase, Phase::CongestionAvoidance);
         assert!(cc_stats.slow_start_exit_cwnd.is_some());
+        assert!(cc_stats.slow_start_exit_reason.is_some());
+        assert!(cc_stats.w_max.is_some());
     }
 
     /// This tests a scenario where spurious detection happens late, after cwnd has recovered and

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -946,14 +946,14 @@ mod tests {
 
     use super::{ClassicCongestionController, PERSISTENT_CONG_THRESH, SlowStart, WindowAdjustment};
     use crate::{
-        MIN_INITIAL_PACKET_SIZE,
+        MIN_INITIAL_PACKET_SIZE, Pmtud,
         cc::{
             CWND_INITIAL_PKTS, ClassicSlowStart, CongestionController,
             CongestionTrigger::{self, Ecn, Loss},
             classic_cc::Phase,
             cubic::Cubic,
             new_reno::NewReno,
-            tests::{RTT, make_cc_cubic, make_cc_hystart, make_cc_newreno},
+            tests::{IP_ADDR, MTU, RTT, make_cc_cubic, make_cc_hystart, make_cc_newreno},
         },
         packet,
         recovery::{self, sent},
@@ -1721,6 +1721,83 @@ mod tests {
         assert_eq!(cc_stats.congestion_events.spurious, 1);
         assert_eq!(cc.cwnd(), cc.cwnd_initial());
         assert_eq!(cc_stats.w_max, None);
+    }
+
+    /// Same scenario as `spurious_congestion_event_detection_and_undo` but with recovery disabled.
+    /// Detection still fires and the spurious counter is incremented, but cwnd is not restored and
+    /// the prior state is never saved.
+    #[test]
+    fn spurious_congestion_event_detection_without_recovery() {
+        let mut cc = ClassicCongestionController::new(
+            ClassicSlowStart::default(),
+            Cubic::default(),
+            Pmtud::new(IP_ADDR, MTU),
+            false,
+        );
+        let now = now();
+        let mut cc_stats = CongestionControlStats::default();
+
+        // 1. Send packets (1, 2) --> `SlowStart`
+        let pkt1 = sent::make_packet(1, now, 1000);
+        let pkt2 = sent::make_packet(2, now, 1000);
+        cc.on_packet_sent(&pkt1, now);
+        cc.on_packet_sent(&pkt2, now);
+        assert_eq!(cc.current.phase, Phase::SlowStart);
+
+        // 2. Lose packets (1, 2) --> `RecoveryStart`, reduced cwnd, but no state saved
+        let mut lost_pkt1 = pkt1.clone();
+        let mut lost_pkt2 = pkt2.clone();
+        lost_pkt1.declare_lost(now, sent::LossTrigger::TimeThreshold);
+        lost_pkt2.declare_lost(now, sent::LossTrigger::TimeThreshold);
+        cc.on_packets_lost(
+            Some(now),
+            None,
+            PTO,
+            &[lost_pkt1, lost_pkt2],
+            now,
+            &mut cc_stats,
+        );
+        assert_eq!(cc.current.phase, Phase::RecoveryStart);
+        assert_eq!(cc_stats.congestion_events.loss, 1);
+        let cwnd_after_loss = cc.cwnd();
+        assert!(cc_stats.slow_start_exit_cwnd.is_some());
+        assert!(cc.stored.is_none());
+
+        // 3. Send packet (3) --> `Recovery`
+        let pkt3 = sent::make_packet(3, now, 1000);
+        cc.on_packet_sent(&pkt3, now);
+        assert_eq!(cc.current.phase, Phase::Recovery);
+
+        // 4. Ack packet (3) --> `CongestionAvoidance`
+        cc.on_packets_acked(
+            &[pkt3],
+            &RttEstimate::new(crate::DEFAULT_INITIAL_RTT),
+            now,
+            &mut cc_stats,
+        );
+        assert_eq!(cc.current.phase, Phase::CongestionAvoidance);
+
+        // 5. Ack packet (1) --> not all lost packets recovered yet
+        cc.on_packets_acked(
+            &[pkt1],
+            &RttEstimate::new(crate::DEFAULT_INITIAL_RTT),
+            now,
+            &mut cc_stats,
+        );
+        assert_eq!(cc_stats.congestion_events.spurious, 0);
+
+        // 6. Ack packet (2) --> spurious event detected, counter incremented, but NO recovery
+        //    because pref is turned off
+        cc.on_packets_acked(
+            &[pkt2],
+            &RttEstimate::new(crate::DEFAULT_INITIAL_RTT),
+            now,
+            &mut cc_stats,
+        );
+        assert_eq!(cc_stats.congestion_events.spurious, 1);
+        assert_eq!(cc.cwnd(), cwnd_after_loss);
+        assert_eq!(cc.current.phase, Phase::CongestionAvoidance);
+        assert!(cc_stats.slow_start_exit_cwnd.is_some());
     }
 
     /// This tests a scenario where spurious detection happens late, after cwnd has recovered and

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -211,6 +211,8 @@ pub struct ClassicCongestionController<S, T> {
     /// - [`Self::bytes_in_flight`] is not stored because if it was to be restored it might get
     ///   out-of-sync with the actual number of bytes-in-flight on the path.
     stored: Option<State>,
+    /// Whether to recover from spurious congestion events by restoring prior state.
+    spurious_recovery: bool,
 }
 
 impl<S: Display, T: Display> Display for ClassicCongestionController<S, T> {
@@ -593,7 +595,12 @@ where
     S: SlowStart,
     T: WindowAdjustment,
 {
-    pub fn new(slow_start: S, congestion_control: T, pmtud: Pmtud) -> Self {
+    pub fn new(
+        slow_start: S,
+        congestion_control: T,
+        pmtud: Pmtud,
+        spurious_recovery: bool,
+    ) -> Self {
         let mtu = pmtud.plpmtu();
         Self {
             slow_start,
@@ -605,6 +612,7 @@ where
             pmtud,
             current: State::new(mtu),
             stored: None,
+            spurious_recovery,
         }
     }
 
@@ -718,6 +726,12 @@ where
     }
 
     fn on_spurious_congestion_event(&mut self, cc_stats: &mut CongestionControlStats) {
+        if !self.spurious_recovery {
+            cc_stats.congestion_events.spurious += 1;
+            qinfo!("[{self}] Spurious cong event detected -> recovery disabled;");
+            return;
+        }
+
         let Some(stored) = self.stored.take() else {
             qdebug!(
                 "[{self}] Spurious cong event -> ABORT, no stored params to restore available."
@@ -859,7 +873,7 @@ where
             return false;
         }
 
-        if congestion_trigger != Ecn {
+        if congestion_trigger != Ecn && self.spurious_recovery {
             self.stored = Some(self.current.clone());
             self.congestion_control.save_undo_state();
         }

--- a/neqo-transport/src/cc/tests/mod.rs
+++ b/neqo-transport/src/cc/tests/mod.rs
@@ -31,6 +31,7 @@ pub fn make_cc_newreno() -> ClassicCongestionController<ClassicSlowStart, NewRen
         ClassicSlowStart::default(),
         NewReno::default(),
         Pmtud::new(IP_ADDR, MTU),
+        true,
     )
 }
 
@@ -40,6 +41,7 @@ pub fn make_cc_cubic() -> ClassicCongestionController<ClassicSlowStart, Cubic> {
         ClassicSlowStart::default(),
         Cubic::default(),
         Pmtud::new(IP_ADDR, MTU),
+        true,
     )
 }
 
@@ -49,5 +51,6 @@ pub fn make_cc_hystart(paced: bool) -> ClassicCongestionController<HyStart, Cubi
         HyStart::new(paced, crate::cc::HyStartCssBaseline::default()),
         Cubic::default(),
         Pmtud::new(IP_ADDR, MTU),
+        true,
     )
 }

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -156,7 +156,7 @@ pub struct ConnectionParameters {
     scone: bool,
     /// Whether to recover from spurious congestion events by restoring prior Congestion Controller
     /// state. Detection and metrics are always active regardless of this setting.
-    spurious_congestion_recovery: bool,
+    spurious_recovery: bool,
 }
 
 impl Default for ConnectionParameters {
@@ -192,7 +192,7 @@ impl Default for ConnectionParameters {
             mlkem: true,
             randomize_first_pn: true,
             scone: false,
-            spurious_congestion_recovery: true,
+            spurious_recovery: true,
         }
     }
 }
@@ -533,13 +533,13 @@ impl ConnectionParameters {
     }
 
     #[must_use]
-    pub const fn spurious_congestion_recovery_enabled(&self) -> bool {
-        self.spurious_congestion_recovery
+    pub const fn spurious_recovery_enabled(&self) -> bool {
+        self.spurious_recovery
     }
 
     #[must_use]
-    pub const fn spurious_congestion_recovery(mut self, v: bool) -> Self {
-        self.spurious_congestion_recovery = v;
+    pub const fn spurious_recovery(mut self, spurious_recovery: bool) -> Self {
+        self.spurious_recovery = spurious_recovery;
         self
     }
 
@@ -651,5 +651,16 @@ mod tests {
         // Default is false; verify builder can toggle it.
         assert!(!ConnectionParameters::default().scone_enabled());
         assert!(ConnectionParameters::default().scone(true).scone_enabled());
+    }
+
+    #[test]
+    fn spurious_recovery_enabled() {
+        // Default is true; verify builder can toggle it.
+        assert!(ConnectionParameters::default().spurious_recovery_enabled());
+        assert!(
+            !ConnectionParameters::default()
+                .spurious_recovery(false)
+                .spurious_recovery_enabled()
+        );
     }
 }

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -154,6 +154,9 @@ pub struct ConnectionParameters {
     randomize_first_pn: bool,
     /// Whether to send the SCONE transport parameter.
     scone: bool,
+    /// Whether to recover from spurious congestion events by restoring prior Congestion Controller
+    /// state. Detection and metrics are always active regardless of this setting.
+    spurious_congestion_recovery: bool,
 }
 
 impl Default for ConnectionParameters {
@@ -189,6 +192,7 @@ impl Default for ConnectionParameters {
             mlkem: true,
             randomize_first_pn: true,
             scone: false,
+            spurious_congestion_recovery: true,
         }
     }
 }
@@ -525,6 +529,17 @@ impl ConnectionParameters {
     #[must_use]
     pub const fn scone(mut self, scone: bool) -> Self {
         self.scone = scone;
+        self
+    }
+
+    #[must_use]
+    pub const fn spurious_congestion_recovery_enabled(&self) -> bool {
+        self.spurious_congestion_recovery
+    }
+
+    #[must_use]
+    pub const fn spurious_congestion_recovery(mut self, v: bool) -> Self {
+        self.spurious_congestion_recovery = v;
         self
     }
 

--- a/neqo-transport/src/sender.rs
+++ b/neqo-transport/src/sender.rs
@@ -38,6 +38,7 @@ impl PacketSender {
     #[must_use]
     pub fn new(conn_params: &ConnectionParameters, pmtud: Pmtud, now: Instant) -> Self {
         let mtu = pmtud.plpmtu();
+        let spurious_recovery = conn_params.spurious_congestion_recovery_enabled();
         Self {
             cc: match (
                 conn_params.get_congestion_control(),
@@ -48,6 +49,7 @@ impl PacketSender {
                         ClassicSlowStart::default(),
                         NewReno::default(),
                         pmtud,
+                        spurious_recovery,
                     ))
                 }
                 (CongestionControl::NewReno, SlowStart::HyStart) => {
@@ -58,6 +60,7 @@ impl PacketSender {
                         ),
                         NewReno::default(),
                         pmtud,
+                        spurious_recovery,
                     ))
                 }
                 (CongestionControl::Cubic, SlowStart::Classic) => {
@@ -65,6 +68,7 @@ impl PacketSender {
                         ClassicSlowStart::default(),
                         Cubic::default(),
                         pmtud,
+                        spurious_recovery,
                     ))
                 }
                 (CongestionControl::Cubic, SlowStart::HyStart) => {
@@ -75,6 +79,7 @@ impl PacketSender {
                         ),
                         Cubic::default(),
                         pmtud,
+                        spurious_recovery,
                     ))
                 }
             },

--- a/neqo-transport/src/sender.rs
+++ b/neqo-transport/src/sender.rs
@@ -38,7 +38,7 @@ impl PacketSender {
     #[must_use]
     pub fn new(conn_params: &ConnectionParameters, pmtud: Pmtud, now: Instant) -> Self {
         let mtu = pmtud.plpmtu();
-        let spurious_recovery = conn_params.spurious_congestion_recovery_enabled();
+        let spurious_recovery = conn_params.spurious_recovery_enabled();
         Self {
             cc: match (
                 conn_params.get_congestion_control(),


### PR DESCRIPTION
#3298 landed in neqo release `v0.22.0`, which got vendored into Firefox 149. In release telemetry we see an increase in [http/3 upload throughput](https://glam.telemetry.mozilla.org/fog/probe/networking_http_3_upload_throughput/explore?aggregationLevel=version&app_id=release&visiblePercentiles=%5B95%2C75%2C50%2C25%5D) across all percentiles and up to **+12.9%** in the 50pct going from 148 to 149.

Spurious congestion event recovery is the only performance impacting feature we landed in neqo in 149, so I would like to run an experiment to confirm impact.