### PR TITLE
fix: reject reserved frame types that start a request stream

### DIFF
--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -56,8 +56,13 @@ impl NewStreamType {
                 // The "stream_type" for a bidirectional stream is a frame type. We accept
                 // WEBTRANSPORT_STREAM (above), and HEADERS, and we have to ignore unknown types,
                 // but any other frame type is bad if we know about it.
-                if <HFrame as FrameDecoder<HFrame>>::is_known_type(HFrameType(stream_type))
-                    && HFrameType(stream_type) != HFrameType::HEADERS
+                let frame_type = HFrameType(stream_type);
+                if HFrameType::RESERVED.contains(&frame_type) {
+                    // A reserved (HTTP/2) frame type is a connection error, not an unknown type
+                    // to ignore, even when it starts a request stream.
+                    Err(Error::HttpFrameUnexpected)
+                } else if <HFrame as FrameDecoder<HFrame>>::is_known_type(frame_type)
+                    && frame_type != HFrameType::HEADERS
                 {
                     Err(Error::HttpFrame)
                 } else {
@@ -444,6 +449,22 @@ mod tests {
             &Err(Error::HttpFrame),
             true,
         );
+    }
+
+    #[test]
+    fn decode_stream_reserved_frame_type() {
+        // A reserved (HTTP/2) frame type that starts a request stream is a connection error of
+        // type H3_FRAME_UNEXPECTED, the same as when it arrives as a later frame, rather than
+        // being discharged like an unknown type (RFC 9114, Sections 7.1 and 11.2.1).
+        for reserved in HFrameType::RESERVED {
+            let mut t = Test::new(StreamType::BiDi, Role::Server);
+            t.decode(
+                &[u64::from(*reserved)],
+                false,
+                &Err(Error::HttpFrameUnexpected),
+                true,
+            );
+        }
     }
 
     #[test]

--- a/neqo-http3/src/stream_type_reader.rs
+++ b/neqo-http3/src/stream_type_reader.rs
@@ -57,11 +57,9 @@ impl NewStreamType {
                 // WEBTRANSPORT_STREAM (above), and HEADERS, and we have to ignore unknown types,
                 // but any other frame type is bad if we know about it.
                 let frame_type = HFrameType(stream_type);
-                if HFrameType::RESERVED.contains(&frame_type) {
-                    // A reserved (HTTP/2) frame type is a connection error, not an unknown type
-                    // to ignore, even when it starts a request stream.
-                    Err(Error::HttpFrameUnexpected)
-                } else if <HFrame as FrameDecoder<HFrame>>::is_known_type(frame_type)
+                // This checks for reserved frame types here, which are not allowed.
+                <HFrame as FrameDecoder<HFrame>>::frame_type_allowed(frame_type)?;
+                if <HFrame as FrameDecoder<HFrame>>::is_known_type(frame_type)
                     && frame_type != HFrameType::HEADERS
                 {
                     Err(Error::HttpFrame)


### PR DESCRIPTION
On a server, `final_stream_type` classifies the first frame type of a client's request stream: a known non-HEADERS type is rejected, and anything else is passed through as an ordinary HTTP stream so unknown grease types are ignored. The reserved HTTP/2 frame types 0x02, 0x06, 0x08, and 0x09 land in that pass-through branch because `is_known_type` does not include them, so a request stream that opens with one of them is accepted. RFC 9114 (Sections 7.1 and 11.2.1) makes receipt of a reserved frame type a connection error of type H3_FRAME_UNEXPECTED.

Every other path that reads a frame type already rejects these through `frame_type_allowed`: later frames on the same stream, the client's response stream, and the control stream. Only the first frame of a server request stream skips it, because that reader is seeded straight into the length read. Adding the reserved check where the type is classified closes the one gap. Before, a reserved first frame produced `NewStream(Http)` and the request continued; after, it returns the same H3_FRAME_UNEXPECTED a later reserved frame already gives. The cost is closing a stream a lenient peer might open with a stray reserved type, which a conforming peer never sends.
