### PR TITLE
fix: guard qpack increment_acked against u64 overflow

### DIFF
--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -362,10 +362,14 @@ impl HeaderTable {
     /// `IncrementAck` if ack is greater than actual number of inserts.
     pub fn increment_acked(&mut self, increment: u64) -> Res<()> {
         qtrace!("[{self}] increment acked by {increment}");
-        self.acked_inserts_cnt += increment;
-        if self.base < self.acked_inserts_cnt {
+        let acked = self
+            .acked_inserts_cnt
+            .checked_add(increment)
+            .ok_or(Error::IncrementAck)?;
+        if self.base < acked {
             return Err(Error::IncrementAck);
         }
+        self.acked_inserts_cnt = acked;
         Ok(())
     }
 
@@ -424,6 +428,25 @@ mod tests {
             assert!(table.can_evict_to(first_entry_size));
             assert!(!table.can_evict_to(0));
         }
+    }
+
+    /// A peer can send an `Insert Count Increment` on the decoder stream with an
+    /// increment large enough to overflow the running acknowledged-inserts count.
+    /// The increment is range-checked against `base`, but only after the add, so
+    /// the overflow has to be caught explicitly.
+    #[test]
+    fn increment_acked_overflow_is_rejected() {
+        let mut table = HeaderTable::new(true);
+        table.set_capacity(10000).unwrap();
+        table.insert(b"header1", b"42").unwrap();
+        table.insert(b"header2", b"42").unwrap();
+
+        // Acknowledge both inserts legitimately so acked_inserts_cnt > 0.
+        table.increment_acked(2).unwrap();
+
+        // A malicious increment that would push the count past u64::MAX must be
+        // reported as an error, not overflow.
+        assert_eq!(table.increment_acked(u64::MAX), Err(Error::IncrementAck));
     }
 
     #[test]


### PR DESCRIPTION
Repro: on the QPACK decoder stream, send an Insert Count Increment whose value pushes the encoder's acknowledged-inserts count past u64::MAX (one valid increment, then a second of u64::MAX).
Cause: increment_acked adds the peer-supplied increment to acked_inserts_cnt before the range check, so the add itself overflows. Debug builds panic; release builds wrap and slip past the `base < acked_inserts_cnt` check, leaving the known-received count corrupted.
Fix: add with checked_add and map overflow to IncrementAck, the same error an over-large increment already produces. Valid increments behave exactly as before; only the overflow edge changes from a panic/wrap to a clean decoder-stream error.