### PR TITLE
fix: cherry-pick of #3573 for Neqo main

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2695,7 +2695,7 @@ impl Connection {
                 path.borrow().pmtud().probe_size()
             } else {
                 profile.limit()
-                    - if space == PacketNumberSpace::Initial {
+                    - if space == PacketNumberSpace::Initial && self.conn_params.scone_enabled() {
                         // Reserve some space for the SCONE indication in an Initial.
                         // This reduces the amount available for building the packet,
                         // but we'll pad to `profile.limit()` when padding.
@@ -2863,16 +2863,20 @@ impl Connection {
         );
         let pad_amount = profile.limit() - encoder.len();
         initial.track_padding(pad_amount);
-        // This ensures that the last bytes are a SCONE indication, if there is enough space.
-        // This is not tracked, other than for congestion control (above)
-        if pad_amount >= Self::SCONE_INDICATION.len() {
-            encoder.pad_to(
-                profile.limit() - Self::SCONE_INDICATION.len() + 1,
-                Self::SCONE_INDICATION[0],
-            );
-            encoder.encode(&Self::SCONE_INDICATION[1..]);
+        if self.conn_params.scone_enabled() {
+            // This ensures that the last bytes are a SCONE indication, if there is enough space.
+            // This is not tracked, other than for congestion control (above)
+            if pad_amount >= Self::SCONE_INDICATION.len() {
+                encoder.pad_to(
+                    profile.limit() - Self::SCONE_INDICATION.len() + 1,
+                    Self::SCONE_INDICATION[0],
+                );
+                encoder.encode(&Self::SCONE_INDICATION[1..]);
+            } else {
+                encoder.pad_to(profile.limit(), Self::SCONE_INDICATION[0]);
+            }
         } else {
-            encoder.pad_to(profile.limit(), Self::SCONE_INDICATION[0]);
+            encoder.pad_to(profile.limit(), 0);
         }
     }
 

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -806,8 +806,7 @@ fn corrupted_initial() {
         .iter()
         .enumerate()
         .rev()
-        .skip(1) // Skip the last byte, which might be a SCONE indicator.
-        .find(|&(_, &v)| v != Connection::SCONE_INDICATION[0]) // The SCONE padding value.
+        .find(|&(_, &v)| v != 0)
         .unwrap();
     corrupted[idx] ^= 0x76;
 
@@ -1640,11 +1639,19 @@ fn scone(enable: bool) {
 
     let ci = client.process_output(now).dgram().unwrap();
     let ci_len = ci.len();
-    assert_eq!(
-        &ci[ci_len - Connection::SCONE_INDICATION.len()..],
-        Connection::SCONE_INDICATION,
-        "Client should send indication"
-    );
+    if enable {
+        assert_eq!(
+            &ci[ci_len - Connection::SCONE_INDICATION.len()..],
+            Connection::SCONE_INDICATION,
+            "Client should send indication"
+        );
+    } else {
+        assert_ne!(
+            &ci[ci_len - Connection::SCONE_INDICATION.len()..],
+            Connection::SCONE_INDICATION,
+            "Client should not send indication when SCONE is disabled"
+        );
+    }
     server.process_input(ci, now);
 
     connect(&mut client, &mut server);
@@ -1714,8 +1721,10 @@ fn scone_enabled() {
     scone(true);
 }
 
-/// The scone test passes, even when the config item isn't set.
-/// This is because the transport parameter is the only thing it affects.
+/// With the connection parameter disabled, the client does not send the SCONE
+/// indicator in Initial padding and does not advertise the SCONE transport
+/// parameter. Inbound SCONE packets are still tolerated but do not generate
+/// `SconeUpdated` events, since neither peer has negotiated the feature.
 #[test]
 fn scone_disabled() {
     scone(false);


### PR DESCRIPTION
### fix: gate SCONE Initial padding on the scone connection parameter

The `scone` connection parameter (off by default since #3492) only gated advertisement of the SCONE transport parameter. The Initial- packet SCONE indication (`0xc8 0x13`) was still emitted unconditionally, so every default-config client was signaling SCONE on the wire without actually negotiating it.

This is suspected — not yet confirmed — to be the cause of a Firefox 150 regression where Facebook's edge reacts to the indicator and Bitdefender's HTTP/3 inspection then trips on the altered server-side frames (bug 2034178). The QUIC handshake still completes, so the H3->H2 fallback never kicks in.

Gate both the build-time reservation and the pad-time indicator on `scone_enabled()`; when disabled, pad Initials with zeros as before SCONE was introduced.

---

Cherry-pick of https://github.com/mozilla/neqo/pull/3573 for the `main` branch.

I can release this in a follow-up pull request as Neqo `v0.27.1`.