### PR TITLE
fix: reject reserved bits set in QUIC packet headers

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1854,8 +1854,10 @@ impl Connection {
                             self.save_datagram(epoch, d, remaining, now);
                             return Ok(());
                         }
-                        Error::KeysExhausted => {
-                            // Exhausting read keys is fatal.
+                        // Exhausting read keys is fatal. So is a packet that
+                        // authenticated but broke the protocol (e.g. reserved
+                        // bits set), which closes the connection.
+                        Error::KeysExhausted | Error::ProtocolViolation => {
                             return Err(e.error);
                         }
                         Error::KeysDiscarded(epoch) => self.handle_keys_discarded(epoch),

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -1350,8 +1350,10 @@ mod tests {
     /// A packet that authenticates but has a reserved bit set in the first byte
     /// is a connection error of type `PROTOCOL_VIOLATION`. The bit is set before
     /// the packet is encrypted so that it is covered by the AEAD and survives
-    /// header protection removal at the receiver.
-    fn reject_reserved_bit(builder: Builder<Vec<u8>>) {
+    /// header protection removal at the receiver. Each reserved bit is checked
+    /// on its own because the long and short header masks differ.
+    fn reject_reserved_bit(mut builder: Builder<Vec<u8>>, bit: u8) {
+        builder.as_mut()[0] |= bit;
         let packet = builder
             .build(&mut CryptoDxState::test_default_write())
             .expect("build");
@@ -1366,34 +1368,38 @@ mod tests {
     #[test]
     fn reserved_bits_short() {
         fixture_init();
-        let mut builder = Builder::short(
-            Encoder::default(),
-            true,
-            Some(ConnectionId::from(SERVER_CID)),
-            packet::LIMIT,
-        );
-        builder.pn(0, 1);
-        builder.encode(SAMPLE_SHORT_PAYLOAD);
-        builder.as_mut()[0] |= 0x08;
-        reject_reserved_bit(builder);
+        // Short header reserved bits are 0x18.
+        for bit in [0x10, 0x08] {
+            let mut builder = Builder::short(
+                Encoder::default(),
+                true,
+                Some(ConnectionId::from(SERVER_CID)),
+                packet::LIMIT,
+            );
+            builder.pn(0, 1);
+            builder.encode(SAMPLE_SHORT_PAYLOAD);
+            reject_reserved_bit(builder, bit);
+        }
     }
 
     #[test]
     fn reserved_bits_long() {
         fixture_init();
-        let mut builder = Builder::long(
-            Encoder::default(),
-            Type::Initial,
-            Version::default(),
-            None::<&[u8]>,
-            Some(ConnectionId::from(SERVER_CID)),
-            packet::LIMIT,
-        );
-        builder.initial_token(&[]);
-        builder.pn(0, 1);
-        builder.encode(SAMPLE_INITIAL_PAYLOAD);
-        builder.as_mut()[0] |= 0x08;
-        reject_reserved_bit(builder);
+        // Long header reserved bits are 0x0c.
+        for bit in [0x08, 0x04] {
+            let mut builder = Builder::long(
+                Encoder::default(),
+                Type::Initial,
+                Version::default(),
+                None::<&[u8]>,
+                Some(ConnectionId::from(SERVER_CID)),
+                packet::LIMIT,
+            );
+            builder.initial_token(&[]);
+            builder.pn(0, 1);
+            builder.encode(SAMPLE_INITIAL_PAYLOAD);
+            reject_reserved_bit(builder, bit);
+        }
     }
 
     #[test]

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -960,6 +960,21 @@ impl<'a> Public<'a> {
             Ok(v) => v,
             Err(e) => return Err((self, e).into()),
         };
+        // The two reserved bits in the first byte (0x0c for long headers, 0x18
+        // for short headers) are header protected, so they can only be checked
+        // now that both header and packet protection have been removed. A peer
+        // that sets either bit is a connection error of type PROTOCOL_VIOLATION.
+        //
+        // <https://www.rfc-editor.org/rfc/rfc9000.html#section-17.2>
+        // <https://www.rfc-editor.org/rfc/rfc9000.html#section-17.3.1>
+        let reserved = if self.packet_type.is_long() {
+            0x0c
+        } else {
+            0x18
+        };
+        if self.data[0] & reserved != 0 {
+            return Err((self, Error::ProtocolViolation).into());
+        }
         let data = &self.data[header_end..header_end + payload_len];
         // Helper for late errors where `self` is partially borrowed.
         let make_err = |error| DecryptionError {
@@ -1330,6 +1345,55 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    /// A packet that authenticates but has a reserved bit set in the first byte
+    /// is a connection error of type `PROTOCOL_VIOLATION`. The bit is set before
+    /// the packet is encrypted so that it is covered by the AEAD and survives
+    /// header protection removal at the receiver.
+    fn reject_reserved_bit(builder: Builder<Vec<u8>>) {
+        let packet = builder
+            .build(&mut CryptoDxState::test_default_write())
+            .expect("build");
+        let mut buf = packet.as_ref().to_vec();
+        let (packet, _) = Public::decode(&mut buf, &cid_mgr()).unwrap();
+        match packet.decrypt(&mut CryptoStates::test_default(), now()) {
+            Err(e) => assert_eq!(e.error, Error::ProtocolViolation),
+            Ok(_) => panic!("reserved bit not rejected"),
+        }
+    }
+
+    #[test]
+    fn reserved_bits_short() {
+        fixture_init();
+        let mut builder = Builder::short(
+            Encoder::default(),
+            true,
+            Some(ConnectionId::from(SERVER_CID)),
+            packet::LIMIT,
+        );
+        builder.pn(0, 1);
+        builder.encode(SAMPLE_SHORT_PAYLOAD);
+        builder.as_mut()[0] |= 0x08;
+        reject_reserved_bit(builder);
+    }
+
+    #[test]
+    fn reserved_bits_long() {
+        fixture_init();
+        let mut builder = Builder::long(
+            Encoder::default(),
+            Type::Initial,
+            Version::default(),
+            None::<&[u8]>,
+            Some(ConnectionId::from(SERVER_CID)),
+            packet::LIMIT,
+        );
+        builder.initial_token(&[]);
+        builder.pn(0, 1);
+        builder.encode(SAMPLE_INITIAL_PAYLOAD);
+        builder.as_mut()[0] |= 0x08;
+        reject_reserved_bit(builder);
     }
 
     #[test]


### PR DESCRIPTION
The two reserved bits in a packet's first byte (0x0c for long headers, 0x18 for short headers) are header protected, so their real values only appear after `Public::decrypt` removes both header and packet protection. `decrypt` reads the first byte to recover the packet number length and key phase but never looks at the reserved bits, so a peer that authenticates a packet with either bit set is accepted. RFC 9000 17.2 and 17.3.1 require that case to be a connection error of type PROTOCOL_VIOLATION.

Before: the reserved bits were ignored on every received packet. After: `decrypt` checks them once the packet is authenticated and returns PROTOCOL_VIOLATION, which the receive loop now treats as fatal. The check runs after AEAD on purpose, so an off-path attacker flipping the protected bits only causes a decryption failure that gets dropped, while a genuine peer violation closes the connection. The tradeoff is that we no longer silently tolerate a peer that sets bits the spec keeps reserved.