### PR TITLE
fix: bound the RETIRE_CONNECTION_ID queue

### DIFF
--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -457,6 +457,11 @@ pub struct ConnectionIdManager {
 impl ConnectionIdManager {
     pub const ACTIVE_LIMIT: usize = 8;
 
+    /// The maximum number of connection IDs that may be pending retirement.
+    /// RFC 9000, Section 5.1.2 recommends allowing for at least twice
+    /// `active_connection_id_limit`.
+    pub const MAX_RETIRE_QUEUE: usize = 2 * Self::ACTIVE_LIMIT;
+
     /// A special value.  See `ConnectionIdManager::add_odcid`.
     const SEQNO_ODCID: u64 = u64::MAX;
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -3417,7 +3417,9 @@ impl Connection {
                     stateless_reset_token,
                 ))?;
                 self.paths.retire_cids(retire_prior, &mut self.cids);
-                if self.cids.len() >= ConnectionIdManager::ACTIVE_LIMIT {
+                if self.cids.len() >= ConnectionIdManager::ACTIVE_LIMIT
+                    || self.paths.retire_queue_len() > ConnectionIdManager::MAX_RETIRE_QUEUE
+                {
                     qinfo!("[{self}] received too many connection IDs");
                     return Err(Error::ConnectionIdLimitExceeded);
                 }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -3417,10 +3417,18 @@ impl Connection {
                     stateless_reset_token,
                 ))?;
                 self.paths.retire_cids(retire_prior, &mut self.cids);
-                if self.cids.len() >= ConnectionIdManager::ACTIVE_LIMIT
-                    || self.paths.retire_queue_len() > ConnectionIdManager::MAX_RETIRE_QUEUE
-                {
-                    qinfo!("[{self}] received too many connection IDs");
+                let too_many = if self.cids.len() >= ConnectionIdManager::ACTIVE_LIMIT {
+                    Some("received too many active connection IDs")
+                } else if self.paths.retire_queue_len() > ConnectionIdManager::MAX_RETIRE_QUEUE {
+                    // `MAX_RETIRE_QUEUE` is the actual allowed maximum.  A single call to
+                    // `retire_cids` above can add at most `ACTIVE_LIMIT` entries, so the
+                    // queue can only ever temporarily exceed the bound by that.
+                    Some("too many connection IDs pending retirement")
+                } else {
+                    None
+                };
+                if let Some(msg) = too_many {
+                    qinfo!("[{self}] {msg}");
                     return Err(Error::ConnectionIdLimitExceeded);
                 }
             }

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -17,7 +17,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Datagram, Decoder, event::Provider as _, qdebug};
+use neqo_common::{Datagram, Decoder, event::Provider as _, qdebug, to_u64};
 use test_fixture::{
     DEFAULT_ADDR, DEFAULT_ADDR_V4,
     assertions::{assert_v4_path, assert_v6_path},
@@ -1069,26 +1069,44 @@ fn migration_invalid_address() {
     );
 }
 
-/// This inserts a frame into packets that provides a single new
-/// connection ID and retires all others.
-struct RetireAll {
+/// Writes `count` `NEW_CONNECTION_ID` frames with consecutive sequence numbers
+/// starting at `seqno`, each retiring every previously issued connection ID.
+struct NewConnectionIds {
+    seqno: u64,
+    count: u64,
     cid_gen: Rc<RefCell<dyn ConnectionIdGenerator>>,
 }
 
-impl crate::connection::test_internal::FrameWriter for RetireAll {
+impl NewConnectionIds {
+    fn new(seqno: u64, count: u64, cid_gen: Rc<RefCell<dyn ConnectionIdGenerator>>) -> Self {
+        Self {
+            seqno,
+            count,
+            cid_gen,
+        }
+    }
+
+    /// A single `NEW_CONNECTION_ID` frame that retires every previously issued
+    /// connection ID.
+    fn retire_all(cid_gen: Rc<RefCell<dyn ConnectionIdGenerator>>) -> Self {
+        Self::new(100, 1, cid_gen)
+    }
+}
+
+impl crate::connection::test_internal::FrameWriter for NewConnectionIds {
     fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
-        // Use a sequence number that is large enough that all existing values
-        // will be lower (so they get retired).  As the code doesn't care about
-        // gaps in sequence numbers, this is safe, even though the gap might
-        // hint that there are more outstanding connection IDs that are allowed.
-        const SEQNO: u64 = 100;
-        let cid = self.cid_gen.borrow_mut().generate_cid().unwrap();
-        builder
-            .encode_varint(FrameType::NewConnectionId)
-            .encode_varint(SEQNO)
-            .encode_varint(SEQNO) // Retire Prior To
-            .encode_vec(1, &cid)
-            .encode([0x7f; 16]);
+        for i in 0..self.count {
+            let seqno = self.seqno + i;
+            let cid = self.cid_gen.borrow_mut().generate_cid().unwrap();
+            let mut srt = [0; 16];
+            srt[..8].copy_from_slice(&seqno.to_be_bytes());
+            builder
+                .encode_varint(FrameType::NewConnectionId)
+                .encode_varint(seqno)
+                .encode_varint(seqno) // Retire Prior To
+                .encode_vec(1, &cid)
+                .encode(srt);
+        }
     }
 }
 
@@ -1110,10 +1128,9 @@ fn retire_all() {
 
     let original_cid = ConnectionId::from(get_cid(&send_something(&mut client, now())));
 
-    let ncid = send_with_extra(&mut server, RetireAll { cid_gen }, now());
-
     let new_cid_before = client.stats().frame_rx.new_connection_id;
     let retire_cid_before = client.stats().frame_tx.retire_connection_id;
+    let ncid = send_with_extra(&mut server, NewConnectionIds::retire_all(cid_gen), now());
     client.process_input(ncid, now());
     let retire = send_something(&mut client, now());
     assert_eq!(
@@ -1126,6 +1143,48 @@ fn retire_all() {
     );
 
     assert_ne!(get_cid(&retire), original_cid);
+}
+
+/// RFC 9000, Section 5.1.2: an endpoint SHOULD bound the number of connection IDs it
+/// has retired but not yet had acknowledged, and MAY treat exceeding that bound as a
+/// `CONNECTION_ID_LIMIT_ERROR`.  A peer that streams `NEW_CONNECTION_ID` frames with an
+/// ever-increasing Retire Prior To value, while the victim cannot flush its
+/// `RETIRE_CONNECTION_ID` frames, must not be able to grow that queue without bound.
+#[test]
+fn retire_cid_queue_bounded() {
+    let mut client = default_client();
+    let cid_gen: Rc<RefCell<dyn ConnectionIdGenerator>> =
+        Rc::new(RefCell::new(CountingConnectionIdGenerator::default()));
+    let mut server = Connection::new_server(
+        test_fixture::DEFAULT_KEYS,
+        test_fixture::DEFAULT_ALPN,
+        Rc::clone(&cid_gen),
+        ConnectionParameters::default(),
+    )
+    .unwrap();
+    connect_force_idle(&mut client, &mut server);
+
+    // The client never runs `process_output` here, so it cannot send (or get
+    // acknowledgement for) any `RETIRE_CONNECTION_ID` frames: its pending-retirement
+    // queue only grows.  Because every frame retires all prior connection IDs, the
+    // store stays at one active connection ID and the existing
+    // active-connection-ID-limit check never fires; only a dedicated bound on the
+    // retirement queue can stop this.
+    let count = to_u64(ConnectionIdManager::MAX_RETIRE_QUEUE) + 1;
+    let ncids = send_with_extra(
+        &mut server,
+        NewConnectionIds::new(100, count, cid_gen),
+        now(),
+    );
+    client.process_input(ncids, now());
+
+    assert!(matches!(
+        client.state(),
+        State::Closing {
+            error: CloseReason::Transport(Error::ConnectionIdLimitExceeded),
+            ..
+        }
+    ));
 }
 
 /// Injects a `RETIRE_CONNECTION_ID` frame for a sequence number that was never issued.
@@ -1192,7 +1251,7 @@ fn retire_prior_to_migration_failure() {
 
     // Have the server receive the probe, but separately have it decide to
     // retire all of the available connection IDs.
-    let retire_all = send_with_extra(&mut server, RetireAll { cid_gen }, now());
+    let retire_all = send_with_extra(&mut server, NewConnectionIds::retire_all(cid_gen), now());
 
     let resp = server.process(Some(probe), now()).dgram().unwrap();
     assert_v4_path(&resp, true);
@@ -1247,7 +1306,7 @@ fn retire_prior_to_migration_success() {
 
     // Have the server receive the probe, but separately have it decide to
     // retire all of the available connection IDs.
-    let retire_all = send_with_extra(&mut server, RetireAll { cid_gen }, now());
+    let retire_all = send_with_extra(&mut server, NewConnectionIds::retire_all(cid_gen), now());
 
     let resp = server.process(Some(probe), now()).dgram().unwrap();
     assert_v4_path(&resp, true);
@@ -1286,7 +1345,7 @@ fn error_on_new_path_with_no_connection_id() {
 
     let cid_gen: Rc<RefCell<dyn ConnectionIdGenerator>> =
         Rc::new(RefCell::new(CountingConnectionIdGenerator::default()));
-    let retire_all = send_with_extra(&mut server, RetireAll { cid_gen }, now());
+    let retire_all = send_with_extra(&mut server, NewConnectionIds::retire_all(cid_gen), now());
 
     client.process_input(retire_all, now());
 

--- a/neqo-transport/src/connection/tests/migration.rs
+++ b/neqo-transport/src/connection/tests/migration.rs
@@ -1069,34 +1069,33 @@ fn migration_invalid_address() {
     );
 }
 
-/// Writes `count` `NEW_CONNECTION_ID` frames with consecutive sequence numbers
-/// starting at `seqno`, each retiring every previously issued connection ID.
+/// Writes `count` `NEW_CONNECTION_ID` frames with consecutive sequence numbers,
+/// each retiring every previously issued connection ID.
 struct NewConnectionIds {
-    seqno: u64,
     count: u64,
     cid_gen: Rc<RefCell<dyn ConnectionIdGenerator>>,
 }
 
 impl NewConnectionIds {
-    fn new(seqno: u64, count: u64, cid_gen: Rc<RefCell<dyn ConnectionIdGenerator>>) -> Self {
-        Self {
-            seqno,
-            count,
-            cid_gen,
-        }
+    // Use a sequence number that is large enough that all existing values
+    // will be lower (so they get retired).
+    const SEQNO: u64 = 100;
+
+    fn new(count: u64, cid_gen: Rc<RefCell<dyn ConnectionIdGenerator>>) -> Self {
+        Self { count, cid_gen }
     }
 
     /// A single `NEW_CONNECTION_ID` frame that retires every previously issued
     /// connection ID.
     fn retire_all(cid_gen: Rc<RefCell<dyn ConnectionIdGenerator>>) -> Self {
-        Self::new(100, 1, cid_gen)
+        Self::new(1, cid_gen)
     }
 }
 
 impl crate::connection::test_internal::FrameWriter for NewConnectionIds {
     fn write_frames(&mut self, builder: &mut packet::Builder<&mut Vec<u8>>) {
         for i in 0..self.count {
-            let seqno = self.seqno + i;
+            let seqno = Self::SEQNO + i;
             let cid = self.cid_gen.borrow_mut().generate_cid().unwrap();
             let mut srt = [0; 16];
             srt[..8].copy_from_slice(&seqno.to_be_bytes());
@@ -1171,11 +1170,7 @@ fn retire_cid_queue_bounded() {
     // active-connection-ID-limit check never fires; only a dedicated bound on the
     // retirement queue can stop this.
     let count = to_u64(ConnectionIdManager::MAX_RETIRE_QUEUE) + 1;
-    let ncids = send_with_extra(
-        &mut server,
-        NewConnectionIds::new(100, count, cid_gen),
-        now(),
-    );
+    let ncids = send_with_extra(&mut server, NewConnectionIds::new(count, cid_gen), now());
     client.process_input(ncids, now());
 
     assert!(matches!(

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -397,9 +397,9 @@ impl Paths {
         });
     }
 
-    /// The number of connection IDs that have been retired locally but not yet
-    /// acknowledged via `RETIRE_CONNECTION_ID`.
-    pub const fn retire_queue_len(&self) -> usize {
+    /// The number of connection IDs that have been retired locally but whose
+    /// `RETIRE_CONNECTION_ID` frames have not yet been ACK'ed.
+    pub(crate) const fn retire_queue_len(&self) -> usize {
         self.to_retire.len()
     }
 

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -397,6 +397,12 @@ impl Paths {
         });
     }
 
+    /// The number of connection IDs that have been retired locally but not yet
+    /// acknowledged via `RETIRE_CONNECTION_ID`.
+    pub const fn retire_queue_len(&self) -> usize {
+        self.to_retire.len()
+    }
+
     /// Write out any `RETIRE_CONNECTION_ID` frames that are outstanding.
     pub fn write_frames<B: Buffer>(
         &mut self,


### PR DESCRIPTION
Cap pending retirements at 2x active_connection_id_limit per RFC 9000 Section 5.1.2, closing with CONNECTION_ID_LIMIT_ERROR if exceeded.
https://bugzilla.mozilla.org/show_bug.cgi?id=2010266