### PR TITLE
fix: reject DATAGRAM frame when max_datagram_frame_size is 0

### DIFF
--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -54,7 +54,7 @@ impl crate::connection::test_internal::FrameWriter for InsertDatagram<'_> {
     }
 }
 
-struct InsertEmptyLenDatagram;
+struct InsertEmptyDatagram;
 
 impl crate::connection::test_internal::FrameWriter for InsertEmptyDatagram {
     fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
@@ -434,7 +434,7 @@ fn dgram_unsupported() {
     // The client advertised max_datagram_frame_size=0, so any DATAGRAM frame,
     // including an empty one, is a connection error (RFC 9221, Section 3).
     let out = server
-        .test_write_frames(InsertEmptyLenDatagram, now())
+        .test_write_frames(InsertEmptyDatagram, now())
         .dgram()
         .unwrap();
     client.process_input(out, now());

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -54,6 +54,15 @@ impl crate::connection::test_internal::FrameWriter for InsertDatagram<'_> {
     }
 }
 
+struct InsertEmptyLenDatagram;
+
+impl crate::connection::test_internal::FrameWriter for InsertEmptyLenDatagram {
+    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+        builder.encode_varint(FrameType::DatagramWithLen);
+        builder.encode_vvec(&[]);
+    }
+}
+
 #[test]
 fn datagram_disabled_both() {
     let mut client = new_client(ConnectionParameters::default().datagram_size(0));
@@ -409,6 +418,23 @@ fn dgram_too_big() {
 
     let out = server
         .test_write_frames(InsertDatagram { data: DATA_MTU }, now())
+        .dgram()
+        .unwrap();
+    client.process_input(out, now());
+
+    assert_error(&client, &CloseReason::Transport(Error::ProtocolViolation));
+}
+
+#[test]
+fn dgram_unsupported() {
+    let mut client = new_client(ConnectionParameters::default().datagram_size(0));
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+
+    // The client advertised max_datagram_frame_size=0, so any DATAGRAM frame,
+    // including an empty one, is a connection error (RFC 9221, Section 3).
+    let out = server
+        .test_write_frames(InsertEmptyLenDatagram, now())
         .dgram()
         .unwrap();
     client.process_input(out, now());

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -56,7 +56,7 @@ impl crate::connection::test_internal::FrameWriter for InsertDatagram<'_> {
 
 struct InsertEmptyLenDatagram;
 
-impl crate::connection::test_internal::FrameWriter for InsertEmptyLenDatagram {
+impl crate::connection::test_internal::FrameWriter for InsertEmptyDatagram {
     fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
         builder.encode_varint(FrameType::DatagramWithLen);
         builder.encode_vvec(&[]);

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -188,7 +188,10 @@ impl QuicDatagrams {
     }
 
     pub fn handle_datagram(&self, data: &[u8], stats: &mut Stats) -> Res<()> {
-        if self.local_datagram_size < u64::try_from(data.len())? {
+        // A `local_datagram_size` of 0 means we advertised a
+        // max_datagram_frame_size of 0, i.e. no DATAGRAM frame support
+        // (RFC 9221, Section 3).
+        if self.local_datagram_size == 0 || self.local_datagram_size < u64::try_from(data.len())? {
             return Err(Error::ProtocolViolation);
         }
         self.conn_events


### PR DESCRIPTION
When an endpoint advertises a `max_datagram_frame_size` of 0 it has no DATAGRAM support, but `QuicDatagrams::handle_datagram` only compares the received payload length against `local_datagram_size`. With that limit at 0 the comparison rejects any non-empty frame, so an empty DATAGRAM frame is the one case that slips through: it is delivered to the application and the connection stays open. RFC 9221 Section 3 makes receipt of a DATAGRAM frame after advertising a max_datagram_frame_size of 0 a connection error of type PROTOCOL_VIOLATION.

Reject the frame when datagrams were never negotiated. The check lives in `handle_datagram` because that is the only place that sees both the received frame and the limit we advertised, and it lines up with the oversized-frame rejection already there. Before, an empty datagram against a disabled endpoint was silently accepted; after, it closes the connection, which is stricter but matches the RFC.