### PR TITLE
feat(cc/stats): Add stats for SEARCH slow start heuristic

### DIFF
--- a/neqo-transport/src/cc/search.rs
+++ b/neqo-transport/src/cc/search.rs
@@ -135,7 +135,11 @@ impl Search {
         clippy::cast_possible_truncation,
         reason = "casting small usize to u32 for use in Duration::saturating_mul"
     )]
-    fn update_bins(&mut self, now: Instant) -> Option<usize> {
+    fn update_bins(
+        &mut self,
+        now: Instant,
+        cc_stats: &mut CongestionControlStats,
+    ) -> Option<usize> {
         let mut curr_idx = self.curr_idx?;
         let mut bin_end = self.bin_end?;
 
@@ -159,6 +163,13 @@ impl Search {
             qdebug!(
                 "SEARCH: update_bins: resetting because we skipped {passed_bins} bins (limit {})",
                 Self::W
+            );
+            cc_stats.search_reset.count += 1;
+            cc_stats.search_reset.max_passed_bins = Some(
+                cc_stats
+                    .search_reset
+                    .max_passed_bins
+                    .map_or(passed_bins, |c| c.max(passed_bins)),
             );
             self.reset();
             return None;
@@ -390,7 +401,7 @@ impl SlowStart for Search {
             return None;
         }
 
-        let curr_idx = self.update_bins(now)?;
+        let curr_idx = self.update_bins(now, cc_stats)?;
 
         // NOTE: SEARCH draft-09 implements a drain-phase to gradually lower the congestion window
         // towards the approximated empty-buffer BDP. I think that could be counter-intuitive while

--- a/neqo-transport/src/cc/search.rs
+++ b/neqo-transport/src/cc/search.rs
@@ -27,7 +27,7 @@ pub enum Outcome {
     /// Not enough data to run SEARCH evaluation (expected early in the connection or after reset).
     WarmingUp,
     /// Can't run SEARCH evaluation because RTT inflated past the point where there isn't enough
-    /// data to look back one RTT. Provides the amount of bins that SEARCH tried to look back.
+    /// data to look back one RTT. Provides the number of bins that SEARCH tried to look back.
     RttInflated(usize),
     /// Haven't sent data for the last RTT thus can't evaluate.
     ZeroSent,
@@ -56,7 +56,7 @@ pub struct Search {
     /// Tracking amount of sent bytes on this connection. Is incremented on every sent packet.
     sent_bytes: usize,
     /// The RTT used to initialize SEARCH (set in [`Self::initialize`]).
-    initial_rtt: Duration,
+    initial_rtt: Option<Duration>,
 }
 
 impl Display for Search {
@@ -98,7 +98,7 @@ impl Search {
             bin_duration: Duration::from_millis(0),
             acked_bytes: 0,
             sent_bytes: 0,
-            initial_rtt: Duration::ZERO,
+            initial_rtt: None,
         }
     }
 
@@ -108,7 +108,7 @@ impl Search {
         reason = "casting small constant usize to u32 for use in Duration::div"
     )]
     fn initialize(&mut self, initial_rtt: Duration, now: Instant) {
-        self.initial_rtt = initial_rtt;
+        self.initial_rtt = Some(initial_rtt);
         // BIN_DURATION = WINDOW_SIZE / W = initial_rtt * WINDOW_SIZE_FACTOR / W
         self.bin_duration =
             initial_rtt * Self::WINDOW_SIZE_FACTOR / Self::SCALE as u32 / Self::W as u32;
@@ -165,12 +165,8 @@ impl Search {
                 Self::W
             );
             cc_stats.search_reset.count += 1;
-            cc_stats.search_reset.max_passed_bins = Some(
-                cc_stats
-                    .search_reset
-                    .max_passed_bins
-                    .map_or(passed_bins, |c| c.max(passed_bins)),
-            );
+            cc_stats.search_reset.max_passed_bins =
+                cc_stats.search_reset.max_passed_bins.max(Some(passed_bins));
             self.reset();
             return None;
         }
@@ -291,6 +287,13 @@ impl Search {
         Outcome::Exit(curr_cwnd)
     }
 
+    /// Converts an RTT duration to the number of bins it spans (rounded up).
+    fn rtt_to_bins(&self, rtt: Duration) -> usize {
+        let rtt_ns = u64::try_from(rtt.as_nanos()).unwrap_or(u64::MAX);
+        let bin_ns = u64::try_from(self.bin_duration.as_nanos()).unwrap_or(u64::MAX);
+        usize::try_from(rtt_ns.div_ceil(bin_ns)).unwrap_or(usize::MAX)
+    }
+
     /// SEARCH suggests a drain-phase to slowly converge towards a BDP estimate. We're currently not
     /// implementing this, but do record the calculated targets for evaluation in this function.
     ///
@@ -298,32 +301,30 @@ impl Search {
     ///
     /// In addition also record an estimate using the current rtt to approximate BDP with full
     /// buffers. This should estimate the upper end of the CUBIC curve during congestion avoidance.
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "casting small u128 division result to usize"
-    )]
-    const fn record_target_cwnd_estimates(
+    fn record_target_cwnd_estimates(
         &self,
         curr_idx: usize,
         rtt: Duration,
         cc_stats: &mut CongestionControlStats,
     ) {
-        let initial_rtt_bins = self
-            .initial_rtt
-            .as_nanos()
-            .div_ceil(self.bin_duration.as_nanos()) as usize;
+        // Only compute estimates if we have an initial RTT. This is a pure precaution, since we
+        // should always have an initial RTT before this method is called.
+        let Some(initial_rtt) = self.initial_rtt else {
+            return;
+        };
+        let initial_rtt_bins = self.rtt_to_bins(initial_rtt);
         let initial_rtt_cong_idx = curr_idx.saturating_sub(initial_rtt_bins);
         let empty_buffer_target = self.compute_delv(initial_rtt_cong_idx, curr_idx);
 
-        cc_stats.search_empty_buffer_target = Some(empty_buffer_target as usize);
+        cc_stats.search_empty_buffer_target = Some(empty_buffer_target);
 
         // Only compute full_buffer_target when the current RTT fits within the acked_bins
         // circular buffer (W + 1 slots). Beyond that, modulo indexing reads overwritten entries.
-        let current_rtt_bins = rtt.as_nanos().div_ceil(self.bin_duration.as_nanos()) as usize;
+        let current_rtt_bins = self.rtt_to_bins(rtt);
         if current_rtt_bins <= Self::W {
             let current_rtt_cong_idx = curr_idx.saturating_sub(current_rtt_bins);
-            cc_stats.search_full_buffer_target =
-                Some(self.compute_delv(current_rtt_cong_idx, curr_idx) as usize);
+            let full_buffer_target = self.compute_delv(current_rtt_cong_idx, curr_idx);
+            cc_stats.search_full_buffer_target = Some(full_buffer_target);
         }
     }
 
@@ -391,8 +392,8 @@ impl SlowStart for Search {
         // Guard on the stats fields so post-reset ACKs don't overwrite the initial samples.
         if cc_stats.search_first_rtt.is_none() {
             cc_stats.search_first_rtt = Some(rtt);
-        } else if cc_stats.search_second_rtt.is_none() {
-            cc_stats.search_second_rtt = Some(rtt);
+        } else {
+            cc_stats.search_second_rtt.get_or_insert(rtt);
         }
 
         // Initialize on first ACK.
@@ -430,19 +431,13 @@ impl SlowStart for Search {
                 Some(cwnd)
             }
             Outcome::RttInflated(lookback_bins) => {
-                cc_stats.search_lookback_bins_needed = Some(
-                    cc_stats
-                        .search_lookback_bins_needed
-                        .map_or(lookback_bins, |c| c.max(lookback_bins)),
-                );
+                cc_stats.search_lookback_bins_needed = cc_stats
+                    .search_lookback_bins_needed
+                    .max(Some(lookback_bins));
                 None
             }
             Outcome::Continue(norm_diff) => {
-                cc_stats.search_max_norm_diff = Some(
-                    cc_stats
-                        .search_max_norm_diff
-                        .map_or(norm_diff, |c| c.max(norm_diff)),
-                );
+                cc_stats.search_max_norm_diff = cc_stats.search_max_norm_diff.max(Some(norm_diff));
                 None
             }
             Outcome::ZeroSent => {

--- a/neqo-transport/src/cc/search.rs
+++ b/neqo-transport/src/cc/search.rs
@@ -388,6 +388,13 @@ impl SlowStart for Search {
     ) -> Option<usize> {
         let rtt = rtt_est.latest_rtt();
 
+        // Guard on the stats fields so post-reset ACKs don't overwrite the initial samples.
+        if cc_stats.search_first_rtt.is_none() {
+            cc_stats.search_first_rtt = Some(rtt);
+        } else if cc_stats.search_second_rtt.is_none() {
+            cc_stats.search_second_rtt = Some(rtt);
+        }
+
         // Initialize on first ACK.
         if self.curr_idx.is_none() {
             self.initialize(rtt, now);

--- a/neqo-transport/src/cc/search.rs
+++ b/neqo-transport/src/cc/search.rs
@@ -54,6 +54,8 @@ pub struct Search {
     acked_bytes: usize,
     /// Tracking amount of sent bytes on this connection. Is incremented on every sent packet.
     sent_bytes: usize,
+    /// The RTT used to initialize SEARCH (set in [`Self::initialize`]).
+    initial_rtt: Duration,
 }
 
 impl Display for Search {
@@ -95,6 +97,7 @@ impl Search {
             bin_duration: Duration::from_millis(0),
             acked_bytes: 0,
             sent_bytes: 0,
+            initial_rtt: Duration::ZERO,
         }
     }
 
@@ -104,6 +107,7 @@ impl Search {
         reason = "casting small constant usize to u32 for use in Duration::div"
     )]
     fn initialize(&mut self, initial_rtt: Duration, now: Instant) {
+        self.initial_rtt = initial_rtt;
         // BIN_DURATION = WINDOW_SIZE / W = initial_rtt * WINDOW_SIZE_FACTOR / W
         self.bin_duration =
             initial_rtt * Self::WINDOW_SIZE_FACTOR / Self::SCALE as u32 / Self::W as u32;
@@ -275,6 +279,42 @@ impl Search {
         Outcome::Exit(curr_cwnd)
     }
 
+    /// SEARCH suggests a drain-phase to slowly converge towards a BDP estimate. We're currently not
+    /// implementing this, but do record the calculated targets for evaluation in this function.
+    ///
+    /// The draft specifies using the initial rtt to approximate an 'empty-buffer BDP'.
+    ///
+    /// In addition also record an estimate using the current rtt to approximate BDP with full
+    /// buffers. This should estimate the upper end of the CUBIC curve during congestion avoidance.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "casting small u128 division result to usize"
+    )]
+    const fn record_target_cwnd_estimates(
+        &self,
+        curr_idx: usize,
+        rtt: Duration,
+        cc_stats: &mut CongestionControlStats,
+    ) {
+        let initial_rtt_bins = self
+            .initial_rtt
+            .as_nanos()
+            .div_ceil(self.bin_duration.as_nanos()) as usize;
+        let initial_rtt_cong_idx = curr_idx.saturating_sub(initial_rtt_bins);
+        let empty_buffer_target = self.compute_delv(initial_rtt_cong_idx, curr_idx);
+
+        cc_stats.search_empty_buffer_target = Some(empty_buffer_target as usize);
+
+        // Only compute full_buffer_target when the current RTT fits within the acked_bins
+        // circular buffer (W + 1 slots). Beyond that, modulo indexing reads overwritten entries.
+        let current_rtt_bins = rtt.as_nanos().div_ceil(self.bin_duration.as_nanos()) as usize;
+        if current_rtt_bins <= Self::W {
+            let current_rtt_cong_idx = curr_idx.saturating_sub(current_rtt_bins);
+            cc_stats.search_full_buffer_target =
+                Some(self.compute_delv(current_rtt_cong_idx, curr_idx) as usize);
+        }
+    }
+
     #[cfg(test)]
     pub const fn curr_idx(&self) -> Option<usize> {
         self.curr_idx
@@ -331,7 +371,7 @@ impl SlowStart for Search {
         rtt_est: &RttEstimate,
         _largest_acked: packet::Number,
         curr_cwnd: usize,
-        _cc_stats: &mut CongestionControlStats,
+        cc_stats: &mut CongestionControlStats,
         now: Instant,
     ) -> Option<usize> {
         let rtt = rtt_est.latest_rtt();
@@ -358,11 +398,14 @@ impl SlowStart for Search {
         // draft-09 undershoots CUBIC's cwnd range in my testing.
         //
         // For now I recommend just exiting slow start without the drain-phase and capturing the
-        // drain-target in telemetry for further analysis (TODO).
+        // drain-target in telemetry for further analysis.
         //
         // <https://datatracker.ietf.org/doc/html/draft-chung-ccwg-search-09#section-3.2-17>
         match self.evaluate(rtt, curr_idx, curr_cwnd) {
-            Outcome::Exit(cwnd) => Some(cwnd),
+            Outcome::Exit(cwnd) => {
+                self.record_target_cwnd_estimates(curr_idx, rtt, cc_stats);
+                Some(cwnd)
+            }
             _ => None,
         }
     }

--- a/neqo-transport/src/cc/search.rs
+++ b/neqo-transport/src/cc/search.rs
@@ -21,8 +21,9 @@ use crate::{cc::classic_cc::SlowStart, packet, rtt::RttEstimate, stats::Congesti
 pub enum Outcome {
     /// Evaluation ran and slow start should be exited with the provided cwnd.
     Exit(usize),
-    /// Evaluation ran and slow start should be continued.
-    Continue,
+    /// Evaluation ran and slow start should be continued. Provides the normalized difference
+    /// between sent and acked bytes, which can be used in metrics to tune the exit threshold.
+    Continue(usize),
     /// Not enough data to run SEARCH evaluation (expected early in the connection or after reset).
     WarmingUp,
     /// Can't run SEARCH evaluation because RTT inflated past the point where there isn't enough
@@ -270,7 +271,7 @@ impl Search {
                 "SEARCH: evaluate: norm_diff {norm_diff} < THRESH {} --> continue",
                 Self::THRESH
             );
-            return Outcome::Continue;
+            return Outcome::Continue(norm_diff);
         }
         qdebug!(
             "SEARCH: evaluate: norm_diff {norm_diff} >= THRESH {} --> exit",
@@ -411,6 +412,14 @@ impl SlowStart for Search {
                     cc_stats
                         .search_lookback_bins_needed
                         .map_or(lookback_bins, |c| c.max(lookback_bins)),
+                );
+                None
+            }
+            Outcome::Continue(norm_diff) => {
+                cc_stats.search_max_norm_diff = Some(
+                    cc_stats
+                        .search_max_norm_diff
+                        .map_or(norm_diff, |c| c.max(norm_diff)),
                 );
                 None
             }

--- a/neqo-transport/src/cc/search.rs
+++ b/neqo-transport/src/cc/search.rs
@@ -25,9 +25,9 @@ pub enum Outcome {
     Continue,
     /// Not enough data to run SEARCH evaluation (expected early in the connection or after reset).
     WarmingUp,
-    /// Can't run SEARCH evaluation because RTT inflated past the point where there is enough
-    /// data to look back one RTT.
-    RttInflated,
+    /// Can't run SEARCH evaluation because RTT inflated past the point where there isn't enough
+    /// data to look back one RTT. Provides the amount of bins that SEARCH tried to look back.
+    RttInflated(usize),
     /// Haven't sent data for the last RTT thus can't evaluate.
     ZeroSent,
 }
@@ -249,7 +249,7 @@ impl Search {
         }
         if curr_idx - prev_idx >= Self::EXTRA_BINS {
             qdebug!("SEARCH: evaluate: not enough data for SEARCH evaluation (RTT inflated)");
-            return Outcome::RttInflated;
+            return Outcome::RttInflated(curr_idx - prev_idx);
         }
 
         let curr_delv = self.compute_delv(curr_idx - Self::W, curr_idx);
@@ -405,6 +405,14 @@ impl SlowStart for Search {
             Outcome::Exit(cwnd) => {
                 self.record_target_cwnd_estimates(curr_idx, rtt, cc_stats);
                 Some(cwnd)
+            }
+            Outcome::RttInflated(lookback_bins) => {
+                cc_stats.search_lookback_bins_needed = Some(
+                    cc_stats
+                        .search_lookback_bins_needed
+                        .map_or(lookback_bins, |c| c.max(lookback_bins)),
+                );
+                None
             }
             _ => None,
         }

--- a/neqo-transport/src/cc/search.rs
+++ b/neqo-transport/src/cc/search.rs
@@ -413,6 +413,10 @@ impl SlowStart for Search {
         // drain-target in telemetry for further analysis.
         //
         // <https://datatracker.ietf.org/doc/html/draft-chung-ccwg-search-09#section-3.2-17>
+        //
+        // The match below handles the different outcomes of the SEARCH evaluation, recording stats
+        // where applicable and mapping the outcomes to this functions `None` or `Some(cwnd)` return
+        // values.
         match self.evaluate(rtt, curr_idx, curr_cwnd) {
             Outcome::Exit(cwnd) => {
                 self.record_target_cwnd_estimates(curr_idx, rtt, cc_stats);
@@ -434,7 +438,11 @@ impl SlowStart for Search {
                 );
                 None
             }
-            _ => None,
+            Outcome::ZeroSent => {
+                cc_stats.search_zero_sent_bytes += 1;
+                None
+            }
+            Outcome::WarmingUp => None,
         }
     }
 

--- a/neqo-transport/src/cc/tests/search.rs
+++ b/neqo-transport/src/cc/tests/search.rs
@@ -419,32 +419,42 @@ fn search_exits_when_delivery_rate_slows_down() {
 
     // Finally keep sending but only ack a quarter of the bytes sent. Eventually SEARCH should
     // detect an exit based on the flattening delivery rate.
-    for i in 1..=2 {
-        search.on_packet_sent(pn, bytes_this_round);
-        now += INITIAL_RTT;
-        let result = ack(
-            &mut search,
-            &RttEstimate::new(INITIAL_RTT),
-            pn,
-            bytes_this_round / 4,
-            bytes_this_round,
-            now,
-        );
-        if i < 2 {
-            assert_eq!(
-                result, None,
-                "SEARCH doesn't immediately exit when delivery slows down"
-            );
-            pn += 1;
-            bytes_this_round += bytes_this_round / 4;
-        } else {
-            assert_eq!(
-                result,
-                Some(bytes_this_round),
-                "Once slow down is not just intermittent SEARCH exits"
-            );
-        }
-    }
+    search.on_packet_sent(pn, bytes_this_round);
+    now += INITIAL_RTT;
+    let result = ack(
+        &mut search,
+        &RttEstimate::new(INITIAL_RTT),
+        pn,
+        bytes_this_round / 4,
+        bytes_this_round,
+        now,
+    );
+    assert_eq!(
+        result, None,
+        "SEARCH doesn't immediately exit when delivery slows down"
+    );
+    pn += 1;
+    bytes_this_round += bytes_this_round / 4;
+
+    // Pass a persistent `cc_stats` to `on_packets_acked` to verify stats are recorded on exit.
+    let mut cc_stats = CongestionControlStats::default();
+    search.on_packet_sent(pn, bytes_this_round);
+    now += INITIAL_RTT;
+    search.record_acked_bytes(bytes_this_round / 4);
+    let result = search.on_packets_acked(
+        &RttEstimate::new(INITIAL_RTT),
+        pn,
+        bytes_this_round,
+        &mut cc_stats,
+        now,
+    );
+    assert_eq!(
+        result,
+        Some(bytes_this_round),
+        "Once slow down is not just intermittent SEARCH exits"
+    );
+    assert!(cc_stats.search_empty_buffer_target.is_some());
+    assert!(cc_stats.search_full_buffer_target.is_some());
 }
 
 #[test]

--- a/neqo-transport/src/cc/tests/search.rs
+++ b/neqo-transport/src/cc/tests/search.rs
@@ -558,6 +558,13 @@ fn no_sent_bytes() {
         search.evaluate_test(INITIAL_RTT, curr_idx, INITIAL_CWND),
         Outcome::ZeroSent,
     );
+
+    // Verify the stat is recorded through the full on_packets_acked path.
+    let mut cc_stats = CongestionControlStats::default();
+    now += bin_duration + Duration::from_nanos(1);
+    search.record_acked_bytes(0);
+    search.on_packets_acked(&rtt_est, pn, INITIAL_CWND, &mut cc_stats, now);
+    assert_eq!(cc_stats.search_zero_sent_bytes, 1);
 }
 
 #[test]

--- a/neqo-transport/src/cc/tests/search.rs
+++ b/neqo-transport/src/cc/tests/search.rs
@@ -216,12 +216,13 @@ fn reset_and_reinitialize_on_too_many_skipped_bins() {
     // a window.
     now += 11 * bin_duration;
     search.on_packet_sent(2, MIN_INITIAL_PACKET_SIZE);
-    ack(
-        &mut search,
+    let mut cc_stats = CongestionControlStats::default();
+    search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
+    search.on_packets_acked(
         &RttEstimate::new(INITIAL_RTT),
         2,
-        MIN_INITIAL_PACKET_SIZE,
         INITIAL_CWND,
+        &mut cc_stats,
         now,
     );
 
@@ -229,6 +230,8 @@ fn reset_and_reinitialize_on_too_many_skipped_bins() {
         search.curr_idx().is_none(),
         "passing more than one window of bins should reset"
     );
+    assert_eq!(cc_stats.search_reset.count, 1);
+    assert_eq!(cc_stats.search_reset.max_passed_bins, Some(11));
 
     search.on_packet_sent(3, MIN_INITIAL_PACKET_SIZE);
     ack(
@@ -256,6 +259,21 @@ fn reset_and_reinitialize_on_too_many_skipped_bins() {
         Some(now + new_bin_duration),
         "bin_end should be re-initialized with the new RTT"
     );
+
+    // Trigger a second reset with more skipped bins to verify max_passed_bins tracks the max.
+    now += 15 * new_bin_duration;
+    search.on_packet_sent(4, MIN_INITIAL_PACKET_SIZE);
+    search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
+    search.on_packets_acked(
+        &RttEstimate::new(HIGH_RTT),
+        4,
+        INITIAL_CWND,
+        &mut cc_stats,
+        now,
+    );
+    assert!(search.curr_idx().is_none());
+    assert_eq!(cc_stats.search_reset.count, 2);
+    assert_eq!(cc_stats.search_reset.max_passed_bins, Some(15));
 }
 
 #[test]

--- a/neqo-transport/src/cc/tests/search.rs
+++ b/neqo-transport/src/cc/tests/search.rs
@@ -587,7 +587,7 @@ fn warming_up() {
     // Now the SEARCH checks should run.
     assert_eq!(
         search.evaluate_test(INITIAL_RTT, curr_idx, INITIAL_CWND),
-        Outcome::Continue,
+        Outcome::Continue(0),
     );
 }
 
@@ -631,7 +631,25 @@ fn continue_when_delivery_rate_steady() {
         let curr_idx = search.curr_idx().unwrap();
         assert_eq!(
             search.evaluate_test(INITIAL_RTT, curr_idx, INITIAL_CWND),
-            Outcome::Continue,
+            Outcome::Continue(0),
         );
     }
+
+    // Verify the stat is recorded and tracks the running max.
+    // Ack less than sent to create a non-zero norm_diff.
+    let mut cc_stats = CongestionControlStats::default();
+    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+    now += bin_duration + Duration::from_nanos(1);
+    search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE / 4);
+    search.on_packets_acked(&rtt_est, pn, INITIAL_CWND, &mut cc_stats, now);
+    let max = cc_stats.search_max_norm_diff;
+    assert!(max > Some(0));
+
+    // A subsequent steady round should not overwrite the max.
+    pn += 1;
+    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+    now += bin_duration + Duration::from_nanos(1);
+    search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
+    search.on_packets_acked(&rtt_est, pn, INITIAL_CWND, &mut cc_stats, now);
+    assert_eq!(cc_stats.search_max_norm_diff, max);
 }

--- a/neqo-transport/src/cc/tests/search.rs
+++ b/neqo-transport/src/cc/tests/search.rs
@@ -485,8 +485,39 @@ fn inflated_rtt_is_guarded() {
     let high_rtt = Duration::from_millis(600);
     assert_eq!(
         search.evaluate_test(high_rtt, curr_idx, INITIAL_CWND),
-        Outcome::RttInflated,
+        Outcome::RttInflated(17),
     );
+
+    // Verify the stat is recorded through the full on_packets_acked path.
+    let mut cc_stats = CongestionControlStats::default();
+    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+    now += bin_duration + Duration::from_nanos(1);
+    search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
+    search.on_packets_acked(
+        &RttEstimate::new(high_rtt),
+        pn,
+        INITIAL_CWND,
+        &mut cc_stats,
+        now,
+    );
+    assert_eq!(cc_stats.search_lookback_bins_needed, Some(17));
+
+    // A lower RTT that still triggers RttInflated should not overwrite the max.
+    // curr_idx is now 29. With 525ms RTT: bins_last_rtt = floor(525/35) = 15,
+    // prev_idx = 29 - 15 = 14 > W(10), curr_idx - prev_idx = 15 >= EXTRA_BINS(15) → RttInflated.
+    pn += 1;
+    let lower_rtt = Duration::from_millis(525);
+    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+    now += bin_duration + Duration::from_nanos(1);
+    search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
+    search.on_packets_acked(
+        &RttEstimate::new(lower_rtt),
+        pn,
+        INITIAL_CWND,
+        &mut cc_stats,
+        now,
+    );
+    assert_eq!(cc_stats.search_lookback_bins_needed, Some(17));
 }
 
 #[test]

--- a/neqo-transport/src/cc/tests/search.rs
+++ b/neqo-transport/src/cc/tests/search.rs
@@ -19,7 +19,9 @@ use crate::{
 };
 
 const INITIAL_RTT: Duration = Duration::from_millis(100);
+const LOW_RTT: Duration = Duration::from_millis(80);
 const HIGH_RTT: Duration = Duration::from_millis(200);
+const POST_RESET_RTT: Duration = Duration::from_millis(150);
 
 /// Helper to call both [`Search::record_acked_bytes`] and [`Search::on_packets_acked`].
 fn ack(
@@ -677,4 +679,65 @@ fn continue_when_delivery_rate_steady() {
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(&rtt_est, pn, INITIAL_CWND, &mut cc_stats, now);
     assert_eq!(cc_stats.search_max_norm_diff, max);
+}
+
+#[test]
+fn first_and_second_rtt_stats() {
+    use crate::cc::classic_cc::SlowStart as _;
+
+    let mut search = Search::new();
+    let mut now = now();
+    let mut cc_stats = CongestionControlStats::default();
+
+    assert!(cc_stats.search_first_rtt.is_none());
+    assert!(cc_stats.search_second_rtt.is_none());
+
+    search.on_packet_sent(0, MIN_INITIAL_PACKET_SIZE);
+    now += INITIAL_RTT;
+    search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
+    search.on_packets_acked(
+        &RttEstimate::new(INITIAL_RTT),
+        0,
+        INITIAL_CWND,
+        &mut cc_stats,
+        now,
+    );
+
+    assert_eq!(cc_stats.search_first_rtt, Some(INITIAL_RTT));
+    assert!(cc_stats.search_second_rtt.is_none());
+
+    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
+    now += LOW_RTT;
+    search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
+    search.on_packets_acked(
+        &RttEstimate::new(LOW_RTT),
+        1,
+        INITIAL_CWND,
+        &mut cc_stats,
+        now,
+    );
+
+    assert_eq!(cc_stats.search_first_rtt, Some(INITIAL_RTT));
+    assert_eq!(cc_stats.search_second_rtt, Some(LOW_RTT));
+
+    // After a reset, two subsequent ACKs with a distinct RTT must not overwrite either recorded
+    // value.
+    search.reset();
+
+    for pn in 2..=3 {
+        search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+        now += POST_RESET_RTT;
+        search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
+        search.on_packets_acked(
+            &RttEstimate::new(POST_RESET_RTT),
+            pn,
+            INITIAL_CWND,
+            &mut cc_stats,
+            now,
+        );
+    }
+
+    // Assert that the recorded RTTs remain unchanged after the reset.
+    assert_eq!(cc_stats.search_first_rtt, Some(INITIAL_RTT));
+    assert_eq!(cc_stats.search_second_rtt, Some(LOW_RTT));
 }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -948,6 +948,7 @@ impl Connection {
             let p = p.borrow();
             v.rtt = p.rtt().estimate();
             v.rttvar = p.rtt().rttvar();
+            v.min_rtt = p.rtt().minimum();
         }
         v
     }

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -187,6 +187,10 @@ pub struct CongestionControlStats {
     /// SEARCH can't run because there is not enough data for lookback. Is `None` if SEARCH never
     /// ran into this issue.
     pub search_lookback_bins_needed: Option<usize>,
+    /// Records the maximum non-exiting value that the normalized difference between sent and acked
+    /// bytes ever reached. Can be used to tune the exit threshold. `None` means that the SEARCH
+    /// check never ran.
+    pub search_max_norm_diff: Option<usize>,
     /// Cubic's `w_max`: the congestion window (in bytes) just before the most recent
     /// congestion reduction (with fast convergence applied). `None` if no congestion event has
     /// occurred or Cubic is not in use. Recorded as a stat to approximate a connection's ideal

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -183,6 +183,10 @@ pub struct CongestionControlStats {
     /// Drain-phase target estimate for the BDP with full buffers. None if we haven't exited slow
     /// start through SEARCH.
     pub search_full_buffer_target: Option<usize>,
+    /// Records the maximum value of lookback bins needed due to RTT inflation. Fires whenever
+    /// SEARCH can't run because there is not enough data for lookback. Is `None` if SEARCH never
+    /// ran into this issue.
+    pub search_lookback_bins_needed: Option<usize>,
     /// Cubic's `w_max`: the congestion window (in bytes) just before the most recent
     /// congestion reduction (with fast convergence applied). `None` if no congestion event has
     /// occurred or Cubic is not in use. Recorded as a stat to approximate a connection's ideal

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -204,6 +204,12 @@ pub struct CongestionControlStats {
     /// Records the number of times per connection that SEARCH calculated zero bytes sent in the
     /// previous RTT. This exists to gain deeper understanding into app-limited behaviour.
     pub search_zero_sent_bytes: usize,
+    /// The `latest_rtt` from the first ACK that initialized SEARCH. Used to evaluate whether the
+    /// initial RTT sample (which sets `bin_duration`) is inflated relative to `min_rtt`.
+    pub search_first_rtt: Option<Duration>,
+    /// The `latest_rtt` from the second ACK processed by SEARCH. Together with `search_first_rtt`,
+    /// allows evaluating whether `min(first, second)` would be a better initialization value.
+    pub search_second_rtt: Option<Duration>,
     /// Cubic's `w_max`: the congestion window (in bytes) just before the most recent
     /// congestion reduction (with fast convergence applied). `None` if no congestion event has
     /// occurred or Cubic is not in use. Recorded as a stat to approximate a connection's ideal

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -186,11 +186,11 @@ pub struct CongestionControlStats {
     /// enabled. Higher values indicate the heuristic spent more time throttling slow start growth.
     pub hystart_css_rounds_finished: usize,
     /// Drain-phase target estimate for the BDP with empty buffers. None if we haven't exited slow
-    /// start through SEARCH.
-    pub search_empty_buffer_target: Option<usize>,
+    /// start through SEARCH. Is `u64` because Firefox uses it as such.
+    pub search_empty_buffer_target: Option<u64>,
     /// Drain-phase target estimate for the BDP with full buffers. None if we haven't exited slow
-    /// start through SEARCH.
-    pub search_full_buffer_target: Option<usize>,
+    /// start through SEARCH. Is `u64` because Firefox uses it as such.
+    pub search_full_buffer_target: Option<u64>,
     /// Records the maximum value of lookback bins needed due to RTT inflation. Fires whenever
     /// SEARCH can't run because there is not enough data for lookback. Is `None` if SEARCH never
     /// ran into this issue.

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -201,6 +201,9 @@ pub struct CongestionControlStats {
     pub search_max_norm_diff: Option<usize>,
     /// Records SEARCH reset occurrences.
     pub search_reset: SearchResetStats,
+    /// Records the number of times per connection that SEARCH calculated zero bytes sent in the
+    /// previous RTT. This exists to gain deeper understanding into app-limited behaviour.
+    pub search_zero_sent_bytes: usize,
     /// Cubic's `w_max`: the congestion window (in bytes) just before the most recent
     /// congestion reduction (with fast convergence applied). `None` if no congestion event has
     /// occurred or Cubic is not in use. Recorded as a stat to approximate a connection's ideal

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -362,6 +362,8 @@ pub struct Stats {
     pub rtt: Duration,
     /// The current, estimated round-trip time variation on the primary path.
     pub rttvar: Duration,
+    /// The current minimum RTT observed on the primary path.
+    pub min_rtt: Duration,
     /// Whether the first RTT sample was guessed from a discarded packet.
     pub rtt_init_guess: bool,
 

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -177,6 +177,12 @@ pub struct CongestionControlStats {
     /// Number of CSS (Conservative Slow Start) rounds completed. Only meaningful when HyStart++ is
     /// enabled. Higher values indicate the heuristic spent more time throttling slow start growth.
     pub hystart_css_rounds_finished: usize,
+    /// Drain-phase target estimate for the BDP with empty buffers. None if we haven't exited slow
+    /// start through SEARCH.
+    pub search_empty_buffer_target: Option<usize>,
+    /// Drain-phase target estimate for the BDP with full buffers. None if we haven't exited slow
+    /// start through SEARCH.
+    pub search_full_buffer_target: Option<usize>,
     /// Cubic's `w_max`: the congestion window (in bytes) just before the most recent
     /// congestion reduction (with fast convergence applied). `None` if no congestion event has
     /// occurred or Cubic is not in use. Recorded as a stat to approximate a connection's ideal

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -158,6 +158,14 @@ pub struct CongestionEventStats {
     pub spurious: usize,
 }
 
+/// Tracks SEARCH reset occurrences: how many times SEARCH reset and the maximum number of bins
+/// skipped across all resets.
+#[derive(Default, Clone, PartialEq, Eq)]
+pub struct SearchResetStats {
+    pub count: usize,
+    pub max_passed_bins: Option<usize>,
+}
+
 /// Congestion Control stats
 #[derive(Default, Clone, PartialEq)]
 pub struct CongestionControlStats {
@@ -191,6 +199,8 @@ pub struct CongestionControlStats {
     /// bytes ever reached. Can be used to tune the exit threshold. `None` means that the SEARCH
     /// check never ran.
     pub search_max_norm_diff: Option<usize>,
+    /// Records SEARCH reset occurrences.
+    pub search_reset: SearchResetStats,
     /// Cubic's `w_max`: the congestion window (in bytes) just before the most recent
     /// congestion reduction (with fast convergence applied). `None` if no congestion event has
     /// occurred or Cubic is not in use. Recorded as a stat to approximate a connection's ideal
@@ -200,6 +210,7 @@ pub struct CongestionControlStats {
     /// lifetime.
     pub cwnd: Option<usize>,
 }
+
 /// ECN counts by QUIC [`packet::Type`].
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct EcnCount(EnumMap<packet::Type, ecn::Count>);


### PR DESCRIPTION
## Summary

Adds telemetry fields to `CongestionControlStats` for tuning and evaluating the SEARCH slow start exit heuristic. Each commit adds one metric with its own test. Uploading as one PR to avoid merge conflicts, as commits touch the same files. If there are concerns with a particular metric it should be easy to pull out so the rest can land swiftly.

Is probably easiest to review commit-by-commit.

I will work on the Gecko side of this now.

## Commits

1. [**record drain-phase target cwnd**](https://github.com/omansfeld/neqo/commit/1e29e0d4) — Records BDP estimates for empty and full buffers at slow start exit. The [SEARCH draft](https://datatracker.ietf.org/doc/html/draft-chung-ccwg-search-09#section-3.2-17) suggests a drain-phase using the empty-buffer target; we record them for evaluation without implementing the drain.

2. [**record EXTRA_BINS needed**](https://github.com/omansfeld/neqo/commit/4567d82e) — Tracks the running maximum of lookback bins needed when RTT inflation prevents SEARCH from evaluating. Helps determine if `EXTRA_BINS=15` is sufficient.

3. [**record norm_diff for THRESH tuning**](https://github.com/omansfeld/neqo/commit/2735ca44) — Tracks the running maximum of the normalized sent/acked difference during `Continue` (i.e. non-exiting) outcomes. Helps evaluate whether `THRESH=0.26` is well-calibrated.

4. [**record if a reset happened**](https://github.com/omansfeld/neqo/commit/e63632d1) — Tracks reset count and maximum bins skipped across all resets via a `SearchResetStats` struct. Helps evaluate whether the reset logic is well-calibrated.

5. [**record zero bytes sent count**](https://github.com/omansfeld/neqo/commit/3063e812) — Counts how often SEARCH observes zero sent bytes in the previous RTT. Provides insight into app-limited behavior during slow start.

6. [**record first and second RTT**](https://github.com/omansfeld/neqo/commit/04088da9) — Captures the `latest_rtt` from the first two ACKs to evaluate whether the initial RTT (which sets `bin_duration`) is inflated and whether a fix using `min(first, second)` would be viable.

7. [**expose min_rtt in connection stats**](https://github.com/omansfeld/neqo/commit/458a9912) — Adds `min_rtt` to `Stats` for comparison with the recorded first/second RTT samples. Helps determine if `initial_rtt` inflation is an issue.