### PR TITLE
fix: activate blapi for bench builds

### DIFF
--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -38,7 +38,7 @@ neqo-transport = { path = ".", default-features = false, features = ["draft-29"]
 test-fixture = { path = "../test-fixture" }
 
 [features]
-bench = ["neqo-common/bench", "nss/bench", "test-fixture/bench", "log/release_max_level_info"]
+bench = ["neqo-common/bench", "nss/bench", "blapi", "test-fixture/bench", "log/release_max_level_info"]
 blapi = ["nss/blapi"]
 default = ["blapi"]
 build-fuzzing-corpus = [


### PR DESCRIPTION
Makes the benches consistent with the code, which uses `blapi` by default now.