### PR TITLE
fix: do not suppress cwnd growth when pacing limits sends

### DIFF
--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -574,7 +574,7 @@ where
         // limited if it would have fully utilized the congestion window without
         // pacing delay."  When the pacer is the reason we cannot send more
         // right now, cwnd underutilization is from pacing, not the application.
-        if !self.app_limited() || pacing_limited {
+        if pacing_limited || !self.app_limited() {
             self.first_app_limited = pkt.pn() + 1;
         }
 

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -553,7 +553,7 @@ where
         );
     }
 
-    fn on_packet_sent(&mut self, pkt: &sent::Packet, now: Instant) {
+    fn on_packet_sent(&mut self, pkt: &sent::Packet, now: Instant, pacing_limited: bool) {
         // Record the recovery time and exit any transient phase.
         if self.current.phase.transient() {
             self.current.recovery_start = Some(pkt.pn());
@@ -570,11 +570,11 @@ where
             self.slow_start.on_packet_sent(pkt.pn(), pkt.len());
         }
 
-        if !self.app_limited() {
-            // Given the current non-app-limited condition, we're fully utilizing the congestion
-            // window. Assume that all in-flight packets up to this one are NOT app-limited.
-            // However, subsequent packets might be app-limited. Set `first_app_limited` to the
-            // next packet number.
+        // RFC 9002 §7.8: "A sender SHOULD NOT consider itself application
+        // limited if it would have fully utilized the congestion window without
+        // pacing delay."  When the pacer is the reason we cannot send more
+        // right now, cwnd underutilization is from pacing, not the application.
+        if !self.app_limited() || pacing_limited {
             self.first_app_limited = pkt.pn() + 1;
         }
 
@@ -1012,7 +1012,7 @@ mod tests {
         let mut cc_stats = CongestionControlStats::default();
 
         for p in lost_packets {
-            cc.on_packet_sent(p, now());
+            cc.on_packet_sent(p, now(), false);
         }
 
         cc.on_packets_lost(Some(now()), None, PTO, lost_packets, now(), &mut cc_stats);
@@ -1400,7 +1400,7 @@ mod tests {
                     cc.max_datagram_size(),
                 );
                 next_pn += 1;
-                cc.on_packet_sent(&p, now);
+                cc.on_packet_sent(&p, now, false);
                 pkts.push(p);
             }
             assert_eq!(
@@ -1433,7 +1433,7 @@ mod tests {
                 cc.max_datagram_size(),
             );
             next_pn += 1;
-            cc.on_packet_sent(&p, now);
+            cc.on_packet_sent(&p, now, false);
             pkts.push(p);
         }
         assert_eq!(
@@ -1492,7 +1492,7 @@ mod tests {
             recovery::Tokens::new(),
             cc.max_datagram_size(),
         );
-        cc.on_packet_sent(&p_lost, now);
+        cc.on_packet_sent(&p_lost, now, false);
         cwnd_is_default(&cc);
         now += PTO;
         cc.on_packets_lost(Some(now), None, PTO, &[p_lost], now, &mut cc_stats);
@@ -1505,7 +1505,7 @@ mod tests {
             recovery::Tokens::new(),
             cc.max_datagram_size(),
         );
-        cc.on_packet_sent(&p_not_lost, now);
+        cc.on_packet_sent(&p_not_lost, now, false);
         now += RTT;
         cc.on_packets_acked(
             &[p_not_lost],
@@ -1534,7 +1534,7 @@ mod tests {
                     cc.max_datagram_size(),
                 );
                 next_pn += 1;
-                cc.on_packet_sent(&p, now);
+                cc.on_packet_sent(&p, now, false);
                 pkts.push(p);
             }
             assert_eq!(
@@ -1572,7 +1572,7 @@ mod tests {
                 cc.max_datagram_size(),
             );
             next_pn += 1;
-            cc.on_packet_sent(&p, now);
+            cc.on_packet_sent(&p, now, false);
             pkts.push(p);
         }
         assert_eq!(
@@ -1616,7 +1616,7 @@ mod tests {
             recovery::Tokens::new(),
             cc.max_datagram_size(),
         );
-        cc.on_packet_sent(&p_ce, now);
+        cc.on_packet_sent(&p_ce, now, false);
         assert_eq!(cc.cwnd(), cc.cwnd_initial());
         assert_eq!(cc.ssthresh(), usize::MAX);
         assert_eq!(cc.current.phase, Phase::SlowStart);
@@ -1649,8 +1649,8 @@ mod tests {
         // 1. Send packets (1, 2) --> `SlowStart`, no events
         let pkt1 = sent::make_packet(1, now, 1000);
         let pkt2 = sent::make_packet(2, now, 1000);
-        cc.on_packet_sent(&pkt1, now);
-        cc.on_packet_sent(&pkt2, now);
+        cc.on_packet_sent(&pkt1, now, false);
+        cc.on_packet_sent(&pkt2, now, false);
         assert_eq!(cc.current.phase, Phase::SlowStart);
         assert_eq!(cc_stats.congestion_events.loss, 0);
         assert_eq!(cc_stats.congestion_events.spurious, 0);
@@ -1691,7 +1691,7 @@ mod tests {
 
         // 3. Send packet (3)     --> `Recovery`, 1 event
         let pkt3 = sent::make_packet(3, now, 1000);
-        cc.on_packet_sent(&pkt3, now);
+        cc.on_packet_sent(&pkt3, now, false);
         assert_eq!(cc.current.phase, Phase::Recovery);
         assert_eq!(cc_stats.congestion_events.loss, 1);
 
@@ -1751,8 +1751,8 @@ mod tests {
         // 1. Send packets (1, 2) --> `SlowStart`
         let pkt1 = sent::make_packet(1, now, 1000);
         let pkt2 = sent::make_packet(2, now, 1000);
-        cc.on_packet_sent(&pkt1, now);
-        cc.on_packet_sent(&pkt2, now);
+        cc.on_packet_sent(&pkt1, now, false);
+        cc.on_packet_sent(&pkt2, now, false);
         assert_eq!(cc.current.phase, Phase::SlowStart);
 
         // 2. Lose packets (1, 2) --> `RecoveryStart` and reduced cwnd
@@ -1775,7 +1775,7 @@ mod tests {
 
         // 3. Send packet (3) --> `Recovery`
         let pkt3 = sent::make_packet(3, now, 1000);
-        cc.on_packet_sent(&pkt3, now);
+        cc.on_packet_sent(&pkt3, now, false);
         assert_eq!(cc.current.phase, Phase::Recovery);
 
         // 4. Ack packet (3) --> `CongestionAvoidance`
@@ -1824,14 +1824,14 @@ mod tests {
 
         // Cause congestion event
         let pkt = sent::make_packet(1, now, 1000);
-        cc.on_packet_sent(&pkt, now);
+        cc.on_packet_sent(&pkt, now, false);
         let pkt_lost = pkt.clone();
         cc.on_packets_lost(Some(now), None, PTO, &[pkt_lost], now, &mut cc_stats);
         assert!(cc.cwnd() < cc.cwnd_initial(), "cwnd should have decreased");
 
         // Send recovery packet
         let pkt_recovery = sent::make_packet(2, now, 1000);
-        cc.on_packet_sent(&pkt_recovery, now);
+        cc.on_packet_sent(&pkt_recovery, now, false);
         cc.on_packets_acked(&[pkt_recovery], &rtt_estimate, now, &mut cc_stats);
 
         // Grow cwnd back naturally.
@@ -1840,7 +1840,7 @@ mod tests {
             let mut sent_packets = Vec::new();
             while cc.bytes_in_flight < cc.cwnd() {
                 let pkt = sent::make_packet(next_pn_to_send, now, cc.max_datagram_size());
-                cc.on_packet_sent(&pkt, now);
+                cc.on_packet_sent(&pkt, now, false);
                 sent_packets.push(pkt);
                 next_pn_to_send += 1;
             }
@@ -1893,8 +1893,8 @@ mod tests {
         let pkt1 = sent::make_packet(1, now, 1000);
         let pkt2 = sent::make_packet(2, now, 1000);
 
-        cc.on_packet_sent(&pkt1, now);
-        cc.on_packet_sent(&pkt2, now);
+        cc.on_packet_sent(&pkt1, now, false);
+        cc.on_packet_sent(&pkt2, now, false);
 
         assert_eq!(cc.current.phase, Phase::SlowStart);
         assert_eq!(cc_stats.congestion_events.loss, 0);
@@ -1919,7 +1919,7 @@ mod tests {
 
         // Step 3: Send packet 3 → enter Recovery phase
         let pkt3 = sent::make_packet(3, now, 1000);
-        cc.on_packet_sent(&pkt3, now);
+        cc.on_packet_sent(&pkt3, now, false);
         assert_eq!(cc.current.phase, Phase::Recovery);
 
         // Step 4: Ack packet 1 → spurious event #1 detected
@@ -1963,7 +1963,7 @@ mod tests {
         let rtt_estimate = RttEstimate::new(crate::DEFAULT_INITIAL_RTT);
 
         let pkt1 = sent::make_packet(1, now, 1000);
-        cc.on_packet_sent(&pkt1, now);
+        cc.on_packet_sent(&pkt1, now, false);
 
         cc.on_packets_lost(
             Some(now),
@@ -1982,7 +1982,7 @@ mod tests {
 
         // The cleanup is called when we ack packets, so we send and ack a new one.
         let pkt2 = sent::make_packet(2, now, 1000);
-        cc.on_packet_sent(&pkt2, now);
+        cc.on_packet_sent(&pkt2, now, false);
         cc.on_packets_acked(&[pkt2], &rtt_estimate, now, &mut cc_stats);
 
         // The packet is exactly the maximum age, so it shouldn't be removed yet. This assert makes
@@ -1994,7 +1994,7 @@ mod tests {
 
         // Send and ack another packet to trigger cleanup.
         let pkt3 = sent::make_packet(3, now, 1000);
-        cc.on_packet_sent(&pkt3, now);
+        cc.on_packet_sent(&pkt3, now, false);
         cc.on_packets_acked(&[pkt3], &rtt_estimate, now, &mut cc_stats);
 
         // Now the packet should be removed.
@@ -2012,7 +2012,7 @@ mod tests {
         assert_eq!(cc_stats.slow_start_exit_reason, None);
 
         let pkt1 = sent::make_packet(1, now, 1000);
-        cc.on_packet_sent(&pkt1, now);
+        cc.on_packet_sent(&pkt1, now, false);
 
         match congestion_trigger {
             Ecn => {
@@ -2042,7 +2042,7 @@ mod tests {
         if congestion_trigger == Loss {
             // Send recovery packet and ack it to exit recovery.
             let pkt2 = sent::make_packet(2, now, 1000);
-            cc.on_packet_sent(&pkt2, now);
+            cc.on_packet_sent(&pkt2, now, false);
             cc.on_packets_acked(&[pkt2], &rtt_estimate, now, &mut cc_stats);
 
             // Late ack of pkt1 triggers spurious congestion detection - should reset to None.
@@ -2088,7 +2088,7 @@ mod tests {
         let mut sent_packets = Vec::new();
         while cc.bytes_in_flight < cc.cwnd() {
             let pkt = sent::make_packet(next_pn, now, cc.max_datagram_size());
-            cc.on_packet_sent(&pkt, now);
+            cc.on_packet_sent(&pkt, now, false);
             sent_packets.push(pkt);
             next_pn += 1;
         }
@@ -2099,7 +2099,7 @@ mod tests {
 
         // Tracks cwnd after congestion event reduction
         let pkt_lost = sent::make_packet(next_pn, now, 1000);
-        cc.on_packet_sent(&pkt_lost, now);
+        cc.on_packet_sent(&pkt_lost, now, false);
         cc.on_packets_lost(Some(now), None, PTO, &[pkt_lost], now, &mut cc_stats);
         assert_eq!(cc_stats.cwnd, Some(cc.cwnd()));
         assert!(cc_stats.cwnd.is_some_and(|cwnd| cwnd < cwnd_after_growth));
@@ -2125,7 +2125,7 @@ mod tests {
 
         // Send and ack a single packet — not enough to fill cwnd, so app-limited.
         let pkt = sent::make_packet(0, now, cc.max_datagram_size());
-        cc.on_packet_sent(&pkt, now);
+        cc.on_packet_sent(&pkt, now, false);
         cc.on_packets_acked(&[pkt], &rtt_estimate, now, &mut cc_stats);
 
         assert_eq!(cc.cwnd(), cwnd_initial);
@@ -2194,7 +2194,7 @@ mod tests {
                 recovery::Tokens::new(),
                 cc.max_datagram_size(),
             );
-            cc.on_packet_sent(&p_ce, now);
+            cc.on_packet_sent(&p_ce, now, false);
             cc.on_ecn_ce_received(&p_ce, now, stats);
         });
     }
@@ -2207,7 +2207,7 @@ mod tests {
         assert_congestion_state_trigger("persistent_congestion", |cc, stats| {
             let lost_pkts = [lost(1, true, ZERO), lost(2, true, PC)];
             for p in &lost_pkts {
-                cc.on_packet_sent(p, now());
+                cc.on_packet_sent(p, now(), false);
             }
             assert_ne!(cc.cwnd(), cc.cwnd_min());
             cc.on_packets_lost(Some(now()), None, PTO, &lost_pkts, now(), stats);
@@ -2246,5 +2246,48 @@ mod tests {
         // there should be no reaction to the non-ack-eliciting packet
         assert_eq!(cc.cwnd(), initial_cwnd);
         assert_eq!(cc_stats.slow_start_exit_cwnd, None);
+    }
+
+    fn send_single_packet_and_ack(pacing_limited: bool) -> (usize, usize) {
+        let mut cc = make_cc_newreno();
+        let now = now();
+        let mut cc_stats = CongestionControlStats::default();
+        let cwnd_before = cc.cwnd();
+
+        let p = sent::Packet::new(
+            packet::Type::Short,
+            0,
+            now,
+            true,
+            recovery::Tokens::new(),
+            cc.max_datagram_size(),
+        );
+        cc.on_packet_sent(&p, now, pacing_limited);
+
+        cc.on_packets_acked(
+            &[p],
+            &RttEstimate::new(crate::DEFAULT_INITIAL_RTT),
+            now + RTT,
+            &mut cc_stats,
+        );
+        (cwnd_before, cc.cwnd())
+    }
+
+    #[test]
+    fn pacing_limited_overrides_app_limited() {
+        let (before, after) = send_single_packet_and_ack(true);
+        assert!(
+            after > before,
+            "cwnd should grow when pacing-limited: {after} vs {before}"
+        );
+    }
+
+    #[test]
+    fn genuinely_app_limited_no_pacing() {
+        let (before, after) = send_single_packet_and_ack(false);
+        assert_eq!(
+            after, before,
+            "cwnd should not grow when genuinely app-limited"
+        );
     }
 }

--- a/neqo-transport/src/cc/mod.rs
+++ b/neqo-transport/src/cc/mod.rs
@@ -90,7 +90,7 @@ pub trait CongestionController: Display + Debug {
 
     fn discard(&mut self, pkt: &sent::Packet, now: Instant);
 
-    fn on_packet_sent(&mut self, pkt: &sent::Packet, now: Instant);
+    fn on_packet_sent(&mut self, pkt: &sent::Packet, now: Instant, pacing_limited: bool);
 
     fn discard_in_flight(&mut self, now: Instant);
 }
@@ -222,8 +222,8 @@ impl CongestionController for CongestionControlImplementation {
         dispatch!(self.discard(pkt, now));
     }
 
-    fn on_packet_sent(&mut self, pkt: &sent::Packet, now: Instant) {
-        dispatch!(self.on_packet_sent(pkt, now));
+    fn on_packet_sent(&mut self, pkt: &sent::Packet, now: Instant, pacing_limited: bool) {
+        dispatch!(self.on_packet_sent(pkt, now, pacing_limited));
     }
 
     fn discard_in_flight(&mut self, now: Instant) {

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -72,7 +72,7 @@ fn fill_cwnd(
 ) -> u64 {
     while cc.bytes_in_flight() < cc.cwnd() {
         let sent = sent::make_packet(next_pn, now, cc.max_datagram_size());
-        cc.on_packet_sent(&sent, now);
+        cc.on_packet_sent(&sent, now, false);
         next_pn += 1;
     }
     next_pn

--- a/neqo-transport/src/cc/tests/hystart.rs
+++ b/neqo-transport/src/cc/tests/hystart.rs
@@ -684,7 +684,7 @@ fn integration_full_slow_start_to_css_to_ca() {
     let initial_cwnd_packets = cc.cwnd() / MIN_INITIAL_PACKET_SIZE;
     for _ in 0..initial_cwnd_packets {
         let pkt = sent::make_packet(next_send, now, MIN_INITIAL_PACKET_SIZE);
-        cc.on_packet_sent(&pkt, now);
+        cc.on_packet_sent(&pkt, now, false);
         next_send += 1;
     }
 
@@ -757,7 +757,7 @@ fn integration_full_slow_start_to_css_to_ca() {
         while cc.bytes_in_flight() < cc.cwnd() {
             let send_pn = next_send;
             let pkt = sent::make_packet(send_pn, now, MIN_INITIAL_PACKET_SIZE);
-            cc.on_packet_sent(&pkt, now);
+            cc.on_packet_sent(&pkt, now, false);
             next_send += 1;
         }
 

--- a/neqo-transport/src/cc/tests/new_reno.rs
+++ b/neqo-transport/src/cc/tests/new_reno.rs
@@ -107,7 +107,7 @@ fn issue_876() {
 
     // Send some more packets so that the cc is not app-limited.
     for p in &sent_packets[..6] {
-        cc.on_packet_sent(p, now);
+        cc.on_packet_sent(p, now, false);
     }
     assert_eq!(cc.acked_bytes(), 0);
     cwnd_is_default(&cc);
@@ -129,7 +129,7 @@ fn issue_876() {
     assert_eq!(cc.bytes_in_flight(), 5 * cc.max_datagram_size() - 2);
 
     // Send a packet after recovery starts
-    cc.on_packet_sent(&sent_packets[6], now);
+    cc.on_packet_sent(&sent_packets[6], now, false);
     assert!(!cc.recovery_packet());
     cwnd_is_halved(&cc);
     assert_eq!(cc.acked_bytes(), 0);
@@ -183,7 +183,7 @@ fn issue_1465() {
     };
     let mut send_next = |cc: &mut ClassicCongestionController<ClassicSlowStart, NewReno>, now| {
         let p = next_packet(now);
-        cc.on_packet_sent(&p, now);
+        cc.on_packet_sent(&p, now, false);
         p
     };
 
@@ -225,7 +225,6 @@ fn issue_1465() {
 
     // send out recovery packet and get it acked to get out of recovery state
     let p4 = send_next(&mut cc, now);
-    cc.on_packet_sent(&p4, now);
     now += RTT;
     cc.on_packets_acked(
         &[p4],
@@ -246,7 +245,7 @@ fn issue_1465() {
     assert!(cc.recovery_packet());
     assert_eq!(cc.cwnd(), cur_cwnd / 2);
     assert_eq!(cc.acked_bytes(), 0);
-    assert_eq!(cc.bytes_in_flight(), 2 * cc.max_datagram_size());
+    assert_eq!(cc.bytes_in_flight(), cc.max_datagram_size());
 
     // this shouldn't introduce further cwnd reduction, but it did before https://github.com/mozilla/neqo/pull/1465
     cc.on_packets_lost(Some(now), None, PTO, &[p6], now, &mut cc_stats);

--- a/neqo-transport/src/pace.rs
+++ b/neqo-transport/src/pace.rs
@@ -197,7 +197,7 @@ mod tests {
         let n = now();
         let mut p = Pacer::new(true, n, PACKET, PACKET);
         assert_eq!(p.next(RTT, CWND), n);
-        p.spend(n, RTT, CWND, PACKET);
+        assert!(p.spend(n, RTT, CWND, PACKET));
         assert_eq!(p.next(RTT, CWND), n + (RTT / 20));
     }
 
@@ -207,7 +207,7 @@ mod tests {
         let mut p = Pacer::new(true, n + RTT, PACKET, PACKET);
         assert_eq!(p.next(RTT, CWND), n + RTT);
         // Now spend some credit in the past using a time machine.
-        p.spend(n, RTT, CWND, PACKET);
+        assert!(p.spend(n, RTT, CWND, PACKET));
         assert_eq!(p.next(RTT, CWND), n + (RTT / 20));
     }
 
@@ -216,7 +216,7 @@ mod tests {
         let n = now();
         let mut p = Pacer::new(false, n, PACKET, PACKET);
         assert_eq!(p.next(RTT, CWND), n);
-        p.spend(n, RTT, CWND, PACKET);
+        assert!(!p.spend(n, RTT, CWND, PACKET));
         assert_eq!(p.next(RTT, CWND), n);
     }
 
@@ -226,11 +226,9 @@ mod tests {
         let n = now();
         let mut p = Pacer::new(true, n, PACKET, PACKET);
         assert_eq!(p.next(SHORT_RTT, CWND), n);
-        p.spend(n, SHORT_RTT, CWND, PACKET);
-        assert_eq!(
-            p.next(SHORT_RTT, CWND),
-            n,
-            "Expect packet to be sent immediately, instead of being paced below timer granularity"
+        assert!(
+            !p.spend(n, SHORT_RTT, CWND, PACKET),
+            "sub-granularity delay should not be pacing-limited"
         );
     }
 
@@ -280,12 +278,9 @@ mod tests {
         const CWND_AT_GRANULARITY: usize = 5000; // yields w = 1ms = GRANULARITY
         let n = now();
         let mut p = Pacer::new(true, n, PACKET, PACKET);
-        p.spend(n, SHORT_RTT, CWND_AT_GRANULARITY, PACKET);
-        // w == GRANULARITY: should schedule for later, not send immediately.
-        assert_ne!(
-            p.next(SHORT_RTT, CWND_AT_GRANULARITY),
-            n,
-            "at exactly GRANULARITY should not send immediately"
+        assert!(
+            p.spend(n, SHORT_RTT, CWND_AT_GRANULARITY, PACKET),
+            "at exactly GRANULARITY should be pacing-limited"
         );
     }
 

--- a/neqo-transport/src/pace.rs
+++ b/neqo-transport/src/pace.rs
@@ -136,17 +136,16 @@ impl Pacer {
         Self::bytes_for(cwnd, rtt, Duration::from_secs(1))
     }
 
-    /// Spend credit. This cannot fail, but instead may carry debt into the
-    /// future (see [`Pacer::c`]). Users of this API are expected to call
-    /// [`Pacer::next`] to determine when to spend.
+    /// Spend credit. Returns `true` when the next send would be pacing-limited,
+    /// i.e., [`Pacer::next`] now returns a time strictly after `now`.
+    /// Always returns `false` when pacing is disabled.
     ///
-    /// This function takes the current time (`now`), an estimate of the round
-    /// trip time (`rtt`), the estimated congestion window (`cwnd`), and the
-    /// number of bytes that were sent (`count`).
-    pub fn spend(&mut self, now: Instant, rtt: Duration, cwnd: usize, count: usize) {
+    /// This cannot fail, but instead may carry debt into the future (see
+    /// [`Pacer::c`]).
+    pub fn spend(&mut self, now: Instant, rtt: Duration, cwnd: usize, count: usize) -> bool {
         if !self.enabled {
             self.t = now;
-            return;
+            return false;
         }
 
         qtrace!("[{self}] spend {count} over {cwnd}, {rtt:?}");
@@ -164,6 +163,7 @@ impl Pacer {
                 .saturating_sub(isize::try_from(count).unwrap_or(isize::MAX)),
         );
         self.t = now;
+        self.next(rtt, cwnd) > now
     }
 }
 

--- a/neqo-transport/src/sender.rs
+++ b/neqo-transport/src/sender.rs
@@ -225,7 +225,8 @@ impl PacketSender {
     pub fn on_packet_sent(&mut self, pkt: &sent::Packet, rtt: Duration, now: Instant) {
         self.pacer
             .spend(pkt.time_sent(), rtt, self.cc.cwnd(), pkt.len());
-        self.cc.on_packet_sent(pkt, now);
+        let pacing_limited = self.pacer.next(rtt, self.cc.cwnd()) > now;
+        self.cc.on_packet_sent(pkt, now, pacing_limited);
     }
 
     #[must_use]

--- a/neqo-transport/src/sender.rs
+++ b/neqo-transport/src/sender.rs
@@ -223,9 +223,9 @@ impl PacketSender {
     }
 
     pub fn on_packet_sent(&mut self, pkt: &sent::Packet, rtt: Duration, now: Instant) {
-        self.pacer
+        let pacing_limited = self
+            .pacer
             .spend(pkt.time_sent(), rtt, self.cc.cwnd(), pkt.len());
-        let pacing_limited = self.pacer.next(rtt, self.cc.cwnd()) > now;
         self.cc.on_packet_sent(pkt, now, pacing_limited);
     }
 
@@ -243,12 +243,18 @@ impl PacketSender {
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr};
+    use std::{
+        net::{IpAddr, Ipv4Addr},
+        time::Duration,
+    };
 
     use test_fixture::now;
 
     use super::PacketSender;
-    use crate::{ConnectionParameters, SlowStart, cc::CongestionControl, pmtud::Pmtud};
+    use crate::{
+        ConnectionParameters, SlowStart, cc::CongestionControl, pmtud::Pmtud, recovery::sent,
+        rtt::RttEstimate, stats::Stats,
+    };
 
     #[test]
     fn packet_sender_creation_and_display() {
@@ -296,5 +302,63 @@ mod tests {
                 "expected prefix {expected_prefix:?}, got {description:?}",
             );
         }
+    }
+
+    const RTT: Duration = Duration::from_millis(100);
+
+    fn make_sender(pacing: bool) -> PacketSender {
+        let params = ConnectionParameters::default().pacing(pacing);
+        PacketSender::new(
+            &params,
+            Pmtud::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), Some(1500)),
+            now(),
+        )
+    }
+
+    /// Send `n` packets at once, ACK them one RTT later, return (cwnd_before, cwnd_after).
+    fn send_and_ack(pacing: bool, n: usize) -> (usize, usize) {
+        let mut sender = make_sender(pacing);
+        let now = now();
+        let mtu = sender.pmtud().plpmtu();
+        let cwnd_before = sender.cwnd();
+
+        let pkts: Vec<_> = (0..n)
+            .map(|pn| {
+                let p = sent::make_packet(pn as u64, now, mtu);
+                sender.on_packet_sent(&p, RTT, now);
+                p
+            })
+            .collect();
+        sender.on_packets_acked(
+            &pkts,
+            &RttEstimate::new(RTT),
+            now + RTT,
+            &mut Stats::default(),
+        );
+
+        (cwnd_before, sender.cwnd())
+    }
+
+    #[test]
+    fn pacing_limited_allows_cwnd_growth() {
+        // Sending more than PACING_BURST_SIZE packets exhausts burst credit,
+        // making subsequent sends pacing-limited rather than app-limited.
+        let (before, after) = send_and_ack(true, super::PACING_BURST_SIZE + 1);
+        assert!(after > before, "cwnd should grow: {after} vs {before}");
+    }
+
+    #[test]
+    fn app_limited_suppresses_cwnd_growth() {
+        // A single packet is well below cwnd and within burst — genuinely app-limited.
+        let (before, after) = send_and_ack(true, 1);
+        assert_eq!(after, before, "cwnd should not grow when app-limited");
+    }
+
+    #[test]
+    fn pacing_disabled_never_pacing_limited() {
+        // With pacing off, spend() always returns false, so single-packet
+        // sends remain app-limited regardless of burst budget.
+        let (before, after) = send_and_ack(false, 1);
+        assert_eq!(after, before, "cwnd should not grow with pacing disabled");
     }
 }

--- a/neqo-transport/src/sender.rs
+++ b/neqo-transport/src/sender.rs
@@ -315,7 +315,7 @@ mod tests {
         )
     }
 
-    /// Send `n` packets at once, ACK them one RTT later, return (cwnd_before, cwnd_after).
+    /// Send `n` packets at once, ACK them one RTT later, return (`cwnd_before`, `cwnd_after`).
     fn send_and_ack(pacing: bool, n: usize) -> (usize, usize) {
         let mut sender = make_sender(pacing);
         let now = now();


### PR DESCRIPTION
RFC 9002 §7.8 states:
> A sender SHOULD NOT consider itself application limited if it would have fully utilized the
  congestion window without pacing delay.

The `first_app_limited` marker in `on_packet_sent` only advanced when `bytes_in_flight` was within 2 MTU of `cwnd`. On paths where `cwnd` exceeded the BDP (common after Cubic overshoot), `bytes_in_flight` could never reach `cwnd` in steady state, so `first_app_limited` got stuck. Every subsequent ACK round then saw all acked packet numbers above the frozen marker and classified the round as app-limited, permanently suppressing cwnd growth.

After each packet send, check whether the pacer would block the next send (`pacer.next() > now`). If so, the pacer — not the application — is the reason `bytes_in_flight` hasn't reached `cwnd`. Advance `first_app_limited` so that ACKs for this packet allow cwnd growth.

When pacing is disabled, `pacer.next()` always returns the past, so `pacing_limited` is always false and the original `app_limited()` heuristic applies unchanged. neqo-transport/src/cc/tests/cubic.rs #	modified: neqo-transport/src/cc/tests/hystart.rs #	modified: neqo-transport/src/cc/tests/new_reno.rs #	modified: neqo-transport/src/sender.rs #