### PR TITLE
chore: prepare v0.30.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -515,7 +515,7 @@ dependencies = [
  "neqo-qpack",
  "neqo-transport",
  "nss-rs",
- "test-fixture 0.30.0",
+ "test-fixture 0.30.1",
 ]
 
 [[package]]
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "cfg_aliases",
  "clap",
@@ -742,14 +742,14 @@ dependencies = [
  "rustc-hash",
  "strum",
  "test-fixture 0.1.0",
- "test-fixture 0.30.0",
+ "test-fixture 0.30.1",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "neqo-common"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -760,14 +760,14 @@ dependencies = [
  "sha1",
  "static_assertions",
  "strum",
- "test-fixture 0.30.0",
+ "test-fixture 0.30.1",
  "thiserror",
  "windows",
 ]
 
 [[package]]
 name = "neqo-http3"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enumset",
@@ -783,13 +783,13 @@ dependencies = [
  "sfv",
  "static_assertions",
  "strum",
- "test-fixture 0.30.0",
+ "test-fixture 0.30.1",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-qpack"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "log",
  "neqo-common",
@@ -797,13 +797,13 @@ dependencies = [
  "qlog",
  "rustc-hash",
  "static_assertions",
- "test-fixture 0.30.0",
+ "test-fixture 0.30.1",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-transport"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -819,13 +819,13 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "strum",
- "test-fixture 0.30.0",
+ "test-fixture 0.30.1",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-udp"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.30.0"
+version = "0.30.1"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
With https://github.com/mozilla/neqo/pull/3776 and https://github.com/mozilla/neqo/pull/3812 merged, I would like to cut `v0.30.1`. 

Firefox CI with current Neqo `main` vendored: https://treeherder.mozilla.org/jobs?repo=try&landoInstance=lando-prod-2025&landoCommitID=68843