### PR TITLE
feat: Update nss-rs to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,8 +901,8 @@ dependencies = [
 
 [[package]]
 name = "nss-rs"
-version = "0.12.2"
-source = "git+https://github.com/mozilla/nss-rs?rev=0.12.2#ee26ca59b52b405be802c1ed669b7252b6caa811"
+version = "0.13.0"
+source = "git+https://github.com/mozilla/nss-rs?rev=0.13.0#2395138084a8892129f024ab813d6c92bb9e1409"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -916,6 +916,7 @@ dependencies = [
  "thiserror",
  "toml",
  "windows",
+ "zeroize",
 ]
 
 [[package]]
@@ -1281,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "test-fixture"
 version = "0.1.0"
-source = "git+https://github.com/mozilla/nss-rs?rev=0.12.2#ee26ca59b52b405be802c1ed669b7252b6caa811"
+source = "git+https://github.com/mozilla/nss-rs?rev=0.13.0#2395138084a8892129f024ab813d6c92bb9e1409"
 dependencies = [
  "log",
  "nss-rs",
@@ -1658,6 +1659,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ hex = { version = "0.4", default-features = false }
 http = { version = "1", default-features = false, features = ["std"] }
 libc = { version = "0.2", default-features = false }
 log = { version = "0.4", default-features = false }
-nss = { rev = "0.12.2", package = "nss-rs", git = "https://github.com/mozilla/nss-rs" }
-nss-test-fixture = { rev = "0.12.2", package = "test-fixture", git = "https://github.com/mozilla/nss-rs" }
+nss = { rev = "0.13.0", package = "nss-rs", git = "https://github.com/mozilla/nss-rs" }
+nss-test-fixture = { rev = "0.13.0", package = "test-fixture", git = "https://github.com/mozilla/nss-rs" }
 qlog = { version = "0.16.0", default-features = false }
 quinn-udp = { version = "0.6", default-features = false, features = ["log", "fast-apple-datapath"] }
 rustc-hash = { version = "2.1", default-features = false, features = [ "std" ]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ hex = { version = "0.4", default-features = false }
 http = { version = "1", default-features = false, features = ["std"] }
 libc = { version = "0.2", default-features = false }
 log = { version = "0.4", default-features = false }
-nss = { rev = "0.13.0", package = "nss-rs", git = "https://github.com/mozilla/nss-rs" }
-nss-test-fixture = { rev = "0.13.0", package = "test-fixture", git = "https://github.com/mozilla/nss-rs" }
+nss = { rev = "0.13.0", version = "0.13.0", package = "nss-rs", git = "https://github.com/mozilla/nss-rs" }
+nss-test-fixture = { rev = "0.13.0", version = "0.1.0", package = "test-fixture", git = "https://github.com/mozilla/nss-rs" }
 qlog = { version = "0.16.0", default-features = false }
 quinn-udp = { version = "0.6", default-features = false, features = ["log", "fast-apple-datapath"] }
 rustc-hash = { version = "2.1", default-features = false, features = [ "std" ]}


### PR DESCRIPTION
Including the new HP `blapi` changes.

~~Draft PR for now to see the benchmark difference.~~