### PR TITLE
fix: limit frame lengths before buffering

### DIFF
--- a/neqo-http3/src/frames/capsule.rs
+++ b/neqo-http3/src/frames/capsule.rs
@@ -11,6 +11,10 @@ use crate::Res;
 
 pub const CAPSULE_TYPE_DATAGRAM: HFrameType = HFrameType(0x00);
 
+/// Limit on the declared length of a `DATAGRAM` capsule we'll buffer before decoding.
+pub const MAX_DATAGRAM_BYTES: usize =
+    neqo_common::to_usize(neqo_transport::MAX_DATAGRAM_FRAME_SIZE);
+
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Capsule {
     Datagram { payload: Bytes },
@@ -48,6 +52,14 @@ impl FrameDecoder<Self> for Capsule {
 
     fn is_known_type(frame_type: HFrameType) -> bool {
         frame_type == CAPSULE_TYPE_DATAGRAM
+    }
+
+    fn max_frame_data(frame_type: HFrameType) -> usize {
+        if frame_type == CAPSULE_TYPE_DATAGRAM {
+            MAX_DATAGRAM_BYTES
+        } else {
+            usize::MAX
+        }
     }
 }
 
@@ -115,6 +127,11 @@ mod tests {
     fn decode_unknown_capsule_type() {
         let res = Capsule::decode(HFrameType(0x17), 4, Some(&[0xaa, 0xbb, 0xcc, 0xdd])).unwrap();
         assert_eq!(res, None);
+    }
+
+    #[test]
+    fn max_frame_data_unknown_type_is_unbounded() {
+        assert_eq!(Capsule::max_frame_data(HFrameType(0x17)), usize::MAX);
     }
 
     #[test]

--- a/neqo-http3/src/frames/connect_udp_frame.rs
+++ b/neqo-http3/src/frames/connect_udp_frame.rs
@@ -20,6 +20,10 @@ impl FrameDecoder<Self> for Frame {
     fn is_known_type(_frame_type: HFrameType) -> bool {
         false
     }
+
+    fn max_frame_data(_frame_type: HFrameType) -> usize {
+        unreachable!("is_known_type is false, so frame_length_decoded never calls this")
+    }
 }
 
 #[cfg(test)]

--- a/neqo-http3/src/frames/hframe.rs
+++ b/neqo-http3/src/frames/hframe.rs
@@ -27,8 +27,7 @@ pub const MAX_HEADER_BYTES: usize = neqo_qpack::reader::LiteralReader::MAX_LEN;
 pub const MAX_SINGLE_VARINT_FRAME_BYTES: usize = 8;
 
 /// Limit for other buffered frame types (`SETTINGS`, `PRIORITY_UPDATE_*`).
-/// Matches Google quiche's `kPayloadLengthLimit`.
-pub const MAX_BUFFERED_FRAME_BYTES: usize = 1024 * 1024;
+pub const MAX_BUFFERED_FRAME_BYTES: usize = 4 * 1024;
 
 impl HFrameType {
     pub const DATA: Self = Self(0x0);

--- a/neqo-http3/src/frames/hframe.rs
+++ b/neqo-http3/src/frames/hframe.rs
@@ -15,6 +15,21 @@ use crate::{Error, Priority, PushId, Res, frames::reader::FrameDecoder, settings
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HFrameType(pub u64);
 
+/// Limit on the declared length of a HEADERS/`PUSH_PROMISE` frame we'll buffer
+/// before decoding.
+///
+/// A conservative reuse of the QPACK decoded-size limit: encoded size is usually smaller than
+/// decoded. Worst-case memory is bounded by the transport's stream concurrency limit, roughly
+/// `max_streams_bidi * MAX_HEADER_BYTES`.
+pub const MAX_HEADER_BYTES: usize = neqo_qpack::reader::LiteralReader::MAX_LEN;
+
+/// Limit for frame types that carry at most a single varint.
+pub const MAX_SINGLE_VARINT_FRAME_BYTES: usize = 8;
+
+/// Limit for other buffered frame types (`SETTINGS`, `PRIORITY_UPDATE_*`).
+/// Matches Google quiche's `kPayloadLengthLimit`.
+pub const MAX_BUFFERED_FRAME_BYTES: usize = 1024 * 1024;
+
 impl HFrameType {
     pub const DATA: Self = Self(0x0);
     pub const HEADERS: Self = Self(0x1);
@@ -160,6 +175,19 @@ impl FrameDecoder<Self> for HFrame {
             return Err(Error::HttpFrameUnexpected);
         }
         Ok(())
+    }
+
+    fn max_frame_data(frame_type: HFrameType) -> usize {
+        match frame_type {
+            HFrameType::HEADERS | HFrameType::PUSH_PROMISE => MAX_HEADER_BYTES,
+            HFrameType::CANCEL_PUSH | HFrameType::GOAWAY | HFrameType::MAX_PUSH_ID => {
+                MAX_SINGLE_VARINT_FRAME_BYTES
+            }
+            HFrameType::SETTINGS
+            | HFrameType::PRIORITY_UPDATE_REQUEST
+            | HFrameType::PRIORITY_UPDATE_PUSH => MAX_BUFFERED_FRAME_BYTES,
+            _ => usize::MAX,
+        }
     }
 
     fn decode(frame_type: HFrameType, frame_len: u64, data: Option<&[u8]>) -> Res<Option<Self>> {

--- a/neqo-http3/src/frames/reader.rs
+++ b/neqo-http3/src/frames/reader.rs
@@ -33,6 +33,9 @@ pub trait FrameDecoder<T> {
         Ok(())
     }
 
+    /// Upper bound on a known frame's declared length that we'll buffer before decoding.
+    fn max_frame_data(frame_type: HFrameType) -> usize;
+
     /// # Errors
     ///
     /// If a frame cannot be properly decoded.
@@ -280,10 +283,12 @@ impl FrameReader {
             }
             None => {
                 if T::is_known_type(self.frame_type) {
+                    let len = usize::try_from(len).or(Err(Error::HttpFrame))?;
+                    if len > T::max_frame_data(self.frame_type) {
+                        return Err(Error::HttpExcessiveLoad);
+                    }
                     self.state = FrameReaderState::GetData {
-                        decoder: IncrementalDecoderBuffer::new(
-                            usize::try_from(len).or(Err(Error::HttpFrame))?,
-                        ),
+                        decoder: IncrementalDecoderBuffer::new(len),
                     };
                 } else if self.frame_len == 0 {
                     self.reset();

--- a/neqo-http3/src/frames/tests/hframe.rs
+++ b/neqo-http3/src/frames/tests/hframe.rs
@@ -17,7 +17,7 @@ use crate::{
 
 #[test]
 fn max_frame_data_unknown_type_is_unbounded() {
-    assert_eq!(HFrame::max_frame_data(HFrameType(0x1234)), usize::MAX);
+    assert_eq!(HFrame::max_frame_data(HFrameType(0x124b)), usize::MAX);
 }
 
 #[test]

--- a/neqo-http3/src/frames/tests/hframe.rs
+++ b/neqo-http3/src/frames/tests/hframe.rs
@@ -11,9 +11,14 @@ use test_fixture::fixture_init;
 use super::enc_dec_hframe;
 use crate::{
     Priority, PushId,
-    frames::HFrame,
+    frames::{HFrame, HFrameType, reader::FrameDecoder as _},
     settings::{HSetting, HSettingType, HSettings},
 };
+
+#[test]
+fn max_frame_data_unknown_type_is_unbounded() {
+    assert_eq!(HFrame::max_frame_data(HFrameType(0x1234)), usize::MAX);
+}
 
 #[test]
 fn data_frame() {

--- a/neqo-http3/src/frames/tests/reader.rs
+++ b/neqo-http3/src/frames/tests/reader.rs
@@ -154,92 +154,70 @@ fn frame_reading_with_stream_push_promise() {
     }
 }
 
-// Oversized HEADERS/PUSH_PROMISE lengths are rejected before any payload is buffered.
-#[test]
-fn headers_frame_length_exceeds_cap_rejected() {
+fn assert_cap_rejected<T: FrameDecoder<T> + PartialEq + Debug>(frame_type: HFrameType, cap: usize) {
     let mut fr = FrameReaderTest::new();
-    let buf = encode_frame_header(HFrameType::HEADERS, MAX_HEADER_BYTES + 1);
-    assert_eq!(
-        Err(Error::HttpExcessiveLoad),
-        fr.try_process::<HFrame>(&buf)
-    );
+    let buf = encode_frame_header(frame_type, cap + 1);
+    assert_eq!(Err(Error::HttpExcessiveLoad), fr.try_process::<T>(&buf));
+}
+
+fn assert_cap_not_rejected<T: FrameDecoder<T> + PartialEq + Debug>(
+    frame_type: HFrameType,
+    cap: usize,
+) {
+    let mut fr = FrameReaderTest::new();
+    let buf = encode_frame_header(frame_type, cap);
+    assert_eq!(Ok((None, false)), fr.try_process::<T>(&buf));
 }
 
 #[test]
-fn push_promise_frame_length_exceeds_cap_rejected() {
-    let mut fr = FrameReaderTest::new();
-    let buf = encode_frame_header(HFrameType::PUSH_PROMISE, MAX_HEADER_BYTES + 1);
-    assert_eq!(
-        Err(Error::HttpExcessiveLoad),
-        fr.try_process::<HFrame>(&buf)
-    );
+fn hframe_length_exceeds_cap_rejected() {
+    const CHECKS: &[(usize, &[HFrameType])] = &[
+        (
+            MAX_HEADER_BYTES,
+            &[HFrameType::HEADERS, HFrameType::PUSH_PROMISE],
+        ),
+        (
+            MAX_SINGLE_VARINT_FRAME_BYTES,
+            &[
+                HFrameType::CANCEL_PUSH,
+                HFrameType::GOAWAY,
+                HFrameType::MAX_PUSH_ID,
+            ],
+        ),
+        (
+            MAX_BUFFERED_FRAME_BYTES,
+            &[
+                HFrameType::SETTINGS,
+                HFrameType::PRIORITY_UPDATE_REQUEST,
+                HFrameType::PRIORITY_UPDATE_PUSH,
+            ],
+        ),
+    ];
+    for &(cap, frame_types) in CHECKS {
+        for &frame_type in frame_types {
+            assert_cap_rejected::<HFrame>(frame_type, cap);
+        }
+    }
 }
 
 #[test]
 fn headers_frame_length_at_cap_not_rejected_by_length_check() {
-    let mut fr = FrameReaderTest::new();
-    let buf = encode_frame_header(HFrameType::HEADERS, MAX_HEADER_BYTES);
-    assert_eq!(Ok((None, false)), fr.try_process::<HFrame>(&buf));
-}
-
-// Same unbounded-buffering shape applies to other known frame types that
-// carry only a small payload; each has its own small cap.
-#[test]
-fn cancel_push_frame_length_exceeds_cap_rejected() {
-    let mut fr = FrameReaderTest::new();
-    let buf = encode_frame_header(HFrameType::CANCEL_PUSH, MAX_SINGLE_VARINT_FRAME_BYTES + 1);
-    assert_eq!(
-        Err(Error::HttpExcessiveLoad),
-        fr.try_process::<HFrame>(&buf)
-    );
-}
-
-#[test]
-fn settings_frame_length_exceeds_cap_rejected() {
-    let mut fr = FrameReaderTest::new();
-    let buf = encode_frame_header(HFrameType::SETTINGS, MAX_BUFFERED_FRAME_BYTES + 1);
-    assert_eq!(
-        Err(Error::HttpExcessiveLoad),
-        fr.try_process::<HFrame>(&buf)
-    );
-}
-
-#[test]
-fn priority_update_frame_length_exceeds_cap_rejected() {
-    let mut fr = FrameReaderTest::new();
-    let buf = encode_frame_header(
-        HFrameType::PRIORITY_UPDATE_REQUEST,
-        MAX_BUFFERED_FRAME_BYTES + 1,
-    );
-    assert_eq!(
-        Err(Error::HttpExcessiveLoad),
-        fr.try_process::<HFrame>(&buf)
-    );
+    assert_cap_not_rejected::<HFrame>(HFrameType::HEADERS, MAX_HEADER_BYTES);
 }
 
 #[test]
 fn wt_close_session_frame_length_exceeds_cap_rejected() {
-    let mut fr = FrameReaderTest::new();
-    let buf = encode_frame_header(
+    assert_cap_rejected::<WebTransportFrame>(
         HFrameType(0x2843), // WebTransportFrame::CLOSE_SESSION
-        WebTransportFrame::MAX_CLOSE_SESSION_BYTES + 1,
-    );
-    assert_eq!(
-        Err(Error::HttpExcessiveLoad),
-        fr.try_process::<WebTransportFrame>(&buf)
+        WebTransportFrame::MAX_CLOSE_SESSION_BYTES,
     );
 }
 
 #[test]
 fn capsule_datagram_length_exceeds_cap_rejected() {
-    let mut fr = FrameReaderTest::new();
-    let buf = encode_frame_header(
+    assert_cap_rejected::<Capsule>(
         HFrameType(0x00), // capsule::CAPSULE_TYPE_DATAGRAM
-        MAX_DATAGRAM_BYTES + 1,
-    );
-    assert_eq!(
-        Err(Error::HttpExcessiveLoad),
-        fr.try_process::<Capsule>(&buf)
+        MAX_DATAGRAM_BYTES,
     );
 }
 

--- a/neqo-http3/src/frames/tests/reader.rs
+++ b/neqo-http3/src/frames/tests/reader.rs
@@ -154,68 +154,62 @@ fn frame_reading_with_stream_push_promise() {
     }
 }
 
-fn assert_cap_rejected<T: FrameDecoder<T> + PartialEq + Debug>(frame_type: HFrameType, cap: usize) {
+/// Assert that a declared length one byte over `cap` is rejected before buffering,
+/// while exactly `cap` is accepted (i.e. the check is `>`, not `>=`).
+fn assert_cap_boundary<T: FrameDecoder<T> + PartialEq + Debug>(frame_type: HFrameType, cap: usize) {
     let mut fr = FrameReaderTest::new();
-    let buf = encode_frame_header(frame_type, cap + 1);
-    assert_eq!(Err(Error::HttpExcessiveLoad), fr.try_process::<T>(&buf));
+    let over = encode_frame_header(frame_type, cap + 1);
+    assert_eq!(Err(Error::HttpExcessiveLoad), fr.try_process::<T>(&over));
+
+    let mut fr = FrameReaderTest::new();
+    let at = encode_frame_header(frame_type, cap);
+    assert_eq!(Ok((None, false)), fr.try_process::<T>(&at));
 }
 
-fn assert_cap_not_rejected<T: FrameDecoder<T> + PartialEq + Debug>(
-    frame_type: HFrameType,
-    cap: usize,
-) {
-    let mut fr = FrameReaderTest::new();
-    let buf = encode_frame_header(frame_type, cap);
-    assert_eq!(Ok((None, false)), fr.try_process::<T>(&buf));
-}
+/// Each buffered `HFrame` type paired with the cap that applies to it.
+const HFRAME_CAPS: &[(usize, &[HFrameType])] = &[
+    (
+        MAX_HEADER_BYTES,
+        &[HFrameType::HEADERS, HFrameType::PUSH_PROMISE],
+    ),
+    (
+        MAX_SINGLE_VARINT_FRAME_BYTES,
+        &[
+            HFrameType::CANCEL_PUSH,
+            HFrameType::GOAWAY,
+            HFrameType::MAX_PUSH_ID,
+        ],
+    ),
+    (
+        MAX_BUFFERED_FRAME_BYTES,
+        &[
+            HFrameType::SETTINGS,
+            HFrameType::PRIORITY_UPDATE_REQUEST,
+            HFrameType::PRIORITY_UPDATE_PUSH,
+        ],
+    ),
+];
 
 #[test]
-fn hframe_length_exceeds_cap_rejected() {
-    const CHECKS: &[(usize, &[HFrameType])] = &[
-        (
-            MAX_HEADER_BYTES,
-            &[HFrameType::HEADERS, HFrameType::PUSH_PROMISE],
-        ),
-        (
-            MAX_SINGLE_VARINT_FRAME_BYTES,
-            &[
-                HFrameType::CANCEL_PUSH,
-                HFrameType::GOAWAY,
-                HFrameType::MAX_PUSH_ID,
-            ],
-        ),
-        (
-            MAX_BUFFERED_FRAME_BYTES,
-            &[
-                HFrameType::SETTINGS,
-                HFrameType::PRIORITY_UPDATE_REQUEST,
-                HFrameType::PRIORITY_UPDATE_PUSH,
-            ],
-        ),
-    ];
-    for &(cap, frame_types) in CHECKS {
+fn hframe_length_cap_boundary() {
+    for &(cap, frame_types) in HFRAME_CAPS {
         for &frame_type in frame_types {
-            assert_cap_rejected::<HFrame>(frame_type, cap);
+            assert_cap_boundary::<HFrame>(frame_type, cap);
         }
     }
 }
 
 #[test]
-fn headers_frame_length_at_cap_not_rejected_by_length_check() {
-    assert_cap_not_rejected::<HFrame>(HFrameType::HEADERS, MAX_HEADER_BYTES);
-}
-
-#[test]
-fn wt_close_session_frame_length_exceeds_cap_rejected() {
-    assert_cap_rejected::<WebTransportFrame>(
+fn wt_close_session_length_cap_boundary() {
+    assert_cap_boundary::<WebTransportFrame>(
         HFrameType(0x2843), // WebTransportFrame::CLOSE_SESSION
         WebTransportFrame::MAX_CLOSE_SESSION_BYTES,
     );
 }
 
 #[test]
-fn capsule_datagram_length_exceeds_cap_rejected() {
-    assert_cap_rejected::<Capsule>(
+fn capsule_datagram_length_cap_boundary() {
+    assert_cap_boundary::<Capsule>(
         HFrameType(0x00), // capsule::CAPSULE_TYPE_DATAGRAM
         MAX_DATAGRAM_BYTES,
     );

--- a/neqo-http3/src/frames/tests/reader.rs
+++ b/neqo-http3/src/frames/tests/reader.rs
@@ -4,7 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(clippy::missing_asserts_for_indexing, reason = "OK in tests")]
+#![allow(
+    clippy::missing_asserts_for_indexing,
+    clippy::unwrap_in_result,
+    reason = "OK in tests"
+)]
 
 use std::{cmp::min, fmt::Debug};
 
@@ -13,9 +17,12 @@ use neqo_transport::{Connection, StreamId, StreamType};
 use test_fixture::{connect, now};
 
 use crate::{
-    Error, PushId,
+    Error, PushId, Res,
     frames::{
-        FrameReader, HFrame, StreamReaderConnectionWrapper, WebTransportFrame, reader::FrameDecoder,
+        FrameReader, HFrame, HFrameType, StreamReaderConnectionWrapper, WebTransportFrame,
+        capsule::{Capsule, MAX_DATAGRAM_BYTES},
+        hframe::{MAX_BUFFERED_FRAME_BYTES, MAX_HEADER_BYTES, MAX_SINGLE_VARINT_FRAME_BYTES},
+        reader::FrameDecoder,
     },
     settings::{HSetting, HSettingType, HSettings},
 };
@@ -53,6 +60,24 @@ impl FrameReaderTest {
         assert!(!fin);
         frame
     }
+
+    fn try_process<T: FrameDecoder<T>>(&mut self, v: &[u8]) -> Res<(Option<T>, bool)> {
+        self.conn_s.stream_send(self.stream_id, v).unwrap();
+        let out = self.conn_s.process_output(now());
+        _ = self.conn_c.process(out.dgram(), now());
+        self.fr.receive::<T>(
+            &mut StreamReaderConnectionWrapper::new(&mut self.conn_c, self.stream_id),
+            now(),
+        )
+    }
+}
+
+// Builds just the type + length varints of a frame header, no payload.
+fn encode_frame_header(frame_type: HFrameType, len: usize) -> Vec<u8> {
+    let mut enc = Encoder::default();
+    enc.encode_varint(frame_type.0);
+    enc.encode_len(len);
+    enc.into()
 }
 
 // Test receiving byte by byte for a SETTINGS frame.
@@ -127,6 +152,95 @@ fn frame_reading_with_stream_push_promise() {
     } else {
         panic!("wrong frame type");
     }
+}
+
+// Oversized HEADERS/PUSH_PROMISE lengths are rejected before any payload is buffered.
+#[test]
+fn headers_frame_length_exceeds_cap_rejected() {
+    let mut fr = FrameReaderTest::new();
+    let buf = encode_frame_header(HFrameType::HEADERS, MAX_HEADER_BYTES + 1);
+    assert_eq!(
+        Err(Error::HttpExcessiveLoad),
+        fr.try_process::<HFrame>(&buf)
+    );
+}
+
+#[test]
+fn push_promise_frame_length_exceeds_cap_rejected() {
+    let mut fr = FrameReaderTest::new();
+    let buf = encode_frame_header(HFrameType::PUSH_PROMISE, MAX_HEADER_BYTES + 1);
+    assert_eq!(
+        Err(Error::HttpExcessiveLoad),
+        fr.try_process::<HFrame>(&buf)
+    );
+}
+
+#[test]
+fn headers_frame_length_at_cap_not_rejected_by_length_check() {
+    let mut fr = FrameReaderTest::new();
+    let buf = encode_frame_header(HFrameType::HEADERS, MAX_HEADER_BYTES);
+    assert_eq!(Ok((None, false)), fr.try_process::<HFrame>(&buf));
+}
+
+// Same unbounded-buffering shape applies to other known frame types that
+// carry only a small payload; each has its own small cap.
+#[test]
+fn cancel_push_frame_length_exceeds_cap_rejected() {
+    let mut fr = FrameReaderTest::new();
+    let buf = encode_frame_header(HFrameType::CANCEL_PUSH, MAX_SINGLE_VARINT_FRAME_BYTES + 1);
+    assert_eq!(
+        Err(Error::HttpExcessiveLoad),
+        fr.try_process::<HFrame>(&buf)
+    );
+}
+
+#[test]
+fn settings_frame_length_exceeds_cap_rejected() {
+    let mut fr = FrameReaderTest::new();
+    let buf = encode_frame_header(HFrameType::SETTINGS, MAX_BUFFERED_FRAME_BYTES + 1);
+    assert_eq!(
+        Err(Error::HttpExcessiveLoad),
+        fr.try_process::<HFrame>(&buf)
+    );
+}
+
+#[test]
+fn priority_update_frame_length_exceeds_cap_rejected() {
+    let mut fr = FrameReaderTest::new();
+    let buf = encode_frame_header(
+        HFrameType::PRIORITY_UPDATE_REQUEST,
+        MAX_BUFFERED_FRAME_BYTES + 1,
+    );
+    assert_eq!(
+        Err(Error::HttpExcessiveLoad),
+        fr.try_process::<HFrame>(&buf)
+    );
+}
+
+#[test]
+fn wt_close_session_frame_length_exceeds_cap_rejected() {
+    let mut fr = FrameReaderTest::new();
+    let buf = encode_frame_header(
+        HFrameType(0x2843), // WebTransportFrame::CLOSE_SESSION
+        WebTransportFrame::MAX_CLOSE_SESSION_BYTES + 1,
+    );
+    assert_eq!(
+        Err(Error::HttpExcessiveLoad),
+        fr.try_process::<WebTransportFrame>(&buf)
+    );
+}
+
+#[test]
+fn capsule_datagram_length_exceeds_cap_rejected() {
+    let mut fr = FrameReaderTest::new();
+    let buf = encode_frame_header(
+        HFrameType(0x00), // capsule::CAPSULE_TYPE_DATAGRAM
+        MAX_DATAGRAM_BYTES + 1,
+    );
+    assert_eq!(
+        Err(Error::HttpExcessiveLoad),
+        fr.try_process::<Capsule>(&buf)
+    );
 }
 
 // Test DATA

--- a/neqo-http3/src/frames/wtframe.rs
+++ b/neqo-http3/src/frames/wtframe.rs
@@ -100,7 +100,7 @@ mod tests {
     #[test]
     fn max_frame_data_unknown_type_is_unbounded() {
         assert_eq!(
-            WebTransportFrame::max_frame_data(HFrameType(0x1234)),
+            WebTransportFrame::max_frame_data(HFrameType(0x1230)),
             usize::MAX
         );
     }

--- a/neqo-http3/src/frames/wtframe.rs
+++ b/neqo-http3/src/frames/wtframe.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::{Decoder, Encoder};
+use neqo_common::{Decoder, Encoder, to_usize};
 
 use super::hframe::HFrameType;
 use crate::{Error, Res, frames::reader::FrameDecoder};
@@ -26,6 +26,9 @@ impl WebTransportFrame {
     /// in [WebTransport over HTTP/3 (RFC 9297, Section 4.6)](https://datatracker.ietf.org/doc/html/rfc9297#section-4.6).
     /// The value 1024 is used to limit the message size for security and interoperability.
     const CLOSE_MAX_MESSAGE_SIZE: u64 = 1024;
+
+    /// Limit on the declared length of a `CLOSE_SESSION` frame.
+    pub const MAX_CLOSE_SESSION_BYTES: usize = to_usize(Self::CLOSE_MAX_MESSAGE_SIZE) + 4;
 
     pub fn encode(&self, enc: &mut Encoder) {
         #[cfg(feature = "build-fuzzing-corpus")]
@@ -69,6 +72,14 @@ impl FrameDecoder<Self> for WebTransportFrame {
     fn is_known_type(frame_type: HFrameType) -> bool {
         frame_type == HFrameType(Self::CLOSE_SESSION)
     }
+
+    fn max_frame_data(frame_type: HFrameType) -> usize {
+        if frame_type == HFrameType(Self::CLOSE_SESSION) {
+            Self::MAX_CLOSE_SESSION_BYTES
+        } else {
+            usize::MAX
+        }
+    }
 }
 
 #[cfg(test)]
@@ -84,6 +95,14 @@ mod tests {
         assert!(WebTransportFrame::is_known_type(HFrameType(
             WebTransportFrame::CLOSE_SESSION
         )));
+    }
+
+    #[test]
+    fn max_frame_data_unknown_type_is_unbounded() {
+        assert_eq!(
+            WebTransportFrame::max_frame_data(HFrameType(0x1234)),
+            usize::MAX
+        );
     }
 
     #[test]

--- a/neqo-qpack/src/reader.rs
+++ b/neqo-qpack/src/reader.rs
@@ -266,7 +266,9 @@ impl LiteralReader {
     /// The Gecko limit is in `network.http.max_response_header_size` and defaults to
     /// 393216 bytes (384 KB), see `modules/libpref/init/StaticPrefList.yaml`. We use
     /// the same limit.
-    pub(crate) const MAX_LEN: usize = 384 * 1024;
+    ///
+    /// Also reused by `neqo-http3` (`hframe::MAX_HEADER_BYTES`).
+    pub const MAX_LEN: usize = 384 * 1024;
 
     /// Creates `LiteralReader` with the first byte. This constructor is always used
     /// when a literal has a prefix.

--- a/neqo-transport/src/connection/params.rs
+++ b/neqo-transport/src/connection/params.rs
@@ -86,8 +86,8 @@ pub const MAX_LOCAL_MAX_STREAM_DATA: u64 = 10 * 1024 * 1024;
 /// See also <https://datatracker.ietf.org/doc/html/rfc9000#frame-max-data>.
 pub const MAX_LOCAL_MAX_DATA: u64 = MAX_LOCAL_MAX_STREAM_DATA * CONNECTION_FACTOR;
 
-// Maximum size of a QUIC DATAGRAM frame, as specified in https://datatracker.ietf.org/doc/html/rfc9221#section-3-4.
-const MAX_DATAGRAM_FRAME_SIZE: u64 = 65535;
+/// Maximum size of a QUIC DATAGRAM frame, as specified in <https://datatracker.ietf.org/doc/html/rfc9221#section-3-4>.
+pub const MAX_DATAGRAM_FRAME_SIZE: u64 = 65535;
 const MAX_QUEUED_DATAGRAMS_DEFAULT: usize = 10;
 
 /// What to do with preferred addresses.

--- a/neqo-transport/src/lib.rs
+++ b/neqo-transport/src/lib.rs
@@ -65,7 +65,7 @@ pub use self::{
         Connection, Output, OutputBatch, State, ZeroRttState,
         params::{
             ConnectionParameters, INITIAL_LOCAL_MAX_DATA, INITIAL_LOCAL_MAX_STREAM_DATA,
-            MAX_LOCAL_MAX_STREAM_DATA,
+            MAX_DATAGRAM_FRAME_SIZE, MAX_LOCAL_MAX_STREAM_DATA,
         },
     },
     events::{ConnectionEvent, ConnectionEvents},


### PR DESCRIPTION
Reject lengths over the existing QPACK decoded-size limit up front.
https://bugzilla.mozilla.org/show_bug.cgi?id=2025290