### PR TITLE
Move WebTransport implementation out of core code

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -22,7 +22,6 @@ use neqo_qpack::Stats as QpackStats;
 use neqo_transport::{
     AppError, Connection, ConnectionEvent, ConnectionId, ConnectionIdGenerator, DatagramTracking,
     Output, OutputBatch, Stats as TransportStats, StreamId, StreamType, Version, ZeroRttState,
-    recv_stream, send_stream, streams::SendOrder,
 };
 use nss::{AuthenticationStatus, ResumptionToken, SecretAgentInfo, agent::CertificateInfo};
 
@@ -31,9 +30,7 @@ use crate::{
     ReceiveOutput, Res,
     client_events::{Http3ClientEvent, Http3ClientEvents, WebTransportEvent},
     connection::{Http3Connection, Http3State, RequestDescription},
-    features::{
-        ConnectType, extended_connect::webtransport_session::WebTransportExportKeyingMaterial as _,
-    },
+    features::ConnectType,
     frames::HFrame,
     push_controller::{PushController, RecvPushEvents},
     recv_message::{RecvMessage, RecvMessageInfo},
@@ -339,6 +336,21 @@ impl Http3Client {
             push_handler: Rc::new(RefCell::new(PushController::new(push_streams, events))),
             base_handler,
         }
+    }
+
+    pub(crate) const fn connection(&self) -> &Connection {
+        &self.conn
+    }
+    pub(crate) const fn connection_mut(&mut self) -> &mut Connection {
+        &mut self.conn
+    }
+    pub(crate) const fn handler(&self) -> &Http3Connection {
+        &self.base_handler
+    }
+    pub(crate) const fn connection_and_handler(
+        &mut self,
+    ) -> (&mut Connection, &mut Http3Connection) {
+        (&mut self.conn, &mut self.base_handler)
     }
 
     /// The function returns the current state of the connection.
@@ -864,106 +876,6 @@ impl Http3Client {
         qtrace!("connect_udp_send_datagram session:{session_id:?}");
         self.base_handler
             .connect_udp_send_datagram(session_id, &mut self.conn, buf, id, now)
-    }
-
-    /// Returns the current max size of a datagram that can fit into a packet.
-    /// The value will change over time depending on the encoded size of the
-    /// packet number, ack frames, etc.
-    ///
-    /// # Errors
-    ///
-    /// The function returns `NotAvailable` if datagrams are not enabled.
-    ///
-    /// # Panics
-    ///
-    /// This cannot panic. The max varint length is 8.
-    pub fn webtransport_max_datagram_size(&self, session_id: StreamId) -> Res<u64> {
-        Ok(self.conn.max_datagram_size()?
-            - u64::try_from(Encoder::varint_len(session_id.as_u64()))
-                .map_err(|_| Error::Internal)?)
-    }
-
-    /// Sets the `SendOrder` for a given stream
-    ///
-    /// # Errors
-    ///
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn webtransport_set_sendorder(
-        &mut self,
-        stream_id: StreamId,
-        sendorder: Option<SendOrder>,
-    ) -> Res<()> {
-        Http3Connection::stream_set_sendorder(&mut self.conn, stream_id, sendorder)
-    }
-
-    /// Sets the `Fairness` for a given stream
-    ///
-    /// # Errors
-    ///
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    //
-    // TODO: Currently not called in neqo or gecko. It should likely be called at least from gecko.
-    pub fn webtransport_set_fairness(&mut self, stream_id: StreamId, fairness: bool) -> Res<()> {
-        Http3Connection::stream_set_fairness(&mut self.conn, stream_id, fairness)
-    }
-
-    /// Returns the current `send_stream::Stats` of a `WebTransportSendStream`.
-    ///
-    /// # Errors
-    ///
-    /// `InvalidStreamId` if the stream does not exist.
-    pub fn webtransport_send_stream_stats(
-        &mut self,
-        stream_id: StreamId,
-    ) -> Res<send_stream::Stats> {
-        self.base_handler
-            .send_streams_mut()
-            .get_mut(&stream_id)
-            .ok_or(Error::InvalidStreamId)?
-            .stats(&mut self.conn)
-    }
-
-    /// Returns the current `recv_stream::Stats` of a `WebTransportRecvStream`.
-    ///
-    /// # Errors
-    ///
-    /// `InvalidStreamId` if the stream does not exist.
-    pub fn webtransport_recv_stream_stats(
-        &mut self,
-        stream_id: StreamId,
-    ) -> Res<recv_stream::Stats> {
-        self.base_handler
-            .recv_streams_mut()
-            .get_mut(&stream_id)
-            .ok_or(Error::InvalidStreamId)?
-            .stats(&mut self.conn)
-    }
-
-    /// Export WebTransport keying material per
-    /// [draft-ietf-webtrans-http3 §4.8](https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-15.html#section-4.8).
-    ///
-    /// Derives keying material scoped to a specific WebTransport session
-    /// by calling the TLS exporter with label `"EXPORTER-WebTransport"`
-    /// and a context struct that binds the session ID, application label,
-    /// and application context together.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Error::InvalidStreamId` if `session_id` does not
-    /// correspond to an active WebTransport session,
-    /// `Error::InvalidInput` if `out` is empty or `label`/`context`
-    /// exceed 255 bytes, or `Error::Transport` on TLS export failure.
-    pub fn webtransport_export_keying_material(
-        &self,
-        session_id: StreamId,
-        label: &[u8],
-        context: &[u8],
-        out: &mut [u8],
-    ) -> Res<()> {
-        self.base_handler
-            .validate_extended_connect_session(session_id)?;
-        self.conn
-            .webtransport_export_keying_material(session_id, label, context, out)
     }
 
     /// This function combines  `process_input` and `process_output` function.

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -341,12 +341,15 @@ impl Http3Client {
     pub(crate) const fn connection(&self) -> &Connection {
         &self.conn
     }
+
     pub(crate) const fn connection_mut(&mut self) -> &mut Connection {
         &mut self.conn
     }
+
     pub(crate) const fn handler(&self) -> &Http3Connection {
         &self.base_handler
     }
+
     pub(crate) const fn connection_and_handler(
         &mut self,
     ) -> (&mut Connection, &mut Http3Connection) {

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -13,7 +13,7 @@ use crate::{
     features::extended_connect::tests::webtransport::{
         DATAGRAM_SIZE, WtTest, wt_default_parameters,
     },
-    webtransport::WebTransportRequest,
+    webtransport::ServerSession,
 };
 
 const DGRAM: &[u8] = &[0, 100];
@@ -55,7 +55,7 @@ fn no_datagrams() {
     wt.check_no_datagram_received_server();
 }
 
-fn do_datagram_test(wt: &mut WtTest, wt_session: &WebTransportRequest) {
+fn do_datagram_test(wt: &mut WtTest, wt_session: &ServerSession) {
     assert_eq!(
         wt_session.max_datagram_size(),
         Ok(DATAGRAM_SIZE

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -9,10 +9,11 @@ use neqo_transport::{ConnectionParameters, Error as TransportError};
 use test_fixture::now;
 
 use crate::{
-    Error, Http3Parameters, WebTransportRequest,
+    Error, Http3Parameters,
     features::extended_connect::tests::webtransport::{
         DATAGRAM_SIZE, WtTest, wt_default_parameters,
     },
+    webtransport::WebTransportRequest,
 };
 
 const DGRAM: &[u8] = &[0, 100];

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     Error, Header, Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3Parameters,
     Http3Server, Http3ServerEvent, Http3State, SessionAcceptAction, WebTransportEvent,
     features::extended_connect::CloseReason,
-    webtransport::{WebTransport as _, WebTransportRequest, WebTransportServerEvent},
+    webtransport::{ClientSession as _, ServerEvent, ServerSession},
 };
 
 // Leave space for large QUIC header.
@@ -145,7 +145,7 @@ impl WtTest {
     fn negotiate_wt_session(
         &mut self,
         accept: &SessionAcceptAction,
-    ) -> (StreamId, Option<WebTransportRequest>) {
+    ) -> (StreamId, Option<ServerSession>) {
         let wt_session_id = self
             .client
             .webtransport_create_session(now(), ("https", "something.com", "/"), &[])
@@ -155,10 +155,7 @@ impl WtTest {
         let mut wt_server_session = None;
         while let Some(event) = self.server.next_event() {
             match event {
-                Http3ServerEvent::WebTransport(WebTransportServerEvent::NewSession {
-                    session,
-                    headers,
-                }) => {
+                Http3ServerEvent::WebTransport(ServerEvent::NewSession { session, headers }) => {
                     assert_wt(&headers);
                     session.response(accept, now()).unwrap();
                     wt_server_session = Some(session);
@@ -174,7 +171,7 @@ impl WtTest {
         (wt_session_id, wt_server_session)
     }
 
-    fn create_wt_session(&mut self) -> WebTransportRequest {
+    fn create_wt_session(&mut self) -> ServerSession {
         let (wt_session_id, wt_server_session) =
             self.negotiate_wt_session(&SessionAcceptAction::Accept);
         let wt_session_negotiated_event = |e| {
@@ -261,7 +258,7 @@ impl WtTest {
         assert!(event_found);
     }
 
-    pub fn cancel_session_server(&mut self, wt_session: &WebTransportRequest) {
+    pub fn cancel_session_server(&mut self, wt_session: &ServerSession) {
         wt_session.cancel_fetch(Error::HttpNone.code()).unwrap();
         self.exchange_packets();
     }
@@ -271,7 +268,7 @@ impl WtTest {
         id: StreamId,
         expected_reason: &CloseReason,
     ) -> bool {
-        if let Http3ServerEvent::WebTransport(WebTransportServerEvent::SessionClosed {
+        if let Http3ServerEvent::WebTransport(ServerEvent::SessionClosed {
             session,
             reason,
             headers,
@@ -285,7 +282,7 @@ impl WtTest {
 
     pub fn check_session_closed_event_server(
         &self,
-        wt_session: &WebTransportRequest,
+        wt_session: &ServerSession,
         expected_reason: &CloseReason,
     ) {
         let event = self.server.next_event().unwrap();
@@ -449,7 +446,7 @@ impl WtTest {
     }
 
     fn create_wt_stream_server(
-        wt_server_session: &WebTransportRequest,
+        wt_server_session: &ServerSession,
         stream_type: StreamType,
     ) -> Http3OrWebTransportStream {
         wt_server_session.create_stream(stream_type).unwrap()
@@ -475,7 +472,7 @@ impl WtTest {
         let mut recv_data = Vec::new();
         while let Some(event) = self.server.next_event() {
             match event {
-                Http3ServerEvent::WebTransport(WebTransportServerEvent::NewStream(request)) => {
+                Http3ServerEvent::WebTransport(ServerEvent::NewStream(request)) => {
                     assert_eq!(stream_id, request.stream_id());
                     new_stream_received = true;
                 }
@@ -565,7 +562,7 @@ impl WtTest {
                     assert_eq!(expected_error_stream_stop_sending.unwrap(), error);
                     stop_sending_ids_count += 1;
                 }
-                Http3ServerEvent::WebTransport(WebTransportServerEvent::SessionClosed {
+                Http3ServerEvent::WebTransport(ServerEvent::SessionClosed {
                     session,
                     reason,
                     headers,
@@ -592,7 +589,7 @@ impl WtTest {
             .unwrap();
     }
 
-    pub fn session_close_frame_server(wt_session: &WebTransportRequest, error: u32, message: &str) {
+    pub fn session_close_frame_server(wt_session: &ServerSession, error: u32, message: &str) {
         wt_session.close_session(error, message, now()).unwrap();
     }
 
@@ -624,13 +621,13 @@ impl WtTest {
 
     fn check_datagram_received_server(
         &self,
-        expected_session: &WebTransportRequest,
+        expected_session: &ServerSession,
         expected_dgram: &[u8],
     ) {
         let wt_datagram_event = |e| {
             matches!(
                 e,
-                Http3ServerEvent::WebTransport(WebTransportServerEvent::Datagram {
+                Http3ServerEvent::WebTransport(ServerEvent::Datagram {
                     session,
                     datagram
                 }) if session.stream_id() == expected_session.stream_id() && datagram.as_ref() == expected_dgram
@@ -653,7 +650,7 @@ impl WtTest {
         let wt_datagram_event = |e| {
             matches!(
                 e,
-                Http3ServerEvent::WebTransport(WebTransportServerEvent::Datagram { .. })
+                Http3ServerEvent::WebTransport(ServerEvent::Datagram { .. })
             )
         };
         assert!(!self.server.events().any(wt_datagram_event));

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -21,7 +21,8 @@ use test_fixture::{
 use crate::{
     Error, Header, Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3Parameters,
     Http3Server, Http3ServerEvent, Http3State, SessionAcceptAction, WebTransportEvent,
-    WebTransportRequest, WebTransportServerEvent, features::extended_connect::CloseReason,
+    features::extended_connect::CloseReason,
+    webtransport::{WebTransport as _, WebTransportRequest, WebTransportServerEvent},
 };
 
 // Leave space for large QUIC header.

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -18,7 +18,7 @@ use crate::{
         },
     },
     frames::WebTransportFrame,
-    webtransport::WebTransportServerEvent,
+    webtransport::ServerEvent,
 };
 
 #[test]
@@ -120,7 +120,7 @@ fn wt_session_response_with_1xx() {
 
     let mut wt_server_session = None;
     while let Some(event) = wt.server.next_event() {
-        if let Http3ServerEvent::WebTransport(WebTransportServerEvent::NewSession {
+        if let Http3ServerEvent::WebTransport(ServerEvent::NewSession {
             session,
             headers,
         }) = event
@@ -184,7 +184,7 @@ fn wt_session_respone_200_with_fin() {
     wt.exchange_packets();
     let mut wt_server_session = None;
     while let Some(event) = wt.server.next_event() {
-        if let Http3ServerEvent::WebTransport(WebTransportServerEvent::NewSession {
+        if let Http3ServerEvent::WebTransport(ServerEvent::NewSession {
             session,
             headers,
         }) = event

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -10,7 +10,7 @@ use test_fixture::now;
 
 use crate::{
     Error, Header, Http3ClientEvent, Http3OrWebTransportStream, Http3Server, Http3ServerEvent,
-    Http3State, Priority, SessionAcceptAction, WebTransportEvent, WebTransportServerEvent,
+    Http3State, Priority, SessionAcceptAction, WebTransportEvent,
     features::extended_connect::{
         CloseReason,
         tests::webtransport::{
@@ -18,6 +18,7 @@ use crate::{
         },
     },
     frames::WebTransportFrame,
+    webtransport::WebTransportServerEvent,
 };
 
 #[test]

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -120,10 +120,7 @@ fn wt_session_response_with_1xx() {
 
     let mut wt_server_session = None;
     while let Some(event) = wt.server.next_event() {
-        if let Http3ServerEvent::WebTransport(ServerEvent::NewSession {
-            session,
-            headers,
-        }) = event
+        if let Http3ServerEvent::WebTransport(ServerEvent::NewSession { session, headers }) = event
         {
             assert_wt(&headers);
             wt_server_session = Some(session);
@@ -184,10 +181,7 @@ fn wt_session_respone_200_with_fin() {
     wt.exchange_packets();
     let mut wt_server_session = None;
     while let Some(event) = wt.server.next_event() {
-        if let Http3ServerEvent::WebTransport(ServerEvent::NewSession {
-            session,
-            headers,
-        }) = event
+        if let Http3ServerEvent::WebTransport(ServerEvent::NewSession { session, headers }) = event
         {
             assert_wt(&headers);
             wt_server_session = Some(session);

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
@@ -9,6 +9,7 @@ use neqo_transport::StreamType;
 use crate::{
     Error,
     features::extended_connect::{CloseReason, tests::webtransport::WtTest},
+    webtransport::WebTransport as _,
 };
 
 #[test]

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
@@ -9,7 +9,7 @@ use neqo_transport::StreamType;
 use crate::{
     Error,
     features::extended_connect::{CloseReason, tests::webtransport::WtTest},
-    webtransport::WebTransport as _,
+    webtransport::ClientSession as _,
 };
 
 #[test]

--- a/neqo-http3/src/features/extended_connect/webtransport_session.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_session.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use neqo_common::{Bytes, Encoder, Header, Role, qtrace};
-use neqo_transport::{Connection, Error as TransportError, StreamId};
+use neqo_transport::{Connection, StreamId};
 use rustc_hash::FxHashSet as HashSet;
 use sfv::{BareItem, Item, Parser};
 
@@ -257,43 +257,5 @@ impl Protocol for Session {
             "[{self}] WebTransport does not support datagram capsules."
         );
         Ok(())
-    }
-}
-
-pub trait WebTransportExportKeyingMaterial {
-    fn webtransport_export_keying_material(
-        &self,
-        session_id: StreamId,
-        label: &[u8],
-        context: &[u8],
-        out: &mut [u8],
-    ) -> Res<()>;
-}
-
-impl WebTransportExportKeyingMaterial for Connection {
-    fn webtransport_export_keying_material(
-        &self,
-        session_id: StreamId,
-        label: &[u8],
-        context: &[u8],
-        out: &mut [u8],
-    ) -> Res<()> {
-        // encode_vec(1, …) uses a 1-byte length prefix, so max 255 bytes.
-        if out.is_empty() || label.len() > 255 || context.len() > 255 {
-            return Err(Error::InvalidInput);
-        }
-
-        let mut wt_context = Encoder::with_capacity(
-            Encoder::varint_len(session_id.as_u64()) + 1 + label.len() + 1 + context.len(),
-        );
-        wt_context.encode_varint(session_id.as_u64());
-        wt_context.encode_vec(1, label);
-        wt_context.encode_vec(1, context);
-
-        self.export_keying_material("EXPORTER-WebTransport", wt_context.as_ref(), out)
-            .map_err(|e| match e {
-                TransportError::InvalidInput => Error::InvalidInput,
-                other => Error::Transport(other),
-            })
     }
 }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -24,8 +24,8 @@ implementation is not meant to be used in production and its only purpose is to 
 of the client-side code.
 
 __`WebTransport`__
-([draft version 2](https://datatracker.ietf.org/doc/html/draft-vvv-webtransport-http3-02)) is
-supported and can be enabled using [`Http3Parameters`](struct.Http3Parameters.html).
+WebTransport is supported
+and can be enabled using [`Http3Parameters`](struct.Http3Parameters.html).
 
 ## Interaction with an application
 
@@ -161,6 +161,7 @@ mod server_connection_events;
 mod server_events;
 mod settings;
 mod stream_type_reader;
+pub mod webtransport;
 
 use std::{cell::RefCell, fmt::Debug, rc::Rc, time::Instant};
 
@@ -180,7 +181,6 @@ pub use push_id::PushId;
 pub use server::Http3Server;
 pub use server_events::{
     ConnectUdpRequest, ConnectUdpServerEvent, Http3OrWebTransportStream, Http3ServerEvent,
-    WebTransportRequest, WebTransportServerEvent,
 };
 #[cfg(fuzzing)]
 pub use settings::HSettings;

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -30,7 +30,7 @@ use crate::{
         ConnectUdpRequest, Http3OrWebTransportStream, Http3ServerEvent, Http3ServerEvents,
     },
     settings::HttpZeroRttChecker,
-    webtransport::{WebTransportRequest, WebTransportServerEvents as _},
+    webtransport::{ServerEvents as _, ServerSession},
 };
 
 type HandlerRef = Rc<RefCell<Http3ServerHandler>>;
@@ -257,7 +257,7 @@ impl Http3Server {
                         headers,
                     }) => {
                         self.events.webtransport_new_session(
-                            WebTransportRequest::new(conn.clone(), Rc::clone(handler), stream_id),
+                            ServerSession::new(conn.clone(), Rc::clone(handler), stream_id),
                             headers,
                         );
                     }
@@ -276,7 +276,7 @@ impl Http3Server {
                         headers,
                         ..
                     }) => self.events.webtransport_session_closed(
-                        WebTransportRequest::new(conn.clone(), Rc::clone(handler), stream_id),
+                        ServerSession::new(conn.clone(), Rc::clone(handler), stream_id),
                         reason,
                         headers,
                     ),
@@ -304,7 +304,7 @@ impl Http3Server {
                         datagram,
                     }) => {
                         self.events.webtransport_datagram(
-                            WebTransportRequest::new(conn.clone(), Rc::clone(handler), session_id),
+                            ServerSession::new(conn.clone(), Rc::clone(handler), session_id),
                             datagram,
                         );
                     }

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -28,9 +28,9 @@ use crate::{
     server_connection_events::{ConnectUdpEvent, Http3ServerConnEvent, WebTransportEvent},
     server_events::{
         ConnectUdpRequest, Http3OrWebTransportStream, Http3ServerEvent, Http3ServerEvents,
-        WebTransportRequest,
     },
     settings::HttpZeroRttChecker,
+    webtransport::{WebTransportRequest, WebTransportServerEvents as _},
 };
 
 type HandlerRef = Rc<RefCell<Http3ServerHandler>>;

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -21,7 +21,6 @@ use crate::{
     connection::{Http3State, SessionAcceptAction},
     connection_server::Http3ServerHandler,
     features::extended_connect,
-    webtransport::WebTransportServerEvent,
 };
 
 #[derive(Debug, Clone)]
@@ -401,7 +400,7 @@ pub enum Http3ServerEvent {
         stream_id: StreamId,
         priority: Priority,
     },
-    WebTransport(WebTransportServerEvent),
+    WebTransport(crate::webtransport::ServerEvent),
     ConnectUdp(ConnectUdpServerEvent),
 }
 

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -13,19 +13,15 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{Bytes, Encoder, Header, qdebug};
-use neqo_transport::{
-    AppError, Connection, DatagramTracking, StreamId, StreamType, server::ConnectionRef,
-};
+use neqo_common::{Bytes, Header, qdebug};
+use neqo_transport::{AppError, Connection, DatagramTracking, StreamId, server::ConnectionRef};
 
 use crate::{
-    Error, Http3StreamInfo, Http3StreamType, Priority, Res,
+    Http3StreamInfo, Http3StreamType, Priority, Res,
     connection::{Http3State, SessionAcceptAction},
     connection_server::Http3ServerHandler,
-    features::{
-        extended_connect,
-        extended_connect::webtransport_session::WebTransportExportKeyingMaterial as _,
-    },
+    features::extended_connect,
+    webtransport::WebTransportServerEvent,
 };
 
 #[derive(Debug, Clone)]
@@ -237,176 +233,6 @@ impl PartialEq for Http3OrWebTransportStream {
 impl Eq for Http3OrWebTransportStream {}
 
 #[derive(Debug, Clone)]
-pub struct WebTransportRequest {
-    stream_handler: StreamHandler,
-}
-
-impl Display for WebTransportRequest {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "WebTransport session {}", self.stream_handler)
-    }
-}
-
-impl WebTransportRequest {
-    pub(crate) const fn new(
-        conn: ConnectionRef,
-        handler: Rc<RefCell<Http3ServerHandler>>,
-        stream_id: StreamId,
-    ) -> Self {
-        Self {
-            stream_handler: StreamHandler {
-                conn,
-                handler,
-                stream_info: Http3StreamInfo::new(stream_id, Http3StreamType::Http),
-            },
-        }
-    }
-
-    #[must_use]
-    pub fn state(&self) -> Http3State {
-        self.stream_handler.handler.borrow().state()
-    }
-
-    /// Respond to a `WebTransport` session request.
-    ///
-    /// # Errors
-    ///
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn response(&self, accept: &SessionAcceptAction, now: Instant) -> Res<()> {
-        qdebug!("[{self}] Set a response for a WebTransport session");
-        self.stream_handler
-            .handler
-            .borrow_mut()
-            .webtransport_session_accept(
-                &mut self.stream_handler.conn.borrow_mut(),
-                self.stream_handler.stream_info.stream_id(),
-                accept,
-                now,
-            )
-    }
-
-    /// # Errors
-    ///
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    /// Also return an error if the stream was closed on the transport layer,
-    /// but that information is not yet consumed on the  http/3 layer.
-    pub fn close_session(&self, error: u32, message: &str, now: Instant) -> Res<()> {
-        self.stream_handler
-            .handler
-            .borrow_mut()
-            .webtransport_close_session(
-                &mut self.stream_handler.conn.borrow_mut(),
-                self.stream_handler.stream_info.stream_id(),
-                error,
-                message,
-                now,
-            )
-    }
-
-    #[must_use]
-    pub const fn stream_id(&self) -> StreamId {
-        self.stream_handler.stream_id()
-    }
-
-    /// Create `WebTransport` stream.
-    ///
-    /// # Errors
-    ///
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn create_stream(&self, stream_type: StreamType) -> Res<Http3OrWebTransportStream> {
-        let session_id = self.stream_handler.stream_id();
-        let id = self
-            .stream_handler
-            .handler
-            .borrow_mut()
-            .webtransport_create_stream(
-                &mut self.stream_handler.conn.borrow_mut(),
-                session_id,
-                stream_type,
-            )?;
-
-        Ok(Http3OrWebTransportStream::new(
-            self.stream_handler.conn.clone(),
-            Rc::clone(&self.stream_handler.handler),
-            Http3StreamInfo::new(id, Http3StreamType::WebTransport(session_id)),
-        ))
-    }
-
-    /// Send `WebTransport` datagram.
-    ///
-    /// # Errors
-    ///
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    /// The function returns `TooMuchData` if the supply buffer is bigger than
-    /// the allowed remote datagram size.
-    pub fn send_datagram<I: Into<DatagramTracking>>(
-        &self,
-        buf: &[u8],
-        id: I,
-        now: Instant,
-    ) -> Res<()> {
-        let session_id = self.stream_handler.stream_id();
-        self.stream_handler
-            .handler
-            .borrow_mut()
-            .webtransport_send_datagram(
-                &mut self.stream_handler.conn.borrow_mut(),
-                session_id,
-                buf,
-                id,
-                now,
-            )
-    }
-
-    // TODO: Currently not called in neqo or gecko. It should likely be called at least from gecko.
-    #[must_use]
-    pub fn remote_datagram_size(&self) -> u64 {
-        self.stream_handler.conn.borrow().remote_datagram_size()
-    }
-
-    /// Returns the current max size of a datagram that can fit into a packet.
-    /// The value will change over time depending on the encoded size of the
-    /// packet number, ack frames, etc.
-    ///
-    /// # Errors
-    ///
-    /// The function returns `NotAvailable` if datagrams are not enabled.
-    ///
-    /// # Panics
-    ///
-    /// This cannot panic. The max varint length is 8.
-    pub fn max_datagram_size(&self) -> Res<u64> {
-        let max_size = self.stream_handler.conn.borrow().max_datagram_size()?;
-        Ok(max_size
-            - u64::try_from(Encoder::varint_len(
-                self.stream_handler.stream_id().as_u64(),
-            ))
-            .map_err(|_| Error::Internal)?)
-    }
-
-    /// Export keying material for this WebTransport session
-    /// (draft-ietf-webtrans-http3 §4.8).
-    ///
-    /// # Errors
-    ///
-    /// Returns `Error::InvalidStreamId` if the session is no longer active,
-    /// `Error::InvalidInput` if `out` is empty or `label`/`context`
-    /// exceed 255 bytes, or `Error::Transport` if the connection is not ready
-    /// or the TLS export fails.
-    pub fn export_keying_material(&self, label: &[u8], context: &[u8], out: &mut [u8]) -> Res<()> {
-        let session_id = self.stream_handler.stream_id();
-        self.stream_handler
-            .handler
-            .borrow()
-            .validate_extended_connect_session(session_id)?;
-        self.stream_handler
-            .conn
-            .borrow()
-            .webtransport_export_keying_material(session_id, label, context, out)
-    }
-}
-
-#[derive(Debug, Clone)]
 pub struct ConnectUdpRequest {
     stream_handler: StreamHandler,
 }
@@ -523,31 +349,6 @@ impl ConnectUdpRequest {
     }
 }
 
-impl Deref for WebTransportRequest {
-    type Target = StreamHandler;
-    fn deref(&self) -> &Self::Target {
-        &self.stream_handler
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum WebTransportServerEvent {
-    NewSession {
-        session: WebTransportRequest,
-        headers: Vec<Header>,
-    },
-    SessionClosed {
-        session: WebTransportRequest,
-        reason: extended_connect::session::CloseReason,
-        headers: Option<Vec<Header>>,
-    },
-    NewStream(Http3OrWebTransportStream),
-    Datagram {
-        session: WebTransportRequest,
-        datagram: Bytes,
-    },
-}
-
 #[derive(Debug, Clone)]
 pub enum ConnectUdpServerEvent {
     NewSession {
@@ -610,7 +411,7 @@ pub struct Http3ServerEvents {
 }
 
 impl Http3ServerEvents {
-    fn insert(&self, event: Http3ServerEvent) {
+    pub(crate) fn insert(&self, event: Http3ServerEvent) {
         self.events.borrow_mut().push_back(event);
     }
 
@@ -708,34 +509,9 @@ impl Http3ServerEvents {
         });
     }
 
-    pub(crate) fn webtransport_new_session(
-        &self,
-        session: WebTransportRequest,
-        headers: Vec<Header>,
-    ) {
-        self.insert(Http3ServerEvent::WebTransport(
-            WebTransportServerEvent::NewSession { session, headers },
-        ));
-    }
-
     pub(crate) fn connect_udp_new_session(&self, session: ConnectUdpRequest, headers: Vec<Header>) {
         self.insert(Http3ServerEvent::ConnectUdp(
             ConnectUdpServerEvent::NewSession { session, headers },
-        ));
-    }
-
-    pub(crate) fn webtransport_session_closed(
-        &self,
-        session: WebTransportRequest,
-        reason: extended_connect::session::CloseReason,
-        headers: Option<Vec<Header>>,
-    ) {
-        self.insert(Http3ServerEvent::WebTransport(
-            WebTransportServerEvent::SessionClosed {
-                session,
-                reason,
-                headers,
-            },
         ));
     }
 
@@ -754,17 +530,6 @@ impl Http3ServerEvents {
         ));
     }
 
-    pub(crate) fn webtransport_new_stream(&self, stream: Http3OrWebTransportStream) {
-        self.insert(Http3ServerEvent::WebTransport(
-            WebTransportServerEvent::NewStream(stream),
-        ));
-    }
-
-    pub(crate) fn webtransport_datagram(&self, session: WebTransportRequest, datagram: Bytes) {
-        self.insert(Http3ServerEvent::WebTransport(
-            WebTransportServerEvent::Datagram { session, datagram },
-        ));
-    }
     pub(crate) fn connect_udp_datagram(&self, session: ConnectUdpRequest, datagram: Bytes) {
         self.insert(Http3ServerEvent::ConnectUdp(
             ConnectUdpServerEvent::Datagram { session, datagram },

--- a/neqo-http3/src/webtransport.rs
+++ b/neqo-http3/src/webtransport.rs
@@ -1,0 +1,437 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{
+    cell::RefCell,
+    fmt::{self, Display, Formatter},
+    ops::Deref,
+    rc::Rc,
+    time::Instant,
+};
+
+use neqo_common::{Bytes, Encoder, Header, qdebug};
+use neqo_transport::{
+    Connection, DatagramTracking, Error as TransportError, StreamId, StreamType, recv_stream,
+    send_stream, server::ConnectionRef, streams::SendOrder,
+};
+
+use crate::{
+    Error, Http3Client, Http3OrWebTransportStream, Http3ServerEvent, Http3State, Http3StreamInfo,
+    Http3StreamType, Res, SessionAcceptAction,
+    connection::Http3Connection,
+    connection_server::Http3ServerHandler,
+    features::extended_connect,
+    server_events::{Http3ServerEvents, StreamHandler},
+};
+
+pub trait WebTransport {
+    /// Returns the current max size of a datagram that can fit into a packet.
+    /// The value will change over time depending on the encoded size of the
+    /// packet number, ack frames, etc.
+    ///
+    /// # Errors
+    ///
+    /// The function returns `NotAvailable` if datagrams are not enabled.
+    ///
+    /// # Panics
+    ///
+    /// This cannot panic. The max varint length is 8.
+    fn webtransport_max_datagram_size(&self, session_id: StreamId) -> Res<u64>;
+
+    /// Sets the `SendOrder` for a given stream
+    ///
+    /// # Errors
+    ///
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    fn webtransport_set_sendorder(
+        &mut self,
+        stream_id: StreamId,
+        sendorder: Option<SendOrder>,
+    ) -> Res<()>;
+
+    /// Sets the `Fairness` for a given stream
+    ///
+    /// # Errors
+    ///
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    //
+    // TODO: Currently not called in neqo or gecko. It should likely be called at least from gecko.
+    fn webtransport_set_fairness(&mut self, stream_id: StreamId, fairness: bool) -> Res<()>;
+
+    /// Returns the current `send_stream::Stats` of a `WebTransportSendStream`.
+    ///
+    /// # Errors
+    ///
+    /// `InvalidStreamId` if the stream does not exist.
+    fn webtransport_send_stream_stats(&mut self, stream_id: StreamId) -> Res<send_stream::Stats>;
+
+    /// Returns the current `recv_stream::Stats` of a `WebTransportRecvStream`.
+    ///
+    /// # Errors
+    ///
+    /// `InvalidStreamId` if the stream does not exist.
+    fn webtransport_recv_stream_stats(&mut self, stream_id: StreamId) -> Res<recv_stream::Stats>;
+
+    /// Export WebTransport keying material per
+    /// [draft-ietf-webtrans-http3 §4.8](https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-15.html#section-4.8).
+    ///
+    /// Derives keying material scoped to a specific WebTransport session
+    /// by calling the TLS exporter with label `"EXPORTER-WebTransport"`
+    /// and a context struct that binds the session ID, application label,
+    /// and application context together.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::InvalidStreamId` if `session_id` does not
+    /// correspond to an active WebTransport session,
+    /// `Error::InvalidInput` if `out` is empty or `label`/`context`
+    /// exceed 255 bytes, or `Error::Transport` on TLS export failure.
+    fn webtransport_export_keying_material(
+        &self,
+        session_id: StreamId,
+        label: &[u8],
+        context: &[u8],
+        out: &mut [u8],
+    ) -> Res<()>;
+}
+
+impl WebTransport for Http3Client {
+    fn webtransport_max_datagram_size(&self, session_id: StreamId) -> Res<u64> {
+        let qsid_len = Encoder::varint_len(session_id.as_u64() >> 2);
+        Ok(self
+            .connection()
+            .max_datagram_size()?
+            .saturating_sub(u64::try_from(qsid_len).map_err(|_| Error::Internal)?))
+    }
+
+    fn webtransport_set_sendorder(
+        &mut self,
+        stream_id: StreamId,
+        sendorder: Option<SendOrder>,
+    ) -> Res<()> {
+        Http3Connection::stream_set_sendorder(self.connection_mut(), stream_id, sendorder)
+    }
+
+    fn webtransport_set_fairness(&mut self, stream_id: StreamId, fairness: bool) -> Res<()> {
+        Http3Connection::stream_set_fairness(self.connection_mut(), stream_id, fairness)
+    }
+
+    fn webtransport_send_stream_stats(&mut self, stream_id: StreamId) -> Res<send_stream::Stats> {
+        let (conn, handler) = self.connection_and_handler();
+        handler
+            .send_streams_mut()
+            .get_mut(&stream_id)
+            .ok_or(Error::InvalidStreamId)?
+            .stats(conn)
+    }
+
+    fn webtransport_recv_stream_stats(&mut self, stream_id: StreamId) -> Res<recv_stream::Stats> {
+        let (conn, handler) = self.connection_and_handler();
+        handler
+            .recv_streams_mut()
+            .get_mut(&stream_id)
+            .ok_or(Error::InvalidStreamId)?
+            .stats(conn)
+    }
+
+    fn webtransport_export_keying_material(
+        &self,
+        session_id: StreamId,
+        label: &[u8],
+        context: &[u8],
+        out: &mut [u8],
+    ) -> Res<()> {
+        self.handler()
+            .validate_extended_connect_session(session_id)?;
+        self.connection()
+            .webtransport_export_keying_material(session_id, label, context, out)
+    }
+}
+
+pub trait WebTransportExportKeyingMaterial {
+    /// Export keying material for WebTransport.
+    ///
+    /// # Errors
+    /// When the input is invalid or the underlying connection fails to export.
+    fn webtransport_export_keying_material(
+        &self,
+        session_id: StreamId,
+        label: &[u8],
+        context: &[u8],
+        out: &mut [u8],
+    ) -> Res<()>;
+}
+
+impl WebTransportExportKeyingMaterial for Connection {
+    fn webtransport_export_keying_material(
+        &self,
+        session_id: StreamId,
+        label: &[u8],
+        context: &[u8],
+        out: &mut [u8],
+    ) -> Res<()> {
+        // encode_vec(1, …) uses a 1-byte length prefix, so max 255 bytes.
+        if out.is_empty() || label.len() > 255 || context.len() > 255 {
+            return Err(Error::InvalidInput);
+        }
+
+        let mut wt_context = Encoder::with_capacity(
+            Encoder::varint_len(session_id.as_u64()) + 1 + label.len() + 1 + context.len(),
+        );
+        wt_context.encode_varint(session_id.as_u64());
+        wt_context.encode_vec(1, label);
+        wt_context.encode_vec(1, context);
+
+        self.export_keying_material("EXPORTER-WebTransport", wt_context.as_ref(), out)
+            .map_err(|e| match e {
+                TransportError::InvalidInput => Error::InvalidInput,
+                other => Error::Transport(other),
+            })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WebTransportRequest {
+    stream_handler: StreamHandler,
+}
+
+impl Display for WebTransportRequest {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "WebTransport session {}", self.stream_handler)
+    }
+}
+
+impl WebTransportRequest {
+    pub(crate) const fn new(
+        conn: ConnectionRef,
+        handler: Rc<RefCell<Http3ServerHandler>>,
+        stream_id: StreamId,
+    ) -> Self {
+        Self {
+            stream_handler: StreamHandler {
+                conn,
+                handler,
+                stream_info: Http3StreamInfo::new(stream_id, Http3StreamType::Http),
+            },
+        }
+    }
+
+    #[must_use]
+    pub fn state(&self) -> Http3State {
+        self.stream_handler.handler.borrow().state()
+    }
+
+    /// Respond to a `WebTransport` session request.
+    ///
+    /// # Errors
+    ///
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn response(&self, accept: &SessionAcceptAction, now: Instant) -> Res<()> {
+        qdebug!("[{self}] Set a response for a WebTransport session");
+        self.stream_handler
+            .handler
+            .borrow_mut()
+            .webtransport_session_accept(
+                &mut self.stream_handler.conn.borrow_mut(),
+                self.stream_handler.stream_info.stream_id(),
+                accept,
+                now,
+            )
+    }
+
+    /// # Errors
+    ///
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    /// Also return an error if the stream was closed on the transport layer,
+    /// but that information is not yet consumed on the  http/3 layer.
+    pub fn close_session(&self, error: u32, message: &str, now: Instant) -> Res<()> {
+        self.stream_handler
+            .handler
+            .borrow_mut()
+            .webtransport_close_session(
+                &mut self.stream_handler.conn.borrow_mut(),
+                self.stream_handler.stream_info.stream_id(),
+                error,
+                message,
+                now,
+            )
+    }
+
+    #[must_use]
+    pub const fn stream_id(&self) -> StreamId {
+        self.stream_handler.stream_id()
+    }
+
+    /// Create `WebTransport` stream.
+    ///
+    /// # Errors
+    ///
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn create_stream(&self, stream_type: StreamType) -> Res<Http3OrWebTransportStream> {
+        let session_id = self.stream_handler.stream_id();
+        let id = self
+            .stream_handler
+            .handler
+            .borrow_mut()
+            .webtransport_create_stream(
+                &mut self.stream_handler.conn.borrow_mut(),
+                session_id,
+                stream_type,
+            )?;
+
+        Ok(Http3OrWebTransportStream::new(
+            self.stream_handler.conn.clone(),
+            Rc::clone(&self.stream_handler.handler),
+            Http3StreamInfo::new(id, Http3StreamType::WebTransport(session_id)),
+        ))
+    }
+
+    /// Send `WebTransport` datagram.
+    ///
+    /// # Errors
+    ///
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    /// The function returns `TooMuchData` if the supply buffer is bigger than
+    /// the allowed remote datagram size.
+    pub fn send_datagram<I: Into<DatagramTracking>>(
+        &self,
+        buf: &[u8],
+        id: I,
+        now: Instant,
+    ) -> Res<()> {
+        let session_id = self.stream_handler.stream_id();
+        self.stream_handler
+            .handler
+            .borrow_mut()
+            .webtransport_send_datagram(
+                &mut self.stream_handler.conn.borrow_mut(),
+                session_id,
+                buf,
+                id,
+                now,
+            )
+    }
+
+    // TODO: Currently not called in neqo or gecko. It should likely be called at least from gecko.
+    #[must_use]
+    pub fn remote_datagram_size(&self) -> u64 {
+        self.stream_handler.conn.borrow().remote_datagram_size()
+    }
+
+    /// Returns the current max size of a datagram that can fit into a packet.
+    /// The value will change over time depending on the encoded size of the
+    /// packet number, ack frames, etc.
+    ///
+    /// # Errors
+    ///
+    /// The function returns `NotAvailable` if datagrams are not enabled.
+    ///
+    /// # Panics
+    ///
+    /// This cannot panic. The max varint length is 8.
+    pub fn max_datagram_size(&self) -> Res<u64> {
+        let qsid_len = Encoder::varint_len(self.stream_handler.stream_id().as_u64() >> 2);
+        Ok(self
+            .stream_handler
+            .conn
+            .borrow()
+            .max_datagram_size()?
+            .saturating_sub(u64::try_from(qsid_len).map_err(|_| Error::Internal)?))
+    }
+
+    /// Export keying material for this WebTransport session
+    /// (draft-ietf-webtrans-http3 §4.8).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::InvalidStreamId` if the session is no longer active,
+    /// `Error::InvalidInput` if `out` is empty or `label`/`context`
+    /// exceed 255 bytes, or `Error::Transport` if the connection is not ready
+    /// or the TLS export fails.
+    pub fn export_keying_material(&self, label: &[u8], context: &[u8], out: &mut [u8]) -> Res<()> {
+        let session_id = self.stream_handler.stream_id();
+        self.stream_handler
+            .handler
+            .borrow()
+            .validate_extended_connect_session(session_id)?;
+        self.stream_handler
+            .conn
+            .borrow()
+            .webtransport_export_keying_material(session_id, label, context, out)
+    }
+}
+
+impl Deref for WebTransportRequest {
+    type Target = StreamHandler;
+    fn deref(&self) -> &Self::Target {
+        &self.stream_handler
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum WebTransportServerEvent {
+    NewSession {
+        session: WebTransportRequest,
+        headers: Vec<Header>,
+    },
+    SessionClosed {
+        session: WebTransportRequest,
+        reason: extended_connect::session::CloseReason,
+        headers: Option<Vec<Header>>,
+    },
+    NewStream(Http3OrWebTransportStream),
+    Datagram {
+        session: WebTransportRequest,
+        datagram: Bytes,
+    },
+}
+
+pub trait WebTransportServerEvents {
+    fn webtransport_new_session(&self, session: WebTransportRequest, headers: Vec<Header>);
+    fn webtransport_session_closed(
+        &self,
+        session: WebTransportRequest,
+        reason: extended_connect::session::CloseReason,
+        headers: Option<Vec<Header>>,
+    );
+    fn webtransport_new_stream(&self, stream: Http3OrWebTransportStream);
+    fn webtransport_datagram(&self, session: WebTransportRequest, datagram: Bytes);
+}
+
+impl WebTransportServerEvents for Http3ServerEvents {
+    fn webtransport_new_session(&self, session: WebTransportRequest, headers: Vec<Header>) {
+        self.insert(Http3ServerEvent::WebTransport(
+            WebTransportServerEvent::NewSession { session, headers },
+        ));
+    }
+
+    fn webtransport_session_closed(
+        &self,
+        session: WebTransportRequest,
+        reason: extended_connect::session::CloseReason,
+        headers: Option<Vec<Header>>,
+    ) {
+        self.insert(Http3ServerEvent::WebTransport(
+            WebTransportServerEvent::SessionClosed {
+                session,
+                reason,
+                headers,
+            },
+        ));
+    }
+
+    fn webtransport_new_stream(&self, stream: Http3OrWebTransportStream) {
+        self.insert(Http3ServerEvent::WebTransport(
+            WebTransportServerEvent::NewStream(stream),
+        ));
+    }
+
+    fn webtransport_datagram(&self, session: WebTransportRequest, datagram: Bytes) {
+        self.insert(Http3ServerEvent::WebTransport(
+            WebTransportServerEvent::Datagram { session, datagram },
+        ));
+    }
+}

--- a/neqo-http3/src/webtransport.rs
+++ b/neqo-http3/src/webtransport.rs
@@ -151,7 +151,7 @@ impl WebTransport for Http3Client {
     }
 }
 
-pub trait WebTransportExportKeyingMaterial {
+pub(crate) trait WebTransportExportKeyingMaterial {
     /// Export keying material for WebTransport.
     ///
     /// # Errors
@@ -389,7 +389,7 @@ pub enum WebTransportServerEvent {
     },
 }
 
-pub trait WebTransportServerEvents {
+pub(crate) trait WebTransportServerEvents {
     fn webtransport_new_session(&self, session: WebTransportRequest, headers: Vec<Header>);
     fn webtransport_session_closed(
         &self,

--- a/neqo-http3/src/webtransport.rs
+++ b/neqo-http3/src/webtransport.rs
@@ -27,7 +27,7 @@ use crate::{
     server_events::{Http3ServerEvents, StreamHandler},
 };
 
-pub trait WebTransport {
+pub trait ClientSession {
     /// Returns the current max size of a datagram that can fit into a packet.
     /// The value will change over time depending on the encoded size of the
     /// packet number, ack frames, etc.
@@ -98,7 +98,7 @@ pub trait WebTransport {
     ) -> Res<()>;
 }
 
-impl WebTransport for Http3Client {
+impl ClientSession for Http3Client {
     fn webtransport_max_datagram_size(&self, session_id: StreamId) -> Res<u64> {
         let qsid_len = Encoder::varint_len(session_id.as_u64() >> 2);
         Ok(self
@@ -151,7 +151,7 @@ impl WebTransport for Http3Client {
     }
 }
 
-pub(crate) trait WebTransportExportKeyingMaterial {
+trait ExportKeyingMaterial {
     /// Export keying material for WebTransport.
     ///
     /// # Errors
@@ -165,7 +165,7 @@ pub(crate) trait WebTransportExportKeyingMaterial {
     ) -> Res<()>;
 }
 
-impl WebTransportExportKeyingMaterial for Connection {
+impl ExportKeyingMaterial for Connection {
     fn webtransport_export_keying_material(
         &self,
         session_id: StreamId,
@@ -194,17 +194,17 @@ impl WebTransportExportKeyingMaterial for Connection {
 }
 
 #[derive(Debug, Clone)]
-pub struct WebTransportRequest {
+pub struct ServerSession {
     stream_handler: StreamHandler,
 }
 
-impl Display for WebTransportRequest {
+impl Display for ServerSession {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "WebTransport session {}", self.stream_handler)
     }
 }
 
-impl WebTransportRequest {
+impl ServerSession {
     pub(crate) const fn new(
         conn: ConnectionRef,
         handler: Rc<RefCell<Http3ServerHandler>>,
@@ -364,7 +364,7 @@ impl WebTransportRequest {
     }
 }
 
-impl Deref for WebTransportRequest {
+impl Deref for ServerSession {
     type Target = StreamHandler;
     fn deref(&self) -> &Self::Target {
         &self.stream_handler
@@ -372,66 +372,66 @@ impl Deref for WebTransportRequest {
 }
 
 #[derive(Debug, Clone)]
-pub enum WebTransportServerEvent {
+pub enum ServerEvent {
     NewSession {
-        session: WebTransportRequest,
+        session: ServerSession,
         headers: Vec<Header>,
     },
     SessionClosed {
-        session: WebTransportRequest,
+        session: ServerSession,
         reason: extended_connect::session::CloseReason,
         headers: Option<Vec<Header>>,
     },
     NewStream(Http3OrWebTransportStream),
     Datagram {
-        session: WebTransportRequest,
+        session: ServerSession,
         datagram: Bytes,
     },
 }
 
-pub(crate) trait WebTransportServerEvents {
-    fn webtransport_new_session(&self, session: WebTransportRequest, headers: Vec<Header>);
+pub trait ServerEvents {
+    fn webtransport_new_session(&self, session: ServerSession, headers: Vec<Header>);
     fn webtransport_session_closed(
         &self,
-        session: WebTransportRequest,
+        session: ServerSession,
         reason: extended_connect::session::CloseReason,
         headers: Option<Vec<Header>>,
     );
     fn webtransport_new_stream(&self, stream: Http3OrWebTransportStream);
-    fn webtransport_datagram(&self, session: WebTransportRequest, datagram: Bytes);
+    fn webtransport_datagram(&self, session: ServerSession, datagram: Bytes);
 }
 
-impl WebTransportServerEvents for Http3ServerEvents {
-    fn webtransport_new_session(&self, session: WebTransportRequest, headers: Vec<Header>) {
-        self.insert(Http3ServerEvent::WebTransport(
-            WebTransportServerEvent::NewSession { session, headers },
-        ));
+impl ServerEvents for Http3ServerEvents {
+    fn webtransport_new_session(&self, session: ServerSession, headers: Vec<Header>) {
+        self.insert(Http3ServerEvent::WebTransport(ServerEvent::NewSession {
+            session,
+            headers,
+        }));
     }
 
     fn webtransport_session_closed(
         &self,
-        session: WebTransportRequest,
+        session: ServerSession,
         reason: extended_connect::session::CloseReason,
         headers: Option<Vec<Header>>,
     ) {
-        self.insert(Http3ServerEvent::WebTransport(
-            WebTransportServerEvent::SessionClosed {
-                session,
-                reason,
-                headers,
-            },
-        ));
+        self.insert(Http3ServerEvent::WebTransport(ServerEvent::SessionClosed {
+            session,
+            reason,
+            headers,
+        }));
     }
 
     fn webtransport_new_stream(&self, stream: Http3OrWebTransportStream) {
-        self.insert(Http3ServerEvent::WebTransport(
-            WebTransportServerEvent::NewStream(stream),
-        ));
+        self.insert(Http3ServerEvent::WebTransport(ServerEvent::NewStream(
+            stream,
+        )));
     }
 
-    fn webtransport_datagram(&self, session: WebTransportRequest, datagram: Bytes) {
-        self.insert(Http3ServerEvent::WebTransport(
-            WebTransportServerEvent::Datagram { session, datagram },
-        ));
+    fn webtransport_datagram(&self, session: ServerSession, datagram: Bytes) {
+        self.insert(Http3ServerEvent::WebTransport(ServerEvent::Datagram {
+            session,
+            datagram,
+        }));
     }
 }

--- a/neqo-http3/src/webtransport.rs
+++ b/neqo-http3/src/webtransport.rs
@@ -246,7 +246,7 @@ impl WebTransportRequest {
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     /// Also return an error if the stream was closed on the transport layer,
-    /// but that information is not yet consumed on the  http/3 layer.
+    /// but that information is not yet consumed on the http/3 layer.
     pub fn close_session(&self, error: u32, message: &str, now: Instant) -> Res<()> {
         self.stream_handler
             .handler

--- a/neqo-http3/tests/webtransport.rs
+++ b/neqo-http3/tests/webtransport.rs
@@ -12,7 +12,7 @@ use neqo_common::{event::Provider as _, header::HeadersExt as _};
 use neqo_http3::{
     Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3Parameters, Http3Server,
     Http3ServerEvent, Http3State, SessionAcceptAction, WebTransportEvent,
-    webtransport::{ServerSession, ClientSession as _, ServerEvent},
+    webtransport::{ClientSession as _, ServerEvent, ServerSession},
 };
 use neqo_transport::{ConnectionParameters, StreamId, StreamType};
 use nss::AuthenticationStatus;
@@ -92,10 +92,7 @@ fn create_wt_session(client: &mut Http3Client, server: &mut Http3Server) -> Serv
     let mut wt_server_session = None;
     while let Some(event) = server.next_event() {
         match event {
-            Http3ServerEvent::WebTransport(ServerEvent::NewSession {
-                session,
-                headers,
-            }) => {
+            Http3ServerEvent::WebTransport(ServerEvent::NewSession { session, headers }) => {
                 assert!(
                     headers.contains_header(":method", "CONNECT")
                         && headers.contains_header(":protocol", "webtransport")
@@ -355,10 +352,8 @@ fn wt_race_condition_server_stream_before_confirmation() {
         let wt_server_session = server
             .events()
             .find_map(|event| {
-                if let Http3ServerEvent::WebTransport(ServerEvent::NewSession {
-                    session,
-                    ..
-                }) = event
+                if let Http3ServerEvent::WebTransport(ServerEvent::NewSession { session, .. }) =
+                    event
                 {
                     Some(session)
                 } else {
@@ -458,11 +453,7 @@ fn wt_session_ok_and_wt_datagram_in_same_udp_datagram() {
     let wt_server_session = server
         .events()
         .find_map(|event| {
-            if let Http3ServerEvent::WebTransport(ServerEvent::NewSession {
-                session,
-                ..
-            }) = event
-            {
+            if let Http3ServerEvent::WebTransport(ServerEvent::NewSession { session, .. }) = event {
                 Some(session)
             } else {
                 None

--- a/neqo-http3/tests/webtransport.rs
+++ b/neqo-http3/tests/webtransport.rs
@@ -12,7 +12,7 @@ use neqo_common::{event::Provider as _, header::HeadersExt as _};
 use neqo_http3::{
     Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3Parameters, Http3Server,
     Http3ServerEvent, Http3State, SessionAcceptAction, WebTransportEvent,
-    webtransport::{WebTransport as _, WebTransportRequest, WebTransportServerEvent},
+    webtransport::{ServerSession, ClientSession as _, ServerEvent},
 };
 use neqo_transport::{ConnectionParameters, StreamId, StreamType};
 use nss::AuthenticationStatus;
@@ -77,13 +77,13 @@ fn connect() -> (Http3Client, Http3Server) {
     (client, server)
 }
 
-fn setup_wt() -> (Http3Client, Http3Server, WebTransportRequest) {
+fn setup_wt() -> (Http3Client, Http3Server, ServerSession) {
     let (mut client, mut server) = connect();
     let wt_session = create_wt_session(&mut client, &mut server);
     (client, server, wt_session)
 }
 
-fn create_wt_session(client: &mut Http3Client, server: &mut Http3Server) -> WebTransportRequest {
+fn create_wt_session(client: &mut Http3Client, server: &mut Http3Server) -> ServerSession {
     let wt_session_id = client
         .webtransport_create_session(now(), ("https", "something.com", "/"), &[])
         .unwrap();
@@ -92,7 +92,7 @@ fn create_wt_session(client: &mut Http3Client, server: &mut Http3Server) -> WebT
     let mut wt_server_session = None;
     while let Some(event) = server.next_event() {
         match event {
-            Http3ServerEvent::WebTransport(WebTransportServerEvent::NewSession {
+            Http3ServerEvent::WebTransport(ServerEvent::NewSession {
                 session,
                 headers,
             }) => {
@@ -206,7 +206,7 @@ fn receive_data_server(
     let mut recv_data = Vec::new();
     while let Some(event) = server.next_event() {
         match event {
-            Http3ServerEvent::WebTransport(WebTransportServerEvent::NewStream(request)) => {
+            Http3ServerEvent::WebTransport(ServerEvent::NewStream(request)) => {
                 assert_eq!(stream_id, request.stream_id());
                 new_stream_received = true;
             }
@@ -355,7 +355,7 @@ fn wt_race_condition_server_stream_before_confirmation() {
         let wt_server_session = server
             .events()
             .find_map(|event| {
-                if let Http3ServerEvent::WebTransport(WebTransportServerEvent::NewSession {
+                if let Http3ServerEvent::WebTransport(ServerEvent::NewSession {
                     session,
                     ..
                 }) = event
@@ -458,7 +458,7 @@ fn wt_session_ok_and_wt_datagram_in_same_udp_datagram() {
     let wt_server_session = server
         .events()
         .find_map(|event| {
-            if let Http3ServerEvent::WebTransport(WebTransportServerEvent::NewSession {
+            if let Http3ServerEvent::WebTransport(ServerEvent::NewSession {
                 session,
                 ..
             }) = event

--- a/neqo-http3/tests/webtransport.rs
+++ b/neqo-http3/tests/webtransport.rs
@@ -11,8 +11,8 @@ use std::{cell::RefCell, rc::Rc};
 use neqo_common::{event::Provider as _, header::HeadersExt as _};
 use neqo_http3::{
     Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3Parameters, Http3Server,
-    Http3ServerEvent, Http3State, SessionAcceptAction, WebTransportEvent, WebTransportRequest,
-    WebTransportServerEvent,
+    Http3ServerEvent, Http3State, SessionAcceptAction, WebTransportEvent,
+    webtransport::{WebTransport as _, WebTransportRequest, WebTransportServerEvent},
 };
 use neqo_transport::{ConnectionParameters, StreamId, StreamType};
 use nss::AuthenticationStatus;


### PR DESCRIPTION
This means that if you want webtransport, you need to import the trait.

This file includes both the client and server pieces because it isn't that much code.  The net effect is a reduction in code size for other files.

This makes webtransport a little more of a discrete add-on.  So that if you hare looking at the WebTransport API, you only see those functions and the amount that it interacts with the rest of the implementation is reduced (an enum arm for events, some switching based on type).

Note that this integrates the fix from #3711, but not the test that was added.  The fix needs to move, but I think we should accept #3711 first.  Taking the fix makes it easy to resolve conflicts.  And the code was untested (!) before.
