### PR TITLE
chore: replace usize↔u64 casts with named helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,6 +758,7 @@ dependencies = [
  "log",
  "qlog",
  "sha1",
+ "static_assertions",
  "strum",
  "test-fixture 0.29.1",
  "thiserror",

--- a/fuzz/fuzz_targets/client_initial.rs
+++ b/fuzz/fuzz_targets/client_initial.rs
@@ -34,7 +34,7 @@ fuzz_target!(|data: &[u8]| {
         .encode_vec(1, d_cid)
         .encode_vec(1, s_cid)
         .encode_vvec(&[])
-        .encode_varint(u64::try_from(payload_enc.len() + aead.expansion() + 1).unwrap())
+        .encode_len(payload_enc.len() + aead.expansion() + 1)
         .encode_uint(2, u16::try_from(pn).unwrap());
 
     let mut ciphertext = header_enc.as_ref().to_vec();

--- a/fuzz/fuzz_targets/qpack.rs
+++ b/fuzz/fuzz_targets/qpack.rs
@@ -18,7 +18,10 @@ fuzz_target!(|data: &[u8]| {
 
     let (encoder_stream_len, data) = if data.len() >= ENCODER_STREAM_LEN_SIZE {
         let (left, right) = data.split_at(ENCODER_STREAM_LEN_SIZE);
-        (u16::from_le_bytes(left.try_into().unwrap()) as usize, right)
+        (
+            usize::from(u16::from_le_bytes(left.try_into().unwrap())),
+            right,
+        )
     } else {
         (0, data)
     };

--- a/fuzz/fuzz_targets/server_initial.rs
+++ b/fuzz/fuzz_targets/server_initial.rs
@@ -40,7 +40,7 @@ fuzz_target!(|data: &[u8]| {
         .encode_vec(1, d_cid)
         .encode_vec(1, s_cid)
         .encode_vvec(&[])
-        .encode_varint(u64::try_from(payload_enc.len() + aead.expansion() + 1).unwrap())
+        .encode_len(payload_enc.len() + aead.expansion() + 1)
         .encode_byte(u8::try_from(pn).unwrap());
 
     let mut ciphertext = header_enc.as_ref().to_vec();

--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -14,6 +14,7 @@ use std::{env, hint::black_box, net::SocketAddr};
 
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use neqo_bin::{client, server};
+use neqo_common::to_u64;
 use tokio::runtime::Builder;
 
 struct Benchmark {
@@ -63,9 +64,9 @@ fn transfer(c: &mut Criterion) {
             .map_or_else(|| name.to_string(), |suffix| format!("{name}{suffix}"));
         let mut group = c.benchmark_group("transfer");
         group.throughput(if num_requests == 1 {
-            Throughput::Bytes((upload_size + download_size) as u64)
+            Throughput::Bytes(to_u64(upload_size + download_size))
         } else {
-            Throughput::Elements(num_requests as u64)
+            Throughput::Elements(to_u64(num_requests))
         });
         group.bench_function(&bench_name, |b| {
             b.to_async(Builder::new_current_thread().enable_all().build().unwrap())

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -23,6 +23,7 @@ hex = { workspace = true, optional = true }
 log = { workspace = true }
 qlog = { workspace = true }
 sha1 = { version = "0.10", default-features = false, optional = true }
+static_assertions = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -9,7 +9,7 @@ use std::{
     io::{self, Cursor},
 };
 
-use crate::hex_with_len;
+use crate::{Length, hex_with_len, to_u64};
 
 pub const MAX_VARINT: u64 = (1 << 62) - 1;
 
@@ -315,17 +315,18 @@ impl<B: Buffer> Encoder<B> {
         }
     }
 
+    /// Encode a length or byte count as a QUIC varint, accepting either `usize` or `u64`.
+    pub fn encode_len<T: Length>(&mut self, v: T) -> &mut Self {
+        self.encode_varint(v.as_u64())
+    }
+
     /// Encode a vector in TLS style.
     ///
     /// # Panics
     ///
     /// When `v` is longer than 2^n.
     pub fn encode_vec(&mut self, n: usize, v: &[u8]) -> &mut Self {
-        self.encode_uint(
-            n,
-            u64::try_from(v.as_ref().len()).expect("v is longer than 2^64"),
-        )
-        .encode(v)
+        self.encode_uint(n, to_u64(v.as_ref().len())).encode(v)
     }
 
     /// Encode a vector in TLS style using a closure for the contents.
@@ -356,8 +357,7 @@ impl<B: Buffer> Encoder<B> {
     ///
     /// When `v` is longer than 2^62.
     pub fn encode_vvec(&mut self, v: &[u8]) -> &mut Self {
-        self.encode_varint(u64::try_from(v.as_ref().len()).expect("v is longer than 2^64"))
-            .encode(v)
+        self.encode_len(v.as_ref().len()).encode(v)
     }
 
     /// Encode a vector with a varint length using a closure.
@@ -452,8 +452,8 @@ impl Encoder<Vec<u8>> {
     ///
     /// When `len` doesn't fit in a `u64`.
     #[must_use]
-    pub fn vvec_len(len: usize) -> usize {
-        Self::varint_len(u64::try_from(len).expect("usize should fit into u64")) + len
+    pub const fn vvec_len(len: usize) -> usize {
+        Self::varint_len(to_u64(len)) + len
     }
 
     /// Construction of a buffer with a predetermined capacity.

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -9,7 +9,7 @@ use std::{
     io::{self, Cursor},
 };
 
-use crate::{Length, hex_with_len, to_u64};
+use crate::{Length, hex_with_len, to_u64, to_usize};
 
 pub const MAX_VARINT: u64 = (1 << 62) - 1;
 
@@ -52,8 +52,7 @@ impl<'a> Decoder<'a> {
     /// Only use this for tests because we panic rather than reporting a result.
     #[cfg(any(test, feature = "test-fixture"))]
     fn skip_inner(&mut self, n: Option<u64>) {
-        #[expect(clippy::unwrap_used, reason = "Only used in tests.")]
-        self.skip(usize::try_from(n.expect("invalid length")).unwrap());
+        self.skip(to_usize(n.expect("invalid length")));
     }
 
     /// Skip a vector.  Panics if there isn't enough space.
@@ -386,7 +385,7 @@ impl<B: Buffer> Encoder<B> {
         // As long as encoding more than 63 bytes is rare, this won't cost much relative
         // to the convenience of being able to use this function.
 
-        let v = u64::try_from(len).expect("encoded value fits in a u64");
+        let v = to_u64(len);
         // The lower order byte fits before the inserted block of bytes.
         self.buf.write_at(start, (v & 0xff) as u8);
         let (count, bits) = match () {
@@ -662,7 +661,7 @@ impl Buffer for &mut Vec<u8> {
 
 impl Buffer for Cursor<&mut [u8]> {
     fn position(&self) -> usize {
-        usize::try_from(self.position()).expect("memory allocation not to exceed usize")
+        to_usize(self.position())
     }
 
     fn as_slice(&self) -> &[u8] {
@@ -677,16 +676,16 @@ impl Buffer for Cursor<&mut [u8]> {
     fn truncate(&mut self, len: usize) {
         let old_position = Buffer::position(self);
         if len < old_position {
-            self.set_position(u64::try_from(len).expect("Position cannot exceed u64"));
+            self.set_position(to_u64(len));
             self.get_mut()[len..old_position].fill(0);
         }
     }
 
     fn pad_to(&mut self, n: usize, v: u8) {
-        let start = usize::try_from(self.position()).expect("Buffer length does not exceed usize");
+        let start = to_usize(self.position());
 
         self.get_mut()[start..n].fill(v);
-        self.set_position(u64::try_from(n).expect("Position cannot exceed u64"));
+        self.set_position(to_u64(n));
     }
 
     fn write_at(&mut self, pos: usize, data: u8) {

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -22,6 +22,7 @@ pub mod tos;
 use std::fmt::Write as _;
 
 use enum_map::Enum;
+use static_assertions::const_assert_eq;
 use strum::Display;
 
 #[cfg(feature = "build-fuzzing-corpus")]
@@ -82,6 +83,30 @@ pub const fn const_max(a: usize, b: usize) -> usize {
 #[must_use]
 pub const fn const_min(a: usize, b: usize) -> usize {
     [a, b][(a > b) as usize]
+}
+
+// Both conversions below are safe on all targets where usize and u64 are the
+// same width (i.e., 64-bit targets). The assertion enforces this at compile time.
+const_assert_eq!(usize::BITS, u64::BITS);
+
+/// Convert a `usize` to `u64`.
+#[expect(clippy::inline_always, reason = "trivial numeric conversion")]
+#[inline(always)]
+#[must_use]
+pub const fn to_u64(v: usize) -> u64 {
+    v as u64
+}
+
+/// Convert a `u64` to `usize`.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "const_assert_eq above ensures usize::BITS == u64::BITS"
+)]
+#[expect(clippy::inline_always, reason = "trivial numeric conversion")]
+#[inline(always)]
+#[must_use]
+pub const fn to_usize(v: u64) -> usize {
+    v as usize
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Enum, Display)]

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -89,11 +89,41 @@ pub const fn const_min(a: usize, b: usize) -> usize {
 // same width (i.e., 64-bit targets). The assertion enforces this at compile time.
 const_assert_eq!(usize::BITS, u64::BITS);
 
+/// A trait for values that represent a length or byte count, convertible
+/// between the wire domain (`u64`) and the in-memory domain (`usize`).
+pub trait Length: Copy {
+    fn as_u64(self) -> u64;
+    fn as_usize(self) -> usize;
+}
+
+impl Length for u64 {
+    fn as_u64(self) -> u64 {
+        self
+    }
+    fn as_usize(self) -> usize {
+        to_usize(self)
+    }
+}
+
+impl Length for usize {
+    fn as_u64(self) -> u64 {
+        to_u64(self)
+    }
+    fn as_usize(self) -> usize {
+        self
+    }
+}
+
 /// Convert a `usize` to `u64`.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "const_assert_eq above ensures usize::BITS == u64::BITS"
+)]
 #[expect(clippy::inline_always, reason = "trivial numeric conversion")]
 #[inline(always)]
 #[must_use]
 pub const fn to_u64(v: usize) -> u64 {
+    debug_assert!(v as u64 as usize == v);
     v as u64
 }
 
@@ -106,6 +136,7 @@ pub const fn to_u64(v: usize) -> u64 {
 #[inline(always)]
 #[must_use]
 pub const fn to_usize(v: u64) -> usize {
+    debug_assert!(v as usize as u64 == v);
     v as usize
 }
 

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -90,18 +90,14 @@ pub const fn const_min(a: usize, b: usize) -> usize {
 const_assert_eq!(usize::BITS, u64::BITS);
 
 /// A trait for values that represent a length or byte count, convertible
-/// between the wire domain (`u64`) and the in-memory domain (`usize`).
+/// to the wire domain (`u64`).
 pub trait Length: Copy {
     fn as_u64(self) -> u64;
-    fn as_usize(self) -> usize;
 }
 
 impl Length for u64 {
     fn as_u64(self) -> u64 {
         self
-    }
-    fn as_usize(self) -> usize {
-        to_usize(self)
     }
 }
 
@@ -109,18 +105,15 @@ impl Length for usize {
     fn as_u64(self) -> u64 {
         to_u64(self)
     }
-    fn as_usize(self) -> usize {
-        self
-    }
 }
 
 /// Convert a `usize` to `u64`.
 #[expect(
     clippy::cast_possible_truncation,
-    reason = "const_assert_eq above ensures usize::BITS == u64::BITS"
+    reason = "debug_assert roundtrip `v as u64 as usize` contains a u64→usize cast; \
+              const_assert_eq above ensures it is lossless on all supported targets"
 )]
-#[expect(clippy::inline_always, reason = "trivial numeric conversion")]
-#[inline(always)]
+#[inline]
 #[must_use]
 pub const fn to_u64(v: usize) -> u64 {
     debug_assert!(v as u64 as usize == v);
@@ -132,8 +125,7 @@ pub const fn to_u64(v: usize) -> u64 {
     clippy::cast_possible_truncation,
     reason = "const_assert_eq above ensures usize::BITS == u64::BITS"
 )]
-#[expect(clippy::inline_always, reason = "trivial numeric conversion")]
-#[inline(always)]
+#[inline]
 #[must_use]
 pub const fn to_usize(v: u64) -> usize {
     debug_assert!(v as usize as u64 == v);

--- a/neqo-http3/benches/common.rs
+++ b/neqo-http3/benches/common.rs
@@ -7,6 +7,7 @@
 use std::{hint::black_box, time::Duration};
 
 use criterion::{BatchSize::SmallInput, Criterion, Throughput};
+use neqo_common::to_u64;
 use test_fixture::{
     boxed, fixture_init,
     sim::{
@@ -90,7 +91,7 @@ pub fn bench(c: &mut Criterion, name_prefix: &str) {
     for (group_name, setup_fn, params) in CONFIGS {
         let mut group = c.benchmark_group(group_name);
         for &(streams, data_size) in params {
-            group.throughput(Throughput::Bytes((streams * data_size) as u64));
+            group.throughput(Throughput::Bytes(to_u64(streams * data_size)));
             group.bench_function(
                 &format!("{name_prefix}/{streams}-streams/each-{data_size}-bytes"),
                 |b| {

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -1189,7 +1189,7 @@ mod tests {
     use std::time::Duration;
 
     use http::Uri;
-    use neqo_common::{Datagram, Decoder, Encoder, event::Provider as _, qtrace};
+    use neqo_common::{Datagram, Decoder, Encoder, event::Provider as _, qtrace, to_u64};
     use neqo_qpack as qpack;
     use neqo_transport::{
         CloseReason, ConnectionEvent, ConnectionParameters, INITIAL_LOCAL_MAX_STREAM_DATA,
@@ -2797,7 +2797,7 @@ mod tests {
     }
 
     fn alloc_buffer(size: usize) -> (Vec<u8>, Vec<u8>) {
-        let data_frame = HFrame::Data { len: size as u64 };
+        let data_frame = HFrame::Data { len: to_u64(size) };
         let mut enc = Encoder::default();
         data_frame.encode(&mut enc);
 
@@ -3878,7 +3878,7 @@ mod tests {
 
         let mut enc = Encoder::with_capacity(UNKNOWN_FRAME_LEN + 4);
         enc.encode_varint(1028_u64); // Arbitrary type.
-        enc.encode_varint(UNKNOWN_FRAME_LEN as u64);
+        enc.encode_varint(to_u64(UNKNOWN_FRAME_LEN));
         let mut buf: Vec<_> = enc.into();
         buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
         _ = server.conn.stream_send(request_stream_id, &buf).unwrap();

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -3878,7 +3878,7 @@ mod tests {
 
         let mut enc = Encoder::with_capacity(UNKNOWN_FRAME_LEN + 4);
         enc.encode_varint(1028_u64); // Arbitrary type.
-        enc.encode_varint(to_u64(UNKNOWN_FRAME_LEN));
+        enc.encode_len(UNKNOWN_FRAME_LEN);
         let mut buf: Vec<_> = enc.into();
         buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
         _ = server.conn.stream_send(request_stream_id, &buf).unwrap();

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -6441,7 +6441,7 @@ mod tests {
         let mut d = Encoder::default();
         hframe.encode(&mut d);
         let d_frame = HFrame::Data {
-            len: u64::try_from(data.len()).unwrap(),
+            len: to_u64(data.len()),
         };
         d_frame.encode(&mut d);
         d.encode(data);

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::Encoder;
+use neqo_common::{Encoder, to_u64};
 use neqo_transport::{ConnectionParameters, Error as TransportError};
 use test_fixture::now;
 
@@ -58,13 +58,11 @@ fn no_datagrams() {
 fn do_datagram_test(wt: &mut WtTest, wt_session: &ServerSession) {
     assert_eq!(
         wt_session.max_datagram_size(),
-        Ok(DATAGRAM_SIZE
-            - u64::try_from(Encoder::varint_len(wt_session.stream_id().as_u64())).unwrap())
+        Ok(DATAGRAM_SIZE - to_u64(Encoder::varint_len(wt_session.stream_id().as_u64())))
     );
     assert_eq!(
         wt.max_datagram_size(wt_session.stream_id()),
-        Ok(DATAGRAM_SIZE
-            - u64::try_from(Encoder::varint_len(wt_session.stream_id().as_u64())).unwrap())
+        Ok(DATAGRAM_SIZE - to_u64(Encoder::varint_len(wt_session.stream_id().as_u64())))
     );
 
     assert_eq!(wt_session.send_datagram(DGRAM, None, now()), Ok(()));
@@ -99,8 +97,7 @@ fn datagrams_server_only() {
     );
     assert_eq!(
         wt.max_datagram_size(wt_session.stream_id()),
-        Ok(DATAGRAM_SIZE
-            - u64::try_from(Encoder::varint_len(wt_session.stream_id().as_u64())).unwrap())
+        Ok(DATAGRAM_SIZE - to_u64(Encoder::varint_len(wt_session.stream_id().as_u64())))
     );
 
     assert_eq!(
@@ -127,8 +124,7 @@ fn datagrams_client_only() {
 
     assert_eq!(
         wt_session.max_datagram_size(),
-        Ok(DATAGRAM_SIZE
-            - u64::try_from(Encoder::varint_len(wt_session.stream_id().as_u64())).unwrap())
+        Ok(DATAGRAM_SIZE - to_u64(Encoder::varint_len(wt_session.stream_id().as_u64())))
     );
     assert_eq!(
         wt.max_datagram_size(wt_session.stream_id()),

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -10,7 +10,7 @@ mod sessions;
 mod streams;
 use std::{cell::RefCell, rc::Rc, time::Duration};
 
-use neqo_common::{event::Provider as _, header::HeadersExt as _};
+use neqo_common::{event::Provider as _, header::HeadersExt as _, to_u64};
 use neqo_transport::{ConnectionParameters, Pmtud, StreamId, StreamType, recv_stream, send_stream};
 use nss::AuthenticationStatus;
 use test_fixture::{
@@ -26,7 +26,7 @@ use crate::{
 };
 
 // Leave space for large QUIC header.
-const DATAGRAM_SIZE: u64 = Pmtud::default_plpmtu(DEFAULT_ADDR.ip()) as u64 - 40;
+const DATAGRAM_SIZE: u64 = to_u64(Pmtud::default_plpmtu(DEFAULT_ADDR.ip())) - 40;
 
 pub fn wt_default_parameters() -> Http3Parameters {
     Http3Parameters::default()

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::{Encoder, event::Provider as _, header::HeadersExt as _, to_u64};
+use neqo_common::{Encoder, event::Provider as _, header::HeadersExt as _};
 use neqo_transport::{StreamId, StreamType};
 use test_fixture::now;
 
@@ -267,7 +267,7 @@ fn wt_unknown_session_frame_client() {
     // Send an unknown frame.
     let mut enc = Encoder::with_capacity(UNKNOWN_FRAME_LEN + 4);
     enc.encode_varint(1028_u64); // Arbitrary type.
-    enc.encode_varint(to_u64(UNKNOWN_FRAME_LEN));
+    enc.encode_len(UNKNOWN_FRAME_LEN);
     let mut buf: Vec<_> = enc.into();
     buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
     wt.client

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::{Encoder, event::Provider as _, header::HeadersExt as _};
+use neqo_common::{Encoder, event::Provider as _, header::HeadersExt as _, to_u64};
 use neqo_transport::{StreamId, StreamType};
 use test_fixture::now;
 
@@ -267,7 +267,7 @@ fn wt_unknown_session_frame_client() {
     // Send an unknown frame.
     let mut enc = Encoder::with_capacity(UNKNOWN_FRAME_LEN + 4);
     enc.encode_varint(1028_u64); // Arbitrary type.
-    enc.encode_varint(UNKNOWN_FRAME_LEN as u64);
+    enc.encode_varint(to_u64(UNKNOWN_FRAME_LEN));
     let mut buf: Vec<_> = enc.into();
     buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
     wt.client

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
@@ -4,6 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use neqo_common::to_u64;
 use neqo_transport::StreamType;
 
 use crate::{
@@ -27,17 +28,17 @@ fn wt_client_stream_uni() {
     wt.send_data_client(wt_stream, BUF_CLIENT);
     wt.receive_data_server(wt_stream, true, BUF_CLIENT, false);
     let send_stats = wt.send_stream_stats(wt_stream).unwrap();
-    assert_eq!(send_stats.bytes_written(), BUF_CLIENT.len() as u64);
-    assert_eq!(send_stats.bytes_sent(), BUF_CLIENT.len() as u64);
-    assert_eq!(send_stats.bytes_acked(), BUF_CLIENT.len() as u64);
+    assert_eq!(send_stats.bytes_written(), to_u64(BUF_CLIENT.len()));
+    assert_eq!(send_stats.bytes_sent(), to_u64(BUF_CLIENT.len()));
+    assert_eq!(send_stats.bytes_acked(), to_u64(BUF_CLIENT.len()));
 
     // Send data again to test if the stats has the expected values.
     wt.send_data_client(wt_stream, BUF_CLIENT);
     wt.receive_data_server(wt_stream, false, BUF_CLIENT, false);
     let send_stats = wt.send_stream_stats(wt_stream).unwrap();
-    assert_eq!(send_stats.bytes_written(), (BUF_CLIENT.len() * 2) as u64);
-    assert_eq!(send_stats.bytes_sent(), (BUF_CLIENT.len() * 2) as u64);
-    assert_eq!(send_stats.bytes_acked(), (BUF_CLIENT.len() * 2) as u64);
+    assert_eq!(send_stats.bytes_written(), to_u64(BUF_CLIENT.len() * 2));
+    assert_eq!(send_stats.bytes_sent(), to_u64(BUF_CLIENT.len() * 2));
+    assert_eq!(send_stats.bytes_acked(), to_u64(BUF_CLIENT.len() * 2));
 
     let recv_stats = wt.recv_stream_stats(wt_stream);
     assert_eq!(recv_stats.unwrap_err(), Error::InvalidStreamId);
@@ -56,13 +57,13 @@ fn wt_client_stream_bidi() {
     wt.send_data_server(&wt_server_stream, BUF_SERVER);
     wt.receive_data_client(wt_client_stream, false, BUF_SERVER, false);
     let send_stats = wt.send_stream_stats(wt_client_stream).unwrap();
-    assert_eq!(send_stats.bytes_written(), BUF_CLIENT.len() as u64);
-    assert_eq!(send_stats.bytes_sent(), BUF_CLIENT.len() as u64);
-    assert_eq!(send_stats.bytes_acked(), BUF_CLIENT.len() as u64);
+    assert_eq!(send_stats.bytes_written(), to_u64(BUF_CLIENT.len()));
+    assert_eq!(send_stats.bytes_sent(), to_u64(BUF_CLIENT.len()));
+    assert_eq!(send_stats.bytes_acked(), to_u64(BUF_CLIENT.len()));
 
     let recv_stats = wt.recv_stream_stats(wt_client_stream).unwrap();
-    assert_eq!(recv_stats.bytes_received(), BUF_SERVER.len() as u64);
-    assert_eq!(recv_stats.bytes_read(), BUF_SERVER.len() as u64);
+    assert_eq!(recv_stats.bytes_received(), to_u64(BUF_SERVER.len()));
+    assert_eq!(recv_stats.bytes_read(), to_u64(BUF_SERVER.len()));
 }
 
 #[test]
@@ -78,8 +79,8 @@ fn wt_server_stream_uni() {
     assert_eq!(send_stats.unwrap_err(), Error::InvalidStreamId);
 
     let recv_stats = wt.recv_stream_stats(wt_server_stream.stream_id()).unwrap();
-    assert_eq!(recv_stats.bytes_received(), BUF_SERVER.len() as u64);
-    assert_eq!(recv_stats.bytes_read(), BUF_SERVER.len() as u64);
+    assert_eq!(recv_stats.bytes_received(), to_u64(BUF_SERVER.len()));
+    assert_eq!(recv_stats.bytes_read(), to_u64(BUF_SERVER.len()));
 }
 
 #[test]
@@ -95,13 +96,13 @@ fn wt_server_stream_bidi() {
     wt.send_data_client(wt_server_stream.stream_id(), BUF_CLIENT);
     drop(wt.receive_data_server(wt_server_stream.stream_id(), false, BUF_CLIENT, false));
     let stats = wt.send_stream_stats(wt_server_stream.stream_id()).unwrap();
-    assert_eq!(stats.bytes_written(), BUF_CLIENT.len() as u64);
-    assert_eq!(stats.bytes_sent(), BUF_CLIENT.len() as u64);
-    assert_eq!(stats.bytes_acked(), BUF_CLIENT.len() as u64);
+    assert_eq!(stats.bytes_written(), to_u64(BUF_CLIENT.len()));
+    assert_eq!(stats.bytes_sent(), to_u64(BUF_CLIENT.len()));
+    assert_eq!(stats.bytes_acked(), to_u64(BUF_CLIENT.len()));
 
     let recv_stats = wt.recv_stream_stats(wt_server_stream.stream_id()).unwrap();
-    assert_eq!(recv_stats.bytes_received(), BUF_SERVER.len() as u64);
-    assert_eq!(recv_stats.bytes_read(), BUF_SERVER.len() as u64);
+    assert_eq!(recv_stats.bytes_received(), to_u64(BUF_SERVER.len()));
+    assert_eq!(recv_stats.bytes_read(), to_u64(BUF_SERVER.len()));
 }
 
 #[test]

--- a/neqo-http3/src/features/extended_connect/webtransport_streams.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_streams.rs
@@ -6,7 +6,7 @@
 
 use std::{cell::RefCell, rc::Rc, time::Instant};
 
-use neqo_common::Encoder;
+use neqo_common::{Encoder, to_u64};
 use neqo_transport::{Connection, StreamId, recv_stream, send_stream};
 
 use super::session::Session;
@@ -92,7 +92,7 @@ impl RecvStream for WebTransportRecvStream {
             } else {
                 TYPE_LEN_BIDI
             };
-            (id_len + Encoder::varint_len(self.session_id.as_u64())) as u64
+            to_u64(id_len + Encoder::varint_len(self.session_id.as_u64()))
         } else {
             0
         };
@@ -243,7 +243,7 @@ impl SendStream for WebTransportSendStream {
             } else {
                 TYPE_LEN_BIDI
             };
-            (id_len + Encoder::varint_len(self.session_id.as_u64())) as u64
+            to_u64(id_len + Encoder::varint_len(self.session_id.as_u64()))
         } else {
             0
         };

--- a/neqo-http3/src/frames/capsule.rs
+++ b/neqo-http3/src/frames/capsule.rs
@@ -54,6 +54,8 @@ impl FrameDecoder<Self> for Capsule {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use neqo_common::to_usize;
+
     use super::*;
 
     #[test]
@@ -129,7 +131,7 @@ mod tests {
         let mut decoder = neqo_common::Decoder::from(encoded);
         let type_int = decoder.decode_varint().unwrap();
         let len = decoder.decode_varint().unwrap();
-        let data = decoder.decode(usize::try_from(len).unwrap()).unwrap();
+        let data = decoder.decode(to_usize(len)).unwrap();
 
         let result = Capsule::decode(HFrameType(type_int), len, Some(data))
             .unwrap()

--- a/neqo-http3/src/frames/hframe.rs
+++ b/neqo-http3/src/frames/hframe.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::{Debug, Write as _};
 
-use neqo_common::{Buffer, Decoder, Encoder, to_u64};
+use neqo_common::{Buffer, Decoder, Encoder};
 use neqo_transport::StreamId;
 use nss::random;
 
@@ -115,9 +115,7 @@ impl HFrame {
                 push_id,
                 header_block,
             } => {
-                enc.encode_varint(to_u64(
-                    header_block.len() + (Encoder::varint_len(u64::from(*push_id))),
-                ));
+                enc.encode_len(header_block.len() + Encoder::varint_len(u64::from(*push_id)));
                 enc.encode_varint(*push_id);
                 enc.encode(header_block);
             }

--- a/neqo-http3/src/frames/hframe.rs
+++ b/neqo-http3/src/frames/hframe.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::{Debug, Write as _};
 
-use neqo_common::{Buffer, Decoder, Encoder};
+use neqo_common::{Buffer, Decoder, Encoder, to_u64};
 use neqo_transport::StreamId;
 use nss::random;
 
@@ -115,9 +115,9 @@ impl HFrame {
                 push_id,
                 header_block,
             } => {
-                enc.encode_varint(
-                    (header_block.len() + (Encoder::varint_len(u64::from(*push_id)))) as u64,
-                );
+                enc.encode_varint(to_u64(
+                    header_block.len() + (Encoder::varint_len(u64::from(*push_id))),
+                ));
                 enc.encode_varint(*push_id);
                 enc.encode(header_block);
             }

--- a/neqo-http3/src/frames/tests/reader.rs
+++ b/neqo-http3/src/frames/tests/reader.rs
@@ -8,7 +8,7 @@
 
 use std::{cmp::min, fmt::Debug};
 
-use neqo_common::Encoder;
+use neqo_common::{Encoder, to_u64};
 use neqo_transport::{Connection, StreamId, StreamType};
 use test_fixture::{connect, now};
 
@@ -155,7 +155,7 @@ fn unknown_frame() {
 
     let mut enc = Encoder::with_capacity(UNKNOWN_FRAME_LEN + 4);
     enc.encode_varint(1028_u64); // Arbitrary type.
-    enc.encode_varint(UNKNOWN_FRAME_LEN as u64);
+    enc.encode_varint(to_u64(UNKNOWN_FRAME_LEN));
     let mut buf: Vec<_> = enc.into();
     buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
     assert!(fr.process::<HFrame>(&buf).is_none());
@@ -199,7 +199,7 @@ fn unknown_wt_frame() {
 
     let mut enc = Encoder::with_capacity(UNKNOWN_FRAME_LEN + 4);
     enc.encode_varint(1028_u64); // Arbitrary type.
-    enc.encode_varint(UNKNOWN_FRAME_LEN as u64);
+    enc.encode_varint(to_u64(UNKNOWN_FRAME_LEN));
     let mut buf: Vec<_> = enc.into();
     buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
     assert!(fr.process::<WebTransportFrame>(&buf).is_none());
@@ -283,7 +283,7 @@ fn complete_and_incomplete_unknown_frame() {
     const UNKNOWN_FRAME_LEN: usize = 832;
     let mut enc = Encoder::with_capacity(UNKNOWN_FRAME_LEN + 4);
     enc.encode_varint(1028_u64); // Arbitrary type.
-    enc.encode_varint(UNKNOWN_FRAME_LEN as u64);
+    enc.encode_varint(to_u64(UNKNOWN_FRAME_LEN));
     let mut buf: Vec<_> = enc.into();
     buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
 
@@ -400,7 +400,7 @@ fn complete_and_incomplete_frames() {
 
     // HFrameType::DATA len=FRAME_LEN
     let f = HFrame::Data {
-        len: FRAME_LEN as u64,
+        len: to_u64(FRAME_LEN),
     };
     let mut enc = Encoder::with_capacity(2);
     f.encode(&mut enc);

--- a/neqo-http3/src/frames/tests/reader.rs
+++ b/neqo-http3/src/frames/tests/reader.rs
@@ -155,7 +155,7 @@ fn unknown_frame() {
 
     let mut enc = Encoder::with_capacity(UNKNOWN_FRAME_LEN + 4);
     enc.encode_varint(1028_u64); // Arbitrary type.
-    enc.encode_varint(to_u64(UNKNOWN_FRAME_LEN));
+    enc.encode_len(UNKNOWN_FRAME_LEN);
     let mut buf: Vec<_> = enc.into();
     buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
     assert!(fr.process::<HFrame>(&buf).is_none());
@@ -199,7 +199,7 @@ fn unknown_wt_frame() {
 
     let mut enc = Encoder::with_capacity(UNKNOWN_FRAME_LEN + 4);
     enc.encode_varint(1028_u64); // Arbitrary type.
-    enc.encode_varint(to_u64(UNKNOWN_FRAME_LEN));
+    enc.encode_len(UNKNOWN_FRAME_LEN);
     let mut buf: Vec<_> = enc.into();
     buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
     assert!(fr.process::<WebTransportFrame>(&buf).is_none());
@@ -283,7 +283,7 @@ fn complete_and_incomplete_unknown_frame() {
     const UNKNOWN_FRAME_LEN: usize = 832;
     let mut enc = Encoder::with_capacity(UNKNOWN_FRAME_LEN + 4);
     enc.encode_varint(1028_u64); // Arbitrary type.
-    enc.encode_varint(to_u64(UNKNOWN_FRAME_LEN));
+    enc.encode_len(UNKNOWN_FRAME_LEN);
     let mut buf: Vec<_> = enc.into();
     buf.resize(UNKNOWN_FRAME_LEN + buf.len(), 0);
 

--- a/neqo-http3/src/frames/wtframe.rs
+++ b/neqo-http3/src/frames/wtframe.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::{Decoder, Encoder};
+use neqo_common::{Decoder, Encoder, to_u64};
 
 use super::hframe::HFrameType;
 use crate::{Error, Res, frames::reader::FrameDecoder};
@@ -33,7 +33,7 @@ impl WebTransportFrame {
 
         enc.encode_varint(Self::CLOSE_SESSION);
         let Self::CloseSession { error, message } = &self;
-        enc.encode_varint(4 + message.len() as u64);
+        enc.encode_varint(4 + to_u64(message.len()));
         enc.encode_uint(4, *error);
         enc.encode(message.as_bytes());
 
@@ -74,6 +74,8 @@ impl FrameDecoder<Self> for WebTransportFrame {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use neqo_common::to_u64;
+
     use super::{HFrameType, WebTransportFrame};
     use crate::frames::reader::FrameDecoder as _;
 
@@ -96,7 +98,7 @@ mod tests {
         let large_message = vec![0u8; 1025];
         let mut payload = vec![0, 0, 0, 0]; // 4-byte error code
         payload.extend(&large_message);
-        let frame_len = payload.len() as u64;
+        let frame_len = to_u64(payload.len());
 
         let result = WebTransportFrame::decode(
             HFrameType(WebTransportFrame::CLOSE_SESSION),
@@ -112,7 +114,7 @@ mod tests {
         let message = vec![b'a'; 1024];
         let mut payload = vec![0, 0, 0, 0]; // 4-byte error code
         payload.extend(&message);
-        let frame_len = payload.len() as u64;
+        let frame_len = to_u64(payload.len());
 
         let result = WebTransportFrame::decode(
             HFrameType(WebTransportFrame::CLOSE_SESSION),

--- a/neqo-http3/src/frames/wtframe.rs
+++ b/neqo-http3/src/frames/wtframe.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::{Decoder, Encoder, to_u64};
+use neqo_common::{Decoder, Encoder};
 
 use super::hframe::HFrameType;
 use crate::{Error, Res, frames::reader::FrameDecoder};
@@ -33,7 +33,7 @@ impl WebTransportFrame {
 
         enc.encode_varint(Self::CLOSE_SESSION);
         let Self::CloseSession { error, message } = &self;
-        enc.encode_varint(4 + to_u64(message.len()));
+        enc.encode_len(4 + message.len());
         enc.encode_uint(4, *error);
         enc.encode(message.as_bytes());
 

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -13,7 +13,7 @@ use std::{
     slice::SliceIndex,
 };
 
-use neqo_common::{Header, qerror, qinfo, qtrace, to_u64};
+use neqo_common::{Header, qerror, qinfo, qtrace, to_u64, to_usize};
 use neqo_transport::{Connection, StreamId};
 
 use crate::{
@@ -79,7 +79,7 @@ impl ActivePushStreams {
             return None;
         }
 
-        let inx = usize::try_from(u64::from(push_id - self.first_push_id)).ok()?;
+        let inx = to_usize(u64::from(push_id - self.first_push_id));
         if inx >= self.push_streams.len() {
             self.push_streams.resize(inx + 1, PushState::Init);
         }

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -13,7 +13,7 @@ use std::{
     slice::SliceIndex,
 };
 
-use neqo_common::{Header, qerror, qinfo, qtrace};
+use neqo_common::{Header, qerror, qinfo, qtrace, to_u64};
 use neqo_transport::{Connection, StreamId};
 
 use crate::{
@@ -112,13 +112,12 @@ impl ActivePushStreams {
     #[must_use]
     pub fn number_done(&self) -> PushId {
         self.first_push_id
-            + u64::try_from(
+            + to_u64(
                 self.push_streams
                     .iter()
                     .filter(|&e| e == &PushState::Closed)
                     .count(),
             )
-            .expect("usize fits in u64")
     }
 
     pub fn clear(&mut self) {

--- a/neqo-http3/src/qlog.rs
+++ b/neqo-http3/src/qlog.rs
@@ -8,7 +8,7 @@
 
 use std::time::Instant;
 
-use neqo_common::qlog::Qlog;
+use neqo_common::{qlog::Qlog, to_u64};
 use neqo_transport::StreamId;
 use qlog::events::{DataRecipient, EventData};
 
@@ -18,7 +18,7 @@ pub fn h3_data_moved_up(qlog: &mut Qlog, stream_id: StreamId, amount: usize, now
             let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
                 stream_id: Some(stream_id.as_u64()),
                 offset: None,
-                length: Some(u64::try_from(amount).expect("usize fits in u64")),
+                length: Some(to_u64(amount)),
                 from: Some(DataRecipient::Transport),
                 to: Some(DataRecipient::Application),
                 raw: None,
@@ -36,7 +36,7 @@ pub fn h3_data_moved_down(qlog: &mut Qlog, stream_id: StreamId, amount: usize, n
             let ev_data = EventData::DataMoved(qlog::events::quic::DataMoved {
                 stream_id: Some(stream_id.as_u64()),
                 offset: None,
-                length: Some(u64::try_from(amount).expect("usize fits in u64")),
+                length: Some(to_u64(amount)),
                 from: Some(DataRecipient::Application),
                 to: Some(DataRecipient::Transport),
                 raw: None,

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -13,7 +13,7 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{Buffer, Encoder, Header, MessageType, qdebug, qtrace};
+use neqo_common::{Buffer, Encoder, Header, MessageType, qdebug, qtrace, to_u64};
 use neqo_qpack as qpack;
 use neqo_transport::{Connection, StreamId};
 
@@ -207,7 +207,7 @@ impl SendStream for SendMessage {
         qdebug!("[{self}] send_request_body: available={available} to_send={to_send}");
 
         let data_frame = HFrame::Data {
-            len: to_send as u64,
+            len: to_u64(to_send),
         };
         let sent_fh = self
             .stream
@@ -295,7 +295,7 @@ impl SendStream for SendMessage {
 
     fn send_data_atomic(&mut self, conn: &mut Connection, buf: &[u8], now: Instant) -> Res<()> {
         let data_frame = HFrame::Data {
-            len: buf.len() as u64,
+            len: to_u64(buf.len()),
         };
         self.stream.encode_with(|e| data_frame.encode(e));
         self.stream.buffer(buf);

--- a/neqo-http3/src/webtransport.rs
+++ b/neqo-http3/src/webtransport.rs
@@ -12,7 +12,7 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{Bytes, Encoder, Header, qdebug, qinfo, qtrace};
+use neqo_common::{Bytes, Encoder, Header, qdebug, qinfo, qtrace, to_u64};
 use neqo_transport::{
     Connection, DatagramTracking, Error as TransportError, StreamId, StreamType, recv_stream,
     send_stream, server::ConnectionRef, streams::SendOrder,
@@ -190,7 +190,7 @@ impl ClientSession for Http3Client {
         Ok(self
             .connection()
             .max_datagram_size()?
-            .saturating_sub(u64::try_from(qsid_len).map_err(|_| Error::Internal)?))
+            .saturating_sub(to_u64(qsid_len)))
     }
 
     fn webtransport_set_sendorder(
@@ -685,7 +685,7 @@ impl ServerSession {
             .conn
             .borrow()
             .max_datagram_size()?
-            .saturating_sub(u64::try_from(qsid_len).map_err(|_| Error::Internal)?))
+            .saturating_sub(to_u64(qsid_len)))
     }
 
     /// Export keying material for this WebTransport session

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -10,7 +10,7 @@ mod common;
 
 use std::time::{Duration, Instant};
 
-use neqo_common::{Datagram, event::Provider as _, qtrace};
+use neqo_common::{Datagram, event::Provider as _, qtrace, to_usize};
 use neqo_http3::{
     Header, Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3Parameters, Http3Server,
     Http3ServerEvent, Http3State, Priority,
@@ -221,7 +221,6 @@ fn response_103() {
 
 /// Test [`neqo_http3::SendMessage::send_data`] to set
 /// [`neqo_transport::SendStream::set_writable_event_low_watermark`].
-#[expect(clippy::cast_possible_truncation, reason = "OK in a test.")]
 #[test]
 fn data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::Error>> {
     const STREAM_LIMIT: u64 = 5000;
@@ -286,7 +285,7 @@ fn data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::Error>
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
 
     // Expect the server's available send space to be back to the stream limit.
-    assert_eq!(request.available()?, STREAM_LIMIT as usize);
+    assert_eq!(request.available()?, to_usize(STREAM_LIMIT));
 
     // Expect the server to emit a DataWritable event, even though it always had
     // at least 1 byte available to send, i.e. it never exhausted the entire

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -279,7 +279,7 @@ fn map_error(err: &Error) -> Error {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use neqo_common::Header;
+    use neqo_common::{Header, to_u64};
     use neqo_transport::{StreamId, StreamType};
     use test_fixture::now;
 
@@ -681,7 +681,7 @@ mod tests {
                 &mut decoder,
                 t.header_block,
                 &t.headers,
-                StreamId::from(u64::try_from(i).unwrap()),
+                StreamId::from(to_u64(i)),
             );
         }
 
@@ -760,7 +760,7 @@ mod tests {
                 &mut decoder,
                 t.header_block,
                 &t.headers,
-                StreamId::from(u64::try_from(i).unwrap()),
+                StreamId::from(to_u64(i)),
             );
         }
 

--- a/neqo-qpack/src/huffman.rs
+++ b/neqo-qpack/src/huffman.rs
@@ -120,7 +120,7 @@ pub fn encode(input: &[u8]) -> Vec<u8> {
     let mut left: u8 = 8;
     let mut saved: u8 = 0;
     for c in input {
-        let mut e = HUFFMAN_TABLE[*c as usize];
+        let mut e = HUFFMAN_TABLE[usize::from(*c)];
 
         // Fill the previous byte
         if e.len < left {

--- a/neqo-qpack/src/huffman_decode_helper.rs
+++ b/neqo-qpack/src/huffman_decode_helper.rs
@@ -6,6 +6,8 @@
 
 use std::sync::OnceLock;
 
+use neqo_common::to_usize;
+
 use crate::huffman_table::HUFFMAN_TABLE;
 
 // Since we're encoding the table length as a u16, we need to ensure that it fits.
@@ -35,7 +37,7 @@ fn make_huffman_tree(prefix: u32, len: u8) -> HuffmanDecoderNode {
         found = true;
         if iter.len == len + 1 {
             // This is a leaf
-            let bit = usize::try_from(iter.val & 1).expect("u32 fits in usize");
+            let bit = to_usize(u64::from(iter.val & 1));
             next[bit] = Some(Box::new(HuffmanDecoderNode {
                 next: [None, None],
                 #[expect(

--- a/neqo-qpack/src/qpack_send_buf.rs
+++ b/neqo-qpack/src/qpack_send_buf.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use neqo_common::to_u64;
+
 use crate::{huffman, prefix::Prefix};
 
 /// Extension trait providing QPACK-specific encoding methods for `Encoder`.
@@ -68,16 +70,10 @@ where
 
         if use_huffman {
             let encoded = huffman::encode(value);
-            self.encode_prefixed_encoded_int(
-                real_prefix,
-                u64::try_from(encoded.len()).expect("usize fits in u64"),
-            );
+            self.encode_prefixed_encoded_int(real_prefix, to_u64(encoded.len()));
             self.encode(&encoded);
         } else {
-            self.encode_prefixed_encoded_int(
-                real_prefix,
-                u64::try_from(value.len()).expect("usize fits in u64"),
-            );
+            self.encode_prefixed_encoded_int(real_prefix, to_u64(value.len()));
             self.encode(value);
         }
     }

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -398,7 +398,7 @@ pub(crate) mod test_receiver {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
 
-    use neqo_common::Encoder;
+    use neqo_common::{Encoder, to_u64};
     use test_receiver::TestReceiver;
 
     use super::{
@@ -737,7 +737,7 @@ mod tests {
         let mut data = Encoder::default();
         data.encode_prefixed_encoded_int(
             Prefix::new(0x00, PREFIX_LEN + 1),
-            (LiteralReader::MAX_LEN + 1) as u64,
+            to_u64(LiteralReader::MAX_LEN + 1),
         );
         let mut buffer = ReceiverBufferWrapper::new(data.as_ref());
         assert_eq!(

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -290,14 +290,13 @@ impl HeaderTable {
             base: self.base,
             refs: 0,
         };
-        if u64::try_from(entry.size()).map_err(|_| Error::Internal)? > self.capacity
-            || !self
-                .evict_to(self.capacity - u64::try_from(entry.size()).map_err(|_| Error::Internal)?)
+        if to_u64(entry.size()) > self.capacity
+            || !self.evict_to(self.capacity - to_u64(entry.size()))
         {
             return Err(Error::DynamicTableFull);
         }
         self.base += 1;
-        self.used += u64::try_from(entry.size()).map_err(|_| Error::Internal)?;
+        self.used += to_u64(entry.size());
         let index = entry.index();
         self.dynamic.push_front(entry);
         Ok(index)

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -9,7 +9,7 @@ use std::{
     fmt::{self, Display, Formatter},
 };
 
-use neqo_common::qtrace;
+use neqo_common::{qtrace, to_u64};
 
 use crate::{
     Error, Res,
@@ -253,7 +253,7 @@ impl HeaderTable {
             if !e.can_reduce(self.acked_inserts_cnt) {
                 return false;
             }
-            self.used -= u64::try_from(e.size()).expect("usize fits in u64");
+            self.used -= to_u64(e.size());
             self.dynamic.pop_back();
         }
         true
@@ -268,11 +268,11 @@ impl HeaderTable {
             .map(DynamicTableEntry::size)
             .sum();
 
-        self.used - u64::try_from(evictable_size).expect("usize fits in u64") <= reduce
+        self.used - to_u64(evictable_size) <= reduce
     }
 
     pub fn insert_possible(&self, size: usize) -> bool {
-        let size = u64::try_from(size).expect("usize fits in u64");
+        let size = to_u64(size);
         size <= self.capacity && self.can_evict_to(self.capacity - size)
     }
 
@@ -423,7 +423,7 @@ mod tests {
 
             table.increment_acked(1).unwrap();
 
-            let first_entry_size = table.get_dynamic_with_abs_index(0).unwrap().size() as u64;
+            let first_entry_size = to_u64(table.get_dynamic_with_abs_index(0).unwrap().size());
 
             assert!(table.can_evict_to(first_entry_size));
             assert!(!table.can_evict_to(0));

--- a/neqo-transport/benches/frame_decode.rs
+++ b/neqo-transport/benches/frame_decode.rs
@@ -12,7 +12,7 @@
 use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use neqo_common::{Decoder, Encoder};
+use neqo_common::{Decoder, Encoder, to_u64};
 use neqo_transport::frame::{Frame, FrameType};
 
 const FRAME_PAYLOAD: usize = 100;
@@ -24,10 +24,10 @@ const FRAME_PAYLOAD: usize = 100;
 /// Frame type 0x0e = StreamWithOffLen (offset present, length present, no FIN).
 fn encode_stream_frames(n: usize) -> Vec<u8> {
     let mut enc = Encoder::default();
-    for i in 0..n as u64 {
+    for i in 0..to_u64(n) {
         enc.encode_varint(FrameType::StreamWithOffLen)
             .encode_varint(1u8) // stream id = 1
-            .encode_varint(i * FRAME_PAYLOAD as u64) // offset
+            .encode_varint(i * to_u64(FRAME_PAYLOAD)) // offset
             .encode_vvec(&[0u8; FRAME_PAYLOAD]); // length-prefixed payload
     }
     enc.into()

--- a/neqo-transport/benches/range_tracker.rs
+++ b/neqo-transport/benches/range_tracker.rs
@@ -12,6 +12,7 @@
 use std::hint::black_box;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use neqo_common::to_u64;
 use neqo_transport::send_stream::RangeTracker;
 
 const CHUNK: usize = 1000;
@@ -20,11 +21,11 @@ fn build_coalesce(count: usize) -> RangeTracker {
     let mut used = RangeTracker::default();
     used.mark_acked(0, CHUNK); // frontier at CHUNK
     // One big Sent range covering exactly the gap and all the acked chunks placed below.
-    used.mark_sent(CHUNK as u64, 2 * count * CHUNK);
+    used.mark_sent(to_u64(CHUNK), 2 * count * CHUNK);
     // ACK every *other* chunk so the acked ranges stay separate (a Sent chunk between
     // each prevents merging); the gap at [CHUNK, 2*CHUNK) keeps the frontier blocked.
     for i in 1..=count {
-        used.mark_acked((2 * i * CHUNK) as u64, CHUNK);
+        used.mark_acked(to_u64(2 * i * CHUNK), CHUNK);
     }
     used
 }
@@ -36,7 +37,7 @@ fn coalesce(c: &mut Criterion, count: usize) {
             // Fill the gap and jump the frontier past all `count` acked ranges in one
             // call; coalesce_acked then walks every entry below the new frontier.
             |used: &mut RangeTracker| {
-                used.mark_acked(CHUNK as u64, 2 * count * CHUNK);
+                used.mark_acked(to_u64(CHUNK), 2 * count * CHUNK);
                 black_box(used);
             },
             BatchSize::SmallInput,
@@ -60,7 +61,7 @@ fn mark_sent_sequential(c: &mut Criterion) {
             RangeTracker::default,
             |mut rt| {
                 for i in 0..SENDS {
-                    rt.mark_sent((i * CHUNK) as u64, CHUNK);
+                    rt.mark_sent(to_u64(i * CHUNK), CHUNK);
                 }
                 black_box(rt)
             },
@@ -78,18 +79,18 @@ fn mark_sent_retransmit(c: &mut Criterion) {
             || {
                 let mut rt = RangeTracker::default();
                 for i in 0..SENDS {
-                    rt.mark_sent((i * CHUNK) as u64, CHUNK);
+                    rt.mark_sent(to_u64(i * CHUNK), CHUNK);
                 }
                 // Simulate loss: unmark every 10th chunk.
                 for i in (0..SENDS).step_by(10) {
-                    rt.mark_as_lost((i * CHUNK) as u64, CHUNK);
+                    rt.mark_as_lost(to_u64(i * CHUNK), CHUNK);
                 }
                 rt
             },
             |mut rt| {
                 // Retransmit the lost chunks.
                 for i in (0..SENDS).step_by(10) {
-                    rt.mark_sent((i * CHUNK) as u64, CHUNK);
+                    rt.mark_sent(to_u64(i * CHUNK), CHUNK);
                 }
                 black_box(rt)
             },
@@ -114,7 +115,7 @@ fn mark_acked_gap_empty_covered(c: &mut Criterion) {
             |mut rt| {
                 // ACK every other chunk starting from chunk 1 (above frontier).
                 for i in (1..SENDS).step_by(2) {
-                    rt.mark_acked((i * CHUNK) as u64, CHUNK);
+                    rt.mark_acked(to_u64(i * CHUNK), CHUNK);
                 }
                 black_box(rt)
             },
@@ -133,14 +134,14 @@ fn mark_acked_fragmented(c: &mut Criterion) {
                 let mut rt = RangeTracker::default();
                 // Send only even chunks, creating a fragmented Sent map.
                 for i in (0..SENDS).step_by(2) {
-                    rt.mark_sent((i * CHUNK) as u64, CHUNK);
+                    rt.mark_sent(to_u64(i * CHUNK), CHUNK);
                 }
                 rt
             },
             |mut rt| {
                 // ACK the sent (even) chunks — covered is non-empty each time.
                 for i in (0..SENDS).step_by(2) {
-                    rt.mark_acked((i * CHUNK) as u64, CHUNK);
+                    rt.mark_acked(to_u64(i * CHUNK), CHUNK);
                 }
                 black_box(rt)
             },

--- a/neqo-transport/benches/rx_stream_orderer.rs
+++ b/neqo-transport/benches/rx_stream_orderer.rs
@@ -12,6 +12,7 @@
 use std::{collections::VecDeque, hint::black_box};
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use neqo_common::to_u64;
 use neqo_transport::recv_stream::RxStreamOrderer;
 
 const CHUNK: usize = 1_350;
@@ -27,7 +28,7 @@ fn inbound_in_order(c: &mut Criterion) {
             |mut rx| {
                 let mut drain = Vec::new();
                 for i in 0..FRAMES {
-                    rx.inbound_frame(i * CHUNK as u64, &PAYLOAD);
+                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD);
                     rx.read_to_end(&mut drain);
                     drain.clear();
                 }
@@ -50,12 +51,12 @@ fn inbound_with_loss(c: &mut Criterion) {
                     if i % 50 == 0 {
                         missing.push_back(i); // "drop" this frame
                     } else {
-                        rx.inbound_frame(i * CHUNK as u64, &PAYLOAD);
+                        rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD);
                     }
                     // Deliver a retransmission ~20 frames later.
                     if i % 20 == 19 {
                         if let Some(lost) = missing.pop_front() {
-                            rx.inbound_frame(lost * CHUNK as u64, &PAYLOAD);
+                            rx.inbound_frame(lost * to_u64(CHUNK), &PAYLOAD);
                         }
                     }
                     rx.read_to_end(&mut drain);
@@ -63,7 +64,7 @@ fn inbound_with_loss(c: &mut Criterion) {
                 }
                 // Flush any remaining retransmits.
                 for lost in missing {
-                    rx.inbound_frame(lost * CHUNK as u64, &PAYLOAD);
+                    rx.inbound_frame(lost * to_u64(CHUNK), &PAYLOAD);
                     rx.read_to_end(&mut drain);
                     drain.clear();
                 }
@@ -89,7 +90,7 @@ fn inbound_reordered(c: &mut Criterion) {
             |mut rx| {
                 let mut drain = Vec::new();
                 for &i in &order {
-                    rx.inbound_frame(i * CHUNK as u64, &PAYLOAD);
+                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD);
                     rx.read_to_end(&mut drain);
                     drain.clear();
                 }
@@ -108,10 +109,10 @@ fn inbound_duplicates(c: &mut Criterion) {
             |mut rx| {
                 let mut drain = Vec::new();
                 for i in 0..FRAMES {
-                    rx.inbound_frame(i * CHUNK as u64, &PAYLOAD);
+                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD);
                     if i % 20 == 0 && i > 0 {
                         // Duplicate of the previous frame.
-                        rx.inbound_frame((i - 1) * CHUNK as u64, &PAYLOAD);
+                        rx.inbound_frame((i - 1) * to_u64(CHUNK), &PAYLOAD);
                     }
                     rx.read_to_end(&mut drain);
                     drain.clear();

--- a/neqo-transport/benches/send_streams.rs
+++ b/neqo-transport/benches/send_streams.rs
@@ -12,7 +12,7 @@
 use std::{cell::RefCell, hint::black_box, rc::Rc};
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use neqo_common::Encoder;
+use neqo_common::{Encoder, to_u64};
 use neqo_transport::{
     ConnectionEvents, FrameStats, SenderFlowControl,
     packet::{self, Builder},
@@ -30,7 +30,7 @@ fn make_streams(n_streams: usize) -> SendStreams {
     let conn_fc = Rc::new(RefCell::new(SenderFlowControl::new((), u64::MAX)));
     let conn_events = ConnectionEvents::default();
     let mut ss = SendStreams::default();
-    for i in 0..n_streams as u64 {
+    for i in 0..to_u64(n_streams) {
         let id = StreamId::from(i * 4); // client-initiated bidi IDs
         let mut s = SendStream::new(
             id,

--- a/neqo-transport/benches/transfer_common.rs
+++ b/neqo-transport/benches/transfer_common.rs
@@ -7,6 +7,7 @@
 use std::{hint::black_box, time::Duration};
 
 use criterion::{BatchSize::SmallInput, Criterion, Throughput};
+use neqo_common::to_u64;
 use neqo_transport::{ConnectionParameters, State};
 use test_fixture::{
     boxed,
@@ -65,7 +66,7 @@ pub fn bench(c: &mut Criterion, name_prefix: &str) {
 
     let mut group = c.benchmark_group("transfer");
     group.noise_threshold(0.03);
-    group.throughput(Throughput::Bytes(TRANSFER_AMOUNT as u64));
+    group.throughput(Throughput::Bytes(to_u64(TRANSFER_AMOUNT)));
     for (label, seed) in configs {
         for pacing in [false, true] {
             group.bench_function(&format!("{name_prefix}/pacing-{pacing}/{label}"), |b| {

--- a/neqo-transport/src/ackrate.rs
+++ b/neqo-transport/src/ackrate.rs
@@ -8,7 +8,7 @@
 
 use std::{cmp::max, time::Duration};
 
-use neqo_common::{Buffer, qtrace};
+use neqo_common::{Buffer, qtrace, to_u64};
 
 use crate::{
     connection::params::ConnectionParameters,
@@ -49,7 +49,7 @@ impl AckRate {
         builder.write_varint_frame(&[
             u64::from(FrameType::AckFrequency),
             seqno,
-            u64::try_from(self.packets + 1).expect("usize fits in u64"),
+            to_u64(self.packets + 1),
             u64::try_from(self.delay.as_micros()).unwrap_or(u64::MAX),
             0,
         ])

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Buffer, Decoder, Encoder, Role, qinfo, qtrace};
+use neqo_common::{Buffer, Decoder, Encoder, Role, qinfo, qtrace, to_usize};
 use nss::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
     selfencrypt::SelfEncrypt,
@@ -208,7 +208,7 @@ impl AddressValidation {
             .zip(TOKEN_IDENTIFIER_RETRY.iter())
             .map(|(a, b)| (a ^ b).count_ones())
             .sum();
-        (difference as usize) < TOKEN_IDENTIFIER_RETRY.len()
+        to_usize(u64::from(difference)) < TOKEN_IDENTIFIER_RETRY.len()
     }
 
     pub fn validate(

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Buffer, Decoder, Encoder, Role, qinfo, qtrace};
+use neqo_common::{Buffer, Decoder, Encoder, Role, qinfo, qtrace, to_usize};
 use nss::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
     selfencrypt::SelfEncrypt,
@@ -208,7 +208,7 @@ impl AddressValidation {
             .zip(TOKEN_IDENTIFIER_RETRY.iter())
             .map(|(a, b)| (a ^ b).count_ones())
             .sum();
-        usize::try_from(difference).expect("u32 fits in usize") < TOKEN_IDENTIFIER_RETRY.len()
+        to_usize(u64::from(difference)) < TOKEN_IDENTIFIER_RETRY.len()
     }
 
     pub fn validate(

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Buffer, Decoder, Encoder, Role, qinfo, qtrace, to_usize};
+use neqo_common::{Buffer, Decoder, Encoder, Role, qinfo, qtrace};
 use nss::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
     selfencrypt::SelfEncrypt,
@@ -208,7 +208,7 @@ impl AddressValidation {
             .zip(TOKEN_IDENTIFIER_RETRY.iter())
             .map(|(a, b)| (a ^ b).count_ones())
             .sum();
-        to_usize(u64::from(difference)) < TOKEN_IDENTIFIER_RETRY.len()
+        (difference as usize) < TOKEN_IDENTIFIER_RETRY.len()
     }
 
     pub fn validate(

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -399,7 +399,7 @@ struct NewTokenFrameStatus {
 }
 
 impl NewTokenFrameStatus {
-    fn len(&self) -> usize {
+    const fn len(&self) -> usize {
         1 + Encoder::vvec_len(self.token.len())
     }
 }

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -985,7 +985,7 @@ where
 mod tests {
     use std::time::{Duration, Instant};
 
-    use neqo_common::qinfo;
+    use neqo_common::{qinfo, to_u64};
     use test_fixture::{new_neqo_qlog, now};
 
     use super::{ClassicCongestionController, PERSISTENT_CONG_THRESH, SlowStart, WindowAdjustment};
@@ -1231,7 +1231,7 @@ mod tests {
             .map(|(i, &t)| {
                 sent::Packet::new(
                     packet::Type::Short,
-                    u64::try_from(i).unwrap(),
+                    to_u64(i),
                     by_pto(t),
                     true,
                     recovery::Tokens::new(),

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{const_max, const_min, qdebug, qinfo, qlog::Qlog, qtrace};
+use neqo_common::{Length, const_max, const_min, qdebug, qinfo, qlog::Qlog, qtrace};
 use rustc_hash::FxHashMap as HashMap;
 
 use super::CongestionController;
@@ -120,7 +120,7 @@ pub trait SlowStart: Display + Debug {
 
     /// This is needed by SEARCH to keep its cumulative byte counters in sync during app-limited
     /// periods, when [`SlowStart::on_packets_acked`] is not called.
-    fn record_acked_bytes(&mut self, _new_acked_bytes: usize) {}
+    fn record_acked_bytes<T: Length>(&mut self, _new_acked_bytes: T) {}
 
     /// Handle packets being acknowledged during slow start. Returns the congestion window in bytes
     /// that slow start should be exited with. If slow start isn't exited returns `None`.

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -1013,7 +1013,7 @@ mod tests {
     const SUB_PC: Duration = Duration::from_millis(100 * PERSISTENT_CONG_THRESH as u64);
     /// The minimum time between packets to cause persistent congestion.
     /// Uses an odd expression because `Duration` arithmetic isn't `const`.
-    const PC: Duration = Duration::from_nanos(100_000_000 * (PERSISTENT_CONG_THRESH as u64) + 1);
+    const PC: Duration = Duration::from_nanos(100_000_000 * PERSISTENT_CONG_THRESH as u64 + 1);
 
     fn cwnd_is_default(cc: &ClassicCongestionController<ClassicSlowStart, NewReno>) {
         assert_eq!(cc.cwnd(), cc.cwnd_initial());

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Length, const_max, const_min, qdebug, qinfo, qlog::Qlog, qtrace};
+use neqo_common::{const_max, const_min, qdebug, qinfo, qlog::Qlog, qtrace};
 use rustc_hash::FxHashMap as HashMap;
 
 use super::CongestionController;
@@ -120,7 +120,7 @@ pub trait SlowStart: Display + Debug {
 
     /// This is needed by SEARCH to keep its cumulative byte counters in sync during app-limited
     /// periods, when [`SlowStart::on_packets_acked`] is not called.
-    fn record_acked_bytes<T: Length>(&mut self, _new_acked_bytes: T) {}
+    fn record_acked_bytes(&mut self, _new_acked_bytes: usize) {}
 
     /// Handle packets being acknowledged during slow start. Returns the congestion window in bytes
     /// that slow start should be exited with. If slow start isn't exited returns `None`.

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -1010,10 +1010,11 @@ mod tests {
     const EPSILON: Duration = Duration::from_nanos(1);
     const GAP: Duration = Duration::from_secs(1);
     /// The largest time between packets without causing persistent congestion.
-    const SUB_PC: Duration = Duration::from_millis(100 * PERSISTENT_CONG_THRESH as u64);
+    const SUB_PC: Duration = Duration::from_millis(100 * to_u64(PERSISTENT_CONG_THRESH as usize));
     /// The minimum time between packets to cause persistent congestion.
     /// Uses an odd expression because `Duration` arithmetic isn't `const`.
-    const PC: Duration = Duration::from_nanos(100_000_000 * PERSISTENT_CONG_THRESH as u64 + 1);
+    const PC: Duration =
+        Duration::from_nanos(100_000_000 * to_u64(PERSISTENT_CONG_THRESH as usize) + 1);
 
     fn cwnd_is_default(cc: &ClassicCongestionController<ClassicSlowStart, NewReno>) {
         assert_eq!(cc.cwnd(), cc.cwnd_initial());

--- a/neqo-transport/src/cc/hystart.rs
+++ b/neqo-transport/src/cc/hystart.rs
@@ -49,7 +49,7 @@ pub struct HyStart {
     css_baseline_mode: HyStartCssBaseline,
     last_round_min_rtt: Option<Duration>,
     current_round_min_rtt: Option<Duration>,
-    rtt_sample_count: usize,
+    rtt_sample_count: u64,
     window_end: Option<packet::Number>,
     css_baseline_min_rtt: Option<Duration>,
     css_round_count: usize,
@@ -68,7 +68,7 @@ impl HyStart {
 
     pub const MIN_RTT_DIVISOR: u32 = 8;
 
-    pub const N_RTT_SAMPLE: usize = 8;
+    pub const N_RTT_SAMPLE: u64 = 8;
 
     pub const CSS_GROWTH_DIVISOR: usize = 4;
 
@@ -169,7 +169,7 @@ impl HyStart {
     }
 
     #[cfg(test)]
-    pub const fn rtt_sample_count(&self) -> usize {
+    pub const fn rtt_sample_count(&self) -> u64 {
         self.rtt_sample_count
     }
 

--- a/neqo-transport/src/cc/search.rs
+++ b/neqo-transport/src/cc/search.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Length, qdebug, to_u64, to_usize};
+use neqo_common::{qdebug, to_u64, to_usize};
 
 use crate::{cc::classic_cc::SlowStart, packet, rtt::RttEstimate, stats::CongestionControlStats};
 
@@ -442,8 +442,8 @@ impl SlowStart for Search {
         }
     }
 
-    fn record_acked_bytes<T: Length>(&mut self, new_acked_bytes: T) {
-        self.acked_bytes = self.acked_bytes.saturating_add(new_acked_bytes.as_u64());
+    fn record_acked_bytes(&mut self, new_acked_bytes: usize) {
+        self.acked_bytes = self.acked_bytes.saturating_add(to_u64(new_acked_bytes));
     }
 
     fn on_packet_sent(&mut self, _sent_pn: packet::Number, sent_bytes: usize) {

--- a/neqo-transport/src/cc/search.rs
+++ b/neqo-transport/src/cc/search.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{qdebug, to_u64, to_usize};
+use neqo_common::{Length, qdebug, to_u64, to_usize};
 
 use crate::{cc::classic_cc::SlowStart, packet, rtt::RttEstimate, stats::CongestionControlStats};
 
@@ -42,9 +42,9 @@ pub enum Outcome {
 #[derive(Debug)]
 pub struct Search {
     /// The circular array used to track acked bytes per bin.
-    acked_bins: [usize; Self::NUM_ACKED_BINS],
+    acked_bins: [u64; Self::NUM_ACKED_BINS],
     /// The circular array used to track sent bytes per bin.
-    sent_bins: [usize; Self::NUM_SENT_BINS],
+    sent_bins: [u64; Self::NUM_SENT_BINS],
     /// The current index of the circular array. `None` if uninitialized.
     curr_idx: Option<usize>,
     /// Time at which the current bin will be passed and the next should start.
@@ -52,9 +52,9 @@ pub struct Search {
     /// The duration of each bin.
     bin_duration: Duration,
     /// Tracking amount of acked bytes on this connection. Is incremented on every ACK.
-    acked_bytes: usize,
+    acked_bytes: u64,
     /// Tracking amount of sent bytes on this connection. Is incremented on every sent packet.
-    sent_bytes: usize,
+    sent_bytes: u64,
     /// The RTT used to initialize SEARCH (set in [`Self::initialize`]).
     initial_rtt: Option<Duration>,
 }
@@ -214,32 +214,23 @@ impl Search {
         (prev_idx, fraction)
     }
 
-    /// Computes delivered bytes between two bin indices. Widens the result to `u64` to avoid
-    /// saturation or overflow further down the line on 32-bit systems with large bandwidths.
+    /// Computes delivered bytes between two bin indices.
     const fn compute_delv(&self, old: usize, new: usize) -> u64 {
-        to_u64(
-            self.acked_bins[new % Self::NUM_ACKED_BINS]
-                .saturating_sub(self.acked_bins[old % Self::NUM_ACKED_BINS]),
-        )
+        self.acked_bins[new % Self::NUM_ACKED_BINS]
+            .saturating_sub(self.acked_bins[old % Self::NUM_ACKED_BINS])
     }
 
     /// Computes sent bytes between two (previous) bin indices. Interpolates a fraction of each bin
     /// on the ends to get the accurate value when the actual previous timestamp is between two
     /// bins. The fraction is an integer out of [`Self::SCALE`], i.e. a value between `0` and `99`.
-    /// Widens intermittent results and returns `u64` to avoid saturation or overflow on 32-bit
-    /// systems with large bandwidths.
     const fn compute_sent(&self, old: usize, new: usize, fraction: u64) -> u64 {
         // NOTE: SEARCH draft-09 does forward interpolation here, i.e. `new + 1` or `old + 1`. That
         // is a mistake in the draft and has been discussed with the SEARCH team. Subtracting is
         // correct.
-        let low_idx = to_u64(
-            self.sent_bins[(new - 1) % Self::NUM_SENT_BINS]
-                .saturating_sub(self.sent_bins[(old - 1) % Self::NUM_SENT_BINS]),
-        );
-        let high_idx = to_u64(
-            self.sent_bins[new % Self::NUM_SENT_BINS]
-                .saturating_sub(self.sent_bins[old % Self::NUM_SENT_BINS]),
-        );
+        let low_idx = self.sent_bins[(new - 1) % Self::NUM_SENT_BINS]
+            .saturating_sub(self.sent_bins[(old - 1) % Self::NUM_SENT_BINS]);
+        let high_idx = self.sent_bins[new % Self::NUM_SENT_BINS]
+            .saturating_sub(self.sent_bins[old % Self::NUM_SENT_BINS]);
         let sent = low_idx * fraction + high_idx * (to_u64(Self::SCALE) - fraction);
         sent / to_u64(Self::SCALE)
     }
@@ -347,12 +338,12 @@ impl Search {
     }
 
     #[cfg(test)]
-    pub const fn acked_bin(&self, idx: usize) -> usize {
+    pub const fn acked_bin(&self, idx: usize) -> u64 {
         self.acked_bins[idx % Self::NUM_ACKED_BINS]
     }
 
     #[cfg(test)]
-    pub const fn sent_bin(&self, idx: usize) -> usize {
+    pub const fn sent_bin(&self, idx: usize) -> u64 {
         self.sent_bins[idx % Self::NUM_SENT_BINS]
     }
 
@@ -451,12 +442,12 @@ impl SlowStart for Search {
         }
     }
 
-    fn record_acked_bytes(&mut self, new_acked_bytes: usize) {
-        self.acked_bytes = self.acked_bytes.saturating_add(new_acked_bytes);
+    fn record_acked_bytes<T: Length>(&mut self, new_acked_bytes: T) {
+        self.acked_bytes = self.acked_bytes.saturating_add(new_acked_bytes.as_u64());
     }
 
     fn on_packet_sent(&mut self, _sent_pn: packet::Number, sent_bytes: usize) {
-        self.sent_bytes = self.sent_bytes.saturating_add(sent_bytes);
+        self.sent_bytes = self.sent_bytes.saturating_add(to_u64(sent_bytes));
     }
 
     fn reset(&mut self) {

--- a/neqo-transport/src/cc/search.rs
+++ b/neqo-transport/src/cc/search.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{qdebug, to_u64};
+use neqo_common::{qdebug, to_u64, to_usize};
 
 use crate::{cc::classic_cc::SlowStart, packet, rtt::RttEstimate, stats::CongestionControlStats};
 
@@ -274,8 +274,7 @@ impl Search {
         }
 
         let diff = prev_sent.saturating_sub(curr_delv);
-        let norm_diff =
-            usize::try_from(diff * to_u64(Self::SCALE) / prev_sent).unwrap_or(usize::MAX);
+        let norm_diff = to_usize(diff * to_u64(Self::SCALE) / prev_sent);
 
         if norm_diff < Self::THRESH {
             qdebug!(

--- a/neqo-transport/src/cc/search.rs
+++ b/neqo-transport/src/cc/search.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::qdebug;
+use neqo_common::{qdebug, to_u64};
 
 use crate::{cc::classic_cc::SlowStart, packet, rtt::RttEstimate, stats::CongestionControlStats};
 
@@ -217,8 +217,10 @@ impl Search {
     /// Computes delivered bytes between two bin indices. Widens the result to `u64` to avoid
     /// saturation or overflow further down the line on 32-bit systems with large bandwidths.
     const fn compute_delv(&self, old: usize, new: usize) -> u64 {
-        self.acked_bins[new % Self::NUM_ACKED_BINS]
-            .saturating_sub(self.acked_bins[old % Self::NUM_ACKED_BINS]) as u64
+        to_u64(
+            self.acked_bins[new % Self::NUM_ACKED_BINS]
+                .saturating_sub(self.acked_bins[old % Self::NUM_ACKED_BINS]),
+        )
     }
 
     /// Computes sent bytes between two (previous) bin indices. Interpolates a fraction of each bin
@@ -230,14 +232,16 @@ impl Search {
         // NOTE: SEARCH draft-09 does forward interpolation here, i.e. `new + 1` or `old + 1`. That
         // is a mistake in the draft and has been discussed with the SEARCH team. Subtracting is
         // correct.
-        let low_idx = (self.sent_bins[(new - 1) % Self::NUM_SENT_BINS]
-            .saturating_sub(self.sent_bins[(old - 1) % Self::NUM_SENT_BINS]))
-            as u64;
-        let high_idx = (self.sent_bins[new % Self::NUM_SENT_BINS]
-            .saturating_sub(self.sent_bins[old % Self::NUM_SENT_BINS]))
-            as u64;
-        let sent = low_idx * fraction + high_idx * (Self::SCALE as u64 - fraction);
-        sent / Self::SCALE as u64
+        let low_idx = to_u64(
+            self.sent_bins[(new - 1) % Self::NUM_SENT_BINS]
+                .saturating_sub(self.sent_bins[(old - 1) % Self::NUM_SENT_BINS]),
+        );
+        let high_idx = to_u64(
+            self.sent_bins[new % Self::NUM_SENT_BINS]
+                .saturating_sub(self.sent_bins[old % Self::NUM_SENT_BINS]),
+        );
+        let sent = low_idx * fraction + high_idx * (to_u64(Self::SCALE) - fraction);
+        sent / to_u64(Self::SCALE)
     }
 
     /// Evaluates whether SEARCH should exit slow start.
@@ -271,7 +275,7 @@ impl Search {
 
         let diff = prev_sent.saturating_sub(curr_delv);
         let norm_diff =
-            usize::try_from(diff * Self::SCALE as u64 / prev_sent).unwrap_or(usize::MAX);
+            usize::try_from(diff * to_u64(Self::SCALE) / prev_sent).unwrap_or(usize::MAX);
 
         if norm_diff < Self::THRESH {
             qdebug!(

--- a/neqo-transport/src/cc/search.rs
+++ b/neqo-transport/src/cc/search.rs
@@ -86,7 +86,7 @@ impl Search {
     /// current delivered bytes, as an integer out of [`Self::SCALE`] (= 0.26).
     const THRESH: usize = 26;
     /// Scale factor for integer approximation of fractional values.
-    const SCALE: usize = 100;
+    const SCALE: u32 = 100;
 
     /// Creates a new SEARCH slow start instance.
     pub const fn new() -> Self {
@@ -110,8 +110,7 @@ impl Search {
     fn initialize(&mut self, initial_rtt: Duration, now: Instant) {
         self.initial_rtt = Some(initial_rtt);
         // BIN_DURATION = WINDOW_SIZE / W = initial_rtt * WINDOW_SIZE_FACTOR / W
-        self.bin_duration =
-            initial_rtt * Self::WINDOW_SIZE_FACTOR / Self::SCALE as u32 / Self::W as u32;
+        self.bin_duration = initial_rtt * Self::WINDOW_SIZE_FACTOR / Self::SCALE / Self::W as u32;
         if self.bin_duration.is_zero() {
             qdebug!(
                 "skipping initialization because bin_duration.is_zero() but bin_duration must be non-zero - initial_rtt: {initial_rtt:?}",
@@ -208,8 +207,8 @@ impl Search {
         let bin_nanos = self.bin_duration.as_nanos();
         let bins_last_rtt = usize::try_from(rtt_nanos / bin_nanos).unwrap_or(usize::MAX);
         let prev_idx = curr_idx.saturating_sub(bins_last_rtt);
-        let fraction =
-            u64::try_from((rtt_nanos % bin_nanos) * Self::SCALE as u128 / bin_nanos).unwrap_or(0);
+        let fraction = u64::try_from((rtt_nanos % bin_nanos) * u128::from(Self::SCALE) / bin_nanos)
+            .unwrap_or(0);
 
         (prev_idx, fraction)
     }
@@ -231,8 +230,8 @@ impl Search {
             .saturating_sub(self.sent_bins[(old - 1) % Self::NUM_SENT_BINS]);
         let high_idx = self.sent_bins[new % Self::NUM_SENT_BINS]
             .saturating_sub(self.sent_bins[old % Self::NUM_SENT_BINS]);
-        let sent = low_idx * fraction + high_idx * (to_u64(Self::SCALE) - fraction);
-        sent / to_u64(Self::SCALE)
+        let sent = low_idx * fraction + high_idx * (Self::SCALE as u64 - fraction);
+        sent / Self::SCALE as u64
     }
 
     /// Evaluates whether SEARCH should exit slow start.
@@ -265,7 +264,7 @@ impl Search {
         }
 
         let diff = prev_sent.saturating_sub(curr_delv);
-        let norm_diff = to_usize(diff * to_u64(Self::SCALE) / prev_sent);
+        let norm_diff = to_usize(diff * u64::from(Self::SCALE) / prev_sent);
 
         if norm_diff < Self::THRESH {
             qdebug!(

--- a/neqo-transport/src/cc/tests/hystart.rs
+++ b/neqo-transport/src/cc/tests/hystart.rs
@@ -8,7 +8,7 @@
 
 use std::time::Duration;
 
-use neqo_common::qdebug;
+use neqo_common::{qdebug, to_u64, to_usize};
 use test_fixture::now;
 
 use super::make_cc_hystart;
@@ -46,7 +46,7 @@ fn maybe_enter_css(
     cc_stats: &mut CongestionControlStats,
 ) {
     // First round with base RTT
-    let window_end = HyStart::N_RTT_SAMPLE as u64;
+    let window_end = to_u64(HyStart::N_RTT_SAMPLE);
     hystart.on_packet_sent(window_end, MIN_INITIAL_PACKET_SIZE);
 
     assert!(hystart.window_end().is_some_and(|pn| pn == window_end));
@@ -65,7 +65,7 @@ fn maybe_enter_css(
     assert!(hystart.window_end().is_none());
 
     // Second round with new RTT value
-    let window_end2 = 2 * HyStart::N_RTT_SAMPLE as u64;
+    let window_end2 = 2 * to_u64(HyStart::N_RTT_SAMPLE);
     hystart.on_packet_sent(window_end2, MIN_INITIAL_PACKET_SIZE);
 
     assert!(hystart.window_end().is_some_and(|pn| pn == window_end2));
@@ -210,10 +210,6 @@ fn rtt_sample_collection_tracks_minimum() {
 }
 
 #[test]
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "No truncation will happen for values from 1 to 10."
-)]
 fn rtt_sample_count_increments_per_ack() {
     let mut hystart = make_hystart_paced();
 
@@ -227,7 +223,7 @@ fn rtt_sample_count_increments_per_ack() {
             &mut CongestionControlStats::default(),
             now(),
         );
-        assert_eq!(hystart.rtt_sample_count(), (i + 1) as usize);
+        assert_eq!(hystart.rtt_sample_count(), to_usize(i + 1));
     }
 }
 
@@ -236,7 +232,7 @@ fn css_entry_not_triggered_with_insufficient_samples() {
     let mut hystart = make_hystart_paced();
 
     // First round to set baseline RTT
-    let window_end1 = (HyStart::N_RTT_SAMPLE) as u64;
+    let window_end1 = to_u64(HyStart::N_RTT_SAMPLE);
     hystart.on_packet_sent(window_end1, MIN_INITIAL_PACKET_SIZE);
 
     for i in 0..=window_end1 {
@@ -250,7 +246,7 @@ fn css_entry_not_triggered_with_insufficient_samples() {
     }
 
     // Second round with increased RTT but insufficient samples
-    let window_end2 = window_end1 + HyStart::N_RTT_SAMPLE as u64;
+    let window_end2 = window_end1 + to_u64(HyStart::N_RTT_SAMPLE);
     hystart.on_packet_sent(window_end2, MIN_INITIAL_PACKET_SIZE);
 
     // Collect only N_RTT_SAMPLE - 1 samples, not enough to enter CSS with
@@ -385,14 +381,14 @@ fn css_exit_after_n_rounds() {
     // round 2.
     for round in 2..=HyStart::CSS_ROUNDS {
         // Start a new round
-        let new_window_end = round as u64 * 100;
+        let new_window_end = to_u64(round) * 100;
         hystart.on_packet_sent(new_window_end, MIN_INITIAL_PACKET_SIZE);
 
         // Collect samples
         for i in 0..HyStart::N_RTT_SAMPLE {
             hystart.on_packets_acked(
                 &RttEstimate::new(HIGH_RTT),
-                i as u64,
+                to_u64(i),
                 INITIAL_CWND,
                 &mut cc_stats,
                 now(),
@@ -445,7 +441,7 @@ fn css_back_to_slow_start_on_rtt_decrease() {
     for i in 0..HyStart::N_RTT_SAMPLE {
         hystart.on_packets_acked(
             &RttEstimate::new(LOWER_RTT),
-            i as u64, // Less than window_end
+            to_u64(i), // Less than window_end
             INITIAL_CWND,
             &mut cc_stats,
             now(),
@@ -468,7 +464,7 @@ fn css_exit_only_with_new_samples() {
     let mut hystart = make_hystart_paced();
 
     // First round with base RTT to set a baseline that we can compare RTT against
-    let window_end = HyStart::N_RTT_SAMPLE as u64;
+    let window_end = to_u64(HyStart::N_RTT_SAMPLE);
     hystart.on_packet_sent(window_end, MIN_INITIAL_PACKET_SIZE);
 
     assert!(hystart.window_end().is_some_and(|pn| pn == window_end));
@@ -491,7 +487,7 @@ fn css_exit_only_with_new_samples() {
     hystart.on_packet_sent(window_end2, MIN_INITIAL_PACKET_SIZE);
 
     // Collect N_RTT_SAMPLE samples with higher RTT to enter CSS
-    for _i in 0..HyStart::N_RTT_SAMPLE as u64 {
+    for _i in 0..to_u64(HyStart::N_RTT_SAMPLE) {
         hystart.on_packets_acked(
             &RttEstimate::new(HIGH_RTT),
             0,
@@ -518,7 +514,7 @@ fn css_exit_only_with_new_samples() {
     );
 
     // Collect N_RTT_SAMPLE-1 more samples with low RTT
-    for _i in 1..HyStart::N_RTT_SAMPLE as u64 {
+    for _i in 1..to_u64(HyStart::N_RTT_SAMPLE) {
         hystart.on_packets_acked(
             &RttEstimate::new(LOW_RTT),
             0,
@@ -555,7 +551,7 @@ fn css_alternative_baseline() {
     for i in 0..HyStart::N_RTT_SAMPLE {
         hystart.on_packets_acked(
             &RttEstimate::new(CSS_ENTRY_RTT.checked_sub(Duration::from_micros(1)).unwrap()),
-            i as u64, // Less than window_end
+            to_u64(i), // Less than window_end
             INITIAL_CWND,
             &mut CongestionControlStats::default(),
             now(),
@@ -613,7 +609,7 @@ fn css_exit_to_slow_start_restores_normal_growth() {
     for i in 0..HyStart::N_RTT_SAMPLE {
         hystart.on_packets_acked(
             &RttEstimate::new(LOWER_RTT),
-            i as u64, // Less than window_end
+            to_u64(i), // Less than window_end
             INITIAL_CWND,
             &mut CongestionControlStats::default(),
             now(),
@@ -700,12 +696,12 @@ fn integration_full_slow_start_to_css_to_ca() {
 
         // Have `base_rtt` for the first cwnd that was sent before the loop. Have `increased_rtt`
         // for all subsequent packets to trigger and go through CSS.
-        let rtt_to_use = if ack_pn < initial_cwnd_packets as u64 {
+        let rtt_to_use = if ack_pn < to_u64(initial_cwnd_packets) {
             base_rtt
         } else {
             increased_rtt
         };
-        let rtt_est = if ack_pn < initial_cwnd_packets as u64 {
+        let rtt_est = if ack_pn < to_u64(initial_cwnd_packets) {
             &base_rtt_est
         } else {
             &increased_rtt_est

--- a/neqo-transport/src/cc/tests/hystart.rs
+++ b/neqo-transport/src/cc/tests/hystart.rs
@@ -8,7 +8,7 @@
 
 use std::time::Duration;
 
-use neqo_common::{qdebug, to_u64, to_usize};
+use neqo_common::{qdebug, to_u64};
 use test_fixture::now;
 
 use super::make_cc_hystart;
@@ -46,7 +46,7 @@ fn maybe_enter_css(
     cc_stats: &mut CongestionControlStats,
 ) {
     // First round with base RTT
-    let window_end = to_u64(HyStart::N_RTT_SAMPLE);
+    let window_end = HyStart::N_RTT_SAMPLE;
     hystart.on_packet_sent(window_end, MIN_INITIAL_PACKET_SIZE);
 
     assert!(hystart.window_end().is_some_and(|pn| pn == window_end));
@@ -65,7 +65,7 @@ fn maybe_enter_css(
     assert!(hystart.window_end().is_none());
 
     // Second round with new RTT value
-    let window_end2 = 2 * to_u64(HyStart::N_RTT_SAMPLE);
+    let window_end2 = 2 * HyStart::N_RTT_SAMPLE;
     hystart.on_packet_sent(window_end2, MIN_INITIAL_PACKET_SIZE);
 
     assert!(hystart.window_end().is_some_and(|pn| pn == window_end2));
@@ -223,7 +223,7 @@ fn rtt_sample_count_increments_per_ack() {
             &mut CongestionControlStats::default(),
             now(),
         );
-        assert_eq!(hystart.rtt_sample_count(), to_usize(i + 1));
+        assert_eq!(hystart.rtt_sample_count(), i + 1);
     }
 }
 
@@ -232,7 +232,7 @@ fn css_entry_not_triggered_with_insufficient_samples() {
     let mut hystart = make_hystart_paced();
 
     // First round to set baseline RTT
-    let window_end1 = to_u64(HyStart::N_RTT_SAMPLE);
+    let window_end1 = HyStart::N_RTT_SAMPLE;
     hystart.on_packet_sent(window_end1, MIN_INITIAL_PACKET_SIZE);
 
     for i in 0..=window_end1 {
@@ -246,7 +246,7 @@ fn css_entry_not_triggered_with_insufficient_samples() {
     }
 
     // Second round with increased RTT but insufficient samples
-    let window_end2 = window_end1 + to_u64(HyStart::N_RTT_SAMPLE);
+    let window_end2 = window_end1 + HyStart::N_RTT_SAMPLE;
     hystart.on_packet_sent(window_end2, MIN_INITIAL_PACKET_SIZE);
 
     // Collect only N_RTT_SAMPLE - 1 samples, not enough to enter CSS with
@@ -388,7 +388,7 @@ fn css_exit_after_n_rounds() {
         for i in 0..HyStart::N_RTT_SAMPLE {
             hystart.on_packets_acked(
                 &RttEstimate::new(HIGH_RTT),
-                to_u64(i),
+                i,
                 INITIAL_CWND,
                 &mut cc_stats,
                 now(),
@@ -441,7 +441,7 @@ fn css_back_to_slow_start_on_rtt_decrease() {
     for i in 0..HyStart::N_RTT_SAMPLE {
         hystart.on_packets_acked(
             &RttEstimate::new(LOWER_RTT),
-            to_u64(i), // Less than window_end
+            i, // Less than window_end
             INITIAL_CWND,
             &mut cc_stats,
             now(),
@@ -464,7 +464,7 @@ fn css_exit_only_with_new_samples() {
     let mut hystart = make_hystart_paced();
 
     // First round with base RTT to set a baseline that we can compare RTT against
-    let window_end = to_u64(HyStart::N_RTT_SAMPLE);
+    let window_end = HyStart::N_RTT_SAMPLE;
     hystart.on_packet_sent(window_end, MIN_INITIAL_PACKET_SIZE);
 
     assert!(hystart.window_end().is_some_and(|pn| pn == window_end));
@@ -487,7 +487,7 @@ fn css_exit_only_with_new_samples() {
     hystart.on_packet_sent(window_end2, MIN_INITIAL_PACKET_SIZE);
 
     // Collect N_RTT_SAMPLE samples with higher RTT to enter CSS
-    for _i in 0..to_u64(HyStart::N_RTT_SAMPLE) {
+    for _i in 0..HyStart::N_RTT_SAMPLE {
         hystart.on_packets_acked(
             &RttEstimate::new(HIGH_RTT),
             0,
@@ -514,7 +514,7 @@ fn css_exit_only_with_new_samples() {
     );
 
     // Collect N_RTT_SAMPLE-1 more samples with low RTT
-    for _i in 1..to_u64(HyStart::N_RTT_SAMPLE) {
+    for _i in 1..HyStart::N_RTT_SAMPLE {
         hystart.on_packets_acked(
             &RttEstimate::new(LOW_RTT),
             0,
@@ -551,7 +551,7 @@ fn css_alternative_baseline() {
     for i in 0..HyStart::N_RTT_SAMPLE {
         hystart.on_packets_acked(
             &RttEstimate::new(CSS_ENTRY_RTT.checked_sub(Duration::from_micros(1)).unwrap()),
-            to_u64(i), // Less than window_end
+            i, // Less than window_end
             INITIAL_CWND,
             &mut CongestionControlStats::default(),
             now(),
@@ -609,7 +609,7 @@ fn css_exit_to_slow_start_restores_normal_growth() {
     for i in 0..HyStart::N_RTT_SAMPLE {
         hystart.on_packets_acked(
             &RttEstimate::new(LOWER_RTT),
-            to_u64(i), // Less than window_end
+            i, // Less than window_end
             INITIAL_CWND,
             &mut CongestionControlStats::default(),
             now(),

--- a/neqo-transport/src/cc/tests/new_reno.rs
+++ b/neqo-transport/src/cc/tests/new_reno.rs
@@ -13,6 +13,7 @@
 
 use std::time::Duration;
 
+use neqo_common::to_u64;
 use test_fixture::now;
 
 use super::{RTT, make_cc_newreno};
@@ -277,7 +278,7 @@ fn congestion_avoidance_no_two_mss_cap() {
     let n = 3 * (cwnd0 / mtu) + 1;
     let mut pkts = Vec::with_capacity(n);
     for pn in 0..n {
-        let p = sent::make_packet(u64::try_from(pn).unwrap(), now, mtu);
+        let p = sent::make_packet(to_u64(pn), now, mtu);
         cc.on_packet_sent(&p, now, false);
         pkts.push(p);
     }

--- a/neqo-transport/src/cc/tests/new_reno.rs
+++ b/neqo-transport/src/cc/tests/new_reno.rs
@@ -277,8 +277,8 @@ fn congestion_avoidance_no_two_mss_cap() {
     // BIF stays well above the app-limited threshold so is_app_limited is false.
     let n = 3 * (cwnd0 / mtu) + 1;
     let mut pkts = Vec::with_capacity(n);
-    for pn in 0..n {
-        let p = sent::make_packet(to_u64(pn), now, mtu);
+    for pn in 0..to_u64(n) {
+        let p = sent::make_packet(pn, now, mtu);
         cc.on_packet_sent(&p, now, false);
         pkts.push(p);
     }

--- a/neqo-transport/src/cc/tests/search.rs
+++ b/neqo-transport/src/cc/tests/search.rs
@@ -8,18 +8,17 @@
 
 use std::time::{Duration, Instant};
 
-use neqo_common::{to_u64, to_usize};
+use neqo_common::to_u64;
 use test_fixture::now;
 
 use crate::{
+    MIN_INITIAL_PACKET_SIZE,
     cc::{
         CongestionControlStats, Outcome, Search, classic_cc::SlowStart as _, tests::INITIAL_CWND,
     },
     rtt::RttEstimate,
 };
 
-// Shadow the usize version with a u64 const for use in assertions against bin values.
-const MIN_INITIAL_PACKET_SIZE: u64 = to_u64(crate::MIN_INITIAL_PACKET_SIZE);
 const INITIAL_RTT: Duration = Duration::from_millis(100);
 const LOW_RTT: Duration = Duration::from_millis(80);
 const HIGH_RTT: Duration = Duration::from_millis(200);
@@ -30,7 +29,7 @@ fn ack(
     search: &mut Search,
     rtt_est: &RttEstimate,
     largest_acked: u64,
-    new_acked_bytes: u64,
+    new_acked_bytes: usize,
     curr_cwnd: usize,
     now: Instant,
 ) -> Option<usize> {
@@ -54,7 +53,7 @@ fn init_search(initial_rtt: Duration) -> (Search, Duration, Instant) {
     let mut now = now();
     let rtt_est = RttEstimate::new(initial_rtt);
 
-    search.on_packet_sent(0, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(0, MIN_INITIAL_PACKET_SIZE);
     now += initial_rtt;
     ack(
         &mut search,
@@ -70,8 +69,8 @@ fn init_search(initial_rtt: Duration) -> (Search, Duration, Instant) {
 
     assert_eq!(search.bin_duration(), bin_duration);
     assert_eq!(search.bin_end(), Some(now + bin_duration));
-    assert_eq!(search.acked_bin(0), MIN_INITIAL_PACKET_SIZE);
-    assert_eq!(search.sent_bin(0), MIN_INITIAL_PACKET_SIZE);
+    assert_eq!(search.acked_bin(0), to_u64(MIN_INITIAL_PACKET_SIZE));
+    assert_eq!(search.sent_bin(0), to_u64(MIN_INITIAL_PACKET_SIZE));
     assert_eq!(search.curr_idx(), Some(0));
 
     (search, bin_duration, now)
@@ -81,7 +80,7 @@ fn init_search(initial_rtt: Duration) -> (Search, Duration, Instant) {
 fn initialize_on_first_ack_only() {
     let (mut search, bin_duration, mut now) = init_search(INITIAL_RTT);
 
-    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
     now += HIGH_RTT;
     ack(
         &mut search,
@@ -117,7 +116,7 @@ fn initialization_with_zero_rtt() {
 fn update_bins_after_bin_end_passed() {
     let (mut search, bin_duration, mut now) = init_search(INITIAL_RTT);
 
-    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
     now += bin_duration;
     ack(
         &mut search,
@@ -134,7 +133,7 @@ fn update_bins_after_bin_end_passed() {
         "now == bin_end, shouldn't update bins"
     );
 
-    search.on_packet_sent(2, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(2, MIN_INITIAL_PACKET_SIZE);
     ack(
         &mut search,
         &RttEstimate::new(INITIAL_RTT),
@@ -154,8 +153,8 @@ fn update_bins_after_bin_end_passed() {
         Some(now + bin_duration),
         "Should've advanced bin_end to the next bin"
     );
-    assert_eq!(search.acked_bin(1), 3 * MIN_INITIAL_PACKET_SIZE);
-    assert_eq!(search.sent_bin(1), 3 * MIN_INITIAL_PACKET_SIZE);
+    assert_eq!(search.acked_bin(1), to_u64(3 * MIN_INITIAL_PACKET_SIZE));
+    assert_eq!(search.sent_bin(1), to_u64(3 * MIN_INITIAL_PACKET_SIZE));
 }
 
 #[test]
@@ -165,7 +164,7 @@ fn update_bins_skipped_bins_propagate_prev_value() {
     let prev_acked = search.acked_bin(0);
     let prev_sent = search.sent_bin(0);
 
-    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
 
     // move time by more than 2 bins, i.e. skip one
     now += 2 * bin_duration + Duration::from_nanos(1);
@@ -190,8 +189,8 @@ fn update_bins_skipped_bins_propagate_prev_value() {
         prev_sent,
         "bin 1 should be propagated from the previous value"
     );
-    assert_eq!(search.acked_bin(2), 2 * MIN_INITIAL_PACKET_SIZE);
-    assert_eq!(search.sent_bin(2), 2 * MIN_INITIAL_PACKET_SIZE);
+    assert_eq!(search.acked_bin(2), to_u64(2 * MIN_INITIAL_PACKET_SIZE));
+    assert_eq!(search.sent_bin(2), to_u64(2 * MIN_INITIAL_PACKET_SIZE));
 }
 
 #[test]
@@ -201,7 +200,7 @@ fn reset_and_reinitialize_on_too_many_skipped_bins() {
     // Pass 10 bins, which is the W SEARCH parameter for how many bins are in a window,
     // which is used as the guard for resetting if passing more than that.
     now += 10 * bin_duration;
-    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
     ack(
         &mut search,
         &RttEstimate::new(INITIAL_RTT),
@@ -219,7 +218,7 @@ fn reset_and_reinitialize_on_too_many_skipped_bins() {
     // Pass 11 bins, which is one bin more than the W SEARCH parameter for how many bins are in
     // a window.
     now += 11 * bin_duration;
-    search.on_packet_sent(2, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(2, MIN_INITIAL_PACKET_SIZE);
     let mut cc_stats = CongestionControlStats::default();
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(
@@ -237,7 +236,7 @@ fn reset_and_reinitialize_on_too_many_skipped_bins() {
     assert_eq!(cc_stats.search_reset.count, 1);
     assert_eq!(cc_stats.search_reset.max_passed_bins, Some(11));
 
-    search.on_packet_sent(3, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(3, MIN_INITIAL_PACKET_SIZE);
     ack(
         &mut search,
         &RttEstimate::new(HIGH_RTT),
@@ -266,7 +265,7 @@ fn reset_and_reinitialize_on_too_many_skipped_bins() {
 
     // Trigger a second reset with more skipped bins to verify max_passed_bins tracks the max.
     now += 15 * new_bin_duration;
-    search.on_packet_sent(4, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(4, MIN_INITIAL_PACKET_SIZE);
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(
         &RttEstimate::new(HIGH_RTT),
@@ -284,9 +283,9 @@ fn reset_and_reinitialize_on_too_many_skipped_bins() {
 fn sent_and_acked_bytes_accumulate() {
     let (mut search, _, mut now) = init_search(INITIAL_RTT);
 
-    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
-    search.on_packet_sent(2, to_usize(MIN_INITIAL_PACKET_SIZE));
-    search.on_packet_sent(3, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(2, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(3, MIN_INITIAL_PACKET_SIZE);
 
     // 10ms pass, not enough to reach bin_end
     now += Duration::from_millis(10);
@@ -326,8 +325,8 @@ fn sent_and_acked_bytes_accumulate() {
     // Assert that the bins got updated and that the bytes from all sent and acked packets are
     // accounted for (1 each from init_search and 3 each from the code above)
     assert_eq!(search.curr_idx(), Some(1));
-    assert_eq!(search.acked_bin(1), 4 * MIN_INITIAL_PACKET_SIZE);
-    assert_eq!(search.sent_bin(1), 4 * MIN_INITIAL_PACKET_SIZE);
+    assert_eq!(search.acked_bin(1), to_u64(4 * MIN_INITIAL_PACKET_SIZE));
+    assert_eq!(search.sent_bin(1), to_u64(4 * MIN_INITIAL_PACKET_SIZE));
 }
 
 #[test]
@@ -336,7 +335,7 @@ fn prev_idx_and_fraction_calculation() {
 
     // Progress time so we have some space to look back for the test's sake.
     now += bin_duration * 5;
-    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
     ack(
         &mut search,
         &RttEstimate::new(INITIAL_RTT),
@@ -409,7 +408,7 @@ fn search_exits_when_delivery_rate_slows_down() {
             &mut search,
             &RttEstimate::new(INITIAL_RTT),
             pn,
-            to_u64(bytes_this_round),
+            bytes_this_round,
             bytes_this_round,
             now,
         );
@@ -427,7 +426,7 @@ fn search_exits_when_delivery_rate_slows_down() {
             &mut search,
             &RttEstimate::new(INITIAL_RTT),
             pn,
-            to_u64(bytes_this_round),
+            bytes_this_round,
             bytes_this_round,
             now,
         );
@@ -447,7 +446,7 @@ fn search_exits_when_delivery_rate_slows_down() {
         &mut search,
         &RttEstimate::new(INITIAL_RTT),
         pn,
-        to_u64(bytes_this_round) / 4,
+        bytes_this_round / 4,
         bytes_this_round,
         now,
     );
@@ -490,7 +489,7 @@ fn inflated_rtt_is_guarded() {
     //   prev_idx = 28 - 17 = 11 > W(10) --> first guard passes
     //   curr_idx - prev_idx = 17 >= EXTRA_BINS(15) --> second guard fires
     while search.curr_idx() < Some(28) {
-        search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
+        search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
         now += bin_duration + Duration::from_nanos(1);
         ack(
             &mut search,
@@ -512,7 +511,7 @@ fn inflated_rtt_is_guarded() {
 
     // Verify the stat is recorded through the full on_packets_acked path.
     let mut cc_stats = CongestionControlStats::default();
-    search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
     now += bin_duration + Duration::from_nanos(1);
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(
@@ -529,7 +528,7 @@ fn inflated_rtt_is_guarded() {
     // prev_idx = 29 - 15 = 14 > W(10), curr_idx - prev_idx = 15 >= EXTRA_BINS(15) → RttInflated.
     pn += 1;
     let lower_rtt = Duration::from_millis(525);
-    search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
     now += bin_duration + Duration::from_nanos(1);
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(
@@ -581,7 +580,7 @@ fn warming_up() {
     // bins_last_rtt = 100ms / 35ms = 2, so prev_idx = 12 - 2 = 10 = W(10).
     // Guard is prev_idx <= W, so this is the last index that returns WarmingUp.
     while search.curr_idx() < Some(12) {
-        search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
+        search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
         now += bin_duration + Duration::from_nanos(1);
         ack(
             &mut search,
@@ -601,7 +600,7 @@ fn warming_up() {
     );
 
     // One more bin crosses the boundary: prev_idx = 13 - 2 = 11 > W(10).
-    search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
     now += bin_duration + Duration::from_nanos(1);
     ack(
         &mut search,
@@ -629,7 +628,7 @@ fn continue_when_delivery_rate_steady() {
     // Advance past warm-up boundary with equal send/ack each bin.
     // With W = 10 and bin_duration = 100ms / 35ms = 2 we need to advance to curr_idx = 12.
     while search.curr_idx() < Some(13) {
-        search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
+        search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
         now += bin_duration + Duration::from_nanos(1);
         ack(
             &mut search,
@@ -645,7 +644,7 @@ fn continue_when_delivery_rate_steady() {
     // Keep going for 10 more bins with steady delivery rate, asserting
     // Continue each time.
     for _ in 0..10 {
-        search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
+        search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
         now += bin_duration + Duration::from_nanos(1);
         ack(
             &mut search,
@@ -667,7 +666,7 @@ fn continue_when_delivery_rate_steady() {
     // Verify the stat is recorded and tracks the running max.
     // Ack less than sent to create a non-zero norm_diff.
     let mut cc_stats = CongestionControlStats::default();
-    search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
     now += bin_duration + Duration::from_nanos(1);
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE / 4);
     search.on_packets_acked(&rtt_est, pn, INITIAL_CWND, &mut cc_stats, now);
@@ -676,7 +675,7 @@ fn continue_when_delivery_rate_steady() {
 
     // A subsequent steady round should not overwrite the max.
     pn += 1;
-    search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
     now += bin_duration + Duration::from_nanos(1);
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(&rtt_est, pn, INITIAL_CWND, &mut cc_stats, now);
@@ -694,7 +693,7 @@ fn first_and_second_rtt_stats() {
     assert!(cc_stats.search_first_rtt.is_none());
     assert!(cc_stats.search_second_rtt.is_none());
 
-    search.on_packet_sent(0, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(0, MIN_INITIAL_PACKET_SIZE);
     now += INITIAL_RTT;
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(
@@ -708,7 +707,7 @@ fn first_and_second_rtt_stats() {
     assert_eq!(cc_stats.search_first_rtt, Some(INITIAL_RTT));
     assert!(cc_stats.search_second_rtt.is_none());
 
-    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
     now += LOW_RTT;
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(
@@ -727,7 +726,7 @@ fn first_and_second_rtt_stats() {
     search.reset();
 
     for pn in 2..=3 {
-        search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
+        search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
         now += POST_RESET_RTT;
         search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
         search.on_packets_acked(

--- a/neqo-transport/src/cc/tests/search.rs
+++ b/neqo-transport/src/cc/tests/search.rs
@@ -669,7 +669,7 @@ fn continue_when_delivery_rate_steady() {
     let mut cc_stats = CongestionControlStats::default();
     search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
     now += bin_duration + Duration::from_nanos(1);
-    search.record_acked_bytes(to_usize(MIN_INITIAL_PACKET_SIZE / 4));
+    search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE / 4);
     search.on_packets_acked(&rtt_est, pn, INITIAL_CWND, &mut cc_stats, now);
     let max = cc_stats.search_max_norm_diff;
     assert!(max > Some(0));

--- a/neqo-transport/src/cc/tests/search.rs
+++ b/neqo-transport/src/cc/tests/search.rs
@@ -8,16 +8,18 @@
 
 use std::time::{Duration, Instant};
 
+use neqo_common::{to_u64, to_usize};
 use test_fixture::now;
 
 use crate::{
-    MIN_INITIAL_PACKET_SIZE,
     cc::{
         CongestionControlStats, Outcome, Search, classic_cc::SlowStart as _, tests::INITIAL_CWND,
     },
     rtt::RttEstimate,
 };
 
+// Shadow the usize version with a u64 const for use in assertions against bin values.
+const MIN_INITIAL_PACKET_SIZE: u64 = to_u64(crate::MIN_INITIAL_PACKET_SIZE);
 const INITIAL_RTT: Duration = Duration::from_millis(100);
 const LOW_RTT: Duration = Duration::from_millis(80);
 const HIGH_RTT: Duration = Duration::from_millis(200);
@@ -28,7 +30,7 @@ fn ack(
     search: &mut Search,
     rtt_est: &RttEstimate,
     largest_acked: u64,
-    new_acked_bytes: usize,
+    new_acked_bytes: u64,
     curr_cwnd: usize,
     now: Instant,
 ) -> Option<usize> {
@@ -52,7 +54,7 @@ fn init_search(initial_rtt: Duration) -> (Search, Duration, Instant) {
     let mut now = now();
     let rtt_est = RttEstimate::new(initial_rtt);
 
-    search.on_packet_sent(0, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(0, to_usize(MIN_INITIAL_PACKET_SIZE));
     now += initial_rtt;
     ack(
         &mut search,
@@ -79,7 +81,7 @@ fn init_search(initial_rtt: Duration) -> (Search, Duration, Instant) {
 fn initialize_on_first_ack_only() {
     let (mut search, bin_duration, mut now) = init_search(INITIAL_RTT);
 
-    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
     now += HIGH_RTT;
     ack(
         &mut search,
@@ -115,7 +117,7 @@ fn initialization_with_zero_rtt() {
 fn update_bins_after_bin_end_passed() {
     let (mut search, bin_duration, mut now) = init_search(INITIAL_RTT);
 
-    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
     now += bin_duration;
     ack(
         &mut search,
@@ -132,7 +134,7 @@ fn update_bins_after_bin_end_passed() {
         "now == bin_end, shouldn't update bins"
     );
 
-    search.on_packet_sent(2, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(2, to_usize(MIN_INITIAL_PACKET_SIZE));
     ack(
         &mut search,
         &RttEstimate::new(INITIAL_RTT),
@@ -163,7 +165,7 @@ fn update_bins_skipped_bins_propagate_prev_value() {
     let prev_acked = search.acked_bin(0);
     let prev_sent = search.sent_bin(0);
 
-    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
 
     // move time by more than 2 bins, i.e. skip one
     now += 2 * bin_duration + Duration::from_nanos(1);
@@ -199,7 +201,7 @@ fn reset_and_reinitialize_on_too_many_skipped_bins() {
     // Pass 10 bins, which is the W SEARCH parameter for how many bins are in a window,
     // which is used as the guard for resetting if passing more than that.
     now += 10 * bin_duration;
-    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
     ack(
         &mut search,
         &RttEstimate::new(INITIAL_RTT),
@@ -217,7 +219,7 @@ fn reset_and_reinitialize_on_too_many_skipped_bins() {
     // Pass 11 bins, which is one bin more than the W SEARCH parameter for how many bins are in
     // a window.
     now += 11 * bin_duration;
-    search.on_packet_sent(2, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(2, to_usize(MIN_INITIAL_PACKET_SIZE));
     let mut cc_stats = CongestionControlStats::default();
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(
@@ -235,7 +237,7 @@ fn reset_and_reinitialize_on_too_many_skipped_bins() {
     assert_eq!(cc_stats.search_reset.count, 1);
     assert_eq!(cc_stats.search_reset.max_passed_bins, Some(11));
 
-    search.on_packet_sent(3, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(3, to_usize(MIN_INITIAL_PACKET_SIZE));
     ack(
         &mut search,
         &RttEstimate::new(HIGH_RTT),
@@ -264,7 +266,7 @@ fn reset_and_reinitialize_on_too_many_skipped_bins() {
 
     // Trigger a second reset with more skipped bins to verify max_passed_bins tracks the max.
     now += 15 * new_bin_duration;
-    search.on_packet_sent(4, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(4, to_usize(MIN_INITIAL_PACKET_SIZE));
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(
         &RttEstimate::new(HIGH_RTT),
@@ -282,9 +284,9 @@ fn reset_and_reinitialize_on_too_many_skipped_bins() {
 fn sent_and_acked_bytes_accumulate() {
     let (mut search, _, mut now) = init_search(INITIAL_RTT);
 
-    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
-    search.on_packet_sent(2, MIN_INITIAL_PACKET_SIZE);
-    search.on_packet_sent(3, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(2, to_usize(MIN_INITIAL_PACKET_SIZE));
+    search.on_packet_sent(3, to_usize(MIN_INITIAL_PACKET_SIZE));
 
     // 10ms pass, not enough to reach bin_end
     now += Duration::from_millis(10);
@@ -334,7 +336,7 @@ fn prev_idx_and_fraction_calculation() {
 
     // Progress time so we have some space to look back for the test's sake.
     now += bin_duration * 5;
-    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
     ack(
         &mut search,
         &RttEstimate::new(INITIAL_RTT),
@@ -407,7 +409,7 @@ fn search_exits_when_delivery_rate_slows_down() {
             &mut search,
             &RttEstimate::new(INITIAL_RTT),
             pn,
-            bytes_this_round,
+            to_u64(bytes_this_round),
             bytes_this_round,
             now,
         );
@@ -425,7 +427,7 @@ fn search_exits_when_delivery_rate_slows_down() {
             &mut search,
             &RttEstimate::new(INITIAL_RTT),
             pn,
-            bytes_this_round,
+            to_u64(bytes_this_round),
             bytes_this_round,
             now,
         );
@@ -445,7 +447,7 @@ fn search_exits_when_delivery_rate_slows_down() {
         &mut search,
         &RttEstimate::new(INITIAL_RTT),
         pn,
-        bytes_this_round / 4,
+        to_u64(bytes_this_round) / 4,
         bytes_this_round,
         now,
     );
@@ -488,7 +490,7 @@ fn inflated_rtt_is_guarded() {
     //   prev_idx = 28 - 17 = 11 > W(10) --> first guard passes
     //   curr_idx - prev_idx = 17 >= EXTRA_BINS(15) --> second guard fires
     while search.curr_idx() < Some(28) {
-        search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+        search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
         now += bin_duration + Duration::from_nanos(1);
         ack(
             &mut search,
@@ -510,7 +512,7 @@ fn inflated_rtt_is_guarded() {
 
     // Verify the stat is recorded through the full on_packets_acked path.
     let mut cc_stats = CongestionControlStats::default();
-    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
     now += bin_duration + Duration::from_nanos(1);
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(
@@ -527,7 +529,7 @@ fn inflated_rtt_is_guarded() {
     // prev_idx = 29 - 15 = 14 > W(10), curr_idx - prev_idx = 15 >= EXTRA_BINS(15) → RttInflated.
     pn += 1;
     let lower_rtt = Duration::from_millis(525);
-    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
     now += bin_duration + Duration::from_nanos(1);
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(
@@ -564,7 +566,7 @@ fn no_sent_bytes() {
     // Verify the stat is recorded through the full on_packets_acked path.
     let mut cc_stats = CongestionControlStats::default();
     now += bin_duration + Duration::from_nanos(1);
-    search.record_acked_bytes(0);
+    search.record_acked_bytes(0_usize);
     search.on_packets_acked(&rtt_est, pn, INITIAL_CWND, &mut cc_stats, now);
     assert_eq!(cc_stats.search_zero_sent_bytes, 1);
 }
@@ -579,7 +581,7 @@ fn warming_up() {
     // bins_last_rtt = 100ms / 35ms = 2, so prev_idx = 12 - 2 = 10 = W(10).
     // Guard is prev_idx <= W, so this is the last index that returns WarmingUp.
     while search.curr_idx() < Some(12) {
-        search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+        search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
         now += bin_duration + Duration::from_nanos(1);
         ack(
             &mut search,
@@ -599,7 +601,7 @@ fn warming_up() {
     );
 
     // One more bin crosses the boundary: prev_idx = 13 - 2 = 11 > W(10).
-    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
     now += bin_duration + Duration::from_nanos(1);
     ack(
         &mut search,
@@ -627,7 +629,7 @@ fn continue_when_delivery_rate_steady() {
     // Advance past warm-up boundary with equal send/ack each bin.
     // With W = 10 and bin_duration = 100ms / 35ms = 2 we need to advance to curr_idx = 12.
     while search.curr_idx() < Some(13) {
-        search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+        search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
         now += bin_duration + Duration::from_nanos(1);
         ack(
             &mut search,
@@ -643,7 +645,7 @@ fn continue_when_delivery_rate_steady() {
     // Keep going for 10 more bins with steady delivery rate, asserting
     // Continue each time.
     for _ in 0..10 {
-        search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+        search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
         now += bin_duration + Duration::from_nanos(1);
         ack(
             &mut search,
@@ -665,16 +667,16 @@ fn continue_when_delivery_rate_steady() {
     // Verify the stat is recorded and tracks the running max.
     // Ack less than sent to create a non-zero norm_diff.
     let mut cc_stats = CongestionControlStats::default();
-    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
     now += bin_duration + Duration::from_nanos(1);
-    search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE / 4);
+    search.record_acked_bytes(to_usize(MIN_INITIAL_PACKET_SIZE / 4));
     search.on_packets_acked(&rtt_est, pn, INITIAL_CWND, &mut cc_stats, now);
     let max = cc_stats.search_max_norm_diff;
     assert!(max > Some(0));
 
     // A subsequent steady round should not overwrite the max.
     pn += 1;
-    search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
     now += bin_duration + Duration::from_nanos(1);
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(&rtt_est, pn, INITIAL_CWND, &mut cc_stats, now);
@@ -692,7 +694,7 @@ fn first_and_second_rtt_stats() {
     assert!(cc_stats.search_first_rtt.is_none());
     assert!(cc_stats.search_second_rtt.is_none());
 
-    search.on_packet_sent(0, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(0, to_usize(MIN_INITIAL_PACKET_SIZE));
     now += INITIAL_RTT;
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(
@@ -706,7 +708,7 @@ fn first_and_second_rtt_stats() {
     assert_eq!(cc_stats.search_first_rtt, Some(INITIAL_RTT));
     assert!(cc_stats.search_second_rtt.is_none());
 
-    search.on_packet_sent(1, MIN_INITIAL_PACKET_SIZE);
+    search.on_packet_sent(1, to_usize(MIN_INITIAL_PACKET_SIZE));
     now += LOW_RTT;
     search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
     search.on_packets_acked(
@@ -725,7 +727,7 @@ fn first_and_second_rtt_stats() {
     search.reset();
 
     for pn in 2..=3 {
-        search.on_packet_sent(pn, MIN_INITIAL_PACKET_SIZE);
+        search.on_packet_sent(pn, to_usize(MIN_INITIAL_PACKET_SIZE));
         now += POST_RESET_RTT;
         search.record_acked_bytes(MIN_INITIAL_PACKET_SIZE);
         search.on_packets_acked(

--- a/neqo-transport/src/cc/tests/search.rs
+++ b/neqo-transport/src/cc/tests/search.rs
@@ -565,7 +565,7 @@ fn no_sent_bytes() {
     // Verify the stat is recorded through the full on_packets_acked path.
     let mut cc_stats = CongestionControlStats::default();
     now += bin_duration + Duration::from_nanos(1);
-    search.record_acked_bytes(0_usize);
+    search.record_acked_bytes(0);
     search.on_packets_acked(&rtt_est, pn, INITIAL_CWND, &mut cc_stats, now);
     assert_eq!(cc_stats.search_zero_sent_bytes, 1);
 }

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -15,7 +15,7 @@ use std::{
     rc::Rc,
 };
 
-use neqo_common::{Buffer, Decoder, Encoder, hex, hex_with_len, qdebug, qinfo};
+use neqo_common::{Buffer, Decoder, Encoder, hex, hex_with_len, qdebug, qinfo, to_usize};
 use nss::{random, randomize};
 use smallvec::{SmallVec, smallvec};
 
@@ -554,10 +554,7 @@ impl ConnectionIdManager {
 
     pub fn set_limit(&mut self, limit: u64) {
         debug_assert!(limit >= 2);
-        self.limit = min(
-            Self::ACTIVE_LIMIT,
-            usize::try_from(limit).unwrap_or(Self::ACTIVE_LIMIT),
-        );
+        self.limit = min(Self::ACTIVE_LIMIT, to_usize(limit));
     }
 
     pub fn write_frames<B: Buffer>(

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -20,6 +20,7 @@ use std::{
 use neqo_common::{
     Buffer, Datagram, Decoder, Ecn, Encoder, Role, Tos, datagram, event::Provider as EventProvider,
     hex, hex_snip_middle, hex_with_len, hrtime, qdebug, qerror, qinfo, qlog::Qlog, qtrace, qwarn,
+    to_u64, to_usize,
 };
 use nss::{
     Agent, AntiReplay, AuthenticationStatus, Cipher, Client, Group, HandshakeState, PrivateKey,
@@ -2307,8 +2308,8 @@ impl Connection {
         let pn = tx.next_pn();
         let unacked_range = largest_acknowledged.map_or_else(|| pn + 1, |la| (pn - la) << 1);
         // Count how many bytes in this range are non-zero.
-        let pn_len = size_of::<packet::Number>()
-            - usize::try_from(unacked_range.leading_zeros() / 8).expect("u32 fits in usize");
+        let pn_len =
+            size_of::<packet::Number>() - to_usize(u64::from(unacked_range.leading_zeros() / 8));
         assert!(
             pn_len > 0,
             "pn_len can't be zero as unacked_range should be > 0, pn {pn}, largest_acknowledged {largest_acknowledged:?}, tx {tx}"
@@ -3051,12 +3052,11 @@ impl Connection {
             let path = self.paths.primary().ok_or(Error::NoAvailablePath)?;
             path.borrow_mut().set_reset_token(reset_token);
 
-            if let Ok(max_udp_payload) = usize::try_from(remote.get_integer(MaxUdpPayloadSize)) {
-                path.borrow_mut()
-                    .pmtud_mut()
-                    .set_peer_max_udp_payload(max_udp_payload);
-                self.stats.borrow_mut().pmtud_peer_max_udp_payload = Some(max_udp_payload);
-            }
+            let max_udp_payload = to_usize(remote.get_integer(MaxUdpPayloadSize));
+            path.borrow_mut()
+                .pmtud_mut()
+                .set_peer_max_udp_payload(max_udp_payload);
+            self.stats.borrow_mut().pmtud_peer_max_udp_payload = Some(max_udp_payload);
 
             let max_ad = Duration::from_millis(remote.get_integer(MaxAckDelay));
             let min_ad = if remote.has_value(MinAckDelay) {
@@ -3985,9 +3985,9 @@ impl Connection {
                 .largest_acknowledged_pn(PacketNumberSpace::ApplicationData),
         );
 
-        let data_len_possible = u64::try_from(
+        let data_len_possible = to_u64(
             mtu.saturating_sub(tx.expansion() + builder.len() + DATAGRAM_FRAME_TYPE_VARINT_LEN),
-        )?;
+        );
         Ok(min(data_len_possible, max_dgram_size))
     }
 

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -6,6 +6,8 @@
 
 use std::{cmp::max, time::Duration};
 
+use neqo_common::to_u64;
+
 pub use crate::recovery::FAST_PTO_SCALE;
 use crate::{
     CongestionControl, DEFAULT_INITIAL_RTT, HyStartCssBaseline, Res, SlowStart,
@@ -64,7 +66,7 @@ pub const INITIAL_LOCAL_MAX_STREAM_DATA: usize = 1024 * 1024;
 /// implementation for details.
 ///
 /// See also <https://datatracker.ietf.org/doc/html/rfc9000#frame-max-data>.
-pub const INITIAL_LOCAL_MAX_DATA: u64 = INITIAL_LOCAL_MAX_STREAM_DATA as u64 * CONNECTION_FACTOR;
+pub const INITIAL_LOCAL_MAX_DATA: u64 = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA) * CONNECTION_FACTOR;
 
 /// Limit for the maximum amount of bytes active on a single stream, i.e. limit
 /// for the size of the stream receive window.
@@ -167,12 +169,9 @@ impl Default for ConnectionParameters {
             slow_start: SlowStart::Classic,
             hystart_css_baseline: HyStartCssBaseline::CurrentRoundMinRtt,
             max_data: INITIAL_LOCAL_MAX_DATA,
-            max_stream_data_bidi_remote: u64::try_from(INITIAL_LOCAL_MAX_STREAM_DATA)
-                .expect("usize fits in u64"),
-            max_stream_data_bidi_local: u64::try_from(INITIAL_LOCAL_MAX_STREAM_DATA)
-                .expect("usize fits in u64"),
-            max_stream_data_uni: u64::try_from(INITIAL_LOCAL_MAX_STREAM_DATA)
-                .expect("usize fits in u64"),
+            max_stream_data_bidi_remote: to_u64(INITIAL_LOCAL_MAX_STREAM_DATA),
+            max_stream_data_bidi_local: to_u64(INITIAL_LOCAL_MAX_STREAM_DATA),
+            max_stream_data_uni: to_u64(INITIAL_LOCAL_MAX_STREAM_DATA),
             max_streams_bidi: LOCAL_STREAM_LIMIT_BIDI,
             max_streams_uni: LOCAL_STREAM_LIMIT_UNI,
             ack_ratio: Self::DEFAULT_ACK_RATIO,

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -555,7 +555,7 @@ impl ConnectionParameters {
         // default parameters
         tps.local_mut().set_integer(
             ActiveConnectionIdLimit,
-            u64::try_from(ConnectionIdManager::ACTIVE_LIMIT)?,
+            to_u64(ConnectionIdManager::ACTIVE_LIMIT),
         );
         if self.disable_migration {
             tps.local_mut().set_empty(DisableMigration);

--- a/neqo-transport/src/connection/tests/cc.rs
+++ b/neqo-transport/src/connection/tests/cc.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use neqo_common::{Datagram, Ecn, qdebug, qinfo};
+use neqo_common::{Datagram, Ecn, qdebug, qinfo, to_u64};
 
 use super::{
     super::Output, CLIENT_HANDSHAKE_1RTT_PACKETS, DEFAULT_RTT, POST_HANDSHAKE_CWND, ack_bytes,
@@ -97,7 +97,7 @@ fn cc_slow_start_to_cong_avoidance_recovery_period(congestion_signal: Congestion
     // Client: send more
     let (mut c_tx_dgrams, mut now) = fill_cwnd(&mut client, stream_id, now);
     assert_full_cwnd(&c_tx_dgrams, POST_HANDSHAKE_CWND * 2, client.plpmtu());
-    let flight2_largest = flight1_largest + u64::try_from(c_tx_dgrams.len()).unwrap();
+    let flight2_largest = flight1_largest + to_u64(c_tx_dgrams.len());
 
     // Server: Receive and generate ack again, but this time add congestion
     // signal first.

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -485,7 +485,7 @@ fn multiple_datagram_events() {
 
     let mut client = new_client(
         ConnectionParameters::default()
-            .datagram_size(u64::try_from(DATA_SIZE).unwrap())
+            .datagram_size(to_u64(DATA_SIZE))
             .incoming_datagram_queue(MAX_QUEUE),
     );
     let mut server = default_server();
@@ -531,7 +531,7 @@ fn too_many_datagram_events() {
 
     let mut client = new_client(
         ConnectionParameters::default()
-            .datagram_size(u64::try_from(DATA_SIZE).unwrap())
+            .datagram_size(to_u64(DATA_SIZE))
             .incoming_datagram_queue(MAX_QUEUE),
     );
     let mut server = default_server();

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -6,7 +6,7 @@
 
 use std::{cell::RefCell, rc::Rc};
 
-use neqo_common::event::Provider as _;
+use neqo_common::{event::Provider as _, to_u64};
 use static_assertions::const_assert;
 
 use super::{
@@ -35,8 +35,8 @@ const DATAGRAM_LEN_MTU: usize =
 const DATA_MTU: &[u8] = &[1; DATAGRAM_LEN_MTU];
 const DATA_BIGGER_THAN_MTU: &[u8] = &[0; 2 * DATAGRAM_LEN_MTU];
 const_assert!(DATA_BIGGER_THAN_MTU.len() > DATAGRAM_LEN_MTU);
-const DATAGRAM_LEN_SMALLER_THAN_MTU: u64 = MIN_INITIAL_PACKET_SIZE as u64;
-const_assert!(DATAGRAM_LEN_SMALLER_THAN_MTU < DATAGRAM_LEN_MTU as u64);
+const DATAGRAM_LEN_SMALLER_THAN_MTU: u64 = to_u64(MIN_INITIAL_PACKET_SIZE);
+const_assert!(DATAGRAM_LEN_SMALLER_THAN_MTU < to_u64(DATAGRAM_LEN_MTU));
 const DATA_SMALLER_THAN_MTU: &[u8] = &[0; MIN_INITIAL_PACKET_SIZE];
 const_assert!(DATA_SMALLER_THAN_MTU.len() < DATAGRAM_LEN_MTU);
 const DATA_SMALLER_THAN_MTU_2: &[u8] = &[0; MIN_INITIAL_PACKET_SIZE / 2];

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -17,7 +17,7 @@ use std::{
     time::Duration,
 };
 
-use neqo_common::{Datagram, event::Provider as _, qdebug};
+use neqo_common::{Datagram, event::Provider as _, qdebug, to_u64};
 use nss::{AuthenticationStatus, constants::TLS_CHACHA20_POLY1305_SHA256, generate_ech_keys};
 #[cfg(not(feature = "disable-encryption"))]
 use test_fixture::datagram;
@@ -1528,7 +1528,7 @@ fn server_initial_retransmits_identical() {
                 // base count for CRYPTO is two per flight, plus any extra
                 crypto: i * 2 + extra,
                 ack: i,
-                largest_acknowledged: (i - i.saturating_sub(1)) as u64,
+                largest_acknowledged: to_u64(i - i.saturating_sub(1)),
                 ..Default::default()
             }
         );

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -6,7 +6,7 @@
 
 use std::{cmp::max, collections::HashMap, fmt::Debug};
 
-use neqo_common::{event::Provider as _, qdebug};
+use neqo_common::{event::Provider as _, qdebug, to_u64};
 use test_fixture::now;
 
 use super::{
@@ -345,9 +345,7 @@ fn sending_max_data() {
     const SMALL_MAX_DATA: usize = 2048;
 
     let mut client = default_client();
-    let mut server = new_server(
-        ConnectionParameters::default().max_data(u64::try_from(SMALL_MAX_DATA).unwrap()),
-    );
+    let mut server = new_server(ConnectionParameters::default().max_data(to_u64(SMALL_MAX_DATA)));
 
     connect(&mut client, &mut server);
 
@@ -394,7 +392,7 @@ fn max_data() {
     server
         .set_local_tparam(
             InitialMaxData,
-            TransportParameter::Integer(u64::try_from(SMALL_MAX_DATA).unwrap()),
+            TransportParameter::Integer(to_u64(SMALL_MAX_DATA)),
         )
         .unwrap();
 
@@ -453,9 +451,7 @@ fn exceed_max_data() {
     const SMALL_MAX_DATA: usize = 1024;
 
     let mut client = default_client();
-    let mut server = new_server(
-        ConnectionParameters::default().max_data(u64::try_from(SMALL_MAX_DATA).unwrap()),
-    );
+    let mut server = new_server(ConnectionParameters::default().max_data(to_u64(SMALL_MAX_DATA)));
 
     connect(&mut client, &mut server);
 
@@ -1012,7 +1008,7 @@ fn change_flow_control(stream_type: StreamType, new_fc: u64) {
     // create a stream
     let stream_id = server.stream_create(stream_type).unwrap();
     let written1 = server.stream_send(stream_id, &[0x0; 10000]).unwrap();
-    assert_eq!(u64::try_from(written1).unwrap(), RECV_BUFFER_START);
+    assert_eq!(to_u64(written1), RECV_BUFFER_START);
 
     // Send the stream to the client.
     let out = server.process_output(now());
@@ -1030,7 +1026,7 @@ fn change_flow_control(stream_type: StreamType, new_fc: u64) {
     // If the flow control window has been increased, server can write more data.
     let written2 = server.stream_send(stream_id, &[0x0; 10000]).unwrap();
     if RECV_BUFFER_START < new_fc {
-        assert_eq!(u64::try_from(written2).unwrap(), new_fc - RECV_BUFFER_START);
+        assert_eq!(to_u64(written2), new_fc - RECV_BUFFER_START);
     } else {
         assert_eq!(written2, 0);
     }
@@ -1043,13 +1039,13 @@ fn change_flow_control(stream_type: StreamType, new_fc: u64) {
     // read all data by client
     let mut buf = [0x0; 10000];
     let (read, _) = client.stream_recv(stream_id, &mut buf).unwrap();
-    assert_eq!(u64::try_from(read).unwrap(), max(RECV_BUFFER_START, new_fc));
+    assert_eq!(to_u64(read), max(RECV_BUFFER_START, new_fc));
 
     let out4 = client.process_output(now());
     drop(server.process(out4.dgram(), now()));
 
     let written3 = server.stream_send(stream_id, &[0x0; 10000]).unwrap();
-    assert_eq!(u64::try_from(written3).unwrap(), new_fc);
+    assert_eq!(to_u64(written3), new_fc);
 }
 
 #[test]
@@ -1069,9 +1065,7 @@ fn session_flow_control_stop_sending_state_recv() {
     const SMALL_MAX_DATA: usize = 1024;
 
     let mut client = default_client();
-    let mut server = new_server(
-        ConnectionParameters::default().max_data(u64::try_from(SMALL_MAX_DATA).unwrap()),
-    );
+    let mut server = new_server(ConnectionParameters::default().max_data(to_u64(SMALL_MAX_DATA)));
 
     connect(&mut client, &mut server);
 
@@ -1118,9 +1112,7 @@ fn session_flow_control_stop_sending_state_size_known() {
     const SMALL_MAX_DATA: usize = 1024;
 
     let mut client = default_client();
-    let mut server = new_server(
-        ConnectionParameters::default().max_data(u64::try_from(SMALL_MAX_DATA).unwrap()),
-    );
+    let mut server = new_server(ConnectionParameters::default().max_data(to_u64(SMALL_MAX_DATA)));
 
     connect(&mut client, &mut server);
 
@@ -1169,9 +1161,7 @@ fn session_flow_control_stop_sending_state_data_recvd() {
     const SMALL_MAX_DATA: usize = 1024;
 
     let mut client = default_client();
-    let mut server = new_server(
-        ConnectionParameters::default().max_data(u64::try_from(SMALL_MAX_DATA).unwrap()),
-    );
+    let mut server = new_server(ConnectionParameters::default().max_data(to_u64(SMALL_MAX_DATA)));
 
     connect(&mut client, &mut server);
 
@@ -1214,9 +1204,7 @@ fn session_flow_control_affects_all_streams() {
     const SMALL_MAX_DATA: usize = 1024;
 
     let mut client = default_client();
-    let mut server = new_server(
-        ConnectionParameters::default().max_data(u64::try_from(SMALL_MAX_DATA).unwrap()),
-    );
+    let mut server = new_server(ConnectionParameters::default().max_data(to_u64(SMALL_MAX_DATA)));
 
     connect(&mut client, &mut server);
 

--- a/neqo-transport/src/connection/tests/zerortt.rs
+++ b/neqo-transport/src/connection/tests/zerortt.rs
@@ -6,7 +6,7 @@
 
 use std::{cell::RefCell, rc::Rc, time::Duration};
 
-use neqo_common::{event::Provider as _, qdebug};
+use neqo_common::{event::Provider as _, qdebug, to_usize};
 use nss::{AllowZeroRtt, AntiReplay};
 use test_fixture::{assertions, now};
 
@@ -215,8 +215,7 @@ fn zero_rtt_send_reject() {
 fn zero_rtt_update_flow_control() {
     const LOW: u64 = 3;
     const HIGH: u64 = 10;
-    #[expect(clippy::cast_possible_truncation, reason = "OK in a test.")]
-    const MESSAGE: &[u8] = &[0; HIGH as usize];
+    const MESSAGE: &[u8] = &[0; to_usize(HIGH)];
 
     let mut client = default_client();
     let mut server = new_server(

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 use enum_map::EnumMap;
-use neqo_common::{Buffer, Encoder, Role, hex, hex_snip_middle, qdebug, qinfo, qtrace};
+use neqo_common::{Buffer, Encoder, Role, hex, hex_snip_middle, qdebug, qinfo, qtrace, to_u64};
 pub use nss::Epoch;
 use nss::{
     Agent, AntiReplay, Cipher, Error as CryptoError, HandshakeState, Mode, PrivateKey, PublicKey,
@@ -1630,8 +1630,7 @@ impl CryptoStreams {
             // - remaining space, less the header, which counts only one byte for the length at
             //   first to avoid underestimating length
             let length = min(data.len(), builder.remaining() - header_len);
-            header_len +=
-                Encoder::varint_len(u64::try_from(length).expect("usize fits in u64")) - 1;
+            header_len += Encoder::varint_len(to_u64(length)) - 1;
             let length = min(data.len(), builder.remaining() - header_len);
 
             builder.encode_frame(FrameType::Crypto, |b| {
@@ -1674,7 +1673,7 @@ impl CryptoStreams {
                 // `left` is short enough to fit into this packet. So send from the *end*
                 // of `right`, so that the second half of the SNI is in another packet.
                 let right_len = right.len() + left.len() - limit;
-                right_offset += right_len as u64;
+                right_offset += to_u64(right_len);
                 (_, right) = right.split_at(right_len);
             } else if right.len() <= limit {
                 // `right` is short enough to fit into this packet. So only send a part of `left`.
@@ -1706,7 +1705,7 @@ impl CryptoStreams {
                     let packets_needed = data.len().div_ceil(builder.limit());
                     let limit = data.len() / packets_needed;
                     let ((left_offset, left), (right_offset, right)) =
-                        limit_chunks((offset, left), (offset + mid as u64, right), limit);
+                        limit_chunks((offset, left), (offset + to_u64(mid), right), limit);
                     (
                         write_chunk(right_offset, right, builder),
                         write_chunk(left_offset, left, builder),

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -765,7 +765,7 @@ mod test {
         time::{Duration, Instant},
     };
 
-    use neqo_common::{Encoder, Role, qdebug};
+    use neqo_common::{Encoder, Role, qdebug, to_u64};
     use nss::random;
 
     use super::{
@@ -1153,9 +1153,9 @@ mod test {
         let rtt = Duration::from_millis(40);
         let now = test_fixture::now();
         let mut fc =
-            ReceiverFlowControl::new(StreamId::new(0), INITIAL_LOCAL_MAX_STREAM_DATA as u64);
+            ReceiverFlowControl::new(StreamId::new(0), to_u64(INITIAL_LOCAL_MAX_STREAM_DATA));
 
-        let fraction = INITIAL_LOCAL_MAX_STREAM_DATA as u64 / WINDOW_UPDATE_FRACTION;
+        let fraction = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA) / WINDOW_UPDATE_FRACTION;
 
         let consumed = fc.set_consumed(fraction)?;
         fc.add_retired(consumed);
@@ -1175,7 +1175,7 @@ mod test {
         let rtt = Duration::from_millis(40);
         let mut now = test_fixture::now();
         let mut fc =
-            ReceiverFlowControl::new(StreamId::new(0), INITIAL_LOCAL_MAX_STREAM_DATA as u64);
+            ReceiverFlowControl::new(StreamId::new(0), to_u64(INITIAL_LOCAL_MAX_STREAM_DATA));
         let initial_max_active = fc.max_active();
 
         // Consume and retire multiple receive windows without increasing time.
@@ -1211,7 +1211,7 @@ mod test {
         let rtt = Duration::from_millis(40);
         let now = test_fixture::now();
         let mut fc =
-            ReceiverFlowControl::new(StreamId::new(0), INITIAL_LOCAL_MAX_STREAM_DATA as u64);
+            ReceiverFlowControl::new(StreamId::new(0), to_u64(INITIAL_LOCAL_MAX_STREAM_DATA));
 
         // Send first window update to give auto-tuning algorithm a baseline.
         let consumed = fc.set_consumed(fc.next_limit())?;
@@ -1278,12 +1278,12 @@ mod test {
             let mut send_to_recv = VecDeque::new();
             let mut recv_to_send = VecDeque::new();
 
-            let mut last_max_active = INITIAL_LOCAL_MAX_STREAM_DATA as u64;
+            let mut last_max_active = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA);
             let mut last_max_active_changed = now;
 
-            let mut sender_window = INITIAL_LOCAL_MAX_STREAM_DATA as u64;
+            let mut sender_window = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA);
             let mut fc =
-                ReceiverFlowControl::new(StreamId::new(0), INITIAL_LOCAL_MAX_STREAM_DATA as u64);
+                ReceiverFlowControl::new(StreamId::new(0), to_u64(INITIAL_LOCAL_MAX_STREAM_DATA));
 
             let mut bytes_received: u64 = 0;
             let start_time = now;
@@ -1374,7 +1374,7 @@ mod test {
 
             assert!(
                 effective_window - TOLERANCE <= bdp
-                    || fc.max_active == INITIAL_LOCAL_MAX_STREAM_DATA as u64,
+                    || fc.max_active == to_u64(INITIAL_LOCAL_MAX_STREAM_DATA),
                 "{summary} Receive window is larger than the bdp."
             );
 
@@ -1399,7 +1399,7 @@ mod test {
     fn connection_flow_control_auto_tune() -> Res<()> {
         let rtt = Duration::from_millis(40);
         let now = test_fixture::now();
-        let initial_window = (INITIAL_LOCAL_MAX_STREAM_DATA * 16) as u64;
+        let initial_window = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA * 16);
         let mut fc = ReceiverFlowControl::new((), initial_window);
         let initial_max_active = fc.max_active();
 
@@ -1440,7 +1440,7 @@ mod test {
     fn connection_flow_control_respects_max_window() -> Res<()> {
         let rtt = Duration::from_millis(40);
         let now = test_fixture::now();
-        let initial_window = (INITIAL_LOCAL_MAX_STREAM_DATA * 16) as u64;
+        let initial_window = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA * 16);
         let mut fc = ReceiverFlowControl::new((), initial_window);
 
         // Helper to write frames

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 use enum_map::EnumMap;
-use neqo_common::{Buffer, MAX_VARINT, Role, qdebug, qtrace};
+use neqo_common::{Buffer, MAX_VARINT, Role, qdebug, qtrace, to_u64, to_usize};
 
 use crate::{
     Error, Res,
@@ -116,14 +116,14 @@ where
 
     /// Consume flow control.
     pub fn consume(&mut self, count: usize) {
-        let amt = u64::try_from(count).expect("usize fits into u64");
+        let amt = to_u64(count);
         debug_assert!(self.used + amt <= self.limit);
         self.used += amt;
     }
 
     /// Get available flow control.
-    pub fn available(&self) -> usize {
-        usize::try_from(self.limit - self.used).unwrap_or(usize::MAX)
+    pub const fn available(&self) -> usize {
+        to_usize(self.limit - self.used)
     }
 
     /// How much data has been written.

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -1150,7 +1150,7 @@ mod tests {
         let mut e = Encoder::default();
         e.encode_varint(FrameType::Padding);
         // `Frame::Padding` uses u16 to store length. Try to overflow length.
-        e.pad_to(u16::MAX as usize + 1, 0);
+        e.pad_to(usize::from(u16::MAX) + 1, 0);
         assert_eq!(Frame::decode(&mut e.as_decoder()), Err(Error::TooMuchData));
     }
 

--- a/neqo-transport/src/pace.rs
+++ b/neqo-transport/src/pace.rs
@@ -21,7 +21,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::qtrace;
+use neqo_common::{qtrace, to_u64};
 
 use crate::rtt::GRANULARITY;
 
@@ -104,7 +104,7 @@ impl Pacer {
             return self.t;
         };
         let rtt_ns = u64::try_from(rtt.as_nanos()).unwrap_or(u64::MAX);
-        let divisor = (cwnd as u64).saturating_mul(Self::SPEEDUP);
+        let divisor = to_u64(cwnd).saturating_mul(Self::SPEEDUP);
         let w_ns = rtt_ns.saturating_mul(deficit) / divisor;
 
         // If the increment is below the timer granularity, send immediately.
@@ -134,7 +134,7 @@ impl Pacer {
     fn bytes_for(cwnd: usize, rtt: Duration, elapsed: Duration) -> Option<u64> {
         let rtt_ns = u64::try_from(rtt.as_nanos()).unwrap_or(u64::MAX);
         let elapsed_ns = u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX);
-        let factor = (cwnd as u64).saturating_mul(Self::SPEEDUP);
+        let factor = to_u64(cwnd).saturating_mul(Self::SPEEDUP);
         elapsed_ns.saturating_mul(factor).checked_div(rtt_ns)
     }
 

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -328,9 +328,7 @@ pub fn recovery_parameters_set(
                 timer_granularity: Some(u16::try_from(GRANULARITY.as_millis()).expect("fits")),
                 initial_rtt: Some(DEFAULT_INITIAL_RTT.as_secs_f32() * 1000.0),
                 max_datagram_size: Some(u32::try_from(plpmtu).expect("MTU fits in u32")),
-                initial_congestion_window: Some(
-                    u64::try_from(CWND_INITIAL_PKTS * plpmtu).expect("fits"),
-                ),
+                initial_congestion_window: Some(to_u64(CWND_INITIAL_PKTS * plpmtu)),
                 minimum_congestion_window: Some(
                     u32::try_from(2 * plpmtu).expect("MTU fits in u32"),
                 ),
@@ -429,13 +427,13 @@ pub fn metrics_updated<M: IntoIterator<Item = Metric>>(
                         pto_count = Some(u16::try_from(v).expect("fits in u16"));
                     }
                     Metric::CongestionWindow(v) => {
-                        congestion_window = Some(u64::try_from(v).expect("fits in u64"));
+                        congestion_window = Some(to_u64(v));
                     }
                     Metric::BytesInFlight(v) => {
-                        bytes_in_flight = Some(u64::try_from(v).expect("fits in u64"));
+                        bytes_in_flight = Some(to_u64(v));
                     }
                     Metric::SsThresh(v) => {
-                        ssthresh = Some(u64::try_from(v).expect("fits in u64"));
+                        ssthresh = Some(to_u64(v));
                     }
                     Metric::PacketsInFlight(v) => packets_in_flight = Some(v),
                     Metric::PacingRate(v) => pacing_rate = Some(v),

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Decoder, Ecn, hex, qinfo, qlog::Qlog};
+use neqo_common::{Decoder, Ecn, hex, qinfo, qlog::Qlog, to_u64};
 use qlog::events::{
     ApplicationErrorCode, ConnectionErrorCode, EventData, RawInfo,
     connectivity::{
@@ -225,7 +225,7 @@ pub fn packet_io(qlog: &mut Qlog, meta: packet::MetaData, now: Instant) {
         || {
             let mut d = Decoder::from(meta.payload());
             let raw = RawInfo {
-                length: Some(meta.length() as u64),
+                length: Some(to_u64(meta.length())),
                 payload_length: None,
                 data: None,
             };
@@ -264,7 +264,7 @@ pub fn packet_dropped(qlog: &mut Qlog, decrypt_err: &packet::DecryptionError, no
             let header =
                 PacketHeader::with_type(decrypt_err.packet_type().into(), None, None, None, None);
             let raw = RawInfo {
-                length: Some(decrypt_err.len() as u64),
+                length: Some(to_u64(decrypt_err.len())),
                 ..Default::default()
             };
 
@@ -642,7 +642,7 @@ impl From<Frame<'_>> for QuicFrame {
             },
             Frame::Crypto { offset, data } => Self::Crypto {
                 offset,
-                length: data.len() as u64,
+                length: to_u64(data.len()),
             },
             Frame::NewToken { token } => Self::NewToken {
                 token: qlog::Token {
@@ -650,7 +650,7 @@ impl From<Frame<'_>> for QuicFrame {
                     details: None,
                     raw: Some(RawInfo {
                         data: Some(hex(token)),
-                        length: Some(token.len() as u64),
+                        length: Some(to_u64(token.len())),
                         payload_length: None,
                     }),
                 },
@@ -664,7 +664,7 @@ impl From<Frame<'_>> for QuicFrame {
             } => Self::Stream {
                 stream_id: stream_id.as_u64(),
                 offset,
-                length: data.len() as u64,
+                length: to_u64(data.len()),
                 fin: Some(fin),
                 raw: None,
             },
@@ -739,7 +739,7 @@ impl From<Frame<'_>> for QuicFrame {
                 raw: None,
             },
             Frame::Datagram { data, .. } => Self::Datagram {
-                length: data.len() as u64,
+                length: to_u64(data.len()),
                 raw: None,
             },
         }

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -163,7 +163,7 @@ impl QuicDatagrams {
         tracking: DatagramTracking,
         stats: &mut Stats,
     ) -> Res<()> {
-        if u64::try_from(data.len())? > self.remote_datagram_size {
+        if to_u64(data.len()) > self.remote_datagram_size {
             qdebug!(
                 "QUIC datagram exceeds remote limit, dropping it, datagram size {}, remote datagram size limit {}.",
                 data.len(),
@@ -187,7 +187,7 @@ impl QuicDatagrams {
     }
 
     pub fn handle_datagram(&self, data: &[u8], stats: &mut Stats) -> Res<()> {
-        if self.local_datagram_size < u64::try_from(data.len())? {
+        if self.local_datagram_size < to_u64(data.len()) {
             return Err(Error::ProtocolViolation);
         }
         self.conn_events

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -8,7 +8,7 @@
 
 use std::{cmp::min, collections::VecDeque};
 
-use neqo_common::{Buffer, Encoder, qdebug};
+use neqo_common::{Buffer, Encoder, qdebug, to_u64};
 
 use crate::{
     ConnectionEvents, Error, Res, Stats,
@@ -112,8 +112,7 @@ impl QuicDatagrams {
             let len = dgram.as_ref().len();
             if len + DATAGRAM_FRAME_TYPE_VARINT_LEN <= builder.remaining() {
                 // The datagram fits into the packet.
-                let length_len =
-                    Encoder::varint_len(u64::try_from(len).expect("usize fits in u64"));
+                let length_len = Encoder::varint_len(to_u64(len));
                 // Include a length if there is space for another frame after this one.
                 if builder.remaining()
                     >= DATAGRAM_FRAME_TYPE_VARINT_LEN

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -1052,7 +1052,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use neqo_common::qlog::Qlog;
+    use neqo_common::{qlog::Qlog, to_u64};
     use test_fixture::{DEFAULT_ADDR, now};
 
     use super::{
@@ -2053,7 +2053,7 @@ mod tests {
         let pto = ms(100);
 
         // Add exactly MIN_OUTSTANDING_UNACK packets → n_pto = 2.
-        add_sent(&mut lrs, (MIN_OUTSTANDING_UNACK - 1) as u64);
+        add_sent(&mut lrs, to_u64(MIN_OUTSTANDING_UNACK - 1));
         assert_eq!(lrs.sent_packets.len(), MIN_OUTSTANDING_UNACK);
 
         lrs.last_ack_eliciting = Some(t);

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -17,7 +17,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Buffer, Role, qtrace};
+use neqo_common::{Buffer, Role, qtrace, to_u64, to_usize};
 use smallvec::SmallVec;
 use strum::Display;
 
@@ -209,7 +209,7 @@ impl RxStreamOrderer {
         // Get entry before where new entry would go, so we can see if we already
         // have the new bytes.
         // Avoid copies and duplicated data.
-        let new_end = new_start + u64::try_from(new_data.len()).expect("usize fits in u64");
+        let new_end = new_start + to_u64(new_data.len());
 
         if new_end <= self.retired {
             // Range already read by application, this frame is very late and unneeded.
@@ -217,8 +217,7 @@ impl RxStreamOrderer {
         }
 
         if new_start < self.retired {
-            new_data =
-                &new_data[usize::try_from(self.retired - new_start).expect("u64 fits in usize")..];
+            new_data = &new_data[to_usize(self.retired - new_start)..];
             new_start = self.retired;
         }
 
@@ -233,12 +232,10 @@ impl RxStreamOrderer {
                 self.end,
                 self.data_ranges
                     .last_key_value()
-                    .map_or(self.retired, |(&k, v)| {
-                        k + u64::try_from(v.len()).expect("usize fits in u64")
-                    }),
+                    .map_or(self.retired, |(&k, v)| { k + to_u64(v.len()) }),
                 "end must equal the end of the last range, or retired if empty"
             );
-            self.received += u64::try_from(new_data.len()).expect("usize fits in u64");
+            self.received += to_u64(new_data.len());
             // Adjacent: extend the last entry to avoid a BTreeMap insert, if small enough.
             // Checks existing length, so the stored chunk may grow slightly past RANGE_TARGET
             // (by up to one frame). Gap (new_start > end): falls through to insert.
@@ -261,7 +258,7 @@ impl RxStreamOrderer {
         let extend = if let Some((&prev_start, prev_vec)) =
             self.data_ranges.range_mut(..=new_start).next_back()
         {
-            let prev_end = prev_start + u64::try_from(prev_vec.len()).expect("usize fits in u64");
+            let prev_end = prev_start + to_u64(prev_vec.len());
             if new_end > prev_end {
                 // PPPPPP    ->  PPPPPP
                 //   NNNNNN            NN
@@ -270,7 +267,7 @@ impl RxStreamOrderer {
                 let overlap = prev_end.saturating_sub(new_start);
                 qtrace!("New frame {new_start}-{new_end} received, overlap: {overlap}");
                 new_start += overlap;
-                new_data = &new_data[usize::try_from(overlap).expect("u64 fits in usize")..];
+                new_data = &new_data[to_usize(overlap)..];
                 // If it is small enough, extend the previous buffer.
                 // Checks existing length, so the chunk may grow slightly past RANGE_TARGET (by up
                 // to one frame). This can't always extend, because otherwise the
@@ -316,8 +313,7 @@ impl RxStreamOrderer {
             let mut to_remove = SmallVec::<[_; 8]>::new();
 
             for (&next_start, next_data) in self.data_ranges.range_mut(new_start..) {
-                let next_end =
-                    next_start + u64::try_from(next_data.len()).expect("usize fits in u64");
+                let next_end = next_start + to_u64(next_data.len());
                 let overlap = new_end.saturating_sub(next_start);
                 if overlap == 0 {
                     // Fills in the hole, exactly (probably common)
@@ -326,8 +322,7 @@ impl RxStreamOrderer {
                     qtrace!(
                         "New frame {new_start}-{new_end} overlaps with next frame by {overlap}, truncating"
                     );
-                    let truncate_to =
-                        new_data.len() - usize::try_from(overlap).expect("u64 fits in usize");
+                    let truncate_to = new_data.len() - to_usize(overlap);
                     to_add = &new_data[..truncate_to];
                     break;
                 }
@@ -344,7 +339,7 @@ impl RxStreamOrderer {
         }
 
         if !to_add.is_empty() {
-            self.received += u64::try_from(to_add.len()).expect("usize fits in u64");
+            self.received += to_u64(to_add.len());
             if extend {
                 if let Some((_, buf)) = self.data_ranges.range_mut(..=new_start).next_back() {
                     buf.extend_from_slice(to_add);
@@ -376,7 +371,7 @@ impl RxStreamOrderer {
             .map(|(start_offset, data)| {
                 // All ranges don't overlap but we could have partially
                 // retired some of the first entry's data.
-                let data_len = data.len() as u64 - self.retired.saturating_sub(*start_offset);
+                let data_len = to_u64(data.len()) - self.retired.saturating_sub(*start_offset);
                 (start_offset, data_len)
             })
             .take_while(|(start_offset, data_len)| {
@@ -409,7 +404,7 @@ impl RxStreamOrderer {
     fn buffered(&self) -> u64 {
         self.data_ranges
             .iter()
-            .map(|(&start, data)| data.len() as u64 - (self.retired.saturating_sub(start)))
+            .map(|(&start, data)| to_u64(data.len()) - (self.retired.saturating_sub(start)))
             .sum()
     }
 
@@ -422,8 +417,7 @@ impl RxStreamOrderer {
             let mut keep = false;
             if self.retired >= range_start {
                 // Frame data has new contiguous bytes.
-                let copy_offset = usize::try_from(max(range_start, self.retired) - range_start)
-                    .expect("u64 fits in usize");
+                let copy_offset = to_usize(max(range_start, self.retired) - range_start);
                 assert!(range_data.len() >= copy_offset);
                 let available = range_data.len() - copy_offset;
                 let space = buf.len() - copied;
@@ -438,7 +432,7 @@ impl RxStreamOrderer {
                     let copy_slc = &range_data[copy_offset..copy_offset + copy_bytes];
                     buf[copied..copied + copy_bytes].copy_from_slice(copy_slc);
                     copied += copy_bytes;
-                    self.retired += u64::try_from(copy_bytes).expect("usize fits in u64");
+                    self.retired += to_u64(copy_bytes);
                 }
             } else {
                 // The data in the buffer isn't contiguous.
@@ -722,7 +716,7 @@ impl RecvStream {
                 recv_buf.inbound_frame(offset, data);
                 if fin {
                     let all_recv =
-                        fc.consumed() == recv_buf.retired() + recv_buf.bytes_ready() as u64;
+                        fc.consumed() == recv_buf.retired() + to_u64(recv_buf.bytes_ready());
                     let buf = mem::replace(recv_buf, RxStreamOrderer::new());
                     let fc_copy = mem::take(fc);
                     let session_fc_copy = mem::take(session_fc);
@@ -747,7 +741,7 @@ impl RecvStream {
                 session_fc,
             } => {
                 recv_buf.inbound_frame(offset, data);
-                if fc.consumed() == recv_buf.retired() + recv_buf.bytes_ready() as u64 {
+                if fc.consumed() == recv_buf.retired() + to_u64(recv_buf.bytes_ready()) {
                     let buf = mem::replace(recv_buf, RxStreamOrderer::new());
                     let fc_copy = mem::take(fc);
                     let session_fc_copy = mem::take(session_fc);
@@ -1092,7 +1086,7 @@ impl RecvStream {
 mod tests {
     use std::{cell::RefCell, fmt::Debug, ops::Range, rc::Rc, time::Duration};
 
-    use neqo_common::{Encoder, qtrace};
+    use neqo_common::{Encoder, qtrace, to_u64, to_usize};
     use test_fixture::now;
 
     use super::RecvStream;
@@ -1591,7 +1585,7 @@ mod tests {
 
     #[test]
     fn stream_flowc_update() {
-        let mut s = create_stream(1024 * INITIAL_LOCAL_MAX_STREAM_DATA as u64);
+        let mut s = create_stream(1024 * to_u64(INITIAL_LOCAL_MAX_STREAM_DATA));
         let mut buf = vec![0u8; INITIAL_LOCAL_MAX_STREAM_DATA + 100]; // Make it overlarge
 
         assert!(!s.has_frames_to_write());
@@ -1627,7 +1621,7 @@ mod tests {
         let conn_events = ConnectionEvents::default();
         RecvStream::new(
             StreamId::from(67),
-            INITIAL_LOCAL_MAX_STREAM_DATA as u64,
+            to_u64(INITIAL_LOCAL_MAX_STREAM_DATA),
             Rc::new(RefCell::new(ReceiverFlowControl::new((), session_fc))),
             conn_events,
         )
@@ -1635,11 +1629,11 @@ mod tests {
 
     #[test]
     fn stream_max_stream_data() {
-        let mut s = create_stream(1024 * INITIAL_LOCAL_MAX_STREAM_DATA as u64);
+        let mut s = create_stream(1024 * to_u64(INITIAL_LOCAL_MAX_STREAM_DATA));
         assert!(!s.has_frames_to_write());
         let big_buf = vec![0; INITIAL_LOCAL_MAX_STREAM_DATA];
         s.inbound_stream_frame(false, 0, &big_buf).unwrap();
-        s.inbound_stream_frame(false, INITIAL_LOCAL_MAX_STREAM_DATA as u64, &[1; 1])
+        s.inbound_stream_frame(false, to_u64(INITIAL_LOCAL_MAX_STREAM_DATA), &[1; 1])
             .unwrap_err();
     }
 
@@ -1680,14 +1674,14 @@ mod tests {
 
     #[test]
     fn no_stream_flowc_event_after_exiting_recv() {
-        let mut s = create_stream(1024 * INITIAL_LOCAL_MAX_STREAM_DATA as u64);
+        let mut s = create_stream(1024 * to_u64(INITIAL_LOCAL_MAX_STREAM_DATA));
         let mut buf = vec![0; INITIAL_LOCAL_MAX_STREAM_DATA];
         // Write from buf at first.
         s.inbound_stream_frame(false, 0, &buf).unwrap();
         // Then read into it.
         s.read(&mut buf).unwrap();
         assert!(s.has_frames_to_write());
-        s.inbound_stream_frame(true, INITIAL_LOCAL_MAX_STREAM_DATA as u64, &[])
+        s.inbound_stream_frame(true, to_u64(INITIAL_LOCAL_MAX_STREAM_DATA), &[])
             .unwrap();
         assert!(!s.has_frames_to_write());
     }
@@ -1711,7 +1705,10 @@ mod tests {
             u64::try_from(SESSION_WINDOW).unwrap(),
         )));
         (
-            create_stream_with_fc(Rc::clone(&session_fc), INITIAL_LOCAL_MAX_STREAM_DATA as u64),
+            create_stream_with_fc(
+                Rc::clone(&session_fc),
+                to_u64(INITIAL_LOCAL_MAX_STREAM_DATA),
+            ),
             session_fc,
         )
     }
@@ -1773,7 +1770,7 @@ mod tests {
         )));
         let mut s = RecvStream::new(
             StreamId::from(567),
-            INITIAL_LOCAL_MAX_STREAM_DATA as u64,
+            to_u64(INITIAL_LOCAL_MAX_STREAM_DATA),
             Rc::clone(&session_fc),
             ConnectionEvents::default(),
         );
@@ -1960,20 +1957,16 @@ mod tests {
     }
 
     /// Test that the flow controls will send updates.
-    #[expect(
-        clippy::too_many_lines,
-        clippy::cast_possible_truncation,
-        reason = "This is test code."
-    )]
+    #[expect(clippy::too_many_lines, reason = "This is test code.")]
     #[test]
     fn fc_state_recv_7() {
         const CONNECTION_WINDOW: u64 = 1024;
-        const CONNECTION_WINDOW_US: usize = CONNECTION_WINDOW as usize;
+        const CONNECTION_WINDOW_US: usize = to_usize(CONNECTION_WINDOW);
 
         const STREAM_WINDOW: u64 = CONNECTION_WINDOW / 2;
-        const STREAM_WINDOW_US: usize = STREAM_WINDOW as usize;
+        const STREAM_WINDOW_US: usize = to_usize(STREAM_WINDOW);
 
-        const WINDOW_UPDATE_FRACTION_US: usize = WINDOW_UPDATE_FRACTION as usize;
+        const WINDOW_UPDATE_FRACTION_US: usize = to_usize(WINDOW_UPDATE_FRACTION);
 
         let fc = Rc::new(RefCell::new(ReceiverFlowControl::new(
             (),

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -232,7 +232,7 @@ impl RxStreamOrderer {
                 self.end,
                 self.data_ranges
                     .last_key_value()
-                    .map_or(self.retired, |(&k, v)| { k + to_u64(v.len()) }),
+                    .map_or(self.retired, |(&k, v)| k + to_u64(v.len())),
                 "end must equal the end of the last range, or retired if empty"
             );
             self.received += to_u64(new_data.len());

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -384,7 +384,7 @@ impl RxStreamOrderer {
             })
             // Accumulate, but saturate at usize::MAX.
             .fold(0, |acc: usize, (_, data_len)| {
-                acc.saturating_add(usize::try_from(data_len).unwrap_or(usize::MAX))
+                acc.saturating_add(to_usize(data_len))
             })
     }
 
@@ -1106,7 +1106,7 @@ mod tests {
 
         let mut s = RxStreamOrderer::default();
         for r in ranges {
-            let data = &ZEROES[..usize::try_from(r.end - r.start).unwrap()];
+            let data = &ZEROES[..to_usize(r.end - r.start)];
             s.inbound_frame(r.start, data);
         }
 
@@ -1280,9 +1280,9 @@ mod tests {
 
         // Add three chunks.
         s.inbound_frame(0, &[0; CHUNK_SIZE]);
-        let offset = u64::try_from(CHUNK_SIZE).unwrap();
+        let offset = to_u64(CHUNK_SIZE);
         s.inbound_frame(offset, &[0; EXTRA_SIZE]);
-        let offset = u64::try_from(CHUNK_SIZE + EXTRA_SIZE).unwrap();
+        let offset = to_u64(CHUNK_SIZE + EXTRA_SIZE);
         s.inbound_frame(offset, &[0; EXTRA_SIZE]);
 
         // Read, providing only enough space for the first.
@@ -1325,7 +1325,7 @@ mod tests {
 
         // Add three chunks.
         s.inbound_frame(0, &[0; CHUNK_SIZE]);
-        let offset = u64::try_from(CHUNK_SIZE + EXTRA_SIZE).unwrap();
+        let offset = to_u64(CHUNK_SIZE + EXTRA_SIZE);
         s.inbound_frame(offset, &[0; EXTRA_SIZE]);
 
         // Read, providing only enough space for the first chunk.
@@ -1334,7 +1334,7 @@ mod tests {
         assert_eq!(count, CHUNK_SIZE);
 
         // Now fill the gap and ensure that everything can be read.
-        let offset = u64::try_from(CHUNK_SIZE).unwrap();
+        let offset = to_u64(CHUNK_SIZE);
         s.inbound_frame(offset, &[0; EXTRA_SIZE]);
         let count = s.read(&mut buf[..]);
         assert_eq!(count, EXTRA_SIZE * 2);
@@ -1349,7 +1349,7 @@ mod tests {
 
         // Add two chunks.
         s.inbound_frame(0, &[0; CHUNK_SIZE]);
-        let offset = u64::try_from(CHUNK_SIZE).unwrap();
+        let offset = to_u64(CHUNK_SIZE);
         s.inbound_frame(offset, &[0; EXTRA_SIZE]);
 
         // Read, providing only enough space for some of the first chunk.
@@ -1370,7 +1370,7 @@ mod tests {
 
         // Add two chunks.
         s.inbound_frame(0, &[0; CHUNK_SIZE]);
-        let offset = u64::try_from(CHUNK_SIZE).unwrap();
+        let offset = to_u64(CHUNK_SIZE);
         s.inbound_frame(offset, &[0; EXTRA_SIZE]);
 
         let mut buf = [0; 1];
@@ -1702,7 +1702,7 @@ mod tests {
         static_assertions::const_assert!(INITIAL_LOCAL_MAX_STREAM_DATA > SESSION_WINDOW);
         let session_fc = Rc::new(RefCell::new(ReceiverFlowControl::new(
             (),
-            u64::try_from(SESSION_WINDOW).unwrap(),
+            to_u64(SESSION_WINDOW),
         )));
         (
             create_stream_with_fc(
@@ -1738,16 +1738,12 @@ mod tests {
         );
 
         // Switch to SizeKnown state
-        s.inbound_stream_frame(true, 2 * u64::try_from(SESSION_WINDOW).unwrap() - 1, &[0])
+        s.inbound_stream_frame(true, 2 * to_u64(SESSION_WINDOW) - 1, &[0])
             .unwrap();
         assert!(!session_fc.borrow().frame_needed());
         // Receive new data that can be read.
-        s.inbound_stream_frame(
-            false,
-            u64::try_from(SESSION_WINDOW).unwrap(),
-            &[0; SESSION_WINDOW / 2 + 1],
-        )
-        .unwrap();
+        s.inbound_stream_frame(false, to_u64(SESSION_WINDOW), &[0; SESSION_WINDOW / 2 + 1])
+            .unwrap();
         assert!(!session_fc.borrow().frame_needed());
         s.read(&mut buf).unwrap();
         assert!(session_fc.borrow().frame_needed());
@@ -1766,7 +1762,7 @@ mod tests {
         // Test DataRecvd state
         let session_fc = Rc::new(RefCell::new(ReceiverFlowControl::new(
             (),
-            u64::try_from(SESSION_WINDOW).unwrap(),
+            to_u64(SESSION_WINDOW),
         )));
         let mut s = RecvStream::new(
             StreamId::from(567),
@@ -1790,8 +1786,7 @@ mod tests {
             .unwrap();
         assert!(!session_fc.borrow().frame_needed());
 
-        s.reset(Error::None.code(), u64::try_from(SESSION_WINDOW).unwrap())
-            .unwrap();
+        s.reset(Error::None.code(), to_u64(SESSION_WINDOW)).unwrap();
         assert!(session_fc.borrow().frame_needed());
     }
 

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -493,7 +493,7 @@ impl TxBuffer {
 
     fn first_unmarked_range(&mut self) -> Option<(u64, Option<u64>)> {
         let (start, maybe_len) = self.ranges.first_unmarked_range();
-        let buffered = u64::try_from(self.buffered()).ok()?;
+        let buffered = to_u64(self.buffered());
         (start != self.retired() + buffered).then_some((start, maybe_len))
     }
 
@@ -516,7 +516,7 @@ impl TxBuffer {
 
         // Convert from ranges-relative-to-zero to
         // ranges-relative-to-buffer-start
-        let buff_off = usize::try_from(start - self.retired()).ok()?;
+        let buff_off = to_usize(start - self.retired());
 
         // Deque returns two slices. Create a subslice from whichever
         // one contains the first unmarked data.
@@ -526,9 +526,7 @@ impl TxBuffer {
             &self.send_buf.as_slices().1[buff_off - self.send_buf.as_slices().0.len()..]
         };
 
-        let len = maybe_len.map_or(slc.len(), |range_len| {
-            min(usize::try_from(range_len).unwrap_or(usize::MAX), slc.len())
-        });
+        let len = maybe_len.map_or(slc.len(), |range_len| min(to_usize(range_len), slc.len()));
 
         debug_assert!(len > 0);
         debug_assert!(len <= slc.len());
@@ -1854,7 +1852,9 @@ pub struct RecoveryToken {
 mod tests {
     use std::{cell::RefCell, collections::VecDeque, num::NonZeroUsize, rc::Rc};
 
-    use neqo_common::{Encoder, MAX_VARINT, event::Provider as _, hex_with_len, qtrace, to_u64};
+    use neqo_common::{
+        Encoder, MAX_VARINT, event::Provider as _, hex_with_len, qtrace, to_u64, to_usize,
+    };
 
     use super::RecoveryToken;
     use crate::{
@@ -2341,7 +2341,7 @@ mod tests {
 
         // Mark almost all as sent. Get what's left
         let one_byte_from_end = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA) - 1;
-        txb.mark_as_sent(0, usize::try_from(one_byte_from_end).unwrap());
+        txb.mark_as_sent(0, to_usize(one_byte_from_end));
         assert!(matches!(txb.next_bytes(),
                          Some((start, x)) if x.len() == 1
                          && start == one_byte_from_end
@@ -2370,7 +2370,7 @@ mod tests {
         // Contig acked range at start means it can be removed from buffer
         // Impl of vecdeque should now result in a split buffer when more data
         // is sent
-        txb.mark_as_acked(0, usize::try_from(five_bytes_from_end).unwrap());
+        txb.mark_as_acked(0, to_usize(five_bytes_from_end));
         assert_eq!(txb.send(&[2; 30]), 30);
         // Just get 5 even though there is more
         assert!(matches!(txb.next_bytes(),
@@ -2403,7 +2403,7 @@ mod tests {
         // As above
         let forty_bytes_from_end = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA) - 40;
 
-        txb.mark_as_acked(0, usize::try_from(forty_bytes_from_end).unwrap());
+        txb.mark_as_acked(0, to_usize(forty_bytes_from_end));
         assert!(matches!(txb.next_bytes(),
                  Some((start, x)) if x.len() == 40
                  && start == forty_bytes_from_end
@@ -2431,7 +2431,7 @@ mod tests {
 
         // Ack entire first slice and into second slice
         let ten_bytes_past_end = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA) + 10;
-        txb.mark_as_acked(0, usize::try_from(ten_bytes_past_end).unwrap());
+        txb.mark_as_acked(0, to_usize(ten_bytes_past_end));
 
         // Get up to marked range A
         assert!(matches!(txb.next_bytes(),
@@ -3144,7 +3144,7 @@ mod tests {
 
         // The minimum amount of extra space for getting another frame in.
         let mut enc = Encoder::default();
-        enc.encode_varint(u64::try_from(data.len()).unwrap());
+        enc.encode_len(data.len());
         let len_buf = Vec::from(enc);
         let minimum_extra = len_buf.len() + packet::Builder::MINIMUM_FRAME_SIZE;
 

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use indexmap::IndexMap;
-use neqo_common::{Buffer, Encoder, Role, qdebug, qerror, qtrace};
+use neqo_common::{Buffer, Encoder, Role, qdebug, qerror, qtrace, to_u64, to_usize};
 use rustc_hash::FxBuildHasher;
 use smallvec::SmallVec;
 use static_assertions::const_assert;
@@ -198,7 +198,7 @@ impl RangeTracker {
         reason = "OK here."
     )]
     pub fn mark_acked(&mut self, new_off: u64, new_len: usize) {
-        let end = new_off + u64::try_from(new_len).expect("usize fits in u64");
+        let end = new_off + to_u64(new_len);
         let new_off = max(self.acked, new_off);
         let mut new_len = end.saturating_sub(new_off);
         if new_len == 0 {
@@ -301,7 +301,7 @@ impl RangeTracker {
         reason = "OK here."
     )]
     pub fn mark_sent(&mut self, mut new_off: u64, new_len: usize) {
-        let new_end = new_off + u64::try_from(new_len).expect("usize fits in u64");
+        let new_end = new_off + to_u64(new_len);
         new_off = max(self.acked, new_off);
         let mut new_len = new_end.saturating_sub(new_off);
         if new_len == 0 {
@@ -392,7 +392,7 @@ impl RangeTracker {
         }
 
         self.first_unmarked = None;
-        let len = u64::try_from(len).expect("usize fits in u64");
+        let len = to_u64(len);
         let end_off = off + len;
 
         let mut to_remove = SmallVec::<[_; 8]>::new();
@@ -451,10 +451,7 @@ impl RangeTracker {
     /// On 32-bit machines where far too much is sent before calling this.
     /// Note that this should not be called for handshakes, which should never exceed that limit.
     pub fn unmark_sent(&mut self) {
-        self.unmark_range(
-            0,
-            usize::try_from(self.highest_offset()).expect("u64 fits in usize"),
-        );
+        self.unmark_range(0, to_usize(self.highest_offset()));
     }
 
     #[cfg(feature = "bench")]
@@ -477,8 +474,7 @@ impl TxBuffer {
     ///
     /// See [`MAX_LOCAL_MAX_STREAM_DATA`] for an explanation of this
     /// concrete value.
-    #[expect(clippy::cast_possible_truncation, reason = "Checked by const_assert!")]
-    pub const MAX_SIZE: usize = MAX_LOCAL_MAX_STREAM_DATA as usize;
+    pub const MAX_SIZE: usize = to_usize(MAX_LOCAL_MAX_STREAM_DATA);
 
     #[must_use]
     pub fn new() -> Self {
@@ -554,8 +550,7 @@ impl TxBuffer {
         self.ranges.mark_acked(offset, len);
 
         // Any newly-retired bytes can be dropped from the buffer.
-        let new_retirable =
-            usize::try_from(self.retired() - prev_retired).expect("u64 fits in usize");
+        let new_retirable = to_usize(self.retired() - prev_retired);
         debug_assert!(new_retirable <= self.buffered());
         self.send_buf.drain(..new_retirable);
     }
@@ -583,7 +578,7 @@ impl TxBuffer {
     }
 
     fn used(&self) -> u64 {
-        self.retired() + u64::try_from(self.buffered()).expect("usize fits in u64")
+        self.retired() + to_u64(self.buffered())
     }
 }
 
@@ -843,7 +838,7 @@ impl SendStream {
     pub fn bytes_written(&self) -> u64 {
         match &self.state {
             State::Send { send_buf, .. } | State::DataSent { send_buf, .. } => {
-                send_buf.retired() + u64::try_from(send_buf.buffered()).expect("usize fits in u64")
+                send_buf.retired() + to_u64(send_buf.buffered())
             }
             State::DataRecvd {
                 retired, written, ..
@@ -955,7 +950,7 @@ impl SendStream {
         // Estimate size of the length field based on the available space,
         // less 1, which is the worst case.
         let length = min(space.saturating_sub(1), data_len);
-        let length_len = Encoder::varint_len(u64::try_from(length).expect("usize fits in u64"));
+        let length_len = Encoder::varint_len(to_u64(length));
         debug_assert!(length_len <= space); // We don't depend on this being true, but it is true.
 
         // From here we can always fit `data_len`, but we might as well fill
@@ -1002,8 +997,7 @@ impl SendStream {
             }
 
             let (length, fill) = Self::length_and_fill(data.len(), builder.remaining() - overhead);
-            let fin = final_size
-                .is_some_and(|fs| fs == offset + u64::try_from(length).expect("usize fits in u64"));
+            let fin = final_size.is_some_and(|fs| fs == offset + to_u64(length));
             if length == 0 && !fin {
                 qtrace!("[{self}] write_frame no data, no fin");
                 return;
@@ -1140,10 +1134,7 @@ impl SendStream {
         reason = "OK here."
     )]
     pub fn mark_as_sent(&mut self, offset: u64, len: usize, fin: bool) {
-        self.bytes_sent = max(
-            self.bytes_sent,
-            offset + u64::try_from(len).expect("usize fits in u64"),
-        );
+        self.bytes_sent = max(self.bytes_sent, offset + to_u64(len));
 
         if let Some(buf) = self.state.tx_buf_mut() {
             buf.mark_as_sent(offset, len);
@@ -1182,7 +1173,7 @@ impl SendStream {
                 if *fin_acked && send_buf.buffered() == 0 {
                     self.conn_events.send_stream_complete(self.stream_id);
                     let retired = send_buf.retired();
-                    let buffered = u64::try_from(send_buf.buffered()).expect("usize fits in u64");
+                    let buffered = to_u64(send_buf.buffered());
                     self.state.transition(State::DataRecvd {
                         retired,
                         written: buffered,
@@ -1199,10 +1190,7 @@ impl SendStream {
         reason = "OK here."
     )]
     pub fn mark_as_lost(&mut self, offset: u64, len: usize, fin: bool) {
-        self.retransmission_offset = max(
-            self.retransmission_offset,
-            offset + u64::try_from(len).expect("usize fits in u64"),
-        );
+        self.retransmission_offset = max(self.retransmission_offset, offset + to_u64(len));
         qtrace!(
             "[{self}] mark_as_lost retransmission offset={}",
             self.retransmission_offset
@@ -1379,7 +1367,7 @@ impl SendStream {
             State::Send { fc, send_buf, .. } => {
                 let final_size = fc.used();
                 let final_retired = send_buf.retired();
-                let buffered = u64::try_from(send_buf.buffered()).expect("usize fits in u64");
+                let buffered = to_u64(send_buf.buffered());
                 self.state.transition(State::ResetSent {
                     err,
                     final_size,
@@ -1391,7 +1379,7 @@ impl SendStream {
             State::DataSent { send_buf, .. } => {
                 let final_size = send_buf.used();
                 let final_retired = send_buf.retired();
-                let buffered = u64::try_from(send_buf.buffered()).expect("usize fits in u64");
+                let buffered = to_u64(send_buf.buffered());
                 self.state.transition(State::ResetSent {
                     err,
                     final_size,
@@ -1866,7 +1854,7 @@ pub struct RecoveryToken {
 mod tests {
     use std::{cell::RefCell, collections::VecDeque, num::NonZeroUsize, rc::Rc};
 
-    use neqo_common::{Encoder, MAX_VARINT, event::Provider as _, hex_with_len, qtrace};
+    use neqo_common::{Encoder, MAX_VARINT, event::Provider as _, hex_with_len, qtrace, to_u64};
 
     use super::RecoveryToken;
     use crate::{
@@ -2352,7 +2340,7 @@ mod tests {
                          && x.iter().all(|ch| *ch == 1)));
 
         // Mark almost all as sent. Get what's left
-        let one_byte_from_end = INITIAL_LOCAL_MAX_STREAM_DATA as u64 - 1;
+        let one_byte_from_end = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA) - 1;
         txb.mark_as_sent(0, usize::try_from(one_byte_from_end).unwrap());
         assert!(matches!(txb.next_bytes(),
                          Some((start, x)) if x.len() == 1
@@ -2372,7 +2360,7 @@ mod tests {
 
         // Mark a larger range lost, including beyond what's in the buffer even.
         // Get a little more
-        let five_bytes_from_end = INITIAL_LOCAL_MAX_STREAM_DATA as u64 - 5;
+        let five_bytes_from_end = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA) - 5;
         txb.mark_as_lost(five_bytes_from_end, 100);
         assert!(matches!(txb.next_bytes(),
                          Some((start, x)) if x.len() == 5
@@ -2397,7 +2385,7 @@ mod tests {
         txb.mark_as_sent(five_bytes_from_end, 5);
         assert!(matches!(txb.next_bytes(),
                          Some((start, x)) if x.len() == 30
-                         && start == INITIAL_LOCAL_MAX_STREAM_DATA as u64
+                         && start == to_u64(INITIAL_LOCAL_MAX_STREAM_DATA)
                          && x.iter().all(|ch| *ch == 2)));
     }
 
@@ -2413,7 +2401,7 @@ mod tests {
                          && x.iter().all(|ch| *ch == 1)));
 
         // As above
-        let forty_bytes_from_end = INITIAL_LOCAL_MAX_STREAM_DATA as u64 - 40;
+        let forty_bytes_from_end = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA) - 40;
 
         txb.mark_as_acked(0, usize::try_from(forty_bytes_from_end).unwrap());
         assert!(matches!(txb.next_bytes(),
@@ -2433,7 +2421,7 @@ mod tests {
                          && x.iter().all(|ch| *ch == 1)));
 
         // Mark a range 'A' in second slice as sent. Should still return the same
-        let range_a_start = INITIAL_LOCAL_MAX_STREAM_DATA as u64 + 30;
+        let range_a_start = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA) + 30;
         let range_a_end = range_a_start + 10;
         txb.mark_as_sent(range_a_start, 10);
         assert!(matches!(txb.next_bytes(),
@@ -2442,7 +2430,7 @@ mod tests {
                          && x.iter().all(|ch| *ch == 1)));
 
         // Ack entire first slice and into second slice
-        let ten_bytes_past_end = INITIAL_LOCAL_MAX_STREAM_DATA as u64 + 10;
+        let ten_bytes_past_end = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA) + 10;
         txb.mark_as_acked(0, usize::try_from(ten_bytes_past_end).unwrap());
 
         // Get up to marked range A
@@ -2499,7 +2487,7 @@ mod tests {
         // should now hit the tx buffer size
         conn_fc
             .borrow_mut()
-            .update(INITIAL_LOCAL_MAX_STREAM_DATA as u64);
+            .update(to_u64(INITIAL_LOCAL_MAX_STREAM_DATA));
         let res = s.send(&big_buf).unwrap();
         assert_eq!(res, INITIAL_LOCAL_MAX_STREAM_DATA - 4096);
 
@@ -3255,7 +3243,7 @@ mod tests {
     }
 
     fn make_send_stream(data: &[u8]) -> (SendStream, u64) {
-        let len = data.len() as u64;
+        let len = to_u64(data.len());
         let mut s = SendStream::new(
             StreamId::new(100),
             0,

--- a/neqo-transport/src/sender.rs
+++ b/neqo-transport/src/sender.rs
@@ -248,6 +248,7 @@ mod tests {
         time::Duration,
     };
 
+    use neqo_common::to_u64;
     use test_fixture::now;
 
     use super::PacketSender;
@@ -324,7 +325,7 @@ mod tests {
 
         let pkts: Vec<_> = (0..n)
             .map(|pn| {
-                let p = sent::make_packet(pn as u64, now, mtu);
+                let p = sent::make_packet(to_u64(pn), now, mtu);
                 sender.on_packet_sent(&p, RTT, now);
                 p
             })

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -910,7 +910,7 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
     use TransportParameterId::*;
-    use neqo_common::{Decoder, Encoder, qdebug};
+    use neqo_common::{Decoder, Encoder, qdebug, to_u64};
 
     use super::PreferredAddress;
     use crate::{
@@ -1315,7 +1315,7 @@ mod tests {
 
     #[test]
     fn max_udp_payload_size_boundary() {
-        let min = crate::packet::MIN_INITIAL_PACKET_SIZE as u64;
+        let min = to_u64(crate::packet::MIN_INITIAL_PACKET_SIZE);
         assert!(decode_tp_integer(MaxUdpPayloadSize, min).is_ok());
         assert!(decode_tp_integer(MaxUdpPayloadSize, min - 1).is_err());
     }

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -16,7 +16,7 @@ use std::{
 use enum_map::{Enum, EnumMap};
 use enumset::{EnumSet, EnumSetType};
 use log::{Level, log_enabled};
-use neqo_common::{Buffer, Ecn, MAX_VARINT, qdebug, qtrace, qwarn};
+use neqo_common::{Buffer, Ecn, MAX_VARINT, qdebug, qtrace, qwarn, to_u64};
 use nss::Epoch;
 use smallvec::SmallVec;
 use strum::{Display, EnumIter};
@@ -468,9 +468,7 @@ impl RecvdPackets {
         // We use the default exponent, so delay is in multiples of 8 microseconds.
         let ack_delay = u64::try_from(elapsed.as_micros() / 8).unwrap_or(u64::MAX);
         let ack_delay = min(MAX_VARINT, ack_delay);
-        let Ok(extra_ranges) = u64::try_from(ranges.len() - 1) else {
-            return;
-        };
+        let extra_ranges = to_u64(ranges.len() - 1);
 
         builder.encode_frame(
             if self.ecn_count.is_some() {

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -626,7 +626,7 @@ impl Default for AckTracker {
 mod tests {
     use std::collections::HashSet;
 
-    use neqo_common::{Decoder, Encoder};
+    use neqo_common::{Decoder, Encoder, to_u64};
     use test_fixture::now;
 
     use super::{
@@ -706,7 +706,7 @@ mod tests {
 
         // This will add one too many disjoint ranges.
         for i in 0..=MAX_TRACKED_RANGES {
-            rp.set_received(now(), (i * 2) as u64, true, &mut stats)
+            rp.set_received(now(), to_u64(i * 2), true, &mut stats)
                 .unwrap();
         }
 
@@ -1205,7 +1205,7 @@ mod tests {
         let mut stats = Stats::default();
         // Fill with MAX_TRACKED_RANGES + 2 disjoint ack-eliciting packets.
         for i in 0..=(MAX_TRACKED_RANGES + 1) {
-            rp.set_received(now(), (i * 2) as u64, true, &mut stats)
+            rp.set_received(now(), to_u64(i * 2), true, &mut stats)
                 .unwrap();
         }
         // Two ranges should have been dropped.

--- a/neqo-transport/tests/connection.rs
+++ b/neqo-transport/tests/connection.rs
@@ -6,7 +6,7 @@
 
 mod common;
 use common::assert_dscp;
-use neqo_common::{Datagram, Decoder, Encoder, Role};
+use neqo_common::{Datagram, Decoder, Encoder, Role, to_u64};
 use neqo_transport::{
     CloseReason, ConnectionParameters, Error, MIN_INITIAL_PACKET_SIZE, State, StreamType, Version,
 };
@@ -172,12 +172,10 @@ fn set_payload(server_packet: Option<&Datagram>, client_dcid: &[u8], payload: &[
     // Re-encode the packet number as four bytes, so we have enough material for the header
     // protection sample if payload is empty.
     let pn_len = usize::from(header[0] & 0b0000_0011) + 1;
-    let len_pos = header.len()
-        - pn_len
-        - Encoder::varint_len(u64::try_from(pn_len + orig_payload.len()).unwrap());
+    let len_pos = header.len() - pn_len - Encoder::varint_len(to_u64(pn_len + orig_payload.len()));
     header.truncate(len_pos);
     let mut enc = Encoder::new_borrowed_vec(&mut header);
-    enc.encode_varint(u64::try_from(4 + payload.len() + aead.expansion()).unwrap());
+    enc.encode_len(4 + payload.len() + aead.expansion());
     enc.encode_uint(4, pn);
     header[0] = header[0] & 0xfc | 0b0000_0011; // Set the packet number length to 4.
 
@@ -282,7 +280,7 @@ fn overflow_crypto() {
             .encode_vec(1, server_dcid)
             .encode_vec(1, server_scid)
             .encode_vvec(&[]) // token
-            .encode_varint(u64::try_from(2 + payload.len() + aead.expansion()).unwrap()); // length
+            .encode_len(2 + payload.len() + aead.expansion()); // length
         let pn_offset = packet.len();
         packet.encode_uint(2, pn);
 

--- a/neqo-transport/tests/network.rs
+++ b/neqo-transport/tests/network.rs
@@ -25,7 +25,7 @@ const DELAY_RANGE: Range<Duration> = DELAY..Duration::from_millis(55);
 const JITTER: Duration = Duration::from_millis(10);
 
 const fn weeks(m: u32) -> Duration {
-    Duration::from_secs((m as u64) * 60 * 60 * 24 * 7)
+    Duration::from_secs(m as u64 * 60 * 60 * 24 * 7)
 }
 
 simulate!(

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -478,7 +478,7 @@ fn mitm_retry() {
         .encode_vec(1, d_cid)
         .encode_vec(1, s_cid)
         .encode_vvec(&[])
-        .encode_varint(u64::try_from(payload.len()).unwrap());
+        .encode_len(payload.len());
     let pn_offset = enc.len();
     let notoken_header = enc.encode_uint(pn_len, pn).as_ref().to_vec();
     qtrace!("notoken_header={}", hex_with_len(&notoken_header));
@@ -561,7 +561,7 @@ fn retry_short_dcid() {
         .encode_vec(1, short_dcid)
         .encode_vec(1, s_cid)
         .encode_vvec(&[])
-        .encode_varint(u64::try_from(payload.len()).unwrap());
+        .encode_len(payload.len());
     let pn_offset = enc.len();
     let short_dcid_header = enc.encode_uint(pn_len, pn).as_ref().to_vec();
 

--- a/neqo-transport/tests/server.rs
+++ b/neqo-transport/tests/server.rs
@@ -460,7 +460,7 @@ fn bad_client_initial() {
         .encode_vec(1, d_cid)
         .encode_vec(1, s_cid)
         .encode_vvec(&[])
-        .encode_varint(u64::try_from(payload_enc.len() + aead_enc.expansion() + PN_LEN).unwrap())
+        .encode_len(payload_enc.len() + aead_enc.expansion() + PN_LEN)
         .encode_byte(u8::try_from(pn >> 8).unwrap())
         .encode_byte(u8::try_from(pn & 0xff).unwrap());
 
@@ -555,7 +555,7 @@ fn bad_client_initial_connection_close() {
         .encode_vec(1, d_cid)
         .encode_vec(1, s_cid)
         .encode_vvec(&[])
-        .encode_varint(u64::try_from(payload_enc.len() + aead.expansion() + 1).unwrap())
+        .encode_len(payload_enc.len() + aead.expansion() + 1)
         .encode_byte(u8::try_from(pn).unwrap());
 
     let mut ciphertext = header_enc.as_ref().to_vec();

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -498,7 +498,7 @@ mod tests {
         // which sets `UDP_SEND_MSG_SIZE` on Windows. With a single segment,
         // `effective_segment_size()` returns `None`, and Windows silently truncates
         // the oversized datagram instead of returning `EMSGSIZE`.
-        let segment_size = u16::MAX as usize + 1;
+        let segment_size = usize::from(u16::MAX) + 1;
         let oversized_batch = datagram::Batch::new(
             sender.inner.local_addr()?,
             receiver.inner.local_addr()?,


### PR DESCRIPTION
Add `to_u64(usize) -> u64` and `to_usize(u64) -> usize` to `neqo-common`, both `const fn`, backed by a compile-time `const_assert_eq!(usize::BITS, u64::BITS)` instead of runtime `try_from().expect()`.

Replace all `try_from().expect("usize fits in u64/usize")` call sites and qualifying `as u64`/`as usize` casts crate-wide.

Convert lossless widening `u8`/`u16`/`u32 → u64`/`usize` casts to `u64::from()`/`usize::from()` where not in const context.

Fixes #3737