### PR TITLE
fix: cherry-pick of #3573 for Neqo v0.26.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "cfg_aliases",
  "clap",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-crypto"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enumset",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "log",
  "neqo-common",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.26.0"
+version = "0.26.1"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2689,7 +2689,9 @@ impl Connection {
                 path.borrow().pmtud().probe_size()
             } else {
                 profile.limit()
-                    - if space == PacketNumberSpace::Initial {
+                    - if space == PacketNumberSpace::Initial
+                        && self.conn_params.scone_enabled()
+                    {
                         // Reserve some space for the SCONE indication in an Initial.
                         // This reduces the amount available for building the packet,
                         // but we'll pad to `profile.limit()` when padding.
@@ -2857,16 +2859,20 @@ impl Connection {
         );
         let pad_amount = profile.limit() - encoder.len();
         initial.track_padding(pad_amount);
-        // This ensures that the last bytes are a SCONE indication, if there is enough space.
-        // This is not tracked, other than for congestion control (above)
-        if pad_amount >= Self::SCONE_INDICATION.len() {
-            encoder.pad_to(
-                profile.limit() - Self::SCONE_INDICATION.len() + 1,
-                Self::SCONE_INDICATION[0],
-            );
-            encoder.encode(&Self::SCONE_INDICATION[1..]);
+        if self.conn_params.scone_enabled() {
+            // This ensures that the last bytes are a SCONE indication, if there is enough space.
+            // This is not tracked, other than for congestion control (above)
+            if pad_amount >= Self::SCONE_INDICATION.len() {
+                encoder.pad_to(
+                    profile.limit() - Self::SCONE_INDICATION.len() + 1,
+                    Self::SCONE_INDICATION[0],
+                );
+                encoder.encode(&Self::SCONE_INDICATION[1..]);
+            } else {
+                encoder.pad_to(profile.limit(), Self::SCONE_INDICATION[0]);
+            }
         } else {
-            encoder.pad_to(profile.limit(), Self::SCONE_INDICATION[0]);
+            encoder.pad_to(profile.limit(), 0);
         }
     }
 

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -806,8 +806,7 @@ fn corrupted_initial() {
         .iter()
         .enumerate()
         .rev()
-        .skip(1) // Skip the last byte, which might be a SCONE indicator.
-        .find(|&(_, &v)| v != Connection::SCONE_INDICATION[0]) // The SCONE padding value.
+        .find(|&(_, &v)| v != 0)
         .unwrap();
     corrupted[idx] ^= 0x76;
 


### PR DESCRIPTION
Cherry-pick of https://github.com/mozilla/neqo/pull/3573 for Neqo v0.26.1 to be landed into Firefox 151 (currently Firefox Beta).

Note that this pull request targets the `v0.26` Git branch, branched off of the `v0.26.1` Git tag.