### PR TITLE
 fix: gate SCONE Initial padding on connection parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "codspeed-criterion-compat",
  "enumset",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "log",
  "neqo-common",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.24.1"
+version = "0.24.2"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2689,7 +2689,9 @@ impl Connection {
                 path.borrow().pmtud().probe_size()
             } else {
                 profile.limit()
-                    - if space == PacketNumberSpace::Initial {
+                    - if space == PacketNumberSpace::Initial
+                        && self.conn_params.scone_enabled()
+                    {
                         // Reserve some space for the SCONE indication in an Initial.
                         // This reduces the amount available for building the packet,
                         // but we'll pad to `profile.limit()` when padding.
@@ -2857,16 +2859,20 @@ impl Connection {
         );
         let pad_amount = profile.limit() - encoder.len();
         initial.track_padding(pad_amount);
-        // This ensures that the last bytes are a SCONE indication, if there is enough space.
-        // This is not tracked, other than for congestion control (above)
-        if pad_amount >= Self::SCONE_INDICATION.len() {
-            encoder.pad_to(
-                profile.limit() - Self::SCONE_INDICATION.len() + 1,
-                Self::SCONE_INDICATION[0],
-            );
-            encoder.encode(&Self::SCONE_INDICATION[1..]);
+        if self.conn_params.scone_enabled() {
+            // This ensures that the last bytes are a SCONE indication, if there is enough space.
+            // This is not tracked, other than for congestion control (above)
+            if pad_amount >= Self::SCONE_INDICATION.len() {
+                encoder.pad_to(
+                    profile.limit() - Self::SCONE_INDICATION.len() + 1,
+                    Self::SCONE_INDICATION[0],
+                );
+                encoder.encode(&Self::SCONE_INDICATION[1..]);
+            } else {
+                encoder.pad_to(profile.limit(), Self::SCONE_INDICATION[0]);
+            }
         } else {
-            encoder.pad_to(profile.limit(), Self::SCONE_INDICATION[0]);
+            encoder.pad_to(profile.limit(), 0);
         }
     }
 

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -806,8 +806,7 @@ fn corrupted_initial() {
         .iter()
         .enumerate()
         .rev()
-        .skip(1) // Skip the last byte, which might be a SCONE indicator.
-        .find(|&(_, &v)| v != Connection::SCONE_INDICATION[0]) // The SCONE padding value.
+        .find(|&(_, &v)| v != 0)
         .unwrap();
     corrupted[idx] ^= 0x76;
 


### PR DESCRIPTION
The `scone` connection parameter (off by default since https://github.com/mozilla/neqo/pull/3492) only gated advertisement of the SCONE transport parameter. The Initial packet SCONE indication (`0xc8 0x13`) was still emitted unconditionally, so every default-config client was signaling SCONE on the wire without actually negotiating it.

This is suspected — not yet confirmed — to be the cause of a Firefox 150 regression where Facebook's edge reacts to the indicator and Bitdefender's HTTP/3 inspection then trips on the altered server-side
frames (bug 2034178). The QUIC handshake still completes, so the H3->H2 fallback never kicks in.

Gate both the build-time reservation and the pad-time indicator on `scone_enabled()`; when disabled, pad Initials with zeros as before SCONE was introduced.

---

Includes the version bump to `v0.24.2`.

Pull request targets the `v0.24` branch, branched off of the `v0.24.1` tag.