### PR TITLE
chore: upgrade http@1.4.0 and bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -623,12 +623,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -765,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "cfg_aliases",
  "clap",
@@ -792,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-common"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -809,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-http3"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enumset",
@@ -830,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-qpack"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "log",
  "neqo-common",
@@ -844,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-transport"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -866,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-udp"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1279,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.28.0"
+version = "0.28.1"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -33,7 +33,7 @@ cfg_aliases = { version = "0.2", default-features = false }
 enum-map = { version = "2.7", default-features = false }
 enumset = { version = "1.1", default-features = false }
 hex = { version = "0.4", default-features = false }
-http = { version = "0.2.9", default-features = false }
+http = { version = "1", default-features = false, features = ["std"] }
 libc = { version = "0.2", default-features = false }
 log = { version = "0.4", default-features = false }
 nss = { rev = "0.9.0", package = "nss-rs", git = "https://github.com/mozilla/nss-rs" }


### PR DESCRIPTION
After `v0.28.0` got released into Firefox we can now upgrade `http` again and bump Neqo to a new `v0.28.1` release that can be used to upgrade `http` across Gecko.

closes #3597 