### PR TITLE
chore(http3,qpack): remove leftover blapi feature

### DIFF
--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -45,8 +45,6 @@ bench = [
         "test-fixture/bench",
         "log/release_max_level_info",
 ]
-blapi = ["neqo-transport/blapi"]
-default = ["blapi"]
 build-fuzzing-corpus = [
         "neqo-common/build-fuzzing-corpus",
         "neqo-transport/disable-encryption",

--- a/neqo-qpack/Cargo.toml
+++ b/neqo-qpack/Cargo.toml
@@ -32,8 +32,6 @@ ignored = ["log"]
 
 [features]
 bench = ["neqo-common/bench", "neqo-transport/bench", "log/release_max_level_info"]
-blapi = ["neqo-transport/blapi"]
-default = ["blapi"]
 build-fuzzing-corpus = [
         "neqo-common/build-fuzzing-corpus",
         "neqo-transport/build-fuzzing-corpus",


### PR DESCRIPTION
The `blapi` feature and `default = ["blapi"]` in neqo-http3 and neqo-qpack aren't needed. `blapi` is enabled in `neqo-transport` and thus transitively enabled in all of the neqo crates.

Follow-up to https://github.com/mozilla/neqo/pull/3601#discussion_r3267787344.