### PR TITLE
fix: reject server-only transport parameters sent by a client

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -3036,6 +3036,23 @@ impl Connection {
             let tps = self.tps.borrow();
             let remote = tps.remote_handshake().ok_or(Error::TransportParameter)?;
 
+            // RFC 9000, Section 18.2: `original_destination_connection_id`,
+            // `retry_source_connection_id`, and `stateless_reset_token` are only sent
+            // by a server. A server that receives one from a client rejects it with a
+            // transport parameter error. `preferred_address`, the fourth server-only
+            // parameter, is handled by the check below.
+            if self.role == Role::Server
+                && [
+                    OriginalDestinationConnectionId,
+                    RetrySourceConnectionId,
+                    StatelessResetToken,
+                ]
+                .into_iter()
+                .any(|tp| remote.has_value(tp))
+            {
+                return Err(Error::TransportParameter);
+            }
+
             // If the peer provided a preferred address, then we have to be a client
             // and they have to be using a non-empty connection ID.
             if remote.get_preferred_address().is_some()

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -961,6 +961,37 @@ fn preferred_address_client() {
     );
 }
 
+/// The other server-only transport parameters (RFC 9000, Section 18.2) also get
+/// rejected by a server when a client sends them.
+#[test]
+fn server_only_tparams_from_client() {
+    for (tp, value) in [
+        (
+            TransportParameterId::OriginalDestinationConnectionId,
+            TransportParameter::Bytes(vec![0x0b; 8]),
+        ),
+        (
+            TransportParameterId::RetrySourceConnectionId,
+            TransportParameter::Bytes(vec![0x0c; 8]),
+        ),
+        (
+            TransportParameterId::StatelessResetToken,
+            TransportParameter::Bytes(vec![0x0d; 16]),
+        ),
+    ] {
+        let mut client = default_client();
+        let mut server = default_server();
+        client.set_local_tparam(tp, value).unwrap();
+
+        connect_fail(
+            &mut client,
+            &mut server,
+            Error::Peer(Error::TransportParameter.code()),
+            Error::TransportParameter,
+        );
+    }
+}
+
 /// Test that migration isn't permitted if the connection isn't in the right state.
 #[test]
 fn migration_invalid_state() {


### PR DESCRIPTION
Injecting a server-only transport parameter into a client and running the
handshake against a default server lands here:

    thread 'connection::tests::migration::server_only_tparams_from_client'
    panicked at neqo-transport/src/connection/tests/mod.rs:314:14:
    bad state Confirmed

RFC 9000, Section 18.2 marks `original_destination_connection_id`,
`retry_source_connection_id`, and `stateless_reset_token` as only sent by a
server (a client MUST NOT send the reset token). `process_tps` already rejects a
client's `preferred_address`; the other three fall through.

Before: a server accepts all three from a client. `validate_cids` only checks
the two connection-id parameters when the role is Client, and `process_tps`
reads `stateless_reset_token` for either role, so a client-supplied reset token
lands on the primary path.

After: a server rejects any of the three with a transport parameter error,
alongside the existing `preferred_address` check. The client path is untouched
and still validates these against the values it observed during the handshake.

Tradeoff is strict rejection of a known set over ignoring unexpected
parameters, matching how `preferred_address` is handled today.