### PR TITLE
fix: reject qpack required insert count that reconstructs to zero

### DIFF
--- a/neqo-qpack/src/header_block.rs
+++ b/neqo-qpack/src/header_block.rs
@@ -930,9 +930,9 @@ mod tests {
     }
 
     /// RFC 9204 Section 4.5.1.1: a non-zero Encoded Insert Count that
-    /// reconstructs to a Required Insert Count of 0 is a decoding error. With
-    /// fewer than `MaxEntries` insertions, an Encoded Insert Count of 1 wraps
-    /// back to 0 and must be rejected.
+    /// reconstructs to a Required Insert Count of 0 is a decoding error.
+    /// A value of 1 maps to a value of 0, which is invalid unless the
+    /// value has wrapped, which this test doesn't cover.
     #[test]
     fn req_insert_count_reconstructed_to_zero() {
         let table = HeaderTable::new(false);

--- a/neqo-qpack/src/header_block.rs
+++ b/neqo-qpack/src/header_block.rs
@@ -300,6 +300,9 @@ impl<'a> HeaderDecoder<'a> {
                 }
                 req_insert_cnt -= full_range;
             }
+            if req_insert_cnt == 0 {
+                return Err(Error::Decompression);
+            }
             Ok(req_insert_cnt)
         }
     }
@@ -923,6 +926,28 @@ mod tests {
         assert_eq!(
             Error::Decompression,
             decoder_h.decode_header_block(&table, 1000, 0).unwrap_err()
+        );
+    }
+
+    /// RFC 9204 Section 4.5.1.1: a non-zero Encoded Insert Count that
+    /// reconstructs to a Required Insert Count of 0 is a decoding error. With
+    /// fewer than `MaxEntries` insertions, an Encoded Insert Count of 1 wraps
+    /// back to 0 and must be rejected.
+    #[test]
+    fn req_insert_count_reconstructed_to_zero() {
+        let table = HeaderTable::new(false);
+        let mut decoder_h = HeaderDecoder::new(&[0x01, 0x00]);
+        assert_eq!(
+            Error::Decompression,
+            decoder_h.decode_header_block(&table, 1000, 0).unwrap_err()
+        );
+
+        // An Encoded Insert Count of 0 legitimately means no dynamic references
+        // and still decodes to an empty field section.
+        let mut decoder_h = HeaderDecoder::new(&[0x00, 0x00]);
+        assert_eq!(
+            HeaderDecoderResult::Headers(Vec::new()),
+            decoder_h.decode_header_block(&table, 1000, 0).unwrap()
         );
     }
 


### PR DESCRIPTION
`calc_req_insert_cnt` reconstructs a header block's Required Insert Count with the RFC 9204 Section 4.5.1.1 algorithm, but stops one step short: a non-zero Encoded Insert Count that reconstructs to a Required Insert Count of 0 is supposed to be a decoding error. With fewer than MaxEntries insertions, an Encoded Insert Count of 1 wraps back to 0, so a peer can send a field section whose prefix claims a dynamic dependency the encoder never expressed.

Reject a reconstructed Required Insert Count of 0 with the same `Error::Decompression` (QPACK_DECOMPRESSION_FAILED) the neighboring checks use. The check sits next to the reconstruction because that is the only place the encoded value and the wrap correction are both in hand. Before, such a block decoded to an empty or static-only field section; after, it closes the connection. The tradeoff is strictness over leniency, but no conformant encoder produces this since a Required Insert Count of 0 is always encoded as 0.