### PR TITLE
Fix off-by-one in max_push_id computation

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -5622,7 +5622,8 @@ mod tests {
         send_push_data_and_exchange_packets(&mut client, &mut server, PushId::new(4), true);
         assert_eq!(client.state(), Http3State::Connected);
 
-        // Read push stream with push_id 5 to make it change to closed state.
+>         // Read push stream with push_id 4 to make it change to closed state.
+> 
         read_response_and_push_events(
             &mut client,
             &[PushPromiseInfo {
@@ -5757,7 +5758,8 @@ mod tests {
             request_stream_id,
             PushId::new(4),
         );
-        // Start a push stream with push_id 5.
+>         // Start a push stream with push_id 4.
+> 
         send_push_data_and_exchange_packets(&mut client, &mut server, PushId::new(4), true);
 
         read_response_and_push_events(

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -5794,12 +5794,12 @@ mod tests {
         // Connect and send a request
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
 
-        // Send a push promise. max_push_id is set to 5, to trigger an error we send push_id=6.
+        // Send a push promise. max_push_id is set to 4, to trigger an error we send push_id=5.
         send_push_promise_and_exchange_packets(
             &mut client,
             &mut server,
             request_stream_id,
-            PushId::new(6),
+            PushId::new(5),
         );
 
         assert_closed(&client, &Error::HttpId);
@@ -5811,8 +5811,8 @@ mod tests {
         // Connect and send a request
         let (mut client, mut server) = connect();
 
-        // Send a push stream. max_push_id is set to 5, to trigger an error we send push_id=6.
-        send_push_data_and_exchange_packets(&mut client, &mut server, PushId::new(6), true);
+        // Send a push stream. max_push_id is set to 4, to trigger an error we send push_id=5.
+        send_push_data_and_exchange_packets(&mut client, &mut server, PushId::new(5), true);
 
         assert_closed(&client, &Error::HttpId);
     }
@@ -5823,8 +5823,8 @@ mod tests {
         // Connect and send a request
         let (mut client, mut server, _request_stream_id) = connect_and_send_request(true);
 
-        // Send CANCEL_PUSH for push_id 6.
-        send_cancel_push_and_exchange_packets(&mut client, &mut server, PushId::new(6));
+        // Send CANCEL_PUSH for push_id 5.
+        send_cancel_push_and_exchange_packets(&mut client, &mut server, PushId::new(5));
 
         assert_closed(&client, &Error::HttpId);
     }
@@ -5835,7 +5835,7 @@ mod tests {
         // Connect and send a request
         let (mut client, _, _) = connect_and_send_request(true);
 
-        assert_eq!(client.cancel_push(PushId::new(6)), Err(Error::HttpId));
+        assert_eq!(client.cancel_push(PushId::new(5)), Err(Error::HttpId));
         assert_eq!(client.state(), Http3State::Connected);
     }
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -1772,7 +1772,7 @@ mod tests {
             assert!(dec.decode_vvec().unwrap().len() < 8);
 
             assert_eq!(dec.decode_varint().unwrap(), 0xd); // MAX_PUSH_ID
-            assert_eq!(dec.decode_vvec().unwrap(), &[5]);
+            assert_eq!(dec.decode_vvec().unwrap(), &[4]);
 
             assert_eq!(dec.remaining(), 0);
             assert!(!fin);
@@ -5531,7 +5531,7 @@ mod tests {
             &mut client,
             &mut server,
             request_stream_id,
-            PushId::new(5),
+            PushId::new(4),
         );
 
         send_push_promise_and_exchange_packets(
@@ -5549,7 +5549,7 @@ mod tests {
             &mut client,
             &[
                 PushPromiseInfo {
-                    push_id: PushId::new(5),
+                    push_id: PushId::new(4),
                     ref_stream_id: request_stream_id,
                 },
                 PushPromiseInfo {
@@ -5575,7 +5575,7 @@ mod tests {
             &mut client,
             &mut server,
             request_stream_id,
-            PushId::new(5),
+            PushId::new(4),
         );
 
         send_push_data_and_exchange_packets(&mut client, &mut server, PushId::new(3), true);
@@ -5590,7 +5590,7 @@ mod tests {
             &mut client,
             &[
                 PushPromiseInfo {
-                    push_id: PushId::new(5),
+                    push_id: PushId::new(4),
                     ref_stream_id: request_stream_id,
                 },
                 PushPromiseInfo {
@@ -5617,19 +5617,19 @@ mod tests {
             &mut client,
             &mut server,
             request_stream_id,
-            PushId::new(5),
+            PushId::new(4),
         );
-        send_push_data_and_exchange_packets(&mut client, &mut server, PushId::new(5), true);
+        send_push_data_and_exchange_packets(&mut client, &mut server, PushId::new(4), true);
         assert_eq!(client.state(), Http3State::Connected);
 
         // Read push stream with push_id 5 to make it change to closed state.
         read_response_and_push_events(
             &mut client,
             &[PushPromiseInfo {
-                push_id: PushId::new(5),
+                push_id: PushId::new(4),
                 ref_stream_id: request_stream_id,
             }],
-            &[PushId::new(5)],
+            &[PushId::new(4)],
             request_stream_id,
         );
 
@@ -5663,7 +5663,7 @@ mod tests {
             &mut client,
             &mut server,
             request_stream_id,
-            PushId::new(5),
+            PushId::new(4),
         );
 
         // make a second request.
@@ -5677,18 +5677,18 @@ mod tests {
             &mut client,
             &mut server,
             request_stream_id_2,
-            PushId::new(5),
+            PushId::new(4),
         );
 
         read_response_and_push_events(
             &mut client,
             &[
                 PushPromiseInfo {
-                    push_id: PushId::new(5),
+                    push_id: PushId::new(4),
                     ref_stream_id: request_stream_id,
                 },
                 PushPromiseInfo {
-                    push_id: PushId::new(5),
+                    push_id: PushId::new(4),
                     ref_stream_id: request_stream_id_2,
                 },
             ],
@@ -5708,9 +5708,9 @@ mod tests {
             &mut client,
             &mut server,
             request_stream_id,
-            PushId::new(5),
+            PushId::new(4),
         );
-        send_push_data_and_exchange_packets(&mut client, &mut server, PushId::new(5), true);
+        send_push_data_and_exchange_packets(&mut client, &mut server, PushId::new(4), true);
 
         // make a second request.
         let request_stream_id_2 = make_request(&mut client, false, &[]);
@@ -5723,22 +5723,22 @@ mod tests {
             &mut client,
             &mut server,
             request_stream_id_2,
-            PushId::new(5),
+            PushId::new(4),
         );
 
         read_response_and_push_events(
             &mut client,
             &[
                 PushPromiseInfo {
-                    push_id: PushId::new(5),
+                    push_id: PushId::new(4),
                     ref_stream_id: request_stream_id,
                 },
                 PushPromiseInfo {
-                    push_id: PushId::new(5),
+                    push_id: PushId::new(4),
                     ref_stream_id: request_stream_id_2,
                 },
             ],
-            &[PushId::new(5)],
+            &[PushId::new(4)],
             request_stream_id,
         );
         assert_eq!(client.state(), Http3State::Connected);
@@ -5755,18 +5755,18 @@ mod tests {
             &mut client,
             &mut server,
             request_stream_id,
-            PushId::new(5),
+            PushId::new(4),
         );
         // Start a push stream with push_id 5.
-        send_push_data_and_exchange_packets(&mut client, &mut server, PushId::new(5), true);
+        send_push_data_and_exchange_packets(&mut client, &mut server, PushId::new(4), true);
 
         read_response_and_push_events(
             &mut client,
             &[PushPromiseInfo {
-                push_id: PushId::new(5),
+                push_id: PushId::new(4),
                 ref_stream_id: request_stream_id,
             }],
-            &[PushId::new(5)],
+            &[PushId::new(4)],
             request_stream_id,
         );
 
@@ -5781,7 +5781,7 @@ mod tests {
             &mut client,
             &mut server,
             request_stream_id_2,
-            PushId::new(5),
+            PushId::new(4),
         );
 
         // Check that we do not have a Http3ClientEvent::PushPromise.
@@ -5842,7 +5842,8 @@ mod tests {
 
     #[test]
     fn max_push_id_frame_update_is_sent() {
-        const MAX_PUSH_ID_FRAME: &[u8] = &[0xd, 0x1, 0x8];
+        // Max concurrent is 5, sent after >5/2 (3) pushes are closed.
+        const MAX_PUSH_ID_FRAME: &[u8] = &[0xd, 0x1, 0x7];
 
         // Connect and send a request
         let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
@@ -5891,9 +5892,9 @@ mod tests {
         assert_eq!(amount, MAX_PUSH_ID_FRAME.len());
         assert_eq!(&buf[..3], MAX_PUSH_ID_FRAME);
 
-        // Check that we can send push_id=8 now
-        send_push_promise(&mut server.conn, request_stream_id, PushId::new(8));
-        send_push_data(&mut server.conn, PushId::new(8), true);
+        // Check that we can send push_id=7 now
+        send_push_promise(&mut server.conn, request_stream_id, PushId::new(7));
+        send_push_data(&mut server.conn, PushId::new(7), true);
 
         let out = server.conn.process_output(now());
         let out = client.process(out.dgram(), now());
@@ -5904,10 +5905,10 @@ mod tests {
         read_response_and_push_events(
             &mut client,
             &[PushPromiseInfo {
-                push_id: PushId::new(8),
+                push_id: PushId::new(7),
                 ref_stream_id: request_stream_id,
             }],
-            &[PushId::new(8)],
+            &[PushId::new(7)],
             request_stream_id,
         );
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -5622,8 +5622,7 @@ mod tests {
         send_push_data_and_exchange_packets(&mut client, &mut server, PushId::new(4), true);
         assert_eq!(client.state(), Http3State::Connected);
 
->         // Read push stream with push_id 4 to make it change to closed state.
-> 
+        // Read push stream with push_id 4 to make it change to closed state.
         read_response_and_push_events(
             &mut client,
             &[PushPromiseInfo {
@@ -5758,8 +5757,6 @@ mod tests {
             request_stream_id,
             PushId::new(4),
         );
->         // Start a push stream with push_id 4.
-> 
         send_push_data_and_exchange_packets(&mut client, &mut server, PushId::new(4), true);
 
         read_response_and_push_events(

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -529,7 +529,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "Do not encode data before the stream is initialized")]
-    fn drop_all() {
+    fn check_underflow_on_closed_pushes() {
         let events = Http3ClientEvents::default();
         let mut pc = PushController::new(1, events);
         assert!(pc.can_receive_push());

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -512,10 +512,8 @@ impl HttpRecvStreamEvents for RecvPushEvents {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use neqo_common::Role;
 
     use super::{CloseType, Http3ClientEvents, PushController, PushId, StreamId};
-    use crate::{Http3Parameters, connection::Http3Connection};
 
     #[test]
     fn can_receive_push() {
@@ -528,8 +526,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)] // This relies on tripping a `debug_assert`.
     #[should_panic(expected = "Do not encode data before the stream is initialized")]
     fn check_underflow_on_closed_pushes() {
+        use neqo_common::Role;
+
+        use crate::{Http3Parameters, connection::Http3Connection};
+
         let events = Http3ClientEvents::default();
         let mut pc = PushController::new(1, events);
         assert!(pc.can_receive_push());

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -410,7 +410,7 @@ impl PushController {
         if self.max_concurent_push > 0
             && (self.current_max_push_id + 1 - push_done) <= (self.max_concurent_push / 2).into()
         {
-            self.current_max_push_id = push_done + self.max_concurent_push;
+            self.current_max_push_id = push_done + self.max_concurent_push - 1;
             base_handler.queue_control_frame(&HFrame::MaxPushId {
                 push_id: self.current_max_push_id,
             });

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -404,8 +404,11 @@ impl PushController {
 
     pub fn maybe_send_max_push_id_frame(&mut self, base_handler: &mut Http3Connection) {
         let push_done = self.push_streams.number_done();
+        // Note: (1) `current_max_push_id` is not a count, but the maximum possible value,
+        // so the zero-based index needs to have one added.
+        // (2) This relies on rounding toward zero when `max_concurrent_push == 1`.
         if self.max_concurent_push > 0
-            && (self.current_max_push_id - push_done) <= (self.max_concurent_push / 2).into()
+            && (self.current_max_push_id + 1 - push_done) <= (self.max_concurent_push / 2).into()
         {
             self.current_max_push_id = push_done + self.max_concurent_push;
             base_handler.queue_control_frame(&HFrame::MaxPushId {
@@ -509,7 +512,10 @@ impl HttpRecvStreamEvents for RecvPushEvents {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use super::{Http3ClientEvents, PushController};
+    use neqo_common::Role;
+
+    use super::{CloseType, Http3ClientEvents, PushController, PushId, StreamId};
+    use crate::{Http3Parameters, connection::Http3Connection};
 
     #[test]
     fn can_receive_push() {
@@ -519,5 +525,24 @@ mod tests {
 
         let enabled = PushController::new(1, events);
         assert!(enabled.can_receive_push());
+    }
+
+    #[test]
+    #[should_panic(expected = "Do not encode data before the stream is initialized")]
+    fn drop_all() {
+        let events = Http3ClientEvents::default();
+        let mut pc = PushController::new(1, events);
+        assert!(pc.can_receive_push());
+
+        let push = PushId::from(0);
+        let stream = StreamId::from(7);
+        assert!(pc.add_new_push_stream(push, stream).unwrap());
+        pc.push_stream_reset(push, CloseType::Done);
+        assert_eq!(pc.push_streams.number_done(), PushId::from(1));
+
+        // This connection won't need to do anything aside from enqueue a frame.
+        // This fails, but we check that the panic message is correct.
+        let mut conn = Http3Connection::new(Http3Parameters::default(), Role::Client);
+        pc.maybe_send_max_push_id_frame(&mut conn);
     }
 }

--- a/neqo-http3/src/push_id.rs
+++ b/neqo-http3/src/push_id.rs
@@ -49,6 +49,14 @@ impl Sub for PushId {
     }
 }
 
+impl Sub<u64> for PushId {
+    type Output = Self;
+
+    fn sub(self, rhs: u64) -> Self {
+        Self(self.0 - rhs)
+    }
+}
+
 impl Add<u64> for PushId {
     type Output = Self;
 


### PR DESCRIPTION
This is the code-minimal version of the change.

A more complete change would involve changing the meaning of `max_current_push_id` to `max_push_count` or similar, from which the value sent in the frame would be derived.

That's more intrusive, and we don't really care much about this code, so that's probably fine.

BTW, the concrete consequence of this particular underflow is that we don't send a frame when there are no active push streams, even if we probably should.  That will lock up server push completely, which would be pretty bad if we cared about it.  The catch, thanks to @uwezkhan, is a good one.

Closes #3706.