### PR TITLE
bench: fix benchmark correctness and CodSpeed metadata

### DIFF
--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -80,12 +80,10 @@ fn transfer(c: &mut Criterion) {
                         ));
                         (server_handle, client)
                     },
-                    |(server_handle, client)| {
-                        black_box(async move {
-                            client.await.unwrap();
-                            // Tell server to shut down.
-                            server_handle.send(()).unwrap();
-                        })
+                    |(server_handle, client)| async move {
+                        black_box(client.await.unwrap());
+                        // Tell server to shut down.
+                        server_handle.send(()).unwrap();
                     },
                     BatchSize::PerIteration,
                 );

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -49,6 +49,7 @@ bench = false
 [[package.metadata.bench]]
 name = "decoder"
 codspeed.mode = "simulation"
+codspeed.memory = false # decode_varint only reads from the input slice; no allocation to profile.
 
 [[bench]]
 name = "decoder"

--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -64,7 +64,7 @@ bench = false
 
 [[package.metadata.bench]]
 name = "streams_simulated"
-codspeed.mode = "simulation"
+codspeed.mode = "walltime" # iter_custom is a no-op in instrumentation mode; exclude from CodSpeed matrix entirely.
 codspeed.memory = false # Memory profiling is incompatible with iter_custom() because CodSpeed's instrumentation hooks are bypassed.
 
 [[package.metadata.bench]]

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -65,7 +65,7 @@ codspeed.memory = false # FIXME: Disabled due to high variance in results.
 
 [[package.metadata.bench]]
 name = "transfer_simulated"
-codspeed.mode = "simulation"
+codspeed.mode = "walltime" # iter_custom is a no-op in instrumentation mode; exclude from CodSpeed matrix entirely.
 codspeed.memory = false # Memory profiling is incompatible with iter_custom() because CodSpeed's instrumentation hooks are bypassed.
 
 [[package.metadata.bench]]
@@ -89,10 +89,12 @@ codspeed.memory = false # Not a Criterion benchmark; plain fn main() with simula
 [[package.metadata.bench]]
 name = "pacer"
 codspeed.mode = "simulation"
+codspeed.memory = false # Pure arithmetic in the measured path; no allocation to profile.
 
 [[package.metadata.bench]]
 name = "frame_decode"
 codspeed.mode = "simulation"
+codspeed.memory = false # Frame::decode borrows the input slice; no allocation to profile.
 
 [[package.metadata.bench]]
 name = "packet_codec"

--- a/neqo-transport/benches/send_streams.rs
+++ b/neqo-transport/benches/send_streams.rs
@@ -22,6 +22,8 @@ use neqo_transport::{
 };
 
 const MAX_STREAM_DATA: u64 = 1 << 20; // 1 MiB credit
+// Must be small enough that a STREAM frame fits inside `packet::LIMIT` with room to spare,
+// so the packet builder doesn't fill before idle streams are visited.
 const DATA: &[u8] = &[0x5a; 200];
 
 fn make_streams(n_streams: usize) -> SendStreams {

--- a/neqo-transport/benches/send_streams.rs
+++ b/neqo-transport/benches/send_streams.rs
@@ -22,7 +22,7 @@ use neqo_transport::{
 };
 
 const MAX_STREAM_DATA: u64 = 1 << 20; // 1 MiB credit
-const DATA: &[u8] = &[0x5a; 4_096];
+const DATA: &[u8] = &[0x5a; 200];
 
 fn make_streams(n_streams: usize) -> SendStreams {
     let conn_fc = Rc::new(RefCell::new(SenderFlowControl::new((), u64::MAX)));


### PR DESCRIPTION
send_streams: DATA (4096 bytes) filled the packet builder before idle streams were visited, making all three variants measure identical work. Shrink to 200 bytes so idle-stream iteration cost scales with count.

neqo-bin: fix black_box fencing the async block instead of its result.

CodSpeed: disable memory runs for zero-allocation benches (pacer, frame_decode, decoder). Switch transfer_simulated and streams_simulated to walltime mode — iter_custom is silently skipped in instrumentation mode, wasting a CI job per run.