### PR TITLE
reject PRIORITY_UPDATE for an unpromised push id

### DIFF
--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -361,15 +361,13 @@ impl Http3ServerHandler {
                         HFrame::Goaway { .. } | HFrame::CancelPush { .. } => {
                             Err(Error::HttpFrameUnexpected)
                         }
-                        HFrame::PriorityUpdatePush {
-                            element_id,
-                            priority,
-                        } => {
-                            // TODO: check if the element_id references a promised push stream or
-                            // is greater than the maximum Push ID.
-                            self.events
-                                .priority_update(StreamId::from(element_id), priority);
-                            Ok(())
+                        HFrame::PriorityUpdatePush { .. } => {
+                            // RFC 9218, Section 7.2: the push variant of PRIORITY_UPDATE must
+                            // reference a promised push stream, and one referencing a Push ID
+                            // greater than the maximum (or never promised) is a connection error
+                            // of type H3_ID_ERROR. This server promises no pushes, so no Push ID
+                            // is ever valid here.
+                            Err(Error::HttpId)
                         }
                         HFrame::PriorityUpdateRequest {
                             element_id,

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -791,6 +791,33 @@ mod tests {
         priority_update_check_id(StreamId::new(1_000_000_000), false);
     }
 
+    // RFC 9218, Section 7.2: the push variant of PRIORITY_UPDATE must reference a
+    // promised push stream. This server promises no pushes, so any Push ID is
+    // invalid and must be a connection error of type H3_ID_ERROR.
+    fn priority_update_push_check(push_id: u64) {
+        let (mut hconn, mut peer_conn) = connect();
+        let frame = HFrame::PriorityUpdatePush {
+            element_id: push_id,
+            priority: Priority::default(),
+        };
+        let mut e = Encoder::default();
+        frame.encode(&mut e);
+        peer_conn.control_send(e.as_ref());
+        let out = peer_conn.process_output(now());
+        hconn.process(out.dgram(), now());
+        assert_closed(&hconn, &Error::HttpId);
+    }
+
+    #[test]
+    fn priority_update_push_id_zero_rejected() {
+        priority_update_push_check(0);
+    }
+
+    #[test]
+    fn priority_update_push_large_id_rejected() {
+        priority_update_push_check(1_000_000_000);
+    }
+
     fn test_wrong_frame_on_control_stream(v: &[u8]) {
         let (mut hconn, mut peer_conn) = connect();
 


### PR DESCRIPTION
On the server, a PRIORITY_UPDATE for a push (type 0xf0701) arriving on the client control stream had its element_id coerced straight into a StreamId and delivered as a priority-update event, with no check on the id. The request variant beside it (0xf0700) already validates its element_id and returns H3_ID_ERROR for anything that is not a client-initiated bidi request stream, so a client could send a push-variant frame carrying any value and have it accepted as a stream priority signal.

RFC 9218 Section 7.2 makes a push-variant PRIORITY_UPDATE that names a Push ID above the maximum, or one never promised, an H3_ID_ERROR. This server never promises a push (it sends no PUSH_PROMISE and already rejects CANCEL_PUSH), so no Push ID is valid and the frame is now rejected with Error::HttpId, matching the request arm. Before, every push-variant frame was accepted and surfaced a bogus StreamId; after, it closes the connection. The tradeoff is that once server push lands this needs to compare against the real maximum Push ID instead of rejecting outright, but until then unconditional rejection is the only correct behavior.