### PR TITLE
fix: prevent PR Comment runs from cancelling each other

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -13,7 +13,7 @@ on:
       - completed # zizmor: ignore[dangerous-triggers]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.name }}-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
The concurrency group used `pull_request.number || github.ref`. For `workflow_run` events `pull_request.number` is always empty, so all three triggering workflows ("QNS PR", "cargo bench", "Performance comparison") resolve to the same key and cancel each other — no comment ever lands.

Key on the triggering workflow name and head SHA instead.