### PR TITLE
ci(mutants): exclude test-fixture/src/assertions.rs from cargo-mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,11 @@
+# cargo-mutants configuration
+# https://mutants.rs/configuration.html
+
+# Files where mutating the source would not affect any test outcome
+# because the file only contains test assertion helpers; a passing test
+# suite by definition never executes the panic paths of these helpers,
+# so every mutation looks "missed" without indicating an actual gap in
+# coverage. See https://github.com/mozilla/neqo/issues/3367.
+exclude_globs = [
+    "test-fixture/src/assertions.rs",
+]


### PR DESCRIPTION
Closes #3367.

cargo-mutants reports many "missed" mutations against `test-fixture/src/assertions.rs`. Those are expected: the file only contains test assertion helpers (`assert_long_packet_type`, `assert_version`, etc.) whose panic paths are by definition never exercised by a passing test suite. Every mutation looks like a coverage gap without indicating one.

Per cargo-mutants's [documented per-file mechanism](https://mutants.rs/configuration.html), this PR adds `.cargo/mutants.toml` with an `exclude_globs` entry covering that file. The `Find mutants` and `Find PR mutants` workflows pick the config file up automatically; no workflow change is needed.

If a similar pattern emerges in another assertion-only helper module later, the same `exclude_globs` list can grow without revisiting the workflows.