### PR TITLE
bench: replace iter_custom with iter_batched 

### DIFF
--- a/neqo-http3/Cargo.toml
+++ b/neqo-http3/Cargo.toml
@@ -64,8 +64,7 @@ bench = false
 
 [[package.metadata.bench]]
 name = "streams_simulated"
-codspeed.mode = "walltime" # iter_custom is a no-op in instrumentation mode; exclude from CodSpeed matrix entirely.
-codspeed.memory = false # Memory profiling is incompatible with iter_custom() because CodSpeed's instrumentation hooks are bypassed.
+codspeed.mode = "simulation"
 
 [[package.metadata.bench]]
 name = "streams_walltime"

--- a/neqo-http3/benches/common.rs
+++ b/neqo-http3/benches/common.rs
@@ -4,14 +4,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![expect(
-    dead_code,
-    reason = "Included by two bench binaries; each uses only one entry point."
-)]
-
 use std::{hint::black_box, time::Duration};
 
-use criterion::{Criterion, Throughput};
+use criterion::{BatchSize::SmallInput, Criterion, Throughput};
 use test_fixture::{
     boxed, fixture_init,
     sim::{
@@ -59,7 +54,7 @@ fn setup_with_link(
 ///
 /// The DSL uplink (200 KB/s, 60 ms one-way delay) keeps the bandwidth-delay
 /// product well below the default flow-control window, so no FC blocking occurs.
-pub fn setup(streams: usize, data_size: usize) -> ReadySimulator {
+fn setup(streams: usize, data_size: usize) -> ReadySimulator {
     setup_with_link(streams, data_size, TailDrop::dsl_uplink)
 }
 
@@ -68,7 +63,7 @@ pub fn setup(streams: usize, data_size: usize) -> ReadySimulator {
 /// At 100 MB/s with a 20 ms RTT the bandwidth-delay product (~2 MB) exceeds the
 /// 1 MB per-stream flow-control window, so streams regularly exhaust their window
 /// and block waiting for `MAX_STREAM_DATA`.
-pub fn setup_flow_controlled(streams: usize, data_size: usize) -> ReadySimulator {
+fn setup_flow_controlled(streams: usize, data_size: usize) -> ReadySimulator {
     // Link delay is zero so propagation RTT comes entirely from the Delay nodes
     // (10 ms each way = 20 ms RTT).
     setup_with_link(streams, data_size, || {
@@ -88,40 +83,24 @@ const CONFIGS: [(&str, SetupFn, &[(usize, usize)]); 2] = [
     ),
 ];
 
-/// Runs all stream benchmarks measuring wall-clock CPU time.
-pub fn walltime(c: &mut Criterion) {
+/// Runs all stream benchmarks using `iter_batched`, grouping results under
+/// `name_prefix` (e.g. `"walltime"` or `"simulated"`).
+pub fn bench(c: &mut Criterion, name_prefix: &str) {
     fixture_init();
     for (group_name, setup_fn, params) in CONFIGS {
         let mut group = c.benchmark_group(group_name);
         for &(streams, data_size) in params {
-            let name = format!("walltime/{streams}-streams/each-{data_size}-bytes");
-            group.bench_function(&name, |b| {
-                b.iter_batched(
-                    || setup_fn(streams, data_size),
-                    |sim| black_box(sim.run()),
-                    criterion::BatchSize::SmallInput,
-                );
-            });
-        }
-        group.finish();
-    }
-}
-
-/// Runs all stream benchmarks measuring simulated network time (throughput).
-pub fn simulated(c: &mut Criterion) {
-    fixture_init();
-    for (group_name, setup_fn, params) in CONFIGS {
-        let mut group = c.benchmark_group(group_name);
-        for &(streams, data_size) in params {
-            let name = format!("simulated/{streams}-streams/each-{data_size}-bytes");
             group.throughput(Throughput::Bytes((streams * data_size) as u64));
-            group.bench_function(&name, |b| {
-                b.iter_custom(|iters| {
-                    (0..iters)
-                        .map(|_| setup_fn(streams, data_size).run())
-                        .sum::<Duration>()
-                });
-            });
+            group.bench_function(
+                &format!("{name_prefix}/{streams}-streams/each-{data_size}-bytes"),
+                |b| {
+                    b.iter_batched(
+                        || setup_fn(streams, data_size),
+                        |sim| black_box(sim.run()),
+                        SmallInput,
+                    );
+                },
+            );
         }
         group.finish();
     }

--- a/neqo-http3/benches/streams_simulated.rs
+++ b/neqo-http3/benches/streams_simulated.rs
@@ -4,9 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Benchmark with simulated time, i.e., measure the network protocol efficiency.
-//!
-//! Given that this uses simulated time, we can measure actual throughput.
+//! Benchmark over a simulated network, measuring instruction count via CodSpeed.
 
 #![expect(
     clippy::significant_drop_tightening,
@@ -19,7 +17,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 mod common;
 
 fn benchmark(c: &mut Criterion) {
-    common::simulated(c);
+    common::bench(c, "simulated");
 }
 
 criterion_group!(benches, benchmark);

--- a/neqo-http3/benches/streams_walltime.rs
+++ b/neqo-http3/benches/streams_walltime.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Benchmark with walltime, i.e., measure the compute efficiency.
+//! Benchmark over a simulated network, measuring wall-clock time on a hardware runner.
 
 #![expect(
     clippy::significant_drop_tightening,
@@ -17,7 +17,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 mod common;
 
 fn benchmark(c: &mut Criterion) {
-    common::walltime(c);
+    common::bench(c, "walltime");
 }
 
 criterion_group!(benches, benchmark);

--- a/neqo-transport/Cargo.toml
+++ b/neqo-transport/Cargo.toml
@@ -65,8 +65,7 @@ codspeed.memory = false # FIXME: Disabled due to high variance in results.
 
 [[package.metadata.bench]]
 name = "transfer_simulated"
-codspeed.mode = "walltime" # iter_custom is a no-op in instrumentation mode; exclude from CodSpeed matrix entirely.
-codspeed.memory = false # Memory profiling is incompatible with iter_custom() because CodSpeed's instrumentation hooks are bypassed.
+codspeed.mode = "simulation"
 
 [[package.metadata.bench]]
 name = "rx_stream_orderer"

--- a/neqo-transport/benches/transfer_common.rs
+++ b/neqo-transport/benches/transfer_common.rs
@@ -4,9 +4,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::time::Duration;
+use std::{hint::black_box, time::Duration};
 
-use criterion::{BenchmarkGroup, Criterion};
+use criterion::{BatchSize::SmallInput, Criterion, Throughput};
 use neqo_transport::{ConnectionParameters, State};
 use test_fixture::{
     boxed,
@@ -18,13 +18,13 @@ use test_fixture::{
 };
 
 const DELAY: Duration = Duration::from_millis(10);
-pub const TRANSFER_AMOUNT: usize = 1 << 22; // 4Mbyte
+const TRANSFER_AMOUNT: usize = 1 << 22; // 4MiB
 
 const FIXED_SEED: &str = "62df6933ba1f543cece01db8f27fb2025529b27f93df39e19f006e1db3b8c843";
 
 /// Creates a ready simulator for benchmarking transfer.
 #[must_use]
-pub fn setup(label: &str, seed: Option<&str>, pacing: bool) -> ReadySimulator {
+fn setup(label: &str, seed: Option<&str>, pacing: bool) -> ReadySimulator {
     let nodes = boxed![
         Node::new_client(
             ConnectionParameters::default()
@@ -54,15 +54,9 @@ pub fn setup(label: &str, seed: Option<&str>, pacing: bool) -> ReadySimulator {
     sim.setup()
 }
 
-/// Runs transfer benchmarks for all configurations.
-///
-/// The closure receives the benchmark group, label, seed, and pacing flag,
-/// allowing each benchmark to define its own measurement approach.
-pub fn benchmark<M>(c: &mut Criterion, mut measure: M)
-where
-    M: FnMut(&mut BenchmarkGroup<'_, criterion::measurement::WallTime>, &str, Option<&str>, bool),
-{
-    // Handle SIMULATION_SEED environment variable for varying-seeds config
+/// Runs transfer benchmarks using `iter_batched`, grouping results under
+/// `name_prefix` (e.g. `"walltime"` or `"simulated"`).
+pub fn bench(c: &mut Criterion, name_prefix: &str) {
     let env_seed = std::env::var("SIMULATION_SEED").ok();
     let configs: [(&str, Option<&str>); 2] = [
         ("varying-seeds", env_seed.as_deref()),
@@ -71,9 +65,16 @@ where
 
     let mut group = c.benchmark_group("transfer");
     group.noise_threshold(0.03);
+    group.throughput(Throughput::Bytes(TRANSFER_AMOUNT as u64));
     for (label, seed) in configs {
         for pacing in [false, true] {
-            measure(&mut group, label, seed, pacing);
+            group.bench_function(&format!("{name_prefix}/pacing-{pacing}/{label}"), |b| {
+                b.iter_batched(
+                    || setup(label, seed, pacing),
+                    |sim| black_box(sim.run()),
+                    SmallInput,
+                );
+            });
         }
     }
     group.finish();

--- a/neqo-transport/benches/transfer_simulated.rs
+++ b/neqo-transport/benches/transfer_simulated.rs
@@ -4,36 +4,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Benchmark with simulated time, i.e., measure the network protocol efficiency.
-//!
-//! Given that this uses simulated time, we can measure actual throughput.
+//! Benchmark over a simulated network, measuring instruction count via CodSpeed.
 
 #![expect(
     clippy::significant_drop_tightening,
     reason = "Inherent in codspeed criterion_group! macro."
 )]
 
-use std::time::Duration;
-
-use criterion::{Throughput, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main};
 
 #[path = "transfer_common.rs"]
 mod common;
 
 fn benchmark(c: &mut criterion::Criterion) {
-    common::benchmark(c, |group, label, seed, pacing| {
-        let bench_name = format!("simulated/pacing-{pacing}/{label}");
-        group.throughput(Throughput::Bytes(common::TRANSFER_AMOUNT as u64));
-        group.bench_function(&bench_name, |b| {
-            b.iter_custom(|iters| {
-                let mut d_sum = Duration::ZERO;
-                for _i in 0..iters {
-                    d_sum += common::setup(label, seed, pacing).run();
-                }
-                d_sum
-            });
-        });
-    });
+    common::bench(c, "simulated");
 }
 
 criterion_group! {

--- a/neqo-transport/benches/transfer_walltime.rs
+++ b/neqo-transport/benches/transfer_walltime.rs
@@ -4,31 +4,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Benchmark with walltime, i.e., measure the compute efficiency.
+//! Benchmark over a simulated network, measuring wall-clock time on a hardware runner.
 
 #![expect(
     clippy::significant_drop_tightening,
     reason = "Inherent in codspeed criterion_group! macro."
 )]
 
-use std::hint::black_box;
-
-use criterion::{BatchSize::SmallInput, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main};
 
 #[path = "transfer_common.rs"]
 mod common;
 
 fn benchmark(c: &mut criterion::Criterion) {
-    common::benchmark(c, |group, label, seed, pacing| {
-        let bench_name = format!("walltime/pacing-{pacing}/{label}");
-        group.bench_function(&bench_name, |b| {
-            b.iter_batched(
-                || common::setup(label, seed, pacing),
-                |sim| black_box(sim.run()),
-                SmallInput,
-            );
-        });
-    });
+    common::bench(c, "walltime");
 }
 
 criterion_group! {


### PR DESCRIPTION
iter_custom is a no-op in CodSpeed's instrumentation build, silently skipping these benches. Switch to iter_batched so the simulated-network benches produce instruction-count data in CodSpeed and wall-clock data on the hardware runner.