### PR TITLE
fix: reject STREAMS_BLOCKED limit above 2^60

### DIFF
--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -603,9 +603,13 @@ impl<'a> Frame<'a> {
                 stream_data_limit: dv(dec)?,
             }),
             FrameType::StreamsBlockedBiDi | FrameType::StreamsBlockedUniDi => {
+                let m = dv(dec)?;
+                if m > (1 << 60) {
+                    return Err(Error::StreamLimit);
+                }
                 Ok(Self::StreamsBlocked {
                     stream_type: t.try_into()?,
-                    stream_limit: dv(dec)?,
+                    stream_limit: m,
                 })
             }
             FrameType::NewConnectionId => {
@@ -1446,6 +1450,18 @@ mod tests {
     fn decode_max_streams_exceeds_limit() {
         let mut enc = Encoder::default();
         enc.encode_byte(0x12); // MaxStreamsBiDi
+        enc.encode_varint((1u64 << 60) + 1);
+        assert_eq!(
+            Frame::decode(&mut enc.as_decoder()).unwrap_err(),
+            Error::StreamLimit
+        );
+    }
+
+    /// A `StreamsBlocked` frame with value > 2^60 is rejected.
+    #[test]
+    fn decode_streams_blocked_exceeds_limit() {
+        let mut enc = Encoder::default();
+        enc.encode_byte(0x16); // StreamsBlockedBiDi
         enc.encode_varint((1u64 << 60) + 1);
         assert_eq!(
             Frame::decode(&mut enc.as_decoder()).unwrap_err(),


### PR DESCRIPTION
StreamsBlocked accepts a limit the encoding cannot represent:

        StreamsBlocked { stream_type: BiDi, stream_limit: 1152921504606846977 }  // 2^60 + 1

RFC 9000 19.14 caps the Maximum Streams field of STREAMS_BLOCKED at 2^60, the same bound 19.11 puts on MAX_STREAMS, and says a larger value must be a connection error. The MAX_STREAMS arm a few lines up already rejects it with `Error::StreamLimit`; the STREAMS_BLOCKED arm read the varint with no check.

Before: a peer STREAMS_BLOCKED above 2^60 is accepted and stored.
After: it returns `Error::StreamLimit`, matching MAX_STREAMS.

Valid frames decode the same as before; the cost is one comparison per STREAMS_BLOCKED frame.