### PR TITLE
fix: grant    discussions:read to Claude review workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,5 +21,6 @@ jobs:
       pull-requests: write # Required to post review comments.
       issues: read # Required to read issue context via MCP tools.
       actions: read # Required to read workflow run context via MCP tools.
+      discussions: read # Required to read discussion context via MCP tools.
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
The \`claude-review\` reusable workflow from \`mozilla/actions\` uses GitHub Discussions
    MCP tools and requires \`discussions: read\`. Without it, GitHub raises a \`startup_failure\` before any jobs run.