### PR TITLE
chore: Better `perf` sampling

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -80,7 +80,7 @@ jobs:
         uses: mozilla/actions/rust@25cb84d060946c0ad6d2c3f79da479b16d180d71 # v1.1.0
         with:
           version: ${{ env.RUSTUP_TOOLCHAIN }}
-          tools: flamegraph, samply
+          tools: inferno, samply
           token: ${{ secrets.GITHUB_TOKEN }}
           sccache: true
 
@@ -162,8 +162,8 @@ jobs:
           for f in *.perf; do
             # Convert for profiler.firefox.com
             samply import "$f" -o "$f.samply.json.gz" --save-only --presymbolicate
-            # Generate flamegraphs
-            flamegraph --perfdata "$f" --palette rust -o "${f//.perf/.svg}"
+            # Generate flamegraphs from the cycles event (perf.data has multiple events)
+            perf script -i "$f" | inferno-collapse-perf --event-filter cycles | inferno-flamegraph --colors rust > "${f//.perf/.svg}"
           done
 
       - name: Format results as Markdown

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,7 +9,7 @@ env:
   CARGO_PROFILE_RELEASE_LTO: true
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
   RUSTUP_TOOLCHAIN: stable
-  PERF_OPT: record -F2999 --call-graph fp -g
+  PERF_OPT: record -F2999 --call-graph fp -e cycles:u,cycles:k,kmem:rss_stat,sched:sched_switch -m 2048
   SCCACHE_CACHE_SIZE: 128G
   SCCACHE_DIRECT: true
   MTU: 1504 # https://github.com/microsoft/msquic/issues/4618

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -139,7 +139,7 @@ jobs:
         uses: mozilla/actions/rust@25cb84d060946c0ad6d2c3f79da479b16d180d71 # v1.1.0
         with:
           version: ${{ env.RUSTUP_TOOLCHAIN }}
-          tools: hyperfine, flamegraph, samply
+          tools: hyperfine, inferno, samply
           token: ${{ secrets.GITHUB_TOKEN }}
           sccache: true
 
@@ -217,8 +217,8 @@ jobs:
           for f in *.perf; do
             # Convert for profiler.firefox.com
             samply import "$f" -o "$f.samply.json.gz" --save-only --presymbolicate
-            # Generate flamegraphs
-            flamegraph --perfdata "$f" --palette rust -o "${f//.perf/.svg}"
+            # Generate flamegraphs from the cycles event (perf.data has multiple events)
+            perf script -i "$f" | inferno-collapse-perf --event-filter cycles | inferno-flamegraph --colors rust > "${f//.perf/.svg}"
           done
 
       - name: Format results as Markdown

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -9,7 +9,7 @@ env:
   CARGO_PROFILE_RELEASE_LTO: true
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
   RUSTUP_TOOLCHAIN: stable
-  PERF_OPT: record -F2999 --call-graph fp -g
+  PERF_OPT: record -F2999 --call-graph fp -e cycles:u,cycles:k,kmem:rss_stat,sched:sched_switch -m 2048
   SCCACHE_CACHE_SIZE: 128G
   SCCACHE_DIRECT: true
   MTU: 1504 # https://github.com/microsoft/msquic/issues/4618

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -10,7 +10,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTUP_TOOLCHAIN: stable
   TRANSFER_SIZE: 33554432 # 32 MiB
-  PERF_OPT: record -F2999 --call-graph fp -g
+  PERF_OPT: record -F2999 --call-graph fp -e cycles:u,cycles:k,kmem:rss_stat,sched:sched_switch -m 2048
   CARGO_PROFILE_RELEASE_LTO: true
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
 


### PR DESCRIPTION
Collect cycle-accurate attribution for user space, and capture kernel-mode execution during syscalls.

Record context switches as PERF_RECORD_SWITCH events. Samply imports these and shows them as markers.

Increase perf ring buffer to 8MB.