### PR TITLE
clamp webtransport datagram size to avoid prefix underflow

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -874,8 +874,8 @@ impl Http3Client {
     ///
     /// The function returns `NotAvailable` if datagrams are not enabled.
     pub fn webtransport_max_datagram_size(&self, session_id: StreamId) -> Res<u64> {
-        let prefix_len =
-            u64::try_from(Encoder::varint_len(session_id.as_u64())).map_err(|_| Error::Internal)?;
+        let qsid = session_id.as_u64() >> 2;
+        let prefix_len = u64::try_from(Encoder::varint_len(qsid)).map_err(|_| Error::Internal)?;
         Ok(self.conn.max_datagram_size()?.saturating_sub(prefix_len))
     }
 

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -873,14 +873,10 @@ impl Http3Client {
     /// # Errors
     ///
     /// The function returns `NotAvailable` if datagrams are not enabled.
-    ///
-    /// # Panics
-    ///
-    /// This cannot panic. The max varint length is 8.
     pub fn webtransport_max_datagram_size(&self, session_id: StreamId) -> Res<u64> {
-        Ok(self.conn.max_datagram_size()?
-            - u64::try_from(Encoder::varint_len(session_id.as_u64()))
-                .map_err(|_| Error::Internal)?)
+        let prefix_len =
+            u64::try_from(Encoder::varint_len(session_id.as_u64())).map_err(|_| Error::Internal)?;
+        Ok(self.conn.max_datagram_size()?.saturating_sub(prefix_len))
     }
 
     /// Sets the `SendOrder` for a given stream

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -155,3 +155,25 @@ fn datagrams_multiple_session() {
     let wt_session_2 = wt.create_wt_session();
     do_datagram_test(&mut wt, &wt_session_2);
 }
+
+// A peer is allowed to advertise a max_datagram_frame_size smaller than the
+// per-datagram session-id prefix. Once a session lands on a stream id whose
+// varint encoding is longer than the available datagram size (>= 64 needs two
+// bytes), the prefix subtraction must clamp to zero instead of wrapping.
+#[test]
+fn max_datagram_size_smaller_than_session_prefix() {
+    let params = || {
+        wt_default_parameters()
+            .connection_parameters(ConnectionParameters::default().datagram_size(1))
+    };
+    let mut wt = WtTest::new_with_params(params(), params());
+
+    let mut wt_session = wt.create_wt_session();
+    while wt_session.stream_id().as_u64() < 64 {
+        wt_session = wt.create_wt_session();
+    }
+    assert_eq!(Encoder::varint_len(wt_session.stream_id().as_u64()), 2);
+
+    assert_eq!(wt_session.max_datagram_size(), Ok(0));
+    assert_eq!(wt.max_datagram_size(wt_session.stream_id()), Ok(0));
+}

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -157,9 +157,10 @@ fn datagrams_multiple_session() {
 }
 
 // A peer is allowed to advertise a max_datagram_frame_size smaller than the
-// per-datagram session-id prefix. Once a session lands on a stream id whose
-// varint encoding is longer than the available datagram size (>= 64 needs two
-// bytes), the prefix subtraction must clamp to zero instead of wrapping.
+// per-datagram quarter-stream-id prefix. Once a session lands on a stream id
+// whose quarter stream id needs a longer varint than the available datagram
+// size (quarter stream id >= 64, i.e. stream id >= 256, needs two bytes), the
+// prefix subtraction must clamp to zero instead of wrapping.
 #[test]
 fn max_datagram_size_smaller_than_session_prefix() {
     let params = || {
@@ -169,10 +170,10 @@ fn max_datagram_size_smaller_than_session_prefix() {
     let mut wt = WtTest::new_with_params(params(), params());
 
     let mut wt_session = wt.create_wt_session();
-    while wt_session.stream_id().as_u64() < 64 {
+    while wt_session.stream_id().as_u64() < 256 {
         wt_session = wt.create_wt_session();
     }
-    assert_eq!(Encoder::varint_len(wt_session.stream_id().as_u64()), 2);
+    assert_eq!(Encoder::varint_len(wt_session.stream_id().as_u64() >> 2), 2);
 
     assert_eq!(wt_session.max_datagram_size(), Ok(0));
     assert_eq!(wt.max_datagram_size(wt_session.stream_id()), Ok(0));

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -371,17 +371,13 @@ impl WebTransportRequest {
     /// # Errors
     ///
     /// The function returns `NotAvailable` if datagrams are not enabled.
-    ///
-    /// # Panics
-    ///
-    /// This cannot panic. The max varint length is 8.
     pub fn max_datagram_size(&self) -> Res<u64> {
         let max_size = self.stream_handler.conn.borrow().max_datagram_size()?;
-        Ok(max_size
-            - u64::try_from(Encoder::varint_len(
-                self.stream_handler.stream_id().as_u64(),
-            ))
-            .map_err(|_| Error::Internal)?)
+        let prefix_len = u64::try_from(Encoder::varint_len(
+            self.stream_handler.stream_id().as_u64(),
+        ))
+        .map_err(|_| Error::Internal)?;
+        Ok(max_size.saturating_sub(prefix_len))
     }
 
     /// Export keying material for this WebTransport session

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -374,7 +374,7 @@ impl WebTransportRequest {
     pub fn max_datagram_size(&self) -> Res<u64> {
         let max_size = self.stream_handler.conn.borrow().max_datagram_size()?;
         let prefix_len = u64::try_from(Encoder::varint_len(
-            self.stream_handler.stream_id().as_u64(),
+            self.stream_handler.stream_id().as_u64() >> 2,
         ))
         .map_err(|_| Error::Internal)?;
         Ok(max_size.saturating_sub(prefix_len))


### PR DESCRIPTION
Repro: a peer advertises `max_datagram_frame_size=1` and a WebTransport session lands on a stream id >= 64 (two-byte varint), then the application queries the datagram size.

Cause: both the client (`webtransport_max_datagram_size`) and the server (`WebTransportRequest::max_datagram_size`) take `Connection::max_datagram_size()` and subtract the session-id prefix varint length. The minuend is capped by the peer's `max_datagram_frame_size`, so it can be smaller than the prefix. The old "max varint length is 8" note only bounded the subtrahend.

Fix: `saturating_sub` at both sites.

Before: debug builds panic with subtract-with-overflow; release builds wrap to a near-`u64::MAX` size, so the caller thinks a huge datagram fits and the later send is rejected as `TooMuchData`.
After: returns 0, matching how a session with no usable room is already reported.

Tradeoff: 0 here reads the same as "too small for any payload", but the disabled case still surfaces as the existing `NotAvailable` error, so the only new behavior is the clamp.
