### PR TITLE
reject connection-specific header fields in HTTP/3 messages

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -7110,45 +7110,12 @@ mod tests {
     }
 
     #[test]
-    fn malformed_response_excluded_header() {
-        let (mut client, mut server, request_stream_id) = connect_and_send_request(true);
-
-        setup_server_side_encoder(&mut client, &mut server);
-
-        let mut d = Encoder::default();
-        server.encode_headers(
-            request_stream_id,
-            &[
-                Header::new(":status", "200"),
-                Header::new("content-type", "text/plain"),
-                Header::new("connection", "close"),
-            ],
-            &mut d,
-        );
-
-        // Send response
-        server_send_response_and_exchange_packet(
-            &mut client,
-            &mut server,
-            request_stream_id,
-            &d,
-            false,
-        );
-
-        // Stream has been reset because of the malformed headers.
-        let e = client.events().next().unwrap();
-        assert_eq!(
-            e,
-            Http3ClientEvent::HeaderReady {
-                stream_id: request_stream_id,
-                headers: vec![
-                    Header::new(":status", "200"),
-                    Header::new("content-type", "text/plain")
-                ],
-                interim: false,
-                fin: false,
-            }
-        );
+    fn malformed_response_connection_specific_header() {
+        do_malformed_response_test(&[
+            Header::new(":status", "200"),
+            Header::new("content-type", "text/plain"),
+            Header::new("connection", "close"),
+        ]);
     }
 
     #[test]

--- a/neqo-http3/src/headers_checks.rs
+++ b/neqo-http3/src/headers_checks.rs
@@ -124,6 +124,18 @@ pub fn headers_valid(headers: &[Header], message_type: MessageType) -> Res<()> {
         if header.value().iter().any(|b| matches!(b, 0 | 0x0a | 0x0d)) {
             return Err(Error::InvalidHeader); // illegal characters.
         }
+
+        // Connection-specific header fields make a message malformed (RFC 9114,
+        // Section 4.2). TE is the only one that may appear, and only with the
+        // value "trailers". Names are already lowercased above.
+        if !is_pseudo {
+            match header.name() {
+                "connection" | "keep-alive" | "proxy-connection" | "transfer-encoding"
+                | "upgrade" => return Err(Error::InvalidHeader),
+                "te" if header.value() != b"trailers" => return Err(Error::InvalidHeader),
+                _ => {}
+            }
+        }
     }
     // Clear the regular header bit, since we only check pseudo headers below.
     pseudo_state.remove(PseudoHeaderState::Regular);
@@ -346,6 +358,47 @@ mod tests {
             Header::new(":path", b"/\r\nx".as_slice()),
         ];
         assert!(headers_valid(&headers, MessageType::Request).is_err());
+    }
+
+    #[test]
+    fn reject_connection_specific_header() {
+        // A message carrying a connection-specific header field is malformed
+        // (RFC 9114, Section 4.2), in either direction.
+        for name in [
+            "connection",
+            "keep-alive",
+            "proxy-connection",
+            "transfer-encoding",
+            "upgrade",
+        ] {
+            let response = vec![Header::new(":status", "200"), Header::new(name, "x")];
+            assert!(headers_valid(&response, MessageType::Response).is_err());
+
+            let request = vec![
+                Header::new(":method", "GET"),
+                Header::new(":scheme", "https"),
+                Header::new(":path", "/"),
+                Header::new(name, "x"),
+            ];
+            assert!(headers_valid(&request, MessageType::Request).is_err());
+        }
+
+        // TE is the sole exception, but only carrying the value "trailers".
+        let ok = vec![
+            Header::new(":method", "GET"),
+            Header::new(":scheme", "https"),
+            Header::new(":path", "/"),
+            Header::new("te", "trailers"),
+        ];
+        assert!(headers_valid(&ok, MessageType::Request).is_ok());
+
+        let bad = vec![
+            Header::new(":method", "GET"),
+            Header::new(":scheme", "https"),
+            Header::new(":path", "/"),
+            Header::new("te", "gzip"),
+        ];
+        assert!(headers_valid(&bad, MessageType::Request).is_err());
     }
 
     #[test]

--- a/neqo-http3/src/headers_checks.rs
+++ b/neqo-http3/src/headers_checks.rs
@@ -128,13 +128,12 @@ pub fn headers_valid(headers: &[Header], message_type: MessageType) -> Res<()> {
         // Connection-specific header fields make a message malformed (RFC 9114,
         // Section 4.2). TE is the only one that may appear, and only with the
         // value "trailers". Names are already lowercased above.
-        if !is_pseudo {
-            match header.name() {
-                "connection" | "keep-alive" | "proxy-connection" | "transfer-encoding"
-                | "upgrade" => return Err(Error::InvalidHeader),
-                "te" if header.value() != b"trailers" => return Err(Error::InvalidHeader),
-                _ => {}
+        match header.name() {
+            "connection" | "keep-alive" | "proxy-connection" | "transfer-encoding" | "upgrade" => {
+                return Err(Error::InvalidHeader);
             }
+            "te" if header.value() != b"trailers" => return Err(Error::InvalidHeader),
+            _ => {}
         }
     }
     // Clear the regular header bit, since we only check pseudo headers below.
@@ -370,6 +369,7 @@ mod tests {
             "proxy-connection",
             "transfer-encoding",
             "upgrade",
+            "te",
         ] {
             let response = vec![Header::new(":status", "200"), Header::new(name, "x")];
             assert!(headers_valid(&response, MessageType::Response).is_err());
@@ -391,14 +391,6 @@ mod tests {
             Header::new("te", "trailers"),
         ];
         assert!(headers_valid(&ok, MessageType::Request).is_ok());
-
-        let bad = vec![
-            Header::new(":method", "GET"),
-            Header::new(":scheme", "https"),
-            Header::new(":path", "/"),
-            Header::new("te", "gzip"),
-        ];
-        assert!(headers_valid(&bad, MessageType::Request).is_err());
     }
 
     #[test]


### PR DESCRIPTION
headers_valid() scans received field names and values for illegal bytes but never rejects the connection-specific field names themselves, so a server response carrying Connection, Transfer-Encoding, Upgrade, Keep-Alive, or Proxy-Connection is accepted. RFC 9114 Section 4.2 makes any message that contains one of these malformed. Today recv_message quietly strips the field with a retain() filter and delivers the rest, which is what malformed_response_excluded_header asserted even though its own comment claimed the stream was reset.

Before, the field was dropped and the response delivered; after, headers_valid rejects it so the stream resets with H3_MESSAGE_ERROR, matching the Section 4.3 CR/LF/NUL checks sitting next to it. The check lives in headers_valid because that is the one point both the client response path and the server request path pass through, and it keeps the send path honest through the existing debug assertion. The tradeoff is strictness over leniency: TE stays allowed, but only with the value trailers.
