### PR TITLE
fix: Do not double-count PMTUD-related packet events in stats

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2469,8 +2469,8 @@ impl Connection {
     }
 
     /// Write frames to the provided builder.  Returns a list of tokens used for
-    /// tracking loss or acknowledgment, whether any frame was ACK eliciting, and
-    /// whether the packet was padded.
+    /// tracking loss or acknowledgment, whether any frame was ACK eliciting,
+    /// whether the packet was padded, and whether this is a PMTUD probe.
     fn write_frames(
         &mut self,
         path: &PathRef,
@@ -2479,10 +2479,11 @@ impl Connection {
         builder: &mut packet::Builder<&mut Vec<u8>>,
         coalesced: bool, // Whether this packet is coalesced behind another one.
         now: Instant,
-    ) -> (recovery::Tokens, bool, bool) {
+    ) -> (recovery::Tokens, bool, bool, bool) {
         let mut tokens = recovery::Tokens::new();
         let primary = path.borrow().is_primary();
         let mut ack_eliciting = false;
+        let mut is_pmtud_probe = false;
 
         if primary {
             let stats = &mut self.stats.borrow_mut().frame_tx;
@@ -2515,7 +2516,7 @@ impl Connection {
 
         if profile.ack_only() {
             // If we are CC limited we can only send ACKs!
-            return (tokens, false, false);
+            return (tokens, false, false, false);
         }
 
         if primary {
@@ -2531,6 +2532,7 @@ impl Connection {
                         &mut self.stats.borrow_mut(),
                     );
                     ack_eliciting = true;
+                    is_pmtud_probe = true;
                 }
                 self.write_appdata_frames(builder, &mut tokens, now);
             } else {
@@ -2569,7 +2571,7 @@ impl Connection {
             false
         };
 
-        (tokens, ack_eliciting, padded)
+        (tokens, ack_eliciting, padded, is_pmtud_probe)
     }
 
     fn write_closing_frames<B: Buffer>(
@@ -2778,12 +2780,12 @@ impl Connection {
 
             // Add frames to the packet.
             let payload_start = builder.len();
-            let (mut tokens, mut ack_eliciting, mut padded) =
-                (recovery::Tokens::new(), false, false);
+            let (mut tokens, mut ack_eliciting, mut padded, mut is_pmtud_probe) =
+                (recovery::Tokens::new(), false, false, false);
             if let Some(close) = closing_frame {
                 self.write_closing_frames(close, &mut builder, space, now, path, &mut tokens);
             } else {
-                (tokens, ack_eliciting, padded) =
+                (tokens, ack_eliciting, padded, is_pmtud_probe) =
                     self.write_frames(path, space, &profile, &mut builder, header_start != 0, now);
             }
             if builder.packet_empty() {
@@ -2810,7 +2812,7 @@ impl Connection {
                 now,
             );
 
-            if !tokens.iter().any(recovery::Token::is_pmtud_probe) {
+            if !is_pmtud_probe {
                 self.stats.borrow_mut().packets_tx += 1;
             }
             // Track which packet types are sent with which ECN codepoints. For
@@ -3058,7 +3060,7 @@ impl Connection {
             path.borrow_mut()
                 .pmtud_mut()
                 .set_peer_max_udp_payload(max_udp_payload);
-            self.stats.borrow_mut().pmtud_peer_max_udp_payload = Some(max_udp_payload);
+            self.stats.borrow_mut().pmtud.peer_max_udp_payload = Some(max_udp_payload);
 
             let max_ad = Duration::from_millis(remote.get_integer(MaxAckDelay));
             let min_ad = if remote.has_value(MinAckDelay) {

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2810,7 +2810,9 @@ impl Connection {
                 now,
             );
 
-            self.stats.borrow_mut().packets_tx += 1;
+            if !tokens.iter().any(recovery::Token::is_pmtud_probe) {
+                self.stats.borrow_mut().packets_tx += 1;
+            }
             // Track which packet types are sent with which ECN codepoints. For
             // coalesced packets, this increases the counts for each packet type
             // contained in the coalesced packet. This is per Section 13.4.1 of

--- a/neqo-transport/src/connection/tests/pmtud.rs
+++ b/neqo-transport/src/connection/tests/pmtud.rs
@@ -111,7 +111,7 @@ fn drive_pmtud(
     now
 }
 
-/// With an unlimited path MTU every probe in the search table is delivered and ACKed.
+/// With an unlimited path MTU every probe in the search table is delivered and acked.
 #[test]
 fn pmtud_stats_no_loss() {
     fixture_init();
@@ -127,18 +127,22 @@ fn pmtud_stats_no_loss() {
     );
     connect(&mut client, &mut server);
     drive_pmtud(&mut client, &mut server, usize::MAX, now());
+    // Every probe in the search table (minus the base) is sent, acked, and not lost.
+    // pmtud_tx is separate from packets_tx; probes are not double-counted there.
     assert_eq!(client.stats().pmtud_tx, SEARCH_TABLE_LEN - 1);
     assert_eq!(client.stats().pmtud_ack, SEARCH_TABLE_LEN - 1);
     assert_eq!(client.stats().pmtud_lost, 0);
 }
 
-/// With `path_mtu = 1420 - header_size`:
-/// * probe at 1380 (payload 1380 - header = 1332 ≤ path_mtu): delivered, ACKed
-/// * probe at 1420 (payload 1420 - header = 1372 = path_mtu): delivered, ACKed
-/// * probe at 1472 (payload 1472 - header = 1424 > path_mtu): dropped every attempt
+/// With `path_mtu = 1420 - header_size` (IPv6, header = 48 bytes, limit = 1372):
+/// * probe at 1380 (payload 1380 - 48 = 1332 ≤ 1372): delivered, acked
+/// * probe at 1420 (payload 1420 - 48 = 1372 = 1372): delivered, acked
+/// * probe at 1470 (payload 1470 - 48 = 1422 > 1372): dropped every attempt
 ///
-/// After `MAX_PROBES` consecutive failures at 1472 the algorithm stops, giving exactly
-/// 2 ACKed probes, `MAX_PROBES` lost probes, and `2 + MAX_PROBES` sent probes.
+/// After `MAX_PROBES` consecutive failures at 1470 the algorithm stops, giving exactly
+/// 2 acked probes, `MAX_PROBES` lost probes, and `2 + MAX_PROBES` sent probes.
+/// Since probes carry stream data (piggybacked via `write_appdata_frames`), lost probes
+/// also increment `stats.lost` in addition to `stats.pmtud_lost`.
 #[test]
 fn pmtud_stats_loss() {
     fixture_init();
@@ -166,6 +170,9 @@ fn pmtud_stats_loss() {
     assert_eq!(client.stats().pmtud_tx, 2 + MAX_PROBES);
     assert_eq!(client.stats().pmtud_ack, 2);
     assert_eq!(client.stats().pmtud_lost, MAX_PROBES);
+    // Probes carry stream data (piggybacked via write_appdata_frames), so lost
+    // probes also count in the general loss counter, not just pmtud_lost.
+    assert_eq!(client.stats().lost, MAX_PROBES);
 }
 
 /// Tests that when a client goes through a VPN (packets arrive from different IP),

--- a/neqo-transport/src/connection/tests/pmtud.rs
+++ b/neqo-transport/src/connection/tests/pmtud.rs
@@ -111,27 +111,32 @@ fn drive_pmtud(
     now
 }
 
+fn pmtud_client_server() -> (Connection, Connection) {
+    fixture_init();
+    let client = new_client(
+        ConnectionParameters::default()
+            .pmtud(true)
+            .pmtud_iface_mtu(false),
+    );
+    let server = new_server(
+        ConnectionParameters::default()
+            .pmtud(true)
+            .pmtud_iface_mtu(false),
+    );
+    (client, server)
+}
+
 /// With an unlimited path MTU every probe in the search table is delivered and acked.
 #[test]
 fn pmtud_stats_no_loss() {
-    fixture_init();
-    let mut client = new_client(
-        ConnectionParameters::default()
-            .pmtud(true)
-            .pmtud_iface_mtu(false),
-    );
-    let mut server = new_server(
-        ConnectionParameters::default()
-            .pmtud(true)
-            .pmtud_iface_mtu(false),
-    );
+    let (mut client, mut server) = pmtud_client_server();
     connect(&mut client, &mut server);
     drive_pmtud(&mut client, &mut server, usize::MAX, now());
     // Every probe in the search table (minus the base) is sent, acked, and not lost.
     // pmtud_tx is separate from packets_tx; probes are not double-counted there.
-    assert_eq!(client.stats().pmtud_tx, SEARCH_TABLE_LEN - 1);
-    assert_eq!(client.stats().pmtud_ack, SEARCH_TABLE_LEN - 1);
-    assert_eq!(client.stats().pmtud_lost, 0);
+    assert_eq!(client.stats().pmtud.tx, SEARCH_TABLE_LEN - 1);
+    assert_eq!(client.stats().pmtud.ack, SEARCH_TABLE_LEN - 1);
+    assert_eq!(client.stats().pmtud.lost, 0);
 }
 
 /// With `path_mtu = 1420 - header_size` (IPv6, header = 48 bytes, limit = 1372):
@@ -142,20 +147,10 @@ fn pmtud_stats_no_loss() {
 /// After `MAX_PROBES` consecutive failures at 1470 the algorithm stops, giving exactly
 /// 2 acked probes, `MAX_PROBES` lost probes, and `2 + MAX_PROBES` sent probes.
 /// Since probes carry stream data (piggybacked via `write_appdata_frames`), lost probes
-/// also increment `stats.lost` in addition to `stats.pmtud_lost`.
+/// also increment `stats.lost` in addition to `stats.pmtud.lost`.
 #[test]
 fn pmtud_stats_loss() {
-    fixture_init();
-    let mut client = new_client(
-        ConnectionParameters::default()
-            .pmtud(true)
-            .pmtud_iface_mtu(false),
-    );
-    let mut server = new_server(
-        ConnectionParameters::default()
-            .pmtud(true)
-            .pmtud_iface_mtu(false),
-    );
+    let (mut client, mut server) = pmtud_client_server();
     connect(&mut client, &mut server);
     let header_size = Pmtud::header_size(
         client
@@ -167,9 +162,9 @@ fn pmtud_stats_loss() {
             .ip(),
     );
     drive_pmtud(&mut client, &mut server, 1420 - header_size, now());
-    assert_eq!(client.stats().pmtud_tx, 2 + MAX_PROBES);
-    assert_eq!(client.stats().pmtud_ack, 2);
-    assert_eq!(client.stats().pmtud_lost, MAX_PROBES);
+    assert_eq!(client.stats().pmtud.tx, 2 + MAX_PROBES);
+    assert_eq!(client.stats().pmtud.ack, 2);
+    assert_eq!(client.stats().pmtud.lost, MAX_PROBES);
     // Probes carry stream data (piggybacked via write_appdata_frames), so lost
     // probes also count in the general loss counter, not just pmtud_lost.
     assert_eq!(client.stats().lost, MAX_PROBES);
@@ -228,7 +223,7 @@ fn vpn_migration_triggers_pmtud() {
     // Client receives the PATH_CHALLENGE. This triggers PMTUD restart on its path.
     let s1 = s1.unwrap();
     let s1_to_client = Datagram::new(s1.source(), c1.source(), s1.tos(), &s1[..]);
-    let client_pmtud_tx_before_challenge = client.stats().pmtud_tx;
+    let client_pmtud_tx_before_challenge = client.stats().pmtud.tx;
     let before_response = client.stats().frame_tx.path_response;
     let c2 = client.process(Some(s1_to_client), now).dgram();
     assert!(c2.is_some(), "Client should respond with PATH_RESPONSE");
@@ -240,15 +235,15 @@ fn vpn_migration_triggers_pmtud() {
     server.process_input(c2_via_vpn, now);
 
     // Record PMTUD probe counts before driving traffic on VPN path.
-    let server_pmtud_tx_before = server.stats().pmtud_tx;
+    let server_pmtud_tx_before = server.stats().pmtud.tx;
 
     // Drive PMTUD probing for both sides on the VPN path with smaller MTU.
     let now = drive_pmtud(&mut client, &mut server, vpn_path_mtu, now);
     drive_pmtud(&mut server, &mut client, vpn_path_mtu, now);
 
     // Verify server and client sent PMTUD probes on the new path.
-    assert!(server.stats().pmtud_tx > server_pmtud_tx_before);
-    assert!(client.stats().pmtud_tx > client_pmtud_tx_before_challenge);
+    assert!(server.stats().pmtud.tx > server_pmtud_tx_before);
+    assert!(client.stats().pmtud.tx > client_pmtud_tx_before_challenge);
 
     // Verify both sides' PMTU reflects the VPN path's smaller MTU.
     // vpn_path_mtu is 1400; the largest IPv6 search table entry <= 1400 is 1380.

--- a/neqo-transport/src/connection/tests/pmtud.rs
+++ b/neqo-transport/src/connection/tests/pmtud.rs
@@ -133,7 +133,7 @@ fn pmtud_stats_no_loss() {
     connect(&mut client, &mut server);
     drive_pmtud(&mut client, &mut server, usize::MAX, now());
     // Every probe in the search table (minus the base) is sent, acked, and not lost.
-    // pmtud_tx is separate from packets_tx; probes are not double-counted there.
+    // pmtud.tx is separate from packets_tx; probes are not double-counted there.
     assert_eq!(client.stats().pmtud.tx, SEARCH_TABLE_LEN - 1);
     assert_eq!(client.stats().pmtud.ack, SEARCH_TABLE_LEN - 1);
     assert_eq!(client.stats().pmtud.lost, 0);

--- a/neqo-transport/src/connection/tests/pmtud.rs
+++ b/neqo-transport/src/connection/tests/pmtud.rs
@@ -20,6 +20,7 @@ use crate::{
         CountingConnectionIdGenerator, DEFAULT_RTT, connect, default_server, fill_stream,
         new_client, new_server, send_something,
     },
+    pmtud::{MAX_PROBES, SEARCH_TABLE_LEN},
 };
 
 /// Test that one can reach the maximum MTU with GSO enabled.
@@ -108,6 +109,63 @@ fn drive_pmtud(
         }
     }
     now
+}
+
+/// With an unlimited path MTU every probe in the search table is delivered and ACKed.
+#[test]
+fn pmtud_stats_no_loss() {
+    fixture_init();
+    let mut client = new_client(
+        ConnectionParameters::default()
+            .pmtud(true)
+            .pmtud_iface_mtu(false),
+    );
+    let mut server = new_server(
+        ConnectionParameters::default()
+            .pmtud(true)
+            .pmtud_iface_mtu(false),
+    );
+    connect(&mut client, &mut server);
+    drive_pmtud(&mut client, &mut server, usize::MAX, now());
+    assert_eq!(client.stats().pmtud_tx, SEARCH_TABLE_LEN - 1);
+    assert_eq!(client.stats().pmtud_ack, SEARCH_TABLE_LEN - 1);
+    assert_eq!(client.stats().pmtud_lost, 0);
+}
+
+/// With `path_mtu = 1420 - header_size`:
+/// * probe at 1380 (payload 1380 - header = 1332 ≤ path_mtu): delivered, ACKed
+/// * probe at 1420 (payload 1420 - header = 1372 = path_mtu): delivered, ACKed
+/// * probe at 1472 (payload 1472 - header = 1424 > path_mtu): dropped every attempt
+///
+/// After `MAX_PROBES` consecutive failures at 1472 the algorithm stops, giving exactly
+/// 2 ACKed probes, `MAX_PROBES` lost probes, and `2 + MAX_PROBES` sent probes.
+#[test]
+fn pmtud_stats_loss() {
+    fixture_init();
+    let mut client = new_client(
+        ConnectionParameters::default()
+            .pmtud(true)
+            .pmtud_iface_mtu(false),
+    );
+    let mut server = new_server(
+        ConnectionParameters::default()
+            .pmtud(true)
+            .pmtud_iface_mtu(false),
+    );
+    connect(&mut client, &mut server);
+    let header_size = Pmtud::header_size(
+        client
+            .paths
+            .primary()
+            .unwrap()
+            .borrow()
+            .local_address()
+            .ip(),
+    );
+    drive_pmtud(&mut client, &mut server, 1420 - header_size, now());
+    assert_eq!(client.stats().pmtud_tx, 2 + MAX_PROBES);
+    assert_eq!(client.stats().pmtud_ack, 2);
+    assert_eq!(client.stats().pmtud_lost, MAX_PROBES);
 }
 
 /// Tests that when a client goes through a VPN (packets arrive from different IP),

--- a/neqo-transport/src/connection/tests/pmtud.rs
+++ b/neqo-transport/src/connection/tests/pmtud.rs
@@ -166,7 +166,7 @@ fn pmtud_stats_loss() {
     assert_eq!(client.stats().pmtud.ack, 2);
     assert_eq!(client.stats().pmtud.lost, MAX_PROBES);
     // Probes carry stream data (piggybacked via write_appdata_frames), so lost
-    // probes also count in the general loss counter, not just pmtud_lost.
+    // probes also count in the general loss counter, not just pmtud.lost.
     assert_eq!(client.stats().lost, MAX_PROBES);
 }
 

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -582,7 +582,7 @@ impl Path {
                         "Outbound interface {name} for destination {ip} has MTU {mtu}",
                         ip = remote.ip()
                     );
-                    stats.pmtud_iface_mtu = mtu;
+                    stats.pmtud.iface_mtu = mtu;
                     Some(mtu)
                 }
                 Err(e) => {

--- a/neqo-transport/src/pmtud.rs
+++ b/neqo-transport/src/pmtud.rs
@@ -105,7 +105,7 @@ impl Pmtud {
     fn set_mtu(&mut self, idx: usize, stats: &mut Stats, now: Instant) {
         let old_mtu = self.plpmtu();
         self.mtu = self.search_table[idx];
-        stats.pmtud_pmtu = self.mtu;
+        stats.pmtud.pmtu = self.mtu;
         let new_mtu = self.plpmtu();
         if old_mtu != new_mtu {
             let done = !self.needs_probe();
@@ -164,7 +164,7 @@ impl Pmtud {
         builder.encode_frame(FrameType::Ping, |_| {});
         tokens.push(recovery::Token::PmtudProbe);
         stats.frame_tx.ping += 1;
-        stats.pmtud_tx += 1;
+        stats.pmtud.tx += 1;
         self.probe_count += 1;
         self.probe_state = Probe::Sent;
         qdebug!(
@@ -201,7 +201,7 @@ impl Pmtud {
         }
 
         // A probe was ACKed, confirm the new MTU and try to probe upwards further.
-        stats.pmtud_ack += acked;
+        stats.pmtud.ack += acked;
         let confirmed_idx = self.probe_index;
         qdebug!(
             "PMTUD probe of size {} succeeded",
@@ -237,7 +237,7 @@ impl Pmtud {
         if lost == 0 {
             return;
         }
-        stats.pmtud_lost += lost;
+        stats.pmtud.lost += lost;
 
         if self.probe_count >= MAX_PROBES {
             // We've sent MAX_PROBES probes and they were all lost. Stop probing at the
@@ -388,15 +388,15 @@ mod tests {
         let encoder = builder.build(prot).unwrap();
         assert_eq!(encoder.len(), pmtud.probe_size());
         assert!(!pmtud.needs_probe());
-        assert_eq!(stats_before.pmtud_tx + 1, stats.pmtud_tx);
+        assert_eq!(stats_before.pmtud.tx + 1, stats.pmtud.tx);
 
         let packet = make_pmtud_probe(pn, now, encoder.len());
         if encoder.len() + Pmtud::header_size(addr) <= mtu {
             pmtud.on_packets_acked(&[packet], now, stats);
-            assert_eq!(stats_before.pmtud_ack + 1, stats.pmtud_ack);
+            assert_eq!(stats_before.pmtud.ack + 1, stats.pmtud.ack);
         } else {
             pmtud.on_packets_lost(&[packet], stats, now);
-            assert_eq!(stats_before.pmtud_lost + 1, stats.pmtud_lost);
+            assert_eq!(stats_before.pmtud.lost + 1, stats.pmtud.lost);
         }
     }
 
@@ -544,7 +544,7 @@ mod tests {
             &mut stats,
         );
         assert_mtu(&pmtud, MTU);
-        let initial_lost = stats.pmtud_lost;
+        let initial_lost = stats.pmtud.lost;
 
         // Lose various non-probe packets - should not change PMTUD state or stats.
         pmtud.on_packets_lost(&[], &mut stats, now);
@@ -557,7 +557,7 @@ mod tests {
         assert_eq!(Probe::NotNeeded, pmtud.probe_state);
 
         // No probe losses should have been recorded.
-        assert_eq!(initial_lost, stats.pmtud_lost);
+        assert_eq!(initial_lost, stats.pmtud.lost);
     }
 
     /// Tests that PMTUD respects the peer's `max_udp_payload_size` transport parameter
@@ -664,9 +664,9 @@ mod tests {
         // With probe_count >= MAX_PROBES, it takes exactly MAX_PROBES losses per probe size
         // before giving up. The first (minimum) probe size always fails MAX_PROBES times.
         assert!(
-            stats.pmtud_lost >= MAX_PROBES,
+            stats.pmtud.lost >= MAX_PROBES,
             "must lose at least MAX_PROBES ({MAX_PROBES}) probes, got {}",
-            stats.pmtud_lost
+            stats.pmtud.lost
         );
     }
 
@@ -688,7 +688,7 @@ mod tests {
             &mut stats,
         );
         assert_mtu(&pmtud, MTU);
-        let initial_ack = stats.pmtud_ack;
+        let initial_ack = stats.pmtud.ack;
 
         // ACK various non-probe packets - should not change PMTUD state.
         pmtud.on_packets_acked(&[], now, &mut stats);
@@ -701,6 +701,6 @@ mod tests {
         assert_eq!(Probe::NotNeeded, pmtud.probe_state);
 
         // No probe ACKs should have been recorded.
-        assert_eq!(initial_ack, stats.pmtud_ack);
+        assert_eq!(initial_ack, stats.pmtud.ack);
     }
 }

--- a/neqo-transport/src/pmtud.rs
+++ b/neqo-transport/src/pmtud.rs
@@ -32,10 +32,10 @@ const MTU_SIZES_V6: &[usize] = &[
     1470, 1500, 2047, 4095, 8191, 16383, 32767, 65535,
 ];
 const_assert!(MTU_SIZES_V4.len() == MTU_SIZES_V6.len());
-pub(crate) const SEARCH_TABLE_LEN: usize = MTU_SIZES_V4.len();
+pub const SEARCH_TABLE_LEN: usize = MTU_SIZES_V4.len();
 
 // From https://datatracker.ietf.org/doc/html/rfc8899#section-5.1
-pub(crate) const MAX_PROBES: usize = 3;
+pub const MAX_PROBES: usize = 3;
 const PMTU_RAISE_TIMER: Duration = Duration::from_secs(600);
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/neqo-transport/src/pmtud.rs
+++ b/neqo-transport/src/pmtud.rs
@@ -32,10 +32,10 @@ const MTU_SIZES_V6: &[usize] = &[
     1470, 1500, 2047, 4095, 8191, 16383, 32767, 65535,
 ];
 const_assert!(MTU_SIZES_V4.len() == MTU_SIZES_V6.len());
-const SEARCH_TABLE_LEN: usize = MTU_SIZES_V4.len();
+pub(crate) const SEARCH_TABLE_LEN: usize = MTU_SIZES_V4.len();
 
 // From https://datatracker.ietf.org/doc/html/rfc8899#section-5.1
-const MAX_PROBES: usize = 3;
+pub(crate) const MAX_PROBES: usize = 3;
 const PMTU_RAISE_TIMER: Duration = Duration::from_secs(600);
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -546,7 +546,7 @@ mod tests {
         assert_mtu(&pmtud, MTU);
         let initial_lost = stats.pmtud_lost;
 
-        // Lose various non-probe packets - should not change PMTUD state.
+        // Lose various non-probe packets - should not change PMTUD state or stats.
         pmtud.on_packets_lost(&[], &mut stats, now);
         assert_eq!(Probe::NotNeeded, pmtud.probe_state);
 

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -266,11 +266,13 @@ impl LossRecoverySpace {
         let mut eliciting = false;
         for p in &acked {
             self.remove_packet(p);
+            // PMTUD probes carry a PING and are ack-eliciting, so they contribute to
+            // `eliciting` for RTT sampling (RFC 9002 §5.1), but their loss/PTO recovery
+            // is handled by the PMTUD state machine, not here.
+            eliciting |= p.ack_eliciting();
             if p.is_pmtud_probe() {
-                // Don't count PMTUD probes as ack-eliciting for RTT/stats purposes.
                 continue;
             }
-            eliciting |= p.ack_eliciting();
             if p.lost() {
                 stats.late_ack += 1;
             }

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -267,6 +267,7 @@ impl LossRecoverySpace {
         for p in &acked {
             self.remove_packet(p);
             if p.is_pmtud_probe() {
+                // Don't count PMTUD probes as ack-eliciting for RTT/stats purposes.
                 continue;
             }
             eliciting |= p.ack_eliciting();

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -266,10 +266,10 @@ impl LossRecoverySpace {
         let mut eliciting = false;
         for p in &acked {
             self.remove_packet(p);
-            eliciting |= p.ack_eliciting();
             if p.is_pmtud_probe() {
                 continue;
             }
+            eliciting |= p.ack_eliciting();
             if p.lost() {
                 stats.late_ack += 1;
             }

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -267,6 +267,9 @@ impl LossRecoverySpace {
         for p in &acked {
             self.remove_packet(p);
             eliciting |= p.ack_eliciting();
+            if p.is_pmtud_probe() {
+                continue;
+            }
             if p.lost() {
                 stats.late_ack += 1;
             }
@@ -510,6 +513,10 @@ impl Loss {
         self.qlog = qlog;
     }
 
+    fn record_packet_loss(&self, packets: &[sent::Packet]) {
+        self.stats.borrow_mut().lost += packets.iter().filter(|p| !p.is_pmtud_probe()).count();
+    }
+
     /// Drop all 0rtt packets.
     pub fn drop_0rtt(&mut self, primary_path: &PathRef, now: Instant) -> Vec<sent::Packet> {
         let Some(sp) = self.spaces.get_mut(PacketNumberSpace::ApplicationData) else {
@@ -673,7 +680,7 @@ impl Loss {
         let loss_delay = primary_path.borrow().rtt().loss_delay();
         let mut lost = Vec::new();
         sp.detect_lost_packets(now, loss_delay, cleanup_delay, &mut lost);
-        self.stats.borrow_mut().lost += lost.len();
+        self.record_packet_loss(&lost);
 
         // Tell the congestion controller about any lost packets.
         // The PTO for congestion control is the raw number, without exponential
@@ -988,7 +995,7 @@ impl Loss {
                 now,
             );
         }
-        self.stats.borrow_mut().lost += lost_packets.len();
+        self.record_packet_loss(&lost_packets);
 
         self.maybe_fire_pto(primary_path, now, &mut lost_packets, has_handshake_keys);
         lost_packets

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -513,10 +513,6 @@ impl Loss {
         self.qlog = qlog;
     }
 
-    fn record_packet_loss(&self, packets: &[sent::Packet]) {
-        self.stats.borrow_mut().lost += packets.iter().filter(|p| !p.is_pmtud_probe()).count();
-    }
-
     /// Drop all 0rtt packets.
     pub fn drop_0rtt(&mut self, primary_path: &PathRef, now: Instant) -> Vec<sent::Packet> {
         let Some(sp) = self.spaces.get_mut(PacketNumberSpace::ApplicationData) else {
@@ -680,7 +676,7 @@ impl Loss {
         let loss_delay = primary_path.borrow().rtt().loss_delay();
         let mut lost = Vec::new();
         sp.detect_lost_packets(now, loss_delay, cleanup_delay, &mut lost);
-        self.record_packet_loss(&lost);
+        self.stats.borrow_mut().lost += lost.len();
 
         // Tell the congestion controller about any lost packets.
         // The PTO for congestion control is the raw number, without exponential
@@ -995,7 +991,7 @@ impl Loss {
                 now,
             );
         }
-        self.record_packet_loss(&lost_packets);
+        self.stats.borrow_mut().lost += lost_packets.len();
 
         self.maybe_fire_pto(primary_path, now, &mut lost_packets, has_handshake_keys);
         lost_packets

--- a/neqo-transport/src/recovery/sent.rs
+++ b/neqo-transport/src/recovery/sent.rs
@@ -90,9 +90,7 @@ impl Packet {
     /// Returns `true` if this packet is a PMTUD probe.
     #[must_use]
     pub fn is_pmtud_probe(&self) -> bool {
-        self.tokens
-            .iter()
-            .any(|t| matches!(t, recovery::Token::PmtudProbe))
+        self.tokens.iter().any(recovery::Token::is_pmtud_probe)
     }
 
     /// The time that this packet was sent.

--- a/neqo-transport/src/recovery/token.rs
+++ b/neqo-transport/src/recovery/token.rs
@@ -70,3 +70,10 @@ pub enum Token {
     /// A PMTUD probe packet.
     PmtudProbe,
 }
+
+impl Token {
+    #[must_use]
+    pub const fn is_pmtud_probe(&self) -> bool {
+        matches!(self, Self::PmtudProbe)
+    }
+}

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -329,6 +329,34 @@ impl DerefMut for DscpCount {
     }
 }
 
+/// PMTUD-specific statistics.
+#[derive(Default, Clone, PartialEq, Eq)]
+pub struct PmtudStats {
+    /// Number of PMTUD probes sent.
+    pub tx: usize,
+    /// Number of PMTUD probes acked.
+    pub ack: usize,
+    /// Number of PMTUD probes lost.
+    pub lost: usize,
+    /// MTU of the local interface used for the most recent path.
+    pub iface_mtu: usize,
+    /// The peer's [`max_udp_payload_size`](https://www.rfc-editor.org/rfc/rfc9000#section-18.2)
+    /// transport parameter, i.e., the maximum UDP payload the peer is willing to receive.
+    pub peer_max_udp_payload: Option<usize>,
+    /// Probed PMTU of the current path.
+    pub pmtu: usize,
+}
+
+impl Debug for PmtudStats {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} sent {} acked {} lost {} iface_mtu {:?} peer_max_udp_payload {} pmtu",
+            self.tx, self.ack, self.lost, self.iface_mtu, self.peer_max_udp_payload, self.pmtu
+        )
+    }
+}
+
 /// Connection statistics
 #[derive(Default, Clone, PartialEq)]
 pub struct Stats {
@@ -347,31 +375,21 @@ pub struct Stats {
     /// The number of packet that were saved for later processing.
     pub saved_datagrams: usize,
 
-    /// Total packets sent, excluding PMTUD probes (see `pmtud_tx`).
+    /// Total packets sent, excluding PMTUD probes (see `pmtud.tx`).
     pub packets_tx: usize,
     /// Total number of packets that are declared lost. PMTUD probes are included here (since they
-    /// always carry at least a PING) and also counted separately in `pmtud_lost`.
+    /// always carry at least a PING) and also counted separately in `pmtud.lost`.
     pub lost: usize,
     /// Late acknowledgments, for packets that were declared lost already, excluding PMTUD probes
-    /// (see `pmtud_ack`).
+    /// (see `pmtud.ack`).
     pub late_ack: usize,
     /// Acknowledgments for packets that contained data that was marked for retransmission when
-    /// the PTO timer popped, excluding PMTUD probes (see `pmtud_ack`).
+    /// the PTO timer popped, excluding PMTUD probes (see `pmtud.ack`).
     pub pto_ack: usize,
     /// Number of times we had to drop an unacknowledged ACK range.
     pub unacked_range_dropped: usize,
-    /// Number of PMTUD probes sent.
-    pub pmtud_tx: usize,
-    /// Number of PMTUD probes ACK'ed.
-    pub pmtud_ack: usize,
-    /// Number of PMTUD probes lost.
-    pub pmtud_lost: usize,
-    /// MTU of the local interface used for the most recent path.
-    pub pmtud_iface_mtu: usize,
-    /// The peer's `max_udp_payload_size` transport parameter.
-    pub pmtud_peer_max_udp_payload: Option<usize>,
-    /// Probed PMTU of the current path.
-    pub pmtud_pmtu: usize,
+    /// PMTUD statistics (probes sent/acked/lost, discovered MTU, etc.).
+    pub pmtud: PmtudStats,
 
     /// Whether the connection was resumed successfully.
     pub resumed: bool,
@@ -493,16 +511,7 @@ impl Debug for Stats {
             self.cc.slow_start_exit.as_ref().map(|e| e.exit_cwnd),
             self.cc.slow_start_exit.as_ref().map(|e| &e.reason),
         )?;
-        writeln!(
-            f,
-            "  pmtud: {} sent {} acked {} lost {} iface_mtu {:?} peer_max_udp_payload {} pmtu",
-            self.pmtud_tx,
-            self.pmtud_ack,
-            self.pmtud_lost,
-            self.pmtud_iface_mtu,
-            self.pmtud_peer_max_udp_payload,
-            self.pmtud_pmtu
-        )?;
+        writeln!(f, "  pmtud: {:?}", self.pmtud)?;
         writeln!(f, "  resumed: {}", self.resumed)?;
         writeln!(f, "  frames rx:")?;
         self.frame_rx.fmt(f)?;

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -349,7 +349,8 @@ pub struct Stats {
 
     /// Total packets sent, excluding PMTUD probes (see `pmtud_tx`).
     pub packets_tx: usize,
-    /// Total number of packets that are declared lost, excluding PMTUD probes (see `pmtud_lost`).
+    /// Total number of packets that are declared lost. PMTUD probes are included here (since they
+    /// always carry at least a PING) and also counted separately in `pmtud_lost`.
     pub lost: usize,
     /// Late acknowledgments, for packets that were declared lost already, excluding PMTUD probes
     /// (see `pmtud_ack`).

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -347,14 +347,15 @@ pub struct Stats {
     /// The number of packet that were saved for later processing.
     pub saved_datagrams: usize,
 
-    /// Total packets sent.
+    /// Total packets sent, excluding PMTUD probes (see `pmtud_tx`).
     pub packets_tx: usize,
-    /// Total number of packets that are declared lost.
+    /// Total number of packets that are declared lost, excluding PMTUD probes (see `pmtud_lost`).
     pub lost: usize,
-    /// Late acknowledgments, for packets that were declared lost already.
+    /// Late acknowledgments, for packets that were declared lost already, excluding PMTUD probes
+    /// (see `pmtud_ack`).
     pub late_ack: usize,
-    /// Acknowledgments for packets that contained data that was marked
-    /// for retransmission when the PTO timer popped.
+    /// Acknowledgments for packets that contained data that was marked for retransmission when
+    /// the PTO timer popped, excluding PMTUD probes (see `pmtud_ack`).
     pub pto_ack: usize,
     /// Number of times we had to drop an unacknowledged ACK range.
     pub unacked_range_dropped: usize,


### PR DESCRIPTION
And minor cleanups.