### PR TITLE
fix: discard server Initial packets that carry a token

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1543,6 +1543,21 @@ impl Connection {
             return Ok(PreprocessResult::Next);
         }
 
+        // RFC 9000, Section 17.2.2: a server MUST set the Token Length field of an
+        // Initial to 0, and a client that receives an Initial with a non-zero Token
+        // Length MUST discard the packet or close with PROTOCOL_VIOLATION. Discarding
+        // is preferred here: the token length sits in the unprotected header, so an
+        // off-path injection must not be able to tear down the connection.
+        if packet.packet_type() == packet::Type::Initial
+            && self.role == Role::Client
+            && !packet.token().is_empty()
+        {
+            self.stats
+                .borrow_mut()
+                .pkt_dropped("Client received an Initial with a token");
+            return Ok(PreprocessResult::Next);
+        }
+
         match (packet.packet_type(), &self.state, &self.role) {
             (packet::Type::Initial, State::Init, Role::Server) => {
                 let version = packet.version().ok_or(Error::ProtocolViolation)?;

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1543,22 +1543,18 @@ impl Connection {
             return Ok(PreprocessResult::Next);
         }
 
-        // RFC 9000, Section 17.2.2: a server MUST set the Token Length field of an
-        // Initial to 0, and a client that receives an Initial with a non-zero Token
-        // Length MUST discard the packet or close with PROTOCOL_VIOLATION. Discarding
-        // is preferred here: the token length sits in the unprotected header, so an
-        // off-path injection must not be able to tear down the connection.
-        if packet.packet_type() == packet::Type::Initial
-            && self.role == Role::Client
-            && !packet.token().is_empty()
-        {
-            self.stats
-                .borrow_mut()
-                .pkt_dropped("Client received an Initial with a token");
-            return Ok(PreprocessResult::Next);
-        }
-
         match (packet.packet_type(), &self.state, &self.role) {
+            // RFC 9000, Section 17.2.2: a server MUST set the Token Length field of an
+            // Initial to 0, and a client that receives an Initial with a non-zero Token
+            // Length MUST discard the packet or close with PROTOCOL_VIOLATION. Discarding
+            // is preferred here: the token length sits in the unprotected header, so an
+            // off-path injection must not be able to tear down the connection.
+            (packet::Type::Initial, _, Role::Client) if !packet.token().is_empty() => {
+                self.stats
+                    .borrow_mut()
+                    .pkt_dropped("Client received an Initial with a token");
+                return Ok(PreprocessResult::Next);
+            }
             (packet::Type::Initial, State::Init, Role::Server) => {
                 let version = packet.version().ok_or(Error::ProtocolViolation)?;
                 if !packet.is_valid_initial()

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -2079,3 +2079,66 @@ fn retry_scid_matching_initial_dcid() {
     drop(client.process(Some(datagram(retry)), now()));
     assert_eq!(client.stats().dropped_rx, 0);
 }
+
+/// RFC 9000, Section 17.2.2: a server MUST set the Token Length field of an Initial
+/// to 0; a client that receives an Initial with a non-zero Token Length MUST discard
+/// it. A token-free server Initial is still processed.
+#[cfg(not(feature = "disable-encryption"))]
+#[test]
+fn client_initial_with_token() {
+    use neqo_common::Encoder;
+
+    use crate::crypto::{CryptoDxDirection, CryptoDxState};
+
+    // A server Initial addressed to the client, encrypted with the Initial keys
+    // seeded by the client's original Destination CID, carrying `token` and a PING.
+    fn server_initial(client_initial: &[u8], token: &[u8]) -> Vec<u8> {
+        // Skip the first byte and 4-byte version, then read the length-prefixed
+        // original Destination CID (the Initial-key seed) and Source CID (which the
+        // client expects as the Destination CID of packets sent back to it).
+        let mut dec = Decoder::from(&client_initial[5..]);
+        let seed = dec.decode_vec(1).expect("client DCID").to_vec();
+        let dcid = dec.decode_vec(1).expect("client SCID").to_vec();
+
+        let version = Version::default();
+        let mut write =
+            CryptoDxState::new_initial(version, CryptoDxDirection::Write, "server in", &seed, 0)
+                .expect("initial keys");
+        let mut builder = crate::packet::Builder::long(
+            Encoder::default(),
+            crate::packet::Type::Initial,
+            version,
+            Some(dcid.as_slice()),
+            Some(&[0x33; 8][..]),
+            crate::packet::LIMIT,
+        );
+        builder.initial_token(token);
+        builder.pn(0, 1);
+        builder.encode([0x01_u8]); // PING, so the packet is ack-eliciting
+        builder.encode([0_u8; 20]); // PADDING, ample sample for header protection
+        builder.build(&mut write).expect("build").as_ref().to_vec()
+    }
+
+    // A token-free server Initial decrypts and is processed (also confirming the
+    // forged packet above is well-formed).
+    let mut client = default_client();
+    let ci = client
+        .process_output(now())
+        .dgram()
+        .expect("a datagram")
+        .to_vec();
+    let dropped = client.stats().dropped_rx;
+    drop(client.process(Some(datagram(server_initial(&ci, &[]))), now()));
+    assert_eq!(client.stats().dropped_rx, dropped);
+
+    // The same Initial carrying a non-empty token is discarded.
+    let mut client = default_client();
+    let ci = client
+        .process_output(now())
+        .dgram()
+        .expect("a datagram")
+        .to_vec();
+    let dropped = client.stats().dropped_rx;
+    drop(client.process(Some(datagram(server_initial(&ci, &[0x01]))), now()));
+    assert_eq!(client.stats().dropped_rx, dropped + 1);
+}

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -2109,7 +2109,7 @@ fn client_initial_with_token() {
             crate::packet::Type::Initial,
             version,
             Some(dcid.as_slice()),
-            Some(&[0x33; 8][..]),
+            Some(b"fakescid"),
             crate::packet::LIMIT,
         );
         builder.initial_token(token);
@@ -2128,7 +2128,7 @@ fn client_initial_with_token() {
         .expect("a datagram")
         .to_vec();
     let dropped = client.stats().dropped_rx;
-    drop(client.process(Some(datagram(server_initial(&ci, &[]))), now()));
+    client.process_input(datagram(server_initial(&ci, &[])), now());
     assert_eq!(client.stats().dropped_rx, dropped);
 
     // The same Initial carrying a non-empty token is discarded.
@@ -2139,6 +2139,6 @@ fn client_initial_with_token() {
         .expect("a datagram")
         .to_vec();
     let dropped = client.stats().dropped_rx;
-    drop(client.process(Some(datagram(server_initial(&ci, &[0x01]))), now()));
+    client.process_input(datagram(server_initial(&ci, &[0x01])), now());
     assert_eq!(client.stats().dropped_rx, dropped + 1);
 }


### PR DESCRIPTION
preprocess_packet validates a received Initial's Token Length only in the server arm, through is_valid_initial. A client-received Initial matches none of those arms, so the token that decode_long already parsed is ignored and the packet goes on to be decrypted and processed. RFC 9000, Section 17.2.2 says a server MUST set the Token Length of an Initial to 0, and a client that receives an Initial with a non-zero Token Length MUST discard it or close with PROTOCOL_VIOLATION. A server, or an off-path injector that derived the public Initial keys, can hand the client an Initial that carries a token and neqo accepts it.

Before: the client silently accepted the illegal token. After: preprocess_packet drops the packet as soon as a client sees an Initial with a non-empty token, beside the existing client Initial/Handshake path check so coalesced and replayed packets are covered too. Discarding is the safer of the two behaviors the RFC permits here, because the token length sits outside packet protection and closing on it would let an off-path packet end the connection; the tradeoff is that a genuinely misbehaving server gets no error signal back.