### PR TITLE
Trait-based refactor for CONNECT_UDP

### DIFF
--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -118,7 +118,7 @@ impl ClientSession for Http3Client {
 }
 
 /// Connection-level connect-udp operations shared by the client and server.
-pub(crate) trait Handler {
+trait Handler {
     fn connect_udp_create_session<T: RequestTarget>(
         &mut self,
         conn: &mut Connection,

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -345,7 +345,7 @@ impl ServerSession {
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     /// Also return an error if the stream was closed on the transport layer,
-    /// but that information is not yet consumed on the  http/3 layer.
+    /// but that information is not yet consumed on the http/3 layer.
     pub fn close_session(&self, error: u32, message: &str, now: Instant) -> Res<()> {
         self.stream_handler
             .handler

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -11,15 +11,110 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{Bytes, Header, qdebug};
+use neqo_common::{Bytes, Header, qdebug, qtrace};
 use neqo_transport::{DatagramTracking, StreamId, server::ConnectionRef};
 
 use crate::{
-    Http3ServerEvent, Http3State, Http3StreamInfo, Http3StreamType, Res, SessionAcceptAction,
+    Http3Client, Http3ServerEvent, Http3State, Http3StreamInfo, Http3StreamType, Res,
+    SessionAcceptAction,
     connection_server::Http3ServerHandler,
     features::extended_connect,
+    request_target::RequestTarget,
     server_events::{Http3ServerEvents, StreamHandler},
 };
+
+pub trait ClientSession {
+    /// Create a MASQUE connect-udp session.
+    ///
+    /// # Errors
+    ///
+    /// If MASQUE connect-udp session cannot be created, e.g. the HTTP CONNECT
+    /// setting is not negotiated or the HTTP/3 connection is closed.
+    fn connect_udp_create_session<T: RequestTarget>(
+        &mut self,
+        now: Instant,
+        target: T,
+        headers: &[Header],
+    ) -> Res<StreamId>;
+
+    /// Close a connect-udp session cleanly.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::InvalidStreamId`](crate::Error::InvalidStreamId) if the stream
+    /// does not exist,
+    /// [`Error::TransportStreamDoesNotExist`](crate::Error::TransportStreamDoesNotExist) if the
+    /// transport stream does not exist (this may happen if [`Http3Client::process_output`] has
+    /// not been called when needed, and HTTP3 layer has not picked up the info that the stream
+    /// has been closed.)
+    fn connect_udp_close_session(
+        &mut self,
+        session_id: StreamId,
+        error: u32,
+        message: &str,
+        now: Instant,
+    ) -> Res<()>;
+
+    /// Send a connect-udp datagram.
+    ///
+    /// # Errors
+    ///
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    /// The function returns `TooMuchData` if the supply buffer is bigger than
+    /// the allowed remote datagram size.
+    fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
+        &mut self,
+        session_id: StreamId,
+        buf: &[u8],
+        id: I,
+        now: Instant,
+    ) -> Res<()>;
+}
+
+impl ClientSession for Http3Client {
+    fn connect_udp_create_session<T: RequestTarget>(
+        &mut self,
+        now: Instant,
+        target: T,
+        headers: &[Header],
+    ) -> Res<StreamId> {
+        let events = Box::new(self.client_events().clone());
+        let output = {
+            let (conn, handler) = self.connection_and_handler();
+            handler.connect_udp_create_session(conn, events, target, headers)
+        };
+
+        if let Err(e) = &output
+            && e.connection_error()
+        {
+            self.close(now, e.code(), "");
+        }
+        output
+    }
+
+    fn connect_udp_close_session(
+        &mut self,
+        session_id: StreamId,
+        error: u32,
+        message: &str,
+        now: Instant,
+    ) -> Res<()> {
+        let (conn, handler) = self.connection_and_handler();
+        handler.connect_udp_close_session(conn, session_id, error, message, now)
+    }
+
+    fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
+        &mut self,
+        session_id: StreamId,
+        buf: &[u8],
+        id: I,
+        now: Instant,
+    ) -> Res<()> {
+        qtrace!("connect_udp_send_datagram session:{session_id:?}");
+        let (conn, handler) = self.connection_and_handler();
+        handler.connect_udp_send_datagram(session_id, conn, buf, id, now)
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct ServerSession {

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -155,7 +155,7 @@ pub enum ServerEvent {
     },
 }
 
-pub trait ServerEvents {
+pub(crate) trait ServerEvents {
     fn connect_udp_new_session(&self, session: ServerSession, headers: Vec<Header>);
     fn connect_udp_session_closed(
         &self,

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -222,6 +222,76 @@ impl Handler for Http3Connection {
     }
 }
 
+/// Server-handler connect-udp operations, exposed on [`Http3ServerHandler`].
+pub(crate) trait ServerHandler {
+    fn connect_udp_session_accept(
+        &mut self,
+        conn: &mut Connection,
+        stream_id: StreamId,
+        accept: &SessionAcceptAction,
+        now: Instant,
+    ) -> Res<()>;
+
+    fn connect_udp_close_session(
+        &mut self,
+        conn: &mut Connection,
+        session_id: StreamId,
+        error: u32,
+        message: &str,
+        now: Instant,
+    ) -> Res<()>;
+
+    fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
+        &mut self,
+        conn: &mut Connection,
+        session_id: StreamId,
+        buf: &[u8],
+        id: I,
+        now: Instant,
+    ) -> Res<()>;
+}
+
+impl ServerHandler for Http3ServerHandler {
+    fn connect_udp_session_accept(
+        &mut self,
+        conn: &mut Connection,
+        stream_id: StreamId,
+        accept: &SessionAcceptAction,
+        now: Instant,
+    ) -> Res<()> {
+        self.mark_needs_processing();
+        let events = Box::new(self.server_events().clone());
+        self.base_handler_mut()
+            .connect_udp_session_accept(conn, stream_id, events, accept, now)
+    }
+
+    fn connect_udp_close_session(
+        &mut self,
+        conn: &mut Connection,
+        session_id: StreamId,
+        error: u32,
+        message: &str,
+        now: Instant,
+    ) -> Res<()> {
+        self.mark_needs_processing();
+        self.base_handler_mut()
+            .connect_udp_close_session(conn, session_id, error, message, now)
+    }
+
+    fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
+        &mut self,
+        conn: &mut Connection,
+        session_id: StreamId,
+        buf: &[u8],
+        id: I,
+        now: Instant,
+    ) -> Res<()> {
+        self.mark_needs_processing();
+        self.base_handler_mut()
+            .connect_udp_send_datagram(session_id, conn, buf, id, now)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ServerSession {
     stream_handler: StreamHandler,

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -42,9 +42,9 @@ pub trait ClientSession {
     ///
     /// # Errors
     ///
-    /// [`Error::InvalidStreamId`](crate::Error::InvalidStreamId) if the stream
+    /// [`Error::InvalidStreamId`] if the stream
     /// does not exist,
-    /// [`Error::TransportStreamDoesNotExist`](crate::Error::TransportStreamDoesNotExist) if the
+    /// [`Error::TransportStreamDoesNotExist`] if the
     /// transport stream does not exist (this may happen if [`Http3Client::process_output`] has
     /// not been called when needed, and HTTP3 layer has not picked up the info that the stream
     /// has been closed.)
@@ -60,7 +60,7 @@ pub trait ClientSession {
     ///
     /// # Errors
     ///
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    /// It may return [`Error::InvalidStreamId`] if a stream does not exist anymore.
     /// The function returns `TooMuchData` if the supply buffer is bigger than
     /// the allowed remote datagram size.
     fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
@@ -113,7 +113,7 @@ impl ClientSession for Http3Client {
     ) -> Res<()> {
         qtrace!("connect_udp_send_datagram session:{session_id:?}");
         let (conn, handler) = self.connection_and_handler();
-        handler.connect_udp_send_datagram(session_id, conn, buf, id, now)
+        handler.connect_udp_send_datagram(conn, session_id, buf, id, now)
     }
 }
 
@@ -147,8 +147,8 @@ trait Handler {
 
     fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
         &self,
-        session_id: StreamId,
         conn: &mut Connection,
+        session_id: StreamId,
         buf: &[u8],
         id: I,
         now: Instant,
@@ -212,8 +212,8 @@ impl Handler for Http3Connection {
 
     fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
         &self,
-        session_id: StreamId,
         conn: &mut Connection,
+        session_id: StreamId,
         buf: &[u8],
         id: I,
         now: Instant,
@@ -288,7 +288,7 @@ impl ServerHandler for Http3ServerHandler {
     ) -> Res<()> {
         self.mark_needs_processing();
         self.base_handler_mut()
-            .connect_udp_send_datagram(session_id, conn, buf, id, now)
+            .connect_udp_send_datagram(conn, session_id, buf, id, now)
     }
 }
 

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -11,12 +11,13 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{Bytes, Header, qdebug, qtrace};
-use neqo_transport::{DatagramTracking, StreamId, server::ConnectionRef};
+use neqo_common::{Bytes, Header, qdebug, qinfo, qtrace};
+use neqo_transport::{Connection, DatagramTracking, StreamId, server::ConnectionRef};
 
 use crate::{
-    Http3Client, Http3ServerEvent, Http3State, Http3StreamInfo, Http3StreamType, Res,
+    Error, Http3Client, Http3ServerEvent, Http3State, Http3StreamInfo, Http3StreamType, Res,
     SessionAcceptAction,
+    connection::Http3Connection,
     connection_server::Http3ServerHandler,
     features::extended_connect,
     request_target::RequestTarget,
@@ -113,6 +114,111 @@ impl ClientSession for Http3Client {
         qtrace!("connect_udp_send_datagram session:{session_id:?}");
         let (conn, handler) = self.connection_and_handler();
         handler.connect_udp_send_datagram(session_id, conn, buf, id, now)
+    }
+}
+
+/// Connection-level connect-udp operations shared by the client and server.
+pub(crate) trait Handler {
+    fn connect_udp_create_session<T: RequestTarget>(
+        &mut self,
+        conn: &mut Connection,
+        events: Box<dyn extended_connect::ExtendedConnectEvents>,
+        target: T,
+        headers: &[Header],
+    ) -> Res<StreamId>;
+
+    fn connect_udp_session_accept(
+        &mut self,
+        conn: &mut Connection,
+        stream_id: StreamId,
+        events: Box<dyn extended_connect::ExtendedConnectEvents>,
+        accept_res: &SessionAcceptAction,
+        now: Instant,
+    ) -> Res<()>;
+
+    fn connect_udp_close_session(
+        &mut self,
+        conn: &mut Connection,
+        session_id: StreamId,
+        error: u32,
+        message: &str,
+        now: Instant,
+    ) -> Res<()>;
+
+    fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
+        &self,
+        session_id: StreamId,
+        conn: &mut Connection,
+        buf: &[u8],
+        id: I,
+        now: Instant,
+    ) -> Res<()>;
+}
+
+impl Handler for Http3Connection {
+    fn connect_udp_create_session<T: RequestTarget>(
+        &mut self,
+        conn: &mut Connection,
+        events: Box<dyn extended_connect::ExtendedConnectEvents>,
+        target: T,
+        headers: &[Header],
+    ) -> Res<StreamId> {
+        qinfo!("[{self}] Create ConnectUdp");
+        if !self.connect_udp_enabled() {
+            return Err(Error::Unavailable);
+        }
+        self.extended_connect_create_session(
+            conn,
+            events,
+            target,
+            headers,
+            extended_connect::ExtendedConnectType::ConnectUdp,
+        )
+    }
+
+    fn connect_udp_session_accept(
+        &mut self,
+        conn: &mut Connection,
+        stream_id: StreamId,
+        events: Box<dyn extended_connect::ExtendedConnectEvents>,
+        accept_res: &SessionAcceptAction,
+        now: Instant,
+    ) -> Res<()> {
+        qtrace!("Respond to ConnectUdp session with accept={accept_res}");
+        if !self.connect_udp_enabled() {
+            return Err(Error::Unavailable);
+        }
+        self.extended_connect_session_accept(
+            conn,
+            stream_id,
+            events,
+            accept_res,
+            extended_connect::ExtendedConnectType::ConnectUdp,
+            now,
+        )
+    }
+
+    fn connect_udp_close_session(
+        &mut self,
+        conn: &mut Connection,
+        session_id: StreamId,
+        error: u32,
+        message: &str,
+        now: Instant,
+    ) -> Res<()> {
+        qtrace!("Close ConnectUdp session {session_id:?}");
+        self.extended_connect_close_session(conn, session_id, error, message, now)
+    }
+
+    fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
+        &self,
+        session_id: StreamId,
+        conn: &mut Connection,
+        buf: &[u8],
+        id: I,
+        now: Instant,
+    ) -> Res<()> {
+        self.extended_connect_send_datagram(session_id, conn, buf, id, now)
     }
 }
 

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -1,0 +1,196 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{
+    cell::RefCell,
+    fmt::{self, Display, Formatter},
+    rc::Rc,
+    time::Instant,
+};
+
+use neqo_common::{Bytes, Header, qdebug};
+use neqo_transport::{DatagramTracking, StreamId, server::ConnectionRef};
+
+use crate::{
+    Http3ServerEvent, Http3State, Http3StreamInfo, Http3StreamType, Res, SessionAcceptAction,
+    connection_server::Http3ServerHandler,
+    features::extended_connect,
+    server_events::{Http3ServerEvents, StreamHandler},
+};
+
+#[derive(Debug, Clone)]
+pub struct ServerSession {
+    stream_handler: StreamHandler,
+}
+
+impl Display for ServerSession {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "ConnectUdp session {}", self.stream_handler)
+    }
+}
+
+impl ServerSession {
+    pub(crate) const fn new(
+        conn: ConnectionRef,
+        handler: Rc<RefCell<Http3ServerHandler>>,
+        stream_id: StreamId,
+    ) -> Self {
+        Self {
+            stream_handler: StreamHandler {
+                conn,
+                handler,
+                stream_info: Http3StreamInfo::new(stream_id, Http3StreamType::Http),
+            },
+        }
+    }
+
+    #[must_use]
+    pub fn state(&self) -> Http3State {
+        self.stream_handler.handler.borrow().state()
+    }
+
+    /// Respond to a `ConnectUdp` session request.
+    ///
+    /// # Errors
+    ///
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn response(&self, accept: &SessionAcceptAction, now: Instant) -> Res<()> {
+        qdebug!("[{self}] Set a response for a ConnectUdp session");
+        self.stream_handler
+            .handler
+            .borrow_mut()
+            .connect_udp_session_accept(
+                &mut self.stream_handler.conn.borrow_mut(),
+                self.stream_handler.stream_info.stream_id(),
+                accept,
+                now,
+            )
+    }
+
+    /// # Errors
+    ///
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    /// Also return an error if the stream was closed on the transport layer,
+    /// but that information is not yet consumed on the  http/3 layer.
+    pub fn close_session(&self, error: u32, message: &str, now: Instant) -> Res<()> {
+        self.stream_handler
+            .handler
+            .borrow_mut()
+            .connect_udp_close_session(
+                &mut self.stream_handler.conn.borrow_mut(),
+                self.stream_handler.stream_info.stream_id(),
+                error,
+                message,
+                now,
+            )
+    }
+
+    #[must_use]
+    pub const fn stream_id(&self) -> StreamId {
+        self.stream_handler.stream_id()
+    }
+
+    /// Send connect-udp datagram.
+    ///
+    /// # Errors
+    ///
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    /// The function returns `TooMuchData` if the supply buffer is bigger than
+    /// the allowed remote datagram size.
+    pub fn send_datagram<I: Into<DatagramTracking>>(
+        &self,
+        buf: &[u8],
+        id: I,
+        now: Instant,
+    ) -> Res<()> {
+        let session_id = self.stream_handler.stream_id();
+        self.stream_handler
+            .handler
+            .borrow_mut()
+            .connect_udp_send_datagram(
+                &mut self.stream_handler.conn.borrow_mut(),
+                session_id,
+                buf,
+                id,
+                now,
+            )
+    }
+
+    #[must_use]
+    pub fn remote_datagram_size(&self) -> u64 {
+        self.stream_handler.conn.borrow().remote_datagram_size()
+    }
+
+    /// Used for testing only.
+    ///
+    /// # Errors
+    ///
+    /// It may return `InvalidStreamId` if a stream does not exist anymore.
+    pub fn reset_send(&self) -> Res<()> {
+        self.stream_handler.handler.borrow_mut().stream_reset_send(
+            self.stream_id(),
+            0,
+            &mut self.stream_handler.conn.borrow_mut(),
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ServerEvent {
+    NewSession {
+        session: ServerSession,
+        headers: Vec<Header>,
+    },
+    SessionClosed {
+        session: ServerSession,
+        reason: extended_connect::session::CloseReason,
+        headers: Option<Vec<Header>>,
+    },
+    Datagram {
+        session: ServerSession,
+        datagram: Bytes,
+    },
+}
+
+pub trait ServerEvents {
+    fn connect_udp_new_session(&self, session: ServerSession, headers: Vec<Header>);
+    fn connect_udp_session_closed(
+        &self,
+        session: ServerSession,
+        reason: extended_connect::session::CloseReason,
+        headers: Option<Vec<Header>>,
+    );
+    fn connect_udp_datagram(&self, session: ServerSession, datagram: Bytes);
+}
+
+impl ServerEvents for Http3ServerEvents {
+    fn connect_udp_new_session(&self, session: ServerSession, headers: Vec<Header>) {
+        self.insert(Http3ServerEvent::ConnectUdp(ServerEvent::NewSession {
+            session,
+            headers,
+        }));
+    }
+
+    fn connect_udp_session_closed(
+        &self,
+        session: ServerSession,
+        reason: extended_connect::session::CloseReason,
+        headers: Option<Vec<Header>>,
+    ) {
+        self.insert(Http3ServerEvent::ConnectUdp(ServerEvent::SessionClosed {
+            session,
+            reason,
+            headers,
+        }));
+    }
+
+    fn connect_udp_datagram(&self, session: ServerSession, datagram: Bytes) {
+        self.insert(Http3ServerEvent::ConnectUdp(ServerEvent::Datagram {
+            session,
+            datagram,
+        }));
+    }
+}

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1184,29 +1184,6 @@ impl Http3Connection {
         )
     }
 
-    pub fn connect_udp_create_session<T>(
-        &mut self,
-        conn: &mut Connection,
-        events: Box<dyn ExtendedConnectEvents>,
-        target: T,
-        headers: &[Header],
-    ) -> Res<StreamId>
-    where
-        T: RequestTarget,
-    {
-        qinfo!("[{self}] Create ConnectUdp");
-        if !self.connect_udp_enabled() {
-            return Err(Error::Unavailable);
-        }
-        self.extended_connect_create_session(
-            conn,
-            events,
-            target,
-            headers,
-            ExtendedConnectType::ConnectUdp,
-        )
-    }
-
     pub fn extended_connect_create_session<T>(
         &mut self,
         conn: &mut Connection,
@@ -1270,29 +1247,7 @@ impl Http3Connection {
         )
     }
 
-    pub(crate) fn connect_udp_session_accept(
-        &mut self,
-        conn: &mut Connection,
-        stream_id: StreamId,
-        events: Box<dyn ExtendedConnectEvents>,
-        accept_res: &SessionAcceptAction,
-        now: Instant,
-    ) -> Res<()> {
-        qtrace!("Respond to ConnectUdp session with accept={accept_res}");
-        if !self.connect_udp_enabled() {
-            return Err(Error::Unavailable);
-        }
-        self.extended_connect_session_accept(
-            conn,
-            stream_id,
-            events,
-            accept_res,
-            ExtendedConnectType::ConnectUdp,
-            now,
-        )
-    }
-
-    fn extended_connect_session_accept(
+    pub(crate) fn extended_connect_session_accept(
         &mut self,
         conn: &mut Connection,
         stream_id: StreamId,
@@ -1435,19 +1390,7 @@ impl Http3Connection {
         Ok(stream.session_protocol())
     }
 
-    pub(crate) fn connect_udp_close_session(
-        &mut self,
-        conn: &mut Connection,
-        session_id: StreamId,
-        error: u32,
-        message: &str,
-        now: Instant,
-    ) -> Res<()> {
-        qtrace!("Close ConnectUdp session {session_id:?}");
-        self.extended_connect_close_session(conn, session_id, error, message, now)
-    }
-
-    fn extended_connect_close_session(
+    pub(crate) fn extended_connect_close_session(
         &mut self,
         conn: &mut Connection,
         session_id: StreamId,
@@ -1608,18 +1551,7 @@ impl Http3Connection {
         self.extended_connect_send_datagram(session_id, conn, buf, id, now)
     }
 
-    pub fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
-        &self,
-        session_id: StreamId,
-        conn: &mut Connection,
-        buf: &[u8],
-        id: I,
-        now: Instant,
-    ) -> Res<()> {
-        self.extended_connect_send_datagram(session_id, conn, buf, id, now)
-    }
-
-    fn extended_connect_send_datagram<I: Into<DatagramTracking>>(
+    pub(crate) fn extended_connect_send_datagram<I: Into<DatagramTracking>>(
         &self,
         session_id: StreamId,
         conn: &mut Connection,

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -356,6 +356,10 @@ impl Http3Client {
         (&mut self.conn, &mut self.base_handler)
     }
 
+    pub(crate) const fn client_events(&self) -> &Http3ClientEvents {
+        &self.events
+    }
+
     /// The function returns the current state of the connection.
     #[must_use]
     pub fn state(&self) -> Http3State {
@@ -752,34 +756,6 @@ impl Http3Client {
         output
     }
 
-    /// # Errors
-    ///
-    /// If MASQUE connect-udp session cannot be created, e.g. the HTTP CONNECT
-    /// setting is not negotiated or the HTTP/3 connection is closed.
-    pub fn connect_udp_create_session<T>(
-        &mut self,
-        now: Instant,
-        target: T,
-        headers: &[Header],
-    ) -> Res<StreamId>
-    where
-        T: RequestTarget,
-    {
-        let output = self.base_handler.connect_udp_create_session(
-            &mut self.conn,
-            Box::new(self.events.clone()),
-            target,
-            headers,
-        );
-
-        if let Err(e) = &output
-            && e.connection_error()
-        {
-            self.close(now, e.code(), "");
-        }
-        output
-    }
-
     /// Close `WebTransport` cleanly
     ///
     /// # Errors
@@ -803,26 +779,6 @@ impl Http3Client {
             message,
             now,
         )
-    }
-
-    /// Close `ConnectUdp` cleanly
-    ///
-    /// # Errors
-    ///
-    /// [`Error::InvalidStreamId`] if the stream does not exist,
-    /// [`Error::TransportStreamDoesNotExist`] if the transport stream does not
-    /// exist (this may happen if [`Http3Client::process_output`] has not been
-    /// called when needed, and HTTP3 layer has not picked up the info that the
-    /// stream has been closed.)
-    pub fn connect_udp_close_session(
-        &mut self,
-        session_id: StreamId,
-        error: u32,
-        message: &str,
-        now: Instant,
-    ) -> Res<()> {
-        self.base_handler
-            .connect_udp_close_session(&mut self.conn, session_id, error, message, now)
     }
 
     /// # Errors
@@ -860,25 +816,6 @@ impl Http3Client {
         qtrace!("webtransport_send_datagram session:{session_id:?}");
         self.base_handler
             .webtransport_send_datagram(session_id, &mut self.conn, buf, id, now)
-    }
-
-    /// Send `ConnectUdp` datagram.
-    ///
-    /// # Errors
-    ///
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    /// The function returns `TooMuchData` if the supply buffer is bigger than
-    /// the allowed remote datagram size.
-    pub fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
-        &mut self,
-        session_id: StreamId,
-        buf: &[u8],
-        id: I,
-        now: Instant,
-    ) -> Res<()> {
-        qtrace!("connect_udp_send_datagram session:{session_id:?}");
-        self.base_handler
-            .connect_udp_send_datagram(session_id, &mut self.conn, buf, id, now)
     }
 
     /// This function combines  `process_input` and `process_output` function.

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -18,7 +18,6 @@ use neqo_transport::{
 use crate::{
     Error, Http3Parameters, Http3StreamType, NewStreamType, Priority, PriorityHandler,
     ReceiveOutput, Res,
-    connect_udp::Handler as _,
     connection::{Http3Connection, Http3State, SessionAcceptAction},
     frames::HFrame,
     recv_message::{RecvMessage, RecvMessageInfo},
@@ -51,6 +50,18 @@ impl Http3ServerHandler {
     #[must_use]
     pub fn state(&self) -> Http3State {
         self.base_handler.state().clone()
+    }
+
+    pub(crate) const fn base_handler_mut(&mut self) -> &mut Http3Connection {
+        &mut self.base_handler
+    }
+
+    pub(crate) const fn server_events(&self) -> &Http3ServerConnEvents {
+        &self.events
+    }
+
+    pub(crate) const fn mark_needs_processing(&mut self) {
+        self.needs_processing = true;
     }
 
     /// Supply a response for a request.
@@ -177,24 +188,6 @@ impl Http3ServerHandler {
         )
     }
 
-    /// Accept a `ConnectUdp` Session request
-    pub(crate) fn connect_udp_session_accept(
-        &mut self,
-        conn: &mut Connection,
-        stream_id: StreamId,
-        accept: &SessionAcceptAction,
-        now: Instant,
-    ) -> Res<()> {
-        self.needs_processing = true;
-        self.base_handler.connect_udp_session_accept(
-            conn,
-            stream_id,
-            Box::new(self.events.clone()),
-            accept,
-            now,
-        )
-    }
-
     /// Close `WebTransport` cleanly
     ///
     /// # Errors
@@ -215,28 +208,6 @@ impl Http3ServerHandler {
         self.needs_processing = true;
         self.base_handler
             .webtransport_close_session(conn, session_id, error, message, now)
-    }
-
-    /// Close `ConnectUdp` cleanly
-    ///
-    /// # Errors
-    ///
-    /// `InvalidStreamId` if the stream does not exist,
-    /// `TransportStreamDoesNotExist` if the transport stream does not exist (this may happen if
-    /// `process_output` has not been called when needed, and HTTP3 layer has not picked up the
-    /// info that the stream has been closed.) `InvalidInput` if an empty buffer has been
-    /// supplied.
-    pub fn connect_udp_close_session(
-        &mut self,
-        conn: &mut Connection,
-        session_id: StreamId,
-        error: u32,
-        message: &str,
-        now: Instant,
-    ) -> Res<()> {
-        self.needs_processing = true;
-        self.base_handler
-            .connect_udp_close_session(conn, session_id, error, message, now)
     }
 
     pub fn webtransport_create_stream(
@@ -266,19 +237,6 @@ impl Http3ServerHandler {
         self.needs_processing = true;
         self.base_handler
             .webtransport_send_datagram(session_id, conn, buf, id, now)
-    }
-
-    pub fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
-        &mut self,
-        conn: &mut Connection,
-        session_id: StreamId,
-        buf: &[u8],
-        id: I,
-        now: Instant,
-    ) -> Res<()> {
-        self.needs_processing = true;
-        self.base_handler
-            .connect_udp_send_datagram(session_id, conn, buf, id, now)
     }
 
     pub(crate) fn validate_extended_connect_session(&self, session_id: StreamId) -> Res<()> {

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -18,6 +18,7 @@ use neqo_transport::{
 use crate::{
     Error, Http3Parameters, Http3StreamType, NewStreamType, Priority, PriorityHandler,
     ReceiveOutput, Res,
+    connect_udp::Handler as _,
     connection::{Http3Connection, Http3State, SessionAcceptAction},
     frames::HFrame,
     recv_message::{RecvMessage, RecvMessageInfo},

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -136,6 +136,7 @@ while let Some(event) = client.next_event() {
 mod buffered_send_stream;
 mod client_events;
 mod conn_params;
+pub mod connect_udp;
 mod connection;
 mod connection_client;
 mod connection_server;
@@ -179,9 +180,7 @@ pub use neqo_transport::{Output, StreamId, streams::SendOrder};
 pub use priority::Priority;
 pub use push_id::PushId;
 pub use server::Http3Server;
-pub use server_events::{
-    ConnectUdpRequest, ConnectUdpServerEvent, Http3OrWebTransportStream, Http3ServerEvent,
-};
+pub use server_events::{Http3OrWebTransportStream, Http3ServerEvent};
 #[cfg(fuzzing)]
 pub use settings::HSettings;
 use stream_type_reader::NewStreamType;

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -23,12 +23,11 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
     Http3Parameters, Http3StreamInfo, Res,
+    connect_udp::{self, ServerEvents as _},
     connection::Http3State,
     connection_server::Http3ServerHandler,
     server_connection_events::{ConnectUdpEvent, Http3ServerConnEvent, WebTransportEvent},
-    server_events::{
-        ConnectUdpRequest, Http3OrWebTransportStream, Http3ServerEvent, Http3ServerEvents,
-    },
+    server_events::{Http3OrWebTransportStream, Http3ServerEvent, Http3ServerEvents},
     settings::HttpZeroRttChecker,
     webtransport::{ServerEvents as _, ServerSession},
 };
@@ -266,7 +265,11 @@ impl Http3Server {
                         headers,
                     }) => {
                         self.events.connect_udp_new_session(
-                            ConnectUdpRequest::new(conn.clone(), Rc::clone(handler), stream_id),
+                            connect_udp::ServerSession::new(
+                                conn.clone(),
+                                Rc::clone(handler),
+                                stream_id,
+                            ),
                             headers,
                         );
                     }
@@ -286,7 +289,11 @@ impl Http3Server {
                         headers,
                         ..
                     }) => self.events.connect_udp_session_closed(
-                        ConnectUdpRequest::new(conn.clone(), Rc::clone(handler), stream_id),
+                        connect_udp::ServerSession::new(
+                            conn.clone(),
+                            Rc::clone(handler),
+                            stream_id,
+                        ),
                         reason,
                         headers,
                     ),
@@ -313,7 +320,11 @@ impl Http3Server {
                         datagram,
                     }) => {
                         self.events.connect_udp_datagram(
-                            ConnectUdpRequest::new(conn.clone(), Rc::clone(handler), session_id),
+                            connect_udp::ServerSession::new(
+                                conn.clone(),
+                                Rc::clone(handler),
+                                session_id,
+                            ),
                             datagram,
                         );
                     }

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -13,14 +13,11 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{Bytes, Header, qdebug};
-use neqo_transport::{AppError, Connection, DatagramTracking, StreamId, server::ConnectionRef};
+use neqo_common::{Header, qdebug};
+use neqo_transport::{AppError, Connection, StreamId, server::ConnectionRef};
 
 use crate::{
-    Http3StreamInfo, Http3StreamType, Priority, Res,
-    connection::{Http3State, SessionAcceptAction},
-    connection_server::Http3ServerHandler,
-    features::extended_connect,
+    Http3StreamInfo, Priority, Res, connection::Http3State, connection_server::Http3ServerHandler,
 };
 
 #[derive(Debug, Clone)]
@@ -231,140 +228,6 @@ impl PartialEq for Http3OrWebTransportStream {
 
 impl Eq for Http3OrWebTransportStream {}
 
-#[derive(Debug, Clone)]
-pub struct ConnectUdpRequest {
-    stream_handler: StreamHandler,
-}
-
-impl Display for ConnectUdpRequest {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "ConnectUdp session {}", self.stream_handler)
-    }
-}
-
-impl ConnectUdpRequest {
-    pub(crate) const fn new(
-        conn: ConnectionRef,
-        handler: Rc<RefCell<Http3ServerHandler>>,
-        stream_id: StreamId,
-    ) -> Self {
-        Self {
-            stream_handler: StreamHandler {
-                conn,
-                handler,
-                stream_info: Http3StreamInfo::new(stream_id, Http3StreamType::Http),
-            },
-        }
-    }
-
-    #[must_use]
-    pub fn state(&self) -> Http3State {
-        self.stream_handler.handler.borrow().state()
-    }
-
-    /// Respond to a `ConnectUdp` session request.
-    ///
-    /// # Errors
-    ///
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn response(&self, accept: &SessionAcceptAction, now: Instant) -> Res<()> {
-        qdebug!("[{self}] Set a response for a ConnectUdp session");
-        self.stream_handler
-            .handler
-            .borrow_mut()
-            .connect_udp_session_accept(
-                &mut self.stream_handler.conn.borrow_mut(),
-                self.stream_handler.stream_info.stream_id(),
-                accept,
-                now,
-            )
-    }
-
-    /// # Errors
-    ///
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    /// Also return an error if the stream was closed on the transport layer,
-    /// but that information is not yet consumed on the  http/3 layer.
-    pub fn close_session(&self, error: u32, message: &str, now: Instant) -> Res<()> {
-        self.stream_handler
-            .handler
-            .borrow_mut()
-            .connect_udp_close_session(
-                &mut self.stream_handler.conn.borrow_mut(),
-                self.stream_handler.stream_info.stream_id(),
-                error,
-                message,
-                now,
-            )
-    }
-
-    #[must_use]
-    pub const fn stream_id(&self) -> StreamId {
-        self.stream_handler.stream_id()
-    }
-
-    /// Send connect-udp datagram.
-    ///
-    /// # Errors
-    ///
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    /// The function returns `TooMuchData` if the supply buffer is bigger than
-    /// the allowed remote datagram size.
-    pub fn send_datagram<I: Into<DatagramTracking>>(
-        &self,
-        buf: &[u8],
-        id: I,
-        now: Instant,
-    ) -> Res<()> {
-        let session_id = self.stream_handler.stream_id();
-        self.stream_handler
-            .handler
-            .borrow_mut()
-            .connect_udp_send_datagram(
-                &mut self.stream_handler.conn.borrow_mut(),
-                session_id,
-                buf,
-                id,
-                now,
-            )
-    }
-
-    #[must_use]
-    pub fn remote_datagram_size(&self) -> u64 {
-        self.stream_handler.conn.borrow().remote_datagram_size()
-    }
-
-    /// Used for testing only.
-    ///
-    /// # Errors
-    ///
-    /// It may return `InvalidStreamId` if a stream does not exist anymore.
-    pub fn reset_send(&self) -> Res<()> {
-        self.stream_handler.handler.borrow_mut().stream_reset_send(
-            self.stream_id(),
-            0,
-            &mut self.stream_handler.conn.borrow_mut(),
-        )
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum ConnectUdpServerEvent {
-    NewSession {
-        session: ConnectUdpRequest,
-        headers: Vec<Header>,
-    },
-    SessionClosed {
-        session: ConnectUdpRequest,
-        reason: extended_connect::session::CloseReason,
-        headers: Option<Vec<Header>>,
-    },
-    Datagram {
-        session: ConnectUdpRequest,
-        datagram: Bytes,
-    },
-}
-
 /// Server events for one or more connections.
 #[derive(Debug, Clone)]
 pub enum Http3ServerEvent {
@@ -401,7 +264,7 @@ pub enum Http3ServerEvent {
         priority: Priority,
     },
     WebTransport(crate::webtransport::ServerEvent),
-    ConnectUdp(ConnectUdpServerEvent),
+    ConnectUdp(crate::connect_udp::ServerEvent),
 }
 
 #[derive(Debug, Default, Clone)]
@@ -506,32 +369,5 @@ impl Http3ServerEvents {
             stream_id,
             priority,
         });
-    }
-
-    pub(crate) fn connect_udp_new_session(&self, session: ConnectUdpRequest, headers: Vec<Header>) {
-        self.insert(Http3ServerEvent::ConnectUdp(
-            ConnectUdpServerEvent::NewSession { session, headers },
-        ));
-    }
-
-    pub(crate) fn connect_udp_session_closed(
-        &self,
-        session: ConnectUdpRequest,
-        reason: extended_connect::session::CloseReason,
-        headers: Option<Vec<Header>>,
-    ) {
-        self.insert(Http3ServerEvent::ConnectUdp(
-            ConnectUdpServerEvent::SessionClosed {
-                session,
-                reason,
-                headers,
-            },
-        ));
-    }
-
-    pub(crate) fn connect_udp_datagram(&self, session: ConnectUdpRequest, datagram: Bytes) {
-        self.insert(Http3ServerEvent::ConnectUdp(
-            ConnectUdpServerEvent::Datagram { session, datagram },
-        ));
     }
 }

--- a/neqo-http3/tests/connect_udp.rs
+++ b/neqo-http3/tests/connect_udp.rs
@@ -9,9 +9,9 @@
 use http::Uri;
 use neqo_common::{Datagram, Tos, event::Provider as _, header::HeadersExt as _, qinfo};
 use neqo_http3::{
-    ConnectUdpEvent, ConnectUdpRequest, ConnectUdpServerEvent, Error, Http3Client,
-    Http3ClientEvent, Http3Parameters, Http3Server, Http3ServerEvent, Http3State, Priority,
-    SessionAcceptAction,
+    ConnectUdpEvent, Error, Http3Client, Http3ClientEvent, Http3Parameters, Http3Server,
+    Http3ServerEvent, Http3State, Priority, SessionAcceptAction,
+    connect_udp::{ServerEvent, ServerSession},
 };
 use neqo_transport::ConnectionParameters;
 use nss::AuthenticationStatus;
@@ -62,17 +62,15 @@ fn establish_new_session() -> (
     Http3Client,
     Http3Server,
     neqo_http3::StreamId,
-    ConnectUdpRequest,
+    ServerSession,
 ) {
     let (mut client, mut proxy, connect_udp_session_id) = initiate_new_session();
     exchange_packets(&mut client, &mut proxy, false, None);
     let proxy_session = proxy
         .events()
         .find_map(|event| {
-            if let Http3ServerEvent::ConnectUdp(ConnectUdpServerEvent::NewSession {
-                session,
-                headers,
-            }) = event
+            if let Http3ServerEvent::ConnectUdp(ServerEvent::NewSession { session, headers }) =
+                event
             {
                 assert_eq!(session.stream_id(), connect_udp_session_id);
 
@@ -108,7 +106,7 @@ fn exchange_packets_through_proxy(
     proxy: &mut Http3Server,
     server: &mut Http3Server,
     connect_udp_session_id: neqo_http3::StreamId,
-    proxy_session: &ConnectUdpRequest,
+    proxy_session: &ServerSession,
 ) {
     qinfo!("Processing client_inner");
     while let Some(dgram) = client_inner.process_output(now()).dgram() {
@@ -135,7 +133,7 @@ fn exchange_packets_through_proxy(
         client_outer.process_multiple_input(dgram.iter_mut(), now());
     }
     let server_dgrams = proxy.events().filter_map(|event| match event {
-        Http3ServerEvent::ConnectUdp(ConnectUdpServerEvent::Datagram { datagram, session }) => {
+        Http3ServerEvent::ConnectUdp(ServerEvent::Datagram { datagram, session }) => {
             assert_eq!(session.stream_id(), connect_udp_session_id);
             Some(Datagram::from_bytes(
                 DEFAULT_ADDR,
@@ -208,10 +206,7 @@ fn session_lifecycle(client_closes: bool) {
     let (id, datagram) = proxy
         .events()
         .find_map(|event| {
-            if let Http3ServerEvent::ConnectUdp(ConnectUdpServerEvent::Datagram {
-                session,
-                datagram,
-            }) = event
+            if let Http3ServerEvent::ConnectUdp(ServerEvent::Datagram { session, datagram }) = event
             {
                 Some((session.stream_id(), datagram))
             } else {
@@ -256,7 +251,7 @@ fn session_lifecycle(client_closes: bool) {
             .find(|event| {
                 matches!(
                     event,
-                    Http3ServerEvent::ConnectUdp(ConnectUdpServerEvent::SessionClosed {
+                    Http3ServerEvent::ConnectUdp(ServerEvent::SessionClosed {
                         session,
                         ..
                     }) if session.stream_id() == session_id
@@ -376,10 +371,7 @@ fn server_datagram_before_accept() {
         let proxy_session = proxy
             .events()
             .find_map(|event| {
-                if let Http3ServerEvent::ConnectUdp(ConnectUdpServerEvent::NewSession {
-                    session,
-                    ..
-                }) = event
+                if let Http3ServerEvent::ConnectUdp(ServerEvent::NewSession { session, .. }) = event
                 {
                     Some(session)
                 } else {
@@ -447,10 +439,7 @@ fn server_stream_reset_results_in_client_session_close() {
     let proxy_session = proxy
         .events()
         .find_map(|event| {
-            if let Http3ServerEvent::ConnectUdp(ConnectUdpServerEvent::NewSession {
-                session, ..
-            }) = event
-            {
+            if let Http3ServerEvent::ConnectUdp(ServerEvent::NewSession { session, .. }) = event {
                 Some(session)
             } else {
                 None
@@ -536,10 +525,8 @@ fn session_lifecycle_with_http_datagram_capsule() {
     let proxy_session = proxy
         .events()
         .find_map(|event| {
-            if let Http3ServerEvent::ConnectUdp(ConnectUdpServerEvent::NewSession {
-                session,
-                headers,
-            }) = event
+            if let Http3ServerEvent::ConnectUdp(ServerEvent::NewSession { session, headers }) =
+                event
             {
                 assert_eq!(session.stream_id(), session_id);
                 assert!(
@@ -580,10 +567,7 @@ fn session_lifecycle_with_http_datagram_capsule() {
     let (id, datagram) = proxy
         .events()
         .find_map(|event| {
-            if let Http3ServerEvent::ConnectUdp(ConnectUdpServerEvent::Datagram {
-                session,
-                datagram,
-            }) = event
+            if let Http3ServerEvent::ConnectUdp(ServerEvent::Datagram { session, datagram }) = event
             {
                 Some((session.stream_id(), datagram))
             } else {
@@ -631,9 +615,7 @@ fn session_lifecycle_with_http_datagram_capsule() {
 
     let mut count = 0;
     for event in proxy.events() {
-        if let Http3ServerEvent::ConnectUdp(ConnectUdpServerEvent::Datagram { session, datagram }) =
-            event
-        {
+        if let Http3ServerEvent::ConnectUdp(ServerEvent::Datagram { session, datagram }) = event {
             assert_eq!(session.stream_id(), session_id);
             assert_eq!(&datagram.as_ref()[..4], PING);
             count += 1;
@@ -653,7 +635,7 @@ fn session_lifecycle_with_http_datagram_capsule() {
         .find(|event| {
             matches!(
                 event,
-                Http3ServerEvent::ConnectUdp(ConnectUdpServerEvent::SessionClosed {
+                Http3ServerEvent::ConnectUdp(ServerEvent::SessionClosed {
                     session,
                     ..
                 }) if session.stream_id() == session_id

--- a/neqo-http3/tests/connect_udp.rs
+++ b/neqo-http3/tests/connect_udp.rs
@@ -11,7 +11,7 @@ use neqo_common::{Datagram, Tos, event::Provider as _, header::HeadersExt as _, 
 use neqo_http3::{
     ConnectUdpEvent, Error, Http3Client, Http3ClientEvent, Http3Parameters, Http3Server,
     Http3ServerEvent, Http3State, Priority, SessionAcceptAction,
-    connect_udp::{ServerEvent, ServerSession},
+    connect_udp::{ClientSession as _, ServerEvent, ServerSession},
 };
 use neqo_transport::ConnectionParameters;
 use nss::AuthenticationStatus;


### PR DESCRIPTION
This does much the same as #3717, but for CONNECT_UDP.

Most of the functions here are simple routing and glue, so it makes sense to bundle them all together.  That also limits the need for `pub` and `pub(crate)` visibility across some of the internal capabilities (`Http3Connection` and the event handling).

After this, I'll have to expand the factoring for WebTransport to include some of the stuff I discovered here.  Claude was not smart enough to do that in this case (it needed extra prompting, even) so I don't feel too bad about missing that.

This is not API-compatible, in case that wasn't clear.