### PR TITLE
fix: reject zero Insert Count Increment on QPACK decoder stream

### DIFF
--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -230,6 +230,12 @@ impl Encoder {
         qdebug!("[{self}] call instruction {instruction:?}");
         match instruction {
             DecoderInstruction::InsertCountIncrement { increment } => {
+                // RFC 9204, Section 4.4.3: an Increment of zero is a connection error
+                // of type QPACK_DECODER_STREAM_ERROR, the same as one that raises the
+                // count past the inserts sent (rejected in `increment_acked`).
+                if increment == 0 {
+                    return Err(Error::DecoderStream);
+                }
                 qlog::qpack_read_insert_count_increment_instruction(
                     qlog,
                     increment,
@@ -1006,6 +1012,29 @@ mod tests {
     #[test]
     fn stream_canceled() {
         test_insertion_blocked_on_waiting_for_header_ack_or_stream_cancel(1);
+    }
+
+    /// RFC 9204, Section 4.4.3: an Insert Count Increment instruction with an
+    /// Increment of zero is a connection error of type `QPACK_DECODER_STREAM_ERROR`,
+    /// the same as one that raises the count past the inserts the encoder has sent
+    /// (already rejected in `increment_acked`).
+    #[test]
+    fn insert_count_increment_zero_is_rejected() {
+        let mut encoder = connect(false);
+
+        // 0x00 is an Insert Count Increment instruction carrying an Increment of 0.
+        encoder
+            .peer_conn
+            .stream_send(encoder.recv_stream_id, &[0x00])
+            .unwrap();
+        let out = encoder.peer_conn.process_output(now());
+        drop(encoder.conn.process(out.dgram(), now()));
+        assert_eq!(
+            encoder
+                .encoder
+                .read_instructions(&mut encoder.conn, encoder.recv_stream_id, now()),
+            Err(Error::DecoderStream)
+        );
     }
 
     fn assert_is_index_to_dynamic(buf: &[u8]) {

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -1028,7 +1028,7 @@ mod tests {
             .stream_send(encoder.recv_stream_id, &[0x00])
             .unwrap();
         let out = encoder.peer_conn.process_output(now());
-        drop(encoder.conn.process(out.dgram(), now()));
+        encoder.conn.process_input(out.dgram().unwrap(), now());
         assert_eq!(
             encoder
                 .encoder


### PR DESCRIPTION
A zero-valued Insert Count Increment on the QPACK decoder stream is accepted today:

    decoder stream: 0x00  (Insert Count Increment, Increment = 0)
    Encoder::call_instruction -> increment_acked(0) -> Ok(())

RFC 9204 Section 4.4.3 lists that in the same sentence as an increment that raises the count past the inserts the encoder has sent, both a connection error of type QPACK_DECODER_STREAM_ERROR. `increment_acked` already rejects the latter; the zero case fell through.

Before: a zero increment is a silent no-op and the connection stays open.
After: it returns Error::DecoderStream (0x0202), the same as an over-large increment.

Tradeoff: less tolerant of a misbehaving peer decoder, but a zero increment conveys nothing and the RFC requires the error, so both halves of 4.4.3 now behave the same.
