### PR TITLE
fix: reject max_ack_delay transport parameter of 2^14 or greater

### DIFF
--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -295,10 +295,14 @@ impl TransportParameter {
             | TransportParameterId::InitialMaxStreamDataBidiLocal
             | TransportParameterId::InitialMaxStreamDataBidiRemote
             | TransportParameterId::InitialMaxStreamDataUni
-            | TransportParameterId::MaxAckDelay
             | TransportParameterId::MaxDatagramFrameSize => match d.decode_varint() {
                 Some(v) => Self::Integer(v),
                 None => return Err(Error::TransportParameter),
+            },
+            TransportParameterId::MaxAckDelay => match d.decode_varint() {
+                // RFC 9000, Section 18.2: "Values of 2^14 or greater are invalid."
+                Some(v) if v < (1 << 14) => Self::Integer(v),
+                _ => return Err(Error::TransportParameter),
             },
             TransportParameterId::InitialMaxStreamsBidi
             | TransportParameterId::InitialMaxStreamsUni => match d.decode_varint() {
@@ -1320,6 +1324,14 @@ mod tests {
     fn ack_delay_exponent_boundary() {
         assert!(decode_tp_integer(AckDelayExponent, 20).is_ok());
         assert!(decode_tp_integer(AckDelayExponent, 21).is_err());
+    }
+
+    #[test]
+    fn max_ack_delay_boundary() {
+        // Just below the limit is valid.
+        assert!(decode_tp_integer(MaxAckDelay, (1 << 14) - 1).is_ok());
+        // At the limit (2^14) and above is an error.
+        assert!(decode_tp_integer(MaxAckDelay, 1 << 14).is_err());
     }
 
     #[test]


### PR DESCRIPTION
RFC 9000, Section 18.2:

    max_ack_delay (0x0b): ... Values of 2^14 or greater are invalid.

`TransportParameter::decode` groups max_ack_delay with the unbounded integer parameters, so a peer can advertise any varint up to 2^62-1 and neqo accepts it. The neighboring arms already bound their values (ack_delay_exponent <= 20, min_ack_delay < 2^24).

Before: max_ack_delay >= 16384 is accepted and used as the peer ACK delay; qlog narrows it to u16, silently truncating.
After: it is rejected with a transport parameter error, matching the sibling checks.

Tradeoff: a non-conforming peer that previously completed the handshake now gets closed during parameter validation, which is the intended behavior per the RFC.