### PR TITLE
Cap qpack tracking

### DIFF
--- a/neqo-http3/src/conn_params.rs
+++ b/neqo-http3/src/conn_params.rs
@@ -13,6 +13,7 @@ use neqo_transport::ConnectionParameters;
 const QPACK_MAX_TABLE_SIZE_DEFAULT: u64 = 65536;
 const QPACK_TABLE_SIZE_LIMIT: u64 = (1 << 30) - 1;
 const QPACK_MAX_BLOCKED_STREAMS_DEFAULT: u16 = 20;
+const QPACK_MAX_TRACKED_STREAMS_DEFAULT: usize = 1 << 12;
 const MAX_PUSH_STREAM_DEFAULT: u64 = 0;
 const WEBTRANSPORT_DEFAULT: bool = false;
 /// Do not support HTTP Extended CONNECT by default.
@@ -38,6 +39,7 @@ impl Default for Http3Parameters {
                 max_table_size_encoder: QPACK_MAX_TABLE_SIZE_DEFAULT,
                 max_table_size_decoder: QPACK_MAX_TABLE_SIZE_DEFAULT,
                 max_blocked_streams: QPACK_MAX_BLOCKED_STREAMS_DEFAULT,
+                max_tracked_streams: QPACK_MAX_TRACKED_STREAMS_DEFAULT,
             },
             max_concurrent_push_streams: MAX_PUSH_STREAM_DEFAULT,
             webtransport: WEBTRANSPORT_DEFAULT,

--- a/neqo-http3/src/conn_params.rs
+++ b/neqo-http3/src/conn_params.rs
@@ -13,7 +13,7 @@ use neqo_transport::ConnectionParameters;
 const QPACK_MAX_TABLE_SIZE_DEFAULT: u64 = 65536;
 const QPACK_TABLE_SIZE_LIMIT: u64 = (1 << 30) - 1;
 const QPACK_MAX_BLOCKED_STREAMS_DEFAULT: u16 = 20;
-const QPACK_MAX_TRACKED_STREAMS_DEFAULT: usize = 1 << 12;
+const QPACK_MAX_TRACKED_STREAMS_DEFAULT: usize = 1000;
 const MAX_PUSH_STREAM_DEFAULT: u64 = 0;
 const WEBTRANSPORT_DEFAULT: bool = false;
 /// Do not support HTTP Extended CONNECT by default.

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -1372,6 +1372,7 @@ mod tests {
                     max_table_size_encoder: max_table_size,
                     max_table_size_decoder: max_table_size,
                     max_blocked_streams,
+                    max_tracked_streams: 4096,
                 },
                 true,
             )));
@@ -1394,6 +1395,7 @@ mod tests {
                     max_table_size_encoder: 128,
                     max_table_size_decoder: 128,
                     max_blocked_streams: 0,
+                    max_tracked_streams: 4096,
                 },
                 true,
             )));

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -438,6 +438,7 @@ mod tests {
         max_table_size_encoder: 100,
         max_table_size_decoder: 100,
         max_blocked_streams: 100,
+        max_tracked_streams: 4096,
     };
 
     fn http3params(qpack_settings: qpack::Settings) -> Http3Parameters {
@@ -662,6 +663,7 @@ mod tests {
                 max_table_size_encoder: 100,
                 max_table_size_decoder: 0,
                 max_blocked_streams: 0,
+                max_tracked_streams: 4096,
             },
             true,
         );

--- a/neqo-qpack/src/decoder.rs
+++ b/neqo-qpack/src/decoder.rs
@@ -308,6 +308,7 @@ mod tests {
             max_table_size_encoder: 0,
             max_table_size_decoder: 300,
             max_blocked_streams: 100,
+            max_tracked_streams: 4096,
         });
         decoder.add_send_stream(send_stream_id);
 
@@ -840,6 +841,7 @@ mod tests {
             max_table_size_encoder: 0,
             max_table_size_decoder: 300,
             max_blocked_streams: 1,
+            max_tracked_streams: 4096,
         });
         // One blocked stream is within the advertised limit.
         assert!(
@@ -860,6 +862,7 @@ mod tests {
             max_table_size_encoder: 0,
             max_table_size_decoder: 300,
             max_blocked_streams: 0,
+            max_tracked_streams: 4096,
         });
         assert!(
             decoder

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -52,6 +52,9 @@ pub struct Encoder {
     instruction_reader: DecoderInstructionReader,
     local_stream: LocalStreamState,
     max_blocked_streams: u16,
+    /// Upper bound on the number of entries in `unacked_header_blocks`; see
+    /// [`Settings::max_tracked_streams`](crate::Settings::max_tracked_streams).
+    max_tracked_streams: usize,
     // Remember header blocks that are referring to dynamic table.
     // There can be multiple header blocks in one stream, headers, trailer, push stream request,
     // etc. This HashMap maps a stream ID to a list of header blocks. Each header block is a
@@ -73,6 +76,7 @@ impl Encoder {
             instruction_reader: DecoderInstructionReader::default(),
             local_stream: LocalStreamState::NoStream,
             max_blocked_streams: 0,
+            max_tracked_streams: qpack_settings.max_tracked_streams,
             unacked_header_blocks: HashMap::default(),
             blocked_stream_cnt: 0,
             use_huffman,
@@ -421,8 +425,15 @@ impl Encoder {
         let mut encoded_h =
             HeaderEncoder::new(self.table.base(), self.use_huffman, self.max_entries);
 
-        let stream_is_blocker = self.is_stream_blocker(stream_id);
-        let can_block = self.blocked_stream_cnt < self.max_blocked_streams || stream_is_blocker;
+        // Avoid the dynamic table unless we have space to track.
+        let can_track = self.unacked_header_blocks.contains_key(&stream_id)
+            || self.unacked_header_blocks.len() < self.max_tracked_streams;
+
+        // Avoid blocking unless we can use the dynamic table and either
+        // the stream is already blocked or we have space for blocked streams.
+        let can_block = can_track
+            && (self.blocked_stream_cnt < self.max_blocked_streams
+                || self.is_stream_blocker(stream_id));
 
         let mut ref_entries = HashSet::default();
 
@@ -431,11 +442,16 @@ impl Encoder {
             let value = iter.value();
             qtrace!("encoding {name:x?} {value:x?}");
 
+            let found = if can_track {
+                self.table.lookup(&name, value, can_block)
+            } else {
+                HeaderTable::static_lookup(&name, value)
+            };
             if let Some(LookupResult {
                 index,
                 static_table,
                 value_matches,
-            }) = self.table.lookup(&name, value, can_block)
+            }) = found
             {
                 qtrace!(
                     "[{self}] found a {} entry, value-match={value_matches}",
@@ -648,6 +664,7 @@ mod tests {
                 max_table_size_encoder: 1500,
                 max_table_size_decoder: 0,
                 max_blocked_streams: 0,
+                max_tracked_streams: 4096,
             },
             huffman,
         );
@@ -1754,5 +1771,65 @@ mod tests {
         recv_instruction(&mut encoder, STREAM_CANCELED_ID_1, now());
 
         recv_instruction(&mut encoder, &[0x01], now());
+    }
+
+    // A peer that acknowledges an insertion (so a dynamic entry becomes referenceable
+    // without blocking) but then resets its streams via STOP_SENDING *without* ever
+    // sending a Header Acknowledgement or Stream Cancellation instruction would, absent
+    // a cap, make `unacked_header_blocks` grow one entry per stream for the lifetime of
+    // the connection: every such stream references the acknowledged entry, which adds an
+    // entry to the map and bumps the table entry's reference count, while
+    // `blocked_stream_cnt` stays at 0 (so `max_blocked_streams` does not contain it).
+    //
+    // `Settings::max_tracked_streams` bounds this: once the map is full, new streams are
+    // encoded from the static table and literals only, so they create no reference and
+    // add nothing to the map.
+    #[test]
+    fn unacked_header_blocks_are_capped() {
+        const CAP: usize = 5;
+
+        let mut encoder = connect(false);
+
+        // The encoder is never allowed to block a stream, and tracks at most CAP streams.
+        encoder.encoder.set_max_blocked_streams(0).unwrap();
+        encoder.encoder.max_tracked_streams = CAP;
+        assert!(encoder.encoder.set_max_capacity(200).is_ok());
+        encoder.send_instructions(CAP_INSTRUCTION_200);
+
+        // Insert "content-length: 1234" and have the peer acknowledge the insertion
+        // (Insert Count Increment). The entry is now referenceable without blocking.
+        encoder.insert(
+            HEADER_CONTENT_LENGTH,
+            VALUE_1,
+            HEADER_CONTENT_LENGTH_VALUE_1_NAME_LITERAL,
+        );
+        recv_instruction(&mut encoder, &[0x01], now());
+
+        assert_eq!(encoder.encoder.blocked_stream_cnt(), 0);
+        assert_eq!(encoder.encoder.unacked_header_blocks.len(), 0);
+
+        // Simulate more streams than the cap: each sends a header block referencing the
+        // acked entry and is then reset via STOP_SENDING, but the peer never sends a
+        // Header Ack or Stream Cancellation instruction for it.
+        for i in 0..u64::try_from(CAP).unwrap() + 10 {
+            let stream_id = StreamId::new(i * 4);
+            let buf = encoder.encoder.encode_header_block(
+                &mut encoder.conn,
+                &[Header::new("content-length", "1234")],
+                stream_id,
+            );
+            if usize::try_from(i).unwrap() < CAP {
+                // Under the cap: the header uses the (acknowledged) dynamic entry.
+                assert_is_index_to_dynamic(&buf);
+            } else {
+                // Over the cap: the encoder falls back to a static name reference.
+                assert_is_index_to_static_name_only(&buf);
+            }
+        }
+
+        // Never blocked (max_blocked_streams == 0 was respected the whole time)...
+        assert_eq!(encoder.encoder.blocked_stream_cnt(), 0);
+        // ...and the tracked state is bounded by the cap, not the number of streams.
+        assert_eq!(encoder.encoder.unacked_header_blocks.len(), CAP);
     }
 }

--- a/neqo-qpack/src/encoder.rs
+++ b/neqo-qpack/src/encoder.rs
@@ -387,8 +387,7 @@ impl Encoder {
                 hb_list
                     .iter()
                     .flatten()
-                    .max()
-                    .is_some_and(|max_ref| *max_ref >= self.table.get_acked_inserts_cnt())
+                    .any(|index| *index >= self.table.get_acked_inserts_cnt())
             })
     }
 
@@ -426,14 +425,15 @@ impl Encoder {
             HeaderEncoder::new(self.table.base(), self.use_huffman, self.max_entries);
 
         // Avoid the dynamic table unless we have space to track.
-        let can_track = self.unacked_header_blocks.contains_key(&stream_id)
+        let stream_was_blocking = self.is_stream_blocker(stream_id);
+        let can_track = stream_was_blocking
+            || self.unacked_header_blocks.contains_key(&stream_id)
             || self.unacked_header_blocks.len() < self.max_tracked_streams;
 
-        // Avoid blocking unless we can use the dynamic table and either
-        // the stream is already blocked or we have space for blocked streams.
-        let can_block = can_track
-            && (self.blocked_stream_cnt < self.max_blocked_streams
-                || self.is_stream_blocker(stream_id));
+        // Avoid blocking unless the stream is already blocked or
+        // we can use the dynamic table and there is space for blocked streams.
+        let can_block = stream_was_blocking
+            || (can_track && self.blocked_stream_cnt < self.max_blocked_streams);
 
         let mut ref_entries = HashSet::default();
 
@@ -501,7 +501,7 @@ impl Encoder {
 
         encoded_h.encode_header_block_prefix();
 
-        if !stream_is_blocker {
+        if !stream_was_blocking {
             // The streams was not a blocker, check if the stream is a blocker now.
             if let Some(max_ref) = ref_entries.iter().max()
                 && *max_ref >= self.table.get_acked_inserts_cnt()
@@ -581,6 +581,7 @@ fn map_stream_send_atomic_error(err: &TransportError) -> Error {
 mod tests {
     use std::time::Instant;
 
+    use neqo_common::to_usize;
     use neqo_transport::{ConnectionParameters, StreamId, StreamType};
     use test_fixture::{
         CountingConnectionIdGenerator, DEFAULT_ALPN, default_client, default_server, handshake,
@@ -707,11 +708,9 @@ mod tests {
     const CAP_INSTRUCTION_1000: &[u8] = &[0x02, 0x3f, 0xc9, 0x07];
     const CAP_INSTRUCTION_1500: &[u8] = &[0x02, 0x3f, 0xbd, 0x0b];
 
-    const HEADER_CONTENT_LENGTH: &[u8] = &[
-        0x63, 0x6f, 0x6e, 0x74, 0x65, 0x6e, 0x74, 0x2d, 0x6c, 0x65, 0x6e, 0x67, 0x74, 0x68,
-    ];
-    const VALUE_1: &[u8] = &[0x31, 0x32, 0x33, 0x34];
-    const VALUE_2: &[u8] = &[0x31, 0x32, 0x33, 0x34, 0x35];
+    const HEADER_CONTENT_LENGTH: &[u8] = b"content-length";
+    const VALUE_1: &[u8] = b"1234";
+    const VALUE_2: &[u8] = b"12345";
 
     // HEADER_CONTENT_LENGTH and VALUE_1 encoded by instruction insert_with_name_literal.
     const HEADER_CONTENT_LENGTH_VALUE_1_NAME_LITERAL: &[u8] = &[
@@ -1786,18 +1785,16 @@ mod tests {
     // add nothing to the map.
     #[test]
     fn unacked_header_blocks_are_capped() {
-        const CAP: usize = 5;
+        const CAP: u64 = 5;
 
         let mut encoder = connect(false);
 
         // The encoder is never allowed to block a stream, and tracks at most CAP streams.
         encoder.encoder.set_max_blocked_streams(0).unwrap();
-        encoder.encoder.max_tracked_streams = CAP;
+        encoder.encoder.max_tracked_streams = to_usize(CAP);
         assert!(encoder.encoder.set_max_capacity(200).is_ok());
         encoder.send_instructions(CAP_INSTRUCTION_200);
 
-        // Insert "content-length: 1234" and have the peer acknowledge the insertion
-        // (Insert Count Increment). The entry is now referenceable without blocking.
         encoder.insert(
             HEADER_CONTENT_LENGTH,
             VALUE_1,
@@ -1811,25 +1808,68 @@ mod tests {
         // Simulate more streams than the cap: each sends a header block referencing the
         // acked entry and is then reset via STOP_SENDING, but the peer never sends a
         // Header Ack or Stream Cancellation instruction for it.
-        for i in 0..u64::try_from(CAP).unwrap() + 10 {
-            let stream_id = StreamId::new(i * 4);
+        for i in 0..CAP + 10 {
             let buf = encoder.encoder.encode_header_block(
                 &mut encoder.conn,
-                &[Header::new("content-length", "1234")],
-                stream_id,
+                &[Header::new(
+                    String::from_utf8_lossy(HEADER_CONTENT_LENGTH),
+                    VALUE_1,
+                )],
+                StreamId::new(i * 4),
             );
-            if usize::try_from(i).unwrap() < CAP {
-                // Under the cap: the header uses the (acknowledged) dynamic entry.
+            // Dynamic entries are used up to the cap.
+            if i < CAP {
                 assert_is_index_to_dynamic(&buf);
             } else {
-                // Over the cap: the encoder falls back to a static name reference.
                 assert_is_index_to_static_name_only(&buf);
             }
         }
 
-        // Never blocked (max_blocked_streams == 0 was respected the whole time)...
+        // Nothing ever blocks, but the tracked state is bounded by the cap.
         assert_eq!(encoder.encoder.blocked_stream_cnt(), 0);
-        // ...and the tracked state is bounded by the cap, not the number of streams.
+        assert_eq!(encoder.encoder.unacked_header_blocks.len(), to_usize(CAP));
+    }
+
+    /// A stream that is already tracked is not subject to the tracking cap.
+    #[test]
+    fn tracked_stream_bypasses_tracked_cap() {
+        const CAP: usize = 1;
+
+        let mut encoder = connect(false);
+
+        encoder.encoder.set_max_blocked_streams(10).unwrap();
+        encoder.encoder.max_tracked_streams = CAP;
+        assert!(encoder.encoder.set_max_capacity(200).is_ok());
+        encoder.send_instructions(CAP_INSTRUCTION_200);
+
+        // STREAM_1 inserts and references a new, unacknowledged entry: it becomes a
+        // blocking stream and fills the single tracked-stream slot.
+        let buf = encoder.encoder.encode_header_block(
+            &mut encoder.conn,
+            &[Header::new("name1", "value1")],
+            STREAM_1,
+        );
+        assert_is_index_to_dynamic_post(&buf);
+        assert_eq!(encoder.encoder.blocked_stream_cnt(), 1);
         assert_eq!(encoder.encoder.unacked_header_blocks.len(), CAP);
+
+        // A brand-new stream is now over the cap and must fall back to a literal.
+        let buf = encoder.encoder.encode_header_block(
+            &mut encoder.conn,
+            &[Header::new("name2", "value2")],
+            STREAM_2,
+        );
+        assert_is_literal_value_literal_name(&buf);
+        assert_eq!(encoder.encoder.unacked_header_blocks.len(), CAP);
+
+        // An already-tracked STREAM_1 is not affected by the cap.
+        let buf = encoder.encoder.encode_header_block(
+            &mut encoder.conn,
+            &[Header::new("name3", "value3")],
+            STREAM_1,
+        );
+        assert_is_index_to_dynamic_post(&buf);
+        assert_eq!(encoder.encoder.unacked_header_blocks.len(), CAP);
+        assert_eq!(encoder.encoder.blocked_stream_cnt(), 1);
     }
 }

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -36,6 +36,9 @@ pub struct Settings {
     pub max_table_size_decoder: u64,
     pub max_table_size_encoder: u64,
     pub max_blocked_streams: u16,
+    /// Upper bound on the number of streams the encoder tracks.
+    /// Dynamic table references will be blocked once this limit is hit.
+    pub max_tracked_streams: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Error)]

--- a/neqo-qpack/src/lib.rs
+++ b/neqo-qpack/src/lib.rs
@@ -37,7 +37,7 @@ pub struct Settings {
     pub max_table_size_encoder: u64,
     pub max_blocked_streams: u16,
     /// Upper bound on the number of streams the encoder tracks.
-    /// Dynamic table references will be blocked once this limit is hit.
+    /// Dynamic table references will be avoided once this limit is hit.
     pub max_tracked_streams: usize,
 }
 

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -232,11 +232,12 @@ impl HeaderTable {
         qtrace!("[{self}] lookup name:{name:?} value {value:?} can_block={can_block}");
         // A static value match wins outright; otherwise a static name-only match is kept
         // as a fallback that a dynamic name-only match must not displace.
-        let mut static_match = Self::static_lookup(name, value);
+        let static_match = Self::static_lookup(name, value);
         if static_match.as_ref().is_some_and(|r| r.value_matches) {
             return static_match;
         }
 
+        let mut name_match = static_match;
         for iter in &self.dynamic {
             if !can_block && iter.index() >= self.acked_inserts_cnt {
                 continue;
@@ -250,14 +251,14 @@ impl HeaderTable {
                     });
                 }
 
-                static_match.get_or_insert_with(|| LookupResult {
+                name_match.get_or_insert_with(|| LookupResult {
                     index: iter.index(),
                     static_table: false,
                     value_matches: false,
                 });
             }
         }
-        static_match
+        name_match
     }
 
     fn evict_to(&mut self, reduce: u64) -> bool {

--- a/neqo-qpack/src/table.rs
+++ b/neqo-qpack/src/table.rs
@@ -194,11 +194,16 @@ impl HeaderTable {
             .add_ref();
     }
 
-    /// Look for a header pair.
-    /// The function returns `LookupResult`: `index`, `static_table` (if it is a static table entry)
-    /// and `value_matches` (if the header value matches as well not only header name)
-    pub fn lookup(&mut self, name: &[u8], value: &[u8], can_block: bool) -> Option<LookupResult> {
-        qtrace!("[{self}] lookup name:{name:?} value {value:?} can_block={can_block}");
+    /// Look for a header pair in the static table only.
+    ///
+    /// Unlike [`Self::lookup`], this does not consult the dynamic table, so it borrows
+    /// nothing and can never return a dynamic entry (which would need a reference to be
+    /// held against eviction). The encoder uses this when it must not create a new
+    /// dynamic-table reference for the stream.
+    ///
+    /// The function returns `LookupResult`: `index`, `static_table` (always `true` here)
+    /// and `value_matches` (if the header value matches as well, not only the header name).
+    pub fn static_lookup(name: &[u8], value: &[u8]) -> Option<LookupResult> {
         let mut name_match = None;
         for iter in HEADER_STATIC_TABLE {
             if iter.name() == name {
@@ -217,8 +222,22 @@ impl HeaderTable {
                 });
             }
         }
+        name_match
+    }
 
-        for iter in &mut self.dynamic {
+    /// Look for a header pair in the static and dynamic tables.
+    /// The function returns `LookupResult`: `index`, `static_table` (if it is a static table entry)
+    /// and `value_matches` (if the header value matches as well not only header name)
+    pub fn lookup(&self, name: &[u8], value: &[u8], can_block: bool) -> Option<LookupResult> {
+        qtrace!("[{self}] lookup name:{name:?} value {value:?} can_block={can_block}");
+        // A static value match wins outright; otherwise a static name-only match is kept
+        // as a fallback that a dynamic name-only match must not displace.
+        let mut static_match = Self::static_lookup(name, value);
+        if static_match.as_ref().is_some_and(|r| r.value_matches) {
+            return static_match;
+        }
+
+        for iter in &self.dynamic {
             if !can_block && iter.index() >= self.acked_inserts_cnt {
                 continue;
             }
@@ -231,14 +250,14 @@ impl HeaderTable {
                     });
                 }
 
-                name_match.get_or_insert_with(|| LookupResult {
+                static_match.get_or_insert_with(|| LookupResult {
                     index: iter.index(),
                     static_table: false,
                     value_matches: false,
                 });
             }
         }
-        name_match
+        static_match
     }
 
     fn evict_to(&mut self, reduce: u64) -> bool {


### PR DESCRIPTION
This puts a hard cap on the number of streams that we'll track in the QPack encoder.  Past that limit, we'll avoid the dynamic table.

An attacker that never acknowledges qpack streams will cause our encoder to hold state for every stream that was ever opened.  That's essentially unbounded, even if the per-stream state is pretty small.  So stop doing that.

This turned out to be a little fiddly, but I think that the end result is pretty comprehensible.

There is an interesting question about the value of the new setting: in one version of this, the value is determined by the number of streams we are willing to track at the transport layer.  Coordinating the values to do that turns out to be super difficult to do.  In the end, I decided not to put the effort in for that.  This is on the basis that the tracking of streams is generally something that doesn't have the same lifetime as a stream.  

A long-lived stream will generally only ever use the encoder near the start of its life, then the tracking goes away.  So the limit we have is probably safe.  I doubt we'll see more than 1k concurrent HEADERS sent to a server.  We're unlikely to get that many streams from a server, let alone be able to make that many concurrent requests.  At which point, a few requests without compression is fine.

As for whether 1k is too much, the cost here is dependent on how many entries each stream references, but that many outstanding `HashSet`s is probably fine. 