### PR TITLE
reject CR, LF, and NUL in HTTP/3 field values

### DIFF
--- a/neqo-http3/src/headers_checks.rs
+++ b/neqo-http3/src/headers_checks.rs
@@ -117,6 +117,13 @@ pub fn headers_valid(headers: &[Header], message_type: MessageType) -> Res<()> {
         if bytes.any(|b| matches!(b, 0 | 0x0a | 0x0d | 0x3a | 0x41..=0x5a)) {
             return Err(Error::InvalidHeader); // illegal characters.
         }
+
+        // CR, LF, and NUL are not permitted in a field value either (RFC 9114,
+        // Section 4.3); carried verbatim into an HTTP/1.1 serialization they
+        // would split the message.
+        if header.value().iter().any(|b| matches!(b, 0 | 0x0a | 0x0d)) {
+            return Err(Error::InvalidHeader); // illegal characters.
+        }
     }
     // Clear the regular header bit, since we only check pseudo headers below.
     pseudo_state.remove(PseudoHeaderState::Regular);
@@ -315,6 +322,30 @@ mod tests {
             Header::new("xname", "value"),
         ];
         assert!(headers_valid(&headers, MessageType::Request).is_ok());
+    }
+
+    #[test]
+    fn reject_cr_lf_nul_in_field_value() {
+        // CR (0x0d), LF (0x0a), and NUL (0x00) in a field value must be treated
+        // as malformed (RFC 9114, Section 4.3), otherwise they can be carried
+        // verbatim into a downstream HTTP/1.1 serialization and split the message.
+        for bad in [b"v\rx".as_slice(), b"v\nx", b"v\r\nx", b"v\0x"] {
+            let headers = vec![
+                Header::new(":method", "GET"),
+                Header::new(":scheme", "https"),
+                Header::new(":path", "/"),
+                Header::new("name", bad),
+            ];
+            assert!(headers_valid(&headers, MessageType::Request).is_err());
+        }
+
+        // The same bytes in a pseudo-header value are rejected too.
+        let headers = vec![
+            Header::new(":method", "GET"),
+            Header::new(":scheme", "https"),
+            Header::new(":path", b"/\r\nx".as_slice()),
+        ];
+        assert!(headers_valid(&headers, MessageType::Request).is_err());
     }
 
     #[test]


### PR DESCRIPTION
`headers_valid` screens received field names for forbidden bytes but never looks at the values, so a value carrying CR/LF/NUL is accepted:

    Header::new("x-thing", "a\r\nset-cookie: b")  ->  Ok(())

RFC 9114, Section 4.3 puts CR (0x0d), LF (0x0a), and NUL (0x00) out of bounds for both field names and field values, since a verbatim copy into a downstream HTTP/1.1 serialization splits the message.

Before, only the name bytes are checked and a malformed value reaches the application through the header events. After, the same three bytes are rejected in the value too, in `headers_valid` so the request and response receive paths are both covered from one place. The value check is limited to CR/LF/NUL rather than the full field-vchar set, so values with SP, HTAB, or obs-text are still accepted. The added test drives the validator with CR, LF, CRLF, and NUL in a regular and a pseudo-header value.