### PR TITLE
fix: improve congestion control and loss timer logging

### DIFF
--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -440,10 +440,7 @@ where
                 qlog::Metric::BytesInFlight(self.bytes_in_flight),
             ]
             .into_iter()
-            .chain(
-                (self.current.ssthresh != usize::MAX)
-                    .then_some(qlog::Metric::SsThresh(self.current.ssthresh)),
-            ),
+            .chain(self.current.ssthresh.map(qlog::Metric::SsThresh)),
             now,
         );
 

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -351,6 +351,11 @@ where
                 self.current.congestion_window,
                 self.current.phase
             );
+            qlog::metrics_updated(
+                &mut self.qlog,
+                [qlog::Metric::BytesInFlight(self.bytes_in_flight)],
+                now,
+            );
             return;
         }
 
@@ -427,7 +432,11 @@ where
             [
                 qlog::Metric::CongestionWindow(self.current.congestion_window),
                 qlog::Metric::BytesInFlight(self.bytes_in_flight),
-            ],
+            ]
+            .into_iter()
+            .chain((self.current.ssthresh != usize::MAX).then_some(
+                qlog::Metric::SsThresh(self.current.ssthresh),
+            )),
             now,
         );
 
@@ -672,7 +681,7 @@ where
         if old_state.to_qlog() != phase.to_qlog() {
             qlog::congestion_state_updated(
                 &mut self.qlog,
-                old_state.to_qlog(),
+                Some(old_state.to_qlog()),
                 phase.to_qlog(),
                 trigger,
                 now,

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -29,19 +29,24 @@ use crate::{
 pub const CWND_INITIAL_PKTS: usize = 10;
 pub const PERSISTENT_CONG_THRESH: u32 = 3;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Phase {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::IntoStaticStr)]
+pub enum Phase {
     /// In either slow start or congestion avoidance, not recovery.
+    #[strum(to_string = "slow_start")]
     SlowStart,
     /// In congestion avoidance.
+    #[strum(to_string = "congestion_avoidance")]
     CongestionAvoidance,
     /// In a recovery period, but no packets have been sent yet.  This is a
     /// transient phase because we want to exempt the first packet sent after
     /// entering recovery from the congestion window.
+    #[strum(to_string = "recovery")]
     RecoveryStart,
     /// In a recovery period, with the first packet sent at this time.
+    #[strum(to_string = "recovery")]
     Recovery,
     /// Start of persistent congestion, which is transient, like `RecoveryStart`.
+    #[strum(to_string = "slow_start")]
     PersistentCongestion,
 }
 
@@ -66,14 +71,6 @@ impl Phase {
             Self::RecoveryStart => Self::Recovery,
             _ => unreachable!(),
         };
-    }
-
-    pub const fn to_qlog(self) -> &'static str {
-        match self {
-            Self::SlowStart | Self::PersistentCongestion => "slow_start",
-            Self::CongestionAvoidance => "congestion_avoidance",
-            Self::Recovery | Self::RecoveryStart => "recovery",
-        }
     }
 }
 
@@ -679,11 +676,11 @@ where
         qdebug!("[{self}] phase -> {phase:?}");
         let old_state = self.current.phase;
         // Only emit a qlog event when a transition changes the qlog state.
-        if old_state.to_qlog() != phase.to_qlog() {
+        if !str::eq(old_state.into(), phase.into()) {
             qlog::congestion_state_updated(
                 &mut self.qlog,
-                Some(old_state.to_qlog()),
-                phase.to_qlog(),
+                Some(old_state.into()),
+                phase.into(),
                 trigger,
                 now,
             );
@@ -2077,11 +2074,12 @@ mod tests {
     #[test]
     fn state_to_qlog() {
         use super::Phase;
-        assert_eq!(Phase::SlowStart.to_qlog(), "slow_start");
-        assert_eq!(Phase::PersistentCongestion.to_qlog(), "slow_start");
-        assert_eq!(Phase::CongestionAvoidance.to_qlog(), "congestion_avoidance");
-        assert_eq!(Phase::Recovery.to_qlog(), "recovery");
-        assert_eq!(Phase::RecoveryStart.to_qlog(), "recovery");
+        let qlog = |p: Phase| -> &str { p.into() };
+        assert_eq!(qlog(Phase::SlowStart), "slow_start");
+        assert_eq!(qlog(Phase::PersistentCongestion), "slow_start");
+        assert_eq!(qlog(Phase::CongestionAvoidance), "congestion_avoidance");
+        assert_eq!(qlog(Phase::Recovery), "recovery");
+        assert_eq!(qlog(Phase::RecoveryStart), "recovery");
     }
 
     #[test]

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -434,9 +434,10 @@ where
                 qlog::Metric::BytesInFlight(self.bytes_in_flight),
             ]
             .into_iter()
-            .chain((self.current.ssthresh != usize::MAX).then_some(
-                qlog::Metric::SsThresh(self.current.ssthresh),
-            )),
+            .chain(
+                (self.current.ssthresh != usize::MAX)
+                    .then_some(qlog::Metric::SsThresh(self.current.ssthresh)),
+            ),
             now,
         );
 

--- a/neqo-transport/src/cc/mod.rs
+++ b/neqo-transport/src/cc/mod.rs
@@ -22,7 +22,9 @@ mod hystart;
 mod new_reno;
 mod search;
 
-pub use classic_cc::{CWND_INITIAL_PKTS, ClassicCongestionController, PERSISTENT_CONG_THRESH};
+pub use classic_cc::{
+    CWND_INITIAL_PKTS, ClassicCongestionController, PERSISTENT_CONG_THRESH, Phase,
+};
 pub use classic_slow_start::ClassicSlowStart;
 pub use cubic::Cubic;
 pub use hystart::{HyStart, HyStartCssBaseline};

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1263,6 +1263,10 @@ impl Connection {
         max_datagrams: NonZeroUsize,
     ) -> OutputBatch {
         if let Some(d) = dgram {
+            // Snapshot timer type before ACKs can alter loss state.
+            if let Some(path) = self.paths.primary() {
+                self.loss_recovery.note_timeout_type(&path.borrow(), now);
+            }
             self.input(d, now, now);
             self.process_saved(now);
         }
@@ -2923,6 +2927,7 @@ impl Connection {
                 self.conn_params.get_congestion_control(),
                 now,
             );
+            qlog::congestion_state_updated(&mut self.qlog, None, "slow_start", None, now);
         }
         qlog::client_version_information_initiated(
             &mut self.qlog,
@@ -3625,6 +3630,7 @@ impl Connection {
                 self.conn_params.get_congestion_control(),
                 now,
             );
+            qlog::congestion_state_updated(&mut self.qlog, None, "slow_start", None, now);
         } else {
             self.zero_rtt_state = if self
                 .crypto

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1105,6 +1105,10 @@ impl Connection {
             return;
         }
 
+        // Snapshot timer type before ACKs can alter loss state.
+        if let Some(path) = self.paths.primary() {
+            self.loss_recovery.note_timeout_type(&path.borrow(), now);
+        }
         for d in dgrams {
             self.input(d, now, now);
         }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -32,6 +32,7 @@ use strum::IntoEnumIterator as _;
 use crate::{
     AppError, CloseReason, Error, Res, StreamId,
     addr_valid::{AddressValidation, NewTokenState},
+    cc::Phase,
     cid::{
         ConnectionId, ConnectionIdEntry, ConnectionIdGenerator, ConnectionIdManager,
         ConnectionIdRef, ConnectionIdStore,
@@ -2931,7 +2932,13 @@ impl Connection {
                 self.conn_params.get_congestion_control(),
                 now,
             );
-            qlog::congestion_state_updated(&mut self.qlog, None, "slow_start", None, now);
+            qlog::congestion_state_updated(
+                &mut self.qlog,
+                None,
+                Phase::SlowStart.into(),
+                None,
+                now,
+            );
         }
         qlog::client_version_information_initiated(
             &mut self.qlog,
@@ -3634,7 +3641,13 @@ impl Connection {
                 self.conn_params.get_congestion_control(),
                 now,
             );
-            qlog::congestion_state_updated(&mut self.qlog, None, "slow_start", None, now);
+            qlog::congestion_state_updated(
+                &mut self.qlog,
+                None,
+                Phase::SlowStart.into(),
+                None,
+                now,
+            );
         } else {
             self.zero_rtt_state = if self
                 .crypto

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -101,9 +101,9 @@ impl ConnectionIdGenerator for CountingConnectionIdGenerator {
 // test_fixture because they produce different - and incompatible - types.
 //
 // These are a direct copy of those functions.
-pub fn new_client(params: ConnectionParameters) -> Connection {
+fn new_client_with_qlog(params: ConnectionParameters) -> (Connection, test_fixture::SharedVec) {
     fixture_init();
-    let (log, _contents) = new_neqo_qlog();
+    let (log, contents) = new_neqo_qlog();
     let mut client = Connection::new_client(
         test_fixture::DEFAULT_SERVER_NAME,
         test_fixture::DEFAULT_ALPN,
@@ -115,7 +115,11 @@ pub fn new_client(params: ConnectionParameters) -> Connection {
     )
     .expect("create a default client");
     client.set_qlog(log);
-    client
+    (client, contents)
+}
+
+pub fn new_client(params: ConnectionParameters) -> Connection {
+    new_client_with_qlog(params).0
 }
 
 pub fn default_client() -> Connection {

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -1169,14 +1169,12 @@ fn split_api_loss_timer_type() {
     _ = client.process_output(now);
 
     // d0 was sent at `now - DEFAULT_RTT`. Loss time = d0_sent + RTT * 9/8.
-    let loss_time = (now - DEFAULT_RTT) + DEFAULT_RTT * 9 / 8;
+    let loss_time = now + DEFAULT_RTT / 8;
 
     // Server receives the "delayed" d0 and generates a new ACK covering both.
-    server.process_input(d0, loss_time - DEFAULT_RTT / 2);
-    let ack_all = server
-        .process_output(loss_time - DEFAULT_RTT / 2)
-        .dgram()
-        .unwrap();
+    let server_rx_time = loss_time.checked_sub(DEFAULT_RTT / 2).unwrap();
+    server.process_input(d0, server_rx_time);
+    let ack_all = server.process_output(server_rx_time).dgram().unwrap();
 
     // At loss_time, deliver the ACK via the split API.  This ACK clears the
     // loss candidate for d0.  Without the timer-type snapshot, timeout()

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -1186,6 +1186,6 @@ fn split_api_loss_timer_type() {
     let log = qlog_contents.to_string();
     assert!(
         log.contains(r#""timer_type":"ack""#),
-        "Expected loss_timer_expired with timer_type ack in qlog"
+        "Expected loss_timer_expired with timer_type ack in qlog: {log}"
     );
 }

--- a/neqo-transport/src/connection/tests/recovery.rs
+++ b/neqo-transport/src/connection/tests/recovery.rs
@@ -19,8 +19,8 @@ use super::{
     super::{Connection, ConnectionParameters, Output, State},
     AT_LEAST_PTO, DEFAULT_ADDR, DEFAULT_RTT, DEFAULT_STREAM_DATA, POST_HANDSHAKE_CWND,
     assert_full_cwnd, connect, connect_force_idle, connect_rtt_idle, connect_with_rtt, cwnd,
-    default_client, default_server, fill_cwnd, maybe_authenticate, new_client, new_server,
-    send_and_receive, send_something,
+    default_client, default_server, fill_cwnd, maybe_authenticate, new_client,
+    new_client_with_qlog, new_server, send_and_receive, send_something,
 };
 use crate::{
     CloseReason, Error, Pmtud, Stats, StreamType,
@@ -1145,4 +1145,49 @@ fn server_resends_1rtt_on_undecryptable_handshake() {
     let s_response = server.process_output(receive_time).dgram();
     assert!(s_response.is_some());
     assert_eq!(server.stats().frame_tx.handshake_done, 2);
+}
+
+#[test]
+fn split_api_loss_timer_type() {
+    let (mut client, qlog_contents) =
+        new_client_with_qlog(ConnectionParameters::default().pacing(false));
+    let mut server = new_server(ConnectionParameters::default().pacing(false));
+    let mut now = connect_rtt_idle(&mut client, &mut server, DEFAULT_RTT);
+
+    // Client sends two datagrams.
+    let d0 = send_something(&mut client, now);
+    let d1 = send_something(&mut client, now);
+
+    // Server receives only d1 (d0 is "delayed in transit").
+    now += DEFAULT_RTT / 2;
+    server.process_input(d1, now);
+    let ack1 = server.process_output(now).dgram().unwrap();
+
+    // Client receives ACK for d1 — d0 becomes a loss candidate.
+    now += DEFAULT_RTT / 2;
+    client.process_input(ack1, now);
+    _ = client.process_output(now);
+
+    // d0 was sent at `now - DEFAULT_RTT`. Loss time = d0_sent + RTT * 9/8.
+    let loss_time = (now - DEFAULT_RTT) + DEFAULT_RTT * 9 / 8;
+
+    // Server receives the "delayed" d0 and generates a new ACK covering both.
+    server.process_input(d0, loss_time - DEFAULT_RTT / 2);
+    let ack_all = server
+        .process_output(loss_time - DEFAULT_RTT / 2)
+        .dgram()
+        .unwrap();
+
+    // At loss_time, deliver the ACK via the split API.  This ACK clears the
+    // loss candidate for d0.  Without the timer-type snapshot, timeout()
+    // cannot determine that the Ack timer (not Pto) was due.
+    client.process_input(ack_all, loss_time);
+    _ = client.process_output(loss_time);
+
+    drop(client);
+    let log = qlog_contents.to_string();
+    assert!(
+        log.contains(r#""timer_type":"ack""#),
+        "Expected loss_timer_expired with timer_type ack in qlog"
+    );
 }

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -496,7 +496,7 @@ impl From<CongestionStateTrigger> for CongestionStateUpdatedTrigger {
 
 pub fn congestion_state_updated(
     qlog: &mut Qlog,
-    old_state: &'static str,
+    old_state: Option<&'static str>,
     new_state: &'static str,
     trigger: Option<CongestionStateTrigger>,
     now: Instant,
@@ -504,7 +504,7 @@ pub fn congestion_state_updated(
     qlog.add_event_at(
         || {
             Some(EventData::CongestionStateUpdated(CongestionStateUpdated {
-                old: Some(old_state.to_owned()),
+                old: old_state.map(ToOwned::to_owned),
                 new: new_state.to_owned(),
                 trigger: trigger.map(Into::into),
             }))
@@ -514,7 +514,7 @@ pub fn congestion_state_updated(
 }
 
 /// The type of loss recovery timer that fired or was updated.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum LossTimerType {
     /// The reordering/loss-detection timer (ACK-based).
     Ack,

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -793,7 +793,7 @@ impl Loss {
     /// Snapshot which timer type is due before input processing, so that ACKs
     /// in the same `process()` call cannot clear loss candidates and cause
     /// [`Self::timeout`] to misattribute the expiry as PTO.
-    pub fn note_timeout_type(&mut self, path: &Path, now: Instant) {
+    pub(crate) fn note_timeout_type(&mut self, path: &Path, now: Instant) {
         if self.qlog.is_enabled() && self.pending_timer_type.is_none() {
             self.pending_timer_type = self.expired_timer_type(path.rtt(), now);
         }

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -799,11 +799,7 @@ impl Loss {
         }
     }
 
-    fn expired_timer_type(
-        &self,
-        rtt: &RttEstimate,
-        now: Instant,
-    ) -> Option<qlog::LossTimerType> {
+    fn expired_timer_type(&self, rtt: &RttEstimate, now: Instant) -> Option<qlog::LossTimerType> {
         if self.earliest_loss_time(rtt).is_some_and(|t| t <= now) {
             Some(qlog::LossTimerType::Ack)
         } else if self.earliest_pto(rtt).is_some_and(|t| t <= now) {

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -794,7 +794,7 @@ impl Loss {
     /// in the same `process()` call cannot clear loss candidates and cause
     /// [`Self::timeout`] to misattribute the expiry as PTO.
     pub fn note_timeout_type(&mut self, path: &Path, now: Instant) {
-        if self.qlog.is_enabled() {
+        if self.qlog.is_enabled() && self.pending_timer_type.is_none() {
             self.pending_timer_type = self.expired_timer_type(path.rtt(), now);
         }
     }

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -485,6 +485,8 @@ pub struct Loss {
     /// The factor by which the PTO period is reduced.
     /// This enables faster probing at a cost in additional lost packets.
     fast_pto: u8,
+    /// Snapshotted before input processing; see [`Self::note_timeout_type`].
+    pending_timer_type: Option<qlog::LossTimerType>,
 }
 
 impl Loss {
@@ -497,6 +499,7 @@ impl Loss {
             qlog: Qlog::default(),
             stats,
             fast_pto,
+            pending_timer_type: None,
         }
     }
 
@@ -787,6 +790,29 @@ impl Loss {
         }
     }
 
+    /// Snapshot which timer type is due before input processing, so that ACKs
+    /// in the same `process()` call cannot clear loss candidates and cause
+    /// [`Self::timeout`] to misattribute the expiry as PTO.
+    pub fn note_timeout_type(&mut self, path: &Path, now: Instant) {
+        if self.qlog.is_enabled() {
+            self.pending_timer_type = self.expired_timer_type(path.rtt(), now);
+        }
+    }
+
+    fn expired_timer_type(
+        &self,
+        rtt: &RttEstimate,
+        now: Instant,
+    ) -> Option<qlog::LossTimerType> {
+        if self.earliest_loss_time(rtt).is_some_and(|t| t <= now) {
+            Some(qlog::LossTimerType::Ack)
+        } else if self.earliest_pto(rtt).is_some_and(|t| t <= now) {
+            Some(qlog::LossTimerType::Pto)
+        } else {
+            None
+        }
+    }
+
     /// Find when the earliest sent packet should be considered lost.
     fn earliest_loss_time(&self, rtt: &RttEstimate) -> Option<Instant> {
         self.spaces
@@ -939,18 +965,13 @@ impl Loss {
         has_handshake_keys: bool,
     ) -> Vec<sent::Packet> {
         qtrace!("[{self}] timeout {now:?}");
-        let timer_type = {
-            let path = primary_path.borrow();
-            if self
-                .earliest_loss_time(path.rtt())
-                .is_some_and(|t| t <= now)
-            {
-                qlog::LossTimerType::Ack
-            } else {
-                qlog::LossTimerType::Pto
-            }
-        };
-        qlog::loss_timer_expired(&mut self.qlog, timer_type, now);
+        if let Some(timer_type) = self
+            .pending_timer_type
+            .take()
+            .or_else(|| self.expired_timer_type(primary_path.borrow().rtt(), now))
+        {
+            qlog::loss_timer_expired(&mut self.qlog, timer_type, now);
+        }
 
         let loss_delay = primary_path.borrow().rtt().loss_delay();
         let confirmed = self.confirmed();
@@ -1086,6 +1107,10 @@ mod tests {
 
         pub fn timeout(&mut self, now: Instant) -> Vec<sent::Packet> {
             self.lr.timeout(&self.path, now, true)
+        }
+
+        pub fn note_timeout_type(&mut self, now: Instant) {
+            self.lr.note_timeout_type(&self.path.borrow(), now);
         }
 
         pub fn next_timeout(&self) -> Option<Instant> {
@@ -2118,6 +2143,38 @@ mod tests {
         assert!(
             log.contains(r#""event_type":"cancelled""#),
             "Expected loss_timer_updated Cancelled event in qlog: {log}"
+        );
+    }
+
+    #[test]
+    fn note_timeout_type_survives_ack() {
+        let (log, contents) = test_fixture::new_neqo_qlog();
+        let mut lr = Fixture::default();
+        lr.lr.set_qlog(log);
+
+        pace(&mut lr, 3);
+
+        // ACK PN 0 to establish RTT, then ACK PN 2 — PN 1 becomes a loss
+        // candidate with a time-based loss timer.
+        ack(&mut lr, 0, TEST_RTT);
+        ack(&mut lr, 2, TEST_RTT);
+        lr.timeout(pn_time(2) + TEST_RTT);
+
+        let pn1_loss_time = pn_time(1) + (TEST_RTT * 9 / 8);
+        assert_eq!(lr.next_timeout(), Some(pn1_loss_time));
+
+        // Snapshot the Ack timer type, then ACK PN 1 to clear the loss candidate.
+        lr.note_timeout_type(pn1_loss_time);
+        ack(&mut lr, 1, TEST_RTT * 9 / 8);
+
+        // timeout() should use the snapshot (Ack), not recompute (would be Pto).
+        lr.timeout(pn1_loss_time);
+        drop(lr);
+
+        let log = contents.to_string();
+        assert!(
+            log.contains(r#""timer_type":"ack""#),
+            "Expected timer_type ack from snapshot, got: {log}"
         );
     }
 }


### PR DESCRIPTION
Three qlog fixes:

1. Emit initial congestion state: Connections now log a `congestion_state_updated` event with `"new": "slow_start"` at startup, so visualizations can shade the slow-start phase from the first packet rather than only showing transitions.

2. Fix loss timer type attribution: `timeout()` re-evaluated the timer type by checking `earliest_loss_time`, but by then the incoming ACK (processed in the same `process()` call) had already cleared the loss candidates. The check fell through to PTO for every expiry. Fix: `note_timeout_type()` snapshots the timer type before input processing; `timeout()` reads the snapshot. Guarded by `qlog.is_enabled()` to avoid overhead when not logging.

3. Log metrics more consistently: The app-limited early-return path in `on_packets_acked` now logs `BytesInFlight` (which changes on every ACK). The non-app-limited path includes `SsThresh` when it has been set (not `usize::MAX`), so visualizations can show the slow-start threshold throughout congestion avoidance. modified: neqo-transport/src/qlog.rs #	modified: neqo-transport/src/recovery/mod.rs #