### PR TITLE
reject trailing data in CANCEL_PUSH, GOAWAY, and MAX_PUSH_ID frames

### DIFF
--- a/neqo-http3/src/frames/hframe.rs
+++ b/neqo-http3/src/frames/hframe.rs
@@ -174,9 +174,15 @@ impl FrameDecoder<Self> for HFrame {
                 HFrameType::HEADERS => Some(Self::Headers {
                     header_block: dec.decode_remainder().to_vec(),
                 }),
-                HFrameType::CANCEL_PUSH => Some(Self::CancelPush {
-                    push_id: dec.decode_varint().ok_or(Error::HttpFrame)?.into(),
-                }),
+                HFrameType::CANCEL_PUSH => {
+                    let push_id = dec.decode_varint().ok_or(Error::HttpFrame)?;
+                    if dec.remaining() != 0 {
+                        return Err(Error::HttpFrame);
+                    }
+                    Some(Self::CancelPush {
+                        push_id: push_id.into(),
+                    })
+                }
                 HFrameType::SETTINGS => {
                     let mut settings = HSettings::default();
                     settings.decode_frame_contents(&mut dec).map_err(|e| {
@@ -192,12 +198,24 @@ impl FrameDecoder<Self> for HFrame {
                     push_id: dec.decode_varint().ok_or(Error::HttpFrame)?.into(),
                     header_block: dec.decode_remainder().to_vec(),
                 }),
-                HFrameType::GOAWAY => Some(Self::Goaway {
-                    stream_id: StreamId::new(dec.decode_varint().ok_or(Error::HttpFrame)?),
-                }),
-                HFrameType::MAX_PUSH_ID => Some(Self::MaxPushId {
-                    push_id: dec.decode_varint().ok_or(Error::HttpFrame)?.into(),
-                }),
+                HFrameType::GOAWAY => {
+                    let stream_id = dec.decode_varint().ok_or(Error::HttpFrame)?;
+                    if dec.remaining() != 0 {
+                        return Err(Error::HttpFrame);
+                    }
+                    Some(Self::Goaway {
+                        stream_id: StreamId::new(stream_id),
+                    })
+                }
+                HFrameType::MAX_PUSH_ID => {
+                    let push_id = dec.decode_varint().ok_or(Error::HttpFrame)?;
+                    if dec.remaining() != 0 {
+                        return Err(Error::HttpFrame);
+                    }
+                    Some(Self::MaxPushId {
+                        push_id: push_id.into(),
+                    })
+                }
                 HFrameType::PRIORITY_UPDATE_REQUEST | HFrameType::PRIORITY_UPDATE_PUSH => {
                     let element_id = dec.decode_varint().ok_or(Error::HttpFrame)?;
                     let priority = dec.decode_remainder();

--- a/neqo-http3/src/frames/tests/hframe.rs
+++ b/neqo-http3/src/frames/tests/hframe.rs
@@ -10,8 +10,8 @@ use test_fixture::fixture_init;
 
 use super::enc_dec_hframe;
 use crate::{
-    Priority, PushId,
-    frames::HFrame,
+    Error, Priority, PushId,
+    frames::{HFrame, hframe::HFrameType, reader::FrameDecoder as _},
     settings::{HSetting, HSettingType, HSettings},
 };
 
@@ -106,6 +106,39 @@ fn priority_update_request_urgency_default() {
         priority: Priority::new(3, true),
     };
     enc_dec_hframe(&f, "800f0700020869", 0); // "i"
+}
+
+/// RFC 9114 Section 7.1: a frame payload with bytes after the identified fields
+/// must be a connection error. `CANCEL_PUSH`, `GOAWAY`, and `MAX_PUSH_ID` each
+/// carry a single varint, so any trailing byte is rejected.
+#[test]
+fn single_field_frames_reject_trailing_data() {
+    // push_id/stream_id = 5 (0x05) followed by an extra byte.
+    let payload = &[0x05, 0xff];
+    for ft in [
+        HFrameType::CANCEL_PUSH,
+        HFrameType::GOAWAY,
+        HFrameType::MAX_PUSH_ID,
+    ] {
+        assert_eq!(
+            HFrame::decode(ft, payload.len() as u64, Some(payload)),
+            Err(Error::HttpFrame),
+            "frame type {ft:?}"
+        );
+    }
+
+    // The same frames without trailing data still decode.
+    let payload = &[0x05];
+    for ft in [
+        HFrameType::CANCEL_PUSH,
+        HFrameType::GOAWAY,
+        HFrameType::MAX_PUSH_ID,
+    ] {
+        assert!(
+            HFrame::decode(ft, payload.len() as u64, Some(payload)).is_ok(),
+            "frame type {ft:?}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
CANCEL_PUSH, GOAWAY, and MAX_PUSH_ID each carry a single varint, but `HFrame::decode` reads that varint and returns without looking at the rest of the payload. A peer that appends extra bytes inside the frame length has them silently discarded. RFC 9114 Section 7.1 says a payload with bytes after the identified fields must be a connection error of type H3_FRAME_ERROR.

Before, these three arms accepted the trailing bytes; after, they return `Error::HttpFrame` (0x106) once `decode_varint` leaves anything in the decoder. The check lives in the decoder because that is the only place the frame length and the consumed length are both known; the frames that legitimately have a variable tail (HEADERS, PUSH_PROMISE, the PRIORITY_UPDATE pair) read their remainder and are untouched. The tradeoff is strictness over leniency for a fixed-shape frame, which matches how SETTINGS already errors on a short trailing setting.