### PR TITLE
feat: add flow-control benchmark scenarios

### DIFF
--- a/neqo-http3/benches/common.rs
+++ b/neqo-http3/benches/common.rs
@@ -4,8 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// This file is included by two bench binaries; each uses only one entry point.
-#![allow(dead_code)]
+#![expect(dead_code, reason = "Included by two bench binaries; each uses only one entry point.")]
 
 use std::{hint::black_box, time::Duration};
 
@@ -30,7 +29,7 @@ const BENCHMARK_PARAMS: [(usize, usize); 3] = [(1, 1_000), (1_000, 1), (1_000, 1
 
 /// Flow-control benchmark parameters: `(streams, data_size)`.
 ///
-/// Data sizes exceed the 1 MB per-stream and 2 MB connection-level flow-control
+/// Data sizes meet or exceed the 1 MB per-stream and 2 MB connection-level flow-control
 /// windows, so streams regularly block waiting for `MAX_STREAM_DATA` grants.
 const FC_BENCHMARK_PARAMS: [(usize, usize); 2] = [
     (1, 4 * 1024 * 1024),  // 4× per-stream window
@@ -89,8 +88,8 @@ const CONFIGS: [(&str, SetupFn, &[(usize, usize)]); 2] = [
 /// Runs all stream benchmarks measuring wall-clock CPU time.
 pub fn walltime(c: &mut Criterion) {
     fixture_init();
-    for (group, setup_fn, params) in CONFIGS {
-        let mut group = c.benchmark_group(group);
+    for (group_name, setup_fn, params) in CONFIGS {
+        let mut group = c.benchmark_group(group_name);
         for &(streams, data_size) in params {
             let name = format!("walltime/{streams}-streams/each-{data_size}-bytes");
             group.bench_function(&name, |b| {
@@ -108,8 +107,8 @@ pub fn walltime(c: &mut Criterion) {
 /// Runs all stream benchmarks measuring simulated network time (throughput).
 pub fn simulated(c: &mut Criterion) {
     fixture_init();
-    for (group, setup_fn, params) in CONFIGS {
-        let mut group = c.benchmark_group(group);
+    for (group_name, setup_fn, params) in CONFIGS {
+        let mut group = c.benchmark_group(group_name);
         for &(streams, data_size) in params {
             let name = format!("simulated/{streams}-streams/each-{data_size}-bytes");
             group.throughput(Throughput::Bytes((streams * data_size) as u64));

--- a/neqo-http3/benches/common.rs
+++ b/neqo-http3/benches/common.rs
@@ -114,7 +114,7 @@ pub fn simulated(c: &mut Criterion) {
             let name = format!("simulated/{streams}-streams/each-{data_size}-bytes");
             group.throughput(Throughput::Bytes((streams * data_size) as u64));
             group.bench_function(&name, |b| {
-                b.iter_custom(|iters| (0..iters).map(|_| setup_fn(streams, data_size).run()).sum());
+                b.iter_custom(|iters| (0..iters).map(|_| setup_fn(streams, data_size).run()).sum::<Duration>());
             });
         }
         group.finish();

--- a/neqo-http3/benches/common.rs
+++ b/neqo-http3/benches/common.rs
@@ -4,9 +4,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::time::Duration;
+// This file is included by two bench binaries; each uses only one entry point.
+#![allow(dead_code)]
 
-use criterion::{BenchmarkGroup, Criterion};
+use std::{hint::black_box, time::Duration};
+
+use criterion::{Criterion, Throughput};
 use test_fixture::{
     boxed, fixture_init,
     sim::{
@@ -19,34 +22,101 @@ use test_fixture::{
 const RTT: Duration = Duration::from_millis(10);
 
 /// Benchmark parameters: `(streams, data_size)`.
+///
+/// Data sizes are well below the 1 MB per-stream flow-control window, so these
+/// benchmarks measure raw throughput and scheduling overhead without any
+/// flow-control blocking.
 const BENCHMARK_PARAMS: [(usize, usize); 3] = [(1, 1_000), (1_000, 1), (1_000, 1_000)];
 
-/// Creates a ready simulator for benchmarking HTTP/3 streams.
-pub fn setup(streams: usize, data_size: usize) -> ReadySimulator {
+/// Flow-control benchmark parameters: `(streams, data_size)`.
+///
+/// Data sizes exceed the 1 MB per-stream and 2 MB connection-level flow-control
+/// windows, so streams regularly block waiting for `MAX_STREAM_DATA` grants.
+const FC_BENCHMARK_PARAMS: [(usize, usize); 2] = [
+    (1, 4 * 1024 * 1024),  // 4× per-stream window
+    (10, 1 * 1024 * 1024), // each stream hits per-stream window; 5× connection-level window
+];
+
+fn setup_with_link(
+    streams: usize,
+    data_size: usize,
+    link: impl Fn() -> TailDrop,
+) -> ReadySimulator {
     let nodes = boxed![
         Node::default_client(boxed![Requests::new(streams, data_size)]),
-        TailDrop::dsl_uplink(),
+        link(),
         Delay::new(RTT),
         Node::default_server(boxed![Responses::new(streams, data_size)]),
-        TailDrop::dsl_uplink(),
+        link(),
         Delay::new(RTT),
     ];
     Simulator::new("", nodes).setup()
 }
 
-/// Runs benchmarks for all parameter combinations.
+/// Creates a ready simulator over a DSL-like link.
 ///
-/// The closure receives the benchmark group and parameters, allowing each
-/// benchmark to define its own measurement approach.
-pub fn benchmark<M>(c: &mut Criterion, mut measure: M)
-where
-    M: FnMut(&mut BenchmarkGroup<'_, criterion::measurement::WallTime>, usize, usize),
-{
-    fixture_init();
+/// The DSL uplink (200 KB/s, 60 ms one-way delay) keeps the bandwidth-delay
+/// product well below the default flow-control window, so no FC blocking occurs.
+pub fn setup(streams: usize, data_size: usize) -> ReadySimulator {
+    setup_with_link(streams, data_size, TailDrop::dsl_uplink)
+}
 
-    let mut group = c.benchmark_group("streams");
-    for (streams, data_size) in BENCHMARK_PARAMS {
-        measure(&mut group, streams, data_size);
+/// Creates a ready simulator over a fast link where flow-control blocking occurs.
+///
+/// At 100 MB/s with a 20 ms RTT the bandwidth-delay product (~2 MB) exceeds the
+/// 1 MB per-stream flow-control window, so streams regularly exhaust their window
+/// and block waiting for `MAX_STREAM_DATA`.
+pub fn setup_flow_controlled(streams: usize, data_size: usize) -> ReadySimulator {
+    // Link delay is zero so propagation RTT comes entirely from the Delay nodes
+    // (10 ms each way = 20 ms RTT).
+    setup_with_link(streams, data_size, || {
+        TailDrop::new(100_000_000, 2_000_000, false, Duration::ZERO)
+    })
+}
+
+type SetupFn = fn(usize, usize) -> ReadySimulator;
+
+/// All benchmark configurations: `(criterion group, setup fn, params)`.
+const CONFIGS: [(&str, SetupFn, &[(usize, usize)]); 2] = [
+    ("streams", setup, &BENCHMARK_PARAMS),
+    (
+        "streams-flow-controlled",
+        setup_flow_controlled,
+        &FC_BENCHMARK_PARAMS,
+    ),
+];
+
+/// Runs all stream benchmarks measuring wall-clock CPU time.
+pub fn walltime(c: &mut Criterion) {
+    fixture_init();
+    for (group, setup_fn, params) in CONFIGS {
+        let mut group = c.benchmark_group(group);
+        for &(streams, data_size) in params {
+            let name = format!("walltime/{streams}-streams/each-{data_size}-bytes");
+            group.bench_function(&name, |b| {
+                b.iter_batched(
+                    || setup_fn(streams, data_size),
+                    |sim| black_box(sim.run()),
+                    criterion::BatchSize::SmallInput,
+                );
+            });
+        }
+        group.finish();
     }
-    group.finish();
+}
+
+/// Runs all stream benchmarks measuring simulated network time (throughput).
+pub fn simulated(c: &mut Criterion) {
+    fixture_init();
+    for (group, setup_fn, params) in CONFIGS {
+        let mut group = c.benchmark_group(group);
+        for &(streams, data_size) in params {
+            let name = format!("simulated/{streams}-streams/each-{data_size}-bytes");
+            group.throughput(Throughput::Bytes((streams * data_size) as u64));
+            group.bench_function(&name, |b| {
+                b.iter_custom(|iters| (0..iters).map(|_| setup_fn(streams, data_size).run()).sum());
+            });
+        }
+        group.finish();
+    }
 }

--- a/neqo-http3/benches/common.rs
+++ b/neqo-http3/benches/common.rs
@@ -4,7 +4,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![expect(dead_code, reason = "Included by two bench binaries; each uses only one entry point.")]
+#![expect(
+    dead_code,
+    reason = "Included by two bench binaries; each uses only one entry point."
+)]
 
 use std::{hint::black_box, time::Duration};
 
@@ -113,7 +116,11 @@ pub fn simulated(c: &mut Criterion) {
             let name = format!("simulated/{streams}-streams/each-{data_size}-bytes");
             group.throughput(Throughput::Bytes((streams * data_size) as u64));
             group.bench_function(&name, |b| {
-                b.iter_custom(|iters| (0..iters).map(|_| setup_fn(streams, data_size).run()).sum::<Duration>());
+                b.iter_custom(|iters| {
+                    (0..iters)
+                        .map(|_| setup_fn(streams, data_size).run())
+                        .sum::<Duration>()
+                });
             });
         }
         group.finish();

--- a/neqo-http3/benches/streams_simulated.rs
+++ b/neqo-http3/benches/streams_simulated.rs
@@ -13,27 +13,13 @@
     reason = "Inherent in codspeed criterion_group! macro."
 )]
 
-use std::time::Duration;
-
-use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 #[path = "common.rs"]
 mod common;
 
 fn benchmark(c: &mut Criterion) {
-    common::benchmark(c, |group, streams, data_size| {
-        let bench_name = format!("simulated/{streams}-streams/each-{data_size}-bytes");
-        group.throughput(Throughput::Bytes((streams * data_size) as u64));
-        group.bench_function(&bench_name, |b| {
-            b.iter_custom(|iters| {
-                let mut d_sum = Duration::ZERO;
-                for _i in 0..iters {
-                    d_sum += common::setup(streams, data_size).run();
-                }
-                d_sum
-            });
-        });
-    });
+    common::simulated(c);
 }
 
 criterion_group!(benches, benchmark);

--- a/neqo-http3/benches/streams_walltime.rs
+++ b/neqo-http3/benches/streams_walltime.rs
@@ -11,24 +11,13 @@
     reason = "Inherent in codspeed criterion_group! macro."
 )]
 
-use std::hint::black_box;
-
 use criterion::{Criterion, criterion_group, criterion_main};
 
 #[path = "common.rs"]
 mod common;
 
 fn benchmark(c: &mut Criterion) {
-    common::benchmark(c, |group, streams, data_size| {
-        let bench_name = format!("walltime/{streams}-streams/each-{data_size}-bytes");
-        group.bench_function(&bench_name, |b| {
-            b.iter_batched(
-                || common::setup(streams, data_size),
-                |sim| black_box(sim.run()),
-                criterion::BatchSize::SmallInput,
-            );
-        });
-    });
+    common::walltime(c);
 }
 
 criterion_group!(benches, benchmark);


### PR DESCRIPTION
Add two benchmark configurations that exercise the HTTP/3 sending path under flow-control pressure.