### PR TITLE
fix: reject PATH_RESPONSE and HANDSHAKE_DONE in 0-RTT packets

### DIFF
--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -430,7 +430,13 @@ impl<'a> Frame<'a> {
                 error_code: CloseError::Transport(_),
                 ..
             } => pt != packet::Type::ZeroRtt,
-            Self::NewToken { .. } | Self::ConnectionClose { .. } => pt == packet::Type::Short,
+            // PATH_RESPONSE and HANDSHAKE_DONE, like NEW_TOKEN and an
+            // application CONNECTION_CLOSE, are marked `___1` in RFC 9000,
+            // Table 3, so they are only permitted in 1-RTT packets.
+            Self::NewToken { .. }
+            | Self::ConnectionClose { .. }
+            | Self::PathResponse { .. }
+            | Self::HandshakeDone => pt == packet::Type::Short,
             _ => pt == packet::Type::ZeroRtt || pt == packet::Type::Short,
         }
     }
@@ -1362,6 +1368,22 @@ mod tests {
         };
         assert!(app_close.is_allowed(packet::Type::Short));
         assert!(!app_close.is_allowed(packet::Type::ZeroRtt));
+    }
+
+    /// `is_allowed`: `PATH_RESPONSE` and `HANDSHAKE_DONE` are only allowed in
+    /// 1-RTT packets (RFC 9000, Table 3).
+    #[test]
+    fn is_allowed_path_response_and_handshake_done() {
+        let path_response = Frame::PathResponse { data: [0; 8] };
+        assert!(path_response.is_allowed(packet::Type::Short));
+        assert!(!path_response.is_allowed(packet::Type::ZeroRtt));
+
+        assert!(Frame::HandshakeDone.is_allowed(packet::Type::Short));
+        assert!(!Frame::HandshakeDone.is_allowed(packet::Type::ZeroRtt));
+
+        // PATH_CHALLENGE, by contrast, is permitted in 0-RTT packets.
+        let path_challenge = Frame::PathChallenge { data: [0; 8] };
+        assert!(path_challenge.is_allowed(packet::Type::ZeroRtt));
     }
 
     /// `decode_ack_frame` rejects invalid range configurations.

--- a/neqo-transport/src/frame.rs
+++ b/neqo-transport/src/frame.rs
@@ -430,9 +430,6 @@ impl<'a> Frame<'a> {
                 error_code: CloseError::Transport(_),
                 ..
             } => pt != packet::Type::ZeroRtt,
-            // PATH_RESPONSE and HANDSHAKE_DONE, like NEW_TOKEN and an
-            // application CONNECTION_CLOSE, are marked `___1` in RFC 9000,
-            // Table 3, so they are only permitted in 1-RTT packets.
             Self::NewToken { .. }
             | Self::ConnectionClose { .. }
             | Self::PathResponse { .. }


### PR DESCRIPTION
Frame::is_allowed carries the RFC 9000 Table 3 rule for which packet types may hold each frame, but PATH_RESPONSE and HANDSHAKE_DONE fall through to the catch-all arm that also permits 0-RTT. Table 3 marks both as 1-RTT only, so a server that accepts 0-RTT will take a PATH_RESPONSE frame out of a client's 0-RTT packet instead of closing with PROTOCOL_VIOLATION the way Section 12.4 requires.

Before, the two frames reached the `_ => ZeroRtt || Short` arm and passed in 0-RTT. After, they sit in the Short-only arm next to NEW_TOKEN and an application CONNECTION_CLOSE. The gate lives here because is_allowed is the single check input_frame runs before dispatch, so both frames are covered without per-frame handling. The tradeoff is strictness over leniency for these two; PATH_CHALLENGE stays 0-RTT-permitted, matching the asymmetry Table 3 draws between it and PATH_RESPONSE.