### PR TITLE
Hex debugging improvements

### DIFF
--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -304,7 +304,7 @@ impl StreamHandler for DownloadStreamHandler {
             } else if let Ok(txt) = std::str::from_utf8(data) {
                 qdebug!("READ[{stream_id}]: {txt}");
             } else {
-                qdebug!("READ[{stream_id}]: 0x{}", &Hex::new(data));
+                qdebug!("READ[{stream_id}]: 0x{}", Hex::new(data));
             }
         }
 
@@ -354,7 +354,7 @@ impl StreamHandler for UploadStreamHandler {
             }
             Ok(())
         } else {
-            qerror!("Unexpected data [{stream_id}]: 0x{}", &Hex::new(data));
+            qerror!("Unexpected data [{stream_id}]: 0x{}", Hex::new(data));
             Err(crate::client::Error::Http3(Error::InvalidInput))
         }
     }

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use http::Uri as Url;
-use neqo_common::{Datagram, event::Provider, hex, qdebug, qerror, qinfo, qwarn};
+use neqo_common::{Datagram, Hex, event::Provider, qdebug, qerror, qinfo, qwarn};
 use neqo_http3::{Error, Http3Client, Http3ClientEvent, Http3Parameters, Http3State, Priority};
 use neqo_transport::{
     AppError, CloseReason, Connection, EmptyConnectionIdGenerator, Error as TransportError,
@@ -304,7 +304,7 @@ impl StreamHandler for DownloadStreamHandler {
             } else if let Ok(txt) = std::str::from_utf8(data) {
                 qdebug!("READ[{stream_id}]: {txt}");
             } else {
-                qdebug!("READ[{stream_id}]: 0x{}", hex(data));
+                qdebug!("READ[{stream_id}]: 0x{}", &Hex::new(data));
             }
         }
 
@@ -354,7 +354,7 @@ impl StreamHandler for UploadStreamHandler {
             }
             Ok(())
         } else {
-            qerror!("Unexpected data [{stream_id}]: 0x{}", hex(data));
+            qerror!("Unexpected data [{stream_id}]: 0x{}", &Hex::new(data));
             Err(crate::client::Error::Http3(Error::InvalidInput))
         }
     }

--- a/neqo-bin/src/client/http3.rs
+++ b/neqo-bin/src/client/http3.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use http::Uri as Url;
-use neqo_common::{Datagram, Hex, event::Provider, qdebug, qerror, qinfo, qwarn};
+use neqo_common::{Datagram, event::Provider, hex::Hex, qdebug, qerror, qinfo, qwarn};
 use neqo_http3::{Error, Http3Client, Http3ClientEvent, Http3Parameters, Http3State, Priority};
 use neqo_transport::{
     AppError, CloseReason, Connection, EmptyConnectionIdGenerator, Error as TransportError,

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -33,7 +33,7 @@ use futures::{
     FutureExt as _,
     future::{Either, select, select_all},
 };
-use neqo_common::{Datagram, Hex, qdebug, qerror, qinfo, qwarn};
+use neqo_common::{Datagram, hex::Hex, qdebug, qerror, qinfo, qwarn};
 use neqo_http3::Http3Server;
 use neqo_transport::{OutputBatch, RandomConnectionIdGenerator, Version, server::ValidateAddress};
 use neqo_udp::{DatagramIter, RecvBuf};

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -269,7 +269,7 @@ pub(super) fn configure_server(server: &mut impl ServerConfig, args: &Args) {
     if args.ech {
         let (sk, pk) = generate_ech_keys().expect("should create ECH keys");
         server.enable_ech(random::<1>()[0], "public.example", &sk, &pk);
-        qinfo!("ECHConfigList: {}", &Hex::new(server.ech_config()));
+        qinfo!("ECHConfigList: {}", Hex::new(server.ech_config()));
     }
 }
 

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -33,7 +33,7 @@ use futures::{
     FutureExt as _,
     future::{Either, select, select_all},
 };
-use neqo_common::{Datagram, hex, qdebug, qerror, qinfo, qwarn};
+use neqo_common::{Datagram, Hex, qdebug, qerror, qinfo, qwarn};
 use neqo_http3::Http3Server;
 use neqo_transport::{OutputBatch, RandomConnectionIdGenerator, Version, server::ValidateAddress};
 use neqo_udp::{DatagramIter, RecvBuf};
@@ -269,7 +269,7 @@ pub(super) fn configure_server(server: &mut impl ServerConfig, args: &Args) {
     if args.ech {
         let (sk, pk) = generate_ech_keys().expect("should create ECH keys");
         server.enable_ech(random::<1>()[0], "public.example", &sk, &pk);
-        qinfo!("ECHConfigList: {}", hex(server.ech_config()));
+        qinfo!("ECHConfigList: {}", &Hex::new(server.ech_config()));
     }
 }
 

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -9,7 +9,7 @@ use std::{
     io::{self, Cursor},
 };
 
-use crate::{HexWithLen, Length, to_u64, to_usize};
+use crate::{Length, hex::HexWithLen, to_u64, to_usize};
 
 pub const MAX_VARINT: u64 = (1 << 62) - 1;
 

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -498,7 +498,7 @@ impl Default for Encoder {
 
 impl Debug for Encoder {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", &HexWithLen::new(self))
+        HexWithLen::fmt(f, self)
     }
 }
 

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -9,7 +9,7 @@ use std::{
     io::{self, Cursor},
 };
 
-use crate::{Length, hex_with_len, to_u64, to_usize};
+use crate::{HexWithLen, Length, to_u64, to_usize};
 
 pub const MAX_VARINT: u64 = (1 << 62) - 1;
 
@@ -184,7 +184,7 @@ impl<'a> AsRef<[u8]> for Decoder<'a> {
 
 impl Debug for Decoder<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.write_str(&hex_with_len(self.as_ref()))
+        HexWithLen::fmt(f, self)
     }
 }
 
@@ -498,7 +498,7 @@ impl Default for Encoder {
 
 impl Debug for Encoder {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.write_str(&hex_with_len(self))
+        write!(f, "{}", &HexWithLen::new(self))
     }
 }
 

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -11,7 +11,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use crate::{Bytes, HexWithLen, Tos};
+use crate::{Bytes, Tos, hex::HexWithLen};
 
 /// A UDP datagram.
 ///

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -11,7 +11,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use crate::{Bytes, Tos, hex_with_len};
+use crate::{Bytes, HexWithLen, Tos};
 
 /// A UDP datagram.
 ///
@@ -118,7 +118,7 @@ impl<D: AsRef<[u8]>> Debug for Datagram<D> {
             self.tos,
             self.src,
             self.dst,
-            hex_with_len(&self.d)
+            &HexWithLen::new(&self.d)
         )
     }
 }
@@ -173,7 +173,7 @@ impl Debug for Batch {
             self.src,
             self.dst,
             self.datagram_size,
-            hex_with_len(&self.d)
+            &HexWithLen::new(&self.d)
         )
     }
 }

--- a/neqo-common/src/datagram.rs
+++ b/neqo-common/src/datagram.rs
@@ -118,7 +118,7 @@ impl<D: AsRef<[u8]>> Debug for Datagram<D> {
             self.tos,
             self.src,
             self.dst,
-            &HexWithLen::new(&self.d)
+            HexWithLen::new(&self.d)
         )
     }
 }
@@ -173,7 +173,7 @@ impl Debug for Batch {
             self.src,
             self.dst,
             self.datagram_size,
-            &HexWithLen::new(&self.d)
+            HexWithLen::new(&self.d)
         )
     }
 }

--- a/neqo-common/src/header.rs
+++ b/neqo-common/src/header.rs
@@ -257,4 +257,19 @@ mod tests {
         );
         assert!(headers.iter().find_header("missing").is_none());
     }
+
+    #[test]
+    fn debug_format() {
+        let h = Header::new(":status", "200");
+        assert_eq!(format!("{h:?}"), r#"<:status>: "200""#);
+
+        let h = Header::new("content-type", "text/html");
+        assert_eq!(format!("{h:?}"), r#"content-type: "text/html""#);
+
+        let h = Header::new("has-quotes", "abc\"123");
+        assert_eq!(format!("{h:?}"), r#"has-quotes: "abc\"123""#);
+
+        let h = Header::new("binary", vec![0xff, 0xfe]);
+        assert_eq!(format!("{h:?}"), "binary: [2]: fffe");
+    }
 }

--- a/neqo-common/src/header.rs
+++ b/neqo-common/src/header.rs
@@ -4,11 +4,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::str::FromStr;
+use std::{
+    fmt::{self, Debug},
+    str::FromStr,
+};
 
 use thiserror::Error;
 
-#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Clone)]
+use crate::HexWithLen;
+
+#[derive(PartialEq, PartialOrd, Eq, Ord, Clone)]
 pub struct Header {
     name: String,
     /// The raw header field value as bytes.
@@ -64,6 +69,22 @@ impl Header {
     /// Returns an error if the value contains invalid UTF-8.
     pub fn value_utf8(&self) -> Result<&str, std::str::Utf8Error> {
         std::str::from_utf8(&self.value)
+    }
+}
+
+impl Debug for Header {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.name.starts_with(':') {
+            write!(f, "<{}>", self.name)?;
+        } else {
+            f.write_str(&self.name)?;
+        }
+        f.write_str(": ")?;
+        if let Ok(s) = self.value_utf8() {
+            write!(f, r#""{s}""#)
+        } else {
+            HexWithLen::fmt(f, &self.value)
+        }
     }
 }
 

--- a/neqo-common/src/header.rs
+++ b/neqo-common/src/header.rs
@@ -11,7 +11,7 @@ use std::{
 
 use thiserror::Error;
 
-use crate::HexWithLen;
+use crate::hex::HexWithLen;
 
 #[derive(PartialEq, PartialOrd, Eq, Ord, Clone)]
 pub struct Header {

--- a/neqo-common/src/header.rs
+++ b/neqo-common/src/header.rs
@@ -81,7 +81,7 @@ impl Debug for Header {
         }
         f.write_str(": ")?;
         if let Ok(s) = self.value_utf8() {
-            write!(f, r#""{s}""#)
+            write!(f, "{s:?}")
         } else {
             HexWithLen::fmt(f, &self.value)
         }

--- a/neqo-common/src/hex.rs
+++ b/neqo-common/src/hex.rs
@@ -34,9 +34,6 @@ impl<T> $n<T> {
     #[doc = concat!(r#"assert_eq!(format!("{:?}", Example("v".to_string(), vec!"#, stringify!($in), ")), expected);")]
     )*
     /// ```
-    ///
-    /// # Errors
-    /// Propagates any errors from the formatter.
     pub const fn new(v: T) -> Self {
         Self(v)
     }

--- a/neqo-common/src/hex.rs
+++ b/neqo-common/src/hex.rs
@@ -145,34 +145,31 @@ mod tests {
 
     #[test]
     fn hex_output() {
-        assert_eq!(format!("{}", &Hex::new([])), "");
-        assert_eq!(format!("{}", &Hex::new([0xab, 0xcd])), "abcd");
+        assert_eq!(format!("{}", Hex::new([])), "");
+        assert_eq!(format!("{}", Hex::new([0xab, 0xcd])), "abcd");
 
-        assert_eq!(format!("{}", &HexSnipMiddle::new([])), "[0]");
-        assert_eq!(format!("{}", &HexWithLen::new([])), "[0]");
+        assert_eq!(format!("{}", HexSnipMiddle::new([])), "[0]");
+        assert_eq!(format!("{}", HexWithLen::new([])), "[0]");
 
-        assert_eq!(
-            format!("{}", &HexSnipMiddle::new([0xab, 0xcd])),
-            "[2]: abcd"
-        );
-        assert_eq!(format!("{}", &HexWithLen::new([0xab, 0xcd])), "[2]: abcd");
+        assert_eq!(format!("{}", HexSnipMiddle::new([0xab, 0xcd])), "[2]: abcd");
+        assert_eq!(format!("{}", HexWithLen::new([0xab, 0xcd])), "[2]: abcd");
     }
 
     #[test]
     fn hex_snip_middle_boundary() {
         // Exactly SHOW_LEN*2 = 16 bytes: should use full hex (no "..").
         let short: Vec<u8> = (0..16).collect();
-        let s = format!("{}", &HexSnipMiddle::new(&short));
+        let s = format!("{}", HexSnipMiddle::new(&short));
         assert!(!s.contains(".."), "16 bytes should not be truncated");
         assert!(s.ends_with("0e0f"));
 
         // 17 bytes: one over the boundary, should be truncated.
         let just_over: Vec<u8> = (0..17).collect();
-        assert!(format!("{}", &HexSnipMiddle::new(&just_over)).contains(".."));
+        assert!(format!("{}", HexSnipMiddle::new(&just_over)).contains(".."));
 
         // 20 bytes: truncated, check first 8 and last 8 bytes are exact.
         let long: Vec<u8> = (0..20).collect();
-        let s = format!("{}", &HexSnipMiddle::new(&long));
+        let s = format!("{}", HexSnipMiddle::new(&long));
         assert!(s.starts_with("[20]: 0001020304050607"));
         assert!(s.contains(".."));
         // Last 8 bytes (12..20 = 0x0c..0x13) must be exactly "0c0d0e0f10111213".

--- a/neqo-common/src/hex.rs
+++ b/neqo-common/src/hex.rs
@@ -115,7 +115,7 @@ hex_struct! {
         chunk_hex(f, &buf[..first])?;
         let last = max(buf.len().saturating_sub(SHOW_LEN), first);
         if last > first {
-            write!(f, "..")?;
+            f.write_str("..")?;
         }
         chunk_hex(f, &buf[last..])
     }

--- a/neqo-common/src/hex.rs
+++ b/neqo-common/src/hex.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 macro_rules! hex_struct {
-    {$(#[$m:meta])* $n:ident, $f:item $($in:expr => $out:expr),*} => {
+    {$(#[$m:meta])* $n:ident, $f:item $($in:expr => $out:expr),*$(,)?} => {
 $(#[$m])*
 pub struct $n<T>(T);
 
@@ -100,7 +100,8 @@ hex_struct! {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         chunk_hex(f, &self.0)
     }
-    [1, 2, 3] => "010203"
+    [] => "",
+    [1, 2, 3] => "010203",
 }
 
 hex_struct! {
@@ -121,7 +122,9 @@ hex_struct! {
         }
         chunk_hex(f, &buf[last..])
     }
-    [1, 2, 3] => "[3]: 010203"
+    [] => "[0]",
+    [1, 2, 3] => "[3]: 010203",
+    [0; 20] => "[20]: 0000000000000000..0000000000000000",
 }
 
 hex_struct! {
@@ -135,7 +138,7 @@ hex_struct! {
         }
         chunk_hex(f, buf)
     }
-    [1, 2, 3] => "[3]: 010203"
+    [1, 2, 3] => "[3]: 010203",
 }
 
 #[cfg(test)]

--- a/neqo-common/src/hex.rs
+++ b/neqo-common/src/hex.rs
@@ -36,7 +36,7 @@ impl<T> $n<T> {
     /// ```
     ///
     /// # Errors
-    /// Propagates and errors from the formatter.
+    /// Propagates any errors from the formatter.
     pub const fn new(v: T) -> Self {
         Self(v)
     }
@@ -60,7 +60,7 @@ impl<T: AsRef<[u8]>> $n<T> {
     /// ```
     ///
     /// # Errors
-    /// Propagates and errors from the formatter.
+    /// Propagates any errors from the formatter.
     pub fn fmt(f: &mut fmt::Formatter<'_>, v: T) -> fmt::Result {
         write!(f, "{}", &Self::new(v))
     }

--- a/neqo-common/src/hex.rs
+++ b/neqo-common/src/hex.rs
@@ -52,7 +52,7 @@ impl<T: AsRef<[u8]>> $n<T> {
     ///     }
     /// }
     $(
-    #[doc = concat!(r#"assert_eq!(format!("{}", VecWrapper(vec!"#, stringify!($in), ")), ", stringify!($out), r");")]
+    #[doc = concat!(r"assert_eq!(VecWrapper(vec!", stringify!($in), ").to_string(), ", stringify!($out), r");")]
     )*
     /// ```
     ///
@@ -145,31 +145,31 @@ mod tests {
 
     #[test]
     fn hex_output() {
-        assert_eq!(format!("{}", Hex::new([])), "");
-        assert_eq!(format!("{}", Hex::new([0xab, 0xcd])), "abcd");
+        assert_eq!(Hex::new([]).to_string(), "");
+        assert_eq!(Hex::new([0xab, 0xcd]).to_string(), "abcd");
 
-        assert_eq!(format!("{}", HexSnipMiddle::new([])), "[0]");
-        assert_eq!(format!("{}", HexWithLen::new([])), "[0]");
+        assert_eq!(HexSnipMiddle::new([]).to_string(), "[0]");
+        assert_eq!(HexWithLen::new([]).to_string(), "[0]");
 
-        assert_eq!(format!("{}", HexSnipMiddle::new([0xab, 0xcd])), "[2]: abcd");
-        assert_eq!(format!("{}", HexWithLen::new([0xab, 0xcd])), "[2]: abcd");
+        assert_eq!(HexSnipMiddle::new([0xab, 0xcd]).to_string(), "[2]: abcd");
+        assert_eq!(HexWithLen::new([0xab, 0xcd]).to_string(), "[2]: abcd");
     }
 
     #[test]
     fn hex_snip_middle_boundary() {
         // Exactly SHOW_LEN*2 = 16 bytes: should use full hex (no "..").
         let short: Vec<u8> = (0..16).collect();
-        let s = format!("{}", HexSnipMiddle::new(&short));
+        let s = HexSnipMiddle::new(&short).to_string();
         assert!(!s.contains(".."), "16 bytes should not be truncated");
         assert!(s.ends_with("0e0f"));
 
         // 17 bytes: one over the boundary, should be truncated.
         let just_over: Vec<u8> = (0..17).collect();
-        assert!(format!("{}", HexSnipMiddle::new(&just_over)).contains(".."));
+        assert!(HexSnipMiddle::new(&just_over).to_string().contains(".."));
 
         // 20 bytes: truncated, check first 8 and last 8 bytes are exact.
         let long: Vec<u8> = (0..20).collect();
-        let s = format!("{}", HexSnipMiddle::new(&long));
+        let s = HexSnipMiddle::new(&long).to_string();
         assert!(s.starts_with("[20]: 0001020304050607"));
         assert!(s.contains(".."));
         // Last 8 bytes (12..20 = 0x0c..0x13) must be exactly "0c0d0e0f10111213".

--- a/neqo-common/src/hex.rs
+++ b/neqo-common/src/hex.rs
@@ -1,0 +1,181 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{
+    cmp::{max, min},
+    fmt,
+};
+
+macro_rules! hex_struct {
+    {$(#[$m:meta])* $n:ident, $f:item $($in:expr => $out:expr),*} => {
+$(#[$m])*
+pub struct $n<T>(T);
+
+impl<T> $n<T> {
+    /// Wrap an object (or reference) for hex formatting.
+    ///
+    /// For example:
+    /// ```
+    #[doc = concat!("# use neqo_common::hex::", stringify!($n), ";")]
+    /// struct Example(String, Vec<u8>);
+    /// impl std::fmt::Debug for Example {
+    ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    ///         f.debug_tuple("Example")
+    ///          .field(&self.0)
+    #[doc = concat!(r#"          .field(&"#, stringify!($n), "::new(&self.1))")]
+    ///          .finish()
+    ///     }
+    /// }
+    $(
+    #[doc = concat!(r##"let expected = concat!(r#"Example("v", "#, "##, stringify!($out), r#", ")");"#)]
+    #[doc = concat!(r#"assert_eq!(format!("{:?}", Example("v".to_string(), vec!"#, stringify!($in), ")), expected);")]
+    )*
+    /// ```
+    ///
+    /// # Errors
+    /// Propagates and errors from the formatter.
+    pub const fn new(v: T) -> Self {
+        Self(v)
+    }
+}
+
+impl<T: AsRef<[u8]>> $n<T> {
+    /// Write hex-formatted text to the formatter.
+    ///
+    /// For example:
+    /// ```
+    #[doc = concat!("# use neqo_common::hex::", stringify!($n), ";")]
+    /// struct VecWrapper(Vec<u8>);
+    /// impl std::fmt::Display for VecWrapper {
+    ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    #[doc = concat!("        ", stringify!($n), "::fmt(f, &self.0)")]
+    ///     }
+    /// }
+    $(
+    #[doc = concat!(r#"assert_eq!(format!("{}", VecWrapper(vec!"#, stringify!($in), ")), ", stringify!($out), r");")]
+    )*
+    /// ```
+    ///
+    /// # Errors
+    /// Propagates and errors from the formatter.
+    pub fn fmt(f: &mut fmt::Formatter<'_>, v: T) -> fmt::Result {
+        write!(f, "{}", &Self::new(v))
+    }
+}
+
+impl<T: AsRef<[u8]>> fmt::Display for $n<T> {
+    $f
+}
+
+impl<T: AsRef<[u8]>> fmt::Debug for $n<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as fmt::Display>::fmt(self, f)
+    }
+}
+    };
+}
+
+/// A fast hex implementation with fixed overhead.
+fn chunk_hex<T: AsRef<[u8]>>(f: &mut fmt::Formatter<'_>, v: T) -> fmt::Result {
+    const HEX: &[u8] = b"0123456789abcdef";
+    const CHUNK_SIZE: usize = 128;
+    let mut chunk = [0u8; CHUNK_SIZE * 2];
+    for slice in v.as_ref().chunks(CHUNK_SIZE) {
+        for (i, &b) in slice.iter().enumerate() {
+            chunk[i * 2] = HEX[usize::from(b >> 4)];
+            chunk[i * 2 + 1] = HEX[usize::from(b & 0xf)];
+        }
+        // SAFETY: only ASCII hex is written to the chunk
+        f.write_str(unsafe { std::str::from_utf8_unchecked(&chunk[..slice.len() * 2]) })?;
+    }
+    Ok(())
+}
+
+hex_struct! {
+    /// Simple Hex converter for formatting.
+    Hex,
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        chunk_hex(f, &self.0)
+    }
+    [1, 2, 3] => "010203"
+}
+
+hex_struct! {
+    /// Hex converter for formatting that trims long sequences.
+    HexSnipMiddle,
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const SHOW_LEN: usize = 8;
+        let buf = self.0.as_ref();
+        write!(f, "[{}]", buf.len())?;
+        if !buf.is_empty() {
+            f.write_str(": ")?;
+        }
+        let first = min(buf.len(), SHOW_LEN);
+        chunk_hex(f, &buf[..first])?;
+        let last = max(buf.len().saturating_sub(SHOW_LEN), first);
+        if last > first {
+            write!(f, "..")?;
+        }
+        chunk_hex(f, &buf[last..])
+    }
+    [1, 2, 3] => "[3]: 010203"
+}
+
+hex_struct! {
+    /// Hex converter for formatting that reports the length of the sequence.
+    HexWithLen,
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let buf = self.0.as_ref();
+        write!(f, "[{}]", buf.len())?;
+        if !buf.is_empty() {
+            f.write_str(": ")?;
+        }
+        chunk_hex(f, buf)
+    }
+    [1, 2, 3] => "[3]: 010203"
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::{Hex, HexSnipMiddle, HexWithLen};
+
+    #[test]
+    fn hex_output() {
+        assert_eq!(format!("{}", &Hex::new([])), "");
+        assert_eq!(format!("{}", &Hex::new([0xab, 0xcd])), "abcd");
+
+        assert_eq!(format!("{}", &HexSnipMiddle::new([])), "[0]");
+        assert_eq!(format!("{}", &HexWithLen::new([])), "[0]");
+
+        assert_eq!(
+            format!("{}", &HexSnipMiddle::new([0xab, 0xcd])),
+            "[2]: abcd"
+        );
+        assert_eq!(format!("{}", &HexWithLen::new([0xab, 0xcd])), "[2]: abcd");
+    }
+
+    #[test]
+    fn hex_snip_middle_boundary() {
+        // Exactly SHOW_LEN*2 = 16 bytes: should use full hex (no "..").
+        let short: Vec<u8> = (0..16).collect();
+        let s = format!("{}", &HexSnipMiddle::new(&short));
+        assert!(!s.contains(".."), "16 bytes should not be truncated");
+        assert!(s.ends_with("0e0f"));
+
+        // 17 bytes: one over the boundary, should be truncated.
+        let just_over: Vec<u8> = (0..17).collect();
+        assert!(format!("{}", &HexSnipMiddle::new(&just_over)).contains(".."));
+
+        // 20 bytes: truncated, check first 8 and last 8 bytes are exact.
+        let long: Vec<u8> = (0..20).collect();
+        let s = format!("{}", &HexSnipMiddle::new(&long));
+        assert!(s.starts_with("[20]: 0001020304050607"));
+        assert!(s.contains(".."));
+        // Last 8 bytes (12..20 = 0x0c..0x13) must be exactly "0c0d0e0f10111213".
+        assert!(s.ends_with("0c0d0e0f10111213"));
+    }
+}

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -101,14 +101,27 @@ impl<T: AsRef<[u8]>> fmt::Debug for $n<T> {
     };
 }
 
+/// A fast hex implementation with fixed overhead.
+fn chunk_hex<T: AsRef<[u8]>>(f: &mut fmt::Formatter<'_>, v: T) -> fmt::Result {
+    const HEX: &[u8] = b"0123456789abcdef";
+    const CHUNK_SIZE: usize = 128;
+    let mut chunk = [0u8; CHUNK_SIZE * 2];
+    for slice in v.as_ref().chunks(CHUNK_SIZE) {
+        for (i, &b) in slice.iter().enumerate() {
+            chunk[i * 2] = HEX[usize::from(b >> 4)];
+            chunk[i * 2 + 1] = HEX[usize::from(b & 0xf)];
+        }
+        // SAFETY: only ASCII hex is written to the chunk
+        f.write_str(unsafe { std::str::from_utf8_unchecked(&chunk[..slice.len() * 2]) })?;
+    }
+    Ok(())
+}
+
 hex_struct! {
     /// Simple Hex converter for formatting.
     Hex,
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for b in self.0.as_ref() {
-            write!(f, "{b:02x}")?;
-        }
-        Ok(())
+        chunk_hex(f, &self.0)
     }
 }
 
@@ -123,17 +136,12 @@ hex_struct! {
             f.write_str(": ")?;
         }
         let first = min(buf.len(), SHOW_LEN);
-        for b in &buf[..first] {
-            write!(f, "{b:02x}")?;
-        }
+        chunk_hex(f, &buf[..first])?;
         let last = max(buf.len().saturating_sub(SHOW_LEN), first);
         if last > first {
             write!(f, "..")?;
         }
-        for b in &buf[last..] {
-            write!(f, "{b:02x}")?;
-        }
-        Ok(())
+        chunk_hex(f, &buf[last..])
     }
 }
 
@@ -146,10 +154,7 @@ hex_struct! {
         if !buf.is_empty() {
             f.write_str(": ")?;
         }
-        for b in buf {
-            write!(f, "{b:02x}")?;
-        }
-        Ok(())
+        chunk_hex(f, buf)
     }
 }
 

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -19,7 +19,10 @@ pub mod log;
 pub mod qlog;
 pub mod tos;
 
-use std::fmt::Write as _;
+use std::{
+    cmp::{max, min},
+    fmt,
+};
 
 use enum_map::Enum;
 use static_assertions::const_assert_eq;
@@ -36,44 +39,118 @@ pub use self::{
     tos::{Dscp, Ecn, Tos},
 };
 
-#[must_use]
-pub fn hex<A: AsRef<[u8]>>(buf: A) -> String {
-    let mut ret = String::with_capacity(buf.as_ref().len() * 2);
-    for b in buf.as_ref() {
-        write!(&mut ret, "{b:02x}").expect("write OK");
+macro_rules! hex_struct {
+    {$(#[$m:meta])* $n:ident, $f:item} => {
+$(#[$m])*
+pub struct $n<T>(T);
+
+impl<T> $n<T> {
+    /// Wrap an object (or reference) for hex formatting.
+    ///
+    /// For example:
+    /// ```
+    #[doc = concat!("# use neqo_common::", stringify!($n), ";")]
+    /// struct Example(String, Vec<u8>);
+    /// impl std::fmt::Debug for Example {
+    ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    ///         f.debug_tuple("Example")
+    ///          .field(&self.0)
+    #[doc = concat!(r#"          .field(&"#, stringify!($n), "::new(&self.1))")]
+    ///          .finish()
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    /// Propagates and errors from the formatter.
+    pub const fn new(v: T) -> Self {
+        Self(v)
     }
-    ret
 }
 
-#[must_use]
-pub fn hex_snip_middle<A: AsRef<[u8]>>(buf: A) -> String {
-    const SHOW_LEN: usize = 8;
-    let buf = buf.as_ref();
-    if buf.len() <= SHOW_LEN * 2 {
-        hex_with_len(buf)
-    } else {
-        let mut ret = String::with_capacity(SHOW_LEN * 2 + 16);
-        write!(&mut ret, "[{}]: ", buf.len()).expect("write OK");
-        for b in &buf[..SHOW_LEN] {
-            write!(&mut ret, "{b:02x}").expect("write OK");
-        }
-        ret.push_str("..");
-        for b in &buf[buf.len() - SHOW_LEN..] {
-            write!(&mut ret, "{b:02x}").expect("write OK");
-        }
-        ret
+impl<T: AsRef<[u8]>> $n<T> {
+    /// Write hex-formatted text to the formatter.
+    ///
+    /// For example:
+    /// ```
+    #[doc = concat!("# use neqo_common::", stringify!($n), ";")]
+    /// struct VecWrapper(Vec<u8>);
+    /// impl std::fmt::Display for VecWrapper {
+    ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    #[doc = concat!("        ", stringify!($n), "::fmt(f, &self.0)")]
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    /// Propagates and errors from the formatter.
+    pub fn fmt(f: &mut fmt::Formatter<'_>, v: T) -> fmt::Result {
+        write!(f, "{}", &Self::new(v))
     }
 }
 
-#[must_use]
-pub fn hex_with_len<A: AsRef<[u8]>>(buf: A) -> String {
-    let buf = buf.as_ref();
-    let mut ret = String::with_capacity(10 + buf.len() * 2);
-    write!(&mut ret, "[{}]: ", buf.len()).expect("write OK");
-    for b in buf {
-        write!(&mut ret, "{b:02x}").expect("write OK");
+impl<T: AsRef<[u8]>> fmt::Display for $n<T> {
+    $f
+}
+
+impl<T: AsRef<[u8]>> fmt::Debug for $n<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as fmt::Display>::fmt(self, f)
     }
-    ret
+}
+    };
+}
+
+hex_struct! {
+    /// Simple Hex converter for formatting.
+    Hex,
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0.as_ref() {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+hex_struct! {
+    /// Hex converter for formatting that trims long sequences.
+    HexSnipMiddle,
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const SHOW_LEN: usize = 8;
+        let buf = self.0.as_ref();
+        write!(f, "[{}]", buf.len())?;
+        if !buf.is_empty() {
+            f.write_str(": ")?;
+        }
+        let first = min(buf.len(), SHOW_LEN);
+        for b in &buf[..first] {
+            write!(f, "{b:02x}")?;
+        }
+        let last = max(buf.len().saturating_sub(SHOW_LEN), first);
+        if last > first {
+            write!(f, "..")?;
+        }
+        for b in &buf[last..] {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+hex_struct! {
+    /// Hex converter for formatting that reports the length of the sequence.
+    HexWithLen,
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let buf = self.0.as_ref();
+        write!(f, "[{}]", buf.len())?;
+        if !buf.is_empty() {
+            f.write_str(": ")?;
+        }
+        for b in buf {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
 }
 
 #[must_use]
@@ -183,12 +260,21 @@ macro_rules! dispatch {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use super::*;
+    use super::{Hex, HexSnipMiddle, HexWithLen, const_max, const_min};
 
     #[test]
     fn hex_output() {
-        assert_eq!(hex([]), "");
-        assert_eq!(hex([0xab, 0xcd]), "abcd");
+        assert_eq!(format!("{}", &Hex::new([])), "");
+        assert_eq!(format!("{}", &Hex::new([0xab, 0xcd])), "abcd");
+
+        assert_eq!(format!("{}", &HexSnipMiddle::new([])), "[0]");
+        assert_eq!(format!("{}", &HexWithLen::new([])), "[0]");
+
+        assert_eq!(
+            format!("{}", &HexSnipMiddle::new([0xab, 0xcd])),
+            "[2]: abcd"
+        );
+        assert_eq!(format!("{}", &HexWithLen::new([0xab, 0xcd])), "[2]: abcd");
     }
 
     #[test]
@@ -203,17 +289,17 @@ mod tests {
     fn hex_snip_middle_boundary() {
         // Exactly SHOW_LEN*2 = 16 bytes: should use full hex (no "..").
         let short: Vec<u8> = (0..16).collect();
-        let s = hex_snip_middle(&short);
+        let s = format!("{}", &HexSnipMiddle::new(&short));
         assert!(!s.contains(".."), "16 bytes should not be truncated");
         assert!(s.ends_with("0e0f"));
 
         // 17 bytes: one over the boundary, should be truncated.
         let just_over: Vec<u8> = (0..17).collect();
-        assert!(hex_snip_middle(&just_over).contains(".."));
+        assert!(format!("{}", &HexSnipMiddle::new(&just_over)).contains(".."));
 
         // 20 bytes: truncated, check first 8 and last 8 bytes are exact.
         let long: Vec<u8> = (0..20).collect();
-        let s = hex_snip_middle(&long);
+        let s = format!("{}", &HexSnipMiddle::new(&long));
         assert!(s.starts_with("[20]: 0001020304050607"));
         assert!(s.contains(".."));
         // Last 8 bytes (12..20 = 0x0c..0x13) must be exactly "0c0d0e0f10111213".

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -13,16 +13,12 @@ pub mod event;
 #[cfg(feature = "build-fuzzing-corpus")]
 mod fuzz;
 pub mod header;
+pub mod hex;
 pub mod hrtime;
 mod incrdecoder;
 pub mod log;
 pub mod qlog;
 pub mod tos;
-
-use std::{
-    cmp::{max, min},
-    fmt,
-};
 
 use enum_map::Enum;
 use static_assertions::const_assert_eq;
@@ -38,125 +34,6 @@ pub use self::{
     incrdecoder::{IncrementalDecoderBuffer, IncrementalDecoderIgnore, IncrementalDecoderUint},
     tos::{Dscp, Ecn, Tos},
 };
-
-macro_rules! hex_struct {
-    {$(#[$m:meta])* $n:ident, $f:item} => {
-$(#[$m])*
-pub struct $n<T>(T);
-
-impl<T> $n<T> {
-    /// Wrap an object (or reference) for hex formatting.
-    ///
-    /// For example:
-    /// ```
-    #[doc = concat!("# use neqo_common::", stringify!($n), ";")]
-    /// struct Example(String, Vec<u8>);
-    /// impl std::fmt::Debug for Example {
-    ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    ///         f.debug_tuple("Example")
-    ///          .field(&self.0)
-    #[doc = concat!(r#"          .field(&"#, stringify!($n), "::new(&self.1))")]
-    ///          .finish()
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// # Errors
-    /// Propagates and errors from the formatter.
-    pub const fn new(v: T) -> Self {
-        Self(v)
-    }
-}
-
-impl<T: AsRef<[u8]>> $n<T> {
-    /// Write hex-formatted text to the formatter.
-    ///
-    /// For example:
-    /// ```
-    #[doc = concat!("# use neqo_common::", stringify!($n), ";")]
-    /// struct VecWrapper(Vec<u8>);
-    /// impl std::fmt::Display for VecWrapper {
-    ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    #[doc = concat!("        ", stringify!($n), "::fmt(f, &self.0)")]
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// # Errors
-    /// Propagates and errors from the formatter.
-    pub fn fmt(f: &mut fmt::Formatter<'_>, v: T) -> fmt::Result {
-        write!(f, "{}", &Self::new(v))
-    }
-}
-
-impl<T: AsRef<[u8]>> fmt::Display for $n<T> {
-    $f
-}
-
-impl<T: AsRef<[u8]>> fmt::Debug for $n<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        <Self as fmt::Display>::fmt(self, f)
-    }
-}
-    };
-}
-
-/// A fast hex implementation with fixed overhead.
-fn chunk_hex<T: AsRef<[u8]>>(f: &mut fmt::Formatter<'_>, v: T) -> fmt::Result {
-    const HEX: &[u8] = b"0123456789abcdef";
-    const CHUNK_SIZE: usize = 128;
-    let mut chunk = [0u8; CHUNK_SIZE * 2];
-    for slice in v.as_ref().chunks(CHUNK_SIZE) {
-        for (i, &b) in slice.iter().enumerate() {
-            chunk[i * 2] = HEX[usize::from(b >> 4)];
-            chunk[i * 2 + 1] = HEX[usize::from(b & 0xf)];
-        }
-        // SAFETY: only ASCII hex is written to the chunk
-        f.write_str(unsafe { std::str::from_utf8_unchecked(&chunk[..slice.len() * 2]) })?;
-    }
-    Ok(())
-}
-
-hex_struct! {
-    /// Simple Hex converter for formatting.
-    Hex,
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        chunk_hex(f, &self.0)
-    }
-}
-
-hex_struct! {
-    /// Hex converter for formatting that trims long sequences.
-    HexSnipMiddle,
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        const SHOW_LEN: usize = 8;
-        let buf = self.0.as_ref();
-        write!(f, "[{}]", buf.len())?;
-        if !buf.is_empty() {
-            f.write_str(": ")?;
-        }
-        let first = min(buf.len(), SHOW_LEN);
-        chunk_hex(f, &buf[..first])?;
-        let last = max(buf.len().saturating_sub(SHOW_LEN), first);
-        if last > first {
-            write!(f, "..")?;
-        }
-        chunk_hex(f, &buf[last..])
-    }
-}
-
-hex_struct! {
-    /// Hex converter for formatting that reports the length of the sequence.
-    HexWithLen,
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let buf = self.0.as_ref();
-        write!(f, "[{}]", buf.len())?;
-        if !buf.is_empty() {
-            f.write_str(": ")?;
-        }
-        chunk_hex(f, buf)
-    }
-}
 
 #[must_use]
 pub const fn const_max(a: usize, b: usize) -> usize {
@@ -265,22 +142,7 @@ macro_rules! dispatch {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use super::{Hex, HexSnipMiddle, HexWithLen, const_max, const_min};
-
-    #[test]
-    fn hex_output() {
-        assert_eq!(format!("{}", &Hex::new([])), "");
-        assert_eq!(format!("{}", &Hex::new([0xab, 0xcd])), "abcd");
-
-        assert_eq!(format!("{}", &HexSnipMiddle::new([])), "[0]");
-        assert_eq!(format!("{}", &HexWithLen::new([])), "[0]");
-
-        assert_eq!(
-            format!("{}", &HexSnipMiddle::new([0xab, 0xcd])),
-            "[2]: abcd"
-        );
-        assert_eq!(format!("{}", &HexWithLen::new([0xab, 0xcd])), "[2]: abcd");
-    }
+    use super::{const_max, const_min};
 
     #[test]
     fn const_minmax() {
@@ -288,26 +150,5 @@ mod tests {
             assert_eq!(const_min(a, b), min);
             assert_eq!(const_max(a, b), max);
         }
-    }
-
-    #[test]
-    fn hex_snip_middle_boundary() {
-        // Exactly SHOW_LEN*2 = 16 bytes: should use full hex (no "..").
-        let short: Vec<u8> = (0..16).collect();
-        let s = format!("{}", &HexSnipMiddle::new(&short));
-        assert!(!s.contains(".."), "16 bytes should not be truncated");
-        assert!(s.ends_with("0e0f"));
-
-        // 17 bytes: one over the boundary, should be truncated.
-        let just_over: Vec<u8> = (0..17).collect();
-        assert!(format!("{}", &HexSnipMiddle::new(&just_over)).contains(".."));
-
-        // 20 bytes: truncated, check first 8 and last 8 bytes are exact.
-        let long: Vec<u8> = (0..20).collect();
-        let s = format!("{}", &HexSnipMiddle::new(&long));
-        assert!(s.starts_with("[20]: 0001020304050607"));
-        assert!(s.contains(".."));
-        // Last 8 bytes (12..20 = 0x0c..0x13) must be exactly "0c0d0e0f10111213".
-        assert!(s.ends_with("0c0d0e0f10111213"));
     }
 }

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -15,8 +15,12 @@ use std::{
 };
 
 use neqo_common::{
-    Datagram, Decoder, Encoder, Header, Hex, HexWithLen, MessageType, Role,
-    event::Provider as EventProvider, qdebug, qinfo, qlog::Qlog, qtrace, qwarn,
+    Datagram, Decoder, Encoder, Header, MessageType, Role,
+    event::Provider as EventProvider,
+    hex::{Hex, HexWithLen},
+    qdebug, qinfo,
+    qlog::Qlog,
+    qtrace, qwarn,
 };
 use neqo_qpack::Stats as QpackStats;
 use neqo_transport::{

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -441,7 +441,7 @@ impl Http3Client {
         let Some(settings_slice) = dec.decode_vvec() else {
             return Err(Error::InvalidResumptionToken);
         };
-        qtrace!("[{self}]   settings {}", &HexWithLen::new(settings_slice));
+        qtrace!("[{self}]   settings {}", HexWithLen::new(settings_slice));
         let mut dec_settings = Decoder::from(settings_slice);
         let mut settings = HSettings::default();
         Error::map_error(
@@ -449,7 +449,7 @@ impl Http3Client {
             Error::InvalidResumptionToken,
         )?;
         let tok = dec.decode_remainder();
-        qtrace!("[{self}]   Transport token {}", &Hex::new(tok));
+        qtrace!("[{self}]   Transport token {}", Hex::new(tok));
         self.conn.enable_resumption(now, tok)?;
         if self.conn.state().closed() {
             let state = self.conn.state().clone();

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -15,8 +15,8 @@ use std::{
 };
 
 use neqo_common::{
-    Datagram, Decoder, Encoder, Header, MessageType, Role, event::Provider as EventProvider, hex,
-    hex_with_len, qdebug, qinfo, qlog::Qlog, qtrace, qwarn,
+    Datagram, Decoder, Encoder, Header, Hex, HexWithLen, MessageType, Role,
+    event::Provider as EventProvider, qdebug, qinfo, qlog::Qlog, qtrace, qwarn,
 };
 use neqo_qpack::Stats as QpackStats;
 use neqo_transport::{
@@ -437,7 +437,7 @@ impl Http3Client {
         let Some(settings_slice) = dec.decode_vvec() else {
             return Err(Error::InvalidResumptionToken);
         };
-        qtrace!("[{self}]   settings {}", hex_with_len(settings_slice));
+        qtrace!("[{self}]   settings {}", &HexWithLen::new(settings_slice));
         let mut dec_settings = Decoder::from(settings_slice);
         let mut settings = HSettings::default();
         Error::map_error(
@@ -445,7 +445,7 @@ impl Http3Client {
             Error::InvalidResumptionToken,
         )?;
         let tok = dec.decode_remainder();
-        qtrace!("[{self}]   Transport token {}", hex(tok));
+        qtrace!("[{self}]   Transport token {}", &Hex::new(tok));
         self.conn.enable_resumption(now, tok)?;
         if self.conn.state().closed() {
             let state = self.conn.state().clone();

--- a/neqo-http3/src/frames/hframe.rs
+++ b/neqo-http3/src/frames/hframe.rs
@@ -4,9 +4,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::{Debug, Write as _};
+use std::fmt::{self, Debug, Write as _};
 
-use neqo_common::{Buffer, Decoder, Encoder};
+use neqo_common::{Buffer, Decoder, Encoder, HexWithLen};
 use neqo_transport::StreamId;
 use nss::random;
 
@@ -37,7 +37,7 @@ impl From<HFrameType> for u64 {
 }
 
 // data for DATA frame is not read into HFrame::Data.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq)]
 pub enum HFrame {
     Data {
         len: u64, // length of the data
@@ -237,5 +237,50 @@ impl FrameDecoder<Self> for HFrame {
                 | HFrameType::PRIORITY_UPDATE_REQUEST
                 | HFrameType::PRIORITY_UPDATE_PUSH
         )
+    }
+}
+
+impl Debug for HFrame {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Data { len } => {
+                write!(f, "DATA[{len}]")
+            }
+            Self::Headers { header_block } => {
+                write!(f, "HEADERS {}", &HexWithLen::new(header_block))
+            }
+            Self::CancelPush { push_id } => {
+                write!(f, "CANCEL_PUSH {push_id}")
+            }
+            Self::Settings { settings } => {
+                write!(f, "SETTINGS {settings:?}")
+            }
+            Self::PushPromise {
+                push_id,
+                header_block,
+            } => {
+                write!(
+                    f,
+                    "PUSH_PROMISE {push_id} {}",
+                    &HexWithLen::new(header_block)
+                )
+            }
+            Self::Goaway { stream_id } => {
+                write!(f, "GOAWAY {stream_id}")
+            }
+            Self::MaxPushId { push_id } => {
+                write!(f, "MAX_PUSH_ID {push_id}")
+            }
+            Self::Grease => f.write_str("GREASE"),
+            Self::PriorityUpdateRequest {
+                element_id,
+                priority,
+            } => write!(f, "PRIORITY_UPDATE request {element_id} {priority}"),
+
+            Self::PriorityUpdatePush {
+                element_id,
+                priority,
+            } => write!(f, "PRIORITY_UPDATE push {element_id} {priority}"),
+        }
     }
 }

--- a/neqo-http3/src/frames/hframe.rs
+++ b/neqo-http3/src/frames/hframe.rs
@@ -247,7 +247,7 @@ impl Debug for HFrame {
                 write!(f, "DATA[{len}]")
             }
             Self::Headers { header_block } => {
-                write!(f, "HEADERS {}", &HexWithLen::new(header_block))
+                write!(f, "HEADERS {}", HexWithLen::new(header_block))
             }
             Self::CancelPush { push_id } => {
                 write!(f, "CANCEL_PUSH {push_id}")
@@ -262,7 +262,7 @@ impl Debug for HFrame {
                 write!(
                     f,
                     "PUSH_PROMISE {push_id} {}",
-                    &HexWithLen::new(header_block)
+                    HexWithLen::new(header_block)
                 )
             }
             Self::Goaway { stream_id } => {

--- a/neqo-http3/src/frames/hframe.rs
+++ b/neqo-http3/src/frames/hframe.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::{self, Debug, Write as _};
 
-use neqo_common::{Buffer, Decoder, Encoder, HexWithLen};
+use neqo_common::{Buffer, Decoder, Encoder, hex::HexWithLen};
 use neqo_transport::StreamId;
 use nss::random;
 

--- a/neqo-http3/src/frames/reader.rs
+++ b/neqo-http3/src/frames/reader.rs
@@ -7,8 +7,8 @@
 use std::{cmp::min, fmt::Debug, time::Instant};
 
 use neqo_common::{
-    Decoder, IncrementalDecoderBuffer, IncrementalDecoderIgnore, IncrementalDecoderUint,
-    hex_snip_middle, hex_with_len, qtrace,
+    Decoder, HexSnipMiddle, HexWithLen, IncrementalDecoderBuffer, IncrementalDecoderIgnore,
+    IncrementalDecoderUint, qtrace,
 };
 use neqo_transport::{Connection, StreamId};
 
@@ -116,7 +116,7 @@ impl Debug for FrameReader {
         f.debug_struct("FrameReader")
             .field("state", &self.state)
             .field("frame_type", &self.frame_type)
-            .field("frame", &hex_snip_middle(&self.buffer[..frame_len]))
+            .field("frame", &HexSnipMiddle::new(&self.buffer[..frame_len]))
             .finish()
     }
 }
@@ -238,7 +238,7 @@ impl FrameReader {
                     qtrace!(
                         "received frame {:?}: {}",
                         self.frame_type,
-                        hex_with_len(&data[..])
+                        &HexWithLen::new(&data[..])
                     );
                     return self.frame_data_decoded::<T>(&data);
                 }

--- a/neqo-http3/src/frames/reader.rs
+++ b/neqo-http3/src/frames/reader.rs
@@ -239,7 +239,7 @@ impl FrameReader {
                     qtrace!(
                         "received frame {:?}: {}",
                         self.frame_type,
-                        &HexWithLen::new(&data[..])
+                        HexWithLen::new(&data[..])
                     );
                     return self.frame_data_decoded::<T>(&data);
                 }

--- a/neqo-http3/src/frames/reader.rs
+++ b/neqo-http3/src/frames/reader.rs
@@ -7,8 +7,9 @@
 use std::{cmp::min, fmt::Debug, time::Instant};
 
 use neqo_common::{
-    Decoder, HexSnipMiddle, HexWithLen, IncrementalDecoderBuffer, IncrementalDecoderIgnore,
-    IncrementalDecoderUint, qtrace,
+    Decoder, IncrementalDecoderBuffer, IncrementalDecoderIgnore, IncrementalDecoderUint,
+    hex::{HexSnipMiddle, HexWithLen},
+    qtrace,
 };
 use neqo_transport::{Connection, StreamId};
 

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -88,7 +88,7 @@ pub struct RecvMessage {
 
 impl Display for RecvMessage {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "RecvMessage stream_id:{}", self.stream_id)
+        write!(f, "RecvMessage {}", self.stream_id)
     }
 }
 
@@ -291,7 +291,7 @@ impl RecvMessage {
                         (None, false) => break Ok(()),
                         (Some(frame), fin) => {
                             qdebug!(
-                                "[{self}] A new frame has been received: {frame:?}; state={:?} fin={fin}",
+                                "[{self}] recv frame: {frame:?}; state={:?} fin={fin}",
                                 self.state,
                             );
                             match frame {

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -8,7 +8,7 @@
 
 use std::time::Instant;
 
-use neqo_common::{Hex, qlog::Qlog};
+use neqo_common::{hex::Hex, qlog::Qlog};
 use qlog::events::{
     EventData, RawInfo,
     qpack::{QPackInstruction, QpackInstructionParsed, QpackInstructionTypeName},

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -8,7 +8,7 @@
 
 use std::time::Instant;
 
-use neqo_common::{hex, qlog::Qlog};
+use neqo_common::{Hex, qlog::Qlog};
 use qlog::events::{
     EventData, RawInfo,
     qpack::{QPackInstruction, QpackInstructionParsed, QpackInstructionTypeName},
@@ -25,7 +25,7 @@ pub fn qpack_read_insert_count_increment_instruction(
             let raw = RawInfo {
                 length: Some(8),
                 payload_length: None,
-                data: Some(hex(data)),
+                data: Some(format!("{}", &Hex::new(data))),
             };
             let ev_data = EventData::QpackInstructionParsed(QpackInstructionParsed {
                 instruction: QPackInstruction::InsertCountIncrementInstruction {

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -25,7 +25,7 @@ pub fn qpack_read_insert_count_increment_instruction(
             let raw = RawInfo {
                 length: Some(8),
                 payload_length: None,
-                data: Some(format!("{}", Hex::new(data))),
+                data: Some(Hex::new(data).to_string()),
             };
             let ev_data = EventData::QpackInstructionParsed(QpackInstructionParsed {
                 instruction: QPackInstruction::InsertCountIncrementInstruction {

--- a/neqo-qpack/src/qlog.rs
+++ b/neqo-qpack/src/qlog.rs
@@ -25,7 +25,7 @@ pub fn qpack_read_insert_count_increment_instruction(
             let raw = RawInfo {
                 length: Some(8),
                 payload_length: None,
-                data: Some(format!("{}", &Hex::new(data))),
+                data: Some(format!("{}", Hex::new(data))),
             };
             let ev_data = EventData::QpackInstructionParsed(QpackInstructionParsed {
                 instruction: QPackInstruction::InsertCountIncrementInstruction {

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -15,7 +15,11 @@ use std::{
     rc::Rc,
 };
 
-use neqo_common::{Buffer, Decoder, Encoder, Hex, HexWithLen, qdebug, qinfo, to_usize};
+use neqo_common::{
+    Buffer, Decoder, Encoder,
+    hex::{Hex, HexWithLen},
+    qdebug, qinfo, to_usize,
+};
 use nss::{random, randomize};
 use smallvec::{SmallVec, smallvec};
 

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -15,7 +15,7 @@ use std::{
     rc::Rc,
 };
 
-use neqo_common::{Buffer, Decoder, Encoder, hex, hex_with_len, qdebug, qinfo, to_usize};
+use neqo_common::{Buffer, Decoder, Encoder, Hex, HexWithLen, qdebug, qinfo, to_usize};
 use nss::{random, randomize};
 use smallvec::{SmallVec, smallvec};
 
@@ -100,13 +100,14 @@ impl Deref for ConnectionId {
 
 impl Debug for ConnectionId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "CID {}", hex_with_len(&self.cid))
+        f.write_str("CID ")?;
+        HexWithLen::fmt(f, &self.cid)
     }
 }
 
 impl Display for ConnectionId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", hex(&self.cid))
+        Hex::fmt(f, &self.cid)
     }
 }
 
@@ -123,13 +124,14 @@ pub struct ConnectionIdRef<'a> {
 
 impl Debug for ConnectionIdRef<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "CID {}", hex_with_len(self.cid))
+        f.write_str("CID ")?;
+        HexWithLen::fmt(f, self.cid)
     }
 }
 
 impl Display for ConnectionIdRef<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", hex(self.cid))
+        Hex::fmt(f, self.cid)
     }
 }
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -18,8 +18,8 @@ use std::{
 };
 
 use neqo_common::{
-    Buffer, Datagram, Decoder, Ecn, Encoder, Role, Tos, datagram, event::Provider as EventProvider,
-    hex, hex_snip_middle, hex_with_len, hrtime, qdebug, qerror, qinfo, qlog::Qlog, qtrace, qwarn,
+    Buffer, Datagram, Decoder, Ecn, Encoder, Hex, HexSnipMiddle, HexWithLen, Role, Tos, datagram,
+    event::Provider as EventProvider, hrtime, qdebug, qerror, qinfo, qlog::Qlog, qtrace, qwarn,
     to_u64, to_usize,
 };
 use nss::{
@@ -782,7 +782,7 @@ impl Connection {
 
         qinfo!(
             "[{self}] resumption token {}",
-            hex_snip_middle(token.as_ref())
+            &HexSnipMiddle::new(token.as_ref())
         );
         let mut dec = Decoder::from(token.as_ref());
 
@@ -799,16 +799,16 @@ impl Connection {
         qtrace!("[{self}]   RTT {rtt:?}");
 
         let tp_slice = dec.decode_vvec().ok_or(Error::InvalidResumptionToken)?;
-        qtrace!("[{self}]   transport parameters {}", hex(tp_slice));
+        qtrace!("[{self}]   transport parameters {}", &Hex::new(tp_slice));
         let mut dec_tp = Decoder::from(tp_slice);
         let tp =
             TransportParameters::decode(&mut dec_tp).map_err(|_| Error::InvalidResumptionToken)?;
 
         let init_token = dec.decode_vvec().ok_or(Error::InvalidResumptionToken)?;
-        qtrace!("[{self}]   Initial token {}", hex(init_token));
+        qtrace!("[{self}]   Initial token {}", &Hex::new(init_token));
 
         let tok = dec.decode_remainder();
-        qtrace!("[{self}]   TLS token {}", hex(tok));
+        qtrace!("[{self}]   TLS token {}", &Hex::new(tok));
 
         match self.crypto.tls_mut() {
             Agent::Client(c) => {
@@ -864,7 +864,7 @@ impl Connection {
             });
             enc.encode(extra);
             let records = s.send_ticket(now, enc.as_ref())?;
-            qdebug!("[{self}] send session ticket {}", hex(&enc));
+            qdebug!("[{self}] send session ticket {}", &Hex::new(&enc));
             self.crypto.buffer_records(records)?;
         } else {
             unreachable!();
@@ -1346,7 +1346,7 @@ impl Connection {
         let retry_scid = ConnectionId::from(packet.scid());
         qinfo!(
             "[{self}] Valid Retry received, token={} scid={retry_scid}",
-            hex(packet.token())
+            &Hex::new(packet.token())
         );
 
         let lost_packets = self.loss_recovery.retry(&path, now);
@@ -1397,7 +1397,7 @@ impl Connection {
             // indicate that there is a stateless reset present.
             qdebug!(
                 "[{self}] Stateless reset: {}",
-                hex(&d[d.len() - Srt::LEN..])
+                &Hex::new(&d[d.len() - Srt::LEN..])
             );
             self.state_signaling.reset();
             self.set_state(
@@ -1764,7 +1764,7 @@ impl Connection {
         mut d: Datagram<impl AsRef<[u8]> + AsMut<[u8]>>,
         now: Instant,
     ) -> Res<()> {
-        qtrace!("[{self}] {} input {}", path.borrow(), hex(&d));
+        qtrace!("[{self}] {} input {}", path.borrow(), &Hex::new(&d));
         let tos = d.tos();
         let remote = d.source();
         let mut slc = d.as_mut();
@@ -3093,7 +3093,7 @@ impl Connection {
             qwarn!(
                 "[{self}] ISCID test failed: self cid {:?} != tp cid {:?}",
                 self.remote_initial_source_cid,
-                tp.map(hex),
+                tp.map(Hex::new),
             );
             return Err(Error::ProtocolViolation);
         }
@@ -3109,7 +3109,7 @@ impl Connection {
                 qwarn!(
                     "[{self}] ODCID test failed: self cid {:?} != tp cid {:?}",
                     self.original_destination_cid,
-                    tp.map(hex),
+                    tp.map(Hex::new),
                 );
                 return Err(Error::ProtocolViolation);
             }
@@ -3126,7 +3126,7 @@ impl Connection {
             if expected != tp.map(ConnectionIdRef::from) {
                 qwarn!(
                     "[{self}] RSCID test failed. self cid {expected:?} != tp cid {:?}",
-                    tp.map(hex),
+                    tp.map(Hex::new),
                 );
                 return Err(Error::ProtocolViolation);
             }
@@ -3231,7 +3231,7 @@ impl Connection {
     ) -> Res<()> {
         qtrace!(
             "[{self}] Handshake space={space} data: {:?}",
-            data.as_ref().map(hex_with_len),
+            data.as_ref().map(HexWithLen::new),
         );
 
         let was_authentication_pending =
@@ -3344,7 +3344,7 @@ impl Connection {
             Frame::Crypto { offset, data } => {
                 qtrace!(
                     "[{self}] Crypto frame on space={space} offset={offset}: {d}",
-                    d = hex_snip_middle(data),
+                    d = &HexSnipMiddle::new(data),
                 );
                 self.stats.borrow_mut().frame_rx.crypto += 1;
                 self.crypto

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -18,9 +18,12 @@ use std::{
 };
 
 use neqo_common::{
-    Buffer, Datagram, Decoder, Ecn, Encoder, Hex, HexSnipMiddle, HexWithLen, Role, Tos, datagram,
-    event::Provider as EventProvider, hrtime, qdebug, qerror, qinfo, qlog::Qlog, qtrace, qwarn,
-    to_u64, to_usize,
+    Buffer, Datagram, Decoder, Ecn, Encoder, Role, Tos, datagram,
+    event::Provider as EventProvider,
+    hex::{Hex, HexSnipMiddle, HexWithLen},
+    hrtime, qdebug, qerror, qinfo,
+    qlog::Qlog,
+    qtrace, qwarn, to_u64, to_usize,
 };
 use nss::{
     Agent, AntiReplay, AuthenticationStatus, Cipher, Client, Group, HandshakeState, PrivateKey,

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -785,7 +785,7 @@ impl Connection {
 
         qinfo!(
             "[{self}] resumption token {}",
-            &HexSnipMiddle::new(token.as_ref())
+            HexSnipMiddle::new(token.as_ref())
         );
         let mut dec = Decoder::from(token.as_ref());
 
@@ -802,16 +802,16 @@ impl Connection {
         qtrace!("[{self}]   RTT {rtt:?}");
 
         let tp_slice = dec.decode_vvec().ok_or(Error::InvalidResumptionToken)?;
-        qtrace!("[{self}]   transport parameters {}", &Hex::new(tp_slice));
+        qtrace!("[{self}]   transport parameters {}", Hex::new(tp_slice));
         let mut dec_tp = Decoder::from(tp_slice);
         let tp =
             TransportParameters::decode(&mut dec_tp).map_err(|_| Error::InvalidResumptionToken)?;
 
         let init_token = dec.decode_vvec().ok_or(Error::InvalidResumptionToken)?;
-        qtrace!("[{self}]   Initial token {}", &Hex::new(init_token));
+        qtrace!("[{self}]   Initial token {}", Hex::new(init_token));
 
         let tok = dec.decode_remainder();
-        qtrace!("[{self}]   TLS token {}", &Hex::new(tok));
+        qtrace!("[{self}]   TLS token {}", Hex::new(tok));
 
         match self.crypto.tls_mut() {
             Agent::Client(c) => {
@@ -867,7 +867,7 @@ impl Connection {
             });
             enc.encode(extra);
             let records = s.send_ticket(now, enc.as_ref())?;
-            qdebug!("[{self}] send session ticket {}", &Hex::new(&enc));
+            qdebug!("[{self}] send session ticket {}", Hex::new(&enc));
             self.crypto.buffer_records(records)?;
         } else {
             unreachable!();
@@ -1349,7 +1349,7 @@ impl Connection {
         let retry_scid = ConnectionId::from(packet.scid());
         qinfo!(
             "[{self}] Valid Retry received, token={} scid={retry_scid}",
-            &Hex::new(packet.token())
+            Hex::new(packet.token())
         );
 
         let lost_packets = self.loss_recovery.retry(&path, now);
@@ -1400,7 +1400,7 @@ impl Connection {
             // indicate that there is a stateless reset present.
             qdebug!(
                 "[{self}] Stateless reset: {}",
-                &Hex::new(&d[d.len() - Srt::LEN..])
+                Hex::new(&d[d.len() - Srt::LEN..])
             );
             self.state_signaling.reset();
             self.set_state(
@@ -1767,7 +1767,7 @@ impl Connection {
         mut d: Datagram<impl AsRef<[u8]> + AsMut<[u8]>>,
         now: Instant,
     ) -> Res<()> {
-        qtrace!("[{self}] {} input {}", path.borrow(), &Hex::new(&d));
+        qtrace!("[{self}] {} input {}", path.borrow(), Hex::new(&d));
         let tos = d.tos();
         let remote = d.source();
         let mut slc = d.as_mut();
@@ -3347,7 +3347,7 @@ impl Connection {
             Frame::Crypto { offset, data } => {
                 qtrace!(
                     "[{self}] Crypto frame on space={space} offset={offset}: {d}",
-                    d = &HexSnipMiddle::new(data),
+                    d = HexSnipMiddle::new(data),
                 );
                 self.stats.borrow_mut().frame_rx.crypto += 1;
                 self.crypto

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -391,7 +391,7 @@ impl Crypto {
     ) -> Option<ResumptionToken> {
         if let Agent::Client(ref mut c) = self.tls {
             c.resumption_token().as_ref().map(|t| {
-                qtrace!("TLS token {}", &Hex::new(t.as_ref()));
+                qtrace!("TLS token {}", Hex::new(t.as_ref()));
                 let mut enc = Encoder::default();
                 enc.encode_uint(4, version.wire_version());
                 enc.encode_varint(rtt);
@@ -400,7 +400,7 @@ impl Crypto {
                 });
                 enc.encode_vvec(new_token.unwrap_or(&[]));
                 enc.encode(t.as_ref());
-                qdebug!("resumption token {}", &HexSnipMiddle::new(enc.as_ref()));
+                qdebug!("resumption token {}", HexSnipMiddle::new(enc.as_ref()));
                 ResumptionToken::new(enc.into(), t.expiration_time())
             })
         } else {
@@ -695,8 +695,8 @@ impl CryptoDxState {
         let mask = self.hpkey.mask(sample)?;
         qtrace!(
             "[{self}] HP sample={} mask={}",
-            &Hex::new(sample),
-            &Hex::new(mask)
+            Hex::new(sample),
+            Hex::new(mask)
         );
         Ok(mask)
     }
@@ -715,8 +715,8 @@ impl CryptoDxState {
         debug_assert_eq!(self.direction, CryptoDxDirection::Write);
         qtrace!(
             "[{self}] encrypt_in_place pn={pn} hdr={} body={}",
-            &Hex::new(data[hdr.clone()].as_ref()),
-            &Hex::new(data[hdr.end..].as_ref())
+            Hex::new(data[hdr.clone()].as_ref()),
+            Hex::new(data[hdr.end..].as_ref())
         );
 
         // The numbers in `Self::limit` assume a maximum packet size of `LIMIT`.
@@ -736,7 +736,7 @@ impl CryptoDxState {
         // Use only the actual current header for AAD.
         let len = self.aead.encrypt_in_place(pn, &prev[hdr], data)?;
 
-        qtrace!("[{self}] encrypt ct={}", &Hex::new(&data[..len]));
+        qtrace!("[{self}] encrypt ct={}", Hex::new(&data[..len]));
         debug_assert_eq!(pn, self.next_pn());
         self.used(pn)?;
         Ok(len)
@@ -756,8 +756,8 @@ impl CryptoDxState {
         debug_assert_eq!(self.direction, CryptoDxDirection::Read);
         qtrace!(
             "[{self}] decrypt_in_place pn={pn} hdr={} body={}",
-            &Hex::new(data[hdr.clone()].as_ref()),
-            &Hex::new(data[hdr.end..].as_ref())
+            Hex::new(data[hdr.clone()].as_ref()),
+            Hex::new(data[hdr.end..].as_ref())
         );
         self.invoked()?;
         let (hdr, data) = data.split_at_mut(hdr.end);
@@ -1084,7 +1084,7 @@ impl CryptoStates {
         for v in versions {
             qdebug!(
                 "[{self}] Creating initial cipher state v={v:?}, role={role:?} dcid={}",
-                &Hex::new(dcid)
+                Hex::new(dcid)
             );
 
             let mut initial = CryptoState {

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 use enum_map::EnumMap;
-use neqo_common::{Buffer, Encoder, Role, hex, hex_snip_middle, qdebug, qinfo, qtrace, to_u64};
+use neqo_common::{Buffer, Encoder, Hex, HexSnipMiddle, Role, qdebug, qinfo, qtrace, to_u64};
 pub use nss::Epoch;
 use nss::{
     Agent, AntiReplay, Cipher, Error as CryptoError, HandshakeState, Mode, PrivateKey, PublicKey,
@@ -387,7 +387,7 @@ impl Crypto {
     ) -> Option<ResumptionToken> {
         if let Agent::Client(ref mut c) = self.tls {
             c.resumption_token().as_ref().map(|t| {
-                qtrace!("TLS token {}", hex(t.as_ref()));
+                qtrace!("TLS token {}", &Hex::new(t.as_ref()));
                 let mut enc = Encoder::default();
                 enc.encode_uint(4, version.wire_version());
                 enc.encode_varint(rtt);
@@ -396,7 +396,7 @@ impl Crypto {
                 });
                 enc.encode_vvec(new_token.unwrap_or(&[]));
                 enc.encode(t.as_ref());
-                qdebug!("resumption token {}", hex_snip_middle(enc.as_ref()));
+                qdebug!("resumption token {}", &HexSnipMiddle::new(enc.as_ref()));
                 ResumptionToken::new(enc.into(), t.expiration_time())
             })
         } else {
@@ -689,7 +689,11 @@ impl CryptoDxState {
         sample: &[u8; hp::Key::SAMPLE_SIZE],
     ) -> Res<[u8; hp::Key::SAMPLE_SIZE]> {
         let mask = self.hpkey.mask(sample)?;
-        qtrace!("[{self}] HP sample={} mask={}", hex(sample), hex(mask));
+        qtrace!(
+            "[{self}] HP sample={} mask={}",
+            &Hex::new(sample),
+            &Hex::new(mask)
+        );
         Ok(mask)
     }
 
@@ -707,8 +711,8 @@ impl CryptoDxState {
         debug_assert_eq!(self.direction, CryptoDxDirection::Write);
         qtrace!(
             "[{self}] encrypt_in_place pn={pn} hdr={} body={}",
-            hex(data[hdr.clone()].as_ref()),
-            hex(data[hdr.end..].as_ref())
+            &Hex::new(data[hdr.clone()].as_ref()),
+            &Hex::new(data[hdr.end..].as_ref())
         );
 
         // The numbers in `Self::limit` assume a maximum packet size of `LIMIT`.
@@ -728,7 +732,7 @@ impl CryptoDxState {
         // Use only the actual current header for AAD.
         let len = self.aead.encrypt_in_place(pn, &prev[hdr], data)?;
 
-        qtrace!("[{self}] encrypt ct={}", hex(&data[..len]));
+        qtrace!("[{self}] encrypt ct={}", &Hex::new(&data[..len]));
         debug_assert_eq!(pn, self.next_pn());
         self.used(pn)?;
         Ok(len)
@@ -748,8 +752,8 @@ impl CryptoDxState {
         debug_assert_eq!(self.direction, CryptoDxDirection::Read);
         qtrace!(
             "[{self}] decrypt_in_place pn={pn} hdr={} body={}",
-            hex(data[hdr.clone()].as_ref()),
-            hex(data[hdr.end..].as_ref())
+            &Hex::new(data[hdr.clone()].as_ref()),
+            &Hex::new(data[hdr.end..].as_ref())
         );
         self.invoked()?;
         let (hdr, data) = data.split_at_mut(hdr.end);
@@ -1076,7 +1080,7 @@ impl CryptoStates {
         for v in versions {
             qdebug!(
                 "[{self}] Creating initial cipher state v={v:?}, role={role:?} dcid={}",
-                hex(dcid)
+                &Hex::new(dcid)
             );
 
             let mut initial = CryptoState {

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -25,7 +25,11 @@ use std::{
 };
 
 use enum_map::EnumMap;
-use neqo_common::{Buffer, Encoder, Hex, HexSnipMiddle, Role, qdebug, qinfo, qtrace, to_u64};
+use neqo_common::{
+    Buffer, Encoder, Role,
+    hex::{Hex, HexSnipMiddle},
+    qdebug, qinfo, qtrace, to_u64,
+};
 pub use nss::Epoch;
 use nss::{
     Agent, AntiReplay, Cipher, Error as CryptoError, HandshakeState, Mode, PrivateKey, PublicKey,

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -15,7 +15,7 @@ use std::{
 
 use enum_map::Enum;
 use log::debug;
-use neqo_common::{Buffer, Decoder, Encoder, hex, hex_with_len, qtrace, qwarn};
+use neqo_common::{Buffer, Decoder, Encoder, Hex, HexWithLen, qtrace, qwarn};
 use nss::{Mode, RecordProtectionOps as _, random};
 use strum::{EnumIter, FromRepr};
 
@@ -492,8 +492,8 @@ impl<B: Buffer> Builder<B> {
         qtrace!(
             "Packet build pn={} hdr={} body={}",
             self.pn,
-            hex(&self.encoder.as_ref()[self.header.clone()]),
-            hex(&self.encoder.as_ref()[self.header.end..])
+            &Hex::new(&self.encoder.as_ref()[self.header.clone()]),
+            &Hex::new(&self.encoder.as_ref()[self.header.end..])
         );
 
         // Add space for crypto expansion.
@@ -515,7 +515,7 @@ impl<B: Buffer> Builder<B> {
             self.encoder.as_mut()[j] ^= mask[i];
         }
 
-        qtrace!("Packet built {}", hex(&self.encoder));
+        qtrace!("Packet built {}", &Hex::new(&self.encoder));
         Ok(self.encoder)
     }
 
@@ -880,7 +880,7 @@ impl<'a> Public<'a> {
         qtrace!(
             "{:?} unmask hdr={}",
             crypto.version(),
-            hex(&self.data[..sample_offset])
+            &Hex::new(&self.data[..sample_offset])
         );
         let mask = crypto.compute_mask(sample)?;
 
@@ -911,7 +911,7 @@ impl<'a> Public<'a> {
         hdrbytes.end = self.header_len + pn_len;
         pn_encoded >>= 8 * (MAX_PACKET_NUMBER_LEN - pn_len);
 
-        qtrace!("unmasked hdr={}", hex(&self.data[hdrbytes.clone()]));
+        qtrace!("unmasked hdr={}", &Hex::new(&self.data[hdrbytes.clone()]));
 
         let key_phase =
             self.packet_type == Type::Short && (first_byte & BIT_KEY_PHASE) == BIT_KEY_PHASE;
@@ -1009,8 +1009,8 @@ impl fmt::Debug for Public<'_> {
             f,
             "{:?}: {} {}",
             self.packet_type(),
-            hex_with_len(&self.data[..self.header_len]),
-            hex_with_len(&self.data[self.header_len..])
+            &HexWithLen::new(&self.data[..self.header_len]),
+            &HexWithLen::new(&self.data[self.header_len..])
         )
     }
 }

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -496,8 +496,8 @@ impl<B: Buffer> Builder<B> {
         qtrace!(
             "Packet build pn={} hdr={} body={}",
             self.pn,
-            &Hex::new(&self.encoder.as_ref()[self.header.clone()]),
-            &Hex::new(&self.encoder.as_ref()[self.header.end..])
+            Hex::new(&self.encoder.as_ref()[self.header.clone()]),
+            Hex::new(&self.encoder.as_ref()[self.header.end..])
         );
 
         // Add space for crypto expansion.
@@ -519,7 +519,7 @@ impl<B: Buffer> Builder<B> {
             self.encoder.as_mut()[j] ^= mask[i];
         }
 
-        qtrace!("Packet built {}", &Hex::new(&self.encoder));
+        qtrace!("Packet built {}", Hex::new(&self.encoder));
         Ok(self.encoder)
     }
 
@@ -884,7 +884,7 @@ impl<'a> Public<'a> {
         qtrace!(
             "{:?} unmask hdr={}",
             crypto.version(),
-            &Hex::new(&self.data[..sample_offset])
+            Hex::new(&self.data[..sample_offset])
         );
         let mask = crypto.compute_mask(sample)?;
 
@@ -915,7 +915,7 @@ impl<'a> Public<'a> {
         hdrbytes.end = self.header_len + pn_len;
         pn_encoded >>= 8 * (MAX_PACKET_NUMBER_LEN - pn_len);
 
-        qtrace!("unmasked hdr={}", &Hex::new(&self.data[hdrbytes.clone()]));
+        qtrace!("unmasked hdr={}", Hex::new(&self.data[hdrbytes.clone()]));
 
         let key_phase =
             self.packet_type == Type::Short && (first_byte & BIT_KEY_PHASE) == BIT_KEY_PHASE;
@@ -1013,8 +1013,8 @@ impl fmt::Debug for Public<'_> {
             f,
             "{:?}: {} {}",
             self.packet_type(),
-            &HexWithLen::new(&self.data[..self.header_len]),
-            &HexWithLen::new(&self.data[self.header_len..])
+            HexWithLen::new(&self.data[..self.header_len]),
+            HexWithLen::new(&self.data[self.header_len..])
         )
     }
 }

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -15,7 +15,11 @@ use std::{
 
 use enum_map::Enum;
 use log::debug;
-use neqo_common::{Buffer, Decoder, Encoder, Hex, HexWithLen, qtrace, qwarn};
+use neqo_common::{
+    Buffer, Decoder, Encoder,
+    hex::{Hex, HexWithLen},
+    qtrace, qwarn,
+};
 use nss::{Mode, RecordProtectionOps as _, random};
 use strum::{EnumIter, FromRepr};
 

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -858,7 +858,7 @@ impl Path {
         let resp_sent = if let Some(challenge) = self.challenge.take() {
             qtrace!(
                 "[{self}] Responding to path challenge {}",
-                &Hex::new(challenge)
+                Hex::new(challenge)
             );
             builder.encode_frame(FrameType::PathResponse, |b| {
                 b.encode(&challenge[..]);

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -13,7 +13,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Buffer, Encoder, Hex, Tos, datagram, qdebug, qinfo, qlog::Qlog, qtrace, qwarn};
+use neqo_common::{
+    Buffer, Encoder, Tos, datagram, hex::Hex, qdebug, qinfo, qlog::Qlog, qtrace, qwarn,
+};
 use nss::random;
 
 use crate::{

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -13,7 +13,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Buffer, Encoder, Tos, datagram, hex, qdebug, qinfo, qlog::Qlog, qtrace, qwarn};
+use neqo_common::{Buffer, Encoder, Hex, Tos, datagram, qdebug, qinfo, qlog::Qlog, qtrace, qwarn};
 use nss::random;
 
 use crate::{
@@ -854,7 +854,10 @@ impl Path {
         }
         // Send PATH_RESPONSE.
         let resp_sent = if let Some(challenge) = self.challenge.take() {
-            qtrace!("[{self}] Responding to path challenge {}", hex(challenge));
+            qtrace!(
+                "[{self}] Responding to path challenge {}",
+                &Hex::new(challenge)
+            );
             builder.encode_frame(FrameType::PathResponse, |b| {
                 b.encode(&challenge[..]);
             });

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -53,7 +53,7 @@ use crate::{
 
 /// Allocation-performing hex conversion for qlog only.
 fn to_hex<T: AsRef<[u8]>>(v: T) -> String {
-    format!("{}", &Hex::new(v))
+    format!("{}", Hex::new(v))
 }
 
 pub fn connection_tparams_set(qlog: &mut Qlog, tph: &TransportParametersHandler, now: Instant) {

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Decoder, Ecn, Hex, qinfo, qlog::Qlog, to_u64};
+use neqo_common::{Decoder, Ecn, hex::Hex, qinfo, qlog::Qlog, to_u64};
 use qlog::events::{
     ApplicationErrorCode, ConnectionErrorCode, EventData, RawInfo,
     connectivity::{

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Decoder, Ecn, hex, qinfo, qlog::Qlog, to_u64};
+use neqo_common::{Decoder, Ecn, Hex, qinfo, qlog::Qlog, to_u64};
 use qlog::events::{
     ApplicationErrorCode, ConnectionErrorCode, EventData, RawInfo,
     connectivity::{
@@ -51,6 +51,11 @@ use crate::{
     version::{self, Version},
 };
 
+/// Allocation-performing hex conversion for qlog only.
+fn to_hex<T: AsRef<[u8]>>(v: T) -> String {
+    format!("{}", &Hex::new(v))
+}
+
 pub fn connection_tparams_set(qlog: &mut Qlog, tph: &TransportParametersHandler, now: Instant) {
     qlog.add_event_at(
         || {
@@ -61,8 +66,8 @@ pub fn connection_tparams_set(qlog: &mut Qlog, tph: &TransportParametersHandler,
                     owner: Some(TransportOwner::Remote),
                     original_destination_connection_id: remote
                         .get_bytes(OriginalDestinationConnectionId)
-                        .map(hex),
-                    stateless_reset_token: remote.get_bytes(StatelessResetToken).map(hex),
+                        .map(to_hex),
+                    stateless_reset_token: remote.get_bytes(StatelessResetToken).map(to_hex),
                     disable_active_migration: remote.get_empty(DisableMigration).then_some(true),
                     max_idle_timeout: Some(remote.get_integer(TransportParameterId::IdleTimeout)),
                     max_udp_payload_size: Some(remote.get_integer(MaxUdpPayloadSize) as u32),
@@ -88,7 +93,7 @@ pub fn connection_tparams_set(qlog: &mut Qlog, tph: &TransportParametersHandler,
                             port_v4: paddr.ipv4()?.port(),
                             port_v6: paddr.ipv6()?.port(),
                             connection_id: cid.connection_id().to_string(),
-                            stateless_reset_token: hex(cid.reset_token()),
+                            stateless_reset_token: to_hex(cid.reset_token()),
                         })
                     }),
                     ..Default::default()
@@ -647,7 +652,7 @@ impl From<Frame<'_>> for QuicFrame {
                     ty: None,
                     details: None,
                     raw: Some(RawInfo {
-                        data: Some(hex(token)),
+                        data: Some(to_hex(token)),
                         length: Some(to_u64(token.len())),
                         payload_length: None,
                     }),
@@ -707,17 +712,17 @@ impl From<Frame<'_>> for QuicFrame {
                 sequence_number: sequence_number as u32,
                 retire_prior_to: retire_prior as u32,
                 connection_id_length: Some(connection_id.len() as u8),
-                connection_id: hex(connection_id),
-                stateless_reset_token: Some(hex(stateless_reset_token)),
+                connection_id: to_hex(connection_id),
+                stateless_reset_token: Some(to_hex(stateless_reset_token)),
             },
             Frame::RetireConnectionId { sequence_number } => Self::RetireConnectionId {
                 sequence_number: sequence_number as u32,
             },
             Frame::PathChallenge { data } => Self::PathChallenge {
-                data: Some(hex(data)),
+                data: Some(to_hex(data)),
             },
             Frame::PathResponse { data } => Self::PathResponse {
-                data: Some(hex(data)),
+                data: Some(to_hex(data)),
             },
             Frame::ConnectionClose {
                 error_code,

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -53,7 +53,7 @@ use crate::{
 
 /// Allocation-performing hex conversion for qlog only.
 fn to_hex<T: AsRef<[u8]>>(v: T) -> String {
-    format!("{}", Hex::new(v))
+    Hex::new(v).to_string()
 }
 
 pub fn connection_tparams_set(qlog: &mut Qlog, tph: &TransportParametersHandler, now: Instant) {

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -3729,7 +3729,7 @@ mod tests {
         );
         qtrace!(
             "STREAM frame: {}",
-            &HexWithLen::new(&builder.as_ref()[header_len..])
+            HexWithLen::new(&builder.as_ref()[header_len..])
         );
         stats.stream > 0
     }

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -2117,7 +2117,7 @@ mod tests {
     use std::{cell::RefCell, collections::VecDeque, num::NonZeroUsize, rc::Rc};
 
     use neqo_common::{
-        Encoder, HexWithLen, MAX_VARINT, event::Provider as _, qtrace, to_u64, to_usize,
+        Encoder, MAX_VARINT, event::Provider as _, hex::HexWithLen, qtrace, to_u64, to_usize,
     };
 
     use super::RecoveryToken;

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -2117,7 +2117,7 @@ mod tests {
     use std::{cell::RefCell, collections::VecDeque, num::NonZeroUsize, rc::Rc};
 
     use neqo_common::{
-        Encoder, MAX_VARINT, event::Provider as _, hex_with_len, qtrace, to_u64, to_usize,
+        Encoder, HexWithLen, MAX_VARINT, event::Provider as _, qtrace, to_u64, to_usize,
     };
 
     use super::RecoveryToken;
@@ -3729,7 +3729,7 @@ mod tests {
         );
         qtrace!(
             "STREAM frame: {}",
-            hex_with_len(&builder.as_ref()[header_len..])
+            &HexWithLen::new(&builder.as_ref()[header_len..])
         );
         stats.stream > 0
     }

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use neqo_common::{
-    Datagram, Role, Tos, event::Provider as _, hex, qdebug, qerror, qinfo, qlog::Qlog, qtrace,
+    Datagram, Hex, Role, Tos, event::Provider as _, qdebug, qerror, qinfo, qlog::Qlog, qtrace,
     qwarn,
 };
 use nss::{
@@ -435,7 +435,7 @@ impl Server {
     ) -> OutputBatch {
         let mut dgrams = dgrams.into_iter();
         while let Some(mut dgram) = dgrams.next() {
-            qtrace!("Process datagram: {}", hex(&dgram[..]));
+            qtrace!("Process datagram: {}", &Hex::new(&dgram[..]));
 
             // This is only looking at the first packet header in the datagram.
             // All packets in the datagram are routed to the same connection.

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use neqo_common::{
-    Datagram, Hex, Role, Tos, event::Provider as _, qdebug, qerror, qinfo, qlog::Qlog, qtrace,
+    Datagram, Role, Tos, event::Provider as _, hex::Hex, qdebug, qerror, qinfo, qlog::Qlog, qtrace,
     qwarn,
 };
 use nss::{

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -435,7 +435,7 @@ impl Server {
     ) -> OutputBatch {
         let mut dgrams = dgrams.into_iter();
         while let Some(mut dgram) = dgrams.next() {
-            qtrace!("Process datagram: {}", &Hex::new(&dgram[..]));
+            qtrace!("Process datagram: {}", Hex::new(&dgram[..]));
 
             // This is only looking at the first packet header in the datagram.
             // All packets in the datagram are routed to the same connection.

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -140,7 +140,7 @@ impl PreferredAddress {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum TransportParameter {
     Bytes(Vec<u8>),
     Integer(u64),
@@ -155,6 +155,31 @@ pub enum TransportParameter {
         current: version::Wire,
         other: Vec<version::Wire>,
     },
+}
+
+impl fmt::Debug for TransportParameter {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::Bytes(a) => f.debug_tuple("Bytes").field(&hex(a)).finish(),
+            Self::Integer(a) => f.debug_tuple("Integer").field(a).finish(),
+            Self::Empty => f.write_str("Empty"),
+            Self::PreferredAddress { v4, v6, cid, srt } => f
+                .debug_struct("PreferredAddress")
+                .field("v4", v4)
+                .field("v6", v6)
+                .field("cid", cid)
+                .field("srt", srt)
+                .finish(),
+            Self::Versions { current, other } => f
+                .debug_struct("Versions")
+                .field("current", &hex(current.to_be_bytes()))
+                .field(
+                    "other",
+                    &other.iter().map(|v| hex(v.to_be_bytes())).collect::<Vec<_>>(),
+                )
+                .finish(),
+        }
+    }
 }
 
 impl TransportParameter {
@@ -929,6 +954,21 @@ mod tests {
         stateless_reset::Token as Srt,
         tparams::{TransportParameter, TransportParameterId, TransportParameters},
     };
+
+    #[test]
+    fn debug_hex() {
+        let bytes = TransportParameter::Bytes(vec![0x01, 0x23, 0xab, 0xcd]);
+        assert_eq!(format!("{bytes:?}"), r#"Bytes("0123abcd")"#);
+
+        let versions = TransportParameter::Versions {
+            current: 0x0000_0001,
+            other: vec![0xff00_001d, 0x709a_50c4],
+        };
+        assert_eq!(
+            format!("{versions:?}"),
+            r#"Versions { current: "00000001", other: ["ff00001d", "709a50c4"] }"#
+        );
+    }
 
     #[test]
     fn basic_tps() {

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -63,7 +63,7 @@ pub enum TransportParameterId {
 
 impl Display for TransportParameterId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}((0x{:02x}))", u64::from(*self))
+        write!(f, "{self:?}(0x{:02x})", u64::from(*self))
     }
 }
 

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -1405,8 +1405,8 @@ mod tests {
 
     #[test]
     fn transport_parameter_id_display() {
-        assert_eq!(InitialMaxData.to_string(), "InitialMaxData((0x04))");
-        assert_eq!(format!("{IdleTimeout}"), "IdleTimeout((0x01))");
+        assert_eq!(InitialMaxData.to_string(), "InitialMaxData(0x04)");
+        assert_eq!(format!("{IdleTimeout}"), "IdleTimeout(0x01)");
     }
 
     // Helper: encode an integer TP, then decode it.

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -8,13 +8,13 @@
 
 use std::{
     cell::RefCell,
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
     rc::Rc,
 };
 
 use enum_map::{Enum, EnumMap};
-use neqo_common::{Buffer, Decoder, Encoder, Role, hex, qdebug, qinfo, qtrace};
+use neqo_common::{Buffer, Decoder, Encoder, Hex, Role, qdebug, qinfo, qtrace};
 use nss::{
     HandshakeMessage, ZeroRttCheckResult, ZeroRttChecker,
     constants::{TLS_HS_CLIENT_HELLO, TLS_HS_ENCRYPTED_EXTENSIONS},
@@ -63,7 +63,7 @@ pub enum TransportParameterId {
 
 impl Display for TransportParameterId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        format!("{self:?}((0x{:02x}))", u64::from(*self)).fmt(f)
+        write!(f, "{self:?}((0x{:02x}))", u64::from(*self))
     }
 }
 
@@ -157,29 +157,32 @@ pub enum TransportParameter {
     },
 }
 
-impl fmt::Debug for TransportParameter {
+impl Debug for TransportParameter {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        struct VersionListDebug<T>(T);
+        impl<T: AsRef<[version::Wire]>> Debug for VersionListDebug<T> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                f.debug_list()
+                    .entries(self.0.as_ref().iter().map(|v| Hex::new(v.to_be_bytes())))
+                    .finish()
+            }
+        }
+
         match self {
-            Self::Bytes(a) => f.debug_tuple("Bytes").field(&hex(a)).finish(),
+            Self::Bytes(a) => f.debug_tuple("Bytes").field(&Hex::new(a)).finish(),
             Self::Integer(a) => f.debug_tuple("Integer").field(a).finish(),
             Self::Empty => f.write_str("Empty"),
             Self::PreferredAddress { v4, v6, cid, srt } => f
                 .debug_struct("PreferredAddress")
                 .field("v4", v4)
                 .field("v6", v6)
-                .field("cid", &hex(cid))
-                .field("srt", &hex(srt))
+                .field("cid", &Hex::new(cid))
+                .field("srt", &Hex::new(srt))
                 .finish(),
             Self::Versions { current, other } => f
                 .debug_struct("Versions")
-                .field("current", &hex(current.to_be_bytes()))
-                .field(
-                    "other",
-                    &other
-                        .iter()
-                        .map(|v| hex(v.to_be_bytes()))
-                        .collect::<Vec<_>>(),
-                )
+                .field("current", &Hex::new(&current.to_be_bytes()))
+                .field("other", &VersionListDebug(other.iter()))
                 .finish(),
         }
     }
@@ -870,7 +873,7 @@ impl ExtensionHandler for TransportParametersHandler {
     fn handle(&mut self, msg: HandshakeMessage, d: &[u8]) -> ExtensionHandlerResult {
         qtrace!(
             "Handling transport parameters, msg={msg:?} value={}",
-            hex(d),
+            &Hex::new(d),
         );
 
         if !matches!(msg, TLS_HS_CLIENT_HELLO | TLS_HS_ENCRYPTED_EXTENSIONS) {
@@ -961,7 +964,7 @@ mod tests {
     #[test]
     fn debug_hex() {
         let bytes = TransportParameter::Bytes(vec![0x01, 0x23, 0xab, 0xcd]);
-        assert_eq!(format!("{bytes:?}"), r#"Bytes("0123abcd")"#);
+        assert_eq!(format!("{bytes:?}"), "Bytes(0123abcd)");
 
         let versions = TransportParameter::Versions {
             current: 0x0000_0001,
@@ -969,14 +972,14 @@ mod tests {
         };
         assert_eq!(
             format!("{versions:?}"),
-            r#"Versions { current: "00000001", other: ["ff00001d", "709a50c4"] }"#
+            "Versions { current: 00000001, other: [ff00001d, 709a50c4] }"
         );
 
         let spa = make_spa();
         let formatted = format!("{spa:?}");
-        assert!(formatted.contains(r#"cid: "0102030405""#), "{formatted}");
+        assert!(formatted.contains("cid: 0102030405"), "{formatted}");
         assert!(
-            formatted.contains(r#"srt: "03030303030303030303030303030303""#),
+            formatted.contains("srt: 03030303030303030303030303030303"),
             "{formatted}"
         );
     }

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -175,7 +175,10 @@ impl fmt::Debug for TransportParameter {
                 .field("current", &hex(current.to_be_bytes()))
                 .field(
                     "other",
-                    &other.iter().map(|v| hex(v.to_be_bytes())).collect::<Vec<_>>(),
+                    &other
+                        .iter()
+                        .map(|v| hex(v.to_be_bytes()))
+                        .collect::<Vec<_>>(),
                 )
                 .finish(),
         }
@@ -971,10 +974,7 @@ mod tests {
 
         let spa = make_spa();
         let formatted = format!("{spa:?}");
-        assert!(
-            formatted.contains(r#"cid: "0102030405""#),
-            "{formatted}"
-        );
+        assert!(formatted.contains(r#"cid: "0102030405""#), "{formatted}");
         assert!(
             formatted.contains(r#"srt: "03030303030303030303030303030303""#),
             "{formatted}"

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use enum_map::{Enum, EnumMap};
-use neqo_common::{Buffer, Decoder, Encoder, Hex, Role, qdebug, qinfo, qtrace};
+use neqo_common::{Buffer, Decoder, Encoder, Role, hex::Hex, qdebug, qinfo, qtrace};
 use nss::{
     HandshakeMessage, ZeroRttCheckResult, ZeroRttChecker,
     constants::{TLS_HS_CLIENT_HELLO, TLS_HS_ENCRYPTED_EXTENSIONS},

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -182,7 +182,7 @@ impl Debug for TransportParameter {
             Self::Versions { current, other } => f
                 .debug_struct("Versions")
                 .field("current", &Hex::new(&current.to_be_bytes()))
-                .field("other", &VersionListDebug(other.iter()))
+                .field("other", &VersionListDebug(other))
                 .finish(),
         }
     }

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -873,7 +873,7 @@ impl ExtensionHandler for TransportParametersHandler {
     fn handle(&mut self, msg: HandshakeMessage, d: &[u8]) -> ExtensionHandlerResult {
         qtrace!(
             "Handling transport parameters, msg={msg:?} value={}",
-            &Hex::new(d),
+            Hex::new(d),
         );
 
         if !matches!(msg, TLS_HS_CLIENT_HELLO | TLS_HS_ENCRYPTED_EXTENSIONS) {

--- a/neqo-transport/src/tparams.rs
+++ b/neqo-transport/src/tparams.rs
@@ -167,8 +167,8 @@ impl fmt::Debug for TransportParameter {
                 .debug_struct("PreferredAddress")
                 .field("v4", v4)
                 .field("v6", v6)
-                .field("cid", cid)
-                .field("srt", srt)
+                .field("cid", &hex(cid))
+                .field("srt", &hex(srt))
                 .finish(),
             Self::Versions { current, other } => f
                 .debug_struct("Versions")
@@ -967,6 +967,17 @@ mod tests {
         assert_eq!(
             format!("{versions:?}"),
             r#"Versions { current: "00000001", other: ["ff00001d", "709a50c4"] }"#
+        );
+
+        let spa = make_spa();
+        let formatted = format!("{spa:?}");
+        assert!(
+            formatted.contains(r#"cid: "0102030405""#),
+            "{formatted}"
+        );
+        assert!(
+            formatted.contains(r#"srt: "03030303030303030303030303030303""#),
+            "{formatted}"
         );
     }
 

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -481,7 +481,7 @@ fn mitm_retry() {
         .encode_len(payload.len());
     let pn_offset = enc.len();
     let notoken_header = enc.encode_uint(pn_len, pn).as_ref().to_vec();
-    qtrace!("notoken_header={}", &HexWithLen::new(&notoken_header));
+    qtrace!("notoken_header={}", HexWithLen::new(&notoken_header));
 
     // Encrypt.
     let mut notoken_packet = Encoder::with_capacity(MIN_INITIAL_PACKET_SIZE)
@@ -501,7 +501,7 @@ fn mitm_retry() {
     // All MIN_INITIAL_PACKET_SIZE bytes are needed to reach the minimum datagram size.
 
     header_protection::apply(&hp, &mut notoken_packet, pn_offset..(pn_offset + pn_len));
-    qtrace!("packet={}", &HexWithLen::new(&notoken_packet));
+    qtrace!("packet={}", HexWithLen::new(&notoken_packet));
 
     let new_datagram = Datagram::new(
         client_initial2.source(),

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use common::{assert_dscp, connected_server, default_server, generate_ticket};
-use neqo_common::{Datagram, Encoder, Role, hex_with_len, qdebug, qtrace};
+use neqo_common::{Datagram, Encoder, HexWithLen, Role, qdebug, qtrace};
 use neqo_transport::{
     CloseReason, ConnectionParameters, Error, MIN_INITIAL_PACKET_SIZE, State, StreamType,
     server::ValidateAddress,
@@ -481,7 +481,7 @@ fn mitm_retry() {
         .encode_len(payload.len());
     let pn_offset = enc.len();
     let notoken_header = enc.encode_uint(pn_len, pn).as_ref().to_vec();
-    qtrace!("notoken_header={}", hex_with_len(&notoken_header));
+    qtrace!("notoken_header={}", &HexWithLen::new(&notoken_header));
 
     // Encrypt.
     let mut notoken_packet = Encoder::with_capacity(MIN_INITIAL_PACKET_SIZE)
@@ -501,7 +501,7 @@ fn mitm_retry() {
     // All MIN_INITIAL_PACKET_SIZE bytes are needed to reach the minimum datagram size.
 
     header_protection::apply(&hp, &mut notoken_packet, pn_offset..(pn_offset + pn_len));
-    qtrace!("packet={}", hex_with_len(&notoken_packet));
+    qtrace!("packet={}", &HexWithLen::new(&notoken_packet));
 
     let new_datagram = Datagram::new(
         client_initial2.source(),

--- a/neqo-transport/tests/retry.rs
+++ b/neqo-transport/tests/retry.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use common::{assert_dscp, connected_server, default_server, generate_ticket};
-use neqo_common::{Datagram, Encoder, HexWithLen, Role, qdebug, qtrace};
+use neqo_common::{Datagram, Encoder, Role, hex::HexWithLen, qdebug, qtrace};
 use neqo_transport::{
     CloseReason, ConnectionParameters, Error, MIN_INITIAL_PACKET_SIZE, State, StreamType,
     server::ValidateAddress,

--- a/test-fixture/src/header_protection.rs
+++ b/test-fixture/src/header_protection.rs
@@ -13,7 +13,7 @@
 
 use std::ops::Range;
 
-use neqo_common::{Datagram, Decoder, HexWithLen, Role, qtrace};
+use neqo_common::{Datagram, Decoder, Role, hex::HexWithLen, qtrace};
 use nss::{
     Mode, RecordProtection as Aead,
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},

--- a/test-fixture/src/header_protection.rs
+++ b/test-fixture/src/header_protection.rs
@@ -13,7 +13,7 @@
 
 use std::ops::Range;
 
-use neqo_common::{Datagram, Decoder, Role, hex_with_len, qtrace};
+use neqo_common::{Datagram, Decoder, HexWithLen, Role, qtrace};
 use nss::{
     Mode, RecordProtection as Aead,
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
@@ -147,8 +147,8 @@ pub fn apply(hp: &hp::Key, packet: &mut [u8], pn_bytes: Range<usize>) {
         .expect("Failed to generate header protection mask");
     qtrace!(
         "sample={} mask={}",
-        hex_with_len(&packet[sample_start..sample_end]),
-        hex_with_len(mask)
+        &HexWithLen::new(&packet[sample_start..sample_end]),
+        &HexWithLen::new(mask)
     );
     packet[0] ^= mask[0] & 0xf;
     for i in 0..(pn_bytes.end - pn_bytes.start) {

--- a/test-fixture/src/header_protection.rs
+++ b/test-fixture/src/header_protection.rs
@@ -147,8 +147,8 @@ pub fn apply(hp: &hp::Key, packet: &mut [u8], pn_bytes: Range<usize>) {
         .expect("Failed to generate header protection mask");
     qtrace!(
         "sample={} mask={}",
-        &HexWithLen::new(&packet[sample_start..sample_end]),
-        &HexWithLen::new(mask)
+        HexWithLen::new(&packet[sample_start..sample_end]),
+        HexWithLen::new(mask)
     );
     packet[0] ^= mask[0] & 0xf;
     for i in 0..(pn_bytes.end - pn_bytes.start) {

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -21,8 +21,9 @@ use std::{
 };
 
 use neqo_common::{
-    Datagram, Decoder, Ecn, Hex, Role,
+    Datagram, Decoder, Ecn, Role,
     event::Provider as _,
+    hex::Hex,
     qlog::{Qlog, new_trace},
     qtrace,
 };

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -21,9 +21,8 @@ use std::{
 };
 
 use neqo_common::{
-    Datagram, Decoder, Ecn, Role,
+    Datagram, Decoder, Ecn, Hex, Role,
     event::Provider as _,
-    hex,
     qlog::{Qlog, new_trace},
     qtrace,
 };
@@ -235,7 +234,7 @@ where
     .expect("create a server");
     if let Ok(dir) = std::env::var("QLOGDIR") {
         // Use random bytes to generate a unique name
-        let unique_name = format!("server-{}", hex(random::<10>()));
+        let unique_name = format!("server-{}", &Hex::new(random::<10>()));
         c.set_qlog(
             Qlog::enabled_with_file(
                 dir.parse().unwrap(),
@@ -445,7 +444,7 @@ fn split_packet(buf: &[u8]) -> (&[u8], Option<&[u8]>) {
     dec.skip_vvec(); // The rest of the packet.
     let p1 = &buf[..dec.offset()];
     let p2 = (dec.remaining() > 0).then(|| dec.decode_remainder());
-    qtrace!("split packet: {} {:?}", hex(p1), p2.map(hex));
+    qtrace!("split packet: {} {:?}", &Hex::new(p1), p2.map(Hex::new));
     (p1, p2)
 }
 

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -235,7 +235,7 @@ where
     .expect("create a server");
     if let Ok(dir) = std::env::var("QLOGDIR") {
         // Use random bytes to generate a unique name
-        let unique_name = format!("server-{}", &Hex::new(random::<10>()));
+        let unique_name = format!("server-{}", Hex::new(random::<10>()));
         c.set_qlog(
             Qlog::enabled_with_file(
                 dir.parse().unwrap(),
@@ -445,7 +445,7 @@ fn split_packet(buf: &[u8]) -> (&[u8], Option<&[u8]>) {
     dec.skip_vvec(); // The rest of the packet.
     let p1 = &buf[..dec.offset()];
     let p2 = (dec.remaining() > 0).then(|| dec.decode_remainder());
-    qtrace!("split packet: {} {:?}", &Hex::new(p1), p2.map(Hex::new));
+    qtrace!("split packet: {} {:?}", Hex::new(p1), p2.map(Hex::new));
     (p1, p2)
 }
 


### PR DESCRIPTION
Yes, this is a lot of change, but it makes a big difference when debugging.

For example, running `RUST_LOG=neqo cargo test` on main, my machine took almost 28 seconds.  With these changes, the same took around 19 seconds.

There are some improvements to the debug implementations of certain common items that I see in logs as well.  Transport Parameters, Headers, and HTTP/3 frames.

@larseggert, WDYT?