### PR TITLE
Simplify use of datagram modifiers in test fixtures

### DIFF
--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -332,7 +332,7 @@ pub fn migration_with_modifiers(
         .unwrap();
 
     let mut migrated = false;
-    let probe = client.process_output(now).dgram().unwrap();
+    let probe = new_path_modifier(client.process_output(now).dgram().unwrap());
     if !drop_new_path {
         assert_v4_path(&probe, true); // Contains PATH_CHALLENGE.
         assert_path_challenge_min_len(&client, &probe, now);

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -441,7 +441,6 @@ fn ecn_migration_zero_burst_all_cases() {
             // Too few packets sent before and after migration to conclude ECN validation.
             assert_ecn_enabled(before);
             assert_ecn_enabled(after);
-            // Migration succeeds except if the new path drops ECN.
             assert!(migrated);
         }
 

--- a/neqo-transport/src/connection/tests/ecn.rs
+++ b/neqo-transport/src/connection/tests/ecn.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{ptr::fn_addr_eq, time::Duration};
+use std::{convert::identity, time::Duration};
 
 use neqo_common::{Datagram, Ecn, Tos, event::Provider as _};
 use strum::IntoEnumIterator as _;
@@ -39,36 +39,24 @@ fn set_tos(mut d: Datagram, ecn: Ecn) -> Datagram {
     d
 }
 
-#[expect(clippy::unnecessary_wraps, reason = "Callers expect an Option.")]
-const fn noop(d: Datagram) -> Option<Datagram> {
-    Some(d)
+fn bleach(d: Datagram) -> Datagram {
+    set_tos(d, Ecn::NotEct)
 }
 
-#[expect(clippy::unnecessary_wraps, reason = "Callers expect an Option.")]
-fn bleach(d: Datagram) -> Option<Datagram> {
-    Some(set_tos(d, Ecn::NotEct))
-}
-
-#[expect(clippy::unnecessary_wraps, reason = "Callers expect an Option.")]
-fn remark(d: Datagram) -> Option<Datagram> {
+fn remark(d: Datagram) -> Datagram {
     if d.tos().is_ecn_marked() {
-        Some(set_tos(d, Ecn::Ect1))
+        set_tos(d, Ecn::Ect1)
     } else {
-        Some(d)
+        d
     }
 }
 
-#[expect(clippy::unnecessary_wraps, reason = "Callers expect an Option.")]
-fn ce(d: Datagram) -> Option<Datagram> {
+fn ce(d: Datagram) -> Datagram {
     if d.tos().is_ecn_marked() {
-        Some(set_tos(d, Ecn::Ce))
+        set_tos(d, Ecn::Ce)
     } else {
-        Some(d)
+        d
     }
-}
-
-fn drop(_d: Datagram) -> Option<Datagram> {
-    None
 }
 
 fn drop_ecn_marked_datagrams(d: Datagram) -> Option<Datagram> {
@@ -308,8 +296,9 @@ fn disables_on_remark() {
 /// The function returns the TOS value of the last packet sent on the old path and the TOS value
 /// of the last packet sent on the new path to allow for verification of correct behavior.
 pub fn migration_with_modifiers(
-    orig_path_modifier: fn(Datagram) -> Option<Datagram>,
-    new_path_modifier: fn(Datagram) -> Option<Datagram>,
+    orig_path_modifier: fn(Datagram) -> Datagram,
+    new_path_modifier: fn(Datagram) -> Datagram,
+    drop_new_path: bool,
     burst: usize,
 ) -> (Tos, Tos, bool) {
     fixture_init();
@@ -322,7 +311,7 @@ pub fn migration_with_modifiers(
     // Right after the handshake, the ECN validation should be in progress.
     let client_pkt = send_something(&mut client, now);
     assert_ecn_enabled(client_pkt.tos());
-    server.process_input(orig_path_modifier(client_pkt).unwrap(), now);
+    server.process_input(orig_path_modifier(client_pkt), now);
 
     // Send some data on the current path.
     for _ in 0..burst {
@@ -336,21 +325,21 @@ pub fn migration_with_modifiers(
 
     let client_pkt = send_something(&mut client, now);
     let tos_before_migration = client_pkt.tos();
-    server.process_input(orig_path_modifier(client_pkt).unwrap(), now);
+    server.process_input(orig_path_modifier(client_pkt), now);
 
     client
         .migrate(Some(DEFAULT_ADDR_V4), Some(DEFAULT_ADDR_V4), false, now)
         .unwrap();
 
     let mut migrated = false;
-    let probe = new_path_modifier(client.process_output(now).dgram().unwrap());
-    if let Some(probe) = probe {
+    let probe = client.process_output(now).dgram().unwrap();
+    if !drop_new_path {
         assert_v4_path(&probe, true); // Contains PATH_CHALLENGE.
         assert_path_challenge_min_len(&client, &probe, now);
         assert_eq!(client.stats().frame_tx.path_challenge, 1);
         let probe_cid = ConnectionId::from(get_cid(&probe));
 
-        let resp = new_path_modifier(server.process(Some(probe), now).dgram().unwrap()).unwrap();
+        let resp = new_path_modifier(server.process(Some(probe), now).dgram().unwrap());
         assert_v4_path(&resp, true);
         assert_eq!(server.stats().frame_tx.path_response, 1);
         assert_eq!(server.stats().frame_tx.path_challenge, 1);
@@ -388,6 +377,7 @@ pub fn migration_with_modifiers(
         server.stats().frame_tx.path_challenge,
         if migrated { 2 } else { 0 }
     );
+    assert_eq!(migrated, !drop_new_path);
     if migrated {
         assert_path_challenge_min_len(&server, &probe_old_server, now);
     }
@@ -399,8 +389,7 @@ pub fn migration_with_modifiers(
 
     if migrated {
         // The server then sends data on the new path.
-        let migrate_server =
-            new_path_modifier(server.process_output(now).dgram().unwrap()).unwrap();
+        let migrate_server = new_path_modifier(server.process_output(now).dgram().unwrap());
         assert_v4_path(&migrate_server, false);
         assert_eq!(server.stats().frame_tx.path_challenge, 2);
         assert_eq!(server.stats().frame_tx.stream, stream_before + 1);
@@ -445,22 +434,28 @@ pub fn migration_with_modifiers(
 
 #[test]
 fn ecn_migration_zero_burst_all_cases() {
-    for orig_path_mod in [noop, bleach, remark, ce] {
-        for new_path_mod in [noop, bleach, remark, ce, drop] {
+    for orig_path_mod in [identity, bleach, remark, ce] {
+        for new_path_mod in [identity, bleach, remark, ce] {
             let (before, after, migrated) =
-                migration_with_modifiers(orig_path_mod, new_path_mod, 0);
+                migration_with_modifiers(orig_path_mod, new_path_mod, false, 0);
             // Too few packets sent before and after migration to conclude ECN validation.
             assert_ecn_enabled(before);
             assert_ecn_enabled(after);
             // Migration succeeds except if the new path drops ECN.
-            assert!(fn_addr_eq(new_path_mod, drop as fn(_) -> _) || migrated);
+            assert!(migrated);
         }
+
+        let (before, after, migrated) = migration_with_modifiers(orig_path_mod, identity, true, 0);
+        assert_ecn_enabled(before);
+        assert_ecn_enabled(after);
+        assert!(!migrated);
     }
 }
 
 #[test]
 fn ecn_migration_noop_bleach_data() {
-    let (before, after, migrated) = migration_with_modifiers(noop, bleach, ecn::TEST_COUNT);
+    let (before, after, migrated) =
+        migration_with_modifiers(identity, bleach, false, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration.
     assert_ecn_disabled(after); // ECN validation fails after migration due to bleaching.
     assert!(migrated);
@@ -468,7 +463,8 @@ fn ecn_migration_noop_bleach_data() {
 
 #[test]
 fn ecn_migration_noop_remark_data() {
-    let (before, after, migrated) = migration_with_modifiers(noop, remark, ecn::TEST_COUNT);
+    let (before, after, migrated) =
+        migration_with_modifiers(identity, remark, false, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration.
     assert_ecn_disabled(after); // ECN validation fails after migration due to remarking.
     assert!(migrated);
@@ -476,7 +472,7 @@ fn ecn_migration_noop_remark_data() {
 
 #[test]
 fn ecn_migration_noop_ce_data() {
-    let (before, after, migrated) = migration_with_modifiers(noop, ce, ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(identity, ce, false, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration.
     assert_ecn_enabled(after); // ECN validation concludes after migration, despite all CE marks.
     assert!(migrated);
@@ -484,7 +480,8 @@ fn ecn_migration_noop_ce_data() {
 
 #[test]
 fn ecn_migration_noop_drop_data() {
-    let (before, after, migrated) = migration_with_modifiers(noop, drop, ecn::TEST_COUNT);
+    let (before, after, migrated) =
+        migration_with_modifiers(identity, identity, true, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration.
     assert_ecn_enabled(after); // Migration failed, ECN on original path is still validated.
     assert!(!migrated);
@@ -492,7 +489,8 @@ fn ecn_migration_noop_drop_data() {
 
 #[test]
 fn ecn_migration_bleach_noop_data() {
-    let (before, after, migrated) = migration_with_modifiers(bleach, noop, ecn::TEST_COUNT);
+    let (before, after, migrated) =
+        migration_with_modifiers(bleach, identity, false, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
     assert_ecn_enabled(after); // ECN validation concludes after migration.
     assert!(migrated);
@@ -500,7 +498,8 @@ fn ecn_migration_bleach_noop_data() {
 
 #[test]
 fn ecn_migration_bleach_bleach_data() {
-    let (before, after, migrated) = migration_with_modifiers(bleach, bleach, ecn::TEST_COUNT);
+    let (before, after, migrated) =
+        migration_with_modifiers(bleach, bleach, false, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
     assert_ecn_disabled(after); // ECN validation fails after migration due to bleaching.
     assert!(migrated);
@@ -508,7 +507,8 @@ fn ecn_migration_bleach_bleach_data() {
 
 #[test]
 fn ecn_migration_bleach_remark_data() {
-    let (before, after, migrated) = migration_with_modifiers(bleach, remark, ecn::TEST_COUNT);
+    let (before, after, migrated) =
+        migration_with_modifiers(bleach, remark, false, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
     assert_ecn_disabled(after); // ECN validation fails after migration due to remarking.
     assert!(migrated);
@@ -516,7 +516,7 @@ fn ecn_migration_bleach_remark_data() {
 
 #[test]
 fn ecn_migration_bleach_ce_data() {
-    let (before, after, migrated) = migration_with_modifiers(bleach, ce, ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(bleach, ce, false, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
     assert_ecn_enabled(after); // ECN validation concludes after migration, despite all CE marks.
     assert!(migrated);
@@ -524,7 +524,8 @@ fn ecn_migration_bleach_ce_data() {
 
 #[test]
 fn ecn_migration_bleach_drop_data() {
-    let (before, after, migrated) = migration_with_modifiers(bleach, drop, ecn::TEST_COUNT);
+    let (before, after, migrated) =
+        migration_with_modifiers(bleach, identity, true, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to bleaching.
     // Migration failed, ECN on original path is still disabled.
     assert_ecn_disabled(after);
@@ -533,7 +534,8 @@ fn ecn_migration_bleach_drop_data() {
 
 #[test]
 fn ecn_migration_remark_noop_data() {
-    let (before, after, migrated) = migration_with_modifiers(remark, noop, ecn::TEST_COUNT);
+    let (before, after, migrated) =
+        migration_with_modifiers(remark, identity, false, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_enabled(after); // ECN validation succeeds after migration.
     assert!(migrated);
@@ -541,7 +543,8 @@ fn ecn_migration_remark_noop_data() {
 
 #[test]
 fn ecn_migration_remark_bleach_data() {
-    let (before, after, migrated) = migration_with_modifiers(remark, bleach, ecn::TEST_COUNT);
+    let (before, after, migrated) =
+        migration_with_modifiers(remark, bleach, false, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_disabled(after); // ECN validation fails after migration due to bleaching.
     assert!(migrated);
@@ -549,7 +552,8 @@ fn ecn_migration_remark_bleach_data() {
 
 #[test]
 fn ecn_migration_remark_remark_data() {
-    let (before, after, migrated) = migration_with_modifiers(remark, remark, ecn::TEST_COUNT);
+    let (before, after, migrated) =
+        migration_with_modifiers(remark, remark, false, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_disabled(after); // ECN validation fails after migration due to remarking.
     assert!(migrated);
@@ -557,7 +561,7 @@ fn ecn_migration_remark_remark_data() {
 
 #[test]
 fn ecn_migration_remark_ce_data() {
-    let (before, after, migrated) = migration_with_modifiers(remark, ce, ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(remark, ce, false, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_enabled(after); // ECN validation concludes after migration, despite all CE marks.
     assert!(migrated);
@@ -565,7 +569,8 @@ fn ecn_migration_remark_ce_data() {
 
 #[test]
 fn ecn_migration_remark_drop_data() {
-    let (before, after, migrated) = migration_with_modifiers(remark, drop, ecn::TEST_COUNT);
+    let (before, after, migrated) =
+        migration_with_modifiers(remark, identity, true, ecn::TEST_COUNT);
     assert_ecn_disabled(before); // ECN validation fails before migration due to remarking.
     assert_ecn_disabled(after); // Migration failed, ECN on original path is still disabled.
     assert!(!migrated);
@@ -573,7 +578,7 @@ fn ecn_migration_remark_drop_data() {
 
 #[test]
 fn ecn_migration_ce_noop_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce, noop, ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce, identity, false, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
     assert_ecn_enabled(after); // ECN validation concludes after migration.
     assert!(migrated);
@@ -581,7 +586,7 @@ fn ecn_migration_ce_noop_data() {
 
 #[test]
 fn ecn_migration_ce_bleach_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce, bleach, ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce, bleach, false, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
     assert_ecn_disabled(after); // ECN validation fails after migration due to bleaching
     assert!(migrated);
@@ -589,7 +594,7 @@ fn ecn_migration_ce_bleach_data() {
 
 #[test]
 fn ecn_migration_ce_remark_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce, remark, ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce, remark, false, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
     assert_ecn_disabled(after); // ECN validation fails after migration due to remarking.
     assert!(migrated);
@@ -597,7 +602,7 @@ fn ecn_migration_ce_remark_data() {
 
 #[test]
 fn ecn_migration_ce_ce_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce, ce, ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce, ce, false, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
     assert_ecn_enabled(after); // ECN validation concludes after migration, despite all CE marks.
     assert!(migrated);
@@ -605,7 +610,7 @@ fn ecn_migration_ce_ce_data() {
 
 #[test]
 fn ecn_migration_ce_drop_data() {
-    let (before, after, migrated) = migration_with_modifiers(ce, drop, ecn::TEST_COUNT);
+    let (before, after, migrated) = migration_with_modifiers(ce, identity, true, ecn::TEST_COUNT);
     assert_ecn_enabled(before); // ECN validation concludes before migration, despite all CE marks.
     // Migration failed, ECN on original path is still enabled.
     assert_ecn_enabled(after);

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -7,6 +7,7 @@
 use std::{
     cell::RefCell,
     cmp::min,
+    convert::identity,
     mem,
     net::SocketAddr,
     rc::Rc,
@@ -271,10 +272,10 @@ fn connect_with_rtt_and_modifier<F>(
     server: &mut Connection,
     now: Instant,
     rtt: Duration,
-    modifier: F,
+    mut modifier: F,
 ) -> Instant
 where
-    F: FnMut(Datagram) -> Option<Datagram>,
+    F: FnMut(Datagram) -> Datagram,
 {
     fn check_rtt(stats: &Stats, rtt: Duration) {
         assert_eq!(stats.rtt, rtt);
@@ -282,7 +283,7 @@ where
         let n = stats.frame_rx.ack + usize::from(stats.rtt_init_guess);
         assert_eq!(stats.rttvar, rttvar_after_n_updates(n, rtt));
     }
-    let now = handshake_with_modifier(client, server, now, rtt, modifier);
+    let now = handshake_with_modifier(client, server, now, rtt, move |d| Some(modifier(d)));
     assert_eq!(*client.state(), State::Confirmed);
     assert_eq!(*server.state(), State::Confirmed);
 
@@ -297,7 +298,7 @@ fn connect_with_rtt(
     now: Instant,
     rtt: Duration,
 ) -> Instant {
-    connect_with_rtt_and_modifier(client, server, now, rtt, Some)
+    connect_with_rtt_and_modifier(client, server, now, rtt, identity)
 }
 
 fn connect(client: &mut Connection, server: &mut Connection) {
@@ -353,7 +354,7 @@ fn connect_rtt_idle_with_modifier<F>(
     modifier: F,
 ) -> Instant
 where
-    F: FnMut(Datagram) -> Option<Datagram>,
+    F: FnMut(Datagram) -> Datagram,
 {
     let now = connect_with_rtt_and_modifier(client, server, now(), rtt, modifier);
     assert_idle(client, server, rtt, now);
@@ -365,19 +366,19 @@ where
 }
 
 fn connect_rtt_idle(client: &mut Connection, server: &mut Connection, rtt: Duration) -> Instant {
-    connect_rtt_idle_with_modifier(client, server, rtt, Some)
+    connect_rtt_idle_with_modifier(client, server, rtt, identity)
 }
 
 fn connect_force_idle_with_modifier(
     client: &mut Connection,
     server: &mut Connection,
-    modifier: fn(Datagram) -> Option<Datagram>,
+    modifier: fn(Datagram) -> Datagram,
 ) {
     connect_rtt_idle_with_modifier(client, server, Duration::new(0, 0), modifier);
 }
 
 fn connect_force_idle(client: &mut Connection, server: &mut Connection) {
-    connect_force_idle_with_modifier(client, server, Some);
+    connect_force_idle_with_modifier(client, server, identity);
 }
 
 fn fill_stream(c: &mut Connection, stream: StreamId) {
@@ -599,7 +600,7 @@ fn send_something_paced_with_modifier(
     sender: &mut Connection,
     mut now: Instant,
     allow_pacing: bool,
-    modifier: fn(Datagram) -> Option<Datagram>,
+    modifier: impl Fn(Datagram) -> Datagram,
 ) -> (Datagram, Instant) {
     let stream_id = sender.stream_create(StreamType::UniDi).unwrap();
     assert!(sender.stream_send(stream_id, DEFAULT_STREAM_DATA).is_ok());
@@ -617,7 +618,7 @@ fn send_something_paced_with_modifier(
         Output::Datagram(d) => d,
         Output::None => panic!("send_something: got Output::None"),
     };
-    (modifier(dgram).unwrap(), now)
+    (modifier(dgram), now)
 }
 
 fn send_something_paced(
@@ -625,13 +626,13 @@ fn send_something_paced(
     now: Instant,
     allow_pacing: bool,
 ) -> (Datagram, Instant) {
-    send_something_paced_with_modifier(sender, now, allow_pacing, Some)
+    send_something_paced_with_modifier(sender, now, allow_pacing, identity)
 }
 
 fn send_something_with_modifier(
     sender: &mut Connection,
     now: Instant,
-    modifier: fn(Datagram) -> Option<Datagram>,
+    modifier: impl Fn(Datagram) -> Datagram,
 ) -> Datagram {
     send_something_paced_with_modifier(sender, now, false, modifier).0
 }
@@ -639,7 +640,7 @@ fn send_something_with_modifier(
 /// Send something on a stream from `sender` to `receiver`.
 /// Return the resulting datagram.
 fn send_something(sender: &mut Connection, now: Instant) -> Datagram {
-    send_something_with_modifier(sender, now, Some)
+    send_something_with_modifier(sender, now, identity)
 }
 
 /// Send something, but add a little something extra into the output.
@@ -648,7 +649,7 @@ where
     W: test_internal::FrameWriter + 'static,
 {
     sender.test_frame_writer = Some(Box::new(writer));
-    let res = send_something_with_modifier(sender, now, Some);
+    let res = send_something_with_modifier(sender, now, identity);
     sender.test_frame_writer = None;
     res
 }
@@ -659,7 +660,7 @@ fn send_with_modifier_and_receive(
     sender: &mut Connection,
     receiver: &mut Connection,
     now: Instant,
-    modifier: fn(Datagram) -> Option<Datagram>,
+    modifier: impl Fn(Datagram) -> Datagram,
 ) -> Option<Datagram> {
     let dgram = send_something_with_modifier(sender, now, modifier);
     receiver.process(Some(dgram), now).dgram()
@@ -672,7 +673,7 @@ fn send_and_receive(
     receiver: &mut Connection,
     now: Instant,
 ) -> Option<Datagram> {
-    send_with_modifier_and_receive(sender, receiver, now, Some)
+    send_with_modifier_and_receive(sender, receiver, now, identity)
 }
 
 fn get_tokens(client: &mut Connection) -> Vec<ResumptionToken> {

--- a/neqo-transport/src/connection/tests/vn.rs
+++ b/neqo-transport/src/connection/tests/vn.rs
@@ -286,9 +286,7 @@ fn compatible_upgrade_large_initial() {
     client.process_input(dgram.unwrap(), now());
 
     // Connect, but strip padding from all the packets to keep the accounting tight.
-    connect_rtt_idle_with_modifier(&mut client, &mut server, Duration::new(0, 0), |dgram| {
-        Some(strip_padding(dgram))
-    });
+    connect_rtt_idle_with_modifier(&mut client, &mut server, Duration::new(0, 0), strip_padding);
     assert_eq!(client.version(), Version::Version2);
     assert_eq!(server.version(), Version::Version2);
     // We removed padding, so no packets should be dropped.


### PR DESCRIPTION
There is only one or two places where dropping is possible.  That allowed for most modifier functions to remove the `Some()` wrapper.

The option form is kept for the innermost handshake, where the `None` option is genuinely used (in two tests, which did make me wonder if the cost is worth it, though the cost is small, so I kept it).

The migration tests also depend on being able to drop on the new path, but the complexity can be contained to those tests.