### PR TITLE
chore: prepare v0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -515,7 +515,7 @@ dependencies = [
  "neqo-qpack",
  "neqo-transport",
  "nss-rs",
- "test-fixture 0.29.1",
+ "test-fixture 0.30.0",
 ]
 
 [[package]]
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "cfg_aliases",
  "clap",
@@ -742,14 +742,14 @@ dependencies = [
  "rustc-hash",
  "strum",
  "test-fixture 0.1.0",
- "test-fixture 0.29.1",
+ "test-fixture 0.30.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "neqo-common"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -760,14 +760,14 @@ dependencies = [
  "sha1",
  "static_assertions",
  "strum",
- "test-fixture 0.29.1",
+ "test-fixture 0.30.0",
  "thiserror",
  "windows",
 ]
 
 [[package]]
 name = "neqo-http3"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enumset",
@@ -782,13 +782,13 @@ dependencies = [
  "rustc-hash",
  "sfv",
  "strum",
- "test-fixture 0.29.1",
+ "test-fixture 0.30.0",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-qpack"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "log",
  "neqo-common",
@@ -796,13 +796,13 @@ dependencies = [
  "qlog",
  "rustc-hash",
  "static_assertions",
- "test-fixture 0.29.1",
+ "test-fixture 0.30.0",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-transport"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -818,13 +818,13 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "strum",
- "test-fixture 0.29.1",
+ "test-fixture 0.30.0",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-udp"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.29.1"
+version = "0.30.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Which pull requests would you like to block on?

Included thus far:

- ea6cea6d fix: reject zero Insert Count Increment on QPACK decoder stream (#3762)
- c7134b79 Hex debugging improvements (#3763)
- c1462a77 Revert "fix: do not suppress cwnd growth when pacing limits sends (#3760)
- 8f3a98c5 Suppress default-valued integer transport parameters (#3746)
- bf725e6a fix: enforce qpack blocked stream limit in decode_header_block (#3755)
- caf09e70 reject CR, LF, and NUL in HTTP/3 field values (#3752)
- 86522d06 fix: reject DATAGRAM frame when max_datagram_frame_size is 0 (#3745)
- 529e41e5 WebTransport sendGroup support (and improve sendOrder) (#3467)
- 0ce39a54 fix: reject stream frames for the wrong unidirectional stream half (#3743)
- 88014524 fix: reject duplicate transport parameters (#3732)
- 44a02797 feat: fast path in RxStreamOrderer::inbound_frame (#3690)
- 8179af16 fix: reject RETIRE_CONNECTION_ID for an unissued sequence number (#3731)
- 9f198284 Reject trailing data in HTTP/3 frames (#3734)
- 694edf61 fix: reject STREAMS_BLOCKED limit above 2^60 (#3727)
- b5ae029a fix: reject max_ack_delay transport parameter of 2^14 or greater (#3730)
- aabda4f2 stats/cc: add new slow_start_exit stats (#3716)
- 9376de1c Add a client-side check for CONNECT_UDP (#3729)
- da676559 Finish WebTransport factoring (#3722)
- ed7cb1f9 Trait-based refactor for CONNECT_UDP (#3721)
- a13809ea fix: make coalesce_acked_from_zero scale with count (#3724)
- 2a75a9ef fix: Allow >1 MSS of `cwnd` growth (#3648)
- 43d0a177 Move WebTransport implementation out of core code (#3717)
- 279c9651 fix: reject invalid NEW_CONNECTION_ID retire_prior and cid length (#3720)
- 943ae21b fix: reject CR and LF in HTTP/3 field names (#3719)
- 277c9130 clamp webtransport datagram size to avoid prefix underflow (#3711)
- b99d991c Fix off-by-one in max_push_id computation (#3707)
- e6de9983 feat: Use `FxHasher` more (#3709)
- 61818465 fix: activate blapi for bench builds (#3701)
- 5241c17c Fix new clippy lints in Rust 1.98 (#3708)
- b585a81e Get the negotiated protocol to support WebTransport (#3466)
- a2400868 Add support for GOAWAY draining events to support WebTransport (#3465)
- 273ab073 feat: store `sent::Packet` tokens inline, removing `Rc` (#3696)
- 30f2b5f4 Add WebTransport ExportKeyingMaterial backend (#3464)
- 281135a7 feat: skip streams with no data in SendStreams::write_frames (#3687)
- 01b205d6 feat: replace Packets `BTreeMap` with `VecDeque` (#3686)
- d050b3af fix: guard qpack increment_acked against u64 overflow (#3684)
