### PR TITLE
fix: enforce qpack blocked stream limit in decode_header_block

### DIFF
--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -216,16 +216,16 @@ impl Decoder {
 
         match decoder.decode_header_block(&self.table, self.max_entries, self.table.base()) {
             Ok(HeaderDecoderResult::Blocked(req_insert_cnt)) => {
-                if self.blocked_streams.len() > self.max_blocked_streams {
+                let found = self
+                    .blocked_streams
+                    .iter()
+                    .any(|(id, _req)| *id == stream_id);
+                if found {
+                    Ok(None)
+                } else if self.blocked_streams.len() >= self.max_blocked_streams {
                     Err(Error::Decompression)
                 } else {
-                    let found = self
-                        .blocked_streams
-                        .iter()
-                        .any(|(id, _req)| *id == stream_id);
-                    if !found {
-                        self.blocked_streams.push((stream_id, req_insert_cnt));
-                    }
+                    self.blocked_streams.push((stream_id, req_insert_cnt));
                     Ok(None)
                 }
             }
@@ -825,5 +825,46 @@ mod tests {
         recv_instruction(&mut decoder, ENCODER_INST, &Ok(()));
 
         decode_headers(&mut decoder, HEADER_BLOCK, &headers, STREAM_0);
+    }
+
+    #[test]
+    fn blocked_stream_limit_enforced() {
+        // A header block whose Required Insert Count refers to a dynamic table
+        // entry that has not been inserted yet leaves the stream blocked. RFC 9204
+        // Section 2.1.2 allows no more blocked streams than the advertised
+        // SETTINGS_QPACK_BLOCKED_STREAMS value; exceeding it is a connection error
+        // of type QPACK_DECOMPRESSION_FAILED (Error::Decompression here).
+        const BLOCKING_HEADER_BLOCK: &[u8] = &[0x02, 0x80, 0x10];
+
+        let mut decoder = Decoder::new(&Settings {
+            max_table_size_encoder: 0,
+            max_table_size_decoder: 300,
+            max_blocked_streams: 1,
+        });
+        // One blocked stream is within the advertised limit.
+        assert!(
+            decoder
+                .decode_header_block(BLOCKING_HEADER_BLOCK, StreamId::new(0))
+                .unwrap()
+                .is_none()
+        );
+        // A second, distinct stream is one more than advertised.
+        assert!(
+            decoder
+                .decode_header_block(BLOCKING_HEADER_BLOCK, StreamId::new(4))
+                .is_err()
+        );
+
+        // A limit of zero leaves no room for any blocked stream.
+        let mut decoder = Decoder::new(&Settings {
+            max_table_size_encoder: 0,
+            max_table_size_decoder: 300,
+            max_blocked_streams: 0,
+        });
+        assert!(
+            decoder
+                .decode_header_block(BLOCKING_HEADER_BLOCK, StreamId::new(0))
+                .is_err()
+        );
     }
 }


### PR DESCRIPTION
The QPACK decoder caps concurrently blocked streams at the SETTINGS_QPACK_BLOCKED_STREAMS value it advertised, but `decode_header_block` compares the count against that limit before the new stream is added to the list. Before this change a peer that references not-yet-inserted dynamic table entries across distinct streams left one more stream blocked than advertised, and with a limit of 0 it could still block one stream.

After this change the limit is checked only when a genuinely new stream would be recorded, so the decoder holds at most the advertised number, matching the encoder which already stops at `blocked_stream_cnt < max_blocked_streams`. RFC 9204 section 2.1.2 treats more blocked streams than advertised as a connection error of type QPACK_DECOMPRESSION_FAILED. The tradeoff is strictness: a peer that previously slipped one stream over the limit now closes the connection, which is what the setting is meant to enforce.