### PR TITLE
Add a client-side check for CONNECT_UDP

### DIFF
--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -25,6 +25,9 @@ use crate::{
 };
 
 pub trait ClientSession {
+    /// Whether `CONNECT_UDP` is enabled on the connection.
+    fn connect_udp_enabled(&self) -> bool;
+
     /// Create a MASQUE connect-udp session.
     ///
     /// # Errors
@@ -73,6 +76,10 @@ pub trait ClientSession {
 }
 
 impl ClientSession for Http3Client {
+    fn connect_udp_enabled(&self) -> bool {
+        self.handler().connect_udp_enabled()
+    }
+
     fn connect_udp_create_session<T: RequestTarget>(
         &mut self,
         now: Instant,

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -26,6 +26,7 @@ use crate::{
 
 pub trait ClientSession {
     /// Whether `CONNECT_UDP` is enabled on the connection.
+    #[must_use]
     fn connect_udp_enabled(&self) -> bool;
 
     /// Create a MASQUE connect-udp session.

--- a/neqo-http3/tests/connect_udp.rs
+++ b/neqo-http3/tests/connect_udp.rs
@@ -23,6 +23,15 @@ use test_fixture::{
 const PING: &[u8] = b"ping";
 const PONG: &[u8] = b"pong";
 
+#[test]
+fn disabled_by_default() {
+    let mut client = default_http3_client();
+    let mut server = default_http3_server();
+    // Connect client and proxy.
+    let _out = test_fixture::connect_peers(&mut client, &mut server);
+    assert!(!client.connect_udp_enabled());
+}
+
 fn initiate_new_session() -> (Http3Client, Http3Server, neqo_http3::StreamId) {
     let conn_params = ConnectionParameters::default()
         .pmtud(true)
@@ -44,6 +53,7 @@ fn initiate_new_session() -> (Http3Client, Http3Server, neqo_http3::StreamId) {
     let out = test_fixture::connect_peers(&mut client, &mut proxy);
     let out = proxy.process(out, now()).dgram().unwrap();
     client.process_input(out, now());
+    assert!(client.connect_udp_enabled());
 
     // Establish connect-udp session.
     let connect_udp_session_id = client


### PR DESCRIPTION
As suggested in https://github.com/mozilla/neqo/pull/3722#discussion_r3433431426

Clean retry of #3723.