### PR TITLE
fix: reject RETIRE_CONNECTION_ID for an unissued sequence number

### DIFF
--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -513,7 +513,14 @@ impl ConnectionIdManager {
         self.connection_ids.contains(cid)
     }
 
-    pub fn retire(&mut self, seqno: u64) {
+    pub fn retire(&mut self, seqno: u64) -> Res<()> {
+        // RFC 9000, Section 19.16: receipt of a RETIRE_CONNECTION_ID frame whose
+        // sequence number is greater than any we have issued (i.e. not below the
+        // next sequence number to be used) is a connection error.
+        if seqno >= self.next_seqno {
+            return Err(Error::ProtocolViolation);
+        }
+
         // TODO(mt) - consider keeping connection IDs around for a short while.
 
         let empty_cid = seqno == Self::SEQNO_EMPTY
@@ -528,6 +535,7 @@ impl ConnectionIdManager {
             self.connection_ids.retire(seqno);
             self.lost_new_connection_id.retain(|cid| cid.seqno != seqno);
         }
+        Ok(())
     }
 
     /// During the handshake, a server needs to regard the client's choice of destination

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -3410,7 +3410,7 @@ impl Connection {
             }
             Frame::RetireConnectionId { sequence_number } => {
                 self.stats.borrow_mut().frame_rx.retire_connection_id += 1;
-                self.cid_manager.retire(sequence_number);
+                self.cid_manager.retire(sequence_number)?;
             }
             Frame::PathChallenge { data } => {
                 self.stats.borrow_mut().frame_rx.path_challenge += 1;

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -1128,6 +1128,38 @@ fn retire_all() {
     assert_ne!(get_cid(&retire), original_cid);
 }
 
+/// Injects a `RETIRE_CONNECTION_ID` frame for a sequence number that was never issued.
+struct RetireUnissued(u64);
+
+impl crate::connection::test_internal::FrameWriter for RetireUnissued {
+    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+        builder
+            .encode_varint(FrameType::RetireConnectionId)
+            .encode_varint(self.0);
+    }
+}
+
+/// RFC 9000, Section 19.16: a `RETIRE_CONNECTION_ID` frame carrying a sequence number
+/// greater than any connection ID the receiver has issued is a connection error.
+#[test]
+fn retire_unissued_connection_id() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+
+    // The largest sequence number the client could have issued is far below this,
+    // so it has never been sent to the server.
+    let retire = send_with_extra(&mut server, RetireUnissued(1000), now());
+    client.process_input(retire, now());
+    assert!(matches!(
+        client.state(),
+        State::Closing {
+            error: CloseReason::Transport(Error::ProtocolViolation),
+            ..
+        }
+    ));
+}
+
 /// During a graceful migration, if the probed path can't get a new connection ID due
 /// to being forced to retire the one it is using, the migration will fail.
 #[test]


### PR DESCRIPTION
`ConnectionIdManager::retire` acted on the sequence number in a RETIRE_CONNECTION_ID frame without comparing it against the connection IDs we have issued. A peer can put any value there, including one at or beyond `next_seqno`; today that frame is silently ignored. RFC 9000 Section 19.16 says a sequence number greater than any we have sent must be treated as a PROTOCOL_VIOLATION connection error.

Reject the frame in `retire` when the sequence number is not below `next_seqno` and propagate the error from the frame handler. The behavioral change is narrow: a sequence number we never issued now closes the connection instead of being dropped, while every in-range retirement behaves as before. Keeping the bound in the manager, next to the counter it checks, means the single caller can't skip it.