### PR TITLE
Fix new clippy lints in Rust 1.98

### DIFF
--- a/neqo-qpack/src/huffman.rs
+++ b/neqo-qpack/src/huffman.rs
@@ -25,7 +25,7 @@ impl<'a> BitReader<'a> {
         }
     }
 
-    pub fn read_bit(&mut self) -> Res<u8> {
+    pub const fn read_bit(&mut self) -> Res<u8> {
         if self.input.len() == self.offset {
             return Err(Error::NeedMoreData);
         }
@@ -41,7 +41,7 @@ impl<'a> BitReader<'a> {
         Ok((self.input[self.offset] >> self.current_bit) & 0x01)
     }
 
-    pub fn verify_ending(&mut self, i: u8) -> Res<()> {
+    pub const fn verify_ending(&mut self, i: u8) -> Res<()> {
         if (i + self.current_bit) > 7 {
             return Err(Error::HuffmanDecompression);
         }

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -1039,6 +1039,11 @@ impl Display for Loss {
 
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(
+    clippy::allow_attributes,
+    clippy::single_range_in_vec_init,
+    reason = "TODO: false positive in clippy 1.98-nightly; re-check when bumping MSRV"
+)]
 mod tests {
     use std::{
         cell::RefCell,

--- a/neqo-transport/src/recovery/sent.rs
+++ b/neqo-transport/src/recovery/sent.rs
@@ -310,6 +310,11 @@ pub const fn make_packet(pn: packet::Number, sent_time: Instant, len: usize) -> 
 
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(
+    clippy::allow_attributes,
+    clippy::single_range_in_vec_init,
+    reason = "TODO: false positive in clippy 1.98-nightly; re-check when bumping MSRV"
+)]
 mod tests {
     use std::{
         cell::OnceCell,


### PR DESCRIPTION
I had a few misfires on some other lints, but those stopped coming up. So this might not be the end of the changes for this time around.