### PR TITLE
fix: reject CR and LF in HTTP/3 field names

### DIFF
--- a/neqo-http3/src/headers_checks.rs
+++ b/neqo-http3/src/headers_checks.rs
@@ -114,7 +114,7 @@ pub fn headers_valid(headers: &[Header], message_type: MessageType) -> Res<()> {
             _ = bytes.next();
         }
 
-        if bytes.any(|b| matches!(b, 0 | 0x10 | 0x13 | 0x3a | 0x41..=0x5a)) {
+        if bytes.any(|b| matches!(b, 0 | 0x0a | 0x0d | 0x3a | 0x41..=0x5a)) {
             return Err(Error::InvalidHeader); // illegal characters.
         }
     }
@@ -288,6 +288,31 @@ mod tests {
             Header::new(":method", "GET"),
             Header::new(":scheme", "https"),
             Header::new(":path", "/index.html"),
+        ];
+        assert!(headers_valid(&headers, MessageType::Request).is_ok());
+    }
+
+    #[test]
+    fn reject_cr_lf_in_field_name() {
+        // CR (0x0d) and LF (0x0a) in a field name must be treated as malformed
+        // (RFC 9114, Section 4.3), otherwise they can be carried verbatim into a
+        // downstream HTTP/1.1 serialization and split the message.
+        for bad in ["x\rname", "x\nname", "x\r\nname"] {
+            let headers = vec![
+                Header::new(":method", "GET"),
+                Header::new(":scheme", "https"),
+                Header::new(":path", "/"),
+                Header::new(bad, "value"),
+            ];
+            assert!(headers_valid(&headers, MessageType::Request).is_err());
+        }
+
+        // The same request with a clean field name is accepted.
+        let headers = vec![
+            Header::new(":method", "GET"),
+            Header::new(":scheme", "https"),
+            Header::new(":path", "/"),
+            Header::new("xname", "value"),
         ];
         assert!(headers_valid(&headers, MessageType::Request).is_ok());
     }


### PR DESCRIPTION
`headers_valid` flags a received message as malformed when a field name contains one of a fixed set of bytes, but the carriage-return and line-feed entries are `0x10` and `0x13` (DLE and DC3), not CR `0x0d` and LF `0x0a`. Those are the decimal numbers 13 and 10 carried over with a `0x` prefix. A name that contains a real CR or LF passes validation today and is handed to the application through the header events, where a downstream HTTP/1.1 serialization can split on it (RFC 9114, Section 4.3).

Before, CR and LF slip through while DLE and DC3 are rejected; after, CR and LF are rejected and the two unrelated control bytes are no longer special-cased. The check stays in `headers_valid` so the request and response paths are both covered from one spot rather than at each caller. The added test drives the validator with CR, LF, and CRLF in a field name.
