### PR TITLE
chore: prepare v0.28.0 and revert http@1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -623,11 +623,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
+ "fnv",
  "itoa",
 ]
 
@@ -764,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "cfg_aliases",
  "clap",
@@ -791,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -808,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enumset",
@@ -829,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "log",
  "neqo-common",
@@ -843,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -865,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1278,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.27.0"
+version = "0.28.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -33,7 +33,7 @@ cfg_aliases = { version = "0.2", default-features = false }
 enum-map = { version = "2.7", default-features = false }
 enumset = { version = "1.1", default-features = false }
 hex = { version = "0.4", default-features = false }
-http = { version = "1", default-features = false, features = ["std"] }
+http = { version = "0.2.9", default-features = false }
 libc = { version = "0.2", default-features = false }
 log = { version = "0.4", default-features = false }
 nss = { rev = "0.9.0", package = "nss-rs", git = "https://github.com/mozilla/nss-rs" }


### PR DESCRIPTION
This PR both reverts the `http` upgrade from #3572 and bumps neqo version to `0.28.0`.

`0.27.0` has still not made it into Firefox since it was supposed to be vendored in together with [the bigger effort](https://bugzilla.mozilla.org/show_bug.cgi?id=2033393#c17) to upgrade `http`. That will still take at least till next week, as the engineer working on it is on PTO tomorrow-Monday.

Let's release our new changes in the meantime to make the 152 cycle before Monday. After this I will do another release to bump `http` again, so the effort to upgrade it across Firefox can continue on Monday.

## Notable Changes
* refactor: Use nss-rs instead of neqo-crypto by @Not-Nik in https://github.com/mozilla/neqo/pull/3399
* docs(README): add release documentation by @mxinden in https://github.com/mozilla/neqo/pull/3586
* fix: cherry-pick of #3573 for Neqo main by @mxinden in https://github.com/mozilla/neqo/pull/3575
* chore: Update nss-rs to 0.9.0 by @Not-Nik in https://github.com/mozilla/neqo/pull/3590
* feat: drain instead of rotate+truncate in TxBuffer::mark_as_acked by @larseggert in https://github.com/mozilla/neqo/pull/3591
* feat: add flow-control benchmark scenarios by @larseggert in https://github.com/mozilla/neqo/pull/3596
* feat: cache effective retransmission priority in `SendStream` by @larseggert in https://github.com/mozilla/neqo/pull/3592
* feat: use u64 arithmetic in `Pacer` instead of u128 by @larseggert in https://github.com/mozilla/neqo/pull/3594
* chore: Avoid `Box<dyn CongestionControl>` by @larseggert in https://github.com/mozilla/neqo/pull/3451
* feat(cc): SEARCH by @omansfeld in https://github.com/mozilla/neqo/pull/3518
* feat: Define a path migration event by @martinthomson in https://github.com/mozilla/neqo/pull/3598
* feat(cc/stats): Add stats for SEARCH slow start heuristic by @omansfeld in https://github.com/mozilla/neqo/pull/3613

## New Contributors
* @Not-Nik made their first contribution in https://github.com/mozilla/neqo/pull/3399