### PR TITLE
feat: reuse ACK scratch buffer in LossRecoverySpace

### DIFF
--- a/neqo-transport/benches/sent_packets.rs
+++ b/neqo-transport/benches/sent_packets.rs
@@ -52,9 +52,12 @@ fn take_ranges(c: &mut Criterion) {
     let now = Instant::now();
     c.bench_function("sent::Packets::take_ranges", |b| {
         b.iter_batched_ref(
-            || make_packets(PACKETS, now),
+            || (make_packets(PACKETS, now), Vec::new()),
             // Take the first 90 packets, minus some gaps.
-            |pkts| black_box(pkts.take_ranges([70..=89, 40..=59, 10..=29])),
+            |(pkts, out)| {
+                pkts.take_ranges([70..=89, 40..=59, 10..=29], out);
+                black_box(out.len())
+            },
             BatchSize::SmallInput,
         );
     });

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -3562,7 +3562,7 @@ impl Connection {
             now,
         );
         let largest_acknowledged = acked_packets.first().map(sent::Packet::pn);
-        qlog::packets_acked(&mut self.qlog, space, &acked_packets, now);
+        qlog::packets_acked(&mut self.qlog, space, acked_packets, now);
         for acked in acked_packets {
             for token in acked.tokens() {
                 match token {

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -138,6 +138,9 @@ pub struct LossRecoverySpace {
     /// This is `None` if there were no out-of-order packets detected.
     /// When set to `Some(T)`, time-based loss detection should be enabled.
     first_ooo_time: Option<Instant>,
+    /// Scratch buffer reused across ACK frames to avoid allocating a fresh
+    /// `Vec<Packet>` on every call to `remove_acked`.
+    acked_scratch: Vec<sent::Packet>,
 }
 
 impl LossRecoverySpace {
@@ -151,6 +154,7 @@ impl LossRecoverySpace {
             in_flight_outstanding: 0,
             sent_packets: sent::Packets::default(),
             first_ooo_time: None,
+            acked_scratch: Vec::new(),
         }
     }
 
@@ -243,38 +247,32 @@ impl LossRecoverySpace {
         debug_assert!(self.in_flight_outstanding >= count);
         self.in_flight_outstanding -= count;
         if self.in_flight_outstanding == 0 {
-            qtrace!("remove_packet outstanding == 0 for space {}", self.space);
-        }
-    }
-
-    fn remove_packet(&mut self, p: &sent::Packet) {
-        if p.ack_eliciting() {
-            self.remove_outstanding(1);
+            qtrace!("remove_outstanding == 0 for space {}", self.space);
         }
     }
 
     /// Remove all newly acknowledged packets.
-    /// Returns all the acknowledged packets, with the largest packet number first.
-    /// ...and a boolean indicating if any of those packets were ack-eliciting.
-    /// This operates more efficiently because it assumes that the input is sorted
-    /// in the order that an ACK frame is (from the top).
-    fn remove_acked<R>(&mut self, acked_ranges: R, stats: &mut Stats) -> (Vec<sent::Packet>, bool)
+    /// Returns a boolean indicating if any of those packets were ack-eliciting.
+    /// The acknowledged packets are placed into `self.acked_scratch`; callers
+    /// must read from that field.  The buffer is reused across calls to avoid a
+    /// fresh allocation per ACK frame.
+    fn remove_acked<R>(&mut self, acked_ranges: R, stats: &mut Stats) -> bool
     where
         R: IntoIterator<Item = RangeInclusive<packet::Number>>,
     {
-        let acked = self.sent_packets.take_ranges(acked_ranges);
-        let mut eliciting = false;
-        for p in &acked {
-            self.remove_packet(p);
-            eliciting |= p.ack_eliciting();
-            if p.lost() {
-                stats.late_ack += 1;
-            }
-            if p.pto_fired() {
-                stats.pto_ack += 1;
-            }
+        self.sent_packets
+            .take_ranges(acked_ranges, &mut self.acked_scratch);
+        // Count first to avoid holding &self.acked_scratch across the &mut self call below.
+        let mut ack_eliciting_count: usize = 0;
+        for p in &self.acked_scratch {
+            ack_eliciting_count += usize::from(p.ack_eliciting());
+            stats.late_ack += usize::from(p.lost());
+            stats.pto_ack += usize::from(p.pto_fired());
         }
-        (acked, eliciting)
+        if ack_eliciting_count > 0 {
+            self.remove_outstanding(ack_eliciting_count);
+        }
+        ack_eliciting_count > 0
     }
 
     /// Remove all tracked packets from the space.
@@ -631,35 +629,36 @@ impl Loss {
             return (Vec::new(), Vec::new());
         };
 
-        let (acked_packets, any_ack_eliciting) =
-            space.remove_acked(acked_ranges, &mut self.stats.borrow_mut());
-        let Some(largest_acked_pkt) = acked_packets.first() else {
+        let any_ack_eliciting = space.remove_acked(acked_ranges, &mut self.stats.borrow_mut());
+        let Some(largest_acked_pkt) = space.acked_scratch.first() else {
             // No new information.
             return (Vec::new(), Vec::new());
         };
 
+        // Extract what we need from the largest acked packet before we mutate other fields.
+        let largest_pn = largest_acked_pkt.pn();
+        let largest_sent_time = largest_acked_pkt.time_sent();
+        let largest_on_primary = largest_acked_pkt.on_primary_path();
+
         // Track largest PN acked per space
         let prev_largest_acked = space.largest_acked_sent_time;
-        if Some(largest_acked_pkt.pn()) > space.largest_acked {
-            space.largest_acked = Some(largest_acked_pkt.pn());
+        if Some(largest_pn) > space.largest_acked {
+            space.largest_acked = Some(largest_pn);
 
             // If the largest acknowledged is newly acked and any newly acked
             // packet was ack-eliciting, update the RTT. (-recovery 5.1)
-            space.largest_acked_sent_time = Some(largest_acked_pkt.time_sent());
-            if any_ack_eliciting && largest_acked_pkt.on_primary_path() {
+            space.largest_acked_sent_time = Some(largest_sent_time);
+            if any_ack_eliciting && largest_on_primary {
                 self.rtt_sample(
                     primary_path.borrow_mut().rtt_mut(),
-                    largest_acked_pkt.time_sent(),
+                    largest_sent_time,
                     now,
                     ack_delay,
                 );
             }
         }
 
-        qdebug!(
-            "[{self}] ACK for {pn_space:?} - largest_acked={}",
-            largest_acked_pkt.pn()
-        );
+        qdebug!("[{self}] ACK for {pn_space:?} - largest_acked={largest_pn}");
 
         // Perform loss detection.
         // PTO is used to remove lost packets from in-flight accounting.
@@ -667,9 +666,7 @@ impl Loss {
         // as we rely on the count of in-flight packets to determine whether to send
         // another probe.  Removing them too soon would result in not sending on PTO.
         let cleanup_delay = self.pto_period(primary_path.borrow().rtt());
-        let Some(sp) = self.spaces.get_mut(pn_space) else {
-            return (Vec::new(), Vec::new());
-        };
+        let sp = self.spaces.get_mut(pn_space).expect("space not removed");
         let loss_delay = primary_path.borrow().rtt().loss_delay();
         let mut lost = Vec::new();
         sp.detect_lost_packets(now, loss_delay, cleanup_delay, &mut lost);
@@ -686,11 +683,13 @@ impl Loss {
             now,
         );
 
+        let space = self.spaces.get_mut(pn_space).expect("space not removed");
+
         // This must happen after on_packets_lost. If in recovery, this could
         // take us out, and then lost packets will start a new recovery period
         // when it shouldn't.
         primary_path.borrow_mut().on_packets_acked(
-            &acked_packets,
+            &space.acked_scratch,
             ack_ecn,
             now,
             &mut self.stats.borrow_mut(),
@@ -701,6 +700,9 @@ impl Loss {
         }
         self.pto_state = None;
 
+        // split_off(0) moves all packets into a new Vec for the caller while
+        // leaving acked_scratch empty with its capacity intact for the next ACK.
+        let acked_packets = space.acked_scratch.split_off(0);
         (acked_packets, lost)
     }
 
@@ -1281,16 +1283,16 @@ mod tests {
         let mut lrs = LossRecoverySpace::new(PacketNumberSpace::ApplicationData);
         let mut stats = Stats::default();
         add_sent(&mut lrs, 10);
-        let (acked, _) = lrs.remove_acked(vec![], &mut stats);
-        assert!(acked.is_empty());
-        let (acked, _) = lrs.remove_acked(vec![7..=8, 2..=4], &mut stats);
-        match_acked(&acked, &[8, 7, 4, 3, 2]);
-        let (acked, _) = lrs.remove_acked(vec![8..=11], &mut stats);
-        match_acked(&acked, &[10, 9]);
-        let (acked, _) = lrs.remove_acked(vec![0..=2], &mut stats);
-        match_acked(&acked, &[1, 0]);
-        let (acked, _) = lrs.remove_acked(vec![5..=6], &mut stats);
-        match_acked(&acked, &[6, 5]);
+        lrs.remove_acked(vec![], &mut stats);
+        assert!(lrs.acked_scratch.is_empty());
+        lrs.remove_acked(vec![7..=8, 2..=4], &mut stats);
+        match_acked(&lrs.acked_scratch, &[8, 7, 4, 3, 2]);
+        lrs.remove_acked(vec![8..=11], &mut stats);
+        match_acked(&lrs.acked_scratch, &[10, 9]);
+        lrs.remove_acked(vec![0..=2], &mut stats);
+        match_acked(&lrs.acked_scratch, &[1, 0]);
+        lrs.remove_acked(vec![5..=6], &mut stats);
+        match_acked(&lrs.acked_scratch, &[6, 5]);
     }
 
     #[test]

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -138,8 +138,9 @@ pub struct LossRecoverySpace {
     /// This is `None` if there were no out-of-order packets detected.
     /// When set to `Some(T)`, time-based loss detection should be enabled.
     first_ooo_time: Option<Instant>,
-    /// Scratch buffer reused across ACK frames to avoid allocating a fresh
-    /// `Vec<Packet>` on every call to `remove_acked`.
+    /// Holds the packets acknowledged by the most recent ACK frame.
+    /// Filled by `take_ranges` inside `remove_acked`; borrowed by `on_ack_received`
+    /// and its caller; cleared and refilled on the next call to `remove_acked`.
     acked: Vec<sent::Packet>,
 }
 
@@ -253,9 +254,9 @@ impl LossRecoverySpace {
 
     /// Remove all newly acknowledged packets.
     /// Returns a boolean indicating if any of those packets were ack-eliciting.
-    /// The acknowledged packets are placed into `self.acked`; callers
-    /// must read from that field.  The buffer is reused across calls to avoid a
-    /// fresh allocation per ACK frame.
+    /// The acknowledged packets are placed into `self.acked` and exposed to the
+    /// caller via the slice returned by `on_ack_received`.  The buffer is
+    /// cleared and refilled on the next call.
     fn remove_acked<R>(&mut self, acked_ranges: R, stats: &mut Stats) -> bool
     where
         R: IntoIterator<Item = RangeInclusive<packet::Number>>,
@@ -610,7 +611,10 @@ impl Loss {
         }
     }
 
-    /// Returns (acked packets, lost packets)
+    /// Returns (acked packets, lost packets).
+    /// The acked-packets slice borrows `self` (via `space.acked`); it is valid
+    /// until the next call to `on_ack_received` for the same space, which will
+    /// refill the buffer via `take_ranges` → `out.clear()`.
     pub fn on_ack_received<R>(
         &mut self,
         primary_path: &PathRef,
@@ -619,19 +623,19 @@ impl Loss {
         ack_ecn: Option<&ecn::Count>,
         ack_delay: Duration,
         now: Instant,
-    ) -> (Vec<sent::Packet>, Vec<sent::Packet>)
+    ) -> (&[sent::Packet], Vec<sent::Packet>)
     where
         R: IntoIterator<Item = RangeInclusive<packet::Number>>,
     {
         let Some(space) = self.spaces.get_mut(pn_space) else {
             qinfo!("ACK on discarded space");
-            return (Vec::new(), Vec::new());
+            return (&[], Vec::new());
         };
 
         let any_ack_eliciting = space.remove_acked(acked_ranges, &mut self.stats.borrow_mut());
         let Some(largest_acked_pkt) = space.acked.first() else {
             // No new information.
-            return (Vec::new(), Vec::new());
+            return (&[], Vec::new());
         };
 
         // Extract what we need from the largest acked packet before we mutate other fields.
@@ -699,10 +703,7 @@ impl Loss {
         }
         self.pto_state = None;
 
-        // split_off(0) moves all packets into a new Vec for the caller while
-        // leaving acked empty with its capacity intact for the next ACK.
-        let acked_packets = space.acked.split_off(0);
-        (acked_packets, lost)
+        (&space.acked, lost)
     }
 
     /// When receiving a retry, get all the sent packets so that they can be flushed.
@@ -1090,7 +1091,7 @@ mod tests {
             ack_ecn: Option<&ecn::Count>,
             ack_delay: Duration,
             now: Instant,
-        ) -> (Vec<sent::Packet>, Vec<sent::Packet>) {
+        ) -> (&[sent::Packet], Vec<sent::Packet>) {
             self.lr
                 .on_ack_received(&self.path, pn_space, acked_ranges, ack_ecn, ack_delay, now)
         }

--- a/neqo-transport/src/recovery/sent.rs
+++ b/neqo-transport/src/recovery/sent.rs
@@ -240,15 +240,15 @@ impl Packets {
         self.packets.iter_mut()
     }
 
-    /// Take values from specified ranges of packet numbers.
-    /// The values returned will be reversed, so that the most recent packet appears first.
-    /// This is because ACK frames arrive with ranges starting from the largest acknowledged
-    /// and we want to match that.
-    pub fn take_ranges<R>(&mut self, acked_ranges: R) -> Vec<Packet>
+    /// Take values from specified ranges of packet numbers into a caller-provided buffer.
+    /// The buffer is cleared first, then filled with the most recent packet first per range.
+    ///
+    /// Reusing the buffer across calls avoids a fresh allocation per ACK frame.
+    pub fn take_ranges<R>(&mut self, acked_ranges: R, out: &mut Vec<Packet>)
     where
         R: IntoIterator<Item = RangeInclusive<packet::Number>>,
     {
-        let mut result = Vec::new();
+        out.clear();
 
         // According to RFC 9000 §19.3.1 ACK ranges are in descending order:
         //
@@ -257,6 +257,9 @@ impl Packets {
         //
         // <https://www.rfc-editor.org/rfc/rfc9000.html#section-19.3.1>
         let mut previous_range_start: Option<packet::Number> = None;
+
+        let acked_ranges = acked_ranges.into_iter();
+        out.reserve(acked_ranges.size_hint().0);
 
         for range in acked_ranges {
             debug_assert!(
@@ -270,9 +273,8 @@ impl Packets {
             if start_idx == end_idx {
                 continue;
             }
-            result.extend(self.packets.drain(start_idx..end_idx).rev());
+            out.extend(self.packets.drain(start_idx..end_idx).rev());
         }
-        result
     }
 
     /// Empty out all tracked packets.
@@ -365,11 +367,11 @@ mod tests {
     }
 
     fn remove_one(pkts: &mut Packets, idx: packet::Number) {
-        let store = pkts.take_ranges([idx..=idx]);
+        let mut store = Vec::new();
+        pkts.take_ranges([idx..=idx], &mut store);
         let mut it = store.into_iter();
         assert_eq!(idx, it.next().unwrap().pn());
         assert!(it.next().is_none());
-        drop(it);
     }
 
     fn assert_zero_and_two<'a, 'b: 'a>(
@@ -426,7 +428,9 @@ mod tests {
     fn ignore_unknown() {
         let mut pkts = Packets::default();
         pkts.track(pkt(0));
-        assert!(pkts.take_ranges([1..=1]).is_empty());
+        let mut out = Vec::new();
+        pkts.take_ranges([1..=1], &mut out);
+        assert!(out.is_empty());
     }
 
     /// Verify `take_ranges` with multiple non-contiguous ranges and multi-packet
@@ -441,7 +445,8 @@ mod tests {
             pkts.track(pkt(i));
         }
         // ACK ranges [4..=5, 1..=2] in descending order (as per RFC 9000 §19.3.1).
-        let acked = pkts.take_ranges([4..=5, 1..=2]);
+        let mut acked = Vec::new();
+        pkts.take_ranges([4..=5, 1..=2], &mut acked);
 
         // Returned in largest-pn-first order: 5, 4, 2, 1.
         let pns: Vec<u32> = acked.iter().map(|p| u32::try_from(p.pn).unwrap()).collect();

--- a/neqo-transport/src/recovery/sent.rs
+++ b/neqo-transport/src/recovery/sent.rs
@@ -242,7 +242,6 @@ impl Packets {
 
     /// Take values from specified ranges of packet numbers into a caller-provided buffer.
     /// The buffer is cleared first, then filled with the most recent packet first per range.
-    ///
     /// Reusing the buffer across calls avoids a fresh allocation per ACK frame.
     pub fn take_ranges<R>(&mut self, acked_ranges: R, out: &mut Vec<Packet>)
     where
@@ -257,9 +256,6 @@ impl Packets {
         //
         // <https://www.rfc-editor.org/rfc/rfc9000.html#section-19.3.1>
         let mut previous_range_start: Option<packet::Number> = None;
-
-        let acked_ranges = acked_ranges.into_iter();
-        out.reserve(acked_ranges.size_hint().0);
 
         for range in acked_ranges {
             debug_assert!(


### PR DESCRIPTION
Change Packets::take_ranges to fill a caller-provided Vec rather than
allocating a fresh one. LossRecoverySpace gains an acked_scratch field
that persists across ACK frames, eliminating one Vec allocation per
ACK received. 