### PR TITLE
chore: Reduce benchmark CI noise

### DIFF
--- a/.github/actions/cpu-tuning/action.yml
+++ b/.github/actions/cpu-tuning/action.yml
@@ -1,5 +1,5 @@
 name: CPU tuning for benchmarks
-description: Configure CPU for consistent benchmark performance (disable turbo boost, SMT, set performance governor, isolate CPUs with cset)
+description: Configure CPU for consistent benchmark performance (disable turbo boost, SMT, THP and deep C-states, set performance governor, isolate CPUs with cset)
 
 inputs:
   mode:
@@ -89,6 +89,19 @@ runs:
           tune_sysfs /sys/devices/system/cpu/intel_pstate/no_turbo "1" "Intel P-state turbo"
           [ -f /proc/sys/kernel/perf_event_paranoid ] && cp /proc/sys/kernel/perf_event_paranoid /tmp/cpu-tuning-perf-paranoid
           tune_sysfs /proc/sys/kernel/perf_event_paranoid "-1" "perf_event_paranoid"
+          # Avoid THP compaction stalls mid-benchmark.
+          if [ -f /sys/kernel/mm/transparent_hugepage/enabled ]; then
+            grep -o '\[[a-z]*\]' /sys/kernel/mm/transparent_hugepage/enabled | tr -d '[]' > /tmp/cpu-tuning-thp-orig
+            tune_sysfs /sys/kernel/mm/transparent_hugepage/enabled "never" "THP"
+          fi
+          # Disable deep idle (C-)states to avoid idle-exit latency spikes.
+          CSTATES_DISABLED=()
+          for state in /sys/devices/system/cpu/cpu*/cpuidle/state[1-9]*; do
+            [ -f "$state/disable" ] || continue
+            [ "$(cat "$state/disable" 2>/dev/null)" = "0" ] || continue
+            echo 1 | sudo tee "$state/disable" > /dev/null 2>&1 && CSTATES_DISABLED+=("$state")
+          done
+          [ ${#CSTATES_DISABLED[@]} -gt 0 ] && printf '%s\n' "${CSTATES_DISABLED[@]}" > /tmp/cpu-tuning-cstates
 
           if [ -n "$MTU" ]; then
             cp /sys/class/net/lo/mtu /tmp/cpu-tuning-mtu-orig
@@ -237,6 +250,17 @@ runs:
           if [ -f /tmp/cpu-tuning-mtu-orig ]; then
             sudo ip link set dev lo mtu "$(< /tmp/cpu-tuning-mtu-orig)"
             rm -f /tmp/cpu-tuning-mtu-orig
+          fi
+
+          if [ -f /tmp/cpu-tuning-thp-orig ]; then
+            tune_sysfs /sys/kernel/mm/transparent_hugepage/enabled "$(< /tmp/cpu-tuning-thp-orig)" "THP"
+            rm -f /tmp/cpu-tuning-thp-orig
+          fi
+          if [ -f /tmp/cpu-tuning-cstates ]; then
+            while IFS= read -r state; do
+              tune_sysfs "$state/disable" "0" "re-enable $state"
+            done < /tmp/cpu-tuning-cstates
+            rm -f /tmp/cpu-tuning-cstates
           fi
 
         fi  # mode

--- a/.github/scripts/perfcompare.py
+++ b/.github/scripts/perfcompare.py
@@ -3,7 +3,6 @@
 
 import argparse
 import json
-import math
 import os
 import re
 import shlex
@@ -13,8 +12,10 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from statistics import mean as avg, variance
+from statistics import NormalDist, median
 from typing import NamedTuple
+
+from scipy.stats import mannwhitneyu
 
 
 class ImplConfig(NamedTuple):
@@ -74,11 +75,25 @@ def _tag(cmd: str) -> str:
     return Path(cmd.split()[0]).name[:15]
 
 
-def is_significant(s1: list[float], s2: list[float]) -> bool:
-    """Welch's t-test with normal approximation. Valid for n >= 30."""
-    v1, v2, n1, n2 = variance(s1), variance(s2), len(s1), len(s2)
-    se = math.sqrt(v1 / n1 + v2 / n2)
-    return se > 0 and abs(avg(s1) - avg(s2)) / se > 1.96
+# Deltas smaller than this are treated as measurement noise regardless of
+# p-value (mirrors Criterion's noise_threshold).
+NOISE_FLOOR_PCT = 1.0
+
+
+def is_significant(s1: list[float], s2: list[float], pct: float) -> bool:
+    """Mann-Whitney U test with a practical-significance floor.
+
+    pct is the caller's already-computed percent change between the two
+    samples' medians.
+    """
+    if not s1 or not s2 or abs(pct) < NOISE_FLOOR_PCT:
+        return False
+    return bool(mannwhitneyu(s1, s2, alternative="two-sided").pvalue < 0.05)
+
+
+def mad(values: list[float], center: float) -> float:
+    """Median absolute deviation, scaled to be comparable to a stddev."""
+    return median(abs(v - center) for v in values) / NormalDist().inv_cdf(0.75)
 
 
 def sh(cmd, **kw):
@@ -92,7 +107,7 @@ def sh(cmd, **kw):
 def mangle(cmd, cc, pacing, flags, disk):
     """Replace placeholders, return (command, filename_extension)."""
     ext = f"-{cc}" if cc else ""
-    if not pacing:
+    if pacing is False:
         ext += "-nopacing"
     cmd = (
         cmd.replace("_cc", f"--cc {cc}" if cc else "")
@@ -224,7 +239,12 @@ def hyperfine(cfg, scmd, ccmd, name, out_dir, md=False):
     if md:
         cmd += ["--export-markdown", str(out_dir / f"{name}.md")]
     cmd.append(f"echo $$ >> /cpusets/{shlex.quote(cfg.client_set)}/tasks; {ws}/{ccmd}")
-    sh(cmd, check=True)
+    result = sh(cmd, check=True, stderr=subprocess.PIPE, text=True)
+    # Surface hyperfine's own outlier warnings in the PR summary, not just the raw log.
+    if result.stderr:
+        print(result.stderr, end="")
+        if "outlier" in result.stderr.lower():
+            (out_dir / f"{name}.outliers").write_text(result.stderr, encoding="utf-8")
 
 
 def perf(cfg, scmd, ccmd, name):
@@ -257,55 +277,65 @@ def perf(cfg, scmd, ccmd, name):
         proc.wait(timeout=5)
 
 
+def _load_result(path):
+    """Load a hyperfine --export-json result, or None if the file is missing."""
+    if not path.exists():
+        return None
+    res = json.loads(path.read_text(encoding="utf-8"))["results"][0]
+    res.setdefault("median", median(res["times"]))
+    return res
+
+
 def process(cfg, name, bold):
     """Process benchmark results into a table row."""
-    rj = cfg.workspace / "hyperfine" / f"{name}.json"
-    rm = cfg.workspace / "hyperfine" / f"{name}.md"
-    bj = cfg.workspace / "hyperfine-baseline" / f"{name}.json"
-    if not rj.exists() or not rm.exists():
+    out_dir = cfg.workspace / "hyperfine"
+    res = _load_result(out_dir / f"{name}.json")
+    if res is None:
         return None
 
-    res = json.loads(rj.read_text(encoding="utf-8"))["results"][0]
-    mean, times = res["mean"], res["times"]
-    md = rm.read_text(encoding="utf-8")
-    match = next(
-        (
-            x
-            for x in md.splitlines()
-            if x.startswith("|") and "Command" not in x and ":--" not in x
-        ),
-        None,
-    )
-    if not match:
-        return None
+    mean, times, med = res["mean"], res["times"], res["median"]
+    md_dev = mad(times, med)
 
-    parts = match.replace("`", "").split("|")
-    b = "**" if bold else ""
-    row = f"| {b}{parts[1].strip()}{b} |{'|'.join(parts[2:5])}|"
-    m = re.search(r"± *(\S+)", md)
-    if not m:
-        raise ValueError(f"Could not parse standard deviation from {rm}")
-    rng = float(m.group(1))
-    row += f" {(cfg.size / 1048576) / mean:.1f} ± {(cfg.size / 1048576) / rng:.1f} "
-
-    if bj.exists():
-        base = json.loads(bj.read_text(encoding="utf-8"))["results"][0]
-        delta = (mean - base["mean"]) * 1000
-        pct = (mean - base["mean"]) / base["mean"] * 100
-        if is_significant(base["times"], times):
-            sym = ":broken_heart:" if delta > 0 else ":green_heart:"
-            print(
-                f"Performance {'regressed' if delta > 0 else 'improved'}: {base['mean']} -> {mean}"
+    outlier_flag = ""
+    if (out_dir / f"{name}.outliers").exists():
+        outliers = [t for t in times if abs(t - med) > 3 * md_dev]
+        if outliers:
+            detail = (
+                f"{len(outliers)} of {len(times)} runs exceeded 3×MAD from the median "
+                f"({med * 1000:.0f}ms); slowest was {max(times) * 1000:.0f}ms"
             )
-            row += f"| {sym} **{delta:.1f}** | **{pct:.1f}%** |\n"
+            outlier_flag = f' <span title="{detail}">⚠️</span>'
+    b = "**" if bold else ""
+    row = f"| {b}{name}{b}{outlier_flag} "
+    row += f"| {mean * 1000:.1f} ± {res['stddev'] * 1000:.1f} "
+    row += f"| {res['min'] * 1000:.1f} – {res['max'] * 1000:.1f} "
+    row += f"| {med * 1000:.1f} ± {md_dev * 1000:.1f} "
+    mibs = (cfg.size / 1048576) / mean
+    mibs_err = (cfg.size / 1048576) * res["stddev"] / mean**2
+    row += f"| {mibs:.1f} ± {mibs_err:.1f} "
+
+    if (base := _load_result(cfg.workspace / "hyperfine-baseline" / f"{name}.json")) is not None:
+        base_med = base["median"]
+        diff = med - base_med
+        delta = diff * 1000
+        pct = diff / base_med * 100
+        change = f"{base_med} -> {med} (median)"
+        if is_significant(base["times"], times, pct):
+            regressed = delta > 0
+            sym = ":broken_heart:" if regressed else ":green_heart:"
+            line = f"{name}: Performance has {'regressed' if regressed else 'improved'}. {change}"
+            print(line)
+            with (cfg.workspace / "results.txt").open("a", encoding="utf-8") as f:
+                f.write(f"{line}\n")
+            row += f"| {sym} **{delta:+.1f} ({pct:+.1f}%)** |\n"
         else:
-            print(f"No significant change: {base['mean']} -> {mean}")
-            row += f"|  {delta:.1f} | {pct:.1f}% |\n"
+            print(f"No significant change: {change}")
+            row += f"| {delta:+.1f} ({pct:+.1f}%) |\n"
     elif "neqo" in name:
         print("No cached baseline found.")
-        row += "| :question: | :question: |\n"
+        row += "| :question: |\n"
     else:
-        row += "| | |\n"
+        row += "| |\n"
     return row
 
 
@@ -344,7 +374,7 @@ def run(cfg, tmp):
             elif client == "neqo" or server == "neqo":
                 opts = [("cubic", True)]
             else:
-                opts = [("", False)]
+                opts = [("", None)]
 
             for cc, pacing in opts:
                 # When neqo is the server, apply the client's interop flags to it.
@@ -381,6 +411,7 @@ def run(cfg, tmp):
 
 
 def main():
+    """Parse arguments, run all comparisons, and write the results tables."""
     p = argparse.ArgumentParser(description="Compare QUIC implementations")
     p.add_argument("--host", default="127.0.0.1")
     p.add_argument("--port", type=int, default=4433)
@@ -413,8 +444,8 @@ def main():
     header = (
         f"Transfer of {cfg.size} bytes over loopback, min. {cfg.runs} runs. "
         "All unit-less numbers are in milliseconds.\n\n"
-        "| Client vs. server (params) | Mean ± σ | Min | Max | MiB/s ± σ | Δ `baseline` | Δ `baseline` |\n"
-        "|:---|---:|---:|---:|---:|---:|---:|\n"
+        "| Client vs. server | Mean±σ | Min–Max | Median±MAD | MiB/s±σ | ΔMedian |\n"
+        "|:---|---:|---:|---:|---:|---:|\n"
     )
     sorted_steps = sorted(steps, key=lambda r: re.sub(r"^\| \*\*", "| ", r))
     (cfg.workspace / "comparison.md").write_text(

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -124,17 +124,28 @@ jobs:
           # Fix any root-owned files left by a previous run before removing them
           sudo chown -R "$(id -u)" target/criterion 2>/dev/null || true
           rm -rf target/criterion
-          # Run the baseline builds first, to establish a baseline.
-          for BENCH in ../dist/neqo-baseline/!(neqo-client|neqo-server); do
-            bench_exec "$BENCH" -- --bench --save-baseline baseline --noplot | filter_cset | tee -a ../results-baseline.txt
-          done
-          # Run pull request builds twice, once without perf for baseline comparison, and once with perf for profiling.
-          # (Perf seems to introduce some variability in the results.)
-          for BENCH in ../dist/neqo/!(neqo-client|neqo-server); do
-            # --baseline-lenient allows us to add new benchmarks in pull requests.
-            bench_exec "$BENCH" -- --bench --baseline-lenient baseline --noplot | filter_cset | tee -a ../results.txt
-          done
+          # Run baseline and PR builds interleaved.
           sanitize_name() { echo "$1" | tr '/ ()' '___-' | tr -s '_'; }
+          for PR_BENCH in ../dist/neqo/!(neqo-client|neqo-server); do
+            BIN_NAME=$(basename "$PR_BENCH")
+            BASELINE_BENCH="../dist/neqo-baseline/$BIN_NAME"
+            [ -f "$BASELINE_BENCH" ] || BASELINE_BENCH=""
+            VARIANTS=$("$PR_BENCH" --bench --list 2>/dev/null | sed -n 's/: benchmark$//p' || true)
+            if [ -n "$VARIANTS" ]; then
+              BASELINE_VARIANTS=""
+              [ -n "$BASELINE_BENCH" ] && BASELINE_VARIANTS=$("$BASELINE_BENCH" --bench --list 2>/dev/null | sed -n 's/: benchmark$//p' || true)
+              while IFS= read -r VARIANT; do
+                if [ -n "$BASELINE_BENCH" ] && grep -qxF "$VARIANT" <<< "$BASELINE_VARIANTS"; then
+                  bench_exec "$BASELINE_BENCH" -- --bench --save-baseline baseline --noplot --exact "$VARIANT" | filter_cset | tee -a ../results-baseline.txt
+                fi
+                # --baseline-lenient allows us to add new benchmarks in pull requests.
+                bench_exec "$PR_BENCH" -- --bench --baseline-lenient baseline --noplot --exact "$VARIANT" | filter_cset | tee -a ../results.txt
+              done <<< "$VARIANTS"
+            else
+              [ -n "$BASELINE_BENCH" ] && bench_exec "$BASELINE_BENCH" -- --bench --save-baseline baseline --noplot | filter_cset | tee -a ../results-baseline.txt
+              bench_exec "$PR_BENCH" -- --bench --baseline-lenient baseline --noplot | filter_cset | tee -a ../results.txt
+            fi
+          done
           for BENCH in ../dist/neqo/!(neqo-client|neqo-server); do
             BIN_NAME=$(basename "$BENCH")
             VARIANTS=$("$BENCH" --bench --list 2>/dev/null | sed -n 's/: benchmark$//p' || true)

--- a/neqo-bin/benches/main.rs
+++ b/neqo-bin/benches/main.rs
@@ -10,12 +10,18 @@
     reason = "Inherent in codspeed criterion_group! macro."
 )]
 
-use std::{env, hint::black_box, net::SocketAddr};
+use std::{env, hint::black_box, net::SocketAddr, time::Duration};
 
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use neqo_bin::{client, server};
 use neqo_common::to_u64;
 use tokio::runtime::Builder;
+
+fn criterion_config() -> Criterion {
+    Criterion::default()
+        .warm_up_time(Duration::from_secs(5))
+        .measurement_time(Duration::from_secs(15))
+}
 
 struct Benchmark {
     name: &'static str,
@@ -63,6 +69,7 @@ fn transfer(c: &mut Criterion) {
             .as_ref()
             .map_or_else(|| name.to_string(), |suffix| format!("{name}{suffix}"));
         let mut group = c.benchmark_group("transfer");
+        group.noise_threshold(0.03);
         group.throughput(if num_requests == 1 {
             Throughput::Bytes(to_u64(upload_size + download_size))
         } else {
@@ -121,5 +128,9 @@ fn spawn_server() -> (tokio::sync::oneshot::Sender<()>, SocketAddr) {
     (done_sender, addr_receiver.recv().unwrap())
 }
 
-criterion_group!(benches, transfer);
+criterion_group! {
+    name = benches;
+    config = criterion_config();
+    targets = transfer
+}
 criterion_main!(benches);

--- a/neqo-http3/benches/common.rs
+++ b/neqo-http3/benches/common.rs
@@ -90,6 +90,7 @@ pub fn bench(c: &mut Criterion, name_prefix: &str) {
     fixture_init();
     for (group_name, setup_fn, params) in CONFIGS {
         let mut group = c.benchmark_group(group_name);
+        group.noise_threshold(0.03);
         for &(streams, data_size) in params {
             group.throughput(Throughput::Bytes(to_u64(streams * data_size)));
             group.bench_function(

--- a/test/ansible/install.yml
+++ b/test/ansible/install.yml
@@ -78,6 +78,7 @@
           - lld
           - ninja-build
           - python-is-python3
+          - python3-scipy
           - r-base-core
           - ripgrep
           - sccache


### PR DESCRIPTION
Tighten CPU tuning, use consistent Criterion noise thresholds, and switch to scipy's Mann-Whitney U so outlier-heavy hyperfine runs don't skew significance. Also fix a perfcompare.py gate that never fired.