### PR TITLE
fix: remove duplicate word in two source comments

### DIFF
--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -339,7 +339,7 @@ impl PushController {
             None => {
                 qtrace!("Push has already been closed");
                 // If we have some events for the push_id in the event queue, the caller still does
-                // not not know that the push has been closed. Otherwise return
+                // not know that the push has been closed. Otherwise return
                 // InvalidStreamId.
                 if self.conn_events.has_push(push_id) {
                     self.conn_events.remove_events_for_push_id(push_id);

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -470,7 +470,7 @@ impl ConnectionIdManager {
             // it is first possible to send `NEW_CONNECTION_ID` is 2.  One is the client-generated
             // destination connection (stored with a sequence number of `HANDSHAKE_SEQNO`); the
             // other being the handshake value (seqno 0).  As a result, `NEW_CONNECTION_ID`
-            // won't be sent until until after the handshake completes, because this initial
+            // won't be sent until after the handshake completes, because this initial
             // value remains until the connection completes and transport parameters are handled.
             limit: 2,
             next_seqno: 1,


### PR DESCRIPTION
## Summary

Two small comment-only fixes:

- `neqo-transport/src/cid.rs:473` — "until until after" → "until after"
- `neqo-http3/src/push_controller.rs:342` — "does not not know" → "does not know"

No behavior changes.