### PR TITLE
chore: Small CI fixes

### DIFF
--- a/.github/actions/check-vm/action.yml
+++ b/.github/actions/check-vm/action.yml
@@ -36,8 +36,7 @@ runs:
             openbsd)    # TODO: Is there a way to not pin the version of llvm? -z to pkg_add does not work.
                         pkg_add rust rust-clippy rust-rustfmt rust-bindgen llvm-21.1.2p0 nss # rustup does not support OpenBSD at all
                         ;;
-            netbsd)     /usr/sbin/pkg_add pkgin && pkgin -y update && pkgin -y install curl clang nss pkgconf rust-bindgen
-                        ;;
+            netbsd)     /usr/sbin/pkg_add pkgin && /usr/pkg/bin/pkgin -y update && /usr/pkg/bin/pkgin -y install curl clang nss pkgconf rust-bindgen cmake ninja                        ;;
             solaris)    pkg refresh && pkg install clang-libs nss pkg-config
                         ;;
             *)          echo "Unsupported OS: $PLATFORM"

--- a/.github/scripts/perfcompare.py
+++ b/.github/scripts/perfcompare.py
@@ -103,8 +103,19 @@ def mangle(cmd, cc, pacing, flags, disk):
     return re.sub(r"\s+", " ", cmd).strip(), ext
 
 
+def kill_port(port: int) -> None:
+    """Kill any processes (including root-owned) listening on the given UDP/TCP port."""
+    for proto in ("udp", "tcp"):
+        subprocess.run(
+            ["sudo", "fuser", "-k", f"{port}/{proto}"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+
 def setup(cfg):
     """Create temp dir with cert/key and test files, set MTU."""
+    kill_port(cfg.port)
     tmp = Path(tempfile.mkdtemp())
     (tmp / "out").mkdir()
     sh(

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -112,6 +112,9 @@ jobs:
           filter_cset() { grep -v '^cset' || test $? = 1; }
           shopt -s extglob nullglob
 
+          # Kill any stale processes from previous runs that may be holding port 4433.
+          sudo fuser -k 4433/udp 4433/tcp 2>/dev/null || true
+
           cd neqo
           # Fix any root-owned files left by a previous run before removing them
           sudo chown -R "$(id -u)" target/criterion 2>/dev/null || true
@@ -126,10 +129,20 @@ jobs:
             # --baseline-lenient allows us to add new benchmarks in pull requests.
             bench_exec "$BENCH" -- --bench --baseline-lenient baseline --noplot | filter_cset | tee -a ../results.txt
           done
+          sanitize_name() { echo "$1" | tr '/ ()' '___-' | tr -s '_'; }
           for BENCH in ../dist/neqo/!(neqo-client|neqo-server); do
-            NAME=$(basename "$BENCH")
-            # shellcheck disable=SC2086
-            bench_exec perf -- $PERF_OPT -o "../$NAME.perf" "$BENCH" --bench --noplot --discard-baseline | filter_cset
+            BIN_NAME=$(basename "$BENCH")
+            VARIANTS=$("$BENCH" --bench --list 2>/dev/null | sed -n 's/: benchmark$//p' || true)
+            if [ -n "$VARIANTS" ]; then
+              while IFS= read -r VARIANT; do
+                SAFE_NAME="${BIN_NAME}_$(sanitize_name "$VARIANT")"
+                # shellcheck disable=SC2086
+                bench_exec perf -- $PERF_OPT -o "../$SAFE_NAME.perf" "$BENCH" --bench --noplot --discard-baseline --exact "$VARIANT" | filter_cset
+              done <<< "$VARIANTS"
+            else
+              # shellcheck disable=SC2086
+              bench_exec perf -- $PERF_OPT -o "../$BIN_NAME.perf" "$BENCH" --bench --noplot --discard-baseline | filter_cset
+            fi
           done
           # bench_exec runs as root via sudo nice, so fix ownership of all files it wrote
           sudo chown -R "$(id -u)" target/criterion ../*.perf

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -43,6 +43,7 @@ bench = [
         "neqo-crypto/bench",
         "neqo-qpack/bench",
         "neqo-transport/bench",
+        "test-fixture/bench",
         "log/release_max_level_info",
 ]
 build-fuzzing-corpus = [

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -38,7 +38,7 @@ neqo-transport = { path = ".", features = ["draft-29"] }
 test-fixture = { path = "../test-fixture" }
 
 [features]
-bench = ["neqo-common/bench", "neqo-crypto/bench", "log/release_max_level_info"]
+bench = ["neqo-common/bench", "neqo-crypto/bench", "test-fixture/bench", "log/release_max_level_info"]
 build-fuzzing-corpus = [
         "neqo-common/build-fuzzing-corpus",
         "neqo-crypto/disable-encryption",


### PR DESCRIPTION
- Kill old processes hogging needed ports.
- Fix `pkgin`.
- Turn off qlog for benches (oops).
- Generate a separate profile for each bench variant.