### PR TITLE
Add a hard flow control cap

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2333,12 +2333,16 @@ impl Connection {
 
     /// Write the frames that are exchanged in the application data space.
     /// The order of calls here determines the relative priority of frames.
+    /// # Errors
+    ///
+    /// [`Error::FlowControlCap`] if a stream has data pending that can never be
+    /// sent because flow control has hit `FC_CAP`.
     fn write_appdata_frames(
         &mut self,
         builder: &mut packet::Builder<&mut Vec<u8>>,
         tokens: &mut recovery::Tokens,
         now: Instant,
-    ) {
+    ) -> Res<()> {
         let rtt = self.paths.primary().map_or_else(
             || RttEstimate::new(self.conn_params.get_initial_rtt()).estimate(),
             |p| p.borrow().rtt().estimate(),
@@ -2354,15 +2358,15 @@ impl Connection {
         }
 
         self.streams
-            .write_frames(TransmissionPriority::Critical, builder, tokens, frame_stats);
+            .write_frames(TransmissionPriority::Critical, builder, tokens, frame_stats)?;
         if builder.is_full() {
-            return;
+            return Ok(());
         }
 
         self.streams
             .write_maintenance_frames(builder, tokens, frame_stats, now, rtt);
         if builder.is_full() {
-            return;
+            return Ok(());
         }
 
         self.streams.write_frames(
@@ -2370,34 +2374,34 @@ impl Connection {
             builder,
             tokens,
             frame_stats,
-        );
+        )?;
         if builder.is_full() {
-            return;
+            return Ok(());
         }
 
         // NEW_CONNECTION_ID, RETIRE_CONNECTION_ID, and ACK_FREQUENCY.
         self.cid_manager.write_frames(builder, tokens, frame_stats);
         if builder.is_full() {
-            return;
+            return Ok(());
         }
 
         self.paths.write_frames(builder, tokens, frame_stats);
         if builder.is_full() {
-            return;
+            return Ok(());
         }
 
         for prio in [TransmissionPriority::High, TransmissionPriority::Normal] {
             self.streams
-                .write_frames(prio, builder, tokens, &mut stats.frame_tx);
+                .write_frames(prio, builder, tokens, &mut stats.frame_tx)?;
             if builder.is_full() {
-                return;
+                return Ok(());
             }
         }
 
         // Datagrams are best-effort and unreliable.  Let streams starve them for now.
         self.quic_datagrams.write_frames(builder, tokens, stats);
         if builder.is_full() {
-            return;
+            return Ok(());
         }
 
         // CRYPTO here only includes NewSessionTicket, plus NEW_TOKEN.
@@ -2411,16 +2415,17 @@ impl Connection {
             frame_stats,
         );
         if builder.is_full() {
-            return;
+            return Ok(());
         }
 
         self.new_token.write_frames(builder, tokens, frame_stats);
         if builder.is_full() {
-            return;
+            return Ok(());
         }
 
         self.streams
-            .write_frames(TransmissionPriority::Low, builder, tokens, frame_stats);
+            .write_frames(TransmissionPriority::Low, builder, tokens, frame_stats)?;
+        Ok(())
     }
 
     // Maybe send a probe.  Return true if the packet was ack-eliciting.
@@ -2483,7 +2488,7 @@ impl Connection {
         builder: &mut packet::Builder<&mut Vec<u8>>,
         coalesced: bool, // Whether this packet is coalesced behind another one.
         now: Instant,
-    ) -> (recovery::Tokens, bool, bool) {
+    ) -> Res<(recovery::Tokens, bool, bool)> {
         let mut tokens = recovery::Tokens::new();
         let primary = path.borrow().is_primary();
         let mut ack_eliciting = false;
@@ -2519,7 +2524,7 @@ impl Connection {
 
         if profile.ack_only() {
             // If we are CC limited we can only send ACKs!
-            return (tokens, false, false);
+            return Ok((tokens, false, false));
         }
 
         if primary {
@@ -2536,7 +2541,7 @@ impl Connection {
                     );
                     ack_eliciting = true;
                 }
-                self.write_appdata_frames(builder, &mut tokens, now);
+                self.write_appdata_frames(builder, &mut tokens, now)?;
             } else {
                 let stats = &mut self.stats.borrow_mut().frame_tx;
                 self.crypto.write_frame(
@@ -2573,7 +2578,7 @@ impl Connection {
             false
         };
 
-        (tokens, ack_eliciting, padded)
+        Ok((tokens, ack_eliciting, padded))
     }
 
     fn write_closing_frames<B: Buffer>(
@@ -2788,7 +2793,7 @@ impl Connection {
                 self.write_closing_frames(close, &mut builder, space, now, path, &mut tokens);
             } else {
                 (tokens, ack_eliciting, padded) =
-                    self.write_frames(path, space, &profile, &mut builder, header_start != 0, now);
+                    self.write_frames(path, space, &profile, &mut builder, header_start != 0, now)?;
             }
             if builder.packet_empty() {
                 // Nothing to include in this packet.

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -487,6 +487,80 @@ fn exceed_max_data() {
     assert_error(&server, &CloseReason::Transport(Error::FlowControl));
 }
 
+/// Reaching the sender-side flow control cap (`FC_CAP`) terminates the
+/// connection with [`Error::FlowControlCap`], rather than stalling forever.
+///
+/// Sending `FC_CAP` bytes (2^62-1 on 64-bit, `usize::MAX` on 32-bit) for real
+/// would be far too slow, so we reach into the stream's send flow control and
+/// fast-forward `used` to just below the cap, then send the last few bytes of
+/// credit to reach it.
+#[test]
+fn sender_flow_control_cap() {
+    // Leave only a few bytes of stream send credit before the cap.
+    const REMAINING: usize = 4;
+
+    let mut client = default_client();
+    let mut server = default_server();
+    connect(&mut client, &mut server);
+
+    let stream_id = client.stream_create(StreamType::UniDi).unwrap();
+
+    // Fast-forward both the stream's and the connection's send flow control so
+    // only a few bytes of credit remain before the cap on each.
+    client
+        .streams
+        .get_send_stream_mut(stream_id)
+        .unwrap()
+        .use_up_flow_control_to_cap(to_u64(REMAINING));
+
+    // Consume the remaining credit, bringing `used` up to `FC_CAP`.
+    assert_eq!(
+        client.stream_send(stream_id, &[0; REMAINING]).unwrap(),
+        REMAINING
+    );
+
+    // The stream now has data pending that can never be sent, so the next output
+    // attempt terminates the connection instead of stalling.
+    drop(client.process_output(now()));
+    assert_error(&client, &CloseReason::Transport(Error::FlowControlCap));
+}
+
+/// Reaching the receive-side flow control cap (`FC_CAP`) terminates the
+/// connection with [`Error::FlowControlCap`].
+///
+/// As with the sender-side test, we fast-forward the receiver's connection-level
+/// flow control to just below the cap rather than actually receiving `FC_CAP`
+/// bytes, then have the peer send the last few bytes of credit.
+#[test]
+fn receiver_flow_control_cap() {
+    // Leave only a few bytes of connection receive credit before the cap.
+    const REMAINING: usize = 4;
+
+    let mut client = default_client();
+    let mut server = default_server();
+    connect(&mut client, &mut server);
+
+    // Fast-forward the server's connection-level receive flow control so only a
+    // few bytes of credit remain before the cap.
+    server
+        .streams
+        .use_up_recv_flow_control_to_cap(to_u64(REMAINING));
+
+    // The client sends the last few bytes of credit; when the server consumes
+    // them its connection-level `consumed` reaches `FC_CAP` and it terminates the
+    // connection.
+    let stream_id = client.stream_create(StreamType::UniDi).unwrap();
+    assert_eq!(
+        client.stream_send(stream_id, &[0; REMAINING]).unwrap(),
+        REMAINING
+    );
+    let dgram = client.process_output(now()).dgram();
+    assert!(dgram.is_some());
+    drop(server.process(dgram, now()));
+
+    assert_error(&server, &CloseReason::Transport(Error::FlowControlCap));
+}
+
 #[test]
 // If we send a stop_sending to the peer, we should not accept more data from the peer.
 fn do_not_accept_data_after_stop_sending() {

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -126,8 +126,11 @@ where
     /// Update the maximum. Returns `Some` with the updated available flow
     /// control if the change was an increase and `None` otherwise.
     pub fn update(&mut self, limit: u64) -> Option<usize> {
+        // Cap values that we can't handle.
+        // Only on 32-bit builds; the cap is higher than the protocol allows otherwise.
+        let limit = min(limit, FC_CAP);
         (limit > self.limit).then(|| {
-            self.limit = min(limit, FC_CAP);
+            self.limit = limit;
             self.blocked_frame = false;
             self.available()
         })

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -53,6 +53,25 @@ pub const WINDOW_UPDATE_FRACTION: u64 = 4;
 /// congestion control window, in order to not unnecessarily limit throughput.
 const WINDOW_INCREASE_MULTIPLIER: u64 = 4;
 
+/// Cap the total amount of flow control credit to `usize::MAX`.
+///
+/// This does nothing on 64-bit systems, but on 32-bit
+/// we tend to assume that `usize` and `u64` are interchangeable,
+/// at least for anything that might be held in memory.
+///
+/// QUIC has the nice characteristic that flow control
+/// is a way to limit just about everything in the protocol.
+/// There are very few places that could involve larger numbers,
+/// unless they get past this control.
+/// Most uses of numbers are downstream from a flow control limit.
+/// On that basis, this stops most paths into the code that might result
+/// in a `u64` carrying a value that will need to transfer into `usize`.
+const FC_CAP: u64 = const_min_u64(MAX_VARINT, to_u64(usize::MAX));
+
+const fn const_min_u64(a: u64, b: u64) -> u64 {
+    [a, b][(a > b) as usize]
+}
+
 /// Subject for flow control auto-tuning, used to avoid heap allocations
 /// when logging.
 #[derive(Debug, Clone, Copy)]
@@ -108,7 +127,7 @@ where
     /// control if the change was an increase and `None` otherwise.
     pub fn update(&mut self, limit: u64) -> Option<usize> {
         (limit > self.limit).then(|| {
-            self.limit = limit;
+            self.limit = min(limit, FC_CAP);
             self.blocked_frame = false;
             self.available()
         })
@@ -129,6 +148,25 @@ where
     /// How much data has been written.
     pub const fn used(&self) -> u64 {
         self.used
+    }
+
+    /// Whether the amount consumed has reached [`FC_CAP`].
+    ///
+    /// When this is true, no more data can ever be sent under this flow
+    /// control: the limit cannot be raised past [`FC_CAP`] (see
+    /// [`Self::update`]), so the connection needs to be terminated rather
+    /// than wait for credit that can never arrive.
+    pub const fn capped_out(&self) -> bool {
+        self.used >= FC_CAP
+    }
+
+    /// Raise the limit to [`FC_CAP`] and mark all but `remaining` bytes of it as
+    /// used. This lets tests reach the cap without actually transferring
+    /// `FC_CAP` bytes, which would be prohibitively slow.
+    #[cfg(test)]
+    pub(crate) const fn use_up_to_cap(&mut self, remaining: u64) {
+        self.limit = FC_CAP;
+        self.used = FC_CAP - remaining;
     }
 
     /// Mark flow control as blocked.
@@ -320,17 +358,28 @@ where
         self.frame_pending
     }
 
-    pub fn next_limit(&self) -> u64 {
+    fn next_limit(&self) -> u64 {
         min(
             self.retired + self.max_active,
             // Flow control limits are encoded as QUIC varints and are thus
-            // limited to the maximum QUIC varint value.
-            MAX_VARINT,
+            // limited to the maximum QUIC varint value.  See `FC_CAP` for details.
+            FC_CAP,
         )
     }
 
     pub const fn max_active(&self) -> u64 {
         self.max_active
+    }
+
+    /// Raise the advertised limit to [`FC_CAP`] and mark all but `remaining`
+    /// bytes of it as consumed. This lets tests reach the cap without the peer
+    /// actually sending `FC_CAP` bytes, which would be prohibitively slow.
+    #[cfg(test)]
+    pub(crate) const fn use_up_to_cap(&mut self, remaining: u64) {
+        self.max_allowed = FC_CAP;
+        self.max_active = FC_CAP;
+        self.consumed = FC_CAP - remaining;
+        self.retired = FC_CAP - remaining;
     }
 
     pub const fn frame_lost(&mut self, maximum_data: u64) {
@@ -514,6 +563,13 @@ impl ReceiverFlowControl<()> {
             );
             return Err(Error::FlowControl);
         }
+        // Ensure that we cap data effectively.
+        // Note: There is no need for a similar cap on the stream limits
+        // as those are always bounded by the connection-level limit.
+        if self.consumed + count >= FC_CAP {
+            return Err(Error::FlowControlCap);
+        }
+
         self.consumed += count;
         Ok(())
     }
@@ -775,7 +831,7 @@ mod test {
     use crate::{
         ConnectionParameters, Error, INITIAL_LOCAL_MAX_DATA, INITIAL_LOCAL_MAX_STREAM_DATA, Res,
         connection::params::{MAX_LOCAL_MAX_DATA, MAX_LOCAL_MAX_STREAM_DATA},
-        fc::WINDOW_UPDATE_FRACTION,
+        fc::{FC_CAP, WINDOW_UPDATE_FRACTION, const_min_u64},
         packet, recovery,
         stats::FrameStats,
         stream_id::{StreamId, StreamType},
@@ -1568,5 +1624,27 @@ mod test {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn const_min_sanity() {
+        assert_eq!(3, const_min_u64(3, 4));
+        assert_eq!(3, const_min_u64(4, 3));
+    }
+
+    #[test]
+    fn update_caps_limit_to_usize_max() {
+        let fc_cap_usize = usize::try_from(FC_CAP).expect("FC_CAP fits in usize");
+
+        let mut fc = SenderFlowControl::new((), 0);
+        assert_eq!(fc.update(u64::MAX), Some(fc_cap_usize)); // clamped, no overflow
+        assert_eq!(fc.available(), fc_cap_usize);
+        fc.consume(fc_cap_usize);
+        assert_eq!(fc.available(), 0);
+
+        let mut fc = ReceiverFlowControl::new((), FC_CAP);
+        fc.consume(100).unwrap();
+        fc.add_retired(100);
+        assert_eq!(fc.next_limit(), FC_CAP);
     }
 }

--- a/neqo-transport/src/fc.rs
+++ b/neqo-transport/src/fc.rs
@@ -564,9 +564,13 @@ impl ReceiverFlowControl<()> {
             return Err(Error::FlowControl);
         }
         // Ensure that we cap data effectively.
+        // This aborts when receiving the ONE BYTE before the actual flow control limit,
+        // so that we can propagate an error that makes it clear what is going on.
+        // The peer has not violated the protocol, we just can't continue.
+        //
         // Note: There is no need for a similar cap on the stream limits
         // as those are always bounded by the connection-level limit.
-        if self.consumed + count >= FC_CAP {
+        if self.consumed + count > FC_CAP - 1 {
             return Err(Error::FlowControlCap);
         }
 

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -143,6 +143,8 @@ pub enum Error {
     Decrypt,
     #[error("disabled version")]
     DisabledVersion,
+    #[error("flow control limit reached the largest representable value")]
+    FlowControlCap,
     #[error("no packets received for longer than the idle timeout")]
     IdleTimeout,
     #[error("integer overflow")]

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -797,27 +797,40 @@ impl SendStream {
         self.has_next_bytes(retransmission)
     }
 
-    /// Return `false` if the builder is full and the caller should stop iterating.
+    /// Returns `Ok(false)` if the builder is full and the caller should stop
+    /// iterating.
     ///
     /// Any new frame type added here must also be reflected in `has_data_at`.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::FlowControlCap`] if the stream or connection flow control has
+    /// hit `FC_CAP` and can never grant more credit, so this stream has data
+    /// pending that can never be sent. This is a fatal condition and terminates
+    /// the connection.
     pub fn write_frames<B: Buffer>(
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
         tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
-    ) -> bool {
+    ) -> Res<bool> {
+        // This stream has data pending (`has_data_at` gated the call), so if
+        // flow control is capped out that data can never be sent.
+        if self.fc_capped_out() {
+            return Err(Error::FlowControlCap);
+        }
         if !self.write_reset_frame(priority, builder, tokens, stats) {
             self.write_blocked_frame(priority, builder, tokens, stats);
             if builder.is_full() {
-                return false;
+                return Ok(false);
             }
             self.write_stream_frame(priority, builder, tokens, stats);
             if builder.is_full() {
-                return false;
+                return Ok(false);
             }
         }
-        true
+        Ok(true)
     }
 
     pub const fn set_fairness(&mut self, make_fair: bool) {
@@ -1450,6 +1463,28 @@ impl SendStream {
             if conn_fc.borrow().available() <= needed_space {
                 conn_fc.borrow_mut().blocked();
             }
+        }
+    }
+
+    /// Whether the stream or connection flow control has hit `FC_CAP`, and so
+    /// can never grant more credit. When this is true, the stream can make no
+    /// further progress and the connection needs to be terminated.
+    fn fc_capped_out(&self) -> bool {
+        if let State::Ready { fc, conn_fc } | State::Send { fc, conn_fc, .. } = &self.state {
+            fc.capped_out() || conn_fc.borrow().capped_out()
+        } else {
+            false
+        }
+    }
+
+    /// Fast-forward both this stream's and the connection's send flow control to
+    /// just below `FC_CAP`, leaving only `remaining` bytes of credit on each, so
+    /// tests can reach the cap without sending `FC_CAP` bytes.
+    #[cfg(test)]
+    pub(crate) fn use_up_flow_control_to_cap(&mut self, remaining: u64) {
+        if let State::Ready { fc, conn_fc } | State::Send { fc, conn_fc, .. } = &mut self.state {
+            fc.use_up_to_cap(remaining);
+            conn_fc.borrow_mut().use_up_to_cap(remaining);
         }
     }
 
@@ -2177,13 +2212,17 @@ impl SendStreams {
         removed
     }
 
+    /// # Errors
+    ///
+    /// [`Error::FlowControlCap`] if a stream has data pending that can never be
+    /// sent because flow control has hit `FC_CAP`.
     pub fn write_frames<B: Buffer>(
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
         tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
-    ) {
+    ) -> Res<()> {
         // WebTransport data (which is Normal) may have a SendOrder
         // priority attached.  The spec states (6.3 write-chunk 6.1):
 
@@ -2223,7 +2262,7 @@ impl SendStreams {
                 continue;
             }
             qtrace!("   {stream}");
-            if !stream.write_frames(priority, builder, tokens, stats) {
+            if !stream.write_frames(priority, builder, tokens, stats)? {
                 break;
             }
         }
@@ -2239,7 +2278,7 @@ impl SendStreams {
             // No fair streams are registered (the common non-WebTransport case), so
             // there is nothing left to send.  Returning here avoids a wasteful second
             // walk of `map` searching for fair streams that don't exist.
-            return;
+            return Ok(());
         }
         let single_group_no_sendorder = num_groups == 1
             && self
@@ -2270,10 +2309,10 @@ impl SendStreams {
                 if !stream.is_fair() || !stream.has_data_at(priority) {
                     continue;
                 }
-                if !stream.write_frames(priority, builder, tokens, stats) {
+                if !stream.write_frames(priority, builder, tokens, stats)? {
                     // Resume after this stream next call so it can't monopolise.
                     self.fair_rr_next = (idx + 1) % n;
-                    return;
+                    return Ok(());
                 }
             }
         } else {
@@ -2327,10 +2366,10 @@ impl SendStreams {
                             // not on any builder growth (see flow-control note above).
                             let before = stats.stream;
                             if let Some(stream) = map.get_mut(&stream_id)
-                                && !stream.write_frames(priority, builder, tokens, stats)
+                                && !stream.write_frames(priority, builder, tokens, stats)?
                             {
                                 *per_group_next = (idx + 1) % num_groups;
-                                return;
+                                return Ok(());
                             }
                             if stats.stream > before {
                                 any_wrote = true;
@@ -2348,10 +2387,10 @@ impl SendStreams {
                         qtrace!("send group {idx}: stream {stream_id}");
                         let before = stats.stream;
                         if let Some(stream) = map.get_mut(&stream_id)
-                            && !stream.write_frames(priority, builder, tokens, stats)
+                            && !stream.write_frames(priority, builder, tokens, stats)?
                         {
                             *per_group_next = (idx + 1) % num_groups;
-                            return;
+                            return Ok(());
                         }
                         if stats.stream > before {
                             any_wrote = true;
@@ -2368,6 +2407,7 @@ impl SendStreams {
             // All groups had a chance this pass; advance the cursor for the next call.
             *per_group_next = (start + 1) % num_groups;
         }
+        Ok(())
     }
 
     #[allow(
@@ -2509,7 +2549,8 @@ mod tests {
                 &mut builder,
                 &mut tokens,
                 &mut FrameStats::default(),
-            );
+            )
+            .unwrap();
             while !tokens.is_empty() {
                 let id = as_stream_token(&tokens.remove(0)).id;
                 if !order.contains(&id) {
@@ -2575,7 +2616,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
 
         let mut served = std::collections::HashSet::new();
         while !tokens.is_empty() {
@@ -2633,7 +2675,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
 
         // Only STREAM frames produce `Stream` tokens; the blocked stream's
         // STREAM_DATA_BLOCKED token is a different variant and is skipped.
@@ -2698,7 +2741,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
 
         let mut served = std::collections::HashSet::new();
         while !tokens.is_empty() {
@@ -2755,7 +2799,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
 
         let mut served = std::collections::HashSet::new();
         while !tokens.is_empty() {
@@ -2803,7 +2848,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
 
         let mut served = std::collections::HashSet::new();
         while !tokens.is_empty() {
@@ -3601,7 +3647,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
         assert_eq!(builder.len(), written + 6);
         assert_eq!(tokens.len(), 1);
         let f1_token = tokens.remove(0);
@@ -3615,7 +3662,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
         assert_eq!(builder.len(), written + 10);
         assert_eq!(tokens.len(), 1);
         let f2_token = tokens.remove(0);
@@ -3628,7 +3676,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
         assert_eq!(builder.len(), written);
         assert!(tokens.is_empty());
 
@@ -3643,7 +3692,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
         assert_eq!(builder.len(), written + 7); // Needs a length this time.
         assert_eq!(tokens.len(), 1);
         let f4_token = tokens.remove(0);
@@ -3659,7 +3709,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
         assert_eq!(builder.len(), written + 10);
         assert_eq!(tokens.len(), 1);
         let f5_token = tokens.remove(0);
@@ -3701,7 +3752,8 @@ mod tests {
                 &mut builder,
                 &mut tokens,
                 &mut FrameStats::default(),
-            );
+            )
+            .unwrap();
             assert_eq!(tokens.len(), 1, "exactly one stream served per packet");
             let token = tokens.remove(0);
             served.insert(as_stream_token(&token).id);
@@ -3734,7 +3786,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
         let f1_token = tokens.remove(0);
         assert_eq!(as_stream_token(&f1_token).offset, 0);
         assert_eq!(as_stream_token(&f1_token).length, 10);
@@ -3746,7 +3799,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
         assert!(tokens.is_empty());
 
         ss.get_mut(StreamId::from(0)).unwrap().close();
@@ -3756,7 +3810,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
         let f2_token = tokens.remove(0);
         assert_eq!(as_stream_token(&f2_token).offset, 10);
         assert_eq!(as_stream_token(&f2_token).length, 0);
@@ -3771,7 +3826,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
         let f3_token = tokens.remove(0);
         assert_eq!(as_stream_token(&f3_token).offset, 10);
         assert_eq!(as_stream_token(&f3_token).length, 0);
@@ -3786,7 +3842,8 @@ mod tests {
             &mut builder,
             &mut tokens,
             &mut FrameStats::default(),
-        );
+        )
+        .unwrap();
         let f4_token = tokens.remove(0);
         assert_eq!(as_stream_token(&f4_token).offset, 0);
         assert_eq!(as_stream_token(&f4_token).length, 10);
@@ -4927,12 +4984,15 @@ mod tests {
             packet::Builder::short(Encoder::default(), false, None::<&[u8]>, packet::LIMIT);
         let mut tokens = recovery::Tokens::new();
         let mut stats = FrameStats::default();
-        assert!(s.write_frames(
-            TransmissionPriority::Normal,
-            &mut builder,
-            &mut tokens,
-            &mut stats
-        ));
+        assert!(
+            s.write_frames(
+                TransmissionPriority::Normal,
+                &mut builder,
+                &mut tokens,
+                &mut stats
+            )
+            .unwrap()
+        );
         assert!(!builder.is_full());
 
         // Both frames should be in this one packet.

--- a/neqo-transport/src/streams.rs
+++ b/neqo-transport/src/streams.rs
@@ -316,14 +316,18 @@ impl Streams {
         self.local_stream_limits[StreamType::UniDi].write_frames(builder, tokens, stats);
     }
 
+    /// # Errors
+    ///
+    /// [`Error::FlowControlCap`] if a stream has data pending that can never be
+    /// sent because flow control has hit `FC_CAP`.
     pub fn write_frames<B: Buffer>(
         &mut self,
         priority: TransmissionPriority,
         builder: &mut packet::Builder<B>,
         tokens: &mut recovery::Tokens,
         stats: &mut FrameStats,
-    ) {
-        self.send.write_frames(priority, builder, tokens, stats);
+    ) -> Res<()> {
+        self.send.write_frames(priority, builder, tokens, stats)
     }
 
     pub fn lost(&mut self, token: &StreamRecoveryToken) {
@@ -577,6 +581,14 @@ impl Streams {
 
     pub fn handle_data_blocked(&self) {
         self.receiver_fc.borrow_mut().send_flowc_update();
+    }
+
+    /// Fast-forward the connection-level receive flow control to just below
+    /// `FC_CAP`, leaving only `remaining` bytes of credit, so tests can drive the
+    /// peer into the cap without receiving `FC_CAP` bytes.
+    #[cfg(test)]
+    pub(crate) fn use_up_recv_flow_control_to_cap(&self, remaining: u64) {
+        self.receiver_fc.borrow_mut().use_up_to_cap(remaining);
     }
 
     pub fn set_initial_limits(&mut self) {


### PR DESCRIPTION
This is aimed at 32-bit systems, but the code is operative for 64-bit systems at the 2^62 limit for flow control as well.

This produces a hard error, which results in connection closure, when connection-level flow control hits the limit of what can be handled on the host system.

**This will cause 32-bit builds to abort connections when 4GB of data has been transferred.**

The way this works is that there is a cap enforced on flow control. When that cap is hit, sending will fail (lots of plumbing of `Res` there) or receiving will fail.  Each will result in the connection being closed with an error.

This is a change to 32-bit builds that will probably hit earlier than might have otherwise prior to the change.  It is conceivable that we did not have troubles when hitting this limit previously, as any `usize` values that were handled might have been smaller than the cap.  But it's not guaranteed in all cases, which could have left us exposed to attacks using integer overflow.

Thus, this is deliberately conservative.

4GB is a fair bit, but it is not an unimaginable value.  There are many cases where HTTP might be used to transfer that amount.  However, I think that this is acceptable on the basis that any transfer of that size should have facilities in place to recover from errors like this. Unfortunately, we can't deal with all the possible problems that might arise from the change.

This is an alternative to #3738.