### PR TITLE
fix: discard retry with scid matching the initial dcid

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1324,14 +1324,24 @@ impl Connection {
             self.stats.borrow_mut().pkt_dropped("Retry without a token");
             return Ok(());
         }
-        if !packet.is_valid_retry(
-            self.original_destination_cid
-                .as_ref()
-                .ok_or(Error::InvalidRetry)?,
-        ) {
+        let odcid = self
+            .original_destination_cid
+            .as_ref()
+            .ok_or(Error::InvalidRetry)?;
+        if !packet.is_valid_retry(odcid) {
             self.stats
                 .borrow_mut()
                 .pkt_dropped("Retry with bad integrity tag");
+            return Ok(());
+        }
+        // RFC 9000, Section 17.2.5.2: a client MUST discard a Retry packet that
+        // carries a Source Connection ID identical to the Destination Connection ID
+        // of its Initial. The Retry integrity key is public, so this comparison is
+        // one of the few checks that constrains an off-path injected Retry.
+        if packet.scid() == *odcid {
+            self.stats
+                .borrow_mut()
+                .pkt_dropped("Retry with SCID matching our Initial DCID");
             return Ok(());
         }
         // At this point, we should only have the connection ID that we generated.

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -2037,6 +2037,8 @@ fn retry_scid_matching_initial_dcid() {
         let mut dec = Decoder::from(&initial[5..]);
         let dcid = dec.decode_vec(1).expect("client DCID").to_vec();
         let scid = dec.decode_vec(1).expect("client SCID").to_vec();
+        assert!(!dcid.is_empty(), "client DCID is non-empty");
+        assert!(!scid.is_empty(), "client SCID is non-empty");
         (dcid, scid)
     }
 
@@ -2051,10 +2053,10 @@ fn retry_scid_matching_initial_dcid() {
     let (dcid, scid) = initial_cids(&initial);
     let retry = crate::packet::Builder::retry(
         Version::default(),
-        &scid,   // Retry Destination CID: the client's Source CID
-        &dcid,   // Retry Source CID equal to the client's Initial Destination CID
+        &scid,   // Destination CID: copied from the client as required
+        &dcid,   // Source CID: copied from client (bad!)
         &[0x01], // non-empty token
-        &dcid,   // integrity tag is keyed on the client's Initial Destination CID
+        &dcid,   // as required: a seed for authenticating the Retry
     )
     .expect("build retry");
     drop(client.process(Some(datagram(retry)), now()));

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -17,6 +17,8 @@ use std::{
     time::Duration,
 };
 
+#[cfg(not(feature = "disable-encryption"))]
+use neqo_common::Decoder;
 use neqo_common::{Datagram, event::Provider as _, qdebug, to_u64};
 use nss::{AuthenticationStatus, constants::TLS_CHACHA20_POLY1305_SHA256, generate_ech_keys};
 #[cfg(not(feature = "disable-encryption"))]
@@ -2021,4 +2023,57 @@ fn export_keying_material_after_closed() {
         server.export_keying_material("EXPORTER-WebTransport", &[], &mut [0u8; 32]),
         Err(Error::NotConnected)
     ));
+}
+
+/// RFC 9000, Section 17.2.5.2: a client MUST discard a Retry packet whose Source
+/// Connection ID is identical to the Destination Connection ID of its Initial. A
+/// Retry with a distinct Source Connection ID is still processed.
+#[cfg(not(feature = "disable-encryption"))]
+#[test]
+fn retry_scid_matching_initial_dcid() {
+    // Read the connection IDs carried in the client's Initial: skip the first byte
+    // and the 4-byte version, then two length-prefixed connection IDs (DCID, SCID).
+    fn initial_cids(initial: &[u8]) -> (Vec<u8>, Vec<u8>) {
+        let mut dec = Decoder::from(&initial[5..]);
+        let dcid = dec.decode_vec(1).expect("client DCID").to_vec();
+        let scid = dec.decode_vec(1).expect("client SCID").to_vec();
+        (dcid, scid)
+    }
+
+    // A Retry whose Source Connection ID equals our Initial's Destination
+    // Connection ID is dropped, leaving the client in its initial state.
+    let mut client = default_client();
+    let initial = client
+        .process_output(now())
+        .dgram()
+        .expect("a datagram")
+        .to_vec();
+    let (dcid, scid) = initial_cids(&initial);
+    let retry = crate::packet::Builder::retry(
+        Version::default(),
+        &scid,   // Retry Destination CID: the client's Source CID
+        &dcid,   // Retry Source CID equal to the client's Initial Destination CID
+        &[0x01], // non-empty token
+        &dcid,   // integrity tag is keyed on the client's Initial Destination CID
+    )
+    .expect("build retry");
+    drop(client.process(Some(datagram(retry)), now()));
+    assert_eq!(client.stats().dropped_rx, 1);
+    assert_eq!(*client.state(), State::WaitInitial);
+
+    // The same Retry with a distinct Source Connection ID is accepted.
+    let mut client = default_client();
+    let initial = client
+        .process_output(now())
+        .dgram()
+        .expect("a datagram")
+        .to_vec();
+    let (dcid, scid) = initial_cids(&initial);
+    let mut server_scid = dcid.clone();
+    server_scid[0] ^= 0xff;
+    let retry =
+        crate::packet::Builder::retry(Version::default(), &scid, &server_scid, &[0x01], &dcid)
+            .expect("build retry");
+    drop(client.process(Some(datagram(retry)), now()));
+    assert_eq!(client.stats().dropped_rx, 0);
 }


### PR DESCRIPTION
handle_retry validates a received Retry against a duplicate Retry, an empty token, and a bad integrity tag, but never compares the Retry's Source Connection ID to the Destination Connection ID the client used in its Initial. RFC 9000 Section 17.2.5.2 requires a client to discard a Retry whose Source Connection ID matches that Destination Connection ID. The Retry integrity key is a fixed public value, so a valid tag does not by itself show the Retry came from the server; a party that observed the Initial can compute one, which is why this comparison exists.

Before, such a Retry was adopted: the client took its Source Connection ID as the new remote CID, saved the token, and re-keyed the initial secrets. After, the packet is dropped and the client stays in WaitInitial. The check sits beside the existing integrity check in handle_retry, the one place a client processes a Retry, so no caller needs a separate guard. The tradeoff is a stricter client that discards one more Retry shape, against the negligible case of a server that reuses the client's random Initial DCID as its own connection ID.