### PR TITLE
fix: limit discontiguous STREAM reassembly ranges

### DIFF
--- a/neqo-transport/benches/rx_stream_orderer.rs
+++ b/neqo-transport/benches/rx_stream_orderer.rs
@@ -28,7 +28,7 @@ fn inbound_in_order(c: &mut Criterion) {
             |mut rx| {
                 let mut drain = Vec::new();
                 for i in 0..FRAMES {
-                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD);
+                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD).unwrap();
                     rx.read_to_end(&mut drain);
                     drain.clear();
                 }
@@ -51,12 +51,12 @@ fn inbound_with_loss(c: &mut Criterion) {
                     if i % 50 == 0 {
                         missing.push_back(i); // "drop" this frame
                     } else {
-                        rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD);
+                        rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD).unwrap();
                     }
                     // Deliver a retransmission ~20 frames later.
                     if i % 20 == 19 {
                         if let Some(lost) = missing.pop_front() {
-                            rx.inbound_frame(lost * to_u64(CHUNK), &PAYLOAD);
+                            rx.inbound_frame(lost * to_u64(CHUNK), &PAYLOAD).unwrap();
                         }
                     }
                     rx.read_to_end(&mut drain);
@@ -64,7 +64,7 @@ fn inbound_with_loss(c: &mut Criterion) {
                 }
                 // Flush any remaining retransmits.
                 for lost in missing {
-                    rx.inbound_frame(lost * to_u64(CHUNK), &PAYLOAD);
+                    rx.inbound_frame(lost * to_u64(CHUNK), &PAYLOAD).unwrap();
                     rx.read_to_end(&mut drain);
                     drain.clear();
                 }
@@ -90,7 +90,7 @@ fn inbound_reordered(c: &mut Criterion) {
             |mut rx| {
                 let mut drain = Vec::new();
                 for &i in &order {
-                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD);
+                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD).unwrap();
                     rx.read_to_end(&mut drain);
                     drain.clear();
                 }
@@ -109,10 +109,10 @@ fn inbound_duplicates(c: &mut Criterion) {
             |mut rx| {
                 let mut drain = Vec::new();
                 for i in 0..FRAMES {
-                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD);
+                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD).unwrap();
                     if i % 20 == 0 && i > 0 {
                         // Duplicate of the previous frame.
-                        rx.inbound_frame((i - 1) * to_u64(CHUNK), &PAYLOAD);
+                        rx.inbound_frame((i - 1) * to_u64(CHUNK), &PAYLOAD).unwrap();
                     }
                     rx.read_to_end(&mut drain);
                     drain.clear();

--- a/neqo-transport/benches/rx_stream_orderer.rs
+++ b/neqo-transport/benches/rx_stream_orderer.rs
@@ -8,6 +8,7 @@
     clippy::significant_drop_tightening,
     reason = "Inherent in codspeed criterion_group! macro."
 )]
+#![expect(clippy::unwrap_used, reason = "OK in a bench.")]
 
 use std::{collections::VecDeque, hint::black_box};
 
@@ -28,7 +29,7 @@ fn inbound_in_order(c: &mut Criterion) {
             |mut rx| {
                 let mut drain = Vec::new();
                 for i in 0..FRAMES {
-                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD);
+                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD).unwrap();
                     rx.read_to_end(&mut drain);
                     drain.clear();
                 }
@@ -51,20 +52,20 @@ fn inbound_with_loss(c: &mut Criterion) {
                     if i % 50 == 0 {
                         missing.push_back(i); // "drop" this frame
                     } else {
-                        rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD);
+                        rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD).unwrap();
                     }
                     // Deliver a retransmission ~20 frames later.
                     if i % 20 == 19
                         && let Some(lost) = missing.pop_front()
                     {
-                        rx.inbound_frame(lost * to_u64(CHUNK), &PAYLOAD);
+                        rx.inbound_frame(lost * to_u64(CHUNK), &PAYLOAD).unwrap();
                     }
                     rx.read_to_end(&mut drain);
                     drain.clear();
                 }
                 // Flush any remaining retransmits.
                 for lost in missing {
-                    rx.inbound_frame(lost * to_u64(CHUNK), &PAYLOAD);
+                    rx.inbound_frame(lost * to_u64(CHUNK), &PAYLOAD).unwrap();
                     rx.read_to_end(&mut drain);
                     drain.clear();
                 }
@@ -90,7 +91,7 @@ fn inbound_reordered(c: &mut Criterion) {
             |mut rx| {
                 let mut drain = Vec::new();
                 for &i in &order {
-                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD);
+                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD).unwrap();
                     rx.read_to_end(&mut drain);
                     drain.clear();
                 }
@@ -109,10 +110,10 @@ fn inbound_duplicates(c: &mut Criterion) {
             |mut rx| {
                 let mut drain = Vec::new();
                 for i in 0..FRAMES {
-                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD);
+                    rx.inbound_frame(i * to_u64(CHUNK), &PAYLOAD).unwrap();
                     if i % 20 == 0 && i > 0 {
                         // Duplicate of the previous frame.
-                        rx.inbound_frame((i - 1) * to_u64(CHUNK), &PAYLOAD);
+                        rx.inbound_frame((i - 1) * to_u64(CHUNK), &PAYLOAD).unwrap();
                     }
                     rx.read_to_end(&mut drain);
                     drain.clear();

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -1527,7 +1527,7 @@ impl CryptoStreams {
 
     pub fn inbound_frame(&mut self, space: PacketNumberSpace, offset: u64, data: &[u8]) -> Res<()> {
         let rx = &mut self.get_mut(space).ok_or(Error::Internal)?.rx;
-        rx.inbound_frame(offset, data);
+        rx.inbound_frame(offset, data)?;
         if rx.received() - rx.retired() <= Self::BUFFER_LIMIT {
             Ok(())
         } else {

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -1528,6 +1528,9 @@ impl CryptoStreams {
     pub fn inbound_frame(&mut self, space: PacketNumberSpace, offset: u64, data: &[u8]) -> Res<()> {
         let rx = &mut self.get_mut(space).ok_or(Error::Internal)?.rx;
         rx.inbound_frame(offset, data);
+        if rx.overly_fragmented() {
+            return Err(Error::ProtocolViolation);
+        }
         if rx.received() - rx.retired() <= Self::BUFFER_LIMIT {
             Ok(())
         } else {

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -1527,10 +1527,7 @@ impl CryptoStreams {
 
     pub fn inbound_frame(&mut self, space: PacketNumberSpace, offset: u64, data: &[u8]) -> Res<()> {
         let rx = &mut self.get_mut(space).ok_or(Error::Internal)?.rx;
-        rx.inbound_frame(offset, data);
-        if rx.overly_fragmented() {
-            return Err(Error::ProtocolViolation);
-        }
+        rx.inbound_frame(offset, data)?;
         if rx.received() - rx.retired() <= Self::BUFFER_LIMIT {
             Ok(())
         } else {

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -353,9 +353,11 @@ impl RxStreamOrderer {
                 // Continue, since we may have more overlaps
             }
 
-            for start in to_remove {
-                self.data_ranges.remove(&start);
-            }
+            self.mutate_ranges(|data_ranges| {
+                for start in to_remove {
+                    data_ranges.remove(&start);
+                }
+            });
         }
 
         if !to_add.is_empty() {
@@ -441,20 +443,21 @@ impl RxStreamOrderer {
         reason = "OK here."
     )]
     pub fn discard_after(&mut self, offset: u64) {
-        self.data_ranges.split_off(&offset);
-        // Truncate a range that straddles `offset`.
-        if let Some(mut e) = self.data_ranges.last_entry() {
-            // Note: no underflow risk, all ranges that start at or after offset are gone.
-            let start = *e.key();
-            let keep = to_usize(offset - start);
-            let data = e.get_mut();
-            data.truncate(keep);
+        let retired = self.retired;
+        self.end = self.mutate_ranges(|data_ranges| {
+            data_ranges.split_off(&offset);
+            // Truncate a range that straddles `offset`.
+            data_ranges.last_entry().map_or(retired, |mut e| {
+                // Note: no underflow risk, all ranges that start at or after offset are gone.
+                let start = *e.key();
+                let keep = to_usize(offset - start);
+                let data = e.get_mut();
+                data.truncate(keep);
 
-            // No overflow risk: neither start nor offset can exceed 1<<62.
-            self.end = start + to_u64(data.len());
-        } else {
-            self.end = self.retired;
-        }
+                // No overflow risk: neither start nor offset can exceed 1<<62.
+                start + to_u64(data.len())
+            })
+        });
     }
 
     /// Count non-adjacent ("split") runs of buffered data, for test validation.
@@ -484,7 +487,6 @@ impl RxStreamOrderer {
     fn read(&mut self, buf: &mut [u8]) -> usize {
         qtrace!("Reading {} bytes, {} available", buf.len(), self.buffered());
         let mut copied = 0;
-        let entries_before = self.data_ranges.len();
 
         for (&range_start, range_data) in &mut self.data_ranges {
             let mut keep = false;
@@ -512,23 +514,27 @@ impl RxStreamOrderer {
                 keep = true;
             }
             if keep {
-                let mut keep = self.data_ranges.split_off(&range_start);
-                mem::swap(&mut self.data_ranges, &mut keep);
-                self.adjust_split_ranges(entries_before);
+                self.mutate_ranges(|data_ranges| {
+                    let mut keep = data_ranges.split_off(&range_start);
+                    mem::swap(data_ranges, &mut keep);
+                });
                 return copied;
             }
         }
 
-        self.data_ranges.clear();
+        self.mutate_ranges(BTreeMap::clear);
         self.end = self.retired; // All entries were consumed.
-        self.adjust_split_ranges(entries_before);
         copied
     }
 
-    /// Reduce `split_ranges` count.
-    fn adjust_split_ranges(&mut self, entries_before: usize) {
+    /// Runs `f` against `data_ranges`, then reduces `split_ranges` by however many
+    /// entries `f` removed.
+    fn mutate_ranges<T>(&mut self, f: impl FnOnce(&mut BTreeMap<u64, Vec<u8>>) -> T) -> T {
+        let entries_before = self.data_ranges.len();
+        let result = f(&mut self.data_ranges);
         let released = entries_before.saturating_sub(self.data_ranges.len());
         self.split_ranges = self.split_ranges.saturating_sub(released);
+        result
     }
 
     /// Extend the given Vector with any available data.
@@ -2034,6 +2040,46 @@ mod tests {
         let read = s.read(&mut buf);
         assert_eq!(read, N * RxStreamOrderer::RANGE_TARGET);
         assert!(s.data_ranges.is_empty());
+        assert_eq!(s.split_ranges, 0);
+    }
+
+    #[test]
+    fn split_ranges_reduced_after_discard_after() {
+        const N: usize = 5;
+        let mut s = RxStreamOrderer::default();
+        for i in 0..N {
+            let offset = to_u64(i * RxStreamOrderer::RANGE_TARGET);
+            s.inbound_frame(offset, &[0u8; RxStreamOrderer::RANGE_TARGET])
+                .unwrap();
+        }
+        assert_eq!(s.split_ranges, N);
+
+        // Discard the last three chunks and verify correct accounting.
+        s.discard_after(to_u64(2 * RxStreamOrderer::RANGE_TARGET));
+        assert_eq!(s.data_ranges.len(), 2);
+        assert_eq!(s.split_ranges, 2);
+    }
+
+    #[test]
+    fn split_ranges_reduced_after_overlap_removal() {
+        let mut s = RxStreamOrderer::default();
+        // The very first insert is always credited.
+        s.inbound_frame(0, &[0u8; 1]).unwrap();
+        assert_eq!(s.split_ranges, 1);
+
+        // Two later, non-adjacent inserts: not credited.
+        s.inbound_frame(10, &[0u8; 1]).unwrap();
+        s.inbound_frame(20, &[0u8; 1]).unwrap();
+        assert_eq!(s.data_ranges.len(), 3);
+        assert_eq!(s.split_ranges, 1);
+
+        // An overlapping frame spanning [0, 20) entirely swallows the entry at 10
+        // (via the `to_remove` path) and extends the entry at 0; the entry at 20
+        // survives untouched. Net effect: one entry disappears.
+        s.inbound_frame(0, &[0u8; 20]).unwrap();
+        assert_eq!(s.data_ranges.len(), 2, "entry at 10 was fully absorbed");
+
+        // The credit accounting must reflect the entry that vanished.
         assert_eq!(s.split_ranges, 0);
     }
 

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -1937,7 +1937,7 @@ mod tests {
         // The stream must now accept `limit - 1` additional discontiguous ranges.
         insert_discontiguous_frames(&mut stream, offset + 1, limit - 1, FRAME_LEN);
         assert_eq!(
-            to_u64(stream.state.recv_buf().unwrap().data_ranges.len()),
+            to_u64(stream.state.recv_buf().unwrap().discontiguous_ranges()),
             limit
         );
     }

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -201,7 +201,7 @@ impl RxStreamOrderer {
     const RANGE_TARGET: usize = 4096;
 
     /// Maximum number of non-adjacent ("split") ranges allowed.
-    const MAX_SPLIT_RANGES: usize = 2048;
+    const MAX_SPLIT_RANGES: usize = 4096;
 
     #[must_use]
     pub fn new() -> Self {
@@ -211,10 +211,14 @@ impl RxStreamOrderer {
     /// Process an incoming stream frame off the wire. This may result in data
     /// being available to upper layers if frame is not out of order (ooo) or
     /// if the frame fills a gap.
+    ///
+    /// # Errors
+    /// `ProtocolViolation` if this pushes buffered non-adjacent ranges over `MAX_SPLIT_RANGES`.
+    ///
     /// # Panics
     /// Only when `u64` values cannot be converted to `usize`, which only
     /// happens on 32-bit machines that hold far too much data at the same time.
-    pub fn inbound_frame(&mut self, mut new_start: u64, mut new_data: &[u8]) {
+    pub fn inbound_frame(&mut self, mut new_start: u64, mut new_data: &[u8]) -> Res<()> {
         qtrace!("Inbound data offset={new_start} len={}", new_data.len());
 
         // Get entry before where new entry would go, so we can see if we already
@@ -224,7 +228,7 @@ impl RxStreamOrderer {
 
         if new_end <= self.retired {
             // Range already read by application, this frame is very late and unneeded.
-            return;
+            return Ok(());
         }
 
         if new_start < self.retired {
@@ -234,7 +238,7 @@ impl RxStreamOrderer {
 
         if new_data.is_empty() {
             // No data to insert
-            return;
+            return Ok(());
         }
 
         // Common case: new_start >= end
@@ -267,7 +271,7 @@ impl RxStreamOrderer {
             }
             // new_end > new_start >= end, so direct assignment is correct.
             self.end = new_end;
-            return;
+            return self.check_split_limit();
         }
 
         // Retransmission/overlap: new_start < end
@@ -295,7 +299,7 @@ impl RxStreamOrderer {
                 // NNNN
                 // Do nothing
                 qtrace!("Dropping frame with already-received range {new_start}-{new_end}");
-                return;
+                return Ok(());
             }
         } else {
             qtrace!("New frame {new_start}-{new_end} received");
@@ -368,6 +372,16 @@ impl RxStreamOrderer {
             // exists, so self.end is already correct — the max() is a no-op in that case.
             self.end = max(self.end, new_end);
         }
+
+        self.check_split_limit()
+    }
+
+    /// Checks the `MAX_SPLIT_RANGES` limit.
+    fn check_split_limit(&self) -> Res<()> {
+        if self.data_ranges.len() > Self::MAX_SPLIT_RANGES + self.split_ranges {
+            return Err(Error::ProtocolViolation);
+        }
+        Ok(())
     }
 
     /// Are any bytes readable?
@@ -774,6 +788,22 @@ impl RecvStream {
         }
     }
 
+    /// Feeds `data` to `recv_buf`, logging and propagating `ProtocolViolation` if this pushes
+    /// the stream over `MAX_SPLIT_RANGES`. (A plain function so it can be called while `self.state`
+    /// is already borrowed mutably.)
+    fn insert_frame_data(
+        recv_buf: &mut RxStreamOrderer,
+        stream_id: StreamId,
+        offset: u64,
+        data: &[u8],
+    ) -> Res<()> {
+        recv_buf.inbound_frame(offset, data).inspect_err(|_| {
+            qwarn!(
+                "Excessive non-adjacent STREAM ranges on stream {stream_id}, closing connection"
+            );
+        })
+    }
+
     /// # Errors
     /// When the incoming data violates flow control limits.
     /// # Panics
@@ -787,13 +817,14 @@ impl RecvStream {
 
         self.state.flow_control_consume_data(new_end, fin)?;
 
+        let stream_id = self.stream_id;
         match &mut self.state {
             RecvStreamState::Recv {
                 recv_buf,
                 fc,
                 session_fc,
             } => {
-                recv_buf.inbound_frame(offset, data);
+                Self::insert_frame_data(recv_buf, stream_id, offset, data)?;
                 if fin {
                     let all_recv =
                         fc.consumed() == recv_buf.retired() + to_u64(recv_buf.bytes_ready());
@@ -820,7 +851,7 @@ impl RecvStream {
                 fc,
                 session_fc,
             } => {
-                recv_buf.inbound_frame(offset, data);
+                Self::insert_frame_data(recv_buf, stream_id, offset, data)?;
                 if fc.consumed() == recv_buf.retired() + to_u64(recv_buf.bytes_ready()) {
                     let buf = mem::replace(recv_buf, RxStreamOrderer::new());
                     let fc_copy = mem::take(fc);
@@ -842,7 +873,7 @@ impl RecvStream {
                 let keep = reliable_size.saturating_sub(offset);
                 if keep > 0 {
                     let keep = min(data.len(), usize::try_from(keep)?);
-                    recv_buf.inbound_frame(offset, &data[..keep]);
+                    Self::insert_frame_data(recv_buf, stream_id, offset, &data[..keep])?;
                 }
             }
             RecvStreamState::DataRecvd { .. }
@@ -852,17 +883,6 @@ impl RecvStream {
             | RecvStreamState::ResetRecvd { .. } => {
                 qtrace!("data received when we are in state {}", self.state);
             }
-        }
-
-        // Limit the memory a peer can pin by sending non-adjacent STREAM frames.
-        if self.state.recv_buf().is_some_and(|recv_buf| {
-            recv_buf.data_ranges.len() > RxStreamOrderer::MAX_SPLIT_RANGES + recv_buf.split_ranges
-        }) {
-            qwarn!(
-                "Excessive non-adjacent STREAM ranges on stream {}, closing connection",
-                self.stream_id
-            );
-            return Err(Error::ProtocolViolation);
         }
 
         if !already_data_ready && (self.data_ready() || self.needs_to_inform_app_about_fin()) {
@@ -1370,7 +1390,7 @@ mod tests {
         let mut s = RxStreamOrderer::default();
         for r in ranges {
             let data = &ZEROES[..to_usize(r.end - r.start)];
-            s.inbound_frame(r.start, data);
+            s.inbound_frame(r.start, data).unwrap();
         }
 
         let mut buf = [0xff; 100];
@@ -1391,10 +1411,10 @@ mod tests {
     fn inbound_frame_no_extend_at_4096() {
         let mut s = RxStreamOrderer::default();
         // Fill to the extend threshold.
-        s.inbound_frame(0, &[0u8; 4096]);
+        s.inbound_frame(0, &[0u8; 4096]).unwrap();
         assert_eq!(s.data_ranges[&0].len(), 4096);
         // The next byte must not be merged; the threshold has been reached.
-        s.inbound_frame(4096, &[1u8]);
+        s.inbound_frame(4096, &[1u8]).unwrap();
         assert_eq!(
             s.data_ranges.len(),
             2,
@@ -1406,8 +1426,8 @@ mod tests {
     #[test]
     fn inbound_frame_extends_below_4096() {
         let mut s = RxStreamOrderer::default();
-        s.inbound_frame(0, &[0u8; 4095]);
-        s.inbound_frame(4095, &[1u8]);
+        s.inbound_frame(0, &[0u8; 4095]).unwrap();
+        s.inbound_frame(4095, &[1u8]).unwrap();
         assert_eq!(s.data_ranges.len(), 1);
         assert_eq!(s.data_ranges[&0].len(), 4096);
     }
@@ -1416,8 +1436,8 @@ mod tests {
     #[test]
     fn read_exact_available_removes_range() {
         let mut s = RxStreamOrderer::default();
-        s.inbound_frame(0, &[1u8; 5]);
-        s.inbound_frame(5, &[2u8; 5]);
+        s.inbound_frame(0, &[1u8; 5]).unwrap();
+        s.inbound_frame(5, &[2u8; 5]).unwrap();
 
         let mut buf = [0u8; 5];
         assert_eq!(s.read(&mut buf), 5);
@@ -1542,11 +1562,11 @@ mod tests {
         let mut s = RxStreamOrderer::new();
 
         // Add three chunks.
-        s.inbound_frame(0, &[0; CHUNK_SIZE]);
+        s.inbound_frame(0, &[0; CHUNK_SIZE]).unwrap();
         let offset = to_u64(CHUNK_SIZE);
-        s.inbound_frame(offset, &[0; EXTRA_SIZE]);
+        s.inbound_frame(offset, &[0; EXTRA_SIZE]).unwrap();
         let offset = to_u64(CHUNK_SIZE + EXTRA_SIZE);
-        s.inbound_frame(offset, &[0; EXTRA_SIZE]);
+        s.inbound_frame(offset, &[0; EXTRA_SIZE]).unwrap();
 
         // Read, providing only enough space for the first.
         let mut buf = [0; 100];
@@ -1561,7 +1581,7 @@ mod tests {
         let mut s = RxStreamOrderer::new();
 
         // Add a chunk
-        s.inbound_frame(0, &[0; 150]);
+        s.inbound_frame(0, &[0; 150]).unwrap();
         assert_eq!(s.data_ranges[&0].len(), 150);
         // Read, providing only enough space for the first 100.
         let mut buf = [0; 100];
@@ -1572,7 +1592,7 @@ mod tests {
         // Add a second frame that overlaps.
         // This shouldn't truncate the first frame, as we're already
         // Reading from it.
-        s.inbound_frame(120, &[0; 60]);
+        s.inbound_frame(120, &[0; 60]).unwrap();
         assert_eq!(s.data_ranges[&0].len(), 180);
         // Read second part of first frame and all of the second frame
         let count = s.read(&mut buf[..]);
@@ -1587,9 +1607,9 @@ mod tests {
         let mut s = RxStreamOrderer::new();
 
         // Add three chunks.
-        s.inbound_frame(0, &[0; CHUNK_SIZE]);
+        s.inbound_frame(0, &[0; CHUNK_SIZE]).unwrap();
         let offset = to_u64(CHUNK_SIZE + EXTRA_SIZE);
-        s.inbound_frame(offset, &[0; EXTRA_SIZE]);
+        s.inbound_frame(offset, &[0; EXTRA_SIZE]).unwrap();
 
         // Read, providing only enough space for the first chunk.
         let mut buf = [0; 100];
@@ -1598,7 +1618,7 @@ mod tests {
 
         // Now fill the gap and ensure that everything can be read.
         let offset = to_u64(CHUNK_SIZE);
-        s.inbound_frame(offset, &[0; EXTRA_SIZE]);
+        s.inbound_frame(offset, &[0; EXTRA_SIZE]).unwrap();
         let count = s.read(&mut buf[..]);
         assert_eq!(count, EXTRA_SIZE * 2);
     }
@@ -1611,9 +1631,9 @@ mod tests {
         let mut s = RxStreamOrderer::new();
 
         // Add two chunks.
-        s.inbound_frame(0, &[0; CHUNK_SIZE]);
+        s.inbound_frame(0, &[0; CHUNK_SIZE]).unwrap();
         let offset = to_u64(CHUNK_SIZE);
-        s.inbound_frame(offset, &[0; EXTRA_SIZE]);
+        s.inbound_frame(offset, &[0; EXTRA_SIZE]).unwrap();
 
         // Read, providing only enough space for some of the first chunk.
         let mut buf = [0; 100];
@@ -1632,9 +1652,9 @@ mod tests {
         let mut s = RxStreamOrderer::new();
 
         // Add two chunks.
-        s.inbound_frame(0, &[0; CHUNK_SIZE]);
+        s.inbound_frame(0, &[0; CHUNK_SIZE]).unwrap();
         let offset = to_u64(CHUNK_SIZE);
-        s.inbound_frame(offset, &[0; EXTRA_SIZE]);
+        s.inbound_frame(offset, &[0; EXTRA_SIZE]).unwrap();
 
         let mut buf = [0; 1];
         for _ in 0..CHUNK_SIZE + EXTRA_SIZE {
@@ -1732,27 +1752,27 @@ mod tests {
     fn stream_rx_dedupe_tail() {
         let mut s = RxStreamOrderer::new();
 
-        s.inbound_frame(0, &[1; 6]);
+        s.inbound_frame(0, &[1; 6]).unwrap();
         check_chunks(&s, &[(0, 6)]);
 
         // New data that overlaps entirely (starting from the head), is ignored.
-        s.inbound_frame(0, &[2; 3]);
+        s.inbound_frame(0, &[2; 3]).unwrap();
         check_chunks(&s, &[(0, 6)]);
 
         // New data that overlaps at the tail has any new data appended.
-        s.inbound_frame(2, &[3; 6]);
+        s.inbound_frame(2, &[3; 6]).unwrap();
         check_chunks(&s, &[(0, 8)]);
 
         // New data that overlaps entirely (up to the tail), is ignored.
-        s.inbound_frame(4, &[4; 4]);
+        s.inbound_frame(4, &[4; 4]).unwrap();
         check_chunks(&s, &[(0, 8)]);
 
         // New data that overlaps, starting from the beginning is appended too.
-        s.inbound_frame(0, &[5; 10]);
+        s.inbound_frame(0, &[5; 10]).unwrap();
         check_chunks(&s, &[(0, 10)]);
 
         // New data that is entirely subsumed is ignored.
-        s.inbound_frame(2, &[6; 2]);
+        s.inbound_frame(2, &[6; 2]).unwrap();
         check_chunks(&s, &[(0, 10)]);
 
         let mut buf = [0; 16];
@@ -1765,15 +1785,15 @@ mod tests {
     fn stream_rx_dedupe_head() {
         let mut s = RxStreamOrderer::new();
 
-        s.inbound_frame(1, &[6; 6]);
+        s.inbound_frame(1, &[6; 6]).unwrap();
         check_chunks(&s, &[(1, 6)]);
 
         // Insertion before an existing chunk causes truncation of the new chunk.
-        s.inbound_frame(0, &[7; 6]);
+        s.inbound_frame(0, &[7; 6]).unwrap();
         check_chunks(&s, &[(0, 1), (1, 6)]);
 
         // Perfect overlap with existing slices has no effect.
-        s.inbound_frame(0, &[8; 7]);
+        s.inbound_frame(0, &[8; 7]).unwrap();
         check_chunks(&s, &[(0, 1), (1, 6)]);
 
         let mut buf = [0; 16];
@@ -1785,16 +1805,16 @@ mod tests {
     fn stream_rx_dedupe_new_tail() {
         let mut s = RxStreamOrderer::new();
 
-        s.inbound_frame(1, &[6; 6]);
+        s.inbound_frame(1, &[6; 6]).unwrap();
         check_chunks(&s, &[(1, 6)]);
 
         // Insertion before an existing chunk causes truncation of the new chunk.
-        s.inbound_frame(0, &[7; 6]);
+        s.inbound_frame(0, &[7; 6]).unwrap();
         check_chunks(&s, &[(0, 1), (1, 6)]);
 
         // New data at the end causes the tail to be added to the first chunk,
         // replacing later chunks entirely.
-        s.inbound_frame(0, &[9; 8]);
+        s.inbound_frame(0, &[9; 8]).unwrap();
         check_chunks(&s, &[(0, 8)]);
 
         let mut buf = [0; 16];
@@ -1806,15 +1826,15 @@ mod tests {
     fn stream_rx_dedupe_replace() {
         let mut s = RxStreamOrderer::new();
 
-        s.inbound_frame(2, &[6; 6]);
+        s.inbound_frame(2, &[6; 6]).unwrap();
         check_chunks(&s, &[(2, 6)]);
 
         // Insertion before an existing chunk causes truncation of the new chunk.
-        s.inbound_frame(1, &[7; 6]);
+        s.inbound_frame(1, &[7; 6]).unwrap();
         check_chunks(&s, &[(1, 1), (2, 6)]);
 
         // New data at the start and end replaces all the slices.
-        s.inbound_frame(0, &[9; 10]);
+        s.inbound_frame(0, &[9; 10]).unwrap();
         check_chunks(&s, &[(0, 10)]);
 
         let mut buf = [0; 16];
@@ -1827,14 +1847,14 @@ mod tests {
         let mut s = RxStreamOrderer::new();
 
         let mut buf = [0; 18];
-        s.inbound_frame(0, &[1; 10]);
+        s.inbound_frame(0, &[1; 10]).unwrap();
 
         // Partially read slices are retained.
         assert_eq!(s.read(&mut buf[..6]), 6);
         check_chunks(&s, &[(0, 10)]);
 
         // Partially read slices are kept and so are added to.
-        s.inbound_frame(3, &buf[..10]);
+        s.inbound_frame(3, &buf[..10]).unwrap();
         check_chunks(&s, &[(0, 13)]);
 
         // Wholly read pieces are dropped.
@@ -1842,7 +1862,7 @@ mod tests {
         assert!(s.data_ranges.is_empty());
 
         // New data that overlaps with retired data is trimmed.
-        s.inbound_frame(0, &buf[..]);
+        s.inbound_frame(0, &buf[..]).unwrap();
         check_chunks(&s, &[(13, 5)]);
     }
 
@@ -2002,7 +2022,8 @@ mod tests {
         let mut s = RxStreamOrderer::default();
         for i in 0..N {
             let offset = to_u64(i * RxStreamOrderer::RANGE_TARGET);
-            s.inbound_frame(offset, &[0u8; RxStreamOrderer::RANGE_TARGET]);
+            s.inbound_frame(offset, &[0u8; RxStreamOrderer::RANGE_TARGET])
+                .unwrap();
         }
         assert_eq!(s.data_ranges.len(), N, "one entry per RANGE_TARGET chunk");
         assert_eq!(s.split_ranges(), 1);
@@ -2020,7 +2041,7 @@ mod tests {
     fn stream_orderer_bytes_ready() {
         let mut rx_ord = RxStreamOrderer::new();
 
-        rx_ord.inbound_frame(0, &[1; 6]);
+        rx_ord.inbound_frame(0, &[1; 6]).unwrap();
         assert_eq!(rx_ord.bytes_ready(), 6);
         assert_eq!(rx_ord.buffered(), 6);
         assert_eq!(rx_ord.retired(), 0);
@@ -2033,19 +2054,19 @@ mod tests {
         assert_eq!(rx_ord.retired(), 2);
 
         // an overlapping frame
-        rx_ord.inbound_frame(5, &[2; 6]);
+        rx_ord.inbound_frame(5, &[2; 6]).unwrap();
         assert_eq!(rx_ord.bytes_ready(), 9);
         assert_eq!(rx_ord.buffered(), 9);
         assert_eq!(rx_ord.retired(), 2);
 
         // a noncontig frame
-        rx_ord.inbound_frame(20, &[3; 6]);
+        rx_ord.inbound_frame(20, &[3; 6]).unwrap();
         assert_eq!(rx_ord.bytes_ready(), 9);
         assert_eq!(rx_ord.buffered(), 15);
         assert_eq!(rx_ord.retired(), 2);
 
         // an old frame
-        rx_ord.inbound_frame(0, &[4; 2]);
+        rx_ord.inbound_frame(0, &[4; 2]).unwrap();
         assert_eq!(rx_ord.bytes_ready(), 9);
         assert_eq!(rx_ord.buffered(), 15);
         assert_eq!(rx_ord.retired(), 2);
@@ -2803,7 +2824,7 @@ mod tests {
     #[test]
     fn orderer_discard_after() {
         let mut o = RxStreamOrderer::new();
-        o.inbound_frame(0, &[1; 10]);
+        o.inbound_frame(0, &[1; 10]).unwrap();
         o.discard_after(4);
         // Only `[0, 4)` remains readable.
         let mut buf = [0; 16];
@@ -2811,19 +2832,19 @@ mod tests {
 
         // A later frame entirely beyond the discard point still slots in correctly.
         let mut o = RxStreamOrderer::new();
-        o.inbound_frame(0, &[1; 4]);
-        o.inbound_frame(8, &[2; 4]); // gap at [4,8)
+        o.inbound_frame(0, &[1; 4]).unwrap();
+        o.inbound_frame(8, &[2; 4]).unwrap(); // gap at [4,8)
         o.discard_after(6); // drops [8,12), keeps [0,4)
-        o.inbound_frame(4, &[3; 2]); // fills [4,6)
+        o.inbound_frame(4, &[3; 2]).unwrap(); // fills [4,6)
         assert_eq!(o.read(&mut buf), 6);
 
         // The end marker is correctly maintained when the discard empties it out.
         let mut o = RxStreamOrderer::new();
-        o.inbound_frame(0, &[1; 4]);
+        o.inbound_frame(0, &[1; 4]).unwrap();
         assert_eq!(o.read(&mut buf), 4);
-        o.inbound_frame(8, &[2; 4]); // gap at [4,8)
+        o.inbound_frame(8, &[2; 4]).unwrap(); // gap at [4,8)
         o.discard_after(6); // drops [8,12), keeps [0,4)
-        o.inbound_frame(4, &[3; 2]); // fills [4,6)
+        o.inbound_frame(4, &[3; 2]).unwrap(); // fills [4,6)
         assert_eq!(o.read(&mut buf), 2);
     }
 

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -198,6 +198,9 @@ impl RxStreamOrderer {
     /// extended chunk can end up slightly larger than `RANGE_TARGET` (by up to one frame's worth).
     const RANGE_TARGET: usize = 4096;
 
+    /// Maximum number of discontiguous ranges buffered.
+    const MAX_DISCONTIGUOUS_RANGES: usize = 2048;
+
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -819,6 +822,13 @@ impl RecvStream {
             | RecvStreamState::ResetRecvd { .. } => {
                 qtrace!("data received when we are in state {}", self.state);
             }
+        }
+
+        // Limit the memory a peer can pin by sending non-contiguous STREAM frames.
+        if self.state.recv_buf().is_some_and(|recv_buf| {
+            recv_buf.data_ranges.len() > RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES
+        }) {
+            return Err(Error::FlowControl);
         }
 
         if !already_data_ready && (self.data_ready() || self.needs_to_inform_app_about_fin()) {
@@ -1847,6 +1857,68 @@ mod tests {
         s.inbound_stream_frame(false, 0, &big_buf).unwrap();
         s.inbound_stream_frame(false, to_u64(INITIAL_LOCAL_MAX_STREAM_DATA), &[1; 1])
             .unwrap_err();
+    }
+
+    /// Feeds `range_count` frames of `frame_len` bytes into `stream`, starting at
+    /// `start_offset` and leaving a one-byte hole before each.
+    fn insert_discontinous_frames(
+        stream: &mut RecvStream,
+        start_offset: u64,
+        range_count: u64,
+        frame_len: u64,
+    ) -> u64 {
+        let payload = vec![0u8; to_usize(frame_len)];
+        let mut offset = start_offset;
+        for _ in 0..range_count {
+            stream
+                .inbound_stream_frame(false, offset, &payload)
+                .unwrap();
+            offset += frame_len + 1;
+        }
+        offset
+    }
+
+    /// A stream must not buffer an unbounded number of out-of-order ranges.
+    #[test]
+    fn rejects_unbounded_fragmentation() {
+        const FRAME_LEN: u64 = 1;
+        let mut stream = create_stream(1024 * to_u64(INITIAL_LOCAL_MAX_STREAM_DATA));
+        let limit = to_u64(RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES);
+        let offset = insert_discontinous_frames(&mut stream, 1, limit - 1, FRAME_LEN);
+
+        // The range that reaches the limit must still be accepted.
+        assert_eq!(stream.inbound_stream_frame(false, offset, &[0u8]), Ok(()));
+        assert!(!stream.data_ready(), "stream must not be readable");
+
+        // The range that pushes the count past the limit must be rejected.
+        assert_eq!(
+            stream.inbound_stream_frame(false, offset + FRAME_LEN + 1, &[0u8]),
+            Err(Error::FlowControl)
+        );
+    }
+
+    /// Ranges freed by coalescing must stop counting towards the limit.
+    #[test]
+    fn release_entries_on_fill() {
+        const FRAME_LEN: u64 = 1;
+        let mut stream = create_stream(1024 * to_u64(INITIAL_LOCAL_MAX_STREAM_DATA));
+        let limit = to_u64(RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES);
+
+        // Accumulate discontiguous ranges up to the limit: every one of these must be accepted.
+        let offset = insert_discontinous_frames(&mut stream, 1, limit, FRAME_LEN);
+        assert!(!stream.data_ready(), "stream must not be readable");
+
+        // Filling every gap coalesces the disjoint ranges into a single one.
+        let filler = vec![0u8; to_usize(offset)];
+        stream.inbound_stream_frame(false, 0, &filler).unwrap();
+        assert_eq!(stream.state.recv_buf().unwrap().data_ranges.len(), 1);
+
+        // The stream must now accept `limit - 1` additional discontiguous ranges.
+        insert_discontinous_frames(&mut stream, offset + 1, limit - 1, FRAME_LEN);
+        assert_eq!(
+            to_u64(stream.state.recv_buf().unwrap().data_ranges.len()),
+            limit
+        );
     }
 
     #[test]

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -189,6 +189,8 @@ pub struct RxStreamOrderer {
     /// Exclusive end offset of the rightmost received range (the end of the
     /// last entry in `data_ranges`, or `retired` if the map is empty).
     end: u64,
+    /// Count entries that are adjacent to existing ones (that have hit `RANGE_TARGET`).
+    split_ranges: usize,
 }
 
 impl RxStreamOrderer {
@@ -198,8 +200,8 @@ impl RxStreamOrderer {
     /// extended chunk can end up slightly larger than `RANGE_TARGET` (by up to one frame's worth).
     const RANGE_TARGET: usize = 4096;
 
-    /// Maximum number of discontiguous ranges buffered.
-    const MAX_DISCONTIGUOUS_RANGES: usize = 2048;
+    /// Maximum number of non-adjacent ("split") ranges allowed.
+    const MAX_SPLIT_RANGES: usize = 2048;
 
     #[must_use]
     pub fn new() -> Self {
@@ -248,7 +250,8 @@ impl RxStreamOrderer {
             // Adjacent: extend the last entry to avoid a BTreeMap insert, if small enough.
             // Checks existing length, so the stored chunk may grow slightly past RANGE_TARGET
             // (by up to one frame). Gap (new_start > end): falls through to insert.
-            if new_start == self.end
+            let adjacent = new_start == self.end;
+            if adjacent
                 && let Some(mut e) = self
                     .data_ranges
                     .last_entry()
@@ -257,6 +260,10 @@ impl RxStreamOrderer {
                 e.get_mut().extend_from_slice(new_data);
             } else {
                 self.data_ranges.insert(new_start, new_data.to_vec());
+                if adjacent {
+                    // New entry only because the existing one hit RANGE_TARGET.
+                    self.split_ranges += 1;
+                }
             }
             // new_end > new_start >= end, so direct assignment is correct.
             self.end = new_end;
@@ -436,16 +443,9 @@ impl RxStreamOrderer {
         }
     }
 
-    /// Number of discontiguous runs of buffered data.
-    ///
-    /// `inbound_frame` may store perfectly contiguous data as several *adjacent*
-    /// `data_ranges` entries once an entry reaches `RANGE_TARGET` bytes (a
-    /// deliberate optimization that avoids repeatedly reallocating a growing
-    /// `Vec`). As a result `data_ranges.len()` overcounts: it cannot tell a
-    /// genuine gap apart from a split of otherwise-contiguous data. This returns
-    /// the number of maximal contiguous runs (entries separated by an actual
-    /// gap), which is the quantity the anti-fragmentation limit must bound.
-    fn discontiguous_ranges(&self) -> usize {
+    /// Count non-adjacent ("split") runs of buffered data, for test validation.
+    #[cfg(test)]
+    fn split_ranges(&self) -> usize {
         let mut runs = 0;
         let mut prev_end = None;
         for (&start, data) in &self.data_ranges {
@@ -470,6 +470,7 @@ impl RxStreamOrderer {
     fn read(&mut self, buf: &mut [u8]) -> usize {
         qtrace!("Reading {} bytes, {} available", buf.len(), self.buffered());
         let mut copied = 0;
+        let entries_before = self.data_ranges.len();
 
         for (&range_start, range_data) in &mut self.data_ranges {
             let mut keep = false;
@@ -499,13 +500,21 @@ impl RxStreamOrderer {
             if keep {
                 let mut keep = self.data_ranges.split_off(&range_start);
                 mem::swap(&mut self.data_ranges, &mut keep);
+                self.adjust_split_ranges(entries_before);
                 return copied;
             }
         }
 
         self.data_ranges.clear();
         self.end = self.retired; // All entries were consumed.
+        self.adjust_split_ranges(entries_before);
         copied
+    }
+
+    /// Reduce `split_ranges` count.
+    fn adjust_split_ranges(&mut self, entries_before: usize) {
+        let released = entries_before.saturating_sub(self.data_ranges.len());
+        self.split_ranges = self.split_ranges.saturating_sub(released);
     }
 
     /// Extend the given Vector with any available data.
@@ -845,10 +854,12 @@ impl RecvStream {
             }
         }
 
-        // Limit the memory a peer can pin by sending non-contiguous STREAM frames.
-        if self.discontiguous_ranges() > RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES {
+        // Limit the memory a peer can pin by sending non-adjacent STREAM frames.
+        if self.state.recv_buf().is_some_and(|recv_buf| {
+            recv_buf.data_ranges.len() > RxStreamOrderer::MAX_SPLIT_RANGES + recv_buf.split_ranges
+        }) {
             qwarn!(
-                "Excessive discontiguous STREAM ranges on stream {}, closing connection",
+                "Excessive non-adjacent STREAM ranges on stream {}, closing connection",
                 self.stream_id
             );
             return Err(Error::ProtocolViolation);
@@ -1089,10 +1100,11 @@ impl RecvStream {
             .is_some_and(RxStreamOrderer::data_ready)
     }
 
-    fn discontiguous_ranges(&self) -> usize {
+    #[cfg(test)]
+    fn split_ranges(&self) -> usize {
         self.state
             .recv_buf()
-            .map_or(0, RxStreamOrderer::discontiguous_ranges)
+            .map_or(0, RxStreamOrderer::split_ranges)
     }
 
     /// # Errors
@@ -1890,7 +1902,7 @@ mod tests {
 
     /// Feeds `range_count` frames of `frame_len` bytes into `stream`, starting at
     /// `start_offset` and leaving a one-byte hole before each.
-    fn insert_discontiguous_frames(
+    fn insert_nonadjacent_frames(
         stream: &mut RecvStream,
         start_offset: u64,
         range_count: u64,
@@ -1907,21 +1919,21 @@ mod tests {
         offset
     }
 
-    /// A stream with a session window large enough that only the discontiguous-range
+    /// A stream with a session window large enough that only the `MAX_SPLIT_RANGES`
     /// limit is exercised, plus that limit for convenience.
     fn create_stream_at_range_limit() -> (RecvStream, u64) {
         (
             create_stream(1024 * to_u64(INITIAL_LOCAL_MAX_STREAM_DATA)),
-            to_u64(RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES),
+            to_u64(RxStreamOrderer::MAX_SPLIT_RANGES),
         )
     }
 
     /// A stream must not buffer an unbounded number of out-of-order ranges.
     #[test]
-    fn rejects_unbounded_fragmentation() {
+    fn reject_unbounded_fragmentation() {
         const FRAME_LEN: u64 = 1;
         let (mut stream, limit) = create_stream_at_range_limit();
-        let offset = insert_discontiguous_frames(&mut stream, 1, limit - 1, FRAME_LEN);
+        let offset = insert_nonadjacent_frames(&mut stream, 1, limit - 1, FRAME_LEN);
 
         // The range that reaches the limit must still be accepted.
         assert_eq!(stream.inbound_stream_frame(false, offset, &[0u8]), Ok(()));
@@ -1940,19 +1952,18 @@ mod tests {
         const FRAME_LEN: u64 = 1;
         let (mut stream, limit) = create_stream_at_range_limit();
 
-        // Accumulate discontiguous ranges up to the limit: every one of these must be accepted.
-        let offset = insert_discontiguous_frames(&mut stream, 1, limit, FRAME_LEN);
+        // Accumulate non-adjacent ranges up to the limit.
+        let offset = insert_nonadjacent_frames(&mut stream, 1, limit, FRAME_LEN);
         assert!(!stream.data_ready(), "stream must not be readable");
 
-        // Filling every gap coalesces the disjoint ranges into a single one.
+        // Filling every gap coalesces these ranges into a single one.
         let filler = vec![0u8; to_usize(offset)];
         stream.inbound_stream_frame(false, 0, &filler).unwrap();
-        assert_eq!(stream.discontiguous_ranges(), 1);
+        assert_eq!(stream.split_ranges(), 1);
 
-        // The stream must now accept `limit - 1` additional discontiguous ranges.
-        let next_offset =
-            insert_discontiguous_frames(&mut stream, offset + 1, limit - 1, FRAME_LEN);
-        assert_eq!(to_u64(stream.discontiguous_ranges()), limit);
+        // The stream must now accept `limit - 1` additional non-adjacent ranges.
+        let next_offset = insert_nonadjacent_frames(&mut stream, offset + 1, limit - 1, FRAME_LEN);
+        assert_eq!(to_u64(stream.split_ranges()), limit);
 
         // One more range must still be rejected.
         assert_eq!(
@@ -1961,17 +1972,13 @@ mod tests {
         );
     }
 
-    /// A slow reader receiving purely in-order data must not be mistaken for a
-    /// fragmentation attack. Once an entry reaches `RANGE_TARGET`, contiguous
-    /// data is stored as additional adjacent `data_ranges` entries, so the raw
-    /// entry count can exceed `MAX_DISCONTIGUOUS_RANGES` with zero gaps. Such a
-    /// stream must be accepted, not torn down.
+    /// Purely in-order data must not be mistaken for a fragmentation attack.
     #[test]
-    fn accepts_contiguous_data_split_across_many_entries() {
+    fn accept_all_adjacent_data() {
         const FRAME_LEN: usize = RxStreamOrderer::RANGE_TARGET;
-        let ranges = RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES + 2;
+        let ranges = RxStreamOrderer::MAX_SPLIT_RANGES + 2;
 
-        // Window large enough to buffer every (unread) contiguous byte, so that
+        // Window large enough to buffer every (unread) byte of adjacent data, so that
         // flow control never fires and only the fragmentation check is exercised.
         let window = to_u64((ranges + 1) * FRAME_LEN);
         let session_fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), window)));
@@ -1980,17 +1987,33 @@ mod tests {
         let payload = vec![0u8; FRAME_LEN];
         for i in 0..ranges {
             let offset = to_u64(i * FRAME_LEN);
-            assert_eq!(
-                stream.inbound_stream_frame(false, offset, &payload),
-                Ok(()),
-                "in-order frame {i} must be accepted"
-            );
+            assert_eq!(stream.inbound_stream_frame(false, offset, &payload), Ok(()));
         }
 
         let raw_entries = stream.state.recv_buf().unwrap().data_ranges.len();
-        assert!(raw_entries > RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES);
-        assert_eq!(stream.discontiguous_ranges(), 1);
+        assert!(raw_entries > RxStreamOrderer::MAX_SPLIT_RANGES);
+        assert_eq!(stream.split_ranges(), 1);
         assert!(stream.data_ready(), "in-order data must be readable");
+    }
+
+    #[test]
+    fn split_ranges_reduced_after_read() {
+        const N: usize = 5;
+        let mut s = RxStreamOrderer::default();
+        for i in 0..N {
+            let offset = to_u64(i * RxStreamOrderer::RANGE_TARGET);
+            s.inbound_frame(offset, &[0u8; RxStreamOrderer::RANGE_TARGET]);
+        }
+        assert_eq!(s.data_ranges.len(), N, "one entry per RANGE_TARGET chunk");
+        assert_eq!(s.split_ranges(), 1);
+        assert_eq!(s.split_ranges, N);
+
+        // Drain everything.
+        let mut buf = vec![0u8; N * RxStreamOrderer::RANGE_TARGET];
+        let read = s.read(&mut buf);
+        assert_eq!(read, N * RxStreamOrderer::RANGE_TARGET);
+        assert!(s.data_ranges.is_empty());
+        assert_eq!(s.split_ranges, 0);
     }
 
     #[test]

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -849,6 +849,7 @@ impl RecvStream {
         if self.state.recv_buf().is_some_and(|recv_buf| {
             recv_buf.discontiguous_ranges() > RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES
         }) {
+            qwarn!("Excessive discontiguous STREAM ranges, closing connection");
             return Err(Error::ProtocolViolation);
         }
 

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -1933,7 +1933,7 @@ mod tests {
         // Filling every gap coalesces the disjoint ranges into a single one.
         let filler = vec![0u8; to_usize(offset)];
         stream.inbound_stream_frame(false, 0, &filler).unwrap();
-        assert_eq!(stream.state.recv_buf().unwrap().data_ranges.len(), 1);
+        assert_eq!(stream.state.recv_buf().unwrap().discontiguous_ranges(), 1);
 
         // The stream must now accept `limit - 1` additional discontiguous ranges.
         insert_discontiguous_frames(&mut stream, offset + 1, limit - 1, FRAME_LEN);

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -849,7 +849,7 @@ impl RecvStream {
         if self.state.recv_buf().is_some_and(|recv_buf| {
             recv_buf.discontiguous_ranges() > RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES
         }) {
-            qwarn!("Excessive discontiguous STREAM ranges, closing connection");
+            qwarn!("Excessive discontiguous STREAM ranges on {}, closing connection", self.stream_id);
             return Err(Error::ProtocolViolation);
         }
 

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -436,6 +436,27 @@ impl RxStreamOrderer {
         }
     }
 
+    /// Number of discontiguous runs of buffered data.
+    ///
+    /// `inbound_frame` may store perfectly contiguous data as several *adjacent*
+    /// `data_ranges` entries once an entry reaches `RANGE_TARGET` bytes (a
+    /// deliberate optimization that avoids repeatedly reallocating a growing
+    /// `Vec`). As a result `data_ranges.len()` overcounts: it cannot tell a
+    /// genuine gap apart from a split of otherwise-contiguous data. This returns
+    /// the number of maximal contiguous runs (entries separated by an actual
+    /// gap), which is the quantity the anti-fragmentation limit must bound.
+    fn discontiguous_ranges(&self) -> usize {
+        let mut runs = 0;
+        let mut prev_end = None;
+        for (&start, data) in &self.data_ranges {
+            if prev_end != Some(start) {
+                runs += 1;
+            }
+            prev_end = Some(start + to_u64(data.len()));
+        }
+        runs
+    }
+
     /// Data bytes buffered. Could be more than `bytes_readable` if there are
     /// ranges missing.
     fn buffered(&self) -> u64 {
@@ -826,9 +847,9 @@ impl RecvStream {
 
         // Limit the memory a peer can pin by sending non-contiguous STREAM frames.
         if self.state.recv_buf().is_some_and(|recv_buf| {
-            recv_buf.data_ranges.len() > RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES
+            recv_buf.discontiguous_ranges() > RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES
         }) {
-            return Err(Error::FlowControl);
+            return Err(Error::ProtocolViolation);
         }
 
         if !already_data_ready && (self.data_ready() || self.needs_to_inform_app_about_fin()) {
@@ -1861,7 +1882,7 @@ mod tests {
 
     /// Feeds `range_count` frames of `frame_len` bytes into `stream`, starting at
     /// `start_offset` and leaving a one-byte hole before each.
-    fn insert_discontinous_frames(
+    fn insert_discontiguous_frames(
         stream: &mut RecvStream,
         start_offset: u64,
         range_count: u64,
@@ -1884,7 +1905,7 @@ mod tests {
         const FRAME_LEN: u64 = 1;
         let mut stream = create_stream(1024 * to_u64(INITIAL_LOCAL_MAX_STREAM_DATA));
         let limit = to_u64(RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES);
-        let offset = insert_discontinous_frames(&mut stream, 1, limit - 1, FRAME_LEN);
+        let offset = insert_discontiguous_frames(&mut stream, 1, limit - 1, FRAME_LEN);
 
         // The range that reaches the limit must still be accepted.
         assert_eq!(stream.inbound_stream_frame(false, offset, &[0u8]), Ok(()));
@@ -1893,7 +1914,7 @@ mod tests {
         // The range that pushes the count past the limit must be rejected.
         assert_eq!(
             stream.inbound_stream_frame(false, offset + FRAME_LEN + 1, &[0u8]),
-            Err(Error::FlowControl)
+            Err(Error::ProtocolViolation)
         );
     }
 
@@ -1905,7 +1926,7 @@ mod tests {
         let limit = to_u64(RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES);
 
         // Accumulate discontiguous ranges up to the limit: every one of these must be accepted.
-        let offset = insert_discontinous_frames(&mut stream, 1, limit, FRAME_LEN);
+        let offset = insert_discontiguous_frames(&mut stream, 1, limit, FRAME_LEN);
         assert!(!stream.data_ready(), "stream must not be readable");
 
         // Filling every gap coalesces the disjoint ranges into a single one.
@@ -1914,11 +1935,43 @@ mod tests {
         assert_eq!(stream.state.recv_buf().unwrap().data_ranges.len(), 1);
 
         // The stream must now accept `limit - 1` additional discontiguous ranges.
-        insert_discontinous_frames(&mut stream, offset + 1, limit - 1, FRAME_LEN);
+        insert_discontiguous_frames(&mut stream, offset + 1, limit - 1, FRAME_LEN);
         assert_eq!(
             to_u64(stream.state.recv_buf().unwrap().data_ranges.len()),
             limit
         );
+    }
+
+    /// A slow reader receiving purely in-order data must not be mistaken for a
+    /// fragmentation attack. Once an entry reaches `RANGE_TARGET`, contiguous
+    /// data is stored as additional adjacent `data_ranges` entries, so the raw
+    /// entry count can exceed `MAX_DISCONTIGUOUS_RANGES` with zero gaps. Such a
+    /// stream must be accepted, not torn down.
+    #[test]
+    fn accepts_contiguous_data_split_across_many_entries() {
+        const FRAME_LEN: usize = RxStreamOrderer::RANGE_TARGET;
+        let ranges = RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES + 2;
+
+        // Window large enough to buffer every (unread) contiguous byte, so that
+        // flow control never fires and only the fragmentation check is exercised.
+        let window = to_u64((ranges + 1) * FRAME_LEN);
+        let session_fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), window)));
+        let mut stream = create_stream_with_fc(Rc::clone(&session_fc), window);
+
+        let payload = vec![0u8; FRAME_LEN];
+        for i in 0..ranges {
+            let offset = to_u64(i * FRAME_LEN);
+            assert_eq!(
+                stream.inbound_stream_frame(false, offset, &payload),
+                Ok(()),
+                "in-order frame {i} must be accepted"
+            );
+        }
+
+        let recv_buf = stream.state.recv_buf().unwrap();
+        assert!(recv_buf.data_ranges.len() > RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES);
+        assert_eq!(recv_buf.discontiguous_ranges(), 1);
+        assert!(stream.data_ready(), "in-order data must be readable");
     }
 
     #[test]

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -17,7 +17,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Buffer, Role, qtrace, to_u64, to_usize};
+use neqo_common::{Buffer, Role, qtrace, qwarn, to_u64, to_usize};
 use smallvec::SmallVec;
 use strum::Display;
 

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -846,10 +846,11 @@ impl RecvStream {
         }
 
         // Limit the memory a peer can pin by sending non-contiguous STREAM frames.
-        if self.state.recv_buf().is_some_and(|recv_buf| {
-            recv_buf.discontiguous_ranges() > RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES
-        }) {
-            qwarn!("Excessive discontiguous STREAM ranges on {}, closing connection", self.stream_id);
+        if self.discontiguous_ranges() > RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES {
+            qwarn!(
+                "Excessive discontiguous STREAM ranges on stream {}, closing connection",
+                self.stream_id
+            );
             return Err(Error::ProtocolViolation);
         }
 
@@ -1086,6 +1087,12 @@ impl RecvStream {
         self.state
             .recv_buf()
             .is_some_and(RxStreamOrderer::data_ready)
+    }
+
+    fn discontiguous_ranges(&self) -> usize {
+        self.state
+            .recv_buf()
+            .map_or(0, RxStreamOrderer::discontiguous_ranges)
     }
 
     /// # Errors
@@ -1900,12 +1907,20 @@ mod tests {
         offset
     }
 
+    /// A stream with a session window large enough that only the discontiguous-range
+    /// limit is exercised, plus that limit for convenience.
+    fn create_stream_at_range_limit() -> (RecvStream, u64) {
+        (
+            create_stream(1024 * to_u64(INITIAL_LOCAL_MAX_STREAM_DATA)),
+            to_u64(RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES),
+        )
+    }
+
     /// A stream must not buffer an unbounded number of out-of-order ranges.
     #[test]
     fn rejects_unbounded_fragmentation() {
         const FRAME_LEN: u64 = 1;
-        let mut stream = create_stream(1024 * to_u64(INITIAL_LOCAL_MAX_STREAM_DATA));
-        let limit = to_u64(RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES);
+        let (mut stream, limit) = create_stream_at_range_limit();
         let offset = insert_discontiguous_frames(&mut stream, 1, limit - 1, FRAME_LEN);
 
         // The range that reaches the limit must still be accepted.
@@ -1923,8 +1938,7 @@ mod tests {
     #[test]
     fn release_entries_on_fill() {
         const FRAME_LEN: u64 = 1;
-        let mut stream = create_stream(1024 * to_u64(INITIAL_LOCAL_MAX_STREAM_DATA));
-        let limit = to_u64(RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES);
+        let (mut stream, limit) = create_stream_at_range_limit();
 
         // Accumulate discontiguous ranges up to the limit: every one of these must be accepted.
         let offset = insert_discontiguous_frames(&mut stream, 1, limit, FRAME_LEN);
@@ -1933,13 +1947,17 @@ mod tests {
         // Filling every gap coalesces the disjoint ranges into a single one.
         let filler = vec![0u8; to_usize(offset)];
         stream.inbound_stream_frame(false, 0, &filler).unwrap();
-        assert_eq!(stream.state.recv_buf().unwrap().discontiguous_ranges(), 1);
+        assert_eq!(stream.discontiguous_ranges(), 1);
 
         // The stream must now accept `limit - 1` additional discontiguous ranges.
-        insert_discontiguous_frames(&mut stream, offset + 1, limit - 1, FRAME_LEN);
+        let next_offset =
+            insert_discontiguous_frames(&mut stream, offset + 1, limit - 1, FRAME_LEN);
+        assert_eq!(to_u64(stream.discontiguous_ranges()), limit);
+
+        // One more range must still be rejected.
         assert_eq!(
-            to_u64(stream.state.recv_buf().unwrap().discontiguous_ranges()),
-            limit
+            stream.inbound_stream_frame(false, next_offset, &[0u8]),
+            Err(Error::ProtocolViolation)
         );
     }
 
@@ -1969,9 +1987,9 @@ mod tests {
             );
         }
 
-        let recv_buf = stream.state.recv_buf().unwrap();
-        assert!(recv_buf.data_ranges.len() > RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES);
-        assert_eq!(recv_buf.discontiguous_ranges(), 1);
+        let raw_entries = stream.state.recv_buf().unwrap().data_ranges.len();
+        assert!(raw_entries > RxStreamOrderer::MAX_DISCONTIGUOUS_RANGES);
+        assert_eq!(stream.discontiguous_ranges(), 1);
         assert!(stream.data_ready(), "in-order data must be readable");
     }
 

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -17,7 +17,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use neqo_common::{Buffer, Role, expect_usize, qtrace, to_u64};
+use neqo_common::{Buffer, Role, expect_usize, qtrace, qwarn, to_u64};
 use smallvec::SmallVec;
 use strum::Display;
 
@@ -189,6 +189,8 @@ pub struct RxStreamOrderer {
     /// Exclusive end offset of the rightmost received range (the end of the
     /// last entry in `data_ranges`, or `retired` if the map is empty).
     end: u64,
+    /// Credit for entries that don't add a gap, and so don't count towards `MAX_SPLIT_RANGES`.
+    split_ranges: usize,
 }
 
 impl RxStreamOrderer {
@@ -197,6 +199,9 @@ impl RxStreamOrderer {
     /// still buffered whole. Because the extend check tests the *existing* entry length, an
     /// extended chunk can end up slightly larger than `RANGE_TARGET` (by up to one frame's worth).
     const RANGE_TARGET: usize = 4096;
+
+    /// Maximum number of buffered ranges that are separated by a gap.
+    const MAX_SPLIT_RANGES: usize = 4096;
 
     #[must_use]
     pub fn new() -> Self {
@@ -246,7 +251,8 @@ impl RxStreamOrderer {
             // Adjacent: extend the last entry to avoid a BTreeMap insert, if small enough.
             // Checks existing length, so the stored chunk may grow slightly past RANGE_TARGET
             // (by up to one frame). Gap (new_start > end): falls through to insert.
-            if new_start == self.end
+            let adjacent = new_start == self.end;
+            if adjacent
                 && let Some(mut e) = self
                     .data_ranges
                     .last_entry()
@@ -254,14 +260,27 @@ impl RxStreamOrderer {
             {
                 e.get_mut().extend_from_slice(new_data);
             } else {
+                // A new entry only because the existing one hit RANGE_TARGET; not a gap.
+                let continues_previous = adjacent && !self.data_ranges.is_empty();
                 self.data_ranges.insert(new_start, new_data.to_vec());
+                if continues_previous {
+                    self.split_ranges += 1;
+                }
             }
             // new_end > new_start >= end, so direct assignment is correct.
             self.end = new_end;
             return;
         }
 
-        // Retransmission/overlap: new_start < end
+        self.inbound_overlapping(new_start, new_data, new_end);
+    }
+
+    /// Handle a frame that overlaps data we already hold, i.e. `new_start < self.end`.
+    ///
+    /// # Panics
+    /// Only when `u64` values cannot be converted to `usize`, which only
+    /// happens on 32-bit machines that hold far too much data at the same time.
+    fn inbound_overlapping(&mut self, mut new_start: u64, mut new_data: &[u8], new_end: u64) {
         let extend = if let Some((&prev_start, prev_vec)) =
             self.data_ranges.range_mut(..=new_start).next_back()
         {
@@ -343,25 +362,50 @@ impl RxStreamOrderer {
                 // Continue, since we may have more overlaps
             }
 
-            for start in to_remove {
-                self.data_ranges.remove(&start);
-            }
+            self.mutate_ranges(|data_ranges| {
+                for start in to_remove {
+                    data_ranges.remove(&start);
+                }
+            });
         }
 
         if !to_add.is_empty() {
             self.received += to_u64(to_add.len());
+            // Credit each side this joins up with, so the count tracks gaps, not entries.
+            let add_end = new_start + to_u64(to_add.len());
+            let joins_next = self
+                .data_ranges
+                .range(add_end..)
+                .next()
+                .is_some_and(|(&start, _)| start == add_end);
             if extend {
                 if let Some((_, buf)) = self.data_ranges.range_mut(..=new_start).next_back() {
                     buf.extend_from_slice(to_add);
                 }
             } else {
+                let continues_previous = self
+                    .data_ranges
+                    .range(..new_start)
+                    .next_back()
+                    .is_some_and(|(&start, data)| start + to_u64(data.len()) == new_start);
                 self.data_ranges.insert(new_start, to_add.to_vec());
+                if continues_previous {
+                    self.split_ranges += 1;
+                }
+            }
+            if joins_next {
+                self.split_ranges += 1;
             }
             // new_start was advanced by overlap, so new_end is still the real end.
             // When to_add is empty, a surviving forward entry with next_end >= new_end
             // exists, so self.end is already correct — the max() is a no-op in that case.
             self.end = max(self.end, new_end);
         }
+    }
+
+    /// Whether we buffer more than `MAX_SPLIT_RANGES` non-adjacent ranges.
+    pub(crate) fn overly_fragmented(&self) -> bool {
+        self.data_ranges.len() > Self::MAX_SPLIT_RANGES + self.split_ranges
     }
 
     /// Are any bytes readable?
@@ -422,21 +466,36 @@ impl RxStreamOrderer {
         reason = "OK here."
     )]
     pub fn discard_after(&mut self, offset: u64) {
-        self.data_ranges.split_off(&offset);
-        // Truncate a range that straddles `offset`.
-        if let Some(mut e) = self.data_ranges.last_entry() {
-            let start = *e.key();
-            // No underflow because all ranges that start at or after `offset` are gone.
-            // Conversion is safe because this cannot be more than what the entry holds.
-            let keep = expect_usize(offset - start);
-            let data = e.get_mut();
-            data.truncate(keep);
+        let retired = self.retired;
+        self.end = self.mutate_ranges(|data_ranges| {
+            data_ranges.split_off(&offset);
+            // Truncate a range that straddles `offset`.
+            data_ranges.last_entry().map_or(retired, |mut e| {
+                let start = *e.key();
+                // No underflow, because all ranges that start at or after `offset` are gone.
+                // Conversion is safe because this cannot be more than what the entry holds.
+                let keep = expect_usize(offset - start);
+                let data = e.get_mut();
+                data.truncate(keep);
 
-            // No overflow risk: neither start nor offset can exceed 1<<62.
-            self.end = start + to_u64(data.len());
-        } else {
-            self.end = self.retired;
+                // No overflow risk: neither start nor offset can exceed 1<<62.
+                start + to_u64(data.len())
+            })
+        });
+    }
+
+    /// Count non-adjacent ("split") runs of buffered data, for test validation.
+    #[cfg(test)]
+    fn split_ranges(&self) -> usize {
+        let mut runs = 0;
+        let mut prev_end = None;
+        for (&start, data) in &self.data_ranges {
+            if prev_end != Some(start) {
+                runs += 1;
+            }
+            prev_end = Some(start + to_u64(data.len()));
         }
+        runs
     }
 
     /// Data bytes buffered. Could be more than `bytes_readable` if there are
@@ -480,15 +539,27 @@ impl RxStreamOrderer {
                 keep = true;
             }
             if keep {
-                let mut keep = self.data_ranges.split_off(&range_start);
-                mem::swap(&mut self.data_ranges, &mut keep);
+                self.mutate_ranges(|data_ranges| {
+                    let mut keep = data_ranges.split_off(&range_start);
+                    mem::swap(data_ranges, &mut keep);
+                });
                 return copied;
             }
         }
 
-        self.data_ranges.clear();
+        self.mutate_ranges(BTreeMap::clear);
         self.end = self.retired; // All entries were consumed.
         copied
+    }
+
+    /// Runs `f` against `data_ranges`, then reduces `split_ranges` by however many
+    /// entries `f` removed. Every removal path has to go through here.
+    fn mutate_ranges<T>(&mut self, f: impl FnOnce(&mut BTreeMap<u64, Vec<u8>>) -> T) -> T {
+        let entries_before = self.data_ranges.len();
+        let result = f(&mut self.data_ranges);
+        let released = entries_before.saturating_sub(self.data_ranges.len());
+        self.split_ranges = self.split_ranges.saturating_sub(released);
+        result
     }
 
     /// Extend the given Vector with any available data.
@@ -749,7 +820,9 @@ impl RecvStream {
     }
 
     /// # Errors
-    /// When the incoming data violates flow control limits.
+    /// When the incoming data violates flow control limits, or
+    /// [`Error::ProtocolViolation`] when it pushes the stream past `MAX_SPLIT_RANGES`
+    /// non-adjacent buffered ranges.
     /// # Panics
     /// Only when `u64` values are so big that they can't fit in a `usize`, which
     /// only happens on a 32-bit machine that has far too much unread data.
@@ -826,6 +899,19 @@ impl RecvStream {
             | RecvStreamState::ResetRecvd { .. } => {
                 qtrace!("data received when we are in state {}", self.state);
             }
+        }
+
+        // Don't let a peer pin memory by forcing us to buffer many non-adjacent ranges.
+        if self
+            .state
+            .recv_buf()
+            .is_some_and(RxStreamOrderer::overly_fragmented)
+        {
+            qwarn!(
+                "Excessive non-adjacent STREAM ranges on {}, closing connection",
+                self.stream_id
+            );
+            return Err(Error::ProtocolViolation);
         }
 
         if !already_data_ready && (self.data_ready() || self.needs_to_inform_app_about_fin()) {
@@ -1061,6 +1147,13 @@ impl RecvStream {
         self.state
             .recv_buf()
             .is_some_and(RxStreamOrderer::data_ready)
+    }
+
+    #[cfg(test)]
+    fn split_ranges(&self) -> usize {
+        self.state
+            .recv_buf()
+            .map_or(0, RxStreamOrderer::split_ranges)
     }
 
     /// # Errors
@@ -1855,6 +1948,183 @@ mod tests {
         s.inbound_stream_frame(false, 0, &big_buf).unwrap();
         s.inbound_stream_frame(false, to_u64(INITIAL_LOCAL_MAX_STREAM_DATA), &[1; 1])
             .unwrap_err();
+    }
+
+    /// Feeds `range_count` frames of `frame_len` bytes into `stream`, starting at
+    /// `start_offset` and leaving a one-byte hole before each.
+    fn insert_nonadjacent_frames(
+        stream: &mut RecvStream,
+        start_offset: u64,
+        range_count: u64,
+        frame_len: u64,
+    ) -> u64 {
+        let payload = vec![0u8; expect_usize(frame_len)];
+        let mut offset = start_offset;
+        for _ in 0..range_count {
+            stream
+                .inbound_stream_frame(false, offset, &payload)
+                .unwrap();
+            offset += frame_len + 1;
+        }
+        offset
+    }
+
+    /// A stream with a session window large enough that only the `MAX_SPLIT_RANGES`
+    /// limit is exercised, plus that limit for convenience.
+    fn create_stream_at_range_limit() -> (RecvStream, u64) {
+        (
+            create_stream(1024 * to_u64(INITIAL_LOCAL_MAX_STREAM_DATA)),
+            to_u64(RxStreamOrderer::MAX_SPLIT_RANGES),
+        )
+    }
+
+    /// A stream must not buffer an unbounded number of out-of-order ranges.
+    #[test]
+    fn reject_unbounded_fragmentation() {
+        const FRAME_LEN: u64 = 1;
+        let (mut stream, limit) = create_stream_at_range_limit();
+        let offset = insert_nonadjacent_frames(&mut stream, 1, limit - 1, FRAME_LEN);
+
+        // The range that reaches the limit must still be accepted.
+        assert_eq!(stream.inbound_stream_frame(false, offset, &[0u8]), Ok(()));
+        assert!(!stream.data_ready(), "stream must not be readable");
+
+        // The range that pushes the count past the limit must be rejected.
+        assert_eq!(
+            stream.inbound_stream_frame(false, offset + FRAME_LEN + 1, &[0u8]),
+            Err(Error::ProtocolViolation)
+        );
+    }
+
+    /// Ranges freed by coalescing must stop counting towards the limit.
+    #[test]
+    fn release_entries_on_fill() {
+        const FRAME_LEN: u64 = 1;
+        let (mut stream, limit) = create_stream_at_range_limit();
+
+        // Accumulate non-adjacent ranges up to the limit.
+        let offset = insert_nonadjacent_frames(&mut stream, 1, limit, FRAME_LEN);
+        assert!(!stream.data_ready(), "stream must not be readable");
+
+        // Filling every gap coalesces these ranges into a single one.
+        let filler = vec![0u8; expect_usize(offset)];
+        stream.inbound_stream_frame(false, 0, &filler).unwrap();
+        assert_eq!(stream.split_ranges(), 1);
+
+        // The stream must now accept `limit - 1` additional non-adjacent ranges.
+        let next_offset = insert_nonadjacent_frames(&mut stream, offset + 1, limit - 1, FRAME_LEN);
+        assert_eq!(to_u64(stream.split_ranges()), limit);
+
+        // One more range must still be rejected.
+        assert_eq!(
+            stream.inbound_stream_frame(false, next_offset, &[0u8]),
+            Err(Error::ProtocolViolation)
+        );
+    }
+
+    /// Purely in-order data must not be mistaken for a fragmentation attack.
+    #[test]
+    fn accept_all_adjacent_data() {
+        const FRAME_LEN: usize = RxStreamOrderer::RANGE_TARGET;
+        let ranges = RxStreamOrderer::MAX_SPLIT_RANGES + 2;
+
+        // Window large enough to buffer every (unread) byte of adjacent data, so that
+        // flow control never fires and only the fragmentation check is exercised.
+        let window = to_u64((ranges + 1) * FRAME_LEN);
+        let session_fc = Rc::new(RefCell::new(ReceiverFlowControl::new((), window)));
+        let mut stream = create_stream_with_fc(Rc::clone(&session_fc), window);
+
+        let payload = vec![0u8; FRAME_LEN];
+        for i in 0..ranges {
+            let offset = to_u64(i * FRAME_LEN);
+            assert_eq!(stream.inbound_stream_frame(false, offset, &payload), Ok(()));
+        }
+
+        let raw_entries = stream.state.recv_buf().unwrap().data_ranges.len();
+        assert!(raw_entries > RxStreamOrderer::MAX_SPLIT_RANGES);
+        assert_eq!(stream.split_ranges(), 1);
+        assert!(stream.data_ready(), "in-order data must be readable");
+    }
+
+    #[test]
+    fn split_ranges_reduced_after_read() {
+        const N: usize = 5;
+        let mut s = RxStreamOrderer::default();
+        for i in 0..N {
+            let offset = to_u64(i * RxStreamOrderer::RANGE_TARGET);
+            s.inbound_frame(offset, &[0u8; RxStreamOrderer::RANGE_TARGET]);
+        }
+        assert_eq!(s.data_ranges.len(), N, "one entry per RANGE_TARGET chunk");
+        assert_eq!(s.split_ranges(), 1);
+        // All but the first entry are credited.
+        assert_eq!(s.split_ranges, N - 1);
+
+        // Drain everything.
+        let mut buf = vec![0u8; N * RxStreamOrderer::RANGE_TARGET];
+        let read = s.read(&mut buf);
+        assert_eq!(read, N * RxStreamOrderer::RANGE_TARGET);
+        assert!(s.data_ranges.is_empty());
+        assert_eq!(s.split_ranges, 0);
+    }
+
+    #[test]
+    fn split_ranges_reduced_after_discard_after() {
+        const N: usize = 5;
+        let mut s = RxStreamOrderer::default();
+        for i in 0..N {
+            let offset = to_u64(i * RxStreamOrderer::RANGE_TARGET);
+            s.inbound_frame(offset, &[0u8; RxStreamOrderer::RANGE_TARGET]);
+        }
+        assert_eq!(s.split_ranges, N - 1);
+
+        // Discard the last three chunks and verify correct accounting.
+        s.discard_after(to_u64(2 * RxStreamOrderer::RANGE_TARGET));
+        assert_eq!(s.data_ranges.len(), 2);
+        assert_eq!(s.split_ranges, N - 4);
+    }
+
+    #[test]
+    fn split_ranges_reduced_after_overlap_removal() {
+        let mut s = RxStreamOrderer::default();
+        // The first insert splits nothing.
+        s.inbound_frame(0, &[0u8; 1]);
+        assert_eq!(s.split_ranges, 0);
+
+        // Two later, non-adjacent inserts: not credited.
+        s.inbound_frame(10, &[0u8; 1]);
+        s.inbound_frame(20, &[0u8; 1]);
+        assert_eq!(s.data_ranges.len(), 3);
+        assert_eq!(s.split_ranges, 0);
+
+        // An overlapping frame spanning [0, 20) entirely swallows the entry at 10
+        // (via the `to_remove` path) and extends the entry at 0; the entry at 20
+        // survives untouched. Net effect: one entry disappears.
+        s.inbound_frame(0, &[0u8; 20]);
+        assert_eq!(s.data_ranges.len(), 2, "entry at 10 was fully absorbed");
+
+        // One credit back for the absorbed entry, one earned for closing the gap at 20.
+        assert_eq!(s.split_ranges, 1);
+        assert_eq!(s.data_ranges.len() - s.split_ranges, s.split_ranges());
+    }
+
+    /// A contiguous run assembled by filling a gap must not consume the gap budget.
+    #[test]
+    fn credit_gap_fill_that_continues_a_full_range() {
+        let target = to_u64(RxStreamOrderer::RANGE_TARGET);
+        let payload = vec![0u8; RxStreamOrderer::RANGE_TARGET];
+        let mut s = RxStreamOrderer::default();
+
+        // A full range, a gap, then the frame that fills the gap.
+        s.inbound_frame(0, &payload);
+        s.inbound_frame(2 * target, &payload);
+        s.inbound_frame(target, &payload);
+
+        assert_eq!(s.data_ranges.len(), 3, "one entry per RANGE_TARGET chunk");
+        assert_eq!(s.split_ranges(), 1, "all of it is one contiguous run");
+        // The filling entry continues the first range and closes the gap before the last.
+        assert_eq!(s.split_ranges, 2);
+        assert_eq!(s.data_ranges.len() - s.split_ranges, s.split_ranges());
+        assert!(!s.overly_fragmented());
     }
 
     #[test]

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -238,41 +238,41 @@ impl RxStreamOrderer {
             return;
         }
 
-        // Common case: new_start >= end
-        if new_start >= self.end {
-            debug_assert_eq!(
-                self.end,
-                self.data_ranges
-                    .last_key_value()
-                    .map_or(self.retired, |(&k, v)| k + to_u64(v.len())),
-                "end must equal the end of the last range, or retired if empty"
-            );
-            self.received += to_u64(new_data.len());
-            // Adjacent: extend the last entry to avoid a BTreeMap insert, if small enough.
-            // Checks existing length, so the stored chunk may grow slightly past RANGE_TARGET
-            // (by up to one frame). Gap (new_start > end): falls through to insert.
-            let adjacent = new_start == self.end;
-            if adjacent
-                && let Some(mut e) = self
-                    .data_ranges
-                    .last_entry()
-                    .filter(|e| e.get().len() < Self::RANGE_TARGET)
-            {
-                e.get_mut().extend_from_slice(new_data);
-            } else {
-                // A new entry only because the existing one hit RANGE_TARGET; not a gap.
-                let continues_previous = adjacent && !self.data_ranges.is_empty();
-                self.data_ranges.insert(new_start, new_data.to_vec());
-                if continues_previous {
-                    self.split_ranges += 1;
-                }
-            }
-            // new_end > new_start >= end, so direct assignment is correct.
-            self.end = new_end;
+        if new_start < self.end {
+            self.inbound_overlapping(new_start, new_data, new_end);
             return;
         }
 
-        self.inbound_overlapping(new_start, new_data, new_end);
+        // Common case: new_start >= end
+        debug_assert_eq!(
+            self.end,
+            self.data_ranges
+                .last_key_value()
+                .map_or(self.retired, |(&k, v)| k + to_u64(v.len())),
+            "end must equal the end of the last range, or retired if empty"
+        );
+        self.received += to_u64(new_data.len());
+        // Adjacent: extend the last entry to avoid a BTreeMap insert, if small enough.
+        // Checks existing length, so the stored chunk may grow slightly past RANGE_TARGET
+        // (by up to one frame). Gap (new_start > end): falls through to insert.
+        let adjacent = new_start == self.end;
+        if adjacent
+            && let Some(mut e) = self
+                .data_ranges
+                .last_entry()
+                .filter(|e| e.get().len() < Self::RANGE_TARGET)
+        {
+            e.get_mut().extend_from_slice(new_data);
+        } else {
+            // A new entry only because the existing one hit RANGE_TARGET; not a gap.
+            let continues_previous = adjacent && !self.data_ranges.is_empty();
+            self.data_ranges.insert(new_start, new_data.to_vec());
+            if continues_previous {
+                self.split_ranges += 1;
+            }
+        }
+        // new_end > new_start >= end, so direct assignment is correct.
+        self.end = new_end;
     }
 
     /// Handle a frame that overlaps data we already hold, i.e. `new_start < self.end`.
@@ -285,23 +285,7 @@ impl RxStreamOrderer {
             self.data_ranges.range_mut(..=new_start).next_back()
         {
             let prev_end = prev_start + to_u64(prev_vec.len());
-            if new_end > prev_end {
-                // PPPPPP    ->  PPPPPP
-                //   NNNNNN            NN
-                // NNNNNNNN            NN
-                // Add a range containing only new data
-                let overlap = prev_end.saturating_sub(new_start);
-                qtrace!("New frame {new_start}-{new_end} received, overlap: {overlap}");
-                new_start += overlap;
-                // This conversion is guaranteed to work because the overlap cannot exceed
-                // the size of the new data, which has to fit in usize.
-                new_data = &new_data[expect_usize(overlap)..];
-                // If it is small enough, extend the previous buffer.
-                // Checks existing length, so the chunk may grow slightly past RANGE_TARGET (by up
-                // to one frame). This can't always extend, because otherwise the
-                // buffer could end up growing indefinitely without being released.
-                prev_vec.len() < Self::RANGE_TARGET && prev_end == new_start
-            } else {
+            if new_end <= prev_end {
                 // PPPPPP    ->  PPPPPP
                 //   NNNN
                 // NNNN
@@ -309,6 +293,21 @@ impl RxStreamOrderer {
                 qtrace!("Dropping frame with already-received range {new_start}-{new_end}");
                 return;
             }
+            // PPPPPP    ->  PPPPPP
+            //   NNNNNN            NN
+            // NNNNNNNN            NN
+            // Add a range containing only new data
+            let overlap = prev_end.saturating_sub(new_start);
+            qtrace!("New frame {new_start}-{new_end} received, overlap: {overlap}");
+            new_start += overlap;
+            // This conversion is guaranteed to work because the overlap cannot exceed
+            // the size of the new data, which has to fit in usize.
+            new_data = &new_data[expect_usize(overlap)..];
+            // If it is small enough, extend the previous buffer.
+            // Checks existing length, so the chunk may grow slightly past RANGE_TARGET (by up
+            // to one frame). This can't always extend, because otherwise the
+            // buffer could end up growing indefinitely without being released.
+            prev_vec.len() < Self::RANGE_TARGET && prev_end == new_start
         } else {
             qtrace!("New frame {new_start}-{new_end} received");
             false
@@ -369,38 +368,40 @@ impl RxStreamOrderer {
             });
         }
 
-        if !to_add.is_empty() {
-            self.received += to_u64(to_add.len());
-            // Credit each side this joins up with, so the count tracks gaps, not entries.
-            let add_end = new_start + to_u64(to_add.len());
-            let joins_next = self
-                .data_ranges
-                .range(add_end..)
-                .next()
-                .is_some_and(|(&start, _)| start == add_end);
-            if extend {
-                if let Some((_, buf)) = self.data_ranges.range_mut(..=new_start).next_back() {
-                    buf.extend_from_slice(to_add);
-                }
-            } else {
-                let continues_previous = self
-                    .data_ranges
-                    .range(..new_start)
-                    .next_back()
-                    .is_some_and(|(&start, data)| start + to_u64(data.len()) == new_start);
-                self.data_ranges.insert(new_start, to_add.to_vec());
-                if continues_previous {
-                    self.split_ranges += 1;
-                }
+        if to_add.is_empty() {
+            // A surviving forward entry with next_end >= new_end exists, so self.end is
+            // already correct.
+            return;
+        }
+
+        self.received += to_u64(to_add.len());
+        // Credit each side this joins up with, so the count tracks gaps, not entries.
+        let add_end = new_start + to_u64(to_add.len());
+        let joins_next = self
+            .data_ranges
+            .range(add_end..)
+            .next()
+            .is_some_and(|(&start, _)| start == add_end);
+        if extend {
+            if let Some((_, buf)) = self.data_ranges.range_mut(..=new_start).next_back() {
+                buf.extend_from_slice(to_add);
             }
-            if joins_next {
+        } else {
+            let continues_previous = self
+                .data_ranges
+                .range(..new_start)
+                .next_back()
+                .is_some_and(|(&start, data)| start + to_u64(data.len()) == new_start);
+            self.data_ranges.insert(new_start, to_add.to_vec());
+            if continues_previous {
                 self.split_ranges += 1;
             }
-            // new_start was advanced by overlap, so new_end is still the real end.
-            // When to_add is empty, a surviving forward entry with next_end >= new_end
-            // exists, so self.end is already correct — the max() is a no-op in that case.
-            self.end = max(self.end, new_end);
         }
+        if joins_next {
+            self.split_ranges += 1;
+        }
+        // new_start was advanced by overlap, so new_end is still the real end.
+        self.end = max(self.end, new_end);
     }
 
     /// Whether we buffer more than `MAX_SPLIT_RANGES` non-adjacent ranges.
@@ -819,6 +820,11 @@ impl RecvStream {
         }
     }
 
+    /// Whether every byte the peer sent is now buffered, i.e. there are no gaps left.
+    fn all_received(fc: &ReceiverFlowControl<StreamId>, recv_buf: &RxStreamOrderer) -> bool {
+        fc.consumed() == recv_buf.retired() + to_u64(recv_buf.bytes_ready())
+    }
+
     /// # Errors
     /// When the incoming data violates flow control limits, or
     /// [`Error::ProtocolViolation`] when it pushes the stream past `MAX_SPLIT_RANGES`
@@ -842,24 +848,23 @@ impl RecvStream {
             } => {
                 recv_buf.inbound_frame(offset, data);
                 if fin {
-                    let all_recv =
-                        fc.consumed() == recv_buf.retired() + to_u64(recv_buf.bytes_ready());
-                    let buf = mem::replace(recv_buf, RxStreamOrderer::new());
-                    let fc_copy = mem::take(fc);
-                    let session_fc_copy = mem::take(session_fc);
-                    if all_recv {
-                        self.set_state(RecvStreamState::DataRecvd {
-                            fc: fc_copy,
-                            session_fc: session_fc_copy,
-                            recv_buf: buf,
-                        });
+                    let all_recv = Self::all_received(fc, recv_buf);
+                    let fc = mem::take(fc);
+                    let session_fc = mem::take(session_fc);
+                    let recv_buf = mem::replace(recv_buf, RxStreamOrderer::new());
+                    self.set_state(if all_recv {
+                        RecvStreamState::DataRecvd {
+                            fc,
+                            session_fc,
+                            recv_buf,
+                        }
                     } else {
-                        self.set_state(RecvStreamState::SizeKnown {
-                            fc: fc_copy,
-                            session_fc: session_fc_copy,
-                            recv_buf: buf,
-                        });
-                    }
+                        RecvStreamState::SizeKnown {
+                            fc,
+                            session_fc,
+                            recv_buf,
+                        }
+                    });
                 }
             }
             RecvStreamState::SizeKnown {
@@ -868,14 +873,14 @@ impl RecvStream {
                 session_fc,
             } => {
                 recv_buf.inbound_frame(offset, data);
-                if fc.consumed() == recv_buf.retired() + to_u64(recv_buf.bytes_ready()) {
-                    let buf = mem::replace(recv_buf, RxStreamOrderer::new());
-                    let fc_copy = mem::take(fc);
-                    let session_fc_copy = mem::take(session_fc);
+                if Self::all_received(fc, recv_buf) {
+                    let fc = mem::take(fc);
+                    let session_fc = mem::take(session_fc);
+                    let recv_buf = mem::replace(recv_buf, RxStreamOrderer::new());
                     self.set_state(RecvStreamState::DataRecvd {
-                        fc: fc_copy,
-                        session_fc: session_fc_copy,
-                        recv_buf: buf,
+                        fc,
+                        session_fc,
+                        recv_buf,
                     });
                 }
             }

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -211,10 +211,12 @@ impl RxStreamOrderer {
     /// Process an incoming stream frame off the wire. This may result in data
     /// being available to upper layers if frame is not out of order (ooo) or
     /// if the frame fills a gap.
+    /// # Errors
+    /// `ProtocolViolation` if this pushes buffered non-adjacent ranges over `MAX_SPLIT_RANGES`.
     /// # Panics
     /// Only when `u64` values cannot be converted to `usize`, which only
     /// happens on 32-bit machines that hold far too much data at the same time.
-    pub fn inbound_frame(&mut self, mut new_start: u64, mut new_data: &[u8]) {
+    pub fn inbound_frame(&mut self, mut new_start: u64, mut new_data: &[u8]) -> Res<()> {
         qtrace!("Inbound data offset={new_start} len={}", new_data.len());
 
         // Get entry before where new entry would go, so we can see if we already
@@ -224,7 +226,7 @@ impl RxStreamOrderer {
 
         if new_end <= self.retired {
             // Range already read by application, this frame is very late and unneeded.
-            return;
+            return Ok(());
         }
 
         if new_start < self.retired {
@@ -235,12 +237,11 @@ impl RxStreamOrderer {
 
         if new_data.is_empty() {
             // No data to insert
-            return;
+            return Ok(());
         }
 
         if new_start < self.end {
-            self.inbound_overlapping(new_start, new_data, new_end);
-            return;
+            return self.inbound_overlapping(new_start, new_data, new_end);
         }
 
         // Common case: new_start >= end
@@ -255,8 +256,7 @@ impl RxStreamOrderer {
         // Adjacent: extend the last entry to avoid a BTreeMap insert, if small enough.
         // Checks existing length, so the stored chunk may grow slightly past RANGE_TARGET
         // (by up to one frame). Gap (new_start > end): falls through to insert.
-        let adjacent = new_start == self.end;
-        if adjacent
+        if new_start == self.end
             && let Some(mut e) = self
                 .data_ranges
                 .last_entry()
@@ -264,8 +264,9 @@ impl RxStreamOrderer {
         {
             e.get_mut().extend_from_slice(new_data);
         } else {
-            // A new entry only because the existing one hit RANGE_TARGET; not a gap.
-            let continues_previous = adjacent && !self.data_ranges.is_empty();
+            // The last range ends exactly at `self.end` and nothing starts in between, so a
+            // gap here means no range ends at `new_start`.
+            let continues_previous = new_start == self.end && !self.data_ranges.is_empty();
             self.data_ranges.insert(new_start, new_data.to_vec());
             if continues_previous {
                 self.split_ranges += 1;
@@ -273,6 +274,7 @@ impl RxStreamOrderer {
         }
         // new_end > new_start >= end, so direct assignment is correct.
         self.end = new_end;
+        self.check_split_limit()
     }
 
     /// Handle a frame that overlaps data we already hold, i.e. `new_start < self.end`.
@@ -280,8 +282,13 @@ impl RxStreamOrderer {
     /// # Panics
     /// Only when `u64` values cannot be converted to `usize`, which only
     /// happens on 32-bit machines that hold far too much data at the same time.
-    fn inbound_overlapping(&mut self, mut new_start: u64, mut new_data: &[u8], new_end: u64) {
-        let extend = if let Some((&prev_start, prev_vec)) =
+    fn inbound_overlapping(
+        &mut self,
+        mut new_start: u64,
+        mut new_data: &[u8],
+        new_end: u64,
+    ) -> Res<()> {
+        let (extend, continues_previous) = if let Some((&prev_start, prev_vec)) =
             self.data_ranges.range_mut(..=new_start).next_back()
         {
             let prev_end = prev_start + to_u64(prev_vec.len());
@@ -291,7 +298,7 @@ impl RxStreamOrderer {
                 // NNNN
                 // Do nothing
                 qtrace!("Dropping frame with already-received range {new_start}-{new_end}");
-                return;
+                return Ok(());
             }
             // PPPPPP    ->  PPPPPP
             //   NNNNNN            NN
@@ -307,10 +314,11 @@ impl RxStreamOrderer {
             // Checks existing length, so the chunk may grow slightly past RANGE_TARGET (by up
             // to one frame). This can't always extend, because otherwise the
             // buffer could end up growing indefinitely without being released.
-            prev_vec.len() < Self::RANGE_TARGET && prev_end == new_start
+            let adjacent = prev_end == new_start;
+            (prev_vec.len() < Self::RANGE_TARGET && adjacent, adjacent)
         } else {
             qtrace!("New frame {new_start}-{new_end} received");
-            false
+            (false, false)
         };
 
         let mut to_add = new_data;
@@ -369,44 +377,35 @@ impl RxStreamOrderer {
         }
 
         if to_add.is_empty() {
-            // A surviving forward entry with next_end >= new_end exists, so self.end is
-            // already correct.
-            return;
+            // A surviving forward entry with next_end >= new_end exists, so self.end is already
+            // correct. Nothing was added, so the limit cannot have been crossed.
+            return Ok(());
         }
 
         self.received += to_u64(to_add.len());
-        // Credit each side this joins up with, so the count tracks gaps, not entries.
-        let add_end = new_start + to_u64(to_add.len());
-        let joins_next = self
-            .data_ranges
-            .range(add_end..)
-            .next()
-            .is_some_and(|(&start, _)| start == add_end);
         if extend {
             if let Some((_, buf)) = self.data_ranges.range_mut(..=new_start).next_back() {
                 buf.extend_from_slice(to_add);
             }
         } else {
-            let continues_previous = self
-                .data_ranges
-                .range(..new_start)
-                .next_back()
-                .is_some_and(|(&start, data)| start + to_u64(data.len()) == new_start);
             self.data_ranges.insert(new_start, to_add.to_vec());
             if continues_previous {
                 self.split_ranges += 1;
             }
         }
-        if joins_next {
-            self.split_ranges += 1;
-        }
         // new_start was advanced by overlap, so new_end is still the real end.
         self.end = max(self.end, new_end);
+
+        self.check_split_limit()
     }
 
-    /// Whether we buffer more than `MAX_SPLIT_RANGES` non-adjacent ranges.
-    pub(crate) fn overly_fragmented(&self) -> bool {
-        self.data_ranges.len() > Self::MAX_SPLIT_RANGES + self.split_ranges
+    /// Checks the `MAX_SPLIT_RANGES` limit.
+    fn check_split_limit(&self) -> Res<()> {
+        if self.data_ranges.len() > Self::MAX_SPLIT_RANGES + self.split_ranges {
+            qwarn!("Excessive non-adjacent reassembly ranges, closing connection");
+            return Err(Error::ProtocolViolation);
+        }
+        Ok(())
     }
 
     /// Are any bytes readable?
@@ -846,7 +845,7 @@ impl RecvStream {
                 fc,
                 session_fc,
             } => {
-                recv_buf.inbound_frame(offset, data);
+                recv_buf.inbound_frame(offset, data)?;
                 if fin {
                     let all_recv = Self::all_received(fc, recv_buf);
                     let fc = mem::take(fc);
@@ -872,7 +871,7 @@ impl RecvStream {
                 fc,
                 session_fc,
             } => {
-                recv_buf.inbound_frame(offset, data);
+                recv_buf.inbound_frame(offset, data)?;
                 if Self::all_received(fc, recv_buf) {
                     let fc = mem::take(fc);
                     let session_fc = mem::take(session_fc);
@@ -894,7 +893,7 @@ impl RecvStream {
                 let keep = reliable_size.saturating_sub(offset);
                 if keep > 0 {
                     let keep = min(data.len(), usize::try_from(keep)?);
-                    recv_buf.inbound_frame(offset, &data[..keep]);
+                    recv_buf.inbound_frame(offset, &data[..keep])?;
                 }
             }
             RecvStreamState::DataRecvd { .. }
@@ -904,19 +903,6 @@ impl RecvStream {
             | RecvStreamState::ResetRecvd { .. } => {
                 qtrace!("data received when we are in state {}", self.state);
             }
-        }
-
-        // Don't let a peer pin memory by forcing us to buffer many non-adjacent ranges.
-        if self
-            .state
-            .recv_buf()
-            .is_some_and(RxStreamOrderer::overly_fragmented)
-        {
-            qwarn!(
-                "Excessive non-adjacent STREAM ranges on {}, closing connection",
-                self.stream_id
-            );
-            return Err(Error::ProtocolViolation);
         }
 
         if !already_data_ready && (self.data_ready() || self.needs_to_inform_app_about_fin()) {
@@ -1425,7 +1411,9 @@ mod tests {
         let mut s = RxStreamOrderer::default();
         for r in ranges {
             let data = &ZEROES[..expect_usize(r.end - r.start)];
-            s.inbound_frame(r.start, data);
+            s.inbound_frame(r.start, data).unwrap();
+            // The credit must never make the limit more permissive than the real run count.
+            assert!(s.split_ranges + s.split_ranges() <= s.data_ranges.len());
         }
 
         let mut buf = [0xff; 100];
@@ -1433,6 +1421,8 @@ mod tests {
         loop {
             let recvd = s.read(&mut buf[..]);
             qtrace!("recv_ranges read {recvd}");
+            // The credit must survive removals without becoming permissive.
+            assert!(s.split_ranges + s.split_ranges() <= s.data_ranges.len());
             total_recvd += recvd;
             if recvd == 0 {
                 assert_eq!(total_recvd, available);
@@ -1446,10 +1436,10 @@ mod tests {
     fn inbound_frame_no_extend_at_4096() {
         let mut s = RxStreamOrderer::default();
         // Fill to the extend threshold.
-        s.inbound_frame(0, &[0u8; 4096]);
+        s.inbound_frame(0, &[0u8; 4096]).unwrap();
         assert_eq!(s.data_ranges[&0].len(), 4096);
         // The next byte must not be merged; the threshold has been reached.
-        s.inbound_frame(4096, &[1u8]);
+        s.inbound_frame(4096, &[1u8]).unwrap();
         assert_eq!(
             s.data_ranges.len(),
             2,
@@ -1461,8 +1451,8 @@ mod tests {
     #[test]
     fn inbound_frame_extends_below_4096() {
         let mut s = RxStreamOrderer::default();
-        s.inbound_frame(0, &[0u8; 4095]);
-        s.inbound_frame(4095, &[1u8]);
+        s.inbound_frame(0, &[0u8; 4095]).unwrap();
+        s.inbound_frame(4095, &[1u8]).unwrap();
         assert_eq!(s.data_ranges.len(), 1);
         assert_eq!(s.data_ranges[&0].len(), 4096);
     }
@@ -1471,8 +1461,8 @@ mod tests {
     #[test]
     fn read_exact_available_removes_range() {
         let mut s = RxStreamOrderer::default();
-        s.inbound_frame(0, &[1u8; 5]);
-        s.inbound_frame(5, &[2u8; 5]);
+        s.inbound_frame(0, &[1u8; 5]).unwrap();
+        s.inbound_frame(5, &[2u8; 5]).unwrap();
 
         let mut buf = [0u8; 5];
         assert_eq!(s.read(&mut buf), 5);
@@ -1597,11 +1587,11 @@ mod tests {
         let mut s = RxStreamOrderer::new();
 
         // Add three chunks.
-        s.inbound_frame(0, &[0; CHUNK_SIZE]);
+        s.inbound_frame(0, &[0; CHUNK_SIZE]).unwrap();
         let offset = to_u64(CHUNK_SIZE);
-        s.inbound_frame(offset, &[0; EXTRA_SIZE]);
+        s.inbound_frame(offset, &[0; EXTRA_SIZE]).unwrap();
         let offset = to_u64(CHUNK_SIZE + EXTRA_SIZE);
-        s.inbound_frame(offset, &[0; EXTRA_SIZE]);
+        s.inbound_frame(offset, &[0; EXTRA_SIZE]).unwrap();
 
         // Read, providing only enough space for the first.
         let mut buf = [0; 100];
@@ -1616,7 +1606,7 @@ mod tests {
         let mut s = RxStreamOrderer::new();
 
         // Add a chunk
-        s.inbound_frame(0, &[0; 150]);
+        s.inbound_frame(0, &[0; 150]).unwrap();
         assert_eq!(s.data_ranges[&0].len(), 150);
         // Read, providing only enough space for the first 100.
         let mut buf = [0; 100];
@@ -1627,7 +1617,7 @@ mod tests {
         // Add a second frame that overlaps.
         // This shouldn't truncate the first frame, as we're already
         // Reading from it.
-        s.inbound_frame(120, &[0; 60]);
+        s.inbound_frame(120, &[0; 60]).unwrap();
         assert_eq!(s.data_ranges[&0].len(), 180);
         // Read second part of first frame and all of the second frame
         let count = s.read(&mut buf[..]);
@@ -1642,9 +1632,9 @@ mod tests {
         let mut s = RxStreamOrderer::new();
 
         // Add three chunks.
-        s.inbound_frame(0, &[0; CHUNK_SIZE]);
+        s.inbound_frame(0, &[0; CHUNK_SIZE]).unwrap();
         let offset = to_u64(CHUNK_SIZE + EXTRA_SIZE);
-        s.inbound_frame(offset, &[0; EXTRA_SIZE]);
+        s.inbound_frame(offset, &[0; EXTRA_SIZE]).unwrap();
 
         // Read, providing only enough space for the first chunk.
         let mut buf = [0; 100];
@@ -1653,7 +1643,7 @@ mod tests {
 
         // Now fill the gap and ensure that everything can be read.
         let offset = to_u64(CHUNK_SIZE);
-        s.inbound_frame(offset, &[0; EXTRA_SIZE]);
+        s.inbound_frame(offset, &[0; EXTRA_SIZE]).unwrap();
         let count = s.read(&mut buf[..]);
         assert_eq!(count, EXTRA_SIZE * 2);
     }
@@ -1666,9 +1656,9 @@ mod tests {
         let mut s = RxStreamOrderer::new();
 
         // Add two chunks.
-        s.inbound_frame(0, &[0; CHUNK_SIZE]);
+        s.inbound_frame(0, &[0; CHUNK_SIZE]).unwrap();
         let offset = to_u64(CHUNK_SIZE);
-        s.inbound_frame(offset, &[0; EXTRA_SIZE]);
+        s.inbound_frame(offset, &[0; EXTRA_SIZE]).unwrap();
 
         // Read, providing only enough space for some of the first chunk.
         let mut buf = [0; 100];
@@ -1687,9 +1677,9 @@ mod tests {
         let mut s = RxStreamOrderer::new();
 
         // Add two chunks.
-        s.inbound_frame(0, &[0; CHUNK_SIZE]);
+        s.inbound_frame(0, &[0; CHUNK_SIZE]).unwrap();
         let offset = to_u64(CHUNK_SIZE);
-        s.inbound_frame(offset, &[0; EXTRA_SIZE]);
+        s.inbound_frame(offset, &[0; EXTRA_SIZE]).unwrap();
 
         let mut buf = [0; 1];
         for _ in 0..CHUNK_SIZE + EXTRA_SIZE {
@@ -1787,27 +1777,27 @@ mod tests {
     fn stream_rx_dedupe_tail() {
         let mut s = RxStreamOrderer::new();
 
-        s.inbound_frame(0, &[1; 6]);
+        s.inbound_frame(0, &[1; 6]).unwrap();
         check_chunks(&s, &[(0, 6)]);
 
         // New data that overlaps entirely (starting from the head), is ignored.
-        s.inbound_frame(0, &[2; 3]);
+        s.inbound_frame(0, &[2; 3]).unwrap();
         check_chunks(&s, &[(0, 6)]);
 
         // New data that overlaps at the tail has any new data appended.
-        s.inbound_frame(2, &[3; 6]);
+        s.inbound_frame(2, &[3; 6]).unwrap();
         check_chunks(&s, &[(0, 8)]);
 
         // New data that overlaps entirely (up to the tail), is ignored.
-        s.inbound_frame(4, &[4; 4]);
+        s.inbound_frame(4, &[4; 4]).unwrap();
         check_chunks(&s, &[(0, 8)]);
 
         // New data that overlaps, starting from the beginning is appended too.
-        s.inbound_frame(0, &[5; 10]);
+        s.inbound_frame(0, &[5; 10]).unwrap();
         check_chunks(&s, &[(0, 10)]);
 
         // New data that is entirely subsumed is ignored.
-        s.inbound_frame(2, &[6; 2]);
+        s.inbound_frame(2, &[6; 2]).unwrap();
         check_chunks(&s, &[(0, 10)]);
 
         let mut buf = [0; 16];
@@ -1820,15 +1810,15 @@ mod tests {
     fn stream_rx_dedupe_head() {
         let mut s = RxStreamOrderer::new();
 
-        s.inbound_frame(1, &[6; 6]);
+        s.inbound_frame(1, &[6; 6]).unwrap();
         check_chunks(&s, &[(1, 6)]);
 
         // Insertion before an existing chunk causes truncation of the new chunk.
-        s.inbound_frame(0, &[7; 6]);
+        s.inbound_frame(0, &[7; 6]).unwrap();
         check_chunks(&s, &[(0, 1), (1, 6)]);
 
         // Perfect overlap with existing slices has no effect.
-        s.inbound_frame(0, &[8; 7]);
+        s.inbound_frame(0, &[8; 7]).unwrap();
         check_chunks(&s, &[(0, 1), (1, 6)]);
 
         let mut buf = [0; 16];
@@ -1840,16 +1830,16 @@ mod tests {
     fn stream_rx_dedupe_new_tail() {
         let mut s = RxStreamOrderer::new();
 
-        s.inbound_frame(1, &[6; 6]);
+        s.inbound_frame(1, &[6; 6]).unwrap();
         check_chunks(&s, &[(1, 6)]);
 
         // Insertion before an existing chunk causes truncation of the new chunk.
-        s.inbound_frame(0, &[7; 6]);
+        s.inbound_frame(0, &[7; 6]).unwrap();
         check_chunks(&s, &[(0, 1), (1, 6)]);
 
         // New data at the end causes the tail to be added to the first chunk,
         // replacing later chunks entirely.
-        s.inbound_frame(0, &[9; 8]);
+        s.inbound_frame(0, &[9; 8]).unwrap();
         check_chunks(&s, &[(0, 8)]);
 
         let mut buf = [0; 16];
@@ -1861,15 +1851,15 @@ mod tests {
     fn stream_rx_dedupe_replace() {
         let mut s = RxStreamOrderer::new();
 
-        s.inbound_frame(2, &[6; 6]);
+        s.inbound_frame(2, &[6; 6]).unwrap();
         check_chunks(&s, &[(2, 6)]);
 
         // Insertion before an existing chunk causes truncation of the new chunk.
-        s.inbound_frame(1, &[7; 6]);
+        s.inbound_frame(1, &[7; 6]).unwrap();
         check_chunks(&s, &[(1, 1), (2, 6)]);
 
         // New data at the start and end replaces all the slices.
-        s.inbound_frame(0, &[9; 10]);
+        s.inbound_frame(0, &[9; 10]).unwrap();
         check_chunks(&s, &[(0, 10)]);
 
         let mut buf = [0; 16];
@@ -1882,14 +1872,14 @@ mod tests {
         let mut s = RxStreamOrderer::new();
 
         let mut buf = [0; 18];
-        s.inbound_frame(0, &[1; 10]);
+        s.inbound_frame(0, &[1; 10]).unwrap();
 
         // Partially read slices are retained.
         assert_eq!(s.read(&mut buf[..6]), 6);
         check_chunks(&s, &[(0, 10)]);
 
         // Partially read slices are kept and so are added to.
-        s.inbound_frame(3, &buf[..10]);
+        s.inbound_frame(3, &buf[..10]).unwrap();
         check_chunks(&s, &[(0, 13)]);
 
         // Wholly read pieces are dropped.
@@ -1897,7 +1887,7 @@ mod tests {
         assert!(s.data_ranges.is_empty());
 
         // New data that overlaps with retired data is trimmed.
-        s.inbound_frame(0, &buf[..]);
+        s.inbound_frame(0, &buf[..]).unwrap();
         check_chunks(&s, &[(13, 5)]);
     }
 
@@ -2057,7 +2047,8 @@ mod tests {
         let mut s = RxStreamOrderer::default();
         for i in 0..N {
             let offset = to_u64(i * RxStreamOrderer::RANGE_TARGET);
-            s.inbound_frame(offset, &[0u8; RxStreamOrderer::RANGE_TARGET]);
+            s.inbound_frame(offset, &[0u8; RxStreamOrderer::RANGE_TARGET])
+                .unwrap();
         }
         assert_eq!(s.data_ranges.len(), N, "one entry per RANGE_TARGET chunk");
         assert_eq!(s.split_ranges(), 1);
@@ -2078,7 +2069,8 @@ mod tests {
         let mut s = RxStreamOrderer::default();
         for i in 0..N {
             let offset = to_u64(i * RxStreamOrderer::RANGE_TARGET);
-            s.inbound_frame(offset, &[0u8; RxStreamOrderer::RANGE_TARGET]);
+            s.inbound_frame(offset, &[0u8; RxStreamOrderer::RANGE_TARGET])
+                .unwrap();
         }
         assert_eq!(s.split_ranges, N - 1);
 
@@ -2092,24 +2084,24 @@ mod tests {
     fn split_ranges_reduced_after_overlap_removal() {
         let mut s = RxStreamOrderer::default();
         // The first insert splits nothing.
-        s.inbound_frame(0, &[0u8; 1]);
+        s.inbound_frame(0, &[0u8; 1]).unwrap();
         assert_eq!(s.split_ranges, 0);
 
         // Two later, non-adjacent inserts: not credited.
-        s.inbound_frame(10, &[0u8; 1]);
-        s.inbound_frame(20, &[0u8; 1]);
+        s.inbound_frame(10, &[0u8; 1]).unwrap();
+        s.inbound_frame(20, &[0u8; 1]).unwrap();
         assert_eq!(s.data_ranges.len(), 3);
         assert_eq!(s.split_ranges, 0);
 
         // An overlapping frame spanning [0, 20) entirely swallows the entry at 10
         // (via the `to_remove` path) and extends the entry at 0; the entry at 20
         // survives untouched. Net effect: one entry disappears.
-        s.inbound_frame(0, &[0u8; 20]);
+        s.inbound_frame(0, &[0u8; 20]).unwrap();
         assert_eq!(s.data_ranges.len(), 2, "entry at 10 was fully absorbed");
 
-        // One credit back for the absorbed entry, one earned for closing the gap at 20.
-        assert_eq!(s.split_ranges, 1);
-        assert_eq!(s.data_ranges.len() - s.split_ranges, s.split_ranges());
+        // Nothing here was ever credited, so there is no credit to give back.
+        assert_eq!(s.split_ranges, 0);
+        assert!(s.split_ranges + s.split_ranges() <= s.data_ranges.len());
     }
 
     /// A contiguous run assembled by filling a gap must not consume the gap budget.
@@ -2120,23 +2112,24 @@ mod tests {
         let mut s = RxStreamOrderer::default();
 
         // A full range, a gap, then the frame that fills the gap.
-        s.inbound_frame(0, &payload);
-        s.inbound_frame(2 * target, &payload);
-        s.inbound_frame(target, &payload);
+        s.inbound_frame(0, &payload).unwrap();
+        s.inbound_frame(2 * target, &payload).unwrap();
+        s.inbound_frame(target, &payload).unwrap();
 
         assert_eq!(s.data_ranges.len(), 3, "one entry per RANGE_TARGET chunk");
         assert_eq!(s.split_ranges(), 1, "all of it is one contiguous run");
-        // The filling entry continues the first range and closes the gap before the last.
-        assert_eq!(s.split_ranges, 2);
-        assert_eq!(s.data_ranges.len() - s.split_ranges, s.split_ranges());
-        assert!(!s.overly_fragmented());
+        // The filling entry continues the first range, so it is credited; the entry that
+        // started the far side of the gap is not, leaving the run charged for two ranges.
+        assert_eq!(s.split_ranges, 1);
+        assert!(s.split_ranges + s.split_ranges() <= s.data_ranges.len());
+        assert_eq!(s.check_split_limit(), Ok(()));
     }
 
     #[test]
     fn stream_orderer_bytes_ready() {
         let mut rx_ord = RxStreamOrderer::new();
 
-        rx_ord.inbound_frame(0, &[1; 6]);
+        rx_ord.inbound_frame(0, &[1; 6]).unwrap();
         assert_eq!(rx_ord.bytes_ready(), 6);
         assert_eq!(rx_ord.buffered(), 6);
         assert_eq!(rx_ord.retired(), 0);
@@ -2149,19 +2142,19 @@ mod tests {
         assert_eq!(rx_ord.retired(), 2);
 
         // an overlapping frame
-        rx_ord.inbound_frame(5, &[2; 6]);
+        rx_ord.inbound_frame(5, &[2; 6]).unwrap();
         assert_eq!(rx_ord.bytes_ready(), 9);
         assert_eq!(rx_ord.buffered(), 9);
         assert_eq!(rx_ord.retired(), 2);
 
         // a noncontig frame
-        rx_ord.inbound_frame(20, &[3; 6]);
+        rx_ord.inbound_frame(20, &[3; 6]).unwrap();
         assert_eq!(rx_ord.bytes_ready(), 9);
         assert_eq!(rx_ord.buffered(), 15);
         assert_eq!(rx_ord.retired(), 2);
 
         // an old frame
-        rx_ord.inbound_frame(0, &[4; 2]);
+        rx_ord.inbound_frame(0, &[4; 2]).unwrap();
         assert_eq!(rx_ord.bytes_ready(), 9);
         assert_eq!(rx_ord.buffered(), 15);
         assert_eq!(rx_ord.retired(), 2);
@@ -2924,7 +2917,7 @@ mod tests {
     #[test]
     fn orderer_discard_after() {
         let mut o = RxStreamOrderer::new();
-        o.inbound_frame(0, &[1; 10]);
+        o.inbound_frame(0, &[1; 10]).unwrap();
         o.discard_after(4);
         // Only `[0, 4)` remains readable.
         let mut buf = [0; 16];
@@ -2932,19 +2925,19 @@ mod tests {
 
         // A later frame entirely beyond the discard point still slots in correctly.
         let mut o = RxStreamOrderer::new();
-        o.inbound_frame(0, &[1; 4]);
-        o.inbound_frame(8, &[2; 4]); // gap at [4,8)
+        o.inbound_frame(0, &[1; 4]).unwrap();
+        o.inbound_frame(8, &[2; 4]).unwrap(); // gap at [4,8)
         o.discard_after(6); // drops [8,12), keeps [0,4)
-        o.inbound_frame(4, &[3; 2]); // fills [4,6)
+        o.inbound_frame(4, &[3; 2]).unwrap(); // fills [4,6)
         assert_eq!(o.read(&mut buf), 6);
 
         // The end marker is correctly maintained when the discard empties it out.
         let mut o = RxStreamOrderer::new();
-        o.inbound_frame(0, &[1; 4]);
+        o.inbound_frame(0, &[1; 4]).unwrap();
         assert_eq!(o.read(&mut buf), 4);
-        o.inbound_frame(8, &[2; 4]); // gap at [4,8)
+        o.inbound_frame(8, &[2; 4]).unwrap(); // gap at [4,8)
         o.discard_after(6); // drops [8,12), keeps [0,4)
-        o.inbound_frame(4, &[3; 2]); // fills [4,6)
+        o.inbound_frame(4, &[3; 2]).unwrap(); // fills [4,6)
         assert_eq!(o.read(&mut buf), 2);
     }
 

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -201,6 +201,9 @@ impl RxStreamOrderer {
     const RANGE_TARGET: usize = 4096;
 
     /// Maximum number of buffered ranges that are separated by a gap.
+    ///
+    /// Enforced against `data_ranges.len() - split_ranges`, which is an upper bound on the
+    /// number of gap-separated ranges, never an under-estimate.
     const MAX_SPLIT_RANGES: usize = 4096;
 
     #[must_use]
@@ -315,66 +318,60 @@ impl RxStreamOrderer {
             // to one frame). This can't always extend, because otherwise the
             // buffer could end up growing indefinitely without being released.
             let adjacent = prev_end == new_start;
-            (prev_vec.len() < Self::RANGE_TARGET && adjacent, adjacent)
+            (
+                (prev_vec.len() < Self::RANGE_TARGET && adjacent).then_some(prev_start),
+                adjacent,
+            )
         } else {
             qtrace!("New frame {new_start}-{new_end} received");
-            (false, false)
+            (None, false)
         };
 
+        // At the end (common case): the loop below finds nothing.
+        //  PPPPPP        -> PPPPPP
+        //        NNNNNNN          NNNNNNN
+        // or
+        //  PPPPPP             -> PPPPPP
+        //             NNNNNNN               NNNNNNN
+        //
+        // Otherwise, handle possible overlap with next entries
+        //  PPPPPP       AAA      -> PPPPPP
+        //        NNNNNNN                  NNNNNNN
+        // or
+        //  PPPPPP     AAAA      -> PPPPPP     AAAA
+        //        NNNNNNN                 NNNNN
+        // or (this is where to_remove is used)
+        //  PPPPPP    AA       -> PPPPPP
+        //        NNNNNNN               NNNNNNN
         let mut to_add = new_data;
-        if self
-            .data_ranges
-            .last_entry()
-            .is_some_and(|e| *e.key() >= new_start)
-        {
-            // Is this at the end (common case)?  If so, nothing to do in this block
-            // Common case:
-            //  PPPPPP        -> PPPPPP
-            //        NNNNNNN          NNNNNNN
-            // or
-            //  PPPPPP             -> PPPPPP
-            //             NNNNNNN               NNNNNNN
-            //
-            // Not the common case, handle possible overlap with next entries
-            //  PPPPPP       AAA      -> PPPPPP
-            //        NNNNNNN                  NNNNNNN
-            // or
-            //  PPPPPP     AAAA      -> PPPPPP     AAAA
-            //        NNNNNNN                 NNNNN
-            // or (this is where to_remove is used)
-            //  PPPPPP    AA       -> PPPPPP
-            //        NNNNNNN               NNNNNNN
-
-            let mut to_remove = SmallVec::<[_; 8]>::new();
-
-            for (&next_start, next_data) in self.data_ranges.range_mut(new_start..) {
-                let next_end = next_start + to_u64(next_data.len());
-                let overlap = new_end.saturating_sub(next_start);
-                if overlap == 0 {
-                    // Fills in the hole, exactly (probably common)
-                    break;
-                } else if next_end >= new_end {
-                    qtrace!(
-                        "New frame {new_start}-{new_end} overlaps with next frame by {overlap}, truncating"
-                    );
-                    // Safe conversion because any overlap has to be held in a buffer.
-                    let truncate_to = new_data.len() - expect_usize(overlap);
-                    to_add = &new_data[..truncate_to];
-                    break;
-                }
-                qtrace!(
-                    "New frame {new_start}-{new_end} spans entire next frame {next_start}-{next_end}, replacing"
-                );
-                to_remove.push(next_start);
-                // Continue, since we may have more overlaps
+        let mut to_remove = SmallVec::<[_; 8]>::new();
+        for (&next_start, next_data) in self.data_ranges.range_mut(new_start..) {
+            let next_end = next_start + to_u64(next_data.len());
+            let overlap = new_end.saturating_sub(next_start);
+            if overlap == 0 {
+                // Fills in the hole, exactly (probably common)
+                break;
             }
-
-            self.mutate_ranges(|data_ranges| {
-                for start in to_remove {
-                    data_ranges.remove(&start);
-                }
-            });
+            if next_end >= new_end {
+                qtrace!(
+                    "New frame {new_start}-{new_end} overlaps with next frame by {overlap}, truncating"
+                );
+                // Safe conversion because any overlap has to be held in a buffer.
+                let truncate_to = new_data.len() - expect_usize(overlap);
+                to_add = &new_data[..truncate_to];
+                break;
+            }
+            qtrace!(
+                "New frame {new_start}-{new_end} spans entire next frame {next_start}-{next_end}, replacing"
+            );
+            to_remove.push(next_start);
+            // Continue, since we may have more overlaps
         }
+        self.mutate_ranges(|data_ranges| {
+            for start in to_remove {
+                data_ranges.remove(&start);
+            }
+        });
 
         if to_add.is_empty() {
             // A surviving forward entry with next_end >= new_end exists, so self.end is already
@@ -382,10 +379,23 @@ impl RxStreamOrderer {
             return Ok(());
         }
 
-        self.received += to_u64(to_add.len());
-        if extend {
-            if let Some((_, buf)) = self.data_ranges.range_mut(..=new_start).next_back() {
+        let added = to_u64(to_add.len());
+        self.received += added;
+        if let Some(prev_start) = extend {
+            // Absorb the following entry when this closes a gap, so filling gaps doesn't leave
+            // the buffer permanently fragmented into tiny entries.
+            let add_end = new_start + added;
+            let next = self
+                .data_ranges
+                .get(&add_end)
+                .is_some_and(|n| to_add.len() + n.len() <= Self::RANGE_TARGET)
+                .then(|| self.mutate_ranges(|r| r.remove(&add_end)))
+                .flatten();
+            if let Some(buf) = self.data_ranges.get_mut(&prev_start) {
                 buf.extend_from_slice(to_add);
+                if let Some(next) = &next {
+                    buf.extend_from_slice(next);
+                }
             }
         } else {
             self.data_ranges.insert(new_start, to_add.to_vec());
@@ -2093,15 +2103,33 @@ mod tests {
         assert_eq!(s.data_ranges.len(), 3);
         assert_eq!(s.split_ranges, 0);
 
-        // An overlapping frame spanning [0, 20) entirely swallows the entry at 10
-        // (via the `to_remove` path) and extends the entry at 0; the entry at 20
-        // survives untouched. Net effect: one entry disappears.
+        // An overlapping frame spanning [0, 20) swallows the entry at 10 via `to_remove`,
+        // extends the entry at 0, and then coalesces the entry at 20 that it now abuts.
         s.inbound_frame(0, &[0u8; 20]).unwrap();
-        assert_eq!(s.data_ranges.len(), 2, "entry at 10 was fully absorbed");
+        assert_eq!(s.data_ranges.len(), 1, "all three entries merged into one");
 
         // Nothing here was ever credited, so there is no credit to give back.
         assert_eq!(s.split_ranges, 0);
         assert!(s.split_ranges + s.split_ranges() <= s.data_ranges.len());
+    }
+
+    /// Repeatedly filling one-byte gaps must not fragment the buffer into one entry per
+    /// gap, or contiguous readable data trips the `MAX_SPLIT_RANGES` limit.
+    #[test]
+    fn gap_fills_are_coalesced() {
+        let mut s = RxStreamOrderer::default();
+        let iterations = to_u64(RxStreamOrderer::MAX_SPLIT_RANGES) * 2;
+        for i in 0..iterations {
+            let offset = 2 * i;
+            s.inbound_frame(offset + 1, &[0u8; 1]).unwrap();
+            s.inbound_frame(offset, &[0u8; 1]).unwrap();
+        }
+        assert_eq!(s.split_ranges(), 1, "all of it is one contiguous run");
+        assert!(
+            s.data_ranges.len() < RxStreamOrderer::MAX_SPLIT_RANGES,
+            "entries stay bounded: {}",
+            s.data_ranges.len()
+        );
     }
 
     /// A contiguous run assembled by filling a gap must not consume the gap budget.


### PR DESCRIPTION
Don't let a peer consume excess memory via many tiny out-of-order STREAM frames.
https://bugzilla.mozilla.org/show_bug.cgi?id=2048871