### PR TITLE
Revert "fix: do not suppress cwnd growth when pacing limits sends (#3640)"

### DIFF
--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -573,7 +573,7 @@ where
         );
     }
 
-    fn on_packet_sent(&mut self, pkt: &sent::Packet, now: Instant, pacing_limited: bool) {
+    fn on_packet_sent(&mut self, pkt: &sent::Packet, now: Instant) {
         // Record the recovery time and exit any transient phase.
         if self.current.phase.transient() {
             self.current.recovery_start = Some(pkt.pn());
@@ -590,11 +590,11 @@ where
             self.slow_start.on_packet_sent(pkt.pn(), pkt.len());
         }
 
-        // RFC 9002 §7.8: "A sender SHOULD NOT consider itself application
-        // limited if it would have fully utilized the congestion window without
-        // pacing delay."  When the pacer is the reason we cannot send more
-        // right now, cwnd underutilization is from pacing, not the application.
-        if pacing_limited || !self.app_limited() {
+        if !self.app_limited() {
+            // Given the current non-app-limited condition, we're fully utilizing the congestion
+            // window. Assume that all in-flight packets up to this one are NOT app-limited.
+            // However, subsequent packets might be app-limited. Set `first_app_limited` to the
+            // next packet number.
             self.first_app_limited = Some(pkt.pn() + 1);
         }
 
@@ -1046,7 +1046,7 @@ mod tests {
         let mut cc_stats = CongestionControlStats::default();
 
         for p in lost_packets {
-            cc.on_packet_sent(p, now(), false);
+            cc.on_packet_sent(p, now());
         }
 
         cc.on_packets_lost(Some(now()), None, PTO, lost_packets, now(), &mut cc_stats);
@@ -1434,7 +1434,7 @@ mod tests {
                     cc.max_datagram_size(),
                 );
                 next_pn += 1;
-                cc.on_packet_sent(&p, now, false);
+                cc.on_packet_sent(&p, now);
                 pkts.push(p);
             }
             assert_eq!(
@@ -1467,7 +1467,7 @@ mod tests {
                 cc.max_datagram_size(),
             );
             next_pn += 1;
-            cc.on_packet_sent(&p, now, false);
+            cc.on_packet_sent(&p, now);
             pkts.push(p);
         }
         assert_eq!(
@@ -1526,7 +1526,7 @@ mod tests {
             recovery::Tokens::new(),
             cc.max_datagram_size(),
         );
-        cc.on_packet_sent(&p_lost, now, false);
+        cc.on_packet_sent(&p_lost, now);
         cwnd_is_default(&cc);
         now += PTO;
         cc.on_packets_lost(Some(now), None, PTO, &[p_lost], now, &mut cc_stats);
@@ -1539,7 +1539,7 @@ mod tests {
             recovery::Tokens::new(),
             cc.max_datagram_size(),
         );
-        cc.on_packet_sent(&p_not_lost, now, false);
+        cc.on_packet_sent(&p_not_lost, now);
         now += RTT;
         cc.on_packets_acked(
             &[p_not_lost],
@@ -1568,7 +1568,7 @@ mod tests {
                     cc.max_datagram_size(),
                 );
                 next_pn += 1;
-                cc.on_packet_sent(&p, now, false);
+                cc.on_packet_sent(&p, now);
                 pkts.push(p);
             }
             assert_eq!(
@@ -1606,7 +1606,7 @@ mod tests {
                 cc.max_datagram_size(),
             );
             next_pn += 1;
-            cc.on_packet_sent(&p, now, false);
+            cc.on_packet_sent(&p, now);
             pkts.push(p);
         }
         assert_eq!(
@@ -1650,7 +1650,7 @@ mod tests {
             recovery::Tokens::new(),
             cc.max_datagram_size(),
         );
-        cc.on_packet_sent(&p_ce, now, false);
+        cc.on_packet_sent(&p_ce, now);
         assert_eq!(cc.cwnd(), cc.cwnd_initial());
         assert_eq!(cc.ssthresh(), None);
         assert_eq!(cc.current.phase, Phase::SlowStart);
@@ -1683,8 +1683,8 @@ mod tests {
         // 1. Send packets (1, 2) --> `SlowStart`, no events
         let pkt1 = sent::make_packet(1, now, 1000);
         let pkt2 = sent::make_packet(2, now, 1000);
-        cc.on_packet_sent(&pkt1, now, false);
-        cc.on_packet_sent(&pkt2, now, false);
+        cc.on_packet_sent(&pkt1, now);
+        cc.on_packet_sent(&pkt2, now);
         assert_eq!(cc.current.phase, Phase::SlowStart);
         assert_eq!(cc_stats.congestion_events.loss, 0);
         assert_eq!(cc_stats.congestion_events.spurious, 0);
@@ -1721,7 +1721,7 @@ mod tests {
 
         // 3. Send packet (3)     --> `Recovery`, 1 event
         let pkt3 = sent::make_packet(3, now, 1000);
-        cc.on_packet_sent(&pkt3, now, false);
+        cc.on_packet_sent(&pkt3, now);
         assert_eq!(cc.current.phase, Phase::Recovery);
         assert_eq!(cc_stats.congestion_events.loss, 1);
 
@@ -1780,8 +1780,8 @@ mod tests {
         // 1. Send packets (1, 2) --> `SlowStart`
         let pkt1 = sent::make_packet(1, now, 1000);
         let pkt2 = sent::make_packet(2, now, 1000);
-        cc.on_packet_sent(&pkt1, now, false);
-        cc.on_packet_sent(&pkt2, now, false);
+        cc.on_packet_sent(&pkt1, now);
+        cc.on_packet_sent(&pkt2, now);
         assert_eq!(cc.current.phase, Phase::SlowStart);
 
         // 2. Lose packets (1, 2) --> `RecoveryStart` and reduced cwnd
@@ -1804,7 +1804,7 @@ mod tests {
 
         // 3. Send packet (3) --> `Recovery`
         let pkt3 = sent::make_packet(3, now, 1000);
-        cc.on_packet_sent(&pkt3, now, false);
+        cc.on_packet_sent(&pkt3, now);
         assert_eq!(cc.current.phase, Phase::Recovery);
 
         // 4. Ack packet (3) --> `CongestionAvoidance`
@@ -1852,14 +1852,14 @@ mod tests {
 
         // Cause congestion event
         let pkt = sent::make_packet(1, now, 1000);
-        cc.on_packet_sent(&pkt, now, false);
+        cc.on_packet_sent(&pkt, now);
         let pkt_lost = pkt.clone();
         cc.on_packets_lost(Some(now), None, PTO, &[pkt_lost], now, &mut cc_stats);
         assert!(cc.cwnd() < cc.cwnd_initial(), "cwnd should have decreased");
 
         // Send recovery packet
         let pkt_recovery = sent::make_packet(2, now, 1000);
-        cc.on_packet_sent(&pkt_recovery, now, false);
+        cc.on_packet_sent(&pkt_recovery, now);
         cc.on_packets_acked(&[pkt_recovery], &rtt_estimate, now, &mut cc_stats);
 
         // Grow cwnd back naturally.
@@ -1868,7 +1868,7 @@ mod tests {
             let mut sent_packets = Vec::new();
             while cc.bytes_in_flight < cc.cwnd() {
                 let pkt = sent::make_packet(next_pn_to_send, now, cc.max_datagram_size());
-                cc.on_packet_sent(&pkt, now, false);
+                cc.on_packet_sent(&pkt, now);
                 sent_packets.push(pkt);
                 next_pn_to_send += 1;
             }
@@ -1921,8 +1921,8 @@ mod tests {
         let pkt1 = sent::make_packet(1, now, 1000);
         let pkt2 = sent::make_packet(2, now, 1000);
 
-        cc.on_packet_sent(&pkt1, now, false);
-        cc.on_packet_sent(&pkt2, now, false);
+        cc.on_packet_sent(&pkt1, now);
+        cc.on_packet_sent(&pkt2, now);
 
         assert_eq!(cc.current.phase, Phase::SlowStart);
         assert_eq!(cc_stats.congestion_events.loss, 0);
@@ -1947,7 +1947,7 @@ mod tests {
 
         // Step 3: Send packet 3 → enter Recovery phase
         let pkt3 = sent::make_packet(3, now, 1000);
-        cc.on_packet_sent(&pkt3, now, false);
+        cc.on_packet_sent(&pkt3, now);
         assert_eq!(cc.current.phase, Phase::Recovery);
 
         // Step 4: Ack packet 1 → spurious event #1 detected
@@ -1991,7 +1991,7 @@ mod tests {
         let rtt_estimate = RttEstimate::new(crate::DEFAULT_INITIAL_RTT);
 
         let pkt1 = sent::make_packet(1, now, 1000);
-        cc.on_packet_sent(&pkt1, now, false);
+        cc.on_packet_sent(&pkt1, now);
 
         cc.on_packets_lost(
             Some(now),
@@ -2010,7 +2010,7 @@ mod tests {
 
         // The cleanup is called when we ack packets, so we send and ack a new one.
         let pkt2 = sent::make_packet(2, now, 1000);
-        cc.on_packet_sent(&pkt2, now, false);
+        cc.on_packet_sent(&pkt2, now);
         cc.on_packets_acked(&[pkt2], &rtt_estimate, now, &mut cc_stats);
 
         // The packet is exactly the maximum age, so it shouldn't be removed yet. This assert makes
@@ -2022,7 +2022,7 @@ mod tests {
 
         // Send and ack another packet to trigger cleanup.
         let pkt3 = sent::make_packet(3, now, 1000);
-        cc.on_packet_sent(&pkt3, now, false);
+        cc.on_packet_sent(&pkt3, now);
         cc.on_packets_acked(&[pkt3], &rtt_estimate, now, &mut cc_stats);
 
         // Now the packet should be removed.
@@ -2041,7 +2041,7 @@ mod tests {
         assert_eq!(cc_stats.slow_start_exit, None);
 
         let pkt1 = sent::make_packet(1, now, 1000);
-        cc.on_packet_sent(&pkt1, now, false);
+        cc.on_packet_sent(&pkt1, now);
 
         match congestion_trigger {
             Ecn => {
@@ -2077,7 +2077,7 @@ mod tests {
         if matches!(congestion_trigger, Loss(_)) {
             // Send recovery packet and ack it to exit recovery.
             let pkt2 = sent::make_packet(2, now, 1000);
-            cc.on_packet_sent(&pkt2, now, false);
+            cc.on_packet_sent(&pkt2, now);
             cc.on_packets_acked(&[pkt2], &rtt_estimate, now, &mut cc_stats);
 
             // Late ack of pkt1 triggers spurious congestion detection - should reset to None.
@@ -2123,7 +2123,7 @@ mod tests {
         let mut sent_packets = Vec::new();
         while cc.bytes_in_flight < cc.cwnd() {
             let pkt = sent::make_packet(next_pn, now, cc.max_datagram_size());
-            cc.on_packet_sent(&pkt, now, false);
+            cc.on_packet_sent(&pkt, now);
             sent_packets.push(pkt);
             next_pn += 1;
         }
@@ -2134,7 +2134,7 @@ mod tests {
 
         // Tracks cwnd after congestion event reduction
         let pkt_lost = sent::make_packet(next_pn, now, 1000);
-        cc.on_packet_sent(&pkt_lost, now, false);
+        cc.on_packet_sent(&pkt_lost, now);
         cc.on_packets_lost(Some(now), None, PTO, &[pkt_lost], now, &mut cc_stats);
         assert_eq!(cc_stats.cwnd, Some(cc.cwnd()));
         assert!(cc_stats.cwnd.is_some_and(|cwnd| cwnd < cwnd_after_growth));
@@ -2160,7 +2160,7 @@ mod tests {
 
         // Send and ack a single packet — not enough to fill cwnd, so app-limited.
         let pkt = sent::make_packet(0, now, cc.max_datagram_size());
-        cc.on_packet_sent(&pkt, now, false);
+        cc.on_packet_sent(&pkt, now);
         cc.on_packets_acked(&[pkt], &rtt_estimate, now, &mut cc_stats);
 
         assert_eq!(cc.cwnd(), cwnd_initial);
@@ -2229,7 +2229,7 @@ mod tests {
                 recovery::Tokens::new(),
                 cc.max_datagram_size(),
             );
-            cc.on_packet_sent(&p_ce, now, false);
+            cc.on_packet_sent(&p_ce, now);
             cc.on_ecn_ce_received(&p_ce, now, stats);
         });
     }
@@ -2242,7 +2242,7 @@ mod tests {
         assert_congestion_state_trigger("persistent_congestion", |cc, stats| {
             let lost_pkts = [lost(1, true, ZERO), lost(2, true, PC)];
             for p in &lost_pkts {
-                cc.on_packet_sent(p, now(), false);
+                cc.on_packet_sent(p, now());
             }
             assert_ne!(cc.cwnd(), cc.cwnd_min());
             cc.on_packets_lost(Some(now()), None, PTO, &lost_pkts, now(), stats);
@@ -2281,48 +2281,5 @@ mod tests {
         // there should be no reaction to the non-ack-eliciting packet
         assert_eq!(cc.cwnd(), initial_cwnd);
         assert_eq!(cc_stats.slow_start_exit, None);
-    }
-
-    fn send_single_packet_and_ack(pacing_limited: bool) -> (usize, usize) {
-        let mut cc = make_cc_newreno();
-        let now = now();
-        let mut cc_stats = CongestionControlStats::default();
-        let cwnd_before = cc.cwnd();
-
-        let p = sent::Packet::new(
-            packet::Type::Short,
-            0,
-            now,
-            true,
-            recovery::Tokens::new(),
-            cc.max_datagram_size(),
-        );
-        cc.on_packet_sent(&p, now, pacing_limited);
-
-        cc.on_packets_acked(
-            &[p],
-            &RttEstimate::new(crate::DEFAULT_INITIAL_RTT),
-            now + RTT,
-            &mut cc_stats,
-        );
-        (cwnd_before, cc.cwnd())
-    }
-
-    #[test]
-    fn pacing_limited_overrides_app_limited() {
-        let (before, after) = send_single_packet_and_ack(true);
-        assert!(
-            after > before,
-            "cwnd should grow when pacing-limited: {after} vs {before}"
-        );
-    }
-
-    #[test]
-    fn genuinely_app_limited_no_pacing() {
-        let (before, after) = send_single_packet_and_ack(false);
-        assert_eq!(
-            after, before,
-            "cwnd should not grow when genuinely app-limited"
-        );
     }
 }

--- a/neqo-transport/src/cc/mod.rs
+++ b/neqo-transport/src/cc/mod.rs
@@ -95,7 +95,7 @@ pub trait CongestionController: Display + Debug {
 
     fn discard(&mut self, pkt: &sent::Packet, now: Instant);
 
-    fn on_packet_sent(&mut self, pkt: &sent::Packet, now: Instant, pacing_limited: bool);
+    fn on_packet_sent(&mut self, pkt: &sent::Packet, now: Instant);
 
     fn discard_in_flight(&mut self, now: Instant);
 }
@@ -227,8 +227,8 @@ impl CongestionController for CongestionControlImplementation {
         dispatch!(self.discard(pkt, now));
     }
 
-    fn on_packet_sent(&mut self, pkt: &sent::Packet, now: Instant, pacing_limited: bool) {
-        dispatch!(self.on_packet_sent(pkt, now, pacing_limited));
+    fn on_packet_sent(&mut self, pkt: &sent::Packet, now: Instant) {
+        dispatch!(self.on_packet_sent(pkt, now));
     }
 
     fn discard_in_flight(&mut self, now: Instant) {

--- a/neqo-transport/src/cc/tests/cubic.rs
+++ b/neqo-transport/src/cc/tests/cubic.rs
@@ -72,7 +72,7 @@ fn fill_cwnd(
 ) -> u64 {
     while cc.bytes_in_flight() < cc.cwnd() {
         let sent = sent::make_packet(next_pn, now, cc.max_datagram_size());
-        cc.on_packet_sent(&sent, now, false);
+        cc.on_packet_sent(&sent, now);
         next_pn += 1;
     }
     next_pn

--- a/neqo-transport/src/cc/tests/hystart.rs
+++ b/neqo-transport/src/cc/tests/hystart.rs
@@ -680,7 +680,7 @@ fn integration_full_slow_start_to_css_to_ca() {
     let initial_cwnd_packets = cc.cwnd() / MIN_INITIAL_PACKET_SIZE;
     for _ in 0..initial_cwnd_packets {
         let pkt = sent::make_packet(next_send, now, MIN_INITIAL_PACKET_SIZE);
-        cc.on_packet_sent(&pkt, now, false);
+        cc.on_packet_sent(&pkt, now);
         next_send += 1;
     }
 
@@ -753,7 +753,7 @@ fn integration_full_slow_start_to_css_to_ca() {
         while cc.bytes_in_flight() < cc.cwnd() {
             let send_pn = next_send;
             let pkt = sent::make_packet(send_pn, now, MIN_INITIAL_PACKET_SIZE);
-            cc.on_packet_sent(&pkt, now, false);
+            cc.on_packet_sent(&pkt, now);
             next_send += 1;
         }
 

--- a/neqo-transport/src/cc/tests/new_reno.rs
+++ b/neqo-transport/src/cc/tests/new_reno.rs
@@ -108,7 +108,7 @@ fn issue_876() {
 
     // Send some more packets so that the cc is not app-limited.
     for p in &sent_packets[..6] {
-        cc.on_packet_sent(p, now, false);
+        cc.on_packet_sent(p, now);
     }
     assert_eq!(cc.acked_bytes(), 0);
     cwnd_is_default(&cc);
@@ -130,7 +130,7 @@ fn issue_876() {
     assert_eq!(cc.bytes_in_flight(), 5 * cc.max_datagram_size() - 2);
 
     // Send a packet after recovery starts
-    cc.on_packet_sent(&sent_packets[6], now, false);
+    cc.on_packet_sent(&sent_packets[6], now);
     assert!(!cc.recovery_packet());
     cwnd_is_halved(&cc);
     assert_eq!(cc.acked_bytes(), 0);
@@ -184,7 +184,7 @@ fn issue_1465() {
     };
     let mut send_next = |cc: &mut ClassicCongestionController<ClassicSlowStart, NewReno>, now| {
         let p = next_packet(now);
-        cc.on_packet_sent(&p, now, false);
+        cc.on_packet_sent(&p, now);
         p
     };
 
@@ -279,7 +279,7 @@ fn congestion_avoidance_no_two_mss_cap() {
     let mut pkts = Vec::with_capacity(n);
     for pn in 0..to_u64(n) {
         let p = sent::make_packet(pn, now, mtu);
-        cc.on_packet_sent(&p, now, false);
+        cc.on_packet_sent(&p, now);
         pkts.push(p);
     }
 

--- a/neqo-transport/src/pace.rs
+++ b/neqo-transport/src/pace.rs
@@ -145,16 +145,17 @@ impl Pacer {
         Self::bytes_for(cwnd, rtt, Duration::from_secs(1))
     }
 
-    /// Spend credit. Returns `true` when the next send would be pacing-limited,
-    /// i.e., [`Pacer::next`] now returns a time strictly after `now`.
-    /// Always returns `false` when pacing is disabled.
+    /// Spend credit. This cannot fail, but instead may carry debt into the
+    /// future (see [`Pacer::c`]). Users of this API are expected to call
+    /// [`Pacer::next`] to determine when to spend.
     ///
-    /// This cannot fail, but instead may carry debt into the future (see
-    /// [`Pacer::c`]).
-    pub fn spend(&mut self, now: Instant, rtt: Duration, cwnd: usize, count: usize) -> bool {
+    /// This function takes the current time (`now`), an estimate of the round
+    /// trip time (`rtt`), the estimated congestion window (`cwnd`), and the
+    /// number of bytes that were sent (`count`).
+    pub fn spend(&mut self, now: Instant, rtt: Duration, cwnd: usize, count: usize) {
         if !self.enabled {
             self.t = now;
-            return false;
+            return;
         }
 
         qtrace!("[{self}] spend {count} over {cwnd}, {rtt:?}");
@@ -172,7 +173,6 @@ impl Pacer {
                 .saturating_sub(isize::try_from(count).unwrap_or(isize::MAX)),
         );
         self.t = now;
-        self.next(rtt, cwnd) > now
     }
 }
 
@@ -206,7 +206,7 @@ mod tests {
         let n = now();
         let mut p = Pacer::new(true, n, PACKET, PACKET);
         assert_eq!(p.next(RTT, CWND), n);
-        assert!(p.spend(n, RTT, CWND, PACKET));
+        p.spend(n, RTT, CWND, PACKET);
         assert_eq!(p.next(RTT, CWND), n + (RTT / 20));
     }
 
@@ -216,7 +216,7 @@ mod tests {
         let mut p = Pacer::new(true, n + RTT, PACKET, PACKET);
         assert_eq!(p.next(RTT, CWND), n + RTT);
         // Now spend some credit in the past using a time machine.
-        assert!(p.spend(n, RTT, CWND, PACKET));
+        p.spend(n, RTT, CWND, PACKET);
         assert_eq!(p.next(RTT, CWND), n + (RTT / 20));
     }
 
@@ -225,7 +225,7 @@ mod tests {
         let n = now();
         let mut p = Pacer::new(false, n, PACKET, PACKET);
         assert_eq!(p.next(RTT, CWND), n);
-        assert!(!p.spend(n, RTT, CWND, PACKET));
+        p.spend(n, RTT, CWND, PACKET);
         assert_eq!(p.next(RTT, CWND), n);
     }
 
@@ -235,9 +235,11 @@ mod tests {
         let n = now();
         let mut p = Pacer::new(true, n, PACKET, PACKET);
         assert_eq!(p.next(SHORT_RTT, CWND), n);
-        assert!(
-            !p.spend(n, SHORT_RTT, CWND, PACKET),
-            "sub-granularity delay should not be pacing-limited"
+        p.spend(n, SHORT_RTT, CWND, PACKET);
+        assert_eq!(
+            p.next(SHORT_RTT, CWND),
+            n,
+            "Expect packet to be sent immediately, instead of being paced below timer granularity"
         );
     }
 
@@ -287,9 +289,12 @@ mod tests {
         const CWND_AT_GRANULARITY: usize = 5000; // yields w = 1ms = GRANULARITY
         let n = now();
         let mut p = Pacer::new(true, n, PACKET, PACKET);
-        assert!(
-            p.spend(n, SHORT_RTT, CWND_AT_GRANULARITY, PACKET),
-            "at exactly GRANULARITY should be pacing-limited"
+        p.spend(n, SHORT_RTT, CWND_AT_GRANULARITY, PACKET);
+        // w == GRANULARITY: should schedule for later, not send immediately.
+        assert_ne!(
+            p.next(SHORT_RTT, CWND_AT_GRANULARITY),
+            n,
+            "at exactly GRANULARITY should not send immediately"
         );
     }
 

--- a/neqo-transport/src/sender.rs
+++ b/neqo-transport/src/sender.rs
@@ -223,10 +223,9 @@ impl PacketSender {
     }
 
     pub fn on_packet_sent(&mut self, pkt: &sent::Packet, rtt: Duration, now: Instant) {
-        let pacing_limited = self
-            .pacer
+        self.pacer
             .spend(pkt.time_sent(), rtt, self.cc.cwnd(), pkt.len());
-        self.cc.on_packet_sent(pkt, now, pacing_limited);
+        self.cc.on_packet_sent(pkt, now);
     }
 
     #[must_use]
@@ -341,25 +340,19 @@ mod tests {
     }
 
     #[test]
-    fn pacing_limited_allows_cwnd_growth() {
-        // Sending more than PACING_BURST_SIZE packets exhausts burst credit,
-        // making subsequent sends pacing-limited rather than app-limited.
-        let (before, after) = send_and_ack(true, super::PACING_BURST_SIZE + 1);
-        assert!(after > before, "cwnd should grow: {after} vs {before}");
-    }
-
-    #[test]
-    fn app_limited_suppresses_cwnd_growth() {
-        // A single packet is well below cwnd and within burst — genuinely app-limited.
-        let (before, after) = send_and_ack(true, 1);
+    fn app_limited_suppresses_cwnd_growth_without_pacing() {
+        // Sending PACING_BURST_SIZE + 1 packets is not filling the initial congestion window, thus
+        // should leave us genuinely app-limited, thus the congestion window shouldn't grow.
+        let (before, after) = send_and_ack(false, super::PACING_BURST_SIZE + 1);
         assert_eq!(after, before, "cwnd should not grow when app-limited");
     }
 
     #[test]
-    fn pacing_disabled_never_pacing_limited() {
-        // With pacing off, spend() always returns false, so single-packet
-        // sends remain app-limited regardless of burst budget.
-        let (before, after) = send_and_ack(false, 1);
-        assert_eq!(after, before, "cwnd should not grow with pacing disabled");
+    fn app_limited_suppresses_cwnd_growth_with_pacing() {
+        // Sending PACING_BURST_SIZE + 1 packets is not filling the initial congestion window, thus
+        // should leave us genuinely app-limited, thus the congestion window shouldn't grow, even
+        // though we are pacing delayed.
+        let (before, after) = send_and_ack(true, super::PACING_BURST_SIZE + 1);
+        assert_eq!(after, before, "cwnd should not grow when app limited");
     }
 }


### PR DESCRIPTION
This reverts commit 1b8abbba5b81dbc7564fd50f65cbb82702e974ca.

The fix made us grow our cwnd when genuinely app-limited but having pacing enabled. I.e. when sending 3 packets with no bytes in flight and an initial window of 12k, this would've treated the first 2 packets as not app-limited (because they would be paced) and would've grown the cwnd when those were acked, despite when only sending 3 packets we are genuinely app-limited.

I rewrote 2 of the tests that the commit added to test the correct behavior, which is not growing the cwnd when only sending and acking 3 packets, no matter if pacing is enabled or not.

Closes #3753

--- 

### Should we uplift?

I see [no regression in throughput when this was landed](https://glam.telemetry.mozilla.org/fog/probe/networking_http_3_upload_throughput/explore?aggregationLevel=version&app_id=beta&ping_type=metrics&visiblePercentiles=%5B99%2C95%2C75%2C50%2C25%2C5%5D). On nightly I see no change in packet loss when this was released into Firefox on June 10th, but [p95 packet loss goes up by 1% with the change rolling into beta with 153](https://glam.telemetry.mozilla.org/fog/probe/networking_http_3_loss_ratio/explore?app_id=beta&ref=2026061710&visiblePercentiles=%5B99%2C95%2C75%2C50%2C25%2C5%5D). Though there it is not clear if that is due to this, or due to something else in 153, or just noise that will normalize with more beta 153 data.

What I do see is a lot more connections growing their connection window that had no business doing so, those now show up in our [`final_cwnd` stat on nightly](https://glam.telemetry.mozilla.org/fog/probe/networking_http_3_final_cwnd/explore?visiblePercentiles=%5B99%2C95%2C75%2C50%2C25%2C5%5D), pulling it significantly down when this was landed. This is purely cosmetic though, because those connections never use their cwnd, so it is mostly a non-factor (apart from maybe those that then start sending a lot at some point with an inflated cwnd, which would show in packet-loss metrics, which it doesn't significantly as seen above).

This is also behaving poorly combined with SEARCH, which is exiting slow start prematurely because of this change, which could have impact on performance. But SEARCH is still only active in experimentation. I will stop the Beta experiment now, so it won't be active in combination there and I won't let it run on Release 153, which goes live on July 21.

Thus imo it is fine to let it roll into Release 153 without an uplift until the revert in this PR rolls out with Release 154. Unless someone thinks the 1% p95 packet loss increase is too much, even though we don't have clear signal of it coming from #3640.
