### PR TITLE
Reliable resets (RESET_STREAM_AT)

### DIFF
--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1046,12 +1046,21 @@ impl Http3Connection {
     /// See [`neqo_transport::Connection::stream_commit`].
     ///
     /// # Errors
-    /// When the transport rejects the commitment (e.g. the peer did not enable reliable reset,
-    /// or the stream does not exist).
-    pub fn stream_commit(&self, conn: &mut Connection, stream_id: StreamId) -> Res<()> {
+    /// `InvalidStreamId` if the stream does not exist, or a transport error when the commitment
+    /// is rejected (e.g. the peer did not enable reliable reset).
+    pub fn stream_commit(
+        &mut self,
+        conn: &mut Connection,
+        stream_id: StreamId,
+        now: Instant,
+    ) -> Res<()> {
         qtrace!("[{self}] Commit reliable size on stream {stream_id}");
-        conn.stream_commit(stream_id)?;
-        Ok(())
+        // The request is routed through the send stream so that any data still buffered in the
+        // HTTP/3 layer is flushed to the transport before the commitment is made.
+        self.send_streams
+            .get_mut(&stream_id)
+            .ok_or(Error::InvalidStreamId)?
+            .commit(conn, now)
     }
 
     pub fn stream_stop_sending(

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1027,7 +1027,7 @@ impl Http3Connection {
         stream_id: StreamId,
         error: AppError,
     ) -> Res<()> {
-        qinfo!("[{self}] Reset sending side of stream {stream_id} error={error}");
+        qdebug!("[{self}] Reset sending side of stream {stream_id} error={error}");
 
         if self.send_stream_is_critical(stream_id) {
             return Err(Error::InvalidStreamId);
@@ -1038,13 +1038,26 @@ impl Http3Connection {
         Ok(())
     }
 
+    /// Commit to reliably delivering the stream data buffered so far. If the stream is
+    /// subsequently reset, that prefix is delivered using `RESET_STREAM_AT`, if possible.
+    /// See [`neqo_transport::Connection::stream_commit`].
+    ///
+    /// # Errors
+    /// When the transport rejects the commitment (e.g. the peer did not enable reliable reset,
+    /// or the stream does not exist).
+    pub fn stream_commit(&self, conn: &mut Connection, stream_id: StreamId) -> Res<()> {
+        qtrace!("[{self}] Commit reliable size on stream {stream_id}");
+        conn.stream_commit(stream_id)?;
+        Ok(())
+    }
+
     pub fn stream_stop_sending(
         &mut self,
         conn: &mut Connection,
         stream_id: StreamId,
         error: AppError,
     ) -> Res<()> {
-        qinfo!("[{self}] Send stop sending for stream {stream_id} error={error}");
+        qdebug!("[{self}] Send stop sending for stream {stream_id} error={error}");
         if self.recv_stream_is_critical(stream_id) {
             return Err(Error::InvalidStreamId);
         }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -604,7 +604,7 @@ impl Http3Client {
     ///
     /// An error will be return if a stream does not exist.
     pub fn cancel_fetch(&mut self, stream_id: StreamId, error: AppError) -> Res<()> {
-        qinfo!("[{self}] reset_stream {stream_id} error={error}");
+        qdebug!("[{self}] reset_stream {stream_id} error={error}");
         self.base_handler
             .cancel_fetch(stream_id, error, &mut self.conn)
     }
@@ -615,7 +615,6 @@ impl Http3Client {
     ///
     /// An error will be return if stream does not exist.
     pub fn stream_close_send(&mut self, stream_id: StreamId, now: Instant) -> Res<()> {
-        qdebug!("[{self}] Close sending side stream={stream_id}");
         self.base_handler
             .stream_close_send(&mut self.conn, stream_id, now)
     }
@@ -624,16 +623,26 @@ impl Http3Client {
     ///
     /// An error will be return if a stream does not exist.
     pub fn stream_reset_send(&mut self, stream_id: StreamId, error: AppError) -> Res<()> {
-        qinfo!("[{self}] stream_reset_send {stream_id} error={error}");
         self.base_handler
             .stream_reset_send(&mut self.conn, stream_id, error)
+    }
+
+    /// Commit to reliably delivering the stream data buffered so far. If the stream is later
+    /// reset with [`Self::stream_reset_send`], that prefix is still delivered using
+    /// `RESET_STREAM_AT` (when the peer supports it). Call this after writing the data to
+    /// protect.
+    ///
+    /// # Errors
+    /// `InvalidStreamId` if the stream does not exist, or `NotAvailable` if the peer did not
+    /// enable reliable reset.
+    pub fn stream_commit(&mut self, stream_id: StreamId) -> Res<()> {
+        self.base_handler.stream_commit(&mut self.conn, stream_id)
     }
 
     /// # Errors
     ///
     /// An error will be return if a stream does not exist.
     pub fn stream_stop_sending(&mut self, stream_id: StreamId, error: AppError) -> Res<()> {
-        qinfo!("[{self}] stream_stop_sending {stream_id} error={error}");
         self.base_handler
             .stream_stop_sending(&mut self.conn, stream_id, error)
     }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -635,8 +635,9 @@ impl Http3Client {
     /// # Errors
     /// `InvalidStreamId` if the stream does not exist, or `NotAvailable` if the peer did not
     /// enable reliable reset.
-    pub fn stream_commit(&mut self, stream_id: StreamId) -> Res<()> {
-        self.base_handler.stream_commit(&mut self.conn, stream_id)
+    pub fn stream_commit(&mut self, stream_id: StreamId, now: Instant) -> Res<()> {
+        self.base_handler
+            .stream_commit(&mut self.conn, stream_id, now)
     }
 
     /// # Errors

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -168,6 +168,15 @@ impl Http3ServerHandler {
         self.base_handler.stream_reset_send(conn, stream_id, error)
     }
 
+    /// Commit to reliably delivering the stream data buffered so far.
+    ///
+    /// # Errors
+    /// When the transport rejects the commitment (see
+    /// [`neqo_transport::Connection::stream_commit`]).
+    pub fn stream_commit(&self, stream_id: StreamId, conn: &mut Connection) -> Res<()> {
+        self.base_handler.stream_commit(conn, stream_id)
+    }
+
     pub(crate) fn validate_extended_connect_session(&self, session_id: StreamId) -> Res<()> {
         self.base_handler
             .validate_extended_connect_session(session_id)

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -173,8 +173,13 @@ impl Http3ServerHandler {
     /// # Errors
     /// When the transport rejects the commitment (see
     /// [`neqo_transport::Connection::stream_commit`]).
-    pub fn stream_commit(&self, stream_id: StreamId, conn: &mut Connection) -> Res<()> {
-        self.base_handler.stream_commit(conn, stream_id)
+    pub fn stream_commit(
+        &mut self,
+        stream_id: StreamId,
+        conn: &mut Connection,
+        now: Instant,
+    ) -> Res<()> {
+        self.base_handler.stream_commit(conn, stream_id, now)
     }
 
     pub(crate) fn validate_extended_connect_session(&self, session_id: StreamId) -> Res<()> {

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -24,8 +24,6 @@ pub struct ControlStreamLocal {
     stream: BufferedStream,
     /// `stream_id`s of outstanding request streams
     outstanding_priority_update: VecDeque<StreamId>,
-    /// Whether the leading stream-type prefix has been committed for reliable delivery.
-    prefix_committed: bool,
 }
 
 impl Display for ControlStreamLocal {
@@ -51,16 +49,7 @@ impl ControlStreamLocal {
         recv_conn: &mut HashMap<StreamId, Box<dyn RecvStream>>,
         now: Instant,
     ) -> Res<()> {
-        let sent = self.stream.send_buffer(conn, now)?;
-        if sent > 0
-            && !self.prefix_committed
-            && let Some(stream_id) = self.stream_id()
-        {
-            // Commit the leading stream-type prefix so it survives a reset.
-            // Best-effort: a no-op when the peer didn't enable reliable reset.
-            _ = conn.stream_commit(stream_id);
-            self.prefix_committed = true;
-        }
+        self.stream.send_buffer(conn, now)?;
         self.send_priority_update(conn, recv_conn, now)
     }
 

--- a/neqo-http3/src/control_stream_local.rs
+++ b/neqo-http3/src/control_stream_local.rs
@@ -24,6 +24,8 @@ pub struct ControlStreamLocal {
     stream: BufferedStream,
     /// `stream_id`s of outstanding request streams
     outstanding_priority_update: VecDeque<StreamId>,
+    /// Whether the leading stream-type prefix has been committed for reliable delivery.
+    prefix_committed: bool,
 }
 
 impl Display for ControlStreamLocal {
@@ -49,7 +51,16 @@ impl ControlStreamLocal {
         recv_conn: &mut HashMap<StreamId, Box<dyn RecvStream>>,
         now: Instant,
     ) -> Res<()> {
-        self.stream.send_buffer(conn, now)?;
+        let sent = self.stream.send_buffer(conn, now)?;
+        if sent > 0
+            && !self.prefix_committed
+            && let Some(stream_id) = self.stream_id()
+        {
+            // Commit the leading stream-type prefix so it survives a reset.
+            // Best-effort: a no-op when the peer didn't enable reliable reset.
+            _ = conn.stream_commit(stream_id);
+            self.prefix_committed = true;
+        }
         self.send_priority_update(conn, recv_conn, now)
     }
 

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -364,6 +364,10 @@ impl WtTest {
         self.exchange_packets();
     }
 
+    fn commit_stream_client(&mut self, wt_stream_id: StreamId) {
+        self.client.stream_commit(wt_stream_id).unwrap();
+    }
+
     fn receive_reset_client(&mut self, expected_stream_id: StreamId) {
         let wt_reset_event = |e| {
             matches!(

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -142,6 +142,7 @@ impl WtTest {
         connect_with(&mut client, &mut server);
         Self { client, server }
     }
+
     fn negotiate_wt_session(
         &mut self,
         accept: &SessionAcceptAction,

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -382,7 +382,7 @@ impl WtTest {
     }
 
     fn commit_stream_client(&mut self, wt_stream_id: StreamId) {
-        self.client.stream_commit(wt_stream_id).unwrap();
+        self.client.stream_commit(wt_stream_id, now()).unwrap();
     }
 
     fn receive_reset_client(&mut self, expected_stream_id: StreamId) {

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
@@ -5,11 +5,15 @@
 // except according to those terms.
 
 use neqo_common::to_u64;
-use neqo_transport::StreamType;
+use neqo_transport::{ConnectionParameters, StreamType};
+use test_fixture::now;
 
 use crate::{
-    Error,
-    features::extended_connect::{CloseReason, tests::webtransport::WtTest},
+    Error, Http3Parameters,
+    features::extended_connect::{
+        CloseReason,
+        tests::webtransport::{DATAGRAM_SIZE, WtTest, wt_default_parameters},
+    },
     webtransport::ClientSession as _,
 };
 
@@ -217,6 +221,45 @@ fn wt_client_stream_uni_commit_reset() {
         before + 1
     );
     wt.receive_reset_server(wt_stream, Error::HttpNone.code());
+}
+
+/// When a WebTransport stream's preface cannot be flushed to the transport (here because the
+/// connection send credit is exhausted), sends are blocked and committing is safe. The preface is
+/// sent atomically, so the transport never holds — and so can never commit — a partial preface.
+#[test]
+fn wt_client_stream_commit_blocked_preface_is_safe() {
+    let mut wt = WtTest::new_with_params(
+        wt_default_parameters(),
+        Http3Parameters::default()
+            .webtransport(true)
+            .connection_parameters(
+                ConnectionParameters::default()
+                    .datagram_size(DATAGRAM_SIZE)
+                    .max_data(2000),
+            ),
+    );
+    let wt_session = wt.create_wt_session();
+
+    // Soak up the connection's send credit on one stream (its preface flushes while credit is
+    // still available).
+    let filler = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::UniDi);
+    let buf = [0; 1024];
+    while wt.client.send_data(filler, &buf, now()).unwrap() > 0 {}
+
+    // A fresh stream can no longer flush its preface.
+    let blocked = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::UniDi);
+
+    // Sending and committing is blocked at this point.
+    assert_eq!(wt.client.send_data(blocked, &[0; 10], now()).unwrap(), 0);
+    assert_eq!(
+        wt.client.stream_commit(blocked, now()),
+        Err(Error::FlowControlLimit)
+    );
+
+    wt.exchange_packets();
+
+    assert_eq!(wt.client.send_data(blocked, &[0; 10], now()).unwrap(), 10);
+    assert_eq!(wt.client.stream_commit(blocked, now()), Ok(()));
 }
 
 #[test]

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
@@ -177,6 +177,27 @@ fn wt_client_stream_uni_reset() {
 }
 
 #[test]
+fn wt_client_stream_uni_reset_is_reliable() {
+    const BUF_CLIENT: &[u8] = &[0; 10];
+
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let wt_stream = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::UniDi);
+    wt.send_data_client(wt_stream, BUF_CLIENT);
+    drop(wt.receive_data_server(wt_stream, true, BUF_CLIENT, false));
+
+    // No explicit commit: the H3 layer auto-commits the session-id prefix when it is sent, so
+    // resetting the stream is delivered as RESET_STREAM_AT.
+    let before = wt.client.transport_stats().frame_tx.reset_stream_at;
+    wt.reset_stream_client(wt_stream);
+    assert_eq!(
+        wt.client.transport_stats().frame_tx.reset_stream_at,
+        before + 1
+    );
+    wt.receive_reset_server(wt_stream, Error::HttpNone.code());
+}
+
+#[test]
 fn wt_client_stream_uni_commit_reset() {
     const BUF_CLIENT: &[u8] = &[0; 10];
 

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/streams.rs
@@ -177,6 +177,27 @@ fn wt_client_stream_uni_reset() {
 }
 
 #[test]
+fn wt_client_stream_uni_commit_reset() {
+    const BUF_CLIENT: &[u8] = &[0; 10];
+
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let wt_stream = wt.create_wt_stream_client(wt_session.stream_id(), StreamType::UniDi);
+    wt.send_data_client(wt_stream, BUF_CLIENT);
+    drop(wt.receive_data_server(wt_stream, true, BUF_CLIENT, false));
+
+    // Commit the buffered data, then reset: this is delivered as RESET_STREAM_AT.
+    wt.commit_stream_client(wt_stream);
+    let before = wt.client.transport_stats().frame_tx.reset_stream_at;
+    wt.reset_stream_client(wt_stream);
+    assert_eq!(
+        wt.client.transport_stats().frame_tx.reset_stream_at,
+        before + 1
+    );
+    wt.receive_reset_server(wt_stream, Error::HttpNone.code());
+}
+
+#[test]
 fn wt_server_stream_uni_reset() {
     const BUF_SERVER: &[u8] = &[2; 30];
 

--- a/neqo-http3/src/features/extended_connect/webtransport_streams.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_streams.rs
@@ -6,8 +6,10 @@
 
 use std::{cell::RefCell, rc::Rc, time::Instant};
 
-use neqo_common::{Encoder, to_u64};
-use neqo_transport::{Connection, StreamId, recv_stream, send_stream, streams::SendGroupId};
+use neqo_common::{Encoder, qdebug, to_u64};
+use neqo_transport::{
+    Connection, Error as TransportError, StreamId, recv_stream, send_stream, streams::SendGroupId,
+};
 
 use super::session::Session;
 use crate::{
@@ -194,36 +196,45 @@ impl Stream for WebTransportSendStream {
 
 impl SendStream for WebTransportSendStream {
     fn send(&mut self, conn: &mut Connection, _now: Instant) -> Res<()> {
-        if let WebTransportSenderStreamState::SendingInit { ref mut buf, fin } = self.state {
-            let sent = conn.stream_send(self.stream_id, &buf[..])?;
-            if sent == buf.len() {
-                // Commit the session-id prefix once it is buffered.
-                // WebTransport requires reliable_reset so pass the error.
-                conn.stream_commit(self.stream_id)?;
-                if fin {
-                    conn.stream_close_send(self.stream_id)?;
-                    self.set_done(CloseType::Done);
-                } else {
-                    self.state = WebTransportSenderStreamState::SendingData;
-                }
-            } else {
-                let b = buf.split_off(sent);
-                *buf = b;
+        let WebTransportSenderStreamState::SendingInit { ref mut buf, fin } = self.state else {
+            return Ok(());
+        };
+
+        let sent = conn.stream_send(self.stream_id, &buf[..])?;
+        if sent == buf.len() {
+            // Note that it is safe to commit here because WebTransport requires reliable reset.
+            // However, there are other reasons that a commit or send might fail
+            // and we don't want to get stuck in the `SendingInit` state.
+            // So defer reporting of errors to guarantee that the state transition completes.
+            let mut res = conn.stream_commit(self.stream_id);
+            if res == Err(TransportError::NotAvailable) {
+                qdebug!("[{conn}]: Peer supports webtransport, but not reliable reset: ignoring");
+                // Old versions might need to work when reliable resets are not available.
+                // TODO: Remove this override when we remove support for old WebTransport versions.
+                res = Ok(());
             }
+            if fin {
+                let close = conn.stream_close_send(self.stream_id);
+                res = res.and(close);
+                self.set_done(CloseType::Done);
+            } else {
+                self.state = WebTransportSenderStreamState::SendingData;
+            }
+            res?;
+        } else {
+            let b = buf.split_off(sent);
+            *buf = b;
         }
         Ok(())
     }
 
     fn commit(&mut self, conn: &mut Connection, now: Instant) -> Res<()> {
-        // Flush the preface if it is still buffered; `send` commits it once it is fully out. The
-        // preface is sent atomically, so the transport never holds a partial preface: committing
-        // here is safe even while the stream is still blocked in `SendingInit` (it commits
-        // nothing) and can never commit a partial preface.
         self.send(conn, now)?;
         if self.state == WebTransportSenderStreamState::SendingData {
             conn.stream_commit(self.stream_id)?;
             Ok(())
         } else {
+            // Avoid committing unless the preface is successfully sent.
             Err(crate::Error::FlowControlLimit)
         }
     }

--- a/neqo-http3/src/features/extended_connect/webtransport_streams.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_streams.rs
@@ -214,6 +214,17 @@ impl SendStream for WebTransportSendStream {
         Ok(())
     }
 
+    fn commit(&mut self, conn: &mut Connection, now: Instant) -> Res<()> {
+        // The session-id prefix must reach the transport before anything can be committed; flush
+        // it if it is still buffered. If it cannot be flushed, fail rather than under-commit.
+        self.send(conn, now)?;
+        if self.has_data_to_send() {
+            return Err(crate::Error::Internal);
+        }
+        conn.stream_commit(self.stream_id)?;
+        Ok(())
+    }
+
     fn has_data_to_send(&self) -> bool {
         matches!(
             self.state,

--- a/neqo-http3/src/features/extended_connect/webtransport_streams.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_streams.rs
@@ -183,6 +183,9 @@ impl SendStream for WebTransportSendStream {
                     conn.stream_close_send(self.stream_id)?;
                     self.set_done(CloseType::Done);
                 } else {
+                    // Commit the session-id prefix once it is buffered.
+                    // WebTransport requires reliable_reset so pass the error.
+                    conn.stream_commit(self.stream_id)?;
                     self.state = WebTransportSenderStreamState::SendingData;
                 }
             } else {

--- a/neqo-http3/src/features/extended_connect/webtransport_streams.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_streams.rs
@@ -197,13 +197,13 @@ impl SendStream for WebTransportSendStream {
         if let WebTransportSenderStreamState::SendingInit { ref mut buf, fin } = self.state {
             let sent = conn.stream_send(self.stream_id, &buf[..])?;
             if sent == buf.len() {
+                // Commit the session-id prefix once it is buffered.
+                // WebTransport requires reliable_reset so pass the error.
+                conn.stream_commit(self.stream_id)?;
                 if fin {
                     conn.stream_close_send(self.stream_id)?;
                     self.set_done(CloseType::Done);
                 } else {
-                    // Commit the session-id prefix once it is buffered.
-                    // WebTransport requires reliable_reset so pass the error.
-                    conn.stream_commit(self.stream_id)?;
                     self.state = WebTransportSenderStreamState::SendingData;
                 }
             } else {
@@ -215,14 +215,17 @@ impl SendStream for WebTransportSendStream {
     }
 
     fn commit(&mut self, conn: &mut Connection, now: Instant) -> Res<()> {
-        // The session-id prefix must reach the transport before anything can be committed; flush
-        // it if it is still buffered. If it cannot be flushed, fail rather than under-commit.
+        // Flush the preface if it is still buffered; `send` commits it once it is fully out. The
+        // preface is sent atomically, so the transport never holds a partial preface: committing
+        // here is safe even while the stream is still blocked in `SendingInit` (it commits
+        // nothing) and can never commit a partial preface.
         self.send(conn, now)?;
-        if self.has_data_to_send() {
-            return Err(crate::Error::Internal);
+        if self.state == WebTransportSenderStreamState::SendingData {
+            conn.stream_commit(self.stream_id)?;
+            Ok(())
+        } else {
+            Err(crate::Error::FlowControlLimit)
         }
-        conn.stream_commit(self.stream_id)?;
-        Ok(())
     }
 
     fn has_data_to_send(&self) -> bool {

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -592,8 +592,8 @@ trait SendStream: Stream {
 
     /// Commit to reliably delivering the data buffered so far, so that it is still delivered
     /// (via `RESET_STREAM_AT`) even if the stream is later reset. Implementations of this are
-    /// expected to send all data they have buffered so the commitment covers everything written so far.
-    /// The default implementation fails immediately.
+    /// expected to send all data they have buffered so the commitment covers everything written so
+    /// far. The default implementation fails immediately.
     ///
     /// # Errors
     /// Transport errors (e.g. the peer did not enable reliable reset),

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -245,6 +245,8 @@ pub enum Error {
     AlreadyInitialized,
     #[error("Fatal error")]
     Fatal,
+    #[error("Flow control limit reached")]
+    FlowControlLimit,
     #[error("HTTP GOAWAY received")]
     HttpGoaway,
     #[error("Internal error")]
@@ -261,8 +263,6 @@ pub enum Error {
     InvalidState,
     #[error("Invalid stream ID")]
     InvalidStreamId,
-    #[error("No more data")]
-    NoMoreData,
     #[error("Not enough data")]
     NotEnoughData,
     #[error("Stream limit reached")]
@@ -590,16 +590,15 @@ trait SendStream: Stream {
     fn stream_writable(&self);
     fn done(&self) -> bool;
 
-    /// Commit to reliably delivering the data buffered so far, so that prefix is still delivered
+    /// Commit to reliably delivering the data buffered so far, so that it is still delivered
     /// (via `RESET_STREAM_AT`) even if the stream is later reset. Implementations of this are
-    /// expected to send any data that is buffered in the HTTP/3 layer is first flushed to the
-    /// transport so the commitment covers everything written so far.
+    /// expected to send all data they have buffered so the commitment covers everything written so far.
     /// The default implementation fails immediately.
     ///
     /// # Errors
-    /// Transport errors (e.g. the peer did not enable reliable reset), or [`Error::Internal`] if
-    /// the buffered data could not be fully flushed to the transport. The latter is not expected:
-    /// the sender only buffers data that flow control already permits sending.
+    /// Transport errors (e.g. the peer did not enable reliable reset),
+    /// or [`Error::FlowControlLimit`] if the buffered data could not be fully flushed.
+    /// The latter should be rare as most cases of buffering should include a couple of bytes.
     fn commit(&mut self, _conn: &mut Connection, _now: Instant) -> Res<()> {
         Err(Error::Unavailable)
     }

--- a/neqo-http3/src/lib.rs
+++ b/neqo-http3/src/lib.rs
@@ -590,6 +590,20 @@ trait SendStream: Stream {
     fn stream_writable(&self);
     fn done(&self) -> bool;
 
+    /// Commit to reliably delivering the data buffered so far, so that prefix is still delivered
+    /// (via `RESET_STREAM_AT`) even if the stream is later reset. Implementations of this are
+    /// expected to send any data that is buffered in the HTTP/3 layer is first flushed to the
+    /// transport so the commitment covers everything written so far.
+    /// The default implementation fails immediately.
+    ///
+    /// # Errors
+    /// Transport errors (e.g. the peer did not enable reliable reset), or [`Error::Internal`] if
+    /// the buffered data could not be fully flushed to the transport. The latter is not expected:
+    /// the sender only buffers data that flow control already permits sending.
+    fn commit(&mut self, _conn: &mut Connection, _now: Instant) -> Res<()> {
+        Err(Error::Unavailable)
+    }
+
     /// # Errors
     ///
     /// Error may occur during sending data, e.g. protocol error, etc.

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -175,7 +175,7 @@ impl SendStream for SendMessage {
         self.state.new_data()?;
 
         self.stream.send_buffer(conn, now)?;
-        if self.stream.has_buffered_data() {
+        if self.has_data_to_send() {
             return Ok(0);
         }
         let available = conn
@@ -224,11 +224,11 @@ impl SendStream for SendMessage {
     }
 
     fn done(&self) -> bool {
-        !self.stream.has_buffered_data() && self.state.done()
+        !self.has_data_to_send() && self.state.done()
     }
 
     fn stream_writable(&self) {
-        if !self.stream.has_buffered_data() && !self.state.done() {
+        if !self.has_data_to_send() && !self.state.done() {
             // DataWritable is just a signal for an application to try to write more data,
             // if writing fails it is fine. Therefore we do not need to properly check
             // whether more credits are available on the transport layer.
@@ -248,7 +248,7 @@ impl SendStream for SendMessage {
         let sent = Error::map_error(self.stream.send_buffer(conn, now), Error::HttpInternal(5))?;
 
         qtrace!("[{self}] {sent} bytes sent");
-        if !self.stream.has_buffered_data() {
+        if !self.has_data_to_send() {
             if self.state.done() {
                 Error::map_error(
                     conn.stream_close_send(self.stream_id()),
@@ -269,9 +269,9 @@ impl SendStream for SendMessage {
         // Flush so the commitment covers everything buffered so far. If it cannot all be flushed
         // the commitment would fall short, so fail rather than silently under-commit.
         self.stream.send_buffer(conn, now)?;
-        if self.stream.has_buffered_data() {
+        if self.has_data_to_send() {
             qdebug!("buffered data at neqo-http3 layer, failing to commit");
-            return Err(Error::Internal);
+            return Err(Error::FlowControlLimit);
         }
         conn.stream_commit(self.stream_id())?;
         Ok(())
@@ -286,7 +286,7 @@ impl SendStream for SendMessage {
 
     fn close(&mut self, conn: &mut Connection, _now: Instant) -> Res<()> {
         self.state.fin()?;
-        if !self.stream.has_buffered_data() {
+        if !self.has_data_to_send() {
             conn.stream_close_send(self.stream_id())?;
         }
 

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -270,6 +270,7 @@ impl SendStream for SendMessage {
         // the commitment would fall short, so fail rather than silently under-commit.
         self.stream.send_buffer(conn, now)?;
         if self.stream.has_buffered_data() {
+            qdebug!("buffered data at neqo-http3 layer, failing to commit");
             return Err(Error::Internal);
         }
         conn.stream_commit(self.stream_id())?;

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -265,6 +265,17 @@ impl SendStream for SendMessage {
         Ok(())
     }
 
+    fn commit(&mut self, conn: &mut Connection, now: Instant) -> Res<()> {
+        // Flush so the commitment covers everything buffered so far. If it cannot all be flushed
+        // the commitment would fall short, so fail rather than silently under-commit.
+        self.stream.send_buffer(conn, now)?;
+        if self.stream.has_buffered_data() {
+            return Err(Error::Internal);
+        }
+        conn.stream_commit(self.stream_id())?;
+        Ok(())
+    }
+
     // SendMessage owns headers and sends them. It may also own data for the server side.
     // This method returns if they're still being sent. Request body (if any) is sent by
     // http client afterwards using `send_request_body` after receiving DataWritable event.

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -136,6 +136,19 @@ impl StreamHandler {
         )
     }
 
+    /// Commit to reliably delivering the stream data buffered so far. If the stream is later
+    /// reset, that prefix is delivered using `RESET_STREAM_AT` (when the peer supports it).
+    ///
+    /// # Errors
+    ///
+    /// It may return `InvalidStreamId` if a stream does not exist anymore, or `NotAvailable`
+    /// if the peer did not enable reliable reset.
+    pub fn stream_commit(&self) -> Res<()> {
+        self.handler
+            .borrow()
+            .stream_commit(self.stream_info.stream_id(), &mut self.conn.borrow_mut())
+    }
+
     /// Reset a stream/request.
     ///
     /// # Errors

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -143,10 +143,12 @@ impl StreamHandler {
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore, or `NotAvailable`
     /// if the peer did not enable reliable reset.
-    pub fn stream_commit(&self) -> Res<()> {
-        self.handler
-            .borrow()
-            .stream_commit(self.stream_info.stream_id(), &mut self.conn.borrow_mut())
+    pub fn stream_commit(&self, now: Instant) -> Res<()> {
+        self.handler.borrow_mut().stream_commit(
+            self.stream_info.stream_id(),
+            &mut self.conn.borrow_mut(),
+            now,
+        )
     }
 
     /// Reset a stream/request.

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -29,6 +29,8 @@ pub struct Decoder {
     max_entries: u64,
     send_buf: Encoder,
     local_stream_id: Option<StreamId>,
+    /// Whether the leading stream-type prefix has been committed for reliable delivery.
+    prefix_committed: bool,
     max_table_size: u64,
     max_blocked_streams: usize,
     blocked_streams: Vec<(StreamId, u64)>, // stream_id and requested inserts count.
@@ -52,6 +54,7 @@ impl Decoder {
             max_entries: qpack_settings.max_table_size_decoder >> 5,
             send_buf,
             local_stream_id: None,
+            prefix_committed: false,
             max_table_size: qpack_settings.max_table_size_decoder,
             max_blocked_streams,
             blocked_streams: Vec::with_capacity(max_blocked_streams),

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -29,8 +29,6 @@ pub struct Decoder {
     max_entries: u64,
     send_buf: Encoder,
     local_stream_id: Option<StreamId>,
-    /// Whether the leading stream-type prefix has been committed for reliable delivery.
-    prefix_committed: bool,
     max_table_size: u64,
     max_blocked_streams: usize,
     blocked_streams: Vec<(StreamId, u64)>, // stream_id and requested inserts count.
@@ -54,7 +52,6 @@ impl Decoder {
             max_entries: qpack_settings.max_table_size_decoder >> 5,
             send_buf,
             local_stream_id: None,
-            prefix_committed: false,
             max_table_size: qpack_settings.max_table_size_decoder,
             max_blocked_streams,
             blocked_streams: Vec::with_capacity(max_blocked_streams),

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -59,7 +59,7 @@ use crate::{
         TransportParameterId::{
             self, AckDelayExponent, ActiveConnectionIdLimit, DisableMigration, GreaseQuicBit,
             InitialSourceConnectionId, MaxAckDelay, MaxDatagramFrameSize, MaxUdpPayloadSize,
-            MinAckDelay, OriginalDestinationConnectionId, RetrySourceConnectionId,
+            MinAckDelay, OriginalDestinationConnectionId, ResetStreamAt, RetrySourceConnectionId,
             StatelessResetToken,
         },
         TransportParameters, TransportParametersHandler,
@@ -3889,7 +3889,27 @@ impl Connection {
         Ok(())
     }
 
+    /// Commit to reliably delivering all stream data buffered so far: if the stream is later
+    /// reset via [`Self::stream_reset_send`], that prefix is still delivered using
+    /// `RESET_STREAM_AT`. Call this after writing the data to be protected.
+    /// # Errors
+    /// When the stream ID is invalid, the peer did not enable reliable reset
+    /// ([`Error::NotAvailable`]), or the stream has already been reset ([`Error::StreamState`]).
+    pub fn stream_commit(&mut self, stream_id: StreamId) -> Res<()> {
+        // Get the stream first: it cannot exist without remote transport parameters, so
+        // `remote()` below won't panic.
+        let stream = self.streams.get_send_stream_mut(stream_id)?;
+        if !self.tps.borrow().remote().get_empty(ResetStreamAt) {
+            return Err(Error::NotAvailable);
+        }
+        stream.commit()
+    }
+
     /// Abandon transmission of in-flight and future stream data.
+    ///
+    /// If a reliable prefix was committed via [`Self::stream_commit`] and the peer advertised
+    /// support for reliable reset, the committed prefix is delivered using `RESET_STREAM_AT`;
+    /// otherwise a plain `RESET_STREAM` is sent.
     /// # Errors
     /// When the stream ID is invalid.
     pub fn stream_reset_send(&mut self, stream_id: StreamId, err: AppError) -> Res<()> {

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -18,7 +18,7 @@ use crate::{
             ActiveConnectionIdLimit, DisableMigration, GreaseQuicBit, IdleTimeout, InitialMaxData,
             InitialMaxStreamDataBidiLocal, InitialMaxStreamDataBidiRemote, InitialMaxStreamDataUni,
             InitialMaxStreamsBidi, InitialMaxStreamsUni, MaxAckDelay, MaxDatagramFrameSize,
-            MinAckDelay, PreferredAddress as PreferredAddressTp, Scone,
+            MinAckDelay, PreferredAddress as PreferredAddressTp, ResetStreamAt, Scone,
         },
         TransportParametersHandler,
     },
@@ -154,6 +154,9 @@ pub struct ConnectionParameters {
     randomize_first_pn: bool,
     /// Whether to send the SCONE transport parameter.
     scone: bool,
+    /// Whether to advertise support for `RESET_STREAM_AT` (reliable stream reset) via the
+    /// `reset_stream_at` transport parameter.
+    reliable_stream_reset: bool,
     /// Whether to recover from spurious congestion events by restoring prior Congestion Controller
     /// state. Detection and metrics are always active regardless of this setting.
     spurious_recovery: bool,
@@ -192,6 +195,7 @@ impl Default for ConnectionParameters {
             mlkem: true,
             randomize_first_pn: true,
             scone: false,
+            reliable_stream_reset: true,
             spurious_recovery: true,
         }
     }
@@ -533,6 +537,17 @@ impl ConnectionParameters {
     }
 
     #[must_use]
+    pub const fn reliable_stream_reset_enabled(&self) -> bool {
+        self.reliable_stream_reset
+    }
+
+    #[must_use]
+    pub const fn reliable_stream_reset(mut self, reliable_stream_reset: bool) -> Self {
+        self.reliable_stream_reset = reliable_stream_reset;
+        self
+    }
+
+    #[must_use]
     pub const fn spurious_recovery_enabled(&self) -> bool {
         self.spurious_recovery
     }
@@ -566,6 +581,9 @@ impl ConnectionParameters {
         }
         if self.scone {
             tps.local_mut().set_empty(Scone);
+        }
+        if self.reliable_stream_reset {
+            tps.local_mut().set_empty(ResetStreamAt);
         }
         tps.local_mut().set_integer(
             MaxAckDelay,
@@ -651,6 +669,17 @@ mod tests {
         // Default is false; verify builder can toggle it.
         assert!(!ConnectionParameters::default().scone_enabled());
         assert!(ConnectionParameters::default().scone(true).scone_enabled());
+    }
+
+    #[test]
+    fn reliable_stream_reset_enabled() {
+        // Default is true; verify builder can toggle it.
+        assert!(ConnectionParameters::default().reliable_stream_reset_enabled());
+        assert!(
+            !ConnectionParameters::default()
+                .reliable_stream_reset(false)
+                .reliable_stream_reset_enabled()
+        );
     }
 
     #[test]

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -48,6 +48,7 @@ mod null;
 mod pmtud;
 mod priority;
 mod recovery;
+mod reset_stream_at;
 mod resumption;
 mod stream;
 mod vn;
@@ -310,6 +311,16 @@ fn assert_error(c: &Connection, expected: &CloseReason) {
             assert_eq!(*error, *expected, "{c} error mismatch");
         }
         _ => panic!("bad state {:?}", c.state()),
+    }
+}
+
+/// Pump datagrams between two peers until neither has anything more to send.
+fn exchange(a: &mut Connection, b: &mut Connection) {
+    let mut d = a.process_output(now()).dgram();
+    while let Some(dgram) = d {
+        let r = b.process(Some(dgram), now()).dgram();
+        mem::swap(a, b);
+        d = r;
     }
 }
 

--- a/neqo-transport/src/connection/tests/reset_stream_at.rs
+++ b/neqo-transport/src/connection/tests/reset_stream_at.rs
@@ -1,0 +1,140 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests for RESET_STREAM_AT (draft-ietf-quic-reliable-stream-reset).
+//
+// The end-to-end tests are `#[ignore]`d for now: the send side emits RESET_STREAM_AT, but the
+// receive-side routing and delivery of the reliable prefix are implemented in later steps. Once
+// those land, the ignore attributes are removed.
+
+use neqo_common::event::Provider as _;
+use test_fixture::now;
+
+use super::{connect, default_client, default_server, exchange, new_server};
+use crate::{
+    Connection, ConnectionParameters, Error, StreamId, StreamType, events::ConnectionEvent,
+};
+
+const DATA: &[u8] = b"the quick brown fox";
+const RELIABLE: usize = 9; // commit "the quick"
+
+/// Create a stream, buffer and commit the reliable prefix, buffer the rest, then reset.
+fn commit_prefix_and_reset(c: &mut Connection) -> StreamId {
+    let stream_id = c.stream_create(StreamType::UniDi).unwrap();
+    c.stream_send(stream_id, &DATA[..RELIABLE]).unwrap();
+    c.stream_commit(stream_id).unwrap();
+    c.stream_send(stream_id, &DATA[RELIABLE..]).unwrap();
+    c.stream_reset_send(stream_id, 0).unwrap();
+    stream_id
+}
+
+/// The send side emits a `RESET_STREAM_AT` frame when a commitment exists and the peer
+/// advertised support. (Send-side only; the server does not process the frame here.)
+#[test]
+fn emits_reset_stream_at_on_wire() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect(&mut client, &mut server);
+
+    _ = commit_prefix_and_reset(&mut client);
+
+    let before = client.stats().frame_tx.reset_stream_at;
+    // Flush; the RESET_STREAM_AT frame should be written.
+    _ = client.process_output(now()).dgram();
+    let after = &client.stats().frame_tx;
+    assert_eq!(after.reset_stream_at, before + 1);
+    assert_eq!(after.reset_stream, 0);
+}
+
+/// Against a peer that did not advertise `reset_stream_at`, `stream_commit` is rejected, and a
+/// plain `RESET_STREAM` is the only option.
+#[test]
+fn commit_unavailable_without_peer_support() {
+    let mut client = default_client();
+    let mut server = new_server(ConnectionParameters::default().reliable_stream_reset(false));
+    connect(&mut client, &mut server);
+
+    let stream_id = client.stream_create(StreamType::UniDi).unwrap();
+    client.stream_send(stream_id, DATA).unwrap();
+    assert_eq!(
+        client.stream_commit(stream_id).unwrap_err(),
+        Error::NotAvailable
+    );
+
+    // A plain reset still works.
+    client.stream_reset_send(stream_id, 0).unwrap();
+    let before = client.stats().frame_tx.reset_stream;
+    _ = client.process_output(now()).dgram();
+    assert_eq!(client.stats().frame_tx.reset_stream, before + 1);
+    assert_eq!(client.stats().frame_tx.reset_stream_at, 0);
+}
+
+/// Happy path: the receiver delivers exactly `[0, RELIABLE)` and then observes the reset; bytes
+/// beyond the reliable offset are not delivered.
+#[test]
+#[ignore = "receive-side handling of RESET_STREAM_AT lands in a later step"]
+fn happy_path() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect(&mut client, &mut server);
+
+    let stream_id = commit_prefix_and_reset(&mut client);
+    exchange(&mut client, &mut server);
+
+    // Until the data is read, no reset is signaled.
+    assert!(
+        !server
+            .events()
+            .any(|e| matches!(e, ConnectionEvent::RecvStreamReset { .. }))
+    );
+
+    // The reliable prefix is readable.
+    let mut buf = [0; 64];
+    let (n, _fin) = server.stream_recv(stream_id, &mut buf).unwrap();
+    assert_eq!(n, RELIABLE);
+    assert_eq!(&buf[..n], &DATA[..n]);
+
+    // After draining the prefix, the reset is surfaced.
+    assert!(server.events().any(
+        |e| matches!(e, ConnectionEvent::RecvStreamReset { stream_id: id, .. } if id == stream_id)
+    ));
+}
+
+/// No STREAM FIN is emitted while a reliable reset is in progress: the receiver never sees a
+/// clean end, only the reset.
+#[test]
+#[ignore = "receive-side handling of RESET_STREAM_AT lands in a later step"]
+fn no_stream_fin() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect(&mut client, &mut server);
+
+    let stream_id = commit_prefix_and_reset(&mut client);
+    exchange(&mut client, &mut server);
+
+    let mut buf = [0; 64];
+    let (_n, fin) = server.stream_recv(stream_id, &mut buf).unwrap();
+    assert!(!fin, "reliable reset must not deliver a STREAM FIN");
+}
+
+/// Reaching `ResetRecvd` after a reliable reset does not surface a `SendStreamComplete` event
+/// (delivery-of-committed-data notification is tracked separately; see the project issue).
+#[test]
+#[ignore = "receive-side handling of RESET_STREAM_AT lands in a later step"]
+fn reliable_reset_emits_no_send_complete() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect(&mut client, &mut server);
+
+    _ = commit_prefix_and_reset(&mut client);
+    exchange(&mut client, &mut server);
+
+    let completes = client
+        .events()
+        .filter(|e| matches!(e, ConnectionEvent::SendStreamComplete { .. }))
+        .count();
+    assert_eq!(completes, 0);
+}

--- a/neqo-transport/src/connection/tests/reset_stream_at.rs
+++ b/neqo-transport/src/connection/tests/reset_stream_at.rs
@@ -5,17 +5,16 @@
 // except according to those terms.
 
 // Tests for RESET_STREAM_AT (draft-ietf-quic-reliable-stream-reset).
-//
-// The end-to-end tests are `#[ignore]`d for now: the send side emits RESET_STREAM_AT, but the
-// receive-side routing and delivery of the reliable prefix are implemented in later steps. Once
-// those land, the ignore attributes are removed.
 
 use neqo_common::event::Provider as _;
 use test_fixture::now;
 
-use super::{connect, default_client, default_server, exchange, new_server};
+use super::{
+    connect, default_client, default_server, exchange, new_client, new_server, send_with_extra,
+};
 use crate::{
-    Connection, ConnectionParameters, Error, StreamId, StreamType, events::ConnectionEvent,
+    Connection, ConnectionParameters, Error, StreamId, StreamType,
+    connection::test_internal::FrameWriter, events::ConnectionEvent, frame::FrameType, packet,
 };
 
 const DATA: &[u8] = b"the quick brown fox";
@@ -49,8 +48,8 @@ fn emits_reset_stream_at_on_wire() {
     assert_eq!(after.reset_stream, 0);
 }
 
-/// Against a peer that did not advertise `reset_stream_at`, `stream_commit` is rejected, and a
-/// plain `RESET_STREAM` is the only option.
+/// Against a peer that did not advertise reliable resets, `stream_commit` is rejected,
+/// and a plain `RESET_STREAM` is the only option.
 #[test]
 fn commit_unavailable_without_peer_support() {
     let mut client = default_client();
@@ -75,7 +74,6 @@ fn commit_unavailable_without_peer_support() {
 /// Happy path: the receiver delivers exactly `[0, RELIABLE)` and then observes the reset; bytes
 /// beyond the reliable offset are not delivered.
 #[test]
-#[ignore = "receive-side handling of RESET_STREAM_AT lands in a later step"]
 fn happy_path() {
     let mut client = default_client();
     let mut server = default_server();
@@ -106,7 +104,6 @@ fn happy_path() {
 /// No STREAM FIN is emitted while a reliable reset is in progress: the receiver never sees a
 /// clean end, only the reset.
 #[test]
-#[ignore = "receive-side handling of RESET_STREAM_AT lands in a later step"]
 fn no_stream_fin() {
     let mut client = default_client();
     let mut server = default_server();
@@ -123,7 +120,6 @@ fn no_stream_fin() {
 /// Reaching `ResetRecvd` after a reliable reset does not surface a `SendStreamComplete` event
 /// (delivery-of-committed-data notification is tracked separately; see the project issue).
 #[test]
-#[ignore = "receive-side handling of RESET_STREAM_AT lands in a later step"]
 fn reliable_reset_emits_no_send_complete() {
     let mut client = default_client();
     let mut server = default_server();
@@ -137,4 +133,28 @@ fn reliable_reset_emits_no_send_complete() {
         .filter(|e| matches!(e, ConnectionEvent::SendStreamComplete { .. }))
         .count();
     assert_eq!(completes, 0);
+}
+
+/// Writes a raw `RESET_STREAM_AT` frame for `stream_id` with zero error/final/reliable sizes.
+struct ResetStreamAtWriter(u64);
+
+impl FrameWriter for ResetStreamAtWriter {
+    fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
+        // type, stream_id, application_error_code, final_size, reliable_size
+        builder.write_varint_frame(&[FrameType::ResetStreamAt.into(), self.0, 0, 0, 0]);
+    }
+}
+
+/// Receiving a `RESET_STREAM_AT` after not advertising support is a protocol violation.
+#[test]
+fn unadvertised_reset_stream_at_is_rejected() {
+    let mut client = new_client(ConnectionParameters::default().reliable_stream_reset(false));
+    let mut server = default_server();
+    connect(&mut client, &mut server);
+
+    // The server sends a crafted RESET_STREAM_AT for a client-initiated stream. The client did
+    // not advertise the extension, so it must close the connection.
+    let dgram = send_with_extra(&mut server, ResetStreamAtWriter(0), now());
+    client.process_input(dgram, now());
+    assert!(client.state().closed());
 }

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -59,6 +59,8 @@ pub enum FrameType {
     ConnectionCloseTransport = 0x1c,
     ConnectionCloseApplication = 0x1d,
     HandshakeDone = 0x1e,
+    // draft-ietf-quic-reliable-stream-reset
+    ResetStreamAt = 0x24,
     // draft-ietf-quic-ack-delay
     AckFrequency = 0xaf,
     // draft-ietf-quic-datagram
@@ -172,6 +174,12 @@ pub enum Frame<'a> {
         application_error_code: AppError,
         final_size: u64,
     },
+    ResetStreamAt {
+        stream_id: StreamId,
+        application_error_code: AppError,
+        final_size: u64,
+        reliable_size: u64,
+    },
     StopSending {
         stream_id: StreamId,
         application_error_code: AppError,
@@ -261,6 +269,7 @@ impl<'a> Frame<'a> {
             Self::Ping => FrameType::Ping,
             Self::Ack { .. } => FrameType::Ack,
             Self::ResetStream { .. } => FrameType::ResetStream,
+            Self::ResetStreamAt { .. } => FrameType::ResetStreamAt,
             Self::StopSending { .. } => FrameType::StopSending,
             Self::Crypto { .. } => FrameType::Crypto,
             Self::NewToken { .. } => FrameType::NewToken,
@@ -301,6 +310,7 @@ impl<'a> Frame<'a> {
         matches!(
             self,
             Self::ResetStream { .. }
+                | Self::ResetStreamAt { .. }
                 | Self::StopSending { .. }
                 | Self::Stream { .. }
                 | Self::MaxData { .. }
@@ -524,6 +534,22 @@ impl<'a> Frame<'a> {
                 application_error_code: dv(dec)?,
                 final_size: dv(dec)?,
             }),
+            FrameType::ResetStreamAt => {
+                let stream_id = StreamId::from(dv(dec)?);
+                let application_error_code = dv(dec)?;
+                let final_size = dv(dec)?;
+                let reliable_size = dv(dec)?;
+                // Reject `reliable_size > final_size` at the earliest point.
+                if reliable_size > final_size {
+                    return Err(Error::FrameEncoding);
+                }
+                Ok(Self::ResetStreamAt {
+                    stream_id,
+                    application_error_code,
+                    final_size,
+                    reliable_size,
+                })
+            }
             FrameType::Ack => decode_ack(dec, false),
             FrameType::AckEcn => decode_ack(dec, true),
             FrameType::StopSending => Ok(Self::StopSending {
@@ -806,6 +832,72 @@ mod tests {
         };
 
         just_dec(&f, "04523440777456");
+    }
+
+    #[test]
+    fn reset_stream_at() {
+        let f = Frame::ResetStreamAt {
+            stream_id: StreamId::from(0x1234),
+            application_error_code: 0x77,
+            final_size: 0x3456,
+            reliable_size: 0x12,
+        };
+
+        just_dec(&f, "2452344077745612");
+    }
+
+    /// A `RESET_STREAM_AT` frame with `reliable_size > final_size` is rejected at decode.
+    #[test]
+    fn reset_stream_at_reliable_exceeds_final() {
+        let mut enc = Encoder::default();
+        enc.encode_varint(FrameType::ResetStreamAt);
+        enc.encode_varint(0x1234u64); // stream_id
+        enc.encode_varint(0x77u64); // application_error_code
+        enc.encode_varint(0x10u64); // final_size
+        enc.encode_varint(0x20u64); // reliable_size > final_size
+        assert_eq!(
+            Frame::decode(&mut enc.as_decoder()).unwrap_err(),
+            Error::FrameEncoding
+        );
+    }
+
+    /// `reliable_size == final_size` is the boundary case and must decode.
+    #[test]
+    fn reset_stream_at_reliable_equals_final() {
+        let mut enc = Encoder::default();
+        enc.encode_varint(FrameType::ResetStreamAt);
+        enc.encode_varint(0x1234u64); // stream_id
+        enc.encode_varint(0x77u64); // application_error_code
+        enc.encode_varint(0x3456u64); // final_size
+        enc.encode_varint(0x3456u64); // reliable_size == final_size
+        assert_eq!(
+            Frame::decode(&mut enc.as_decoder()).unwrap(),
+            Frame::ResetStreamAt {
+                stream_id: StreamId::from(0x1234),
+                application_error_code: 0x77,
+                final_size: 0x3456,
+                reliable_size: 0x3456,
+            }
+        );
+    }
+
+    /// `RESET_STREAM_AT` relies on the default arms of `ack_eliciting`/`is_allowed`,
+    /// matching `RESET_STREAM`: ack-eliciting, and allowed only in `ZeroRtt`/`Short`.
+    #[test]
+    fn reset_stream_at_ack_eliciting_and_allowed() {
+        let f = Frame::ResetStreamAt {
+            stream_id: StreamId::from(1),
+            application_error_code: 2,
+            final_size: 3,
+            reliable_size: 1,
+        };
+        assert!(f.ack_eliciting());
+        assert!(f.is_allowed(packet::Type::Short));
+        assert!(f.is_allowed(packet::Type::ZeroRtt));
+        assert!(!f.is_allowed(packet::Type::Handshake));
+        assert!(!f.is_allowed(packet::Type::Initial));
+        assert!(f.is_stream());
+        assert_eq!(f.get_type(), FrameType::ResetStreamAt);
     }
 
     #[test]

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -620,10 +620,18 @@ impl From<Frame<'_>> for QuicFrame {
                     payload_length: None,
                 }
             }
+            // Note that qlog doesn't currently support `RESET_STREAM_AT`,
+            // so map it into `RESET_STREAM` for now.
             Frame::ResetStream {
                 stream_id,
                 application_error_code,
                 final_size,
+            }
+            | Frame::ResetStreamAt {
+                stream_id,
+                application_error_code,
+                final_size,
+                ..
             } => Self::ResetStream {
                 stream_id: stream_id.as_u64(),
                 error_code: application_error_code,
@@ -733,13 +741,13 @@ impl From<Frame<'_>> for QuicFrame {
                 trigger_frame_type: Some(frame_type),
             },
             Frame::HandshakeDone => Self::HandshakeDone,
-            Frame::AckFrequency { .. } | Frame::ResetStreamAt { .. } => Self::Unknown {
-                frame_type_value: None,
-                raw_frame_type: frame.get_type().into(),
-                raw: None,
-            },
             Frame::Datagram { data, .. } => Self::Datagram {
                 length: data.len() as u64,
+                raw: None,
+            },
+            Frame::AckFrequency { .. } => Self::Unknown {
+                frame_type_value: None,
+                raw_frame_type: frame.get_type().into(),
                 raw: None,
             },
         }

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -733,7 +733,7 @@ impl From<Frame<'_>> for QuicFrame {
                 trigger_frame_type: Some(frame_type),
             },
             Frame::HandshakeDone => Self::HandshakeDone,
-            Frame::AckFrequency { .. } => Self::Unknown {
+            Frame::AckFrequency { .. } | Frame::ResetStreamAt { .. } => Self::Unknown {
                 frame_type_value: None,
                 raw_frame_type: frame.get_type().into(),
                 raw: None,

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -132,7 +132,7 @@ impl RecvStreams {
     ///
     /// # Errors
     /// When flow control or the frame encoding is violated (see [`RecvStream::reset_at`]).
-    pub fn reset_at(
+    pub fn reset(
         &mut self,
         stream_id: StreamId,
         application_error_code: AppError,
@@ -140,7 +140,7 @@ impl RecvStreams {
         reliable_size: u64,
     ) -> Res<()> {
         if let Ok(rs) = self.get_mut(stream_id) {
-            let ended = rs.reset_at(application_error_code, final_size, reliable_size)?;
+            let ended = rs.reset(application_error_code, final_size, reliable_size)?;
             self.set_ended(ended);
         }
         Ok(())
@@ -834,8 +834,9 @@ impl RecvStream {
         Ok(())
     }
 
-    /// Handle a `RESET_STREAM_AT` frame: the reliable prefix `[0, reliable_size)` must be
-    /// delivered before the reset is surfaced.
+    /// Handle a `RESET_STREAM` or `RESET_STREAM_AT` frame.
+    ///
+    /// Any reliable prefix `[0, reliable_size)` is delivered before the reset event.
     ///
     /// # Errors
     /// [`Error::FrameEncoding`] if `reliable_size > final_size`, [`Error::FinalSize`] if a
@@ -845,7 +846,7 @@ impl RecvStream {
     /// # Returns
     /// `true` when the stream reaches `ResetRecvd` (ended); `false` while it remains in
     /// `SizeKnownAt` awaiting delivery of the prefix, or for a no-op in a terminal state.
-    pub fn reset_at(
+    pub fn reset(
         &mut self,
         application_error_code: AppError,
         final_size: u64,
@@ -1960,7 +1961,7 @@ mod tests {
             .unwrap();
         assert!(!session_fc.borrow().frame_needed());
 
-        s.reset_at(
+        s.reset(
             Error::None.code(),
             u64::try_from(SESSION_WINDOW).unwrap(),
             0,
@@ -2638,7 +2639,7 @@ mod tests {
         let mut s = reliable_recv_stream(events.clone());
         s.inbound_stream_frame(false, 0, &[0x42; 10]).unwrap();
 
-        assert!(s.reset_at(7, 10, 4).is_ok());
+        assert!(s.reset(7, 10, 4).is_ok());
         assert!(!s.is_ended());
         assert!(matches!(s.state, RecvStreamState::SizeKnownAt { .. }));
         assert_eq!(reset_count(&mut events), 0);
@@ -2658,7 +2659,7 @@ mod tests {
         let mut events = ConnectionEvents::default();
         let mut s = reliable_recv_stream(events.clone());
         s.inbound_stream_frame(false, 0, &[0x42; 10]).unwrap();
-        assert!(s.reset_at(7, 10, 0).is_ok());
+        assert!(s.reset(7, 10, 0).is_ok());
         assert!(s.is_ended());
         assert_eq!(reset_count(&mut events), 1);
     }
@@ -2669,7 +2670,7 @@ mod tests {
         let mut events = ConnectionEvents::default();
         let mut s = reliable_recv_stream(events.clone());
         // RESET_STREAM_AT arrives before the committed data.
-        assert!(s.reset_at(7, 8, 8).is_ok());
+        assert!(s.reset(7, 8, 8).is_ok());
         assert!(matches!(s.state, RecvStreamState::SizeKnownAt { .. }));
 
         // Partial prefix: read what's there, not yet complete.
@@ -2690,23 +2691,23 @@ mod tests {
     #[test]
     fn reset_at_reliable_exceeds_final() {
         let mut s = reliable_recv_stream(ConnectionEvents::default());
-        assert_eq!(s.reset_at(7, 4, 8).unwrap_err(), Error::FrameEncoding);
+        assert_eq!(s.reset(7, 4, 8).unwrap_err(), Error::FrameEncoding);
     }
 
     /// A later frame changing the final size is a `FINAL_SIZE_ERROR`.
     #[test]
     fn reset_at_changed_final_size() {
         let mut s = reliable_recv_stream(ConnectionEvents::default());
-        assert!(s.reset_at(7, 10, 4).is_ok());
-        assert_eq!(s.reset_at(7, 12, 4).unwrap_err(), Error::FinalSize);
+        assert!(s.reset(7, 10, 4).is_ok());
+        assert_eq!(s.reset(7, 12, 4).unwrap_err(), Error::FinalSize);
     }
 
     /// A later frame changing the error code is a `STREAM_STATE_ERROR`.
     #[test]
     fn reset_at_changed_error_code() {
         let mut s = reliable_recv_stream(ConnectionEvents::default());
-        assert!(s.reset_at(7, 10, 4).is_ok());
-        assert_eq!(s.reset_at(9, 10, 4).unwrap_err(), Error::StreamState);
+        assert!(s.reset(7, 10, 4).is_ok());
+        assert_eq!(s.reset(9, 10, 4).unwrap_err(), Error::StreamState);
     }
 
     /// `reliable_size` may be reduced (dropping newly-excess data) but increases are ignored.
@@ -2714,12 +2715,12 @@ mod tests {
     fn reset_at_reduce_and_ignore_increase() {
         let mut s = reliable_recv_stream(ConnectionEvents::default());
         s.inbound_stream_frame(false, 0, &[0x42; 10]).unwrap();
-        assert!(s.reset_at(7, 10, 8).is_ok());
+        assert!(s.reset(7, 10, 8).is_ok());
 
         // An increase is ignored.
-        assert!(s.reset_at(7, 10, 9).is_ok());
+        assert!(s.reset(7, 10, 9).is_ok());
         // A reduction drops the newly-excess data.
-        assert!(s.reset_at(7, 10, 4).is_ok());
+        assert!(s.reset(7, 10, 4).is_ok());
 
         let mut buf = [0; 64];
         // Only `[0, 4)` survives.
@@ -2734,7 +2735,7 @@ mod tests {
         let mut s = reliable_recv_stream(events.clone());
         s.inbound_stream_frame(false, 0, &[0x42; 4]).unwrap();
         assert!(!s.stop_sending(9));
-        assert!(s.reset_at(7, 10, 8).is_ok());
+        assert!(s.reset(7, 10, 8).is_ok());
         assert!(s.is_ended());
         assert_eq!(reset_count(&mut events), 1);
     }
@@ -2745,7 +2746,7 @@ mod tests {
         let mut events = ConnectionEvents::default();
         let mut s = reliable_recv_stream(events.clone());
         s.inbound_stream_frame(false, 0, &[0x42; 10]).unwrap();
-        assert!(s.reset_at(7, 10, 8).is_ok());
+        assert!(s.reset(7, 10, 8).is_ok());
         assert!(matches!(s.state, RecvStreamState::SizeKnownAt { .. }));
 
         assert!(s.stop_sending(9)); // ends the stream
@@ -2762,7 +2763,7 @@ mod tests {
         let mut s = create_stream_with_fc(Rc::clone(&session_fc), FC_LIMIT);
         s.inbound_stream_frame(false, 0, &[0x42; 100]).unwrap();
         // Reliable size 40, final size 100: the [40,100) tail is dropped.
-        assert!(s.reset_at(7, 100, 40).is_ok());
+        assert!(s.reset(7, 100, 40).is_ok());
 
         let mut buf = [0; 256];
         assert_eq!(s.read(&mut buf).unwrap(), (40, false));
@@ -2772,7 +2773,7 @@ mod tests {
 
         // Doing this again without data has the same effect.
         let mut s = create_stream_with_fc(Rc::clone(&session_fc), FC_LIMIT);
-        assert!(s.reset_at(7, 100, 40).is_ok());
+        assert!(s.reset(7, 100, 40).is_ok());
         check_fc(&session_fc.borrow(), 200, 100);
         assert!(s.stop_sending(9));
         check_fc(&session_fc.borrow(), 200, 200);

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -872,6 +872,15 @@ impl RecvStream {
             } => {
                 // Keep the buffered reliable prefix; drop anything at or beyond `reliable_size`.
                 recv_buf.discard_after(reliable_size);
+                // Return credit for the dropped tail immediately; only the still-unread prefix
+                // keeps its credit (retired as the application reads it).
+                Self::retire_undeliverable(
+                    final_size,
+                    reliable_size,
+                    recv_buf.retired(),
+                    fc,
+                    session_fc,
+                );
                 let fc = mem::take(fc);
                 let session_fc = mem::take(session_fc);
                 let recv_buf = mem::replace(recv_buf, RxStreamOrderer::new());
@@ -886,10 +895,12 @@ impl RecvStream {
                 Ok(self.complete_reliable_reset_if_drained())
             }
             RecvStreamState::SizeKnownAt {
+                fc,
+                session_fc,
                 recv_buf,
                 err,
+                final_size,
                 reliable_size: stored,
-                ..
             } => {
                 // The final size is already validated above; a changed error code is a state
                 // error. `reliable_size` may only be reduced (increases are ignored).
@@ -899,6 +910,14 @@ impl RecvStream {
                 if reliable_size < *stored {
                     *stored = reliable_size;
                     recv_buf.discard_after(reliable_size);
+                    // Return credit for the newly-dropped range immediately.
+                    Self::retire_undeliverable(
+                        *final_size,
+                        reliable_size,
+                        recv_buf.retired(),
+                        fc,
+                        session_fc,
+                    );
                     Ok(self.complete_reliable_reset_if_drained())
                 } else {
                     Ok(false)
@@ -976,6 +995,24 @@ impl RecvStream {
             fc.add_retired(new_read);
             session_fc.borrow_mut().add_retired(new_read);
         }
+    }
+
+    /// On a reliable reset, retire the flow control for everything that will never be delivered,
+    /// i.e. all but the still-unread reliable prefix `[read, reliable_size)`. This returns
+    /// stream- and connection-level credit to the peer immediately, rather than only once the
+    /// application has drained the prefix (the prefix's own credit is retired as it is read).
+    ///
+    /// `read` is the number of bytes the application has read so far (`recv_buf.retired()`).
+    fn retire_undeliverable(
+        final_size: u64,
+        reliable_size: u64,
+        read: u64,
+        fc: &mut ReceiverFlowControl<StreamId>,
+        session_fc: &Rc<RefCell<ReceiverFlowControl<()>>>,
+    ) {
+        let still_needed = reliable_size.saturating_sub(read);
+        let target_retired = final_size - still_needed;
+        Self::flow_control_retire_data(target_retired.saturating_sub(fc.retired()), fc, session_fc);
     }
 
     /// Send a flow control update.
@@ -2771,11 +2808,59 @@ mod tests {
         // All 100 bytes of session flow control are retired (40 read + 60 dropped tail).
         check_fc(&session_fc.borrow(), 100, 100);
 
-        // Doing this again without data has the same effect.
+        // Doing this again without reading retires the dropped tail [40,100) immediately; the
+        // still-unread prefix is retired only when the read side is later abandoned.
         let mut s = create_stream_with_fc(Rc::clone(&session_fc), FC_LIMIT);
         assert!(s.reset(7, 100, 40).is_ok());
-        check_fc(&session_fc.borrow(), 200, 100);
+        check_fc(&session_fc.borrow(), 200, 160);
         assert!(s.stop_sending(9));
         check_fc(&session_fc.borrow(), 200, 200);
+    }
+
+    /// The undeliverable tail's flow control is returned immediately on a reliable reset, before
+    /// the application reads the prefix.
+    #[test]
+    fn reset_releases_tail_flow_control_immediately() {
+        const FC_LIMIT: u64 = 1024;
+        let session_fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), FC_LIMIT)));
+        let mut s = create_stream_with_fc(Rc::clone(&session_fc), FC_LIMIT);
+        s.inbound_stream_frame(false, 0, &[0x42; 100]).unwrap();
+
+        // Reliable size 40, final size 100: the [40,100) tail is retired right away, even though
+        // the 40-byte prefix has not been read yet.
+        assert!(s.reset(7, 100, 40).is_ok());
+        check_fc(&session_fc.borrow(), 100, 60);
+
+        // Reading the prefix retires the rest.
+        let mut buf = [0; 256];
+        assert_eq!(s.read(&mut buf).unwrap(), (40, false));
+        assert!(s.is_ended());
+        check_fc(&session_fc.borrow(), 100, 100);
+    }
+
+    /// Reducing `reliable_size` with a later frame returns credit for the newly-dropped range.
+    #[test]
+    fn reset_reduce_releases_more_flow_control() {
+        const FC_LIMIT: u64 = 1024;
+        let session_fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), FC_LIMIT)));
+        let mut s = create_stream_with_fc(Rc::clone(&session_fc), FC_LIMIT);
+        s.inbound_stream_frame(false, 0, &[0x42; 100]).unwrap();
+
+        // The difference between reliable (80) and final (100) sizes is retired.
+        assert!(s.reset(7, 100, 80).is_ok());
+        check_fc(&session_fc.borrow(), 100, 20);
+
+        // Increases are ignored.
+        assert!(s.reset(7, 100, 90).is_ok());
+        check_fc(&session_fc.borrow(), 100, 20);
+
+        // Only the reduction is retired.
+        assert!(s.reset(7, 100, 40).is_ok());
+        check_fc(&session_fc.borrow(), 100, 60);
+
+        let mut buf = [0; 256];
+        assert_eq!(s.read(&mut buf).unwrap(), (40, false));
+        assert!(s.is_ended());
+        check_fc(&session_fc.borrow(), 100, 100);
     }
 }

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -924,36 +924,55 @@ impl RecvStream {
                 }
             }
             RecvStreamState::AbortReading {
-                fc,
-                session_fc,
                 final_received,
                 final_read,
                 ..
             }
             | RecvStreamState::WaitForReset {
-                fc,
-                session_fc,
                 final_received,
                 final_read,
+                ..
             } => {
                 // The application abandoned the read side (via stop_sending). We can discard the
                 // reliable and ignore `reliable_size`, which can't be validated here
                 // because this is the first `RESET_STREAM[_AT]` we've received.
                 // Note: we don't check that subsequent frames contain a correct `reliable_size`.
-                Self::flow_control_retire_data(final_size - fc.retired(), fc, session_fc);
-                self.conn_events
-                    .recv_stream_reset(self.stream_id, application_error_code);
-                let received = *final_received;
-                let read = *final_read;
-                self.set_state(RecvStreamState::ResetRecvd {
-                    final_received: received,
-                    final_read: read,
-                });
-                Ok(true)
+                let final_received = *final_received;
+                let final_read = *final_read;
+                Ok(self.finish_reset(
+                    final_size,
+                    application_error_code,
+                    final_received,
+                    final_read,
+                ))
             }
             // DataRecvd / DataRead / ResetRecvd: nothing to do.
             _ => Ok(false),
         }
+    }
+
+    /// Finalize a reset: release any flow control still held up to `final_size` (the dropped tail
+    /// is never delivered), surface the reset to the application, and move to `ResetRecvd`. Returns
+    /// `true` to signal that the stream has ended.
+    fn finish_reset(
+        &mut self,
+        final_size: u64,
+        err: AppError,
+        final_received: u64,
+        final_read: u64,
+    ) -> bool {
+        if let RecvStreamState::SizeKnownAt { fc, session_fc, .. }
+        | RecvStreamState::AbortReading { fc, session_fc, .. }
+        | RecvStreamState::WaitForReset { fc, session_fc, .. } = &mut self.state
+        {
+            Self::flow_control_retire_data(final_size - fc.retired(), fc, session_fc);
+        }
+        self.conn_events.recv_stream_reset(self.stream_id, err);
+        self.set_state(RecvStreamState::ResetRecvd {
+            final_received,
+            final_read,
+        });
+        true
     }
 
     /// While in `SizeKnownAt`, once the application has read the entire reliable prefix, release
@@ -962,28 +981,22 @@ impl RecvStream {
     fn complete_reliable_reset_if_drained(&mut self) -> bool {
         let RecvStreamState::SizeKnownAt {
             recv_buf,
-            fc,
-            session_fc,
             err,
             final_size,
             reliable_size,
-        } = &mut self.state
+            ..
+        } = &self.state
         else {
             return false;
         };
         if recv_buf.retired() < *reliable_size {
             return false;
         }
-        // Release flow control for the whole stream; the dropped tail is never delivered.
-        Self::flow_control_retire_data(*final_size - fc.retired(), fc, session_fc);
+        let final_size = *final_size;
+        let err = *err;
         let final_received = recv_buf.received();
         let final_read = recv_buf.retired();
-        self.conn_events.recv_stream_reset(self.stream_id, *err);
-        self.set_state(RecvStreamState::ResetRecvd {
-            final_received,
-            final_read,
-        });
-        true
+        self.finish_reset(final_size, err, final_received, final_read)
     }
 
     fn flow_control_retire_data(
@@ -1159,8 +1172,6 @@ impl RecvStream {
                 true
             }
             RecvStreamState::SizeKnownAt {
-                fc,
-                session_fc,
                 recv_buf,
                 err,
                 final_size,
@@ -1168,15 +1179,11 @@ impl RecvStream {
             } => {
                 // The reset is already known; the application is abandoning the (not fully
                 // delivered) reliable prefix. Release flow control, surface the reset, and end.
-                Self::flow_control_retire_data(*final_size - fc.retired(), fc, session_fc);
+                let final_size = *final_size;
+                let err = *err;
                 let final_received = recv_buf.received();
                 let final_read = recv_buf.retired();
-                self.conn_events.recv_stream_reset(self.stream_id, *err);
-                self.set_state(RecvStreamState::ResetRecvd {
-                    final_received,
-                    final_read,
-                });
-                true
+                self.finish_reset(final_size, err, final_received, final_read)
             }
             RecvStreamState::DataRead { .. }
             | RecvStreamState::AbortReading { .. }

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -131,7 +131,7 @@ impl RecvStreams {
     /// `RESET_STREAM` is a reliable reset with `reliable_size == 0`.
     ///
     /// # Errors
-    /// When flow control or the frame encoding is violated (see [`RecvStream::reset_at`]).
+    /// When flow control or the frame encoding is violated (see [`RecvStream::reset`]).
     pub fn reset(
         &mut self,
         stream_id: StreamId,

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -2757,6 +2757,21 @@ mod tests {
         assert!(s.is_ended());
     }
 
+    /// A plain `RESET_STREAM` is handled correctly after receiving `RESET_STREAM_AT`.
+    #[test]
+    fn reset_at_canceled_by_plain_reset() {
+        let mut events = ConnectionEvents::default();
+        let mut s = reliable_recv_stream(events.clone());
+        s.inbound_stream_frame(false, 0, &[0x42; 10]).unwrap();
+        assert!(s.reset(7, 10, 8).is_ok());
+        assert!(matches!(s.state, RecvStreamState::SizeKnownAt { .. }));
+        assert_eq!(reset_count(&mut events), 0);
+
+        assert!(s.reset(7, 10, 0).is_ok());
+        assert!(s.is_ended());
+        assert_eq!(reset_count(&mut events), 1);
+    }
+
     /// After `STOP_SENDING`, a `RESET_STREAM_AT` ignores `reliable_size` and ends promptly.
     #[test]
     fn reset_at_after_stop_sending() {

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -9,7 +9,7 @@
 
 use std::{
     cell::RefCell,
-    cmp::max,
+    cmp::{max, min},
     collections::BTreeMap,
     fmt::Debug,
     mem,
@@ -108,8 +108,12 @@ impl RecvStreams {
     /// # Errors
     /// When the stream does not exist or has no more data.
     pub fn read(&mut self, stream_id: StreamId, data: &mut [u8]) -> Res<(usize, bool)> {
-        let (n, fin) = self.get_mut(stream_id)?.read(data)?;
-        self.set_ended(fin);
+        let s = self.get_mut(stream_id)?;
+        let (n, fin) = s.read(data)?;
+        // A read can end the stream cleanly (`fin`) or, for a reliable reset, by draining the
+        // reliable prefix and reaching `ResetRecvd`; flag both.
+        let ended = s.is_ended();
+        self.set_ended(ended);
         Ok((n, fin))
     }
 
@@ -123,18 +127,20 @@ impl RecvStreams {
         Ok(())
     }
 
-    /// Reset a stream, noting if it ended.
+    /// Handle a `RESET_STREAM` or `RESET_STREAM_AT` for a stream, noting if it ended. A plain
+    /// `RESET_STREAM` is a reliable reset with `reliable_size == 0`.
     ///
     /// # Errors
-    /// When flow control is violated.
-    pub fn reset(
+    /// When flow control or the frame encoding is violated (see [`RecvStream::reset_at`]).
+    pub fn reset_at(
         &mut self,
         stream_id: StreamId,
         application_error_code: AppError,
         final_size: u64,
+        reliable_size: u64,
     ) -> Res<()> {
         if let Ok(rs) = self.get_mut(stream_id) {
-            let ended = rs.reset(application_error_code, final_size)?;
+            let ended = rs.reset_at(application_error_code, final_size, reliable_size)?;
             self.set_ended(ended);
         }
         Ok(())
@@ -404,6 +410,34 @@ impl RxStreamOrderer {
         self.received
     }
 
+    /// Discard any buffered data at or beyond `offset`, truncating a range that straddles it.
+    ///
+    /// Used by a reliable reset (`RESET_STREAM_AT`) to drop data above the reliable size. The
+    /// dropped bytes were already charged to flow control, so this only affects what can be
+    /// delivered to the application; `received` (a received-bytes stat) is intentionally left
+    /// unchanged.
+    #[allow(
+        clippy::allow_attributes,
+        clippy::missing_panics_doc,
+        reason = "OK here."
+    )]
+    pub fn discard_after(&mut self, offset: u64) {
+        self.data_ranges.split_off(&offset);
+        // Truncate a range that straddles `offset`.
+        if let Some(mut e) = self.data_ranges.last_entry() {
+            // Note: no underflow risk, all ranges that start at or after offset are gone.
+            let start = *e.key();
+            let keep = usize::try_from(offset - start).expect("u64 fits in usize");
+            let data = e.get_mut();
+            data.truncate(keep);
+
+            // No overflow risk: neither start nor offset can exceed 1<<62.
+            self.end = start + u64::try_from(data.len()).expect("usize fits in u64");
+        } else {
+            self.end = self.retired;
+        }
+    }
+
     /// Data bytes buffered. Could be more than `bytes_readable` if there are
     /// ranges missing.
     fn buffered(&self) -> u64 {
@@ -478,6 +512,17 @@ enum RecvStreamState {
         session_fc: Rc<RefCell<ReceiverFlowControl<()>>>,
         recv_buf: RxStreamOrderer,
     },
+    // A `RESET_STREAM_AT` has been received: the final size is known and the reliable prefix
+    // `[0, reliable_size)` must be delivered before the reset is surfaced. Data at or beyond
+    // `reliable_size` is dropped. Transition to `ResetRecvd` when data is `read()`.
+    SizeKnownAt {
+        fc: ReceiverFlowControl<StreamId>,
+        session_fc: Rc<RefCell<ReceiverFlowControl<()>>>,
+        recv_buf: RxStreamOrderer,
+        err: AppError,
+        final_size: u64,
+        reliable_size: u64,
+    },
     DataRecvd {
         fc: ReceiverFlowControl<StreamId>,
         session_fc: Rc<RefCell<ReceiverFlowControl<()>>>,
@@ -526,6 +571,7 @@ impl RecvStreamState {
         match self {
             Self::Recv { recv_buf, .. }
             | Self::SizeKnown { recv_buf, .. }
+            | Self::SizeKnownAt { recv_buf, .. }
             | Self::DataRecvd { recv_buf, .. } => Some(recv_buf),
             Self::DataRead { .. }
             | Self::AbortReading { .. }
@@ -538,9 +584,9 @@ impl RecvStreamState {
         let (fc, session_fc, final_size_reached, retire_data) = match self {
             Self::Recv { fc, session_fc, .. } => (fc, session_fc, false, false),
             Self::WaitForReset { fc, session_fc, .. } => (fc, session_fc, false, true),
-            Self::SizeKnown { fc, session_fc, .. } | Self::DataRecvd { fc, session_fc, .. } => {
-                (fc, session_fc, true, false)
-            }
+            Self::SizeKnown { fc, session_fc, .. }
+            | Self::SizeKnownAt { fc, session_fc, .. }
+            | Self::DataRecvd { fc, session_fc, .. } => (fc, session_fc, true, false),
             Self::AbortReading {
                 fc,
                 session_fc,
@@ -670,6 +716,7 @@ impl RecvStream {
         match &self.state {
             RecvStreamState::Recv { recv_buf, .. }
             | RecvStreamState::SizeKnown { recv_buf, .. }
+            | RecvStreamState::SizeKnownAt { recv_buf, .. }
             | RecvStreamState::DataRecvd { recv_buf, .. } => {
                 let received = recv_buf.received();
                 let read = recv_buf.retired();
@@ -758,6 +805,19 @@ impl RecvStream {
                     });
                 }
             }
+            RecvStreamState::SizeKnownAt {
+                recv_buf,
+                reliable_size,
+                ..
+            } => {
+                // Buffer the reliable prefix; data at or beyond `reliable_size` is dropped.
+                // Completion is driven by `read()`, not by frame arrival.
+                let keep = reliable_size.saturating_sub(offset);
+                if keep > 0 {
+                    let keep = min(data.len(), usize::try_from(keep)?);
+                    recv_buf.inbound_frame(offset, &data[..keep]);
+                }
+            }
             RecvStreamState::DataRecvd { .. }
             | RecvStreamState::DataRead { .. }
             | RecvStreamState::AbortReading { .. }
@@ -774,14 +834,30 @@ impl RecvStream {
         Ok(())
     }
 
+    /// Handle a `RESET_STREAM_AT` frame: the reliable prefix `[0, reliable_size)` must be
+    /// delivered before the reset is surfaced.
+    ///
     /// # Errors
-    /// When the reset occurs at an invalid point.
+    /// [`Error::FrameEncoding`] if `reliable_size > final_size`, [`Error::FinalSize`] if a
+    /// previously-known final size changes, or [`Error::StreamState`] if a later frame changes
+    /// the error code.
     ///
     /// # Returns
-    /// `true` when the stream transitions to `ResetRecvd` (ended).
-    /// `false` if the stream is already in a terminal state and the reset is a no-op.
-    pub fn reset(&mut self, application_error_code: AppError, final_size: u64) -> Res<bool> {
+    /// `true` when the stream reaches `ResetRecvd` (ended); `false` while it remains in
+    /// `SizeKnownAt` awaiting delivery of the prefix, or for a no-op in a terminal state.
+    pub fn reset_at(
+        &mut self,
+        application_error_code: AppError,
+        final_size: u64,
+        reliable_size: u64,
+    ) -> Res<bool> {
+        // Defensive: also rejected at frame decode.
+        if reliable_size > final_size {
+            return Err(Error::FrameEncoding);
+        }
+        // Catches a changed final size as FINAL_SIZE_ERROR.
         self.state.flow_control_consume_data(final_size, true)?;
+
         match &mut self.state {
             RecvStreamState::Recv {
                 fc,
@@ -793,17 +869,39 @@ impl RecvStream {
                 session_fc,
                 recv_buf,
             } => {
-                // make flow control consumes new data that not really exist.
-                Self::flow_control_retire_data(final_size - fc.retired(), fc, session_fc);
-                self.conn_events
-                    .recv_stream_reset(self.stream_id, application_error_code);
-                let received = recv_buf.received();
-                let read = recv_buf.retired();
-                self.set_state(RecvStreamState::ResetRecvd {
-                    final_received: received,
-                    final_read: read,
+                // Keep the buffered reliable prefix; drop anything at or beyond `reliable_size`.
+                recv_buf.discard_after(reliable_size);
+                let fc = mem::take(fc);
+                let session_fc = mem::take(session_fc);
+                let recv_buf = mem::replace(recv_buf, RxStreamOrderer::new());
+                self.set_state(RecvStreamState::SizeKnownAt {
+                    fc,
+                    session_fc,
+                    recv_buf,
+                    err: application_error_code,
+                    final_size,
+                    reliable_size,
                 });
-                Ok(true)
+                Ok(self.complete_reliable_reset_if_drained())
+            }
+            RecvStreamState::SizeKnownAt {
+                recv_buf,
+                err,
+                reliable_size: stored,
+                ..
+            } => {
+                // The final size is already validated above; a changed error code is a state
+                // error. `reliable_size` may only be reduced (increases are ignored).
+                if application_error_code != *err {
+                    return Err(Error::StreamState);
+                }
+                if reliable_size < *stored {
+                    *stored = reliable_size;
+                    recv_buf.discard_after(reliable_size);
+                    Ok(self.complete_reliable_reset_if_drained())
+                } else {
+                    Ok(false)
+                }
             }
             RecvStreamState::AbortReading {
                 fc,
@@ -818,7 +916,10 @@ impl RecvStream {
                 final_received,
                 final_read,
             } => {
-                // make flow control consumes new data that not really exist.
+                // The application abandoned the read side (via stop_sending). We can discard the
+                // reliable and ignore `reliable_size`, which can't be validated here
+                // because this is the first `RESET_STREAM[_AT]` we've received.
+                // Note: we don't check that subsequent frames contain a correct `reliable_size`.
                 Self::flow_control_retire_data(final_size - fc.retired(), fc, session_fc);
                 self.conn_events
                     .recv_stream_reset(self.stream_id, application_error_code);
@@ -830,8 +931,39 @@ impl RecvStream {
                 });
                 Ok(true)
             }
-            _ => Ok(false), // Ignore reset if in DataRecvd, DataRead, or ResetRecvd
+            // DataRecvd / DataRead / ResetRecvd: nothing to do.
+            _ => Ok(false),
         }
+    }
+
+    /// While in `SizeKnownAt`, once the application has read the entire reliable prefix, release
+    /// the remaining flow control, surface the reset, and move to `ResetRecvd`. Returns whether
+    /// the stream ended.
+    fn complete_reliable_reset_if_drained(&mut self) -> bool {
+        let RecvStreamState::SizeKnownAt {
+            recv_buf,
+            fc,
+            session_fc,
+            err,
+            final_size,
+            reliable_size,
+        } = &mut self.state
+        else {
+            return false;
+        };
+        if recv_buf.retired() < *reliable_size {
+            return false;
+        }
+        // Release flow control for the whole stream; the dropped tail is never delivered.
+        Self::flow_control_retire_data(*final_size - fc.retired(), fc, session_fc);
+        let final_received = recv_buf.received();
+        let final_read = recv_buf.retired();
+        self.conn_events.recv_stream_reset(self.stream_id, *err);
+        self.set_state(RecvStreamState::ResetRecvd {
+            final_received,
+            final_read,
+        });
+        true
     }
 
     fn flow_control_retire_data(
@@ -919,6 +1051,19 @@ impl RecvStream {
                 };
                 Ok((bytes_read, fin_read))
             }
+            RecvStreamState::SizeKnownAt {
+                recv_buf,
+                fc,
+                session_fc,
+                ..
+            } => {
+                let bytes_read = recv_buf.read(buf);
+                Self::flow_control_retire_data(u64::try_from(bytes_read)?, fc, session_fc);
+                // Once the whole reliable prefix has been read, surface the reset. A reliable
+                // reset never delivers a FIN, so `fin_read` is always `false`.
+                self.complete_reliable_reset_if_drained();
+                Ok((bytes_read, false))
+            }
             RecvStreamState::DataRead { .. }
             | RecvStreamState::AbortReading { .. }
             | RecvStreamState::WaitForReset { .. }
@@ -967,11 +1112,31 @@ impl RecvStream {
                 recv_buf,
             } => {
                 Self::flow_control_retire_data(fc.consumed() - fc.retired(), fc, session_fc);
-                let received = recv_buf.received();
-                let read = recv_buf.retired();
+                let final_received = recv_buf.received();
+                let final_read = recv_buf.retired();
                 self.set_state(RecvStreamState::DataRead {
-                    final_received: received,
-                    final_read: read,
+                    final_received,
+                    final_read,
+                });
+                true
+            }
+            RecvStreamState::SizeKnownAt {
+                fc,
+                session_fc,
+                recv_buf,
+                err,
+                final_size,
+                ..
+            } => {
+                // The reset is already known; the application is abandoning the (not fully
+                // delivered) reliable prefix. Release flow control, surface the reset, and end.
+                Self::flow_control_retire_data(*final_size - fc.retired(), fc, session_fc);
+                let final_received = recv_buf.received();
+                let final_read = recv_buf.retired();
+                self.conn_events.recv_stream_reset(self.stream_id, *err);
+                self.set_state(RecvStreamState::ResetRecvd {
+                    final_received,
+                    final_read,
                 });
                 true
             }
@@ -1079,6 +1244,7 @@ impl RecvStream {
         match &self.state {
             RecvStreamState::Recv { fc, .. }
             | RecvStreamState::SizeKnown { fc, .. }
+            | RecvStreamState::SizeKnownAt { fc, .. }
             | RecvStreamState::DataRecvd { fc, .. }
             | RecvStreamState::AbortReading { fc, .. }
             | RecvStreamState::WaitForReset { fc, .. } => Some(fc),
@@ -1092,12 +1258,13 @@ impl RecvStream {
 mod tests {
     use std::{cell::RefCell, fmt::Debug, ops::Range, rc::Rc, time::Duration};
 
-    use neqo_common::{Encoder, qtrace};
+    use neqo_common::{Encoder, event::Provider as _, qtrace};
     use test_fixture::now;
 
-    use super::RecvStream;
+    use super::{RecvStream, RecvStreamState};
     use crate::{
         ConnectionEvents, Error, INITIAL_LOCAL_MAX_STREAM_DATA, StreamId,
+        events::ConnectionEvent,
         fc::{ReceiverFlowControl, WINDOW_UPDATE_FRACTION},
         packet, recovery,
         recv_stream::RxStreamOrderer,
@@ -1793,8 +1960,12 @@ mod tests {
             .unwrap();
         assert!(!session_fc.borrow().frame_needed());
 
-        s.reset(Error::None.code(), u64::try_from(SESSION_WINDOW).unwrap())
-            .unwrap();
+        s.reset_at(
+            Error::None.code(),
+            u64::try_from(SESSION_WINDOW).unwrap(),
+            0,
+        )
+        .unwrap();
         assert!(session_fc.borrow().frame_needed());
     }
 
@@ -2405,5 +2576,205 @@ mod tests {
         s.inbound_stream_frame(false, SW / 2, &[0; 10]).unwrap();
         check_fc(&fc.borrow(), SW / 2 + 10, SW / 2 + 10);
         check_fc(s.fc().unwrap(), SW / 2 + 10, SW / 2 + 10);
+    }
+
+    // --- RESET_STREAM_AT (reliable stream reset) receive side ---
+
+    const RR_STREAM: StreamId = StreamId::new(67);
+
+    fn reliable_recv_stream(events: ConnectionEvents) -> RecvStream {
+        RecvStream::new(
+            RR_STREAM,
+            INITIAL_LOCAL_MAX_STREAM_DATA as u64,
+            Rc::new(RefCell::new(ReceiverFlowControl::new((), 1024 * 1024))),
+            events,
+        )
+    }
+
+    fn reset_count(events: &mut ConnectionEvents) -> usize {
+        events
+            .events()
+            .filter(|e| {
+                matches!(e, ConnectionEvent::RecvStreamReset { stream_id, .. }
+                if *stream_id == RR_STREAM)
+            })
+            .count()
+    }
+
+    /// `RxStreamOrderer::discard_after` drops whole ranges beyond the offset and truncates a
+    /// straddling range, leaving the `end` invariant intact for later frames.
+    #[test]
+    fn orderer_discard_after() {
+        let mut o = RxStreamOrderer::new();
+        o.inbound_frame(0, &[1; 10]);
+        o.discard_after(4);
+        // Only `[0, 4)` remains readable.
+        let mut buf = [0; 16];
+        assert_eq!(o.read(&mut buf), 4);
+
+        // A later frame entirely beyond the discard point still slots in correctly.
+        let mut o = RxStreamOrderer::new();
+        o.inbound_frame(0, &[1; 4]);
+        o.inbound_frame(8, &[2; 4]); // gap at [4,8)
+        o.discard_after(6); // drops [8,12), keeps [0,4)
+        o.inbound_frame(4, &[3; 2]); // fills [4,6)
+        assert_eq!(o.read(&mut buf), 6);
+
+        // The end marker is correctly maintained when the discard empties it out.
+        let mut o = RxStreamOrderer::new();
+        o.inbound_frame(0, &[1; 4]);
+        assert_eq!(o.read(&mut buf), 4);
+        o.inbound_frame(8, &[2; 4]); // gap at [4,8)
+        o.discard_after(6); // drops [8,12), keeps [0,4)
+        o.inbound_frame(4, &[3; 2]); // fills [4,6)
+        assert_eq!(o.read(&mut buf), 2);
+    }
+
+    /// Happy path: receive all data, then `RESET_STREAM_AT`; only the reliable prefix is
+    /// delivered, and the reset is surfaced once it has been read.
+    #[test]
+    fn reset_at_delivers_prefix_then_resets() {
+        let mut events = ConnectionEvents::default();
+        let mut s = reliable_recv_stream(events.clone());
+        s.inbound_stream_frame(false, 0, &[0x42; 10]).unwrap();
+
+        assert!(s.reset_at(7, 10, 4).is_ok());
+        assert!(!s.is_ended());
+        assert!(matches!(s.state, RecvStreamState::SizeKnownAt { .. }));
+        assert_eq!(reset_count(&mut events), 0);
+
+        // Only `[0, 4)` is delivered; no FIN, and the bytes beyond `reliable_size` are gone.
+        let mut buf = [0; 64];
+        assert_eq!(s.read(&mut buf).unwrap(), (4, false));
+        // Reading drained the prefix → reset surfaced, stream ended.
+        assert!(s.is_ended());
+        assert_eq!(reset_count(&mut events), 1);
+        assert_eq!(s.read(&mut buf).unwrap_err(), Error::NoMoreData);
+    }
+
+    /// `RESET_STREAM` (`reliable_size == 0`) completes immediately.
+    #[test]
+    fn reset_at_zero_completes_immediately() {
+        let mut events = ConnectionEvents::default();
+        let mut s = reliable_recv_stream(events.clone());
+        s.inbound_stream_frame(false, 0, &[0x42; 10]).unwrap();
+        assert!(s.reset_at(7, 10, 0).is_ok());
+        assert!(s.is_ended());
+        assert_eq!(reset_count(&mut events), 1);
+    }
+
+    /// The reset waits for the reliable prefix to arrive (reordering) and be read.
+    #[test]
+    fn reset_at_waits_for_prefix() {
+        let mut events = ConnectionEvents::default();
+        let mut s = reliable_recv_stream(events.clone());
+        // RESET_STREAM_AT arrives before the committed data.
+        assert!(s.reset_at(7, 8, 8).is_ok());
+        assert!(matches!(s.state, RecvStreamState::SizeKnownAt { .. }));
+
+        // Partial prefix: read what's there, not yet complete.
+        s.inbound_stream_frame(false, 0, &[0x42; 4]).unwrap();
+        let mut buf = [0; 64];
+        assert_eq!(s.read(&mut buf).unwrap(), (4, false));
+        assert!(!s.is_ended());
+        assert_eq!(reset_count(&mut events), 0);
+
+        // Deliver the remainder.
+        s.inbound_stream_frame(false, 4, &[0x42; 4]).unwrap();
+        assert_eq!(s.read(&mut buf).unwrap(), (4, false));
+        assert!(s.is_ended());
+        assert_eq!(reset_count(&mut events), 1);
+    }
+
+    /// `reliable_size > final_size` is rejected with a frame-encoding error.
+    #[test]
+    fn reset_at_reliable_exceeds_final() {
+        let mut s = reliable_recv_stream(ConnectionEvents::default());
+        assert_eq!(s.reset_at(7, 4, 8).unwrap_err(), Error::FrameEncoding);
+    }
+
+    /// A later frame changing the final size is a `FINAL_SIZE_ERROR`.
+    #[test]
+    fn reset_at_changed_final_size() {
+        let mut s = reliable_recv_stream(ConnectionEvents::default());
+        assert!(s.reset_at(7, 10, 4).is_ok());
+        assert_eq!(s.reset_at(7, 12, 4).unwrap_err(), Error::FinalSize);
+    }
+
+    /// A later frame changing the error code is a `STREAM_STATE_ERROR`.
+    #[test]
+    fn reset_at_changed_error_code() {
+        let mut s = reliable_recv_stream(ConnectionEvents::default());
+        assert!(s.reset_at(7, 10, 4).is_ok());
+        assert_eq!(s.reset_at(9, 10, 4).unwrap_err(), Error::StreamState);
+    }
+
+    /// `reliable_size` may be reduced (dropping newly-excess data) but increases are ignored.
+    #[test]
+    fn reset_at_reduce_and_ignore_increase() {
+        let mut s = reliable_recv_stream(ConnectionEvents::default());
+        s.inbound_stream_frame(false, 0, &[0x42; 10]).unwrap();
+        assert!(s.reset_at(7, 10, 8).is_ok());
+
+        // An increase is ignored.
+        assert!(s.reset_at(7, 10, 9).is_ok());
+        // A reduction drops the newly-excess data.
+        assert!(s.reset_at(7, 10, 4).is_ok());
+
+        let mut buf = [0; 64];
+        // Only `[0, 4)` survives.
+        assert_eq!(s.read(&mut buf).unwrap(), (4, false));
+        assert!(s.is_ended());
+    }
+
+    /// After `STOP_SENDING`, a `RESET_STREAM_AT` ignores `reliable_size` and ends promptly.
+    #[test]
+    fn reset_at_after_stop_sending() {
+        let mut events = ConnectionEvents::default();
+        let mut s = reliable_recv_stream(events.clone());
+        s.inbound_stream_frame(false, 0, &[0x42; 4]).unwrap();
+        assert!(!s.stop_sending(9));
+        assert!(s.reset_at(7, 10, 8).is_ok());
+        assert!(s.is_ended());
+        assert_eq!(reset_count(&mut events), 1);
+    }
+
+    /// `STOP_SENDING` while delivering a reliable prefix abandons it and ends promptly.
+    #[test]
+    fn stop_sending_in_size_known_at() {
+        let mut events = ConnectionEvents::default();
+        let mut s = reliable_recv_stream(events.clone());
+        s.inbound_stream_frame(false, 0, &[0x42; 10]).unwrap();
+        assert!(s.reset_at(7, 10, 8).is_ok());
+        assert!(matches!(s.state, RecvStreamState::SizeKnownAt { .. }));
+
+        assert!(s.stop_sending(9)); // ends the stream
+        assert!(s.is_ended());
+        assert_eq!(reset_count(&mut events), 1);
+    }
+
+    /// A reliable reset releases all of the stream's flow control once complete.
+    #[test]
+    fn reset_at_releases_flow_control() {
+        const FC_LIMIT: u64 = 1024;
+
+        let session_fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), FC_LIMIT)));
+        let mut s = create_stream_with_fc(Rc::clone(&session_fc), FC_LIMIT);
+        s.inbound_stream_frame(false, 0, &[0x42; 100]).unwrap();
+        // Reliable size 40, final size 100: the [40,100) tail is dropped.
+        assert!(s.reset_at(7, 100, 40).is_ok());
+
+        let mut buf = [0; 256];
+        assert_eq!(s.read(&mut buf).unwrap(), (40, false));
+        assert!(s.is_ended());
+        // All 100 bytes of session flow control are retired (40 read + 60 dropped tail).
+        check_fc(&session_fc.borrow(), 100, 100);
+
+        // Doing this again without data has the same effect.
+        let mut s = create_stream_with_fc(Rc::clone(&session_fc), FC_LIMIT);
+        assert!(s.reset_at(7, 100, 40).is_ok());
+        check_fc(&session_fc.borrow(), 200, 100);
+        assert!(s.stop_sending(9));
+        check_fc(&session_fc.borrow(), 200, 200);
     }
 }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1648,6 +1648,55 @@ impl SendStream {
         self.state.transition(new_state);
     }
 
+    /// Drop any commitment made via [`Self::commit`] in response to a `STOP_SENDING`: the peer has
+    /// no interest in the data, so there is nothing left to deliver reliably.
+    ///
+    /// Before a reset is sent, this just clears the committed offset so that a subsequent
+    /// [`Self::reset`] emits a plain `RESET_STREAM` (`reliable_size == 0`). If a `RESET_STREAM_AT`
+    /// has already been sent (`ResetSentReliable`), the buffer of still-in-flight committed data is
+    /// dropped and the stream moves to `ResetSent` with `reliable_size` reset to 0 (so any
+    /// retransmission of the reset frame is a plain `RESET_STREAM`), or straight to `ResetRecvd` if
+    /// the reset frame is already acked.
+    pub(crate) fn drop_commitment(&mut self) {
+        match &mut self.state {
+            State::Send { committed, .. } | State::DataSent { committed, .. } => {
+                *committed = 0;
+            }
+            State::ResetSentReliable {
+                send_buf,
+                err,
+                final_size,
+                reset_acked,
+                priority,
+                ..
+            } => {
+                let final_retired = send_buf.retired();
+                let final_written = to_u64(send_buf.buffered());
+                let new_state = if *reset_acked {
+                    // The reset is already acked, so abandoning the data completes the reset.
+                    State::ResetRecvd {
+                        final_retired,
+                        final_written,
+                    }
+                } else {
+                    // Drop the buffer and await the frame ack in `ResetSent`. Clearing
+                    // `reliable_size` makes any retransmission of the reset frame a plain
+                    // `RESET_STREAM`.
+                    State::ResetSent {
+                        err: *err,
+                        final_size: *final_size,
+                        reliable_size: 0,
+                        priority: *priority,
+                        final_retired,
+                        final_written,
+                    }
+                };
+                self.state.transition(new_state);
+            }
+            _ => {}
+        }
+    }
+
     #[cfg(test)]
     pub(crate) const fn state(&mut self) -> &mut State {
         &mut self.state
@@ -4559,6 +4608,82 @@ mod tests {
         let stats = send_reset_frame(&mut s);
         assert_eq!(stats.reset_stream, 0);
         assert_eq!(stats.reset_stream_at, 1);
+    }
+
+    /// A `STOP_SENDING` drops any commitment, so the reset is a plain `RESET_STREAM` even though
+    /// data was committed.
+    #[test]
+    fn stop_sending_drops_commitment_emits_reset_stream() {
+        let mut s = reliable_stream_committed(&[0x42; 5], &[0x42; 5], ConnectionEvents::default());
+        s.drop_commitment();
+        s.reset(0);
+        assert!(matches!(
+            s.state(),
+            State::ResetSent {
+                reliable_size: 0,
+                ..
+            }
+        ));
+        let stats = send_reset_frame(&mut s);
+        assert_eq!(stats.reset_stream, 1);
+        assert_eq!(stats.reset_stream_at, 0);
+    }
+
+    /// A `STOP_SENDING` after a `RESET_STREAM_AT` was already sent drops the in-flight committed
+    /// data (moving to `ResetSent`) but leaves `reliable_size` unchanged.
+    #[test]
+    fn stop_sending_after_reset_stream_at_drops_to_reset_sent() {
+        let mut s = reliable_stream_committed(&[0x42; 5], &[0x42; 5], ConnectionEvents::default());
+        s.reset(0);
+        s.mark_as_sent(0, 5, false);
+        _ = send_reset_frame(&mut s);
+        assert!(matches!(
+            s.state(),
+            State::ResetSentReliable {
+                reliable_size: 5,
+                reset_acked: false,
+                ..
+            }
+        ));
+
+        // STOP_SENDING: stop delivering the committed prefix, dropping to `ResetSent` with
+        // `reliable_size` cleared to 0 (any frame retransmission is now a plain `RESET_STREAM`).
+        s.drop_commitment();
+        assert!(matches!(
+            s.state(),
+            State::ResetSent {
+                reliable_size: 0,
+                ..
+            }
+        ));
+        assert!(!s.is_ended());
+
+        // A retransmission of the reset frame is now a plain RESET_STREAM.
+        s.reset_lost();
+        let stats = send_reset_frame(&mut s);
+        assert_eq!(stats.reset_stream, 1);
+        assert_eq!(stats.reset_stream_at, 0);
+
+        // Once the frame is acked, the stream ends without waiting for the data.
+        s.reset_acked();
+        assert!(s.is_ended());
+    }
+
+    /// A `STOP_SENDING` after a `RESET_STREAM_AT` whose frame is already acked completes the reset
+    /// immediately, abandoning the still-in-flight committed data.
+    #[test]
+    fn stop_sending_after_reset_stream_at_acked_completes() {
+        let mut s = reliable_stream_committed(&[0x42; 5], &[0x42; 5], ConnectionEvents::default());
+        s.reset(0);
+        s.mark_as_sent(0, 5, false);
+        _ = send_reset_frame(&mut s);
+        // Frame acked, committed data still in flight.
+        s.reset_acked();
+        assert!(matches!(s.state(), State::ResetSentReliable { .. }));
+        assert!(!s.is_ended());
+
+        s.drop_commitment();
+        assert!(s.is_ended());
     }
 
     /// When all committed data is already acked at reset time, the buffer is dropped (the

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1186,6 +1186,10 @@ impl SendStream {
     }
 
     /// Maybe write a `RESET_STREAM` or `RESET_STREAM_AT` frame.
+    /// Returns true if the reset is successfully sent
+    /// and that is the only data that needs sending.
+    /// Returns false when there is no reset to send
+    /// or when a `RESET_STREAM_AT` frame needs to be followed by stream data.
     pub fn write_reset_frame<B: Buffer>(
         &mut self,
         p: TransmissionPriority,
@@ -1241,7 +1245,8 @@ impl SendStream {
             }
             *priority = None;
         }
-        written
+        // Even if the write was successful, if we have reliable data pending, return false.
+        written && !matches!(self.state, State::ResetSentReliable { .. })
     }
 
     pub fn blocked_lost(&mut self, limit: u64) {
@@ -4329,8 +4334,8 @@ mod tests {
             packet::Builder::short(Encoder::default(), false, None::<&[u8]>, packet::LIMIT);
         let mut tokens = recovery::Tokens::new();
         let mut stats = FrameStats::default();
-        s.write_reset_frame(priority, &mut builder, &mut tokens, &mut stats)
-            && (stats.reset_stream + stats.reset_stream_at == 1)
+        s.write_reset_frame(priority, &mut builder, &mut tokens, &mut stats);
+        stats.reset_stream + stats.reset_stream_at == 1
     }
 
     #[test]
@@ -4531,12 +4536,13 @@ mod tests {
             packet::Builder::short(Encoder::default(), false, None::<&[u8]>, packet::LIMIT);
         let mut tokens = recovery::Tokens::new();
         let mut stats = FrameStats::default();
-        assert!(s.write_reset_frame(
+        s.write_reset_frame(
             TransmissionPriority::Normal,
             &mut builder,
             &mut tokens,
-            &mut stats
-        ));
+            &mut stats,
+        );
+        assert_eq!(stats.reset_stream + stats.reset_stream_at, 1);
         stats
     }
 
@@ -4898,5 +4904,39 @@ mod tests {
         s.reset_lost();
         let eff = TransmissionPriority::Normal + RetransmissionPriority::default();
         assert!(reset_frame_written(&mut s, eff));
+    }
+
+    /// A reliably-reset stream with committed data still in flight has both a `RESET_STREAM_AT`
+    /// frame and the committed STREAM data pending at the same priority. A single `write_frames`
+    /// call into a packet with ample room should emit both, so the reset and the data it protects
+    /// travel together in one packet.
+    #[test]
+    fn reset_and_committed_data_are_coalesced() {
+        let mut s = reliable_stream_committed(&[0x42; 5], &[0x42; 5], ConnectionEvents::default());
+        s.reset(0);
+        assert!(matches!(
+            s.state(),
+            State::ResetSentReliable {
+                reliable_size: 5,
+                ..
+            }
+        ));
+        assert!(s.has_data_at(TransmissionPriority::Normal));
+
+        let mut builder =
+            packet::Builder::short(Encoder::default(), false, None::<&[u8]>, packet::LIMIT);
+        let mut tokens = recovery::Tokens::new();
+        let mut stats = FrameStats::default();
+        assert!(s.write_frames(
+            TransmissionPriority::Normal,
+            &mut builder,
+            &mut tokens,
+            &mut stats
+        ));
+        assert!(!builder.is_full());
+
+        // Both frames should be in this one packet.
+        assert_eq!(stats.reset_stream_at, 1);
+        assert_eq!(stats.stream, 1);
     }
 }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -4634,6 +4634,9 @@ mod tests {
     #[test]
     fn stop_sending_after_reset_stream_at_drops_to_reset_sent() {
         let mut s = reliable_stream_committed(&[0x42; 5], &[0x42; 5], ConnectionEvents::default());
+        // Keep effective priority == Normal so the post-`reset_lost` retransmission is written at
+        // the same priority as the initial send.
+        s.set_priority(TransmissionPriority::Normal, RetransmissionPriority::Same);
         s.reset(0);
         s.mark_as_sent(0, 5, false);
         _ = send_reset_frame(&mut s);

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -598,6 +598,8 @@ pub enum State {
         fc: SenderFlowControl<StreamId>,
         conn_fc: Rc<RefCell<SenderFlowControl<()>>>,
         send_buf: TxBuffer,
+        /// The committed (reliable) offset, set via [`SendStream::commit`].
+        committed: u64,
     },
     // Note: `DataSent` is entered when the stream is closed, not when all data has been
     // sent for the first time.
@@ -605,17 +607,35 @@ pub enum State {
         send_buf: TxBuffer,
         fin_sent: bool,
         fin_acked: bool,
+        /// See [`State::Send::committed`].
+        committed: u64,
     },
     DataRecvd {
         retired: u64,
         written: u64,
     },
+    // A reset has been sent and no committed data below `reliable_size` is still outstanding
+    // (either `reliable_size == 0`, i.e. a plain `RESET_STREAM`, or all committed data has
+    // already been acked). The send buffer is dropped.
     ResetSent {
         err: AppError,
         final_size: u64,
+        /// The reliable size. `0` ⇒ emit `RESET_STREAM`; `> 0` ⇒ emit `RESET_STREAM_AT`.
+        reliable_size: u64,
         priority: Option<TransmissionPriority>,
         final_retired: u64,
         final_written: u64,
+    },
+    // A `RESET_STREAM_AT` has been sent, but committed data below `reliable_size` is still in
+    // flight, so the `TxBuffer` is retained to (re)transmit it.
+    ResetSentReliable {
+        send_buf: TxBuffer,
+        err: AppError,
+        final_size: u64,
+        reliable_size: u64,
+        priority: Option<TransmissionPriority>,
+        /// Whether the `RESET_STREAM_AT` frame itself has been acked.
+        reset_acked: bool,
     },
     ResetRecvd {
         final_retired: u64,
@@ -626,7 +646,9 @@ pub enum State {
 impl State {
     const fn tx_buf_mut(&mut self) -> Option<&mut TxBuffer> {
         match self {
-            Self::Send { send_buf, .. } | Self::DataSent { send_buf, .. } => Some(send_buf),
+            Self::Send { send_buf, .. }
+            | Self::DataSent { send_buf, .. }
+            | Self::ResetSentReliable { send_buf, .. } => Some(send_buf),
             Self::Ready { .. }
             | Self::DataRecvd { .. }
             | Self::ResetSent { .. }
@@ -639,7 +661,11 @@ impl State {
             // In Ready, TxBuffer not yet allocated but size is known
             Self::Ready { .. } => TxBuffer::MAX_SIZE,
             Self::Send { send_buf, .. } | Self::DataSent { send_buf, .. } => send_buf.avail(),
-            Self::DataRecvd { .. } | Self::ResetSent { .. } | Self::ResetRecvd { .. } => 0,
+            // No application data can be added after a reset.
+            Self::DataRecvd { .. }
+            | Self::ResetSent { .. }
+            | Self::ResetSentReliable { .. }
+            | Self::ResetRecvd { .. } => 0,
         }
     }
 
@@ -744,12 +770,19 @@ impl SendStream {
     /// Must mirror every frame-emission path in [`Self::write_frames`]; any new
     /// frame type added there must also be reflected here.
     fn has_data_at(&mut self, priority: TransmissionPriority) -> bool {
-        // RESET_STREAM pending?
-        if let State::ResetSent {
-            priority: Some(p), ..
-        } = self.state
-        {
-            return p == priority;
+        // RESET_STREAM / RESET_STREAM_AT pending?
+        match self.state {
+            // A plain reset emits no other frames, so this is the only thing to check.
+            State::ResetSent {
+                priority: reset_priority,
+                ..
+            } => return reset_priority == Some(priority),
+            // A reliable reset may also have committed STREAM data pending, so only short-circuit
+            // when the reset frame itself is queued at this priority; otherwise fall through.
+            State::ResetSentReliable {
+                priority: Some(p), ..
+            } if p == priority => return true,
+            _ => {}
         }
         // STREAM_DATA_BLOCKED pending?
         if priority == self.priority
@@ -842,7 +875,9 @@ impl SendStream {
     )]
     pub fn bytes_written(&self) -> u64 {
         match &self.state {
-            State::Send { send_buf, .. } | State::DataSent { send_buf, .. } => {
+            State::Send { send_buf, .. }
+            | State::DataSent { send_buf, .. }
+            | State::ResetSentReliable { send_buf, .. } => {
                 send_buf.retired() + u64::try_from(send_buf.buffered()).expect("usize fits in u64")
             }
             State::DataRecvd {
@@ -865,7 +900,9 @@ impl SendStream {
     #[must_use]
     pub const fn bytes_acked(&self) -> u64 {
         match &self.state {
-            State::Send { send_buf, .. } | State::DataSent { send_buf, .. } => send_buf.retired(),
+            State::Send { send_buf, .. }
+            | State::DataSent { send_buf, .. }
+            | State::ResetSentReliable { send_buf, .. } => send_buf.retired(),
             State::DataRecvd { retired, .. } => *retired,
             State::ResetSent { final_retired, .. } | State::ResetRecvd { final_retired, .. } => {
                 *final_retired
@@ -891,6 +928,20 @@ impl SendStream {
                 fin_sent,
                 ..
             } => send_buf.has_next_bytes() || !fin_sent,
+            // Only committed data below `reliable_size` is (re)transmitted (and on a
+            // retransmission, only data below the retransmission offset); no FIN.
+            State::ResetSentReliable {
+                ref mut send_buf,
+                reliable_size,
+                ..
+            } => {
+                let limit = if retransmission_only {
+                    min(self.retransmission_offset, reliable_size)
+                } else {
+                    reliable_size
+                };
+                send_buf.has_next_bytes_before(limit)
+            }
             _ => false,
         }
     }
@@ -935,6 +986,28 @@ impl SendStream {
                     // Send empty stream frame with fin set
                     Some((used, &[]))
                 }
+            }
+            // (Re)transmit committed data, truncated so `offset + len <= reliable_size`, and
+            // never a FIN (the end is signalled by the RESET_STREAM_AT frame). This caps fresh
+            // sends at `reliable_size` and, on a retransmission, additionally caps at the
+            // retransmission offset so only lost data below `reliable_size` is resent.
+            State::ResetSentReliable {
+                ref mut send_buf,
+                reliable_size,
+                ..
+            } => {
+                let limit = if retransmission_only {
+                    min(self.retransmission_offset, reliable_size)
+                } else {
+                    reliable_size
+                };
+                let (offset, slice) = send_buf.next_bytes()?;
+                if offset >= limit {
+                    return None;
+                }
+                let cap = usize::try_from(limit - offset).unwrap_or(usize::MAX);
+                let len = min(cap, slice.len());
+                Some((offset, &slice[..len]))
             }
             State::Ready { .. }
             | State::DataRecvd { .. }
@@ -1040,6 +1113,11 @@ impl SendStream {
         }
     }
 
+    #[allow(
+        clippy::allow_attributes,
+        clippy::missing_panics_doc,
+        reason = "OK here."
+    )]
     pub fn reset_acked(&mut self) {
         match self.state {
             State::Ready { .. }
@@ -1052,10 +1130,33 @@ impl SendStream {
                 final_retired,
                 final_written,
                 ..
-            } => self.state.transition(State::ResetRecvd {
-                final_retired,
-                final_written,
-            }),
+            } => {
+                // Reaching `ResetRecvd` does not signal stream completion, even for a reliable
+                // reset that delivered committed data.
+                self.state.transition(State::ResetRecvd {
+                    final_retired,
+                    final_written,
+                });
+            }
+            State::ResetSentReliable {
+                ref mut send_buf,
+                reliable_size,
+                reset_acked: ref mut frame_acked,
+                ..
+            } => {
+                // Complete only once all committed data has also been acked.
+                if send_buf.retired() >= reliable_size {
+                    let final_retired = send_buf.retired();
+                    let final_written =
+                        u64::try_from(send_buf.buffered()).expect("usize fits in u64");
+                    self.state.transition(State::ResetRecvd {
+                        final_retired,
+                        final_written,
+                    });
+                } else {
+                    *frame_acked = true;
+                }
+            }
             State::ResetRecvd { .. } => qtrace!("[{self}] already in ResetRecvd state"),
         }
     }
@@ -1063,6 +1164,9 @@ impl SendStream {
     pub fn reset_lost(&mut self) {
         match self.state {
             State::ResetSent {
+                ref mut priority, ..
+            }
+            | State::ResetSentReliable {
                 ref mut priority, ..
             } => {
                 *priority = Some(self.effective_priority);
@@ -1072,7 +1176,7 @@ impl SendStream {
         }
     }
 
-    /// Maybe write a `RESET_STREAM` frame.
+    /// Maybe write a `RESET_STREAM` or `RESET_STREAM_AT` frame.
     pub fn write_reset_frame<B: Buffer>(
         &mut self,
         p: TransmissionPriority,
@@ -1080,34 +1184,55 @@ impl SendStream {
         tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
     ) -> bool {
-        if let State::ResetSent {
-            final_size,
+        let (State::ResetSent {
             err,
-            ref mut priority,
+            final_size,
+            reliable_size,
+            priority,
             ..
-        } = self.state
-        {
-            if *priority != Some(p) {
-                return false;
-            }
-            if builder.write_varint_frame(&[
+        }
+        | State::ResetSentReliable {
+            err,
+            final_size,
+            reliable_size,
+            priority,
+            ..
+        }) = &mut self.state
+        else {
+            return false;
+        };
+        if *priority != Some(p) {
+            return false;
+        }
+        // `reliable_size == 0` ⇒ plain `RESET_STREAM`; otherwise `RESET_STREAM_AT`.
+        let written = if *reliable_size == 0 {
+            builder.write_varint_frame(&[
                 FrameType::ResetStream.into(),
                 self.stream_id.as_u64(),
-                err,
-                final_size,
-            ]) {
-                tokens.push(recovery::Token::Stream(StreamRecoveryToken::ResetStream {
-                    stream_id: self.stream_id,
-                }));
-                stats.reset_stream += 1;
-                *priority = None;
-                true
-            } else {
-                false
-            }
+                *err,
+                *final_size,
+            ])
         } else {
-            false
+            builder.write_varint_frame(&[
+                FrameType::ResetStreamAt.into(),
+                self.stream_id.as_u64(),
+                *err,
+                *final_size,
+                *reliable_size,
+            ])
+        };
+        if written {
+            tokens.push(recovery::Token::Stream(StreamRecoveryToken::ResetStream {
+                stream_id: self.stream_id,
+            }));
+            if *reliable_size == 0 {
+                stats.reset_stream += 1;
+            } else {
+                stats.reset_stream_at += 1;
+            }
+            *priority = None;
         }
+        written
     }
 
     pub fn blocked_lost(&mut self, limit: u64) {
@@ -1187,6 +1312,41 @@ impl SendStream {
                         retired,
                         written: buffered,
                     });
+                }
+            }
+            State::ResetSentReliable {
+                ref mut send_buf,
+                reliable_size,
+                reset_acked,
+                err,
+                final_size,
+                priority,
+            } => {
+                send_buf.mark_as_acked(offset, len);
+                // Wait until all committed data (`< reliable_size`) is acked.
+                if send_buf.retired() >= reliable_size {
+                    let final_retired = send_buf.retired();
+                    let final_written =
+                        u64::try_from(send_buf.buffered()).expect("usize fits in u64");
+                    if reset_acked {
+                        // Both the frame and the committed data are acked: reach `ResetRecvd`.
+                        self.state.transition(State::ResetRecvd {
+                            final_retired,
+                            final_written,
+                        });
+                    } else {
+                        // Committed data is acked but the frame is not: drop the buffer and
+                        // await the frame ack in `ResetSent` (which keeps `reliable_size` so
+                        // that the frame is still retransmitted as RESET_STREAM_AT).
+                        self.state.transition(State::ResetSent {
+                            err,
+                            final_size,
+                            reliable_size,
+                            priority,
+                            final_retired,
+                            final_written,
+                        });
+                    }
                 }
             }
             _ => qtrace!("[{self}] mark_as_acked called from state {:?}", self.state),
@@ -1299,6 +1459,7 @@ impl SendStream {
                 fc: owned_fc,
                 conn_fc: owned_conn_fc,
                 send_buf: TxBuffer::new(),
+                committed: 0,
             });
         }
 
@@ -1325,6 +1486,7 @@ impl SendStream {
                 fc,
                 conn_fc,
                 send_buf,
+                ..
             } => {
                 let sent = send_buf.send(buf);
                 fc.consume(sent);
@@ -1342,68 +1504,146 @@ impl SendStream {
                     send_buf: TxBuffer::new(),
                     fin_sent: false,
                     fin_acked: false,
+                    committed: 0,
                 });
             }
-            State::Send { send_buf, .. } => {
+            State::Send {
+                send_buf,
+                committed,
+                ..
+            } => {
                 let owned_buf = mem::replace(send_buf, TxBuffer::new());
+                let committed = *committed;
                 self.state.transition(State::DataSent {
                     send_buf: owned_buf,
                     fin_sent: false,
                     fin_acked: false,
+                    committed,
                 });
             }
             State::DataSent { .. } => qtrace!("[{self}] already in DataSent state"),
             State::DataRecvd { .. } => qtrace!("[{self}] already in DataRecvd state"),
             State::ResetSent { .. } => qtrace!("[{self}] already in ResetSent state"),
+            State::ResetSentReliable { .. } => {
+                qtrace!("[{self}] already in ResetSentReliable state");
+            }
             State::ResetRecvd { .. } => qtrace!("[{self}] already in ResetRecvd state"),
         }
     }
 
+    /// Commit to reliably delivering all data buffered so far: that prefix is delivered even if
+    /// the stream is later reset (via `RESET_STREAM_AT`). Call this *after* writing the data to
+    /// be protected. The committed offset only ever grows (the buffered total never shrinks).
+    /// The caller is responsible for ensuring that their peer supports this feature.
+    ///
+    /// # Errors
+    /// [`Error::StreamState`] when the stream has already been reset.
+    pub fn commit(&mut self) -> Res<()> {
+        match &mut self.state {
+            // Nothing has been buffered yet, so the implicit committed offset stays 0; and once
+            // all data has been received there is nothing left to commit. Both are no-ops.
+            State::Ready { .. } | State::DataRecvd { .. } => Ok(()),
+            State::Send {
+                send_buf,
+                committed,
+                ..
+            }
+            | State::DataSent {
+                send_buf,
+                committed,
+                ..
+            } => {
+                *committed = send_buf.used();
+                Ok(())
+            }
+            State::ResetSent { .. }
+            | State::ResetSentReliable { .. }
+            | State::ResetRecvd { .. } => Err(Error::StreamState),
+        }
+    }
+
+    /// Reset the stream. When a non-zero commitment exists (set via [`Self::commit`], which is
+    /// only reachable when the peer supports the feature), a `RESET_STREAM_AT` is emitted
+    /// (reliably delivering `[0, reliable_size)`); otherwise a plain `RESET_STREAM` is sent.
     #[allow(
         clippy::allow_attributes,
         clippy::missing_panics_doc,
         reason = "OK here."
     )]
     pub fn reset(&mut self, err: AppError) {
-        match &self.state {
-            State::Ready { fc, .. } => {
-                let final_size = fc.used();
-                self.state.transition(State::ResetSent {
+        /// Build the reset state for a stream that has a `send_buf`, choosing between a buffer-less
+        /// `ResetSent` and a `ResetSentReliable` that retains the buffer for committed data.
+        fn make_reset_state(
+            err: AppError,
+            priority: TransmissionPriority,
+            send_buf: &mut TxBuffer,
+            final_size: u64,
+            committed: u64,
+        ) -> State {
+            // A non-zero committed offset implies the peer supports reliable reset (`commit`
+            // enforces that), so it is safe to emit `RESET_STREAM_AT`.
+            let reliable_size = min(committed, final_size);
+            let final_retired = send_buf.retired();
+            let final_written = u64::try_from(send_buf.buffered()).expect("usize fits in u64");
+            if reliable_size == 0 || final_retired >= reliable_size {
+                // No committed data is still outstanding: drop the buffer.
+                State::ResetSent {
                     err,
                     final_size,
-                    priority: Some(self.priority),
-                    final_retired: 0,
-                    final_written: 0,
-                });
-            }
-            State::Send { fc, send_buf, .. } => {
-                let final_size = fc.used();
-                let final_retired = send_buf.retired();
-                let buffered = u64::try_from(send_buf.buffered()).expect("usize fits in u64");
-                self.state.transition(State::ResetSent {
-                    err,
-                    final_size,
-                    priority: Some(self.priority),
+                    reliable_size,
+                    priority: Some(priority),
                     final_retired,
-                    final_written: buffered,
-                });
-            }
-            State::DataSent { send_buf, .. } => {
-                let final_size = send_buf.used();
-                let final_retired = send_buf.retired();
-                let buffered = u64::try_from(send_buf.buffered()).expect("usize fits in u64");
-                self.state.transition(State::ResetSent {
+                    final_written,
+                }
+            } else {
+                // Committed data below `reliable_size` is still in flight: keep the buffer.
+                State::ResetSentReliable {
+                    send_buf: mem::take(send_buf),
                     err,
                     final_size,
-                    priority: Some(self.priority),
-                    final_retired,
-                    final_written: buffered,
-                });
+                    reliable_size,
+                    reset_acked: false,
+                    priority: Some(priority),
+                }
             }
-            State::DataRecvd { .. } => qtrace!("[{self}] already in DataRecvd state"),
-            State::ResetSent { .. } => qtrace!("[{self}] already in ResetSent state"),
-            State::ResetRecvd { .. } => qtrace!("[{self}] already in ResetRecvd state"),
         }
+
+        let priority = self.priority;
+        let new_state = match &mut self.state {
+            State::Ready { fc, .. } => State::ResetSent {
+                err,
+                final_size: fc.used(),
+                reliable_size: 0,
+                priority: Some(priority),
+                final_retired: 0,
+                final_written: 0,
+            },
+            State::Send {
+                fc,
+                send_buf,
+                committed,
+                ..
+            } => {
+                let final_size = fc.used();
+                make_reset_state(err, priority, send_buf, final_size, *committed)
+            }
+            State::DataSent {
+                send_buf,
+                committed,
+                ..
+            } => {
+                let final_size = send_buf.used();
+                make_reset_state(err, priority, send_buf, final_size, *committed)
+            }
+            State::DataRecvd { .. }
+            | State::ResetSent { .. }
+            | State::ResetSentReliable { .. }
+            | State::ResetRecvd { .. } => {
+                qtrace!("[{}] reset called in terminal state", self.stream_id);
+                return;
+            }
+        };
+        self.state.transition(new_state);
     }
 
     #[cfg(test)]
@@ -1870,7 +2110,7 @@ mod tests {
 
     use super::RecoveryToken;
     use crate::{
-        ConnectionEvents, INITIAL_LOCAL_MAX_STREAM_DATA, StreamId,
+        ConnectionEvents, Error, INITIAL_LOCAL_MAX_STREAM_DATA, StreamId,
         connection::{RetransmissionPriority, TransmissionPriority},
         events::ConnectionEvent,
         fc::SenderFlowControl,
@@ -3015,6 +3255,7 @@ mod tests {
             fc,
             conn_fc,
             send_buf,
+            committed: 0,
         };
         s
     }
@@ -3355,6 +3596,7 @@ mod tests {
         let mut tokens = recovery::Tokens::new();
         let mut stats = FrameStats::default();
         s.write_reset_frame(priority, &mut builder, &mut tokens, &mut stats)
+            && (stats.reset_stream + stats.reset_stream_at == 1)
     }
 
     #[test]
@@ -3514,5 +3756,307 @@ mod tests {
         // Reset lost: priority set back to Some(effective_priority).
         s.reset_lost();
         assert_has_data_only_at(&mut s, &[eff]);
+    }
+
+    // --- RESET_STREAM_AT (reliable stream reset) ---
+
+    const RR_STREAM: StreamId = StreamId::new(100);
+
+    /// A `Send`-state stream with `data` buffered and a generous flow-control window, sharing the
+    /// caller's `ConnectionEvents` so emitted events (e.g. `SendStreamComplete`) can be observed.
+    fn reliable_stream(data: &[u8], events: ConnectionEvents) -> SendStream {
+        let len = data.len() as u64;
+        let mut s = SendStream::new(RR_STREAM, 0, connection_fc(len * 2), events);
+        s.set_max_stream_data(len * 2);
+        s.send(data).unwrap();
+        s
+    }
+
+    /// A `Send`-state stream that buffers `prefix`, commits it (so the committed offset is
+    /// `prefix.len()`), then buffers `rest`. Used to test a committed prefix smaller than the
+    /// final size.
+    fn reliable_stream_committed(
+        prefix: &[u8],
+        rest: &[u8],
+        events: ConnectionEvents,
+    ) -> SendStream {
+        let total = (prefix.len() + rest.len()) as u64;
+        let mut s = SendStream::new(RR_STREAM, 0, connection_fc(total * 2), events);
+        s.set_max_stream_data(total * 2);
+        s.send(prefix).unwrap();
+        s.commit().unwrap();
+        if !rest.is_empty() {
+            s.send(rest).unwrap();
+        }
+        s
+    }
+
+    /// Write the pending reset frame at `Normal` priority and return the frame stats.
+    fn send_reset_frame(s: &mut SendStream) -> FrameStats {
+        let mut builder =
+            packet::Builder::short(Encoder::default(), false, None::<&[u8]>, packet::LIMIT);
+        let mut tokens = recovery::Tokens::new();
+        let mut stats = FrameStats::default();
+        assert!(s.write_reset_frame(
+            TransmissionPriority::Normal,
+            &mut builder,
+            &mut tokens,
+            &mut stats
+        ));
+        stats
+    }
+
+    /// `commit` is a no-op in `Ready`, succeeds once data is buffered, and fails after reset.
+    #[test]
+    fn commit_validation() {
+        let mut s = SendStream::new(
+            RR_STREAM,
+            1024,
+            connection_fc(1024),
+            ConnectionEvents::default(),
+        );
+        // In `Ready` there is nothing to commit, but it is not an error.
+        assert!(matches!(s.state(), State::Ready { .. }));
+        assert!(s.commit().is_ok());
+
+        // In `Send`, commit captures the buffered data.
+        s.send(&[0x42; 10]).unwrap();
+        assert!(matches!(s.state(), State::Send { .. }));
+        assert!(s.commit().is_ok());
+
+        // After reset, commit fails with a stream-state error.
+        s.reset(0);
+        assert!(matches!(s.state(), State::ResetSentReliable { .. }));
+        assert_eq!(s.commit().unwrap_err(), Error::StreamState);
+    }
+
+    /// `commit` after the stream has been fully received (`DataRecvd`) is a no-op.
+    #[test]
+    fn commit_after_received_is_noop() {
+        let mut s = reliable_stream(&[0x42; 5], ConnectionEvents::default());
+        s.close();
+        s.mark_as_sent(0, 5, true);
+        s.mark_as_acked(0, 5, true);
+        assert!(matches!(s.state(), State::DataRecvd { .. }));
+        assert!(s.commit().is_ok());
+    }
+
+    /// Without a commitment, a reset emits a plain `RESET_STREAM`.
+    #[test]
+    fn reset_without_commit_is_plain() {
+        let mut s = reliable_stream(&[0x42; 10], ConnectionEvents::default());
+        s.reset(0);
+        assert!(matches!(
+            s.state(),
+            State::ResetSent {
+                reliable_size: 0,
+                ..
+            }
+        ));
+        let stats = send_reset_frame(&mut s);
+        assert_eq!(stats.reset_stream, 1);
+        assert_eq!(stats.reset_stream_at, 0);
+    }
+
+    /// A commitment with the peer's support and data still in flight enters `ResetSentReliable`
+    /// and emits `RESET_STREAM_AT`.
+    #[test]
+    fn reset_with_commit_emits_reset_stream_at() {
+        let mut s = reliable_stream_committed(&[0x42; 5], &[0x42; 5], ConnectionEvents::default());
+        s.reset(0);
+        assert!(matches!(
+            s.state(),
+            State::ResetSentReliable {
+                reliable_size: 5,
+                ..
+            }
+        ));
+        let stats = send_reset_frame(&mut s);
+        assert_eq!(stats.reset_stream, 0);
+        assert_eq!(stats.reset_stream_at, 1);
+    }
+
+    /// When all committed data is already acked at reset time, the buffer is dropped (the
+    /// stream uses `ResetSent`) but `RESET_STREAM_AT` is still emitted.
+    #[test]
+    fn reset_with_commit_already_acked_drops_buffer() {
+        let mut s = reliable_stream_committed(&[0x42; 5], &[0x42; 5], ConnectionEvents::default());
+        s.mark_as_sent(0, 10, false);
+        s.mark_as_acked(0, 5, false); // retire up to the committed offset
+        s.reset(0);
+        assert!(matches!(
+            s.state(),
+            State::ResetSent {
+                reliable_size: 5,
+                ..
+            }
+        ));
+        let stats = send_reset_frame(&mut s);
+        assert_eq!(stats.reset_stream_at, 1);
+    }
+
+    /// A reliable reset commits at most `final_size` and never emits a STREAM FIN, capping
+    /// (re)transmission at the reliable offset.
+    #[test]
+    fn reliable_reset_caps_data_and_omits_fin() {
+        let mut s = reliable_stream_committed(&[0x42; 4], &[0x42; 6], ConnectionEvents::default());
+        s.reset(0);
+
+        // No final size is reported, so STREAM frames never carry a FIN.
+        assert_eq!(s.final_size(), None);
+
+        // Only `[0, 4)` is offered.
+        let (offset, data) = s.next_bytes(false).expect("committed data");
+        assert_eq!(offset, 0);
+        assert_eq!(data.len(), 4);
+        s.mark_as_sent(0, 4, false);
+        assert!(!s.has_next_bytes(false));
+
+        // A loss below the reliable offset is retransmitted; nothing above it ever is.
+        s.mark_as_lost(0, 4, false);
+        let (offset, data) = s.next_bytes(false).expect("retransmit committed data");
+        assert_eq!(offset, 0);
+        assert_eq!(data.len(), 4);
+    }
+
+    /// On a retransmission, only lost data below the retransmission offset is offered; fresh
+    /// data (still below `reliable_size`) is not pulled forward to the retransmission priority.
+    #[test]
+    fn reliable_reset_retransmission_respects_offset() {
+        // Commit all 8 bytes, so `reliable_size == 8`.
+        let mut s = reliable_stream_committed(&[0x42; 8], &[], ConnectionEvents::default());
+        s.reset(0);
+
+        // Send `[0, 4)`; `[4, 8)` remains unsent. Then lose `[0, 2)` (retransmission offset = 2).
+        s.mark_as_sent(0, 4, false);
+        s.mark_as_lost(0, 2, false);
+
+        // Retransmission only offers the lost `[0, 2)`.
+        assert!(s.has_next_bytes(true));
+        let (offset, data) = s.next_bytes(true).expect("retransmit lost data");
+        assert_eq!(offset, 0);
+        assert_eq!(data.len(), 2);
+        s.mark_as_sent(0, 2, false);
+
+        // Nothing more to retransmit: fresh `[4, 8)` is above the retransmission offset.
+        assert!(!s.has_next_bytes(true));
+        assert!(s.next_bytes(true).is_none());
+
+        // But it is still available as a fresh send (below `reliable_size`).
+        assert!(s.has_next_bytes(false));
+        let (offset, data) = s.next_bytes(false).expect("fresh committed data");
+        assert_eq!(offset, 4);
+        assert_eq!(data.len(), 4);
+    }
+
+    /// Data-then-frame ack order reaches `ResetRecvd` without firing `SendStreamComplete`.
+    #[test]
+    fn reliable_reset_completion_data_then_frame() {
+        let events = ConnectionEvents::default();
+        let mut s = reliable_stream_committed(&[0x42; 5], &[0x42; 5], events);
+        s.reset(0);
+        s.mark_as_sent(0, 5, false);
+        _ = send_reset_frame(&mut s);
+        assert!(matches!(
+            s.state(),
+            State::ResetSentReliable {
+                reliable_size: 5,
+                reset_acked: false,
+                ..
+            }
+        ));
+
+        // Ack the committed data first: collapses to ResetSent, not yet ended.
+        s.mark_as_acked(0, 5, false);
+        assert!(matches!(
+            s.state(),
+            State::ResetSent {
+                reliable_size: 5,
+                ..
+            }
+        ));
+        assert!(!s.is_ended());
+
+        s.reset_acked();
+        assert!(s.is_ended());
+    }
+
+    /// Frame-then-data ack order reaches `ResetRecvd` without firing `SendStreamComplete`.
+    #[test]
+    fn reliable_reset_completion_frame_then_data() {
+        let events = ConnectionEvents::default();
+        let mut s = reliable_stream_committed(&[0x42; 5], &[0x42; 5], events);
+        s.reset(0);
+        s.mark_as_sent(0, 5, false);
+        _ = send_reset_frame(&mut s);
+
+        // Ack the frame first: stays in ResetSentReliable awaiting the data.
+        s.reset_acked();
+        assert!(matches!(s.state(), State::ResetSentReliable { .. }));
+        assert!(!s.is_ended());
+
+        s.mark_as_acked(0, 5, false);
+        assert!(s.is_ended());
+    }
+
+    /// When the committed data is already acked at reset time, the eventual frame ack reaches
+    /// `ResetRecvd` without firing `SendStreamComplete`.
+    #[test]
+    fn reliable_reset_completion_preacked() {
+        let events = ConnectionEvents::default();
+        let mut s = reliable_stream_committed(&[0x42; 5], &[0x42; 5], events);
+        s.mark_as_sent(0, 10, false);
+        s.mark_as_acked(0, 5, false);
+        s.reset(0);
+        _ = send_reset_frame(&mut s);
+        assert!(matches!(
+            s.state(),
+            State::ResetSent {
+                reliable_size: 5,
+                ..
+            }
+        ));
+
+        s.reset_acked();
+        assert!(s.is_ended());
+    }
+
+    /// Neither a plain reset nor a reliable reset fires `SendStreamComplete`.
+    #[test]
+    fn reset_does_not_complete() {
+        let mut events = ConnectionEvents::default();
+        let mut s = reliable_stream(&[0x42; 10], events.clone());
+        s.reset(0);
+        _ = send_reset_frame(&mut s);
+        s.reset_acked();
+        assert!(s.is_ended());
+
+        let mut s = reliable_stream_committed(&[0x42; 5], &[0x42; 5], events.clone());
+        s.mark_as_sent(0, 10, false);
+        s.mark_as_acked(0, 5, false);
+        s.reset(0);
+        _ = send_reset_frame(&mut s);
+        s.reset_acked();
+        assert!(s.is_ended());
+
+        let completions = events
+            .events()
+            .filter(|e| matches!(e, ConnectionEvent::SendStreamComplete { .. }))
+            .count();
+        assert_eq!(completions, 0);
+    }
+
+    /// A lost reliable reset frame is re-armed for retransmission.
+    #[test]
+    fn reliable_reset_frame_lost_rearms() {
+        let mut s = reliable_stream_committed(&[0x42; 5], &[0x42; 5], ConnectionEvents::default());
+        s.reset(0);
+        assert!(reset_frame_written(&mut s, TransmissionPriority::Normal));
+        // In flight: nothing pending at Normal.
+        assert!(!reset_frame_written(&mut s, TransmissionPriority::Normal));
+        // Lost: re-armed at effective priority (Normal + default retransmission).
+        s.reset_lost();
+        let eff = TransmissionPriority::Normal + RetransmissionPriority::default();
+        assert!(reset_frame_written(&mut s, eff));
     }
 }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -852,12 +852,15 @@ impl SendStream {
         self.sendorder = sendorder;
     }
 
-    /// If all data has been buffered or written, how much was sent.
+    /// If the stream's final size is established, what it is. This is known once the stream is
+    /// closed (`DataSent`) or reset (`ResetSent`/`ResetSentReliable`).
     #[must_use]
     pub fn final_size(&self) -> Option<u64> {
         match &self.state {
             State::DataSent { send_buf, .. } => Some(send_buf.used()),
-            State::ResetSent { final_size, .. } => Some(*final_size),
+            State::ResetSent { final_size, .. } | State::ResetSentReliable { final_size, .. } => {
+                Some(*final_size)
+            }
             _ => None,
         }
     }
@@ -1060,7 +1063,13 @@ impl SendStream {
         };
 
         let id = self.stream_id;
-        let final_size = self.final_size();
+        // Avoid `Self::final_size`, because we don't want to send the FIN flag
+        // after `RESET_STREAM_AT`, even if we have all the data.
+        // If we did, packet loss or reordering could drop the reset being delivered.
+        let fin_offset = match &self.state {
+            State::DataSent { send_buf, .. } => Some(send_buf.used()),
+            _ => None,
+        };
         if let Some((offset, data)) = self.next_bytes(retransmission) {
             let overhead = 1 // Frame type
                 + Encoder::varint_len(id.as_u64())
@@ -1075,8 +1084,8 @@ impl SendStream {
             }
 
             let (length, fill) = Self::length_and_fill(data.len(), builder.remaining() - overhead);
-            let fin = final_size
-                .is_some_and(|fs| fs == offset + u64::try_from(length).expect("usize fits in u64"));
+            let fin = fin_offset
+                .is_some_and(|fo| fo == offset + u64::try_from(length).expect("usize fits in u64"));
             if length == 0 && !fin {
                 qtrace!("[{self}] write_frame no data, no fin");
                 return;
@@ -3902,8 +3911,8 @@ mod tests {
         let mut s = reliable_stream_committed(&[0x42; 4], &[0x42; 6], ConnectionEvents::default());
         s.reset(0);
 
-        // No final size is reported, so STREAM frames never carry a FIN.
-        assert_eq!(s.final_size(), None);
+        // The final size is reported accurately even while reliably resetting.
+        assert_eq!(s.final_size(), Some(10));
 
         // Only `[0, 4)` is offered.
         let (offset, data) = s.next_bytes(false).expect("committed data");
@@ -3917,6 +3926,33 @@ mod tests {
         let (offset, data) = s.next_bytes(false).expect("retransmit committed data");
         assert_eq!(offset, 0);
         assert_eq!(data.len(), 4);
+    }
+
+    /// Even when the committed prefix equals the final size (so the written data offset reaches
+    /// `final_size`), a reliable reset's STREAM frame carries no FIN.
+    #[test]
+    fn reliable_reset_omits_fin_at_final_size() {
+        // Commit all 5 bytes, so reliable_size == final_size == 5.
+        let mut s = reliable_stream_committed(&[0x42; 5], &[], ConnectionEvents::default());
+        s.reset(0);
+        assert_eq!(s.final_size(), Some(5));
+
+        let mut builder =
+            packet::Builder::short(Encoder::default(), false, None::<&[u8]>, packet::LIMIT);
+        let mut tokens = recovery::Tokens::new();
+        let mut stats = FrameStats::default();
+        s.write_stream_frame(
+            TransmissionPriority::Normal,
+            &mut builder,
+            &mut tokens,
+            &mut stats,
+        );
+        assert_eq!(stats.stream, 1);
+        assert_eq!(tokens.len(), 1);
+        assert!(
+            !as_stream_token(&tokens.remove(0)).fin,
+            "reliable reset must not emit a FIN"
+        );
     }
 
     /// On a retransmission, only lost data below the retransmission offset is offered; fresh

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -28,6 +28,7 @@ pub struct FrameStats {
     pub crypto: usize,
     pub stream: usize,
     pub reset_stream: usize,
+    pub reset_stream_at: usize,
     pub stop_sending: usize,
 
     pub ping: usize,
@@ -68,8 +69,8 @@ impl Debug for FrameStats {
         )?;
         writeln!(
             f,
-            "    stream {} reset {} stop {}",
-            self.stream, self.reset_stream, self.stop_sending,
+            "    stream {} reset {} reset_at {} stop {}",
+            self.stream, self.reset_stream, self.reset_stream_at, self.stop_sending,
         )?;
         writeln!(
             f,
@@ -101,6 +102,7 @@ impl FrameStats {
             + self.crypto
             + self.stream
             + self.reset_stream
+            + self.reset_stream_at
             + self.stop_sending
             + self.ping
             + self.padding
@@ -604,7 +606,7 @@ fn debug() {
   frames rx:
     crypto 0 done 0 token 0 close 0
     ack 0 (max 0) ping 0 padding 0
-    stream 0 reset 0 stop 0
+    stream 0 reset 0 reset_at 0 stop 0
     max: stream 0 data 0 stream_data 0
     blocked: stream 0 data 0 stream_data 0
     datagram 0
@@ -613,7 +615,7 @@ fn debug() {
   frames tx:
     crypto 0 done 0 token 0 close 0
     ack 0 (max 0) ping 0 padding 0
-    stream 0 reset 0 stop 0
+    stream 0 reset 0 reset_at 0 stop 0
     max: stream 0 data 0 stream_data 0
     blocked: stream 0 data 0 stream_data 0
     datagram 0

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -161,6 +161,7 @@ impl Streams {
                 final_size,
                 reliable_size,
             } => {
+                stats.reset_stream_at += 1;
                 // We must have advertised support to legitimately receive this frame.
                 if !self.tps.borrow().local().get_empty(ResetStreamAt) {
                     return Err(Error::ProtocolViolation);
@@ -168,7 +169,6 @@ impl Streams {
                 if stream_id.is_send_only(self.role) {
                     return Err(Error::StreamState);
                 }
-                stats.reset_stream_at += 1;
                 if self.obtain_stream(*stream_id)?.1.is_some() {
                     self.recv.reset(
                         *stream_id,

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -191,6 +191,9 @@ impl Streams {
                 self.events
                     .send_stream_stop_sending(*stream_id, *application_error_code);
                 if let (Some(ss), _) = self.obtain_stream(*stream_id)? {
+                    // The peer has no interest in this data, so drop any commitment and send a
+                    // plain RESET_STREAM rather than reliably delivering the committed prefix.
+                    ss.drop_commitment();
                     ss.reset(*application_error_code);
                 }
             }

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -27,7 +27,7 @@ use crate::{
     tparams::{
         TransportParameterId::{
             InitialMaxData, InitialMaxStreamDataBidiLocal, InitialMaxStreamDataBidiRemote,
-            InitialMaxStreamDataUni, InitialMaxStreamsBidi, InitialMaxStreamsUni,
+            InitialMaxStreamDataUni, InitialMaxStreamsBidi, InitialMaxStreamsUni, ResetStreamAt,
         },
         TransportParametersHandler,
     },
@@ -121,8 +121,29 @@ impl Streams {
             } => {
                 stats.reset_stream += 1;
                 if self.obtain_stream(*stream_id)?.1.is_some() {
+                    // A plain RESET_STREAM is a reliable reset with `reliable_size == 0`.
                     self.recv
-                        .reset_at(*stream_id, *application_error_code, *final_size, 0)?;
+                        .reset(*stream_id, *application_error_code, *final_size, 0)?;
+                }
+            }
+            Frame::ResetStreamAt {
+                stream_id,
+                application_error_code,
+                final_size,
+                reliable_size,
+            } => {
+                // We must have advertised support to legitimately receive this frame.
+                if !self.tps.borrow().local().get_empty(ResetStreamAt) {
+                    return Err(Error::ProtocolViolation);
+                }
+                stats.reset_stream_at += 1;
+                if self.obtain_stream(*stream_id)?.1.is_some() {
+                    self.recv.reset(
+                        *stream_id,
+                        *application_error_code,
+                        *final_size,
+                        *reliable_size,
+                    )?;
                 }
             }
             Frame::StopSending {

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -122,7 +122,7 @@ impl Streams {
                 stats.reset_stream += 1;
                 if self.obtain_stream(*stream_id)?.1.is_some() {
                     self.recv
-                        .reset(*stream_id, *application_error_code, *final_size)?;
+                        .reset_at(*stream_id, *application_error_code, *final_size, 0)?;
                 }
             }
             Frame::StopSending {

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -55,6 +55,8 @@ pub enum TransportParameterId {
     VersionInformation = 0x11,
     Scone = 0x219e,
     GreaseQuicBit = 0x2ab2,
+    // draft-ietf-quic-reliable-stream-reset
+    ResetStreamAt = 0x17_f758_6d2c_b571,
     MinAckDelay = 0xff02_de1a,
     MaxDatagramFrameSize = 0x0020,
     #[cfg(test)]
@@ -323,7 +325,8 @@ impl TransportParameter {
             },
             TransportParameterId::DisableMigration
             | TransportParameterId::GreaseQuicBit
-            | TransportParameterId::Scone => Self::Empty,
+            | TransportParameterId::Scone
+            | TransportParameterId::ResetStreamAt => Self::Empty,
             TransportParameterId::PreferredAddress => Self::decode_preferred_address(&mut d)?,
             TransportParameterId::MinAckDelay => match d.decode_varint() {
                 Some(v) if v < (1 << 24) => Self::Integer(v),
@@ -514,7 +517,8 @@ impl TransportParameters {
         match tp {
             TransportParameterId::DisableMigration
             | TransportParameterId::GreaseQuicBit
-            | TransportParameterId::Scone => {
+            | TransportParameterId::Scone
+            | TransportParameterId::ResetStreamAt => {
                 self.set(tp, TransportParameter::Empty);
             }
             _ => panic!("Transport parameter not known or not type empty"),
@@ -586,6 +590,17 @@ impl TransportParameters {
                 continue;
             }
 
+            // Other parameters need to be checked manually, because they
+            // require that the previous value be remembered and available for use.
+            // Thus, the new setting needs to be compatible with the old one.
+            //
+            // This is because the feature might be used in 0-RTT, which is impossible
+            // to separate from regular 1-RTT data (given retransmission), so features
+            // used in 0-RTT cannot be disabled if they are remembered.
+            //
+            // For empty values, that just means being present;
+            // for integer values, *generally* the value has to be larger;
+            // any other types either need to be ignorable or have special handling.
             let ok = self.params[k]
                 .as_ref()
                 .is_some_and(|v_self| match (v_self, v_rem) {
@@ -963,6 +978,7 @@ mod tests {
         assert!(!tps2.has_value(RetrySourceConnectionId));
         assert!(!tps2.has_value(Scone));
         assert!(!tps2.has_value(PreferredAddress));
+        assert!(!tps2.has_value(ResetStreamAt));
         assert!(tps2.has_value(StatelessResetToken));
 
         let mut enc = Encoder::default();
@@ -1237,6 +1253,67 @@ mod tests {
         let tps = TransportParameters::decode(&mut enc.as_decoder()).expect("should decode");
         assert_eq!(tps.get_integer(IdleTimeout), 10);
         assert_eq!(tps.get_integer(InitialMaxData), 20);
+    }
+
+    /// The `reset_stream_at` transport parameter is an empty parameter that round-trips.
+    #[test]
+    fn reset_stream_at_empty_round_trip() {
+        let mut tps = TransportParameters::default();
+        assert!(!tps.get_empty(ResetStreamAt));
+        tps.set_empty(ResetStreamAt);
+        assert!(tps.get_empty(ResetStreamAt));
+
+        let mut enc = Encoder::default();
+        tps.encode(&mut enc);
+        let tps2 = TransportParameters::decode(&mut enc.as_decoder()).expect("should decode");
+        assert!(tps2.get_empty(ResetStreamAt));
+        assert_eq!(tps, tps2);
+    }
+
+    /// A `reset_stream_at` transport parameter carrying a non-empty value is rejected.
+    #[test]
+    fn reset_stream_at_non_empty_rejected() {
+        let mut enc = Encoder::default();
+        enc.encode_varint(ResetStreamAt);
+        enc.encode_vvec(&[0x01]); // non-empty content
+        assert_eq!(
+            TransportParameter::decode(&mut enc.as_decoder()).unwrap_err(),
+            Error::TooMuchData
+        );
+    }
+
+    /// A duplicate `reset_stream_at` transport parameter is rejected.
+    #[test]
+    fn reset_stream_at_duplicate_rejected() {
+        let mut enc = Encoder::default();
+        TransportParameter::Empty.encode(&mut enc, ResetStreamAt);
+        TransportParameter::Empty.encode(&mut enc, ResetStreamAt);
+        assert_eq!(
+            TransportParameters::decode(&mut enc.as_decoder()).unwrap_err(),
+            Error::TransportParameter
+        );
+    }
+
+    /// When the server accepts 0-RTT it MUST NOT disable `reset_stream_at` on the resumed
+    /// connection: if it was remembered (advertised on the original connection) but is not
+    /// currently offered, 0-RTT must be rejected.
+    #[test]
+    fn reset_stream_at_ok_for_0rtt() {
+        let mut remembered = TransportParameters::default();
+        remembered.set_empty(ResetStreamAt);
+
+        // Remembered, but not currently offered: 0-RTT is NOT OK (would disable the extension).
+        let current = TransportParameters::default();
+        assert!(!current.ok_for_0rtt(&remembered));
+
+        // Offered on both sides: OK (extension is preserved).
+        let mut current = TransportParameters::default();
+        current.set_empty(ResetStreamAt);
+        assert!(current.ok_for_0rtt(&remembered));
+
+        // Not remembered, but currently offered: OK (offering more is always fine).
+        let remembered = TransportParameters::default();
+        assert!(current.ok_for_0rtt(&remembered));
     }
 
     #[test]

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -53,10 +53,11 @@ pub enum TransportParameterId {
     InitialSourceConnectionId = 0x0f,
     RetrySourceConnectionId = 0x10,
     VersionInformation = 0x11,
+    // draft-ietf-quic-reliable-stream-reset
+    ResetStreamAt = 0x1d,
+    // draft-ietf-scone-protocol
     Scone = 0x219e,
     GreaseQuicBit = 0x2ab2,
-    // draft-ietf-quic-reliable-stream-reset
-    ResetStreamAt = 0x17_f758_6d2c_b571,
     MinAckDelay = 0xff02_de1a,
     MaxDatagramFrameSize = 0x0020,
     #[cfg(test)]


### PR DESCRIPTION
This implements [draft-ietf-quic-reliable-stream-reset-07](https://datatracker.ietf.org/doc/html/draft-ietf-quic-reliable-stream-reset-07).

Draft until I've rebased, but the work is basically complete.