### PR TITLE
fix(transport/quic-datagram): remove inbound queue limit

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -954,7 +954,6 @@ impl Http3Client {
                 }
                 ConnectionEvent::SendStreamComplete { .. }
                 | ConnectionEvent::OutgoingDatagramOutcome { .. }
-                | ConnectionEvent::IncomingDatagramDropped
                 | ConnectionEvent::SconeUpdated(_)
                 | ConnectionEvent::PathMigrated { .. } => {}
             }

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -277,7 +277,6 @@ impl Http3ServerHandler {
                 ConnectionEvent::SendStreamComplete { .. }
                 | ConnectionEvent::SendStreamCreatable { .. }
                 | ConnectionEvent::OutgoingDatagramOutcome { .. }
-                | ConnectionEvent::IncomingDatagramDropped
                 | ConnectionEvent::SconeUpdated(_)
                 | ConnectionEvent::PathMigrated { .. } => {}
             }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -441,7 +441,6 @@ impl Connection {
         let quic_datagrams = QuicDatagrams::new(
             conn_params.get_datagram_size(),
             conn_params.get_outgoing_datagram_queue(),
-            conn_params.get_incoming_datagram_queue(),
             events.clone(),
         );
 
@@ -3494,8 +3493,7 @@ impl Connection {
             }
             Frame::Datagram { data, .. } => {
                 self.stats.borrow_mut().frame_rx.datagram += 1;
-                self.quic_datagrams
-                    .handle_datagram(data, &mut self.stats.borrow_mut())?;
+                self.quic_datagrams.handle_datagram(data)?;
             }
             _ => unreachable!("All other frames are for streams"),
         }

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -138,7 +138,6 @@ pub struct ConnectionParameters {
     preferred_address: PreferredAddressConfig,
     datagram_size: u64,
     outgoing_datagram_queue: usize,
-    incoming_datagram_queue: usize,
     initial_rtt: Duration,
     fast_pto: u8,
     grease: bool,
@@ -179,7 +178,6 @@ impl Default for ConnectionParameters {
             preferred_address: PreferredAddressConfig::Default,
             datagram_size: MAX_DATAGRAM_FRAME_SIZE,
             outgoing_datagram_queue: MAX_QUEUED_DATAGRAMS_DEFAULT,
-            incoming_datagram_queue: MAX_QUEUED_DATAGRAMS_DEFAULT,
             initial_rtt: DEFAULT_INITIAL_RTT,
             fast_pto: FAST_PTO_SCALE,
             grease: true,
@@ -395,18 +393,6 @@ impl ConnectionParameters {
     pub fn outgoing_datagram_queue(mut self, v: usize) -> Self {
         // The max queue length must be at least 1.
         self.outgoing_datagram_queue = max(v, 1);
-        self
-    }
-
-    #[must_use]
-    pub const fn get_incoming_datagram_queue(&self) -> usize {
-        self.incoming_datagram_queue
-    }
-
-    #[must_use]
-    pub fn incoming_datagram_queue(mut self, v: usize) -> Self {
-        // The max queue length must be at least 1.
-        self.incoming_datagram_queue = max(v, 1);
         self
     }
 

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -503,17 +503,12 @@ fn send_datagram(sender: &mut Connection, receiver: &mut Connection, data: Vec<u
 #[test]
 fn multiple_datagram_events() {
     const DATA_SIZE: usize = MIN_INITIAL_PACKET_SIZE;
-    const MAX_QUEUE: usize = 3;
     const FIRST_DATAGRAM: &[u8] = &[0; DATA_SIZE];
     const SECOND_DATAGRAM: &[u8] = &[1; DATA_SIZE];
     const THIRD_DATAGRAM: &[u8] = &[2; DATA_SIZE];
     const FOURTH_DATAGRAM: &[u8] = &[3; DATA_SIZE];
 
-    let mut client = new_client(
-        ConnectionParameters::default()
-            .datagram_size(to_u64(DATA_SIZE))
-            .incoming_datagram_queue(MAX_QUEUE),
-    );
+    let mut client = new_client(ConnectionParameters::default().datagram_size(to_u64(DATA_SIZE)));
     let mut server = default_server();
     connect_force_idle(&mut client, &mut server);
 
@@ -544,53 +539,6 @@ fn multiple_datagram_events() {
     });
     assert_eq!(datagrams.next().unwrap(), FOURTH_DATAGRAM);
     assert!(datagrams.next().is_none());
-}
-
-#[test]
-fn too_many_datagram_events() {
-    const DATA_SIZE: usize = MIN_INITIAL_PACKET_SIZE;
-    const MAX_QUEUE: usize = 2;
-    const FIRST_DATAGRAM: &[u8] = &[0; DATA_SIZE];
-    const SECOND_DATAGRAM: &[u8] = &[1; DATA_SIZE];
-    const THIRD_DATAGRAM: &[u8] = &[2; DATA_SIZE];
-    const FOURTH_DATAGRAM: &[u8] = &[3; DATA_SIZE];
-
-    let mut client = new_client(
-        ConnectionParameters::default()
-            .datagram_size(to_u64(DATA_SIZE))
-            .incoming_datagram_queue(MAX_QUEUE),
-    );
-    let mut server = default_server();
-    connect_force_idle(&mut client, &mut server);
-
-    send_datagram(&mut server, &mut client, FIRST_DATAGRAM.to_vec());
-    send_datagram(&mut server, &mut client, SECOND_DATAGRAM.to_vec());
-    send_datagram(&mut server, &mut client, THIRD_DATAGRAM.to_vec());
-
-    // Datagram with FIRST_DATAGRAM data will be dropped.
-    assert!(matches!(
-        client.next_event().unwrap(),
-        ConnectionEvent::IncomingDatagramDropped
-    ));
-    assert!(matches!(
-        client.next_event().unwrap(),
-        ConnectionEvent::Datagram(data) if data == SECOND_DATAGRAM
-    ));
-    assert!(matches!(
-        client.next_event().unwrap(),
-        ConnectionEvent::Datagram(data) if data == THIRD_DATAGRAM
-    ));
-    assert!(client.next_event().is_none());
-    assert_eq!(client.stats().incoming_datagram_dropped, 1);
-
-    // New events can be queued.
-    send_datagram(&mut server, &mut client, FOURTH_DATAGRAM.to_vec());
-    assert!(matches!(
-        client.next_event().unwrap(),
-        ConnectionEvent::Datagram(data) if data == FOURTH_DATAGRAM
-    ));
-    assert!(client.next_event().is_none());
-    assert_eq!(client.stats().incoming_datagram_dropped, 1);
 }
 
 #[test]

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -12,7 +12,7 @@ use neqo_common::event::Provider as EventProvider;
 use nss::ResumptionToken;
 
 use crate::{
-    AppError, Stats,
+    AppError,
     connection::State,
     quic_datagrams::DatagramTracking,
     scone::Bitrate,
@@ -78,7 +78,6 @@ pub enum ConnectionEvent {
         id: u64,
         outcome: OutgoingDatagramOutcome,
     },
-    IncomingDatagramDropped,
     /// An update was received to SCONE throughput advice.
     /// The value is the approximate rate in bits per second; None = unknown.
     SconeUpdated(Option<NonZeroU64>),
@@ -180,30 +179,7 @@ impl ConnectionEvents {
         self.insert(ConnectionEvent::SconeUpdated(Option::from(scone)));
     }
 
-    // The number of datagrams in the events queue is limited to max_queued_datagrams.
-    // This function ensure this and deletes the oldest datagrams (head-drop) if needed.
-    fn check_datagram_queued(&self, max_queued_datagrams: usize, stats: &mut Stats) {
-        let mut queue = self.events.borrow_mut();
-        let count = queue
-            .iter()
-            .filter(|evt| matches!(evt, ConnectionEvent::Datagram(_)))
-            .count();
-        if count < max_queued_datagrams {
-            // Below the limit. No action needed.
-            return;
-        }
-        let first = queue
-            .iter_mut()
-            .find(|evt| matches!(evt, ConnectionEvent::Datagram(_)))
-            .expect("Checked above");
-        // Remove the oldest (head-drop), replacing it with an
-        // IncomingDatagramDropped placeholder.
-        *first = ConnectionEvent::IncomingDatagramDropped;
-        stats.incoming_datagram_dropped += 1;
-    }
-
-    pub fn add_datagram(&self, max_queued_datagrams: usize, data: &[u8], stats: &mut Stats) {
-        self.check_datagram_queued(max_queued_datagrams, stats);
+    pub fn add_datagram(&self, data: &[u8]) {
         self.events
             .borrow_mut()
             .push_back(ConnectionEvent::Datagram(data.to_vec()));
@@ -271,7 +247,7 @@ impl EventProvider for ConnectionEvents {
 mod tests {
     use neqo_common::event::Provider as _;
 
-    use crate::{CloseReason, ConnectionEvent, ConnectionEvents, Error, State, Stats, StreamId};
+    use crate::{CloseReason, ConnectionEvent, ConnectionEvents, Error, State, StreamId};
 
     #[test]
     fn event_culling() {
@@ -333,71 +309,5 @@ mod tests {
         evts.send_stream_stop_sending(10.into(), 55);
         evts.connection_state_change(State::Closed(CloseReason::Transport(Error::StreamState)));
         assert_eq!(evts.events().count(), 1);
-    }
-
-    #[test]
-    fn datagram_queue_drops_oldest() {
-        const MAX_QUEUED: usize = 2;
-
-        // Fill the queue to capacity, verify that and that there are no drops yet.
-        let e = ConnectionEvents::default();
-        let mut stats = Stats::default();
-        e.add_datagram(MAX_QUEUED, &[1], &mut stats);
-        e.add_datagram(MAX_QUEUED, &[2], &mut stats);
-        assert_eq!(stats.incoming_datagram_dropped, 0);
-        assert_eq!(e.events.borrow().len(), MAX_QUEUED);
-
-        // Add one more datagram - this should drop the oldest ("1").
-        e.add_datagram(MAX_QUEUED, &[3], &mut stats);
-        assert_eq!(stats.incoming_datagram_dropped, 1);
-
-        // Should have one `IncomingDatagramDropped` event + `MAX_QUEUED` datagrams.
-        assert_eq!(
-            e.events.borrow().iter().collect::<Vec<_>>(),
-            [
-                &ConnectionEvent::IncomingDatagramDropped,
-                &ConnectionEvent::Datagram(vec![2]),
-                &ConnectionEvent::Datagram(vec![3]),
-            ]
-        );
-    }
-
-    /// Previously `check_datagram_queued` had a bug that caused it to
-    /// potentially drop an unrelated event.
-    ///
-    /// See <https://github.com/mozilla/neqo/pull/3105> for details.
-    #[test]
-    fn datagram_queue_drops_datagram_not_unrelated_event() {
-        const MAX_QUEUED: usize = 2;
-
-        let e = ConnectionEvents::default();
-        let mut stats = Stats::default();
-
-        // Add unrelated event.
-        e.new_stream(4.into());
-
-        // Fill the queue with datagrams to capacity.
-        e.add_datagram(MAX_QUEUED, &[1], &mut stats);
-        e.add_datagram(MAX_QUEUED, &[2], &mut stats);
-        assert_eq!(stats.incoming_datagram_dropped, 0);
-        assert_eq!(e.events.borrow().len(), 1 + MAX_QUEUED);
-
-        // Add one more datagram - this should drop the oldest ("1"), not the
-        // unrelated event.
-        e.add_datagram(MAX_QUEUED, &[3], &mut stats);
-        assert_eq!(stats.incoming_datagram_dropped, 1);
-
-        // Should have one `IncomingDatagramDropped` event + `MAX_QUEUED` datagrams.
-        assert_eq!(
-            e.events.borrow().iter().collect::<Vec<_>>(),
-            [
-                &ConnectionEvent::NewStream {
-                    stream_id: StreamId::new(4)
-                },
-                &ConnectionEvent::IncomingDatagramDropped,
-                &ConnectionEvent::Datagram(vec![2]),
-                &ConnectionEvent::Datagram(vec![3]),
-            ]
-        );
     }
 }

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -66,9 +66,6 @@ pub struct QuicDatagrams {
     /// The max size of a datagram that would be acceptable by the peer.
     remote_datagram_size: u64,
     max_queued_outgoing_datagrams: usize,
-    /// The max number of datagrams that will be queued in connection events.
-    /// If the number is exceeded, the oldest datagram will be dropped.
-    max_queued_incoming_datagrams: usize,
     /// Datagram queued for sending.
     datagrams: VecDeque<QuicDatagram>,
     conn_events: ConnectionEvents,
@@ -78,14 +75,12 @@ impl QuicDatagrams {
     pub fn new(
         local_datagram_size: u64,
         max_queued_outgoing_datagrams: usize,
-        max_queued_incoming_datagrams: usize,
         conn_events: ConnectionEvents,
     ) -> Self {
         Self {
             local_datagram_size,
             remote_datagram_size: 0,
             max_queued_outgoing_datagrams,
-            max_queued_incoming_datagrams,
             datagrams: VecDeque::with_capacity(max_queued_outgoing_datagrams),
             conn_events,
         }
@@ -186,15 +181,14 @@ impl QuicDatagrams {
         Ok(())
     }
 
-    pub fn handle_datagram(&self, data: &[u8], stats: &mut Stats) -> Res<()> {
+    pub fn handle_datagram(&self, data: &[u8]) -> Res<()> {
         // A `local_datagram_size` of 0 means we advertised a
         // max_datagram_frame_size of 0, i.e. no DATAGRAM frame support
         // (RFC 9221, Section 3).
         if self.local_datagram_size == 0 || self.local_datagram_size < to_u64(data.len()) {
             return Err(Error::ProtocolViolation);
         }
-        self.conn_events
-            .add_datagram(self.max_queued_incoming_datagrams, data, stats);
+        self.conn_events.add_datagram(data);
         Ok(())
     }
 }

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -392,10 +392,6 @@ pub struct Stats {
     /// Count frames sent.
     pub frame_tx: FrameStats,
 
-    /// The number of incoming datagrams dropped due to reaching the limit
-    /// of the incoming queue.
-    pub incoming_datagram_dropped: usize,
-
     pub datagram_tx: DatagramStats,
 
     pub cc: CongestionControlStats,


### PR DESCRIPTION
The inbound queue head-dropped the oldest datagram once full. The drop itself hurts: the discarded datagram is gone for good, and on the MASQUE connect-udp path it looks like loss to the inner connection, shrinking its congestion window and throughput.

Removing the limit is safe as long as we cap how much we read from the socket per iteration and deplete neqo's event queue regularly, so the queue cannot grow without bound. Both are still to be done on the consumer side.

Also removes the now-unused plumbing:

- the `incoming_datagram_queue` connection parameter
- the `IncomingDatagramDropped` event
- the `incoming_datagram_dropped` stat
- the `check_datagram_queued` bookkeeping

Fixes #1373