### PR TITLE
fix: reject stream frames for the wrong unidirectional stream half

### DIFF
--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -566,6 +566,36 @@ fn illegal_stream_related_frames() {
 }
 
 #[test]
+/// Server sends a stream-related frame for the wrong half of an existing
+/// unidirectional stream. This should cause the client to close the connection
+/// with `STREAM_STATE_ERROR`.
+fn wrong_directional_stream_frames() {
+    // Frames a sender may not receive. A send-only stream is client-initiated
+    // unidirectional (id 2); it has to exist so the directional check is what
+    // closes the connection rather than the not-yet-created check.
+    for frame_type in [FrameType::ResetStream, FrameType::Stream] {
+        let mut client = default_client();
+        let mut server = default_server();
+        connect(&mut client, &mut server);
+        assert_eq!(client.stream_create(StreamType::UniDi).unwrap(), 2);
+        let dgram = send_with_extra(&mut server, Writer(vec![frame_type.into(), 2, 0, 0]), now());
+        client.process_input(dgram, now());
+        assert!(client.state().closed());
+    }
+
+    // Frames a receiver may not receive. A receive-only stream is
+    // server-initiated unidirectional (id 3); obtain_stream creates it.
+    for frame_type in [FrameType::StopSending, FrameType::MaxStreamData] {
+        let mut client = default_client();
+        let mut server = default_server();
+        connect(&mut client, &mut server);
+        let dgram = send_with_extra(&mut server, Writer(vec![frame_type.into(), 3, 0, 0]), now());
+        client.process_input(dgram, now());
+        assert!(client.state().closed());
+    }
+}
+
+#[test]
 /// Regression <https://github.com/mozilla/neqo/pull/2358>.
 fn legal_out_of_order_frame_on_remote_initiated_closed_stream() {
     const REQUEST: &[u8] = b"ping";

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -6,7 +6,7 @@
 
 use std::{cmp::max, collections::HashMap, fmt::Debug};
 
-use neqo_common::{event::Provider as _, qdebug};
+use neqo_common::{Role, event::Provider as _, qdebug};
 use test_fixture::now;
 
 use super::{
@@ -570,28 +570,39 @@ fn illegal_stream_related_frames() {
 /// unidirectional stream. This should cause the client to close the connection
 /// with `STREAM_STATE_ERROR`.
 fn wrong_directional_stream_frames() {
-    // Frames a sender may not receive. A send-only stream is client-initiated
-    // unidirectional (id 2); it has to exist so the directional check is what
-    // closes the connection rather than the not-yet-created check.
-    for frame_type in [FrameType::ResetStream, FrameType::Stream] {
+    // The directional check only fires once the targeted half exists, so the
+    // creating role makes the stream before the offending frame is injected.
+    fn client_rejects(frame_type: FrameType, stream_creator: Role) {
         let mut client = default_client();
         let mut server = default_server();
         connect(&mut client, &mut server);
-        assert_eq!(client.stream_create(StreamType::UniDi).unwrap(), 2);
-        let dgram = send_with_extra(&mut server, Writer(vec![frame_type.into(), 2, 0, 0]), now());
+        let creator = match stream_creator {
+            Role::Client => &mut client,
+            Role::Server => &mut server,
+        };
+        let stream_id = creator.stream_create(StreamType::UniDi).unwrap().as_u64();
+        // The trailing 0s are PADDING for the frames that don't need them.
+        let dgram = send_with_extra(
+            &mut server,
+            Writer(vec![frame_type.into(), stream_id, 0, 0]),
+            now(),
+        );
         client.process_input(dgram, now());
-        assert!(client.state().closed());
+        assert_error(&client, &CloseReason::Transport(Error::StreamState));
     }
 
-    // Frames a receiver may not receive. A receive-only stream is
-    // server-initiated unidirectional (id 3); obtain_stream creates it.
+    // Frames a sender may not receive, on a client-initiated send-only stream.
+    for frame_type in [
+        FrameType::ResetStream,
+        FrameType::Stream,
+        FrameType::StreamDataBlocked,
+    ] {
+        client_rejects(frame_type, Role::Client);
+    }
+
+    // Frames a receiver may not receive, on a server-initiated receive-only stream.
     for frame_type in [FrameType::StopSending, FrameType::MaxStreamData] {
-        let mut client = default_client();
-        let mut server = default_server();
-        connect(&mut client, &mut server);
-        let dgram = send_with_extra(&mut server, Writer(vec![frame_type.into(), 3, 0, 0]), now());
-        client.process_input(dgram, now());
-        assert!(client.state().closed());
+        client_rejects(frame_type, Role::Server);
     }
 }
 

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -120,6 +120,11 @@ impl Streams {
                 final_size,
             } => {
                 stats.reset_stream += 1;
+                // Terminate connection with STREAM_STATE_ERROR if send-only
+                // stream (-transport 19.4)
+                if stream_id.is_send_only(self.role) {
+                    return Err(Error::StreamState);
+                }
                 if self.obtain_stream(*stream_id)?.1.is_some() {
                     self.recv
                         .reset(*stream_id, *application_error_code, *final_size)?;
@@ -130,6 +135,11 @@ impl Streams {
                 application_error_code,
             } => {
                 stats.stop_sending += 1;
+                // Terminate connection with STREAM_STATE_ERROR if receive-only
+                // stream (-transport 19.5)
+                if stream_id.is_recv_only(self.role) {
+                    return Err(Error::StreamState);
+                }
                 self.events
                     .send_stream_stop_sending(*stream_id, *application_error_code);
                 if let (Some(ss), _) = self.obtain_stream(*stream_id)? {
@@ -144,6 +154,11 @@ impl Streams {
                 ..
             } => {
                 stats.stream += 1;
+                // Terminate connection with STREAM_STATE_ERROR if send-only
+                // stream (-transport 19.8)
+                if stream_id.is_send_only(self.role) {
+                    return Err(Error::StreamState);
+                }
                 if let (_, Some(rs)) = self.obtain_stream(*stream_id)? {
                     rs.inbound_stream_frame(*fin, *offset, data)?;
                 }
@@ -162,6 +177,11 @@ impl Streams {
                     *maximum_stream_data
                 );
                 stats.max_stream_data += 1;
+                // Terminate connection with STREAM_STATE_ERROR if receive-only
+                // stream (-transport 19.10)
+                if stream_id.is_recv_only(self.role) {
+                    return Err(Error::StreamState);
+                }
                 if let (Some(ss), _) = self.obtain_stream(*stream_id)? {
                     ss.set_max_stream_data(*maximum_stream_data);
                 }


### PR DESCRIPTION
`Streams::input_frame` already closes the connection with `STREAM_STATE_ERROR` when a `STREAM_DATA_BLOCKED` frame arrives for a send-only stream (RFC 9000, 19.13), but the four sibling per-stream frames skip that check. Once the targeted half-stream exists, a `RESET_STREAM` or `STREAM` frame for a send-only stream, or a `STOP_SENDING` or `MAX_STREAM_DATA` frame for a receive-only stream, is accepted and silently dropped rather than rejected.

Before, only `STREAM_DATA_BLOCKED` carried the directional guard; after, the other arms apply the same `is_send_only`/`is_recv_only` test before touching the stream. The check belongs in `input_frame` because that is where a frame is dispatched against the connection role, and sections 19.4, 19.5, 19.8, and 19.10 each make the wrong-direction case a connection error rather than a per-stream concern. The tradeoff is that a peer which previously got these frames ignored now sees the connection closed, matching what neqo already does for `STREAM_DATA_BLOCKED`.