### PR TITLE
chore: neqo 0.29.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -509,7 +509,7 @@ dependencies = [
  "neqo-qpack",
  "neqo-transport",
  "nss-rs",
- "test-fixture 0.29.0",
+ "test-fixture 0.29.1",
 ]
 
 [[package]]
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "cfg_aliases",
  "clap",
@@ -742,14 +742,14 @@ dependencies = [
  "rustc-hash",
  "strum",
  "test-fixture 0.1.0",
- "test-fixture 0.29.0",
+ "test-fixture 0.29.1",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "neqo-common"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -759,14 +759,14 @@ dependencies = [
  "qlog",
  "sha1",
  "strum",
- "test-fixture 0.29.0",
+ "test-fixture 0.29.1",
  "thiserror",
  "windows",
 ]
 
 [[package]]
 name = "neqo-http3"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enumset",
@@ -781,13 +781,13 @@ dependencies = [
  "rustc-hash",
  "sfv",
  "strum",
- "test-fixture 0.29.0",
+ "test-fixture 0.29.1",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-qpack"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "log",
  "neqo-common",
@@ -795,13 +795,13 @@ dependencies = [
  "qlog",
  "rustc-hash",
  "static_assertions",
- "test-fixture 0.29.0",
+ "test-fixture 0.29.1",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-transport"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -817,13 +817,13 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "strum",
- "test-fixture 0.29.0",
+ "test-fixture 0.29.1",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-udp"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -857,8 +857,8 @@ dependencies = [
 
 [[package]]
 name = "nss-rs"
-version = "0.13.0"
-source = "git+https://github.com/mozilla/nss-rs#2395138084a8892129f024ab813d6c92bb9e1409"
+version = "0.13.1"
+source = "git+https://github.com/mozilla/nss-rs#a8548a8c1de72f4f10e0928162dad82abb41c6b2"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "test-fixture"
 version = "0.1.0"
-source = "git+https://github.com/mozilla/nss-rs#2395138084a8892129f024ab813d6c92bb9e1409"
+source = "git+https://github.com/mozilla/nss-rs#a8548a8c1de72f4f10e0928162dad82abb41c6b2"
 dependencies = [
  "log",
  "nss-rs",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.29.0"
+version = "0.29.1"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -36,7 +36,7 @@ hex = { version = "0.4", default-features = false }
 http = { version = "1", default-features = false, features = ["std"] }
 libc = { version = "0.2", default-features = false }
 log = { version = "0.4", default-features = false }
-nss = { version = "0.13.0", package = "nss-rs", git = "https://github.com/mozilla/nss-rs" }
+nss = { version = "0.13.1", package = "nss-rs", git = "https://github.com/mozilla/nss-rs" }
 nss-test-fixture = { version = "0.1.0", package = "test-fixture", git = "https://github.com/mozilla/nss-rs" }
 qlog = { version = "0.16.0", default-features = false }
 quinn-udp = { version = "0.6", default-features = false, features = ["log", "fast-apple-datapath"] }


### PR DESCRIPTION
Pulls in nss-rs 0.13.1 with Gecko build fixes.