### PR TITLE
fix: Patches for Redox targets

### DIFF
--- a/mtu/src/lib.rs
+++ b/mtu/src/lib.rs
@@ -110,7 +110,7 @@ const fn aligned_by(size: usize, align: usize) -> usize {
 // Platforms currently not supported.
 //
 // See <https://github.com/mozilla/mtu/issues/82>.
-#[cfg(any(target_os = "ios", target_os = "tvos", target_os = "visionos"))]
+#[cfg(any(target_os = "ios", target_os = "tvos", target_os = "visionos", target_os = "redox"))]
 pub fn interface_and_mtu_impl(remote: IpAddr) -> Result<(String, usize)> {
     return Err(default_err());
 }

--- a/mtu/src/lib.rs
+++ b/mtu/src/lib.rs
@@ -110,7 +110,12 @@ const fn aligned_by(size: usize, align: usize) -> usize {
 // Platforms currently not supported.
 //
 // See <https://github.com/mozilla/mtu/issues/82>.
-#[cfg(any(target_os = "ios", target_os = "tvos", target_os = "visionos", target_os = "redox"))]
+#[cfg(any(
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "visionos",
+    target_os = "redox"
+))]
 pub fn interface_and_mtu_impl(remote: IpAddr) -> Result<(String, usize)> {
     return Err(default_err());
 }


### PR DESCRIPTION
This add `target_os = "redox"` to the list of unsupported `mtu` implementation, so it can compile for [the platform](https://doc.rust-lang.org/rustc/platform-support/redox.html).

This is part of patches that's used to port Firefox for Redox OS, other patches such as [quinn](`https://github.com/quinn-rs/quinn/pull/2659`) and a number of C libraries (e.g. nspr) is needed to actually compile.

I'm looking for `neqo-crypto` which was patched for Firefox 150 but it seems disappear or moved recently, so it's not included here.