### PR TITLE
feat: cache has_data_at result in SendStream

### DIFF
--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -728,8 +728,7 @@ pub struct SendStream {
     fair: bool,
     send_group: Option<SendGroupId>,
     writable_event_low_watermark: NonZeroUsize,
-    /// Cached result: true iff `has_data_at(self.priority)` would return true.
-    /// Maintained at every state transition so the common path is an O(1) field read.
+    /// `has_data_at` cache: true iff `has_data_at(self.priority)` would return true.
     has_data: bool,
 }
 
@@ -785,19 +784,22 @@ impl SendStream {
         }
 
         if priority == self.priority {
-            // STREAM_DATA_BLOCKED pending? O(1) bool read — checked live to avoid
-            // staleness when fc state changes outside our update sites.
+            // STREAM_DATA_BLOCKED pending?
             if let State::Ready { fc, .. } | State::Send { fc, .. } = &self.state
                 && fc.is_blocked()
             {
                 return true;
             }
-            // STREAM pending? Use cached result: avoids the expensive BTree probe.
+            // STREAM pending?
+            #[cfg(debug_assertions)]
+            {
+                let computed = self.has_next_bytes(false);
+                assert_eq!(self.has_data, computed, "has_data cache out of sync");
+            }
             return self.has_data;
         }
 
         if priority == self.effective_priority {
-            // Retransmission path: check TxBuffer for lost bytes.
             return self.has_next_bytes(true);
         }
 
@@ -806,19 +808,10 @@ impl SendStream {
 
     /// Update the cache that backs the `has_data_at(self.priority)` STREAM check.
     ///
-    /// `fc.is_blocked()` and `ResetSent` are checked live in `has_data_at` (both
-    /// are O(1)), so only the `has_next_bytes` result — the expensive `BTree` probe —
-    /// needs to be cached here.  Call this whenever the `TxBuffer` or stream state
-    /// changes in a way that could affect whether there are unsent data bytes.
+    /// Call this whenever the `TxBuffer` or stream state changes in a way that could affect whether
+    /// there are unsent data bytes.
     fn update_has_data(&mut self) {
-        self.has_data = self.compute_has_data();
-    }
-
-    /// Returns true iff the stream has unsent data bytes at `self.priority`.
-    /// Does NOT account for `fc.is_blocked()` or `ResetSent` — those are checked
-    /// live in `has_data_at`.
-    fn compute_has_data(&mut self) -> bool {
-        self.has_next_bytes(false)
+        self.has_data = self.has_next_bytes(false);
     }
 
     /// Return `false` if the builder is full and the caller should stop iterating.
@@ -868,8 +861,7 @@ impl SendStream {
         retransmission: RetransmissionPriority,
     ) {
         let new_effective = transmission + retransmission;
-        // If a RESET_STREAM is pending, keep its stored priority aligned with
-        // the updated stream priority so it remains schedulable.
+        // Keep a pending RESET_STREAM priority-aligned so it remains schedulable.
         if let State::ResetSent {
             priority: Some(ref mut p),
             ..
@@ -1296,8 +1288,6 @@ impl SendStream {
     pub fn blocked_lost(&mut self, limit: u64) {
         if let State::Ready { fc, .. } | State::Send { fc, .. } = &mut self.state {
             fc.frame_lost(limit);
-            // frame_lost re-arms blocked_frame, so the cache needs refreshing.
-            self.update_has_data();
         } else {
             qtrace!("[{self}] Ignoring lost STREAM_DATA_BLOCKED({limit})");
         }
@@ -1316,8 +1306,6 @@ impl SendStream {
             && let State::Ready { fc, .. } | State::Send { fc, .. } = &mut self.state
         {
             fc.write_frames(builder, tokens, stats);
-            // write_frames may clear blocked_frame; refresh the cache.
-            self.update_has_data();
         }
     }
 
@@ -1332,12 +1320,13 @@ impl SendStream {
         if let Some(buf) = self.state.tx_buf_mut() {
             buf.mark_as_sent(offset, len);
             self.send_blocked_if_space_needed(0);
-            // `send_blocked_if_space_needed` already calls `update_has_data`.
         }
 
         if fin && let State::DataSent { fin_sent, .. } = &mut self.state {
             *fin_sent = true;
-            // fin_sent may affect has_next_bytes; refresh the cache.
+        }
+
+        if len > 0 || fin {
             self.update_has_data();
         }
     }
@@ -1504,7 +1493,6 @@ impl SendStream {
                 conn_fc.borrow_mut().blocked();
             }
         }
-        self.update_has_data();
     }
 
     fn send_internal(&mut self, buf: &[u8], atomic: bool) -> Res<usize> {

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -875,7 +875,6 @@ impl SendStream {
         }
         self.priority = transmission;
         self.effective_priority = new_effective;
-        self.update_has_data();
     }
 
     #[must_use]
@@ -1545,7 +1544,7 @@ impl SendStream {
             _ => Err(Error::FinalSize),
         };
         if result.is_ok() {
-            self.update_has_data();
+            self.has_data = true;
         }
         result
     }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -728,6 +728,9 @@ pub struct SendStream {
     fair: bool,
     send_group: Option<SendGroupId>,
     writable_event_low_watermark: NonZeroUsize,
+    /// Cached result: true iff `has_data_at(self.priority)` would return true.
+    /// Maintained at every state transition so the common path is an O(1) field read.
+    has_data: bool,
 }
 
 impl SendStream {
@@ -752,6 +755,7 @@ impl SendStream {
             fair: false,
             send_group: None,
             writable_event_low_watermark: NonZeroUsize::MIN,
+            has_data: false,
         };
         if ss.avail() > 0 {
             ss.conn_events.send_stream_writable(stream_id);
@@ -779,22 +783,42 @@ impl SendStream {
             } if p == priority => return true,
             _ => {}
         }
-        // STREAM_DATA_BLOCKED pending?
-        if priority == self.priority
-            && let State::Ready { fc, .. } | State::Send { fc, .. } = &self.state
-            && fc.is_blocked()
-        {
-            return true;
+
+        if priority == self.priority {
+            // STREAM_DATA_BLOCKED pending? O(1) bool read — checked live to avoid
+            // staleness when fc state changes outside our update sites.
+            if let State::Ready { fc, .. } | State::Send { fc, .. } = &self.state
+                && fc.is_blocked()
+            {
+                return true;
+            }
+            // STREAM pending? Use cached result: avoids the expensive BTree probe.
+            return self.has_data;
         }
-        // STREAM pending?
-        let retransmission = if priority == self.priority {
-            false
-        } else if priority == self.effective_priority {
-            true
-        } else {
-            return false;
-        };
-        self.has_next_bytes(retransmission)
+
+        if priority == self.effective_priority {
+            // Retransmission path: check TxBuffer for lost bytes.
+            return self.has_next_bytes(true);
+        }
+
+        false
+    }
+
+    /// Update the cache that backs the `has_data_at(self.priority)` STREAM check.
+    ///
+    /// `fc.is_blocked()` and `ResetSent` are checked live in `has_data_at` (both
+    /// are O(1)), so only the `has_next_bytes` result — the expensive `BTree` probe —
+    /// needs to be cached here.  Call this whenever the `TxBuffer` or stream state
+    /// changes in a way that could affect whether there are unsent data bytes.
+    fn update_has_data(&mut self) {
+        self.has_data = self.compute_has_data();
+    }
+
+    /// Returns true iff the stream has unsent data bytes at `self.priority`.
+    /// Does NOT account for `fc.is_blocked()` or `ResetSent` — those are checked
+    /// live in `has_data_at`.
+    fn compute_has_data(&mut self) -> bool {
+        self.has_next_bytes(false)
     }
 
     /// Return `false` if the builder is full and the caller should stop iterating.
@@ -843,8 +867,23 @@ impl SendStream {
         transmission: TransmissionPriority,
         retransmission: RetransmissionPriority,
     ) {
+        let new_effective = transmission + retransmission;
+        // If a RESET_STREAM is pending, keep its stored priority aligned with
+        // the updated stream priority so it remains schedulable.
+        if let State::ResetSent {
+            priority: Some(ref mut p),
+            ..
+        } = self.state
+        {
+            if *p == self.priority {
+                *p = transmission;
+            } else if *p == self.effective_priority {
+                *p = new_effective;
+            }
+        }
         self.priority = transmission;
-        self.effective_priority = transmission + retransmission;
+        self.effective_priority = new_effective;
+        self.update_has_data();
     }
 
     #[must_use]
@@ -1168,6 +1207,7 @@ impl SendStream {
             }
             State::ResetRecvd { .. } => qtrace!("[{self}] already in ResetRecvd state"),
         }
+        self.update_has_data();
     }
 
     pub fn reset_lost(&mut self) {
@@ -1183,6 +1223,7 @@ impl SendStream {
             State::ResetRecvd { .. } => (),
             _ => unreachable!(),
         }
+        self.update_has_data();
     }
 
     /// Maybe write a `RESET_STREAM` or `RESET_STREAM_AT` frame.
@@ -1245,6 +1286,9 @@ impl SendStream {
             }
             *priority = None;
         }
+        if written {
+            self.update_has_data();
+        }
         // Even if the write was successful, if we have reliable data pending, return false.
         written && !matches!(self.state, State::ResetSentReliable { .. })
     }
@@ -1252,6 +1296,8 @@ impl SendStream {
     pub fn blocked_lost(&mut self, limit: u64) {
         if let State::Ready { fc, .. } | State::Send { fc, .. } = &mut self.state {
             fc.frame_lost(limit);
+            // frame_lost re-arms blocked_frame, so the cache needs refreshing.
+            self.update_has_data();
         } else {
             qtrace!("[{self}] Ignoring lost STREAM_DATA_BLOCKED({limit})");
         }
@@ -1270,6 +1316,8 @@ impl SendStream {
             && let State::Ready { fc, .. } | State::Send { fc, .. } = &mut self.state
         {
             fc.write_frames(builder, tokens, stats);
+            // write_frames may clear blocked_frame; refresh the cache.
+            self.update_has_data();
         }
     }
 
@@ -1284,10 +1332,13 @@ impl SendStream {
         if let Some(buf) = self.state.tx_buf_mut() {
             buf.mark_as_sent(offset, len);
             self.send_blocked_if_space_needed(0);
+            // `send_blocked_if_space_needed` already calls `update_has_data`.
         }
 
         if fin && let State::DataSent { fin_sent, .. } = &mut self.state {
             *fin_sent = true;
+            // fin_sent may affect has_next_bytes; refresh the cache.
+            self.update_has_data();
         }
     }
 
@@ -1361,6 +1412,7 @@ impl SendStream {
             }
             _ => qtrace!("[{self}] mark_as_acked called from state {:?}", self.state),
         }
+        self.update_has_data();
     }
 
     #[allow(
@@ -1387,6 +1439,7 @@ impl SendStream {
         {
             *fin_sent = *fin_acked;
         }
+        self.update_has_data();
     }
 
     /// Bytes sendable on stream. Constrained by stream credit available,
@@ -1451,6 +1504,7 @@ impl SendStream {
                 conn_fc.borrow_mut().blocked();
             }
         }
+        self.update_has_data();
     }
 
     fn send_internal(&mut self, buf: &[u8], atomic: bool) -> Res<usize> {
@@ -1487,7 +1541,7 @@ impl SendStream {
             buf
         };
 
-        match &mut self.state {
+        let result = match &mut self.state {
             State::Ready { .. } => unreachable!(),
             State::Send {
                 fc,
@@ -1501,7 +1555,11 @@ impl SendStream {
                 Ok(sent)
             }
             _ => Err(Error::FinalSize),
+        };
+        if result.is_ok() {
+            self.update_has_data();
         }
+        result
     }
 
     pub fn close(&mut self) {
@@ -1536,6 +1594,7 @@ impl SendStream {
             }
             State::ResetRecvd { .. } => qtrace!("[{self}] already in ResetRecvd state"),
         }
+        self.update_has_data();
     }
 
     /// Commit to reliably delivering all data buffered so far: that prefix is delivered even if
@@ -1700,6 +1759,7 @@ impl SendStream {
             }
             _ => {}
         }
+        self.update_has_data();
     }
 
     #[cfg(test)]

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -728,8 +728,12 @@ pub struct SendStream {
     fair: bool,
     send_group: Option<SendGroupId>,
     writable_event_low_watermark: NonZeroUsize,
-    /// `has_data_at` cache: true iff `has_data_at(self.priority)` would return true.
-    has_data: bool,
+    /// `has_data_at` cache: `Some(true) if has_data_at(self.priority) would return true`,
+    /// or `None` if stale.
+    has_data: Option<bool>,
+    /// Whether a pending `ResetSent`/`ResetSentReliable` priority is tracking
+    /// `effective_priority` (set by `reset_lost`) rather than `priority` (set by `reset`).
+    reset_priority_is_effective: bool,
 }
 
 impl SendStream {
@@ -754,7 +758,8 @@ impl SendStream {
             fair: false,
             send_group: None,
             writable_event_low_watermark: NonZeroUsize::MIN,
-            has_data: false,
+            has_data: Some(false),
+            reset_priority_is_effective: false,
         };
         if ss.avail() > 0 {
             ss.conn_events.send_stream_writable(stream_id);
@@ -790,13 +795,9 @@ impl SendStream {
             {
                 return true;
             }
-            // STREAM pending?
-            #[cfg(debug_assertions)]
-            {
-                let computed = self.has_next_bytes(false);
-                assert_eq!(self.has_data, computed, "has_data cache out of sync");
-            }
-            return self.has_data;
+            let has_data = self.has_data.unwrap_or_else(|| self.has_next_bytes(false));
+            self.has_data = Some(has_data);
+            return has_data;
         }
 
         if priority == self.effective_priority {
@@ -804,14 +805,6 @@ impl SendStream {
         }
 
         false
-    }
-
-    /// Update the cache that backs the `has_data_at(self.priority)` STREAM check.
-    ///
-    /// Call this whenever the `TxBuffer` or stream state changes in a way that could affect whether
-    /// there are unsent data bytes.
-    fn update_has_data(&mut self) {
-        self.has_data = self.has_next_bytes(false);
     }
 
     /// Return `false` if the builder is full and the caller should stop iterating.
@@ -861,17 +854,21 @@ impl SendStream {
         retransmission: RetransmissionPriority,
     ) {
         let new_effective = transmission + retransmission;
-        // Keep a pending RESET_STREAM priority-aligned so it remains schedulable.
+        // Keep a pending RESET_STREAM/RESET_STREAM_AT priority-aligned so it remains schedulable.
         if let State::ResetSent {
+            priority: Some(ref mut p),
+            ..
+        }
+        | State::ResetSentReliable {
             priority: Some(ref mut p),
             ..
         } = self.state
         {
-            if *p == self.priority {
-                *p = transmission;
-            } else if *p == self.effective_priority {
-                *p = new_effective;
-            }
+            *p = if self.reset_priority_is_effective {
+                new_effective
+            } else {
+                transmission
+            };
         }
         self.priority = transmission;
         self.effective_priority = new_effective;
@@ -1159,6 +1156,7 @@ impl SendStream {
         reason = "OK here."
     )]
     pub fn reset_acked(&mut self) {
+        self.has_data = None;
         match self.state {
             State::Ready { .. }
             | State::Send { .. }
@@ -1198,10 +1196,10 @@ impl SendStream {
             }
             State::ResetRecvd { .. } => qtrace!("[{self}] already in ResetRecvd state"),
         }
-        self.update_has_data();
     }
 
     pub fn reset_lost(&mut self) {
+        self.has_data = None;
         match self.state {
             State::ResetSent {
                 ref mut priority, ..
@@ -1210,11 +1208,11 @@ impl SendStream {
                 ref mut priority, ..
             } => {
                 *priority = Some(self.effective_priority);
+                self.reset_priority_is_effective = true;
             }
             State::ResetRecvd { .. } => (),
             _ => unreachable!(),
         }
-        self.update_has_data();
     }
 
     /// Maybe write a `RESET_STREAM` or `RESET_STREAM_AT` frame.
@@ -1277,9 +1275,7 @@ impl SendStream {
             }
             *priority = None;
         }
-        if written {
-            self.update_has_data();
-        }
+        self.has_data = None;
         // Even if the write was successful, if we have reliable data pending, return false.
         written && !matches!(self.state, State::ResetSentReliable { .. })
     }
@@ -1315,6 +1311,7 @@ impl SendStream {
     )]
     pub fn mark_as_sent(&mut self, offset: u64, len: usize, fin: bool) {
         self.bytes_sent = max(self.bytes_sent, offset + to_u64(len));
+        self.has_data = None;
 
         if let Some(buf) = self.state.tx_buf_mut() {
             buf.mark_as_sent(offset, len);
@@ -1324,10 +1321,6 @@ impl SendStream {
         if fin && let State::DataSent { fin_sent, .. } = &mut self.state {
             *fin_sent = true;
         }
-
-        if len > 0 || fin {
-            self.update_has_data();
-        }
     }
 
     #[allow(
@@ -1336,6 +1329,7 @@ impl SendStream {
         reason = "OK here."
     )]
     pub fn mark_as_acked(&mut self, offset: u64, len: usize, fin: bool) {
+        self.has_data = None;
         match self.state {
             State::Send {
                 ref mut send_buf, ..
@@ -1400,7 +1394,6 @@ impl SendStream {
             }
             _ => qtrace!("[{self}] mark_as_acked called from state {:?}", self.state),
         }
-        self.update_has_data();
     }
 
     #[allow(
@@ -1414,6 +1407,8 @@ impl SendStream {
             "[{self}] mark_as_lost retransmission offset={}",
             self.retransmission_offset
         );
+        self.has_data = None;
+
         if let Some(buf) = self.state.tx_buf_mut() {
             buf.mark_as_lost(offset, len);
         }
@@ -1427,7 +1422,6 @@ impl SendStream {
         {
             *fin_sent = *fin_acked;
         }
-        self.update_has_data();
     }
 
     /// Bytes sendable on stream. Constrained by stream credit available,
@@ -1544,12 +1538,14 @@ impl SendStream {
             _ => Err(Error::FinalSize),
         };
         if result.is_ok() {
-            self.has_data = true;
+            // Just buffered unsent data, so there is definitely something to send.
+            self.has_data = Some(true);
         }
         result
     }
 
     pub fn close(&mut self) {
+        self.has_data = None;
         match &mut self.state {
             State::Ready { .. } => {
                 self.state.transition(State::DataSent {
@@ -1581,7 +1577,6 @@ impl SendStream {
             }
             State::ResetRecvd { .. } => qtrace!("[{self}] already in ResetRecvd state"),
         }
-        self.update_has_data();
     }
 
     /// Commit to reliably delivering all data buffered so far: that prefix is delivered even if
@@ -1661,6 +1656,8 @@ impl SendStream {
             }
         }
 
+        self.has_data = None;
+        self.reset_priority_is_effective = false;
         let priority = self.priority;
         let new_state = match &mut self.state {
             State::Ready { fc, .. } => State::ResetSent {
@@ -1709,6 +1706,7 @@ impl SendStream {
     /// retransmission of the reset frame is a plain `RESET_STREAM`), or straight to `ResetRecvd` if
     /// the reset frame is already acked.
     pub(crate) fn drop_commitment(&mut self) {
+        self.has_data = None;
         match &mut self.state {
             State::Send { committed, .. } | State::DataSent { committed, .. } => {
                 *committed = 0;
@@ -1746,7 +1744,6 @@ impl SendStream {
             }
             _ => {}
         }
-        self.update_has_data();
     }
 
     #[cfg(test)]
@@ -4542,6 +4539,33 @@ mod tests {
         // Reset lost: priority set back to Some(effective_priority).
         s.reset_lost();
         assert_has_data_only_at(&mut s, &[eff]);
+    }
+
+    #[test]
+    fn set_priority_after_reset_lost_disambiguates_bucket() {
+        // Critical + Higher == Critical (see the TransmissionPriority::Add impl), so
+        // priority == effective_priority here even with the *default* RetransmissionPriority.
+        let mut s = stream_with_priority(
+            TransmissionPriority::Critical,
+            RetransmissionPriority::Higher,
+        );
+        assert_eq!(s.priority, TransmissionPriority::Critical);
+        assert_eq!(s.effective_priority, TransmissionPriority::Critical);
+
+        s.send(b"hello").unwrap();
+        s.reset(0);
+        assert!(reset_frame_written(&mut s, TransmissionPriority::Critical));
+        // Reset frame lost: stored priority moves to Some(effective_priority) == Some(Critical).
+        s.reset_lost();
+
+        // Now diverge priority and effective_priority.
+        s.set_priority(
+            TransmissionPriority::Low,
+            RetransmissionPriority::MuchHigher,
+        );
+        let new_eff = TransmissionPriority::Low + RetransmissionPriority::MuchHigher;
+        assert_eq!(new_eff, TransmissionPriority::High);
+        assert_has_data_only_at(&mut s, &[new_eff]);
     }
 
     // --- RESET_STREAM_AT (reliable stream reset) ---


### PR DESCRIPTION
Replace the per-call BTree probe with a bool maintained at every state-transition site.