### PR TITLE
chore: Benchmark "bypass SSL AEAD wrapper in RecordProtection"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "nss-rs"
 version = "0.9.0"
-source = "git+https://github.com/mozilla/nss-rs?rev=0.9.0#0ea3df78a294136cab1e11b50d1e60e6582c1395"
+source = "git+https://github.com/mozilla/nss-rs?rev=0920a201bea7f9dc1e350991fe5d9bf1abd05f96#0920a201bea7f9dc1e350991fe5d9bf1abd05f96"
 dependencies = [
  "bindgen",
  "enum-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ hex = { version = "0.4", default-features = false }
 http = { version = "1", default-features = false, features = ["std"] }
 libc = { version = "0.2", default-features = false }
 log = { version = "0.4", default-features = false }
-nss = { rev = "0.9.0", package = "nss-rs", git = "https://github.com/mozilla/nss-rs" }
+nss = { rev = "0920a201bea7f9dc1e350991fe5d9bf1abd05f96", package = "nss-rs", git = "https://github.com/mozilla/nss-rs" }
 qlog = { version = "0.16.0", default-features = false }
 quinn-udp = { version = "0.6", default-features = false, features = ["log", "fast-apple-datapath"] }
 rustc-hash = { version = "2.1", default-features = false, features = [ "std" ]}

--- a/neqo-bin/src/bin/client.rs
+++ b/neqo-bin/src/bin/client.rs
@@ -14,7 +14,5 @@ use clap::Parser as _;
 )]
 async fn main() -> Result<(), neqo_bin::client::Error> {
     let args = neqo_bin::client::Args::parse();
-
-    #[cfg_attr(apple, expect(clippy::large_futures, reason = "OK in test code."))]
     neqo_bin::client::client(args).await
 }

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -644,9 +644,7 @@ pub async fn client(mut args: Args) -> Res<()> {
 
                 let handler = http3::Handler::new(to_request, args.clone());
 
-                Runner::new(real_local, &mut socket, client, handler, &args)
-                    .run()
-                    .await?
+                Box::pin(Runner::new(real_local, &mut socket, client, handler, &args).run()).await?
             } else {
                 let client = http09::create_client(&args, real_local, remote_addr, &host, token)
                     .expect("failed to create client");


### PR DESCRIPTION
Try of https://github.com/mozilla/nss-rs/pull/49 in neqo. #3601 is even faster, so I prefer landing that in neqo.