### PR TITLE
fix: reject server push when the maximum push id is unset

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -5630,6 +5630,80 @@ mod tests {
         assert_eq!(client.state(), Http3State::Connected);
     }
 
+    // A client that does not enable server push never sends a MAX_PUSH_ID frame,
+    // so its maximum Push ID stays unset and every Push ID is above it. The
+    // default connect helpers assume a MAX_PUSH_ID frame on the control stream,
+    // so drive the setup here and drain the control stream without that check.
+    fn connect_push_disabled_and_send_request() -> (Http3Client, TestServer, StreamId) {
+        fixture_init();
+        let mut client = Http3Client::new(
+            DEFAULT_SERVER_NAME,
+            Rc::new(RefCell::new(CountingConnectionIdGenerator::default())),
+            DEFAULT_ADDR,
+            DEFAULT_ADDR,
+            Http3Parameters::default()
+                .connection_parameters(
+                    ConnectionParameters::default()
+                        .versions(Version::default(), vec![Version::default()]),
+                )
+                .max_table_size_encoder(100)
+                .max_table_size_decoder(100)
+                .max_blocked_streams(100),
+            now(),
+        )
+        .expect("create a push-disabled client");
+        let mut server = TestServer::new();
+
+        connect_only_transport_with(&mut client, &mut server);
+
+        let out = client.process_output(now());
+        server.conn.process_input(out.dgram().unwrap(), now());
+        let mut buf = [0_u8; 100];
+        while let Some(e) = server.conn.next_event() {
+            if let ConnectionEvent::RecvStreamReadable { stream_id } = e {
+                if stream_id == CLIENT_SIDE_ENCODER_STREAM_ID {
+                    server.read_and_check_stream_data(stream_id, ENCODER_STREAM_DATA, false);
+                } else {
+                    _ = server.conn.stream_recv(stream_id, &mut buf).unwrap();
+                }
+            }
+        }
+
+        server.create_control_stream();
+        server.create_qpack_streams();
+        let out = server.conn.process(None::<Datagram>, now());
+        client.process_input(out.dgram().unwrap(), now());
+        assert_eq!(client.state(), Http3State::Connected);
+
+        let request_stream_id = make_request_and_exchange_pkts(&mut client, &mut server, true);
+        (client, server, request_stream_id)
+    }
+
+    // A PUSH_PROMISE received when the maximum Push ID is unset is an H3_ID_ERROR.
+    #[test]
+    fn push_promise_when_push_disabled() {
+        let (mut client, mut server, request_stream_id) = connect_push_disabled_and_send_request();
+
+        send_push_promise_and_exchange_packets(
+            &mut client,
+            &mut server,
+            request_stream_id,
+            PushId::new(0),
+        );
+
+        assert_closed(&client, &Error::HttpId);
+    }
+
+    // A CANCEL_PUSH received when the maximum Push ID is unset is an H3_ID_ERROR.
+    #[test]
+    fn cancel_push_when_push_disabled() {
+        let (mut client, mut server, _request_stream_id) = connect_push_disabled_and_send_request();
+
+        send_cancel_push_and_exchange_packets(&mut client, &mut server, PushId::new(0));
+
+        assert_closed(&client, &Error::HttpId);
+    }
+
     #[test]
     fn max_push_id_frame_update_is_sent() {
         // Max concurrent is 5, sent after >5/2 (3) pushes are closed.

--- a/neqo-http3/src/push_controller.rs
+++ b/neqo-http3/src/push_controller.rs
@@ -268,9 +268,11 @@ impl PushController {
     }
 
     fn check_push_id(&self, push_id: PushId) -> Res<()> {
-        // Check if push id is greater than what we allow.
-        if push_id > self.current_max_push_id {
-            qerror!("Push id is greater than current_max_push_id");
+        // A client that does not enable push never sends a MAX_PUSH_ID frame, so
+        // its maximum push id is unset and no push id is allowed; the zero-valued
+        // `current_max_push_id` sentinel would otherwise admit push id 0.
+        if !self.can_receive_push() || push_id > self.current_max_push_id {
+            qerror!("Push id is not allowed");
             Err(Error::HttpId)
         } else {
             Ok(())


### PR DESCRIPTION
Default client (`max_concurrent_push_streams` = 0), server sends a PUSH_PROMISE with push id 0:

    check_push_id(0):  0 > current_max_push_id(0)  ->  false  ->  accepted

A client that does not enable push never sends a MAX_PUSH_ID frame, so its maximum push id is unset. RFC 9114 (7.2.3, 7.2.7) makes a PUSH_PROMISE or CANCEL_PUSH carrying a push id above what the client advertised an H3_ID_ERROR, and with nothing advertised every push id, including 0, is above the maximum. `current_max_push_id` is a plain `PushId` initialized to 0, so the `>` check cannot tell "unset" from "0 allowed" and admits push id 0. `check_push_id` is the single gate for the PUSH_PROMISE, CANCEL_PUSH, and push-stream paths.

Before: a push-disabled client accepts a PUSH_PROMISE or CANCEL_PUSH with push id 0, decodes the header block, and reports a PushPromise event to the application.

After: `check_push_id` rejects any push id while push is disabled and closes the connection with H3_ID_ERROR. `can_receive_push()` is false exactly when no MAX_PUSH_ID is ever sent, so the guard matches the unset-maximum state and leaves the enabled path (push id vs the advertised maximum) unchanged.

Tradeoff: strict rejection over silently dropping an unsolicited push. A push-enabled client is unaffected because `can_receive_push()` is true for it.
