### PR TITLE
fix(common): support 32-bit targets (partial revert of #3738)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,6 @@ dependencies = [
  "log",
  "qlog",
  "sha1",
- "static_assertions",
  "strum",
  "test-fixture 0.30.0",
  "thiserror",

--- a/neqo-common/Cargo.toml
+++ b/neqo-common/Cargo.toml
@@ -23,7 +23,6 @@ hex = { workspace = true, optional = true }
 log = { workspace = true }
 qlog = { workspace = true }
 sha1 = { version = "0.10", default-features = false, optional = true }
-static_assertions = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 

--- a/neqo-common/src/codec.rs
+++ b/neqo-common/src/codec.rs
@@ -9,7 +9,7 @@ use std::{
     io::{self, Cursor},
 };
 
-use crate::{Length, hex::HexWithLen, to_u64, to_usize};
+use crate::{Length, hex::HexWithLen, to_u64};
 
 pub const MAX_VARINT: u64 = (1 << 62) - 1;
 
@@ -52,7 +52,8 @@ impl<'a> Decoder<'a> {
     /// Only use this for tests because we panic rather than reporting a result.
     #[cfg(any(test, feature = "test-fixture"))]
     fn skip_inner(&mut self, n: Option<u64>) {
-        self.skip(to_usize(n.expect("invalid length")));
+        #[expect(clippy::unwrap_used, reason = "Only used in tests.")]
+        self.skip(usize::try_from(n.expect("invalid length")).unwrap());
     }
 
     /// Skip a vector.  Panics if there isn't enough space.
@@ -661,7 +662,7 @@ impl Buffer for &mut Vec<u8> {
 
 impl Buffer for Cursor<&mut [u8]> {
     fn position(&self) -> usize {
-        to_usize(self.position())
+        usize::try_from(self.position()).expect("memory allocation not to exceed usize")
     }
 
     fn as_slice(&self) -> &[u8] {
@@ -682,7 +683,7 @@ impl Buffer for Cursor<&mut [u8]> {
     }
 
     fn pad_to(&mut self, n: usize, v: u8) {
-        let start = to_usize(self.position());
+        let start = usize::try_from(self.position()).expect("Buffer length does not exceed usize");
 
         self.get_mut()[start..n].fill(v);
         self.set_position(to_u64(n));

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -21,7 +21,6 @@ pub mod qlog;
 pub mod tos;
 
 use enum_map::Enum;
-use static_assertions::const_assert_eq;
 use strum::Display;
 
 #[cfg(feature = "build-fuzzing-corpus")]
@@ -43,10 +42,6 @@ pub const fn const_max(a: usize, b: usize) -> usize {
 pub const fn const_min(a: usize, b: usize) -> usize {
     [a, b][(a > b) as usize]
 }
-
-// Both conversions below are safe on all targets where usize and u64 are the
-// same width (i.e., 64-bit targets). The assertion enforces this at compile time.
-const_assert_eq!(usize::BITS, u64::BITS);
 
 /// A trait for values that represent a length or byte count, convertible
 /// to the wire domain (`u64`).
@@ -70,25 +65,13 @@ impl Length for usize {
 #[expect(
     clippy::cast_possible_truncation,
     reason = "debug_assert roundtrip `v as u64 as usize` contains a u64→usize cast; \
-              const_assert_eq above ensures it is lossless on all supported targets"
+              a usize is never wider than u64, so widening to u64 is always lossless"
 )]
 #[inline]
 #[must_use]
 pub const fn to_u64(v: usize) -> u64 {
     debug_assert!(v as u64 as usize == v);
     v as u64
-}
-
-/// Convert a `u64` to `usize`.
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "const_assert_eq above ensures usize::BITS == u64::BITS"
-)]
-#[inline]
-#[must_use]
-pub const fn to_usize(v: u64) -> usize {
-    debug_assert!(v as usize as u64 == v);
-    v as usize
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Enum, Display)]

--- a/neqo-http3/src/frames/capsule.rs
+++ b/neqo-http3/src/frames/capsule.rs
@@ -12,8 +12,11 @@ use crate::Res;
 pub const CAPSULE_TYPE_DATAGRAM: HFrameType = HFrameType(0x00);
 
 /// Limit on the declared length of a `DATAGRAM` capsule we'll buffer before decoding.
-pub const MAX_DATAGRAM_BYTES: usize =
-    neqo_common::to_usize(neqo_transport::MAX_DATAGRAM_FRAME_SIZE);
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "MAX_DATAGRAM_FRAME_SIZE is 65535, well within usize on all targets"
+)]
+pub const MAX_DATAGRAM_BYTES: usize = neqo_transport::MAX_DATAGRAM_FRAME_SIZE as usize;
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Capsule {
@@ -66,7 +69,6 @@ impl FrameDecoder<Self> for Capsule {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use neqo_common::to_usize;
 
     use super::*;
 
@@ -148,7 +150,7 @@ mod tests {
         let mut decoder = neqo_common::Decoder::from(encoded);
         let type_int = decoder.decode_varint().unwrap();
         let len = decoder.decode_varint().unwrap();
-        let data = decoder.decode(to_usize(len)).unwrap();
+        let data = decoder.decode(usize::try_from(len).unwrap()).unwrap();
 
         let result = Capsule::decode(HFrameType(type_int), len, Some(data))
             .unwrap()

--- a/neqo-http3/src/frames/wtframe.rs
+++ b/neqo-http3/src/frames/wtframe.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::{Decoder, Encoder, to_usize};
+use neqo_common::{Decoder, Encoder};
 
 use super::hframe::HFrameType;
 use crate::{Error, Res, frames::reader::FrameDecoder};
@@ -28,7 +28,11 @@ impl WebTransportFrame {
     const CLOSE_MAX_MESSAGE_SIZE: u64 = 1024;
 
     /// Limit on the declared length of a `CLOSE_SESSION` frame.
-    pub const MAX_CLOSE_SESSION_BYTES: usize = to_usize(Self::CLOSE_MAX_MESSAGE_SIZE) + 4;
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "CLOSE_MAX_MESSAGE_SIZE is 1024, well within usize on all targets"
+    )]
+    pub const MAX_CLOSE_SESSION_BYTES: usize = Self::CLOSE_MAX_MESSAGE_SIZE as usize + 4;
 
     pub fn encode(&self, enc: &mut Encoder) {
         #[cfg(feature = "build-fuzzing-corpus")]

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -13,7 +13,7 @@ use std::{
     slice::SliceIndex,
 };
 
-use neqo_common::{Header, qerror, qinfo, qtrace, to_u64, to_usize};
+use neqo_common::{Header, qerror, qinfo, qtrace, to_u64};
 use neqo_transport::{Connection, StreamId};
 
 use crate::{
@@ -79,7 +79,7 @@ impl ActivePushStreams {
             return None;
         }
 
-        let inx = to_usize(u64::from(push_id - self.first_push_id));
+        let inx = usize::try_from(u64::from(push_id - self.first_push_id)).ok()?;
         if inx >= self.push_streams.len() {
             self.push_streams.resize(inx + 1, PushState::Init);
         }

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -10,7 +10,7 @@ mod common;
 
 use std::time::{Duration, Instant};
 
-use neqo_common::{Datagram, event::Provider as _, qtrace, to_usize};
+use neqo_common::{Datagram, event::Provider as _, qtrace};
 use neqo_http3::{
     Header, Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3Parameters, Http3Server,
     Http3ServerEvent, Http3State, Priority,
@@ -221,6 +221,7 @@ fn response_103() {
 
 /// Test [`neqo_http3::SendMessage::send_data`] to set
 /// [`neqo_transport::SendStream::set_writable_event_low_watermark`].
+#[expect(clippy::cast_possible_truncation, reason = "OK in a test.")]
 #[test]
 fn data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::Error>> {
     const STREAM_LIMIT: u64 = 5000;
@@ -285,7 +286,7 @@ fn data_writable_events_low_watermark() -> Result<(), Box<dyn std::error::Error>
     exchange_packets(&mut hconn_c, &mut hconn_s, false, None);
 
     // Expect the server's available send space to be back to the stream limit.
-    assert_eq!(request.available()?, to_usize(STREAM_LIMIT));
+    assert_eq!(request.available()?, STREAM_LIMIT as usize);
 
     // Expect the server to emit a DataWritable event, even though it always had
     // at least 1 byte available to send, i.e. it never exhausted the entire

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -581,7 +581,6 @@ fn map_stream_send_atomic_error(err: &TransportError) -> Error {
 mod tests {
     use std::time::Instant;
 
-    use neqo_common::to_usize;
     use neqo_transport::{ConnectionParameters, StreamId, StreamType};
     use test_fixture::{
         CountingConnectionIdGenerator, DEFAULT_ALPN, default_client, default_server, handshake,
@@ -1791,7 +1790,7 @@ mod tests {
 
         // The encoder is never allowed to block a stream, and tracks at most CAP streams.
         encoder.encoder.set_max_blocked_streams(0).unwrap();
-        encoder.encoder.max_tracked_streams = to_usize(CAP);
+        encoder.encoder.max_tracked_streams = usize::try_from(CAP).unwrap();
         assert!(encoder.encoder.set_max_capacity(200).is_ok());
         encoder.send_instructions(CAP_INSTRUCTION_200);
 
@@ -1827,7 +1826,10 @@ mod tests {
 
         // Nothing ever blocks, but the tracked state is bounded by the cap.
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 0);
-        assert_eq!(encoder.encoder.unacked_header_blocks.len(), to_usize(CAP));
+        assert_eq!(
+            encoder.encoder.unacked_header_blocks.len(),
+            usize::try_from(CAP).unwrap()
+        );
     }
 
     /// A stream that is already tracked is not subject to the tracking cap.

--- a/neqo-qpack/src/huffman_decode_helper.rs
+++ b/neqo-qpack/src/huffman_decode_helper.rs
@@ -6,8 +6,6 @@
 
 use std::sync::OnceLock;
 
-use neqo_common::to_usize;
-
 use crate::huffman_table::HUFFMAN_TABLE;
 
 // Since we're encoding the table length as a u16, we need to ensure that it fits.
@@ -37,7 +35,7 @@ fn make_huffman_tree(prefix: u32, len: u8) -> HuffmanDecoderNode {
         found = true;
         if iter.len == len + 1 {
             // This is a leaf
-            let bit = to_usize(u64::from(iter.val & 1));
+            let bit = usize::try_from(iter.val & 1).expect("u32 fits in usize");
             next[bit] = Some(Box::new(HuffmanDecoderNode {
                 next: [None, None],
                 #[expect(

--- a/neqo-transport/src/addr_valid.rs
+++ b/neqo-transport/src/addr_valid.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Buffer, Decoder, Encoder, Role, qinfo, qtrace, to_usize};
+use neqo_common::{Buffer, Decoder, Encoder, Role, qinfo, qtrace};
 use nss::{
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
     selfencrypt::SelfEncrypt,
@@ -208,7 +208,7 @@ impl AddressValidation {
             .zip(TOKEN_IDENTIFIER_RETRY.iter())
             .map(|(a, b)| (a ^ b).count_ones())
             .sum();
-        to_usize(u64::from(difference)) < TOKEN_IDENTIFIER_RETRY.len()
+        usize::try_from(difference).expect("u32 fits in usize") < TOKEN_IDENTIFIER_RETRY.len()
     }
 
     pub fn validate(

--- a/neqo-transport/src/cc/search.rs
+++ b/neqo-transport/src/cc/search.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{qdebug, to_u64, to_usize};
+use neqo_common::{qdebug, to_u64};
 
 use crate::{cc::classic_cc::SlowStart, packet, rtt::RttEstimate, stats::CongestionControlStats};
 
@@ -264,7 +264,8 @@ impl Search {
         }
 
         let diff = prev_sent.saturating_sub(curr_delv);
-        let norm_diff = to_usize(diff * u64::from(Self::SCALE) / prev_sent);
+        let norm_diff =
+            usize::try_from(diff * u64::from(Self::SCALE) / prev_sent).unwrap_or(usize::MAX);
 
         if norm_diff < Self::THRESH {
             qdebug!(

--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -18,7 +18,7 @@ use std::{
 use neqo_common::{
     Buffer, Decoder, Encoder,
     hex::{Hex, HexWithLen},
-    qdebug, qinfo, to_usize,
+    qdebug, qinfo,
 };
 use nss::{random, randomize};
 use smallvec::{SmallVec, smallvec};
@@ -565,7 +565,10 @@ impl ConnectionIdManager {
 
     pub fn set_limit(&mut self, limit: u64) {
         debug_assert!(limit >= 2);
-        self.limit = min(Self::ACTIVE_LIMIT, to_usize(limit));
+        self.limit = min(
+            Self::ACTIVE_LIMIT,
+            usize::try_from(limit).unwrap_or(Self::ACTIVE_LIMIT),
+        );
     }
 
     pub fn write_frames<B: Buffer>(

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -23,7 +23,7 @@ use neqo_common::{
     hex::{Hex, HexSnipMiddle, HexWithLen},
     hrtime, qdebug, qerror, qinfo,
     qlog::Qlog,
-    qtrace, qwarn, to_u64, to_usize,
+    qtrace, qwarn, to_u64,
 };
 use nss::{
     Agent, AntiReplay, AuthenticationStatus, Cipher, Client, Group, HandshakeState, PrivateKey,
@@ -2322,8 +2322,8 @@ impl Connection {
         let pn = tx.next_pn();
         let unacked_range = largest_acknowledged.map_or_else(|| pn + 1, |la| (pn - la) << 1);
         // Count how many bytes in this range are non-zero.
-        let pn_len =
-            size_of::<packet::Number>() - to_usize(u64::from(unacked_range.leading_zeros() / 8));
+        let pn_len = size_of::<packet::Number>()
+            - usize::try_from(unacked_range.leading_zeros() / 8).expect("u32 fits in usize");
         assert!(
             pn_len > 0,
             "pn_len can't be zero as unacked_range should be > 0, pn {pn}, largest_acknowledged {largest_acknowledged:?}, tx {tx}"
@@ -3066,11 +3066,12 @@ impl Connection {
             let path = self.paths.primary().ok_or(Error::NoAvailablePath)?;
             path.borrow_mut().set_reset_token(reset_token);
 
-            let max_udp_payload = to_usize(remote.get_integer(MaxUdpPayloadSize));
-            path.borrow_mut()
-                .pmtud_mut()
-                .set_peer_max_udp_payload(max_udp_payload);
-            self.stats.borrow_mut().pmtud_peer_max_udp_payload = Some(max_udp_payload);
+            if let Ok(max_udp_payload) = usize::try_from(remote.get_integer(MaxUdpPayloadSize)) {
+                path.borrow_mut()
+                    .pmtud_mut()
+                    .set_peer_max_udp_payload(max_udp_payload);
+                self.stats.borrow_mut().pmtud_peer_max_udp_payload = Some(max_udp_payload);
+            }
 
             let max_ad = Duration::from_millis(remote.get_integer(MaxAckDelay));
             let min_ad = if remote.has_value(MinAckDelay) {

--- a/neqo-transport/src/connection/tests/zerortt.rs
+++ b/neqo-transport/src/connection/tests/zerortt.rs
@@ -6,7 +6,7 @@
 
 use std::{cell::RefCell, rc::Rc, time::Duration};
 
-use neqo_common::{event::Provider as _, qdebug, to_usize};
+use neqo_common::{event::Provider as _, qdebug};
 use nss::{AllowZeroRtt, AntiReplay};
 use test_fixture::{assertions, now};
 
@@ -215,7 +215,8 @@ fn zero_rtt_send_reject() {
 fn zero_rtt_update_flow_control() {
     const LOW: u64 = 3;
     const HIGH: u64 = 10;
-    const MESSAGE: &[u8] = &[0; to_usize(HIGH)];
+    #[expect(clippy::cast_possible_truncation, reason = "OK in a test.")]
+    const MESSAGE: &[u8] = &[0; HIGH as usize];
 
     let mut client = default_client();
     let mut server = new_server(

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 use enum_map::EnumMap;
-use neqo_common::{Buffer, MAX_VARINT, Role, qdebug, qtrace, to_u64, to_usize};
+use neqo_common::{Buffer, MAX_VARINT, Role, qdebug, qtrace, to_u64};
 
 use crate::{
     Error, Res,
@@ -122,8 +122,8 @@ where
     }
 
     /// Get available flow control.
-    pub const fn available(&self) -> usize {
-        to_usize(self.limit - self.used)
+    pub fn available(&self) -> usize {
+        usize::try_from(self.limit - self.used).unwrap_or(usize::MAX)
     }
 
     /// How much data has been written.

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -17,7 +17,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Buffer, Role, qtrace, to_u64, to_usize};
+use neqo_common::{Buffer, Role, qtrace, to_u64};
 use smallvec::SmallVec;
 use strum::Display;
 
@@ -223,7 +223,8 @@ impl RxStreamOrderer {
         }
 
         if new_start < self.retired {
-            new_data = &new_data[to_usize(self.retired - new_start)..];
+            new_data =
+                &new_data[usize::try_from(self.retired - new_start).expect("u64 fits in usize")..];
             new_start = self.retired;
         }
 
@@ -273,7 +274,7 @@ impl RxStreamOrderer {
                 let overlap = prev_end.saturating_sub(new_start);
                 qtrace!("New frame {new_start}-{new_end} received, overlap: {overlap}");
                 new_start += overlap;
-                new_data = &new_data[to_usize(overlap)..];
+                new_data = &new_data[usize::try_from(overlap).expect("u64 fits in usize")..];
                 // If it is small enough, extend the previous buffer.
                 // Checks existing length, so the chunk may grow slightly past RANGE_TARGET (by up
                 // to one frame). This can't always extend, because otherwise the
@@ -328,7 +329,8 @@ impl RxStreamOrderer {
                     qtrace!(
                         "New frame {new_start}-{new_end} overlaps with next frame by {overlap}, truncating"
                     );
-                    let truncate_to = new_data.len() - to_usize(overlap);
+                    let truncate_to =
+                        new_data.len() - usize::try_from(overlap).expect("u64 fits in usize");
                     to_add = &new_data[..truncate_to];
                     break;
                 }
@@ -390,7 +392,7 @@ impl RxStreamOrderer {
             })
             // Accumulate, but saturate at usize::MAX.
             .fold(0, |acc: usize, (_, data_len)| {
-                acc.saturating_add(to_usize(data_len))
+                acc.saturating_add(usize::try_from(data_len).unwrap_or(usize::MAX))
             })
     }
 
@@ -422,7 +424,7 @@ impl RxStreamOrderer {
         if let Some(mut e) = self.data_ranges.last_entry() {
             // Note: no underflow risk, all ranges that start at or after offset are gone.
             let start = *e.key();
-            let keep = to_usize(offset - start);
+            let keep = usize::try_from(offset - start).expect("u64 fits in usize");
             let data = e.get_mut();
             data.truncate(keep);
 
@@ -451,7 +453,8 @@ impl RxStreamOrderer {
             let mut keep = false;
             if self.retired >= range_start {
                 // Frame data has new contiguous bytes.
-                let copy_offset = to_usize(max(range_start, self.retired) - range_start);
+                let copy_offset = usize::try_from(max(range_start, self.retired) - range_start)
+                    .expect("u64 fits in usize");
                 assert!(range_data.len() >= copy_offset);
                 let available = range_data.len() - copy_offset;
                 let space = buf.len() - copied;
@@ -1297,7 +1300,7 @@ impl RecvStream {
 mod tests {
     use std::{cell::RefCell, fmt::Debug, ops::Range, rc::Rc, time::Duration};
 
-    use neqo_common::{Encoder, event::Provider as _, qtrace, to_u64, to_usize};
+    use neqo_common::{Encoder, event::Provider as _, qtrace, to_u64};
     use test_fixture::now;
 
     use super::{RecvStream, RecvStreamState};
@@ -1318,7 +1321,7 @@ mod tests {
 
         let mut s = RxStreamOrderer::default();
         for r in ranges {
-            let data = &ZEROES[..to_usize(r.end - r.start)];
+            let data = &ZEROES[..usize::try_from(r.end - r.start).unwrap()];
             s.inbound_frame(r.start, data);
         }
 
@@ -2165,16 +2168,20 @@ mod tests {
     }
 
     /// Test that the flow controls will send updates.
-    #[expect(clippy::too_many_lines, reason = "This is test code.")]
+    #[expect(
+        clippy::too_many_lines,
+        clippy::cast_possible_truncation,
+        reason = "This is test code."
+    )]
     #[test]
     fn fc_state_recv_7() {
         const CONNECTION_WINDOW: u64 = 1024;
-        const CONNECTION_WINDOW_US: usize = to_usize(CONNECTION_WINDOW);
+        const CONNECTION_WINDOW_US: usize = CONNECTION_WINDOW as usize;
 
         const STREAM_WINDOW: u64 = CONNECTION_WINDOW / 2;
-        const STREAM_WINDOW_US: usize = to_usize(STREAM_WINDOW);
+        const STREAM_WINDOW_US: usize = STREAM_WINDOW as usize;
 
-        const WINDOW_UPDATE_FRACTION_US: usize = to_usize(WINDOW_UPDATE_FRACTION);
+        const WINDOW_UPDATE_FRACTION_US: usize = WINDOW_UPDATE_FRACTION as usize;
 
         let fc = Rc::new(RefCell::new(ReceiverFlowControl::new(
             (),

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use indexmap::IndexMap;
-use neqo_common::{Buffer, Encoder, Role, qdebug, qerror, qtrace, to_u64, to_usize};
+use neqo_common::{Buffer, Encoder, Role, qdebug, qerror, qtrace, to_u64};
 use rustc_hash::FxBuildHasher;
 use smallvec::SmallVec;
 use static_assertions::const_assert;
@@ -451,7 +451,10 @@ impl RangeTracker {
     /// On 32-bit machines where far too much is sent before calling this.
     /// Note that this should not be called for handshakes, which should never exceed that limit.
     pub fn unmark_sent(&mut self) {
-        self.unmark_range(0, to_usize(self.highest_offset()));
+        self.unmark_range(
+            0,
+            usize::try_from(self.highest_offset()).expect("u64 fits in usize"),
+        );
     }
 
     #[cfg(feature = "bench")]
@@ -474,7 +477,8 @@ impl TxBuffer {
     ///
     /// See [`MAX_LOCAL_MAX_STREAM_DATA`] for an explanation of this
     /// concrete value.
-    pub const MAX_SIZE: usize = to_usize(MAX_LOCAL_MAX_STREAM_DATA);
+    #[expect(clippy::cast_possible_truncation, reason = "Checked by const_assert!")]
+    pub const MAX_SIZE: usize = MAX_LOCAL_MAX_STREAM_DATA as usize;
 
     #[must_use]
     pub fn new() -> Self {
@@ -516,7 +520,7 @@ impl TxBuffer {
 
         // Convert from ranges-relative-to-zero to
         // ranges-relative-to-buffer-start
-        let buff_off = to_usize(start - self.retired());
+        let buff_off = usize::try_from(start - self.retired()).ok()?;
 
         // Deque returns two slices. Create a subslice from whichever
         // one contains the first unmarked data.
@@ -526,7 +530,9 @@ impl TxBuffer {
             &self.send_buf.as_slices().1[buff_off - self.send_buf.as_slices().0.len()..]
         };
 
-        let len = maybe_len.map_or(slc.len(), |range_len| min(to_usize(range_len), slc.len()));
+        let len = maybe_len.map_or(slc.len(), |range_len| {
+            min(usize::try_from(range_len).unwrap_or(usize::MAX), slc.len())
+        });
 
         debug_assert!(len > 0);
         debug_assert!(len <= slc.len());
@@ -548,7 +554,8 @@ impl TxBuffer {
         self.ranges.mark_acked(offset, len);
 
         // Any newly-retired bytes can be dropped from the buffer.
-        let new_retirable = to_usize(self.retired() - prev_retired);
+        let new_retirable =
+            usize::try_from(self.retired() - prev_retired).expect("u64 fits in usize");
         debug_assert!(new_retirable <= self.buffered());
         self.send_buf.drain(..new_retirable);
     }
@@ -2415,9 +2422,7 @@ pub struct RecoveryToken {
 mod tests {
     use std::{cell::RefCell, collections::VecDeque, num::NonZeroUsize, rc::Rc};
 
-    use neqo_common::{
-        Encoder, MAX_VARINT, event::Provider as _, hex::HexWithLen, qtrace, to_u64, to_usize,
-    };
+    use neqo_common::{Encoder, MAX_VARINT, event::Provider as _, hex::HexWithLen, qtrace, to_u64};
 
     use super::RecoveryToken;
     use crate::{
@@ -3284,7 +3289,7 @@ mod tests {
 
         // Mark almost all as sent. Get what's left
         let one_byte_from_end = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA) - 1;
-        txb.mark_as_sent(0, to_usize(one_byte_from_end));
+        txb.mark_as_sent(0, usize::try_from(one_byte_from_end).unwrap());
         assert!(matches!(txb.next_bytes(),
                          Some((start, x)) if x.len() == 1
                          && start == one_byte_from_end
@@ -3313,7 +3318,7 @@ mod tests {
         // Contig acked range at start means it can be removed from buffer
         // Impl of vecdeque should now result in a split buffer when more data
         // is sent
-        txb.mark_as_acked(0, to_usize(five_bytes_from_end));
+        txb.mark_as_acked(0, usize::try_from(five_bytes_from_end).unwrap());
         assert_eq!(txb.send(&[2; 30]), 30);
         // Just get 5 even though there is more
         assert!(matches!(txb.next_bytes(),
@@ -3346,7 +3351,7 @@ mod tests {
         // As above
         let forty_bytes_from_end = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA) - 40;
 
-        txb.mark_as_acked(0, to_usize(forty_bytes_from_end));
+        txb.mark_as_acked(0, usize::try_from(forty_bytes_from_end).unwrap());
         assert!(matches!(txb.next_bytes(),
                  Some((start, x)) if x.len() == 40
                  && start == forty_bytes_from_end
@@ -3374,7 +3379,7 @@ mod tests {
 
         // Ack entire first slice and into second slice
         let ten_bytes_past_end = to_u64(INITIAL_LOCAL_MAX_STREAM_DATA) + 10;
-        txb.mark_as_acked(0, to_usize(ten_bytes_past_end));
+        txb.mark_as_acked(0, usize::try_from(ten_bytes_past_end).unwrap());
 
         // Get up to marked range A
         assert!(matches!(txb.next_bytes(),


### PR DESCRIPTION
#3738 added `const_assert_eq!(usize::BITS, u64::BITS)` and a `to_usize` helper. The assertion requires a 64-bit usize and breaks compilation on 32-bit targets. Firefox still ships 32-bit Tier-1 builds (Windows x86 and Android ARMv7), see
https://firefox-source-docs.mozilla.org/contributing/build/supported.html

This is a partial revert of #3738: it removes the u64 -> usize direction. The `to_usize` helper and the assertion are dropped, and the call sites are restored to their original fallible `usize::try_from(...)` form, which handles the 32-bit case correctly. A centralized infallible `to_usize` is not viable, since narrowing a u64 to usize is lossy on 32-bit, and as a const fn with a debug_assert it can panic during const evaluation, i.e. at compile time.

The usize -> u64 direction (`to_u64`) is always lossless and is kept.