### PR TITLE
Support handling queuing and highwatermarks/max-age for outgoing datagrams per the WebTransport spec

### DIFF
--- a/neqo-common/src/bytes.rs
+++ b/neqo-common/src/bytes.rs
@@ -39,6 +39,15 @@ impl Bytes {
         self.len() == 0
     }
 
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        if self.offset == 0 {
+            self.data
+        } else {
+            self.data[self.offset..].to_vec()
+        }
+    }
+
     /// Skips the first `n` bytes, consuming and returning `self`.
     ///
     /// # Panics

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -45,6 +45,10 @@ pub enum WebTransportEvent {
         session_id: StreamId,
         datagram: Bytes,
     },
+    DatagramOutcome {
+        session_id: StreamId,
+        outcome: extended_connect::datagram_queue::DatagramOutcome,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -47,6 +47,10 @@ pub enum WebTransportEvent {
         session_id: StreamId,
         datagram: Bytes,
     },
+    DatagramOutcome {
+        session_id: StreamId,
+        outcome: extended_connect::DatagramOutcome,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -68,6 +72,10 @@ pub enum ConnectUdpEvent {
     Datagram {
         session_id: StreamId,
         datagram: Bytes,
+    },
+    DatagramOutcome {
+        session_id: StreamId,
+        outcome: extended_connect::DatagramOutcome,
     },
 }
 
@@ -285,6 +293,29 @@ impl ExtendedConnectEvents for Http3ClientEvents {
                 Http3ClientEvent::ConnectUdp(ConnectUdpEvent::Datagram {
                     session_id,
                     datagram,
+                })
+            }
+        };
+        self.events.push(event);
+    }
+
+    fn datagram_outcome(
+        &self,
+        session_id: StreamId,
+        outcome: extended_connect::DatagramOutcome,
+        connect_type: ExtendedConnectType,
+    ) {
+        let event = match connect_type {
+            ExtendedConnectType::WebTransport => {
+                Http3ClientEvent::WebTransport(WebTransportEvent::DatagramOutcome {
+                    session_id,
+                    outcome,
+                })
+            }
+            ExtendedConnectType::ConnectUdp => {
+                Http3ClientEvent::ConnectUdp(ConnectUdpEvent::DatagramOutcome {
+                    session_id,
+                    outcome,
                 })
             }
         };

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum WebTransportEvent {
     Negotiated(
         /// Whether WebTransport was negotiated.
@@ -54,6 +55,7 @@ pub enum WebTransportEvent {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum ConnectUdpEvent {
     Negotiated(
         /// Whether CONNECT-UDP was negotiated.

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -62,6 +62,12 @@ pub trait ClientSession {
 
     /// Send a connect-udp datagram.
     ///
+    /// If the peer has no QUIC DATAGRAM support, this falls back to the HTTP
+    /// DATAGRAM Capsule and bypasses the datagram queue entirely: the
+    /// returned `DatagramQueueOutcome` is always `Ok` on that path and does
+    /// not reflect any real backpressure (see `DatagramOutcome::Sent`'s
+    /// docs).
+    ///
     /// # Errors
     ///
     /// It may return [`Error::InvalidStreamId`] if a stream does not exist anymore.

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -73,7 +73,7 @@ pub trait ClientSession {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<(bool, Option<extended_connect::DatagramOutcome>)>;
 }
 
 impl ClientSession for Http3Client {
@@ -118,7 +118,7 @@ impl ClientSession for Http3Client {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<(bool, Option<extended_connect::DatagramOutcome>)> {
         qtrace!("connect_udp_send_datagram session:{session_id:?}");
         let (conn, handler) = self.connection_and_handler();
         handler.connect_udp_send_datagram(conn, session_id, buf, id, now)
@@ -160,7 +160,7 @@ trait Handler {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<(bool, Option<extended_connect::DatagramOutcome>)>;
 }
 
 impl Handler for Http3Connection {
@@ -232,7 +232,7 @@ impl Handler for Http3Connection {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<(bool, Option<extended_connect::DatagramOutcome>)> {
         self.extended_connect_send_datagram(session_id, conn, buf, id, now)
     }
 }
@@ -304,6 +304,7 @@ impl ServerHandler for Http3ServerHandler {
         self.mark_needs_processing();
         self.base_handler_mut()
             .connect_udp_send_datagram(conn, session_id, buf, id, now)
+            .map(|_| ())
     }
 }
 

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -73,7 +73,7 @@ pub trait ClientSession {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<extended_connect::DatagramQueueOutcome>;
 }
 
 impl ClientSession for Http3Client {
@@ -118,7 +118,7 @@ impl ClientSession for Http3Client {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<extended_connect::DatagramQueueOutcome> {
         qtrace!("connect_udp_send_datagram session:{session_id:?}");
         let (conn, handler) = self.connection_and_handler();
         handler.connect_udp_send_datagram(conn, session_id, buf, id, now)
@@ -160,7 +160,7 @@ trait Handler {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<extended_connect::DatagramQueueOutcome>;
 }
 
 impl Handler for Http3Connection {
@@ -232,7 +232,7 @@ impl Handler for Http3Connection {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<extended_connect::DatagramQueueOutcome> {
         self.extended_connect_send_datagram(session_id, conn, buf, id, now)
     }
 }
@@ -304,6 +304,7 @@ impl ServerHandler for Http3ServerHandler {
         self.mark_needs_processing();
         self.base_handler_mut()
             .connect_udp_send_datagram(conn, session_id, buf, id, now)
+            .map(|_| ())
     }
 }
 
@@ -439,6 +440,10 @@ pub enum ServerEvent {
         session: ServerSession,
         datagram: Bytes,
     },
+    DatagramOutcome {
+        session: ServerSession,
+        outcome: extended_connect::DatagramOutcome,
+    },
 }
 
 pub(crate) trait ServerEvents {
@@ -450,6 +455,11 @@ pub(crate) trait ServerEvents {
         headers: Option<Vec<Header>>,
     );
     fn connect_udp_datagram(&self, session: ServerSession, datagram: Bytes);
+    fn connect_udp_datagram_outcome(
+        &self,
+        session: ServerSession,
+        outcome: extended_connect::DatagramOutcome,
+    );
 }
 
 impl ServerEvents for Http3ServerEvents {
@@ -477,6 +487,17 @@ impl ServerEvents for Http3ServerEvents {
         self.push(Http3ServerEvent::ConnectUdp(ServerEvent::Datagram {
             session,
             datagram,
+        }));
+    }
+
+    fn connect_udp_datagram_outcome(
+        &self,
+        session: ServerSession,
+        outcome: extended_connect::DatagramOutcome,
+    ) {
+        self.push(Http3ServerEvent::ConnectUdp(ServerEvent::DatagramOutcome {
+            session,
+            outcome,
         }));
     }
 }

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -263,7 +263,7 @@ pub(crate) trait ServerHandler {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<extended_connect::DatagramQueueOutcome>;
 }
 
 impl ServerHandler for Http3ServerHandler {
@@ -300,11 +300,10 @@ impl ServerHandler for Http3ServerHandler {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<extended_connect::DatagramQueueOutcome> {
         self.mark_needs_processing();
         self.base_handler_mut()
             .connect_udp_send_datagram(conn, session_id, buf, id, now)
-            .map(|_| ())
     }
 }
 
@@ -392,7 +391,7 @@ impl ServerSession {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<extended_connect::DatagramQueueOutcome> {
         let session_id = self.stream_handler.stream_id();
         self.stream_handler
             .handler

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -431,6 +431,7 @@ impl ServerSession {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum ServerEvent {
     NewSession {
         session: ServerSession,

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1657,10 +1657,82 @@ impl Http3Connection {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<(
+        bool,
+        Option<extended_connect::datagram_queue::DatagramOutcome>,
+    )> {
         self.validate_extended_connect_session(session_id)?
             .borrow_mut()
             .send_datagram(conn, buf, id, now)
+    }
+
+    /// # Errors
+    /// Returns `InvalidStreamId` if the session does not exist or is not a `WebTransport`
+    /// session.
+    pub fn webtransport_set_datagram_high_water_mark(
+        &self,
+        session_id: StreamId,
+        mark: f64,
+    ) -> Res<()> {
+        self.webtransport_session(session_id)?
+            .borrow_mut()
+            .set_datagram_high_water_mark(mark);
+        Ok(())
+    }
+
+    /// # Errors
+    /// Returns `InvalidStreamId` if the session does not exist or is not a `WebTransport`
+    /// session.
+    pub fn webtransport_set_datagram_max_age(
+        &self,
+        session_id: StreamId,
+        age_ms: f64,
+        now: Instant,
+    ) -> Res<Vec<extended_connect::datagram_queue::DatagramOutcome>> {
+        Ok(self
+            .webtransport_session(session_id)?
+            .borrow_mut()
+            .set_datagram_max_age(age_ms, now))
+    }
+
+    /// Drain one session's datagram queue into the QUIC layer.
+    ///
+    /// Applies to every extended-CONNECT protocol, not just `WebTransport`: connect-udp
+    /// sessions queue their datagrams the same way.
+    ///
+    /// # Errors
+    /// Returns `InvalidStreamId` if the session does not exist.
+    fn process_datagram_queue(
+        &self,
+        session_id: StreamId,
+        conn: &mut Connection,
+        now: Instant,
+    ) -> Res<Vec<extended_connect::datagram_queue::DatagramOutcome>> {
+        Ok(self
+            .get_extended_connect_session(session_id)?
+            .borrow_mut()
+            .process_datagram_queue(conn, now))
+    }
+
+    pub(crate) fn process_all_datagram_queues(
+        &self,
+        conn: &mut Connection,
+        now: Instant,
+        mut on_outcome: impl FnMut(StreamId, extended_connect::datagram_queue::DatagramOutcome),
+    ) {
+        let session_ids: Vec<StreamId> = self
+            .recv_streams
+            .iter()
+            .filter_map(|(id, stream)| stream.extended_connect_session().is_some().then_some(*id))
+            .collect();
+
+        for session_id in session_ids {
+            if let Ok(outcomes) = self.process_datagram_queue(session_id, conn, now) {
+                for outcome in outcomes {
+                    on_outcome(session_id, outcome);
+                }
+            }
+        }
     }
 
     /// If the control stream has received frames `MaxPushId`, `Goaway`, `PriorityUpdateRequest` or

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1670,11 +1670,11 @@ impl Http3Connection {
         session_id: StreamId,
         max_age: Duration,
         now: Instant,
-    ) -> Res<Vec<extended_connect::DatagramOutcome>> {
-        Ok(self
-            .webtransport_session(session_id)?
+    ) -> Res<()> {
+        self.webtransport_session(session_id)?
             .borrow_mut()
-            .set_datagram_max_age(max_age, now))
+            .set_datagram_max_age(max_age, now);
+        Ok(())
     }
 
     /// Drain every session's datagram queue into the QUIC layer.

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1687,6 +1687,11 @@ impl Http3Connection {
     /// Also refreshes the cache [`Self::next_datagram_expiry`] reads, using
     /// the same `recv_streams` walk this already has to do rather than
     /// paying for a second one.
+    ///
+    /// Invariant callers must preserve: the cache is only as fresh as the
+    /// last call to this function, so a caller that clamps a callback delay
+    /// against [`Self::next_datagram_expiry`] must call this *first*, in the
+    /// same processing round, or it clamps against last round's deadline.
     pub(crate) fn process_all_datagram_queues(&mut self, conn: &mut Connection, now: Instant) {
         self.datagram_next_expiry = self
             .recv_streams

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1693,6 +1693,10 @@ impl Http3Connection {
     /// against [`Self::next_datagram_expiry`] must call this *first*, in the
     /// same processing round, or it clamps against last round's deadline.
     pub(crate) fn process_all_datagram_queues(&mut self, conn: &mut Connection, now: Instant) {
+        if !self.webtransport.enabled() && !self.connect_udp.enabled() {
+            self.datagram_next_expiry = None;
+            return;
+        }
         self.datagram_next_expiry = self
             .recv_streams
             .values()

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -17,7 +17,8 @@ use neqo_common::{
 };
 use neqo_qpack as qpack;
 use neqo_transport::{
-    AppError, CloseReason, Connection, DatagramTracking, State, StreamId, StreamType, ZeroRttState,
+    AppError, CloseReason, Connection, DatagramTracking, OutputBatch, State, StreamId, StreamType,
+    ZeroRttState,
     streams::{SendGroupId, SendOrder},
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -2032,6 +2033,24 @@ impl Http3Connection {
     #[must_use]
     pub fn recv_streams_mut(&mut self) -> &mut HashMap<StreamId, Box<dyn RecvStream>> {
         &mut self.recv_streams
+    }
+}
+
+/// Clamp an [`OutputBatch::Callback`]'s delay to `expiry`, if that's sooner:
+/// the transport layer's callback delay has no notion of an http3-layer
+/// datagram queue's max-age deadline, so without this an otherwise-idle
+/// connection with a queued datagram would wait on whatever unrelated timer
+/// happens to fire next instead of waking up in time to expire it. A no-op
+/// on every other [`OutputBatch`] variant, and on an `expiry` that's already
+/// passed or absent.
+pub fn clamp_to_expiry(out: OutputBatch, expiry: Option<Instant>, now: Instant) -> OutputBatch {
+    match out {
+        OutputBatch::Callback(delay) => OutputBatch::Callback(
+            expiry
+                .filter(|expiry| *expiry > now)
+                .map_or(delay, |expiry| delay.min(expiry - now)),
+        ),
+        out => out,
     }
 }
 

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -304,6 +304,11 @@ pub struct Http3Connection {
     /// read by [`Self::next_datagram_expiry`] instead of re-walking
     /// `recv_streams`.
     datagram_next_expiry: Option<Instant>,
+    /// The stream id of every extended-CONNECT session's control stream,
+    /// kept in sync with `recv_streams` on session create/remove so
+    /// [`Self::process_all_datagram_queues`] doesn't need to walk every
+    /// stream on the connection to find the handful that are sessions.
+    extended_connect_session_ids: HashSet<StreamId>,
 }
 
 impl Display for Http3Connection {
@@ -343,6 +348,7 @@ impl Http3Connection {
             send_group_generator: SendGroupGenerator::default(),
             role,
             datagram_next_expiry: None,
+            extended_connect_session_ids: HashSet::default(),
         }
     }
 
@@ -662,6 +668,7 @@ impl Http3Connection {
             // TODO: investigate whether this code can automatically retry failed transactions.
             self.send_streams.clear();
             self.recv_streams.clear();
+            self.extended_connect_session_ids.clear();
             Ok(())
         } else {
             debug_assert!(false, "Zero rtt rejected in the wrong state");
@@ -787,6 +794,7 @@ impl Http3Connection {
         }
         self.send_streams.clear();
         self.recv_streams.clear();
+        self.extended_connect_session_ids.clear();
     }
 
     /// This function will not handle the output of the function completely, but only
@@ -1225,6 +1233,7 @@ impl Http3Connection {
             Box::new(Rc::clone(&extended_conn)),
             Box::new(Rc::clone(&extended_conn)),
         );
+        self.extended_connect_session_ids.insert(id);
 
         let final_headers = Self::create_request_headers(&RequestDescription {
             method: "CONNECT",
@@ -1335,6 +1344,7 @@ impl Http3Connection {
                 Box::new(Rc::clone(&extended_conn)),
                 Box::new(extended_conn),
             );
+            self.extended_connect_session_ids.insert(stream_id);
             self.streams_with_pending_data.insert(stream_id);
         } else {
             self.cancel_fetch(stream_id, Error::HttpRequestRejected.code(), conn)?;
@@ -1685,8 +1695,10 @@ impl Http3Connection {
     /// callback here for a caller to mis-tag by protocol.
     ///
     /// Also refreshes the cache [`Self::next_datagram_expiry`] reads, using
-    /// the same `recv_streams` walk this already has to do rather than
-    /// paying for a second one.
+    /// [`Self::extended_connect_session_ids`] instead of walking all of
+    /// `recv_streams`: most streams on a connection aren't extended-CONNECT
+    /// sessions at all, and the per-feature check below only helps when the
+    /// feature is off entirely.
     ///
     /// Invariant callers must preserve: the cache is only as fresh as the
     /// last call to this function, so a caller that clamps a callback delay
@@ -1698,8 +1710,9 @@ impl Http3Connection {
             return;
         }
         self.datagram_next_expiry = self
-            .recv_streams
-            .values()
+            .extended_connect_session_ids
+            .iter()
+            .filter_map(|id| self.recv_streams.get(id))
             .filter_map(|s| s.extended_connect_session())
             .filter_map(|session| {
                 session.borrow_mut().process_datagram_queue(conn, now);
@@ -1939,6 +1952,7 @@ impl Http3Connection {
         if let Some(s) = &stream
             && s.stream_type() == Http3StreamType::ExtendedConnect
         {
+            self.extended_connect_session_ids.remove(&stream_id);
             self.send_streams.remove(&stream_id)?;
             if let Some(wt) = s.extended_connect_session() {
                 self.remove_extended_connect(&wt, conn);
@@ -1955,12 +1969,15 @@ impl Http3Connection {
         let stream = self.send_streams.remove(&stream_id);
         if let Some(s) = &stream
             && s.stream_type() == Http3StreamType::ExtendedConnect
-            && let Some(wt) = self
+        {
+            self.extended_connect_session_ids.remove(&stream_id);
+            if let Some(wt) = self
                 .recv_streams
                 .remove(&stream_id)?
                 .extended_connect_session()
-        {
-            self.remove_extended_connect(&wt, conn);
+            {
+                self.remove_extended_connect(&wt, conn);
+            }
         }
         stream
     }

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -9,7 +9,7 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
     mem,
     rc::Rc,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use neqo_common::{
@@ -300,6 +300,10 @@ pub struct Http3Connection {
     webtransport: ExtendedConnectFeature,
     connect_udp: ExtendedConnectFeature,
     send_group_generator: SendGroupGenerator,
+    /// Cached result of the last [`Self::process_all_datagram_queues`] call,
+    /// read by [`Self::next_datagram_expiry`] instead of re-walking
+    /// `recv_streams`.
+    datagram_next_expiry: Option<Instant>,
 }
 
 impl Display for Http3Connection {
@@ -338,6 +342,7 @@ impl Http3Connection {
             recv_streams: HashMap::default(),
             send_group_generator: SendGroupGenerator::default(),
             role,
+            datagram_next_expiry: None,
         }
     }
 
@@ -1637,10 +1642,73 @@ impl Http3Connection {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<extended_connect::DatagramQueueOutcome> {
         self.validate_extended_connect_session(session_id)?
             .borrow_mut()
             .send_datagram(conn, buf, id, now)
+    }
+
+    /// # Errors
+    /// Returns `InvalidStreamId` if the session does not exist or is not a `WebTransport`
+    /// session.
+    pub fn webtransport_set_datagram_high_water_mark(
+        &self,
+        session_id: StreamId,
+        mark: Option<usize>,
+    ) -> Res<()> {
+        self.webtransport_session(session_id)?
+            .borrow_mut()
+            .set_datagram_high_water_mark(mark);
+        Ok(())
+    }
+
+    /// # Errors
+    /// Returns `InvalidStreamId` if the session does not exist or is not a `WebTransport`
+    /// session.
+    pub fn webtransport_set_datagram_max_age(
+        &self,
+        session_id: StreamId,
+        max_age: Duration,
+        now: Instant,
+    ) -> Res<Vec<extended_connect::DatagramOutcome>> {
+        Ok(self
+            .webtransport_session(session_id)?
+            .borrow_mut()
+            .set_datagram_max_age(max_age, now))
+    }
+
+    /// Drain every session's datagram queue into the QUIC layer.
+    ///
+    /// Applies to every extended-CONNECT protocol, not just `WebTransport`: connect-udp
+    /// sessions queue their datagrams the same way. Each session reports its own
+    /// outcomes through its own `events`/`connect_type`, so there is no per-outcome
+    /// callback here for a caller to mis-tag by protocol.
+    ///
+    /// Also refreshes the cache [`Self::next_datagram_expiry`] reads, using
+    /// the same `recv_streams` walk this already has to do rather than
+    /// paying for a second one.
+    pub(crate) fn process_all_datagram_queues(&mut self, conn: &mut Connection, now: Instant) {
+        self.datagram_next_expiry = self
+            .recv_streams
+            .values()
+            .filter_map(|s| s.extended_connect_session())
+            .filter_map(|session| {
+                session.borrow_mut().process_datagram_queue(conn, now);
+                session.borrow().next_datagram_expiry()
+            })
+            .min();
+    }
+
+    /// The earliest instant at which any session's outgoing datagram queue
+    /// needs [`Self::process_all_datagram_queues`] called again to expire a
+    /// stale datagram, even if nothing else - no packets to send or receive,
+    /// no other timer - would otherwise trigger it. `None` if no session has
+    /// a datagram queued with an expiry pending.
+    ///
+    /// Reads the cache [`Self::process_all_datagram_queues`] refreshes,
+    /// instead of walking `recv_streams` a second time.
+    pub(crate) const fn next_datagram_expiry(&self) -> Option<Instant> {
+        self.datagram_next_expiry
     }
 
     /// Frames whose handling is specific to the client and server (`Goaway`,

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -32,7 +32,7 @@ use nss::{AuthenticationStatus, ResumptionToken, SecretAgentInfo, agent::Certifi
 use crate::{
     Error, Http3Parameters, NewStreamType, Priority, ReceiveOutput, Res, SendGroupId,
     client_events::{Http3ClientEvent, Http3ClientEvents, WebTransportEvent},
-    connection::{Http3Connection, Http3State, RequestDescription},
+    connection::{Http3Connection, Http3State, RequestDescription, clamp_to_expiry},
     features::ConnectType,
     frames::HFrame,
     request_target::RequestTarget,
@@ -826,20 +826,7 @@ impl Http3Client {
         // Update H3 for any transport state changes and events
         self.process_http3(now);
 
-        // `self.conn`'s callback delay only accounts for transport-layer
-        // timers; it has no notion of an http3-layer datagram queue's
-        // max-age deadline. Clamp it so an otherwise-idle connection still
-        // wakes up in time to expire a stale queued datagram, instead of
-        // waiting on whatever unrelated timer happens to fire next.
-        match out {
-            OutputBatch::Callback(delay) => OutputBatch::Callback(
-                self.base_handler
-                    .next_datagram_expiry()
-                    .filter(|expiry| *expiry > now)
-                    .map_or(delay, |expiry| delay.min(expiry - now)),
-            ),
-            out => out,
-        }
+        clamp_to_expiry(out, self.base_handler.next_datagram_expiry(), now)
     }
 
     /// This function takes the provided result and check for an error.

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -752,6 +752,14 @@ impl Http3Client {
                 }
                 let res = self.base_handler.process_sending(&mut self.conn, now);
                 self.check_result(now, &res);
+
+                // Drain per-session datagram queues into the QUIC layer.
+                // Datagrams are enqueued by webtransport_send_datagram() and only
+                // moved to the QUIC send queue here, during process_http3(). This
+                // is called from process_output()/process(), so datagrams are sent
+                // on the next outgoing packet after the caller triggers processing.
+                self.base_handler
+                    .process_all_datagram_queues(&mut self.conn, now);
             }
             Http3State::Closed { .. } => {}
             _ => {
@@ -794,6 +802,12 @@ impl Http3Client {
     ///    state-change event.
     ///  - Therefore the HTTP/3 layer processing (`process_http3`) is called again.
     ///
+    /// The returned [`OutputBatch::Callback`] duration is also clamped to any
+    /// pending WebTransport datagram-queue max-age deadline
+    /// (`Http3Connection::next_datagram_expiry`), so a session with a queued
+    /// datagram and no other timer pending still gets `process_output`
+    /// called again in time to expire it.
+    ///
     /// [1]: ../neqo_transport/enum.Output.html
     /// [2]: ../neqo_transport/struct.ConnectionEvents.html
     /// [3]: ../neqo_transport/struct.Connection.html#method.process_output
@@ -812,7 +826,20 @@ impl Http3Client {
         // Update H3 for any transport state changes and events
         self.process_http3(now);
 
-        out
+        // `self.conn`'s callback delay only accounts for transport-layer
+        // timers; it has no notion of an http3-layer datagram queue's
+        // max-age deadline. Clamp it so an otherwise-idle connection still
+        // wakes up in time to expire a stale queued datagram, instead of
+        // waiting on whatever unrelated timer happens to fire next.
+        match out {
+            OutputBatch::Callback(delay) => OutputBatch::Callback(
+                self.base_handler
+                    .next_datagram_expiry()
+                    .filter(|expiry| *expiry > now)
+                    .map_or(delay, |expiry| delay.min(expiry - now)),
+            ),
+            out => out,
+        }
     }
 
     /// This function takes the provided result and check for an error.

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -802,6 +802,24 @@ impl Http3Client {
                     .maybe_send_max_push_id_frame(&mut self.base_handler);
                 let res = self.base_handler.process_sending(&mut self.conn, now);
                 self.check_result(now, &res);
+
+                // Drain per-session datagram queues into the QUIC layer.
+                // Datagrams are enqueued by webtransport_send_datagram() and only
+                // moved to the QUIC send queue here, during process_http3(). This
+                // is called from process_output()/process(), so datagrams are sent
+                // on the next outgoing packet after the caller triggers processing.
+                self.base_handler.process_all_datagram_queues(
+                    &mut self.conn,
+                    now,
+                    |session_id, outcome| {
+                        self.events.insert(Http3ClientEvent::WebTransport(
+                            WebTransportEvent::DatagramOutcome {
+                                session_id,
+                                outcome,
+                            },
+                        ));
+                    },
+                );
             }
             Http3State::Closed { .. } => {}
             _ => {

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -227,6 +227,12 @@ impl Http3ServerHandler {
     /// connection whose only pending work is an expired datagram is never
     /// processed, so it never expires and `set_datagram_max_age` has no
     /// effect on an otherwise-idle connection.
+    ///
+    /// The expiry check is gated on `active()`: once a connection stops
+    /// being processed (see `Http3ServerHandler::process_http3`), nothing
+    /// refreshes its cached expiry, so a stale `Some(t <= now)` left over
+    /// from before it went inactive would otherwise make this return `true`
+    /// forever, spinning the handler until it's finally removed.
     pub(crate) fn should_be_processed(&mut self, now: Instant) -> bool {
         if self.needs_processing {
             self.needs_processing = false;
@@ -234,7 +240,8 @@ impl Http3ServerHandler {
         }
         self.base_handler.has_data_to_send()
             || self.events.has_events()
-            || self.next_datagram_expiry().is_some_and(|e| e <= now)
+            || (self.base_handler.state().active()
+                && self.next_datagram_expiry().is_some_and(|e| e <= now))
     }
 
     // This function takes the provided result and check for an error.

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -199,6 +199,10 @@ impl Http3ServerHandler {
         if !self.check_result(conn, now, &res) && self.base_handler.state().active() {
             let res = self.base_handler.process_sending(conn, now);
             self.check_result(conn, now, &res);
+
+            // Process datagram queues to send any queued datagrams
+            self.base_handler
+                .process_all_datagram_queues(conn, now, |_, _| {});
         }
     }
 

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -54,6 +54,11 @@ impl Http3ServerHandler {
         &mut self.base_handler
     }
 
+    /// See [`Http3Connection::next_datagram_expiry`].
+    pub(crate) const fn next_datagram_expiry(&self) -> Option<Instant> {
+        self.base_handler.next_datagram_expiry()
+    }
+
     pub(crate) const fn server_events(&self) -> &Http3ServerConnEvents {
         &self.events
     }
@@ -199,6 +204,9 @@ impl Http3ServerHandler {
         if !self.check_result(conn, now, &res) && self.base_handler.state().active() {
             let res = self.base_handler.process_sending(conn, now);
             self.check_result(conn, now, &res);
+
+            // Process datagram queues to send any queued datagrams
+            self.base_handler.process_all_datagram_queues(conn, now);
         }
     }
 
@@ -214,13 +222,19 @@ impl Http3ServerHandler {
         self.needs_processing = true;
     }
 
-    /// Whether this connection has events to process or data to send.
-    pub(crate) fn should_be_processed(&mut self) -> bool {
+    /// Whether this connection has events to process, data to send, or a
+    /// queued datagram past its max-age: without the last check, a
+    /// connection whose only pending work is an expired datagram is never
+    /// processed, so it never expires and `set_datagram_max_age` has no
+    /// effect on an otherwise-idle connection.
+    pub(crate) fn should_be_processed(&mut self, now: Instant) -> bool {
         if self.needs_processing {
             self.needs_processing = false;
             return true;
         }
-        self.base_handler.has_data_to_send() || self.events.has_events()
+        self.base_handler.has_data_to_send()
+            || self.events.has_events()
+            || self.next_datagram_expiry().is_some_and(|e| e <= now)
     }
 
     // This function takes the provided result and check for an error.

--- a/neqo-http3/src/features/extended_connect/datagram_queue.rs
+++ b/neqo-http3/src/features/extended_connect/datagram_queue.rs
@@ -1,0 +1,537 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant},
+};
+
+use neqo_common::{qdebug, qtrace};
+
+pub const DEFAULT_HARD_LIMIT: usize = 1000;
+const DEFAULT_MAX_AGE: Duration = Duration::MAX;
+
+/// Caller-supplied identifier used to report the fate of a tracked datagram.
+pub type DatagramId = u64;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DatagramOutcome {
+    /// Handed to the QUIC layer's outgoing queue. Not a delivery or even a
+    /// transmission guarantee; the transport reports the eventual fate
+    /// separately via `ConnectionEvent::OutgoingDatagramOutcome`.
+    Sent(DatagramId),
+    Expired(DatagramId),
+    /// Discarded without being sent: either the QUIC layer refused it when it
+    /// was finally handed over, or the session closed while it was still queued.
+    Dropped(DatagramId),
+}
+
+impl DatagramOutcome {
+    #[must_use]
+    pub const fn id(&self) -> DatagramId {
+        match *self {
+            Self::Sent(id) | Self::Expired(id) | Self::Dropped(id) => id,
+        }
+    }
+}
+
+/// The state of the queue after accepting a datagram, which is what the
+/// application needs in order to apply backpressure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DatagramQueueOutcome {
+    /// The queue was below the high water mark.
+    Ok,
+    /// The queue had space, but it was at or above the high water mark.
+    AboveWatermark,
+    /// The queue was full, so the oldest datagram was dropped to make room.
+    /// `dropped` is its tracking ID, or `None` if it was sent untracked.
+    Overflowed { dropped: Option<DatagramId> },
+}
+
+#[derive(Debug)]
+pub struct QueuedDatagram {
+    pub data: Vec<u8>,
+    /// Caller-supplied tracking ID, or `None` if the caller sent the datagram
+    /// untracked (in which case no [`DatagramOutcome`] is ever reported for it).
+    pub id: Option<DatagramId>,
+    pub timestamp: Instant,
+}
+
+impl QueuedDatagram {
+    pub const fn new(data: Vec<u8>, id: Option<DatagramId>, now: Instant) -> Self {
+        Self {
+            data,
+            id,
+            timestamp: now,
+        }
+    }
+
+    pub fn age(&self, now: Instant) -> Duration {
+        now.saturating_duration_since(self.timestamp)
+    }
+}
+
+/// Per-session outgoing datagram queue with high water mark and max-age support.
+///
+/// Datagrams are enqueued here by [`Self::enqueue`] and drained into
+/// the QUIC layer by [`Self::drain`], which is called during `process_http3()` as part
+/// of `process_output()`. The caller must call `process_output()` after enqueuing
+/// to ensure datagrams are actually transmitted. In Gecko, this happens via
+/// `StreamHasDataToWrite()` -> `ForceSend()`, which asynchronously dispatches
+/// `SendData()` -> `ProcessOutput()` on the next event loop cycle.
+#[derive(Debug)]
+pub struct WebTransportDatagramQueue {
+    queue: VecDeque<QueuedDatagram>,
+    hard_limit: usize,
+    high_water_mark: Option<usize>,
+    max_age: Duration,
+}
+
+impl WebTransportDatagramQueue {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+            hard_limit: DEFAULT_HARD_LIMIT,
+            high_water_mark: None,
+            max_age: DEFAULT_MAX_AGE,
+        }
+    }
+
+    /// Clamped to [`Self::hard_limit`]: a watermark above it would never be
+    /// reached, since the queue never grows past the hard limit, leaving
+    /// [`DatagramQueueOutcome::AboveWatermark`] permanently unreachable and
+    /// the caller with no warning before [`DatagramQueueOutcome::Overflowed`].
+    pub fn set_high_water_mark(&mut self, mark: Option<usize>) {
+        let clamped = mark.map(|m| m.min(self.hard_limit));
+        qtrace!("Setting high water mark to {mark:?} (clamped: {clamped:?})");
+        self.high_water_mark = clamped;
+    }
+
+    /// Returns one entry per expired datagram, `Some(id)` for tracked ones.
+    /// The caller reports outcomes for the tracked ones and counts them all.
+    pub fn set_max_age(&mut self, max_age: Duration, now: Instant) -> Vec<Option<DatagramId>> {
+        qtrace!("Setting max age to {max_age:?}");
+        self.max_age = max_age;
+        self.expire_old_datagrams(now)
+    }
+
+    fn expire_old_datagrams(&mut self, now: Instant) -> Vec<Option<DatagramId>> {
+        let mut expired = Vec::new();
+        while self
+            .queue
+            .front()
+            .is_some_and(|d| d.age(now) > self.max_age)
+        {
+            expired.extend(self.queue.pop_front().map(|d| d.id));
+        }
+        expired
+    }
+
+    pub fn enqueue(
+        &mut self,
+        data: Vec<u8>,
+        id: Option<DatagramId>,
+        now: Instant,
+    ) -> DatagramQueueOutcome {
+        // `hard_limit` is a fixed constant today, always > 0, so
+        // `pop_front` always finds something to evict here. But nothing
+        // enforces that invariant, so degrade to no eviction if it were
+        // ever violated (e.g. `hard_limit` made configurable down to 0)
+        // rather than panic on an empty queue.
+        let overflowed = (self.queue.len() >= self.hard_limit)
+            .then(|| self.queue.pop_front())
+            .flatten()
+            .map(|oldest| {
+                qdebug!(
+                    "Queue at hard limit ({}), dropping oldest datagram {:?}",
+                    self.hard_limit,
+                    oldest.id
+                );
+                oldest.id
+            });
+
+        self.queue.push_back(QueuedDatagram::new(data, id, now));
+
+        let below_watermark = self
+            .high_water_mark
+            .is_none_or(|mark| self.queue.len() < mark);
+        // An overflowing queue is full, so backpressure applies regardless of where
+        // the high water mark sits.
+        let outcome = match (overflowed, below_watermark) {
+            (Some(dropped), _) => DatagramQueueOutcome::Overflowed { dropped },
+            (None, true) => DatagramQueueOutcome::Ok,
+            (None, false) => DatagramQueueOutcome::AboveWatermark,
+        };
+        qtrace!(
+            "Enqueued datagram {id:?}, queue size: {}, outcome: {outcome:?}",
+            self.queue.len()
+        );
+
+        outcome
+    }
+
+    /// Drain up to `budget` datagrams, expiring old ones first and returning
+    /// ready-to-send ones.
+    ///
+    /// `budget` is how many datagrams the QUIC layer can currently accept, i.e.
+    /// [`Connection::remaining_datagram_queue_capacity`][neqo_transport::Connection::remaining_datagram_queue_capacity].
+    /// Whatever exceeds it stays queued here, subject to this queue's own
+    /// max-age/hard-limit policy, rather than being handed to the QUIC layer's
+    /// fixed-size queue only to be head-dropped there with no signal back to
+    /// the application.
+    ///
+    /// Returns `(expired, datagrams_to_send)`, where `expired` has one entry per
+    /// expired datagram (`Some(id)` for tracked ones). The caller is responsible
+    /// for passing each returned [`QueuedDatagram`] to
+    /// [`Connection::send_datagram`][neqo_transport::Connection::send_datagram],
+    /// which enqueues it in the QUIC layer's own outgoing queue. Congestion
+    /// control and MTU checks happen later at packet creation time, not during
+    /// [`Connection::send_datagram`][neqo_transport::Connection::send_datagram],
+    /// so the only error that call can produce is
+    /// [`neqo_transport::Error::TooMuchData`] (datagram exceeds the peer's
+    /// `max_datagram_frame_size` transport parameter). Since
+    /// [`Session::send_datagram`][super::session::Session::send_datagram]
+    /// already validates size before calling [`Self::enqueue`], this error should
+    /// not occur in practice.
+    pub fn drain(
+        &mut self,
+        now: Instant,
+        budget: usize,
+    ) -> (Vec<Option<DatagramId>>, Vec<QueuedDatagram>) {
+        // Expiry is not a send, so it must not be gated on `budget`: otherwise
+        // stale datagrams pile up while the QUIC layer's queue is full.
+        let expired = self.expire_old_datagrams(now);
+        let count = budget.min(self.queue.len());
+        let to_send = self.queue.drain(..count).collect();
+        (expired, to_send)
+    }
+
+    /// Every remaining queued datagram, regardless of age. Used when the
+    /// session is closing and nothing will call [`Self::drain`] again.
+    pub fn take_all(&mut self) -> Vec<QueuedDatagram> {
+        self.queue.drain(..).collect()
+    }
+
+    /// The instant at which the oldest queued datagram crosses `max_age`, if
+    /// any datagram is queued. The caller uses this to schedule a wakeup so
+    /// that expiry is not left to whichever unrelated timer happens to fire
+    /// next (see `Http3Connection::next_datagram_expiry`).
+    ///
+    /// Datagrams are served/expired oldest-first, so the front of the queue
+    /// is always the next one to expire. `None` if the queue is empty, or if
+    /// `max_age` is `DEFAULT_MAX_AGE` (no expiry has ever been requested).
+    #[must_use]
+    pub fn next_expiry(&self) -> Option<Instant> {
+        self.queue.front()?.timestamp.checked_add(self.max_age)
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+}
+
+impl Default for WebTransportDatagramQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_fixture::now;
+
+    use super::*;
+
+    #[test]
+    fn queue_basic() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+
+        let outcome = queue.enqueue(vec![1, 2, 3], Some(1), t);
+        assert_eq!(outcome, DatagramQueueOutcome::Ok);
+        assert_eq!(queue.len(), 1);
+    }
+
+    #[test]
+    fn high_water_mark() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+        queue.set_high_water_mark(Some(2));
+
+        assert_eq!(queue.enqueue(vec![1], Some(1), t), DatagramQueueOutcome::Ok);
+        assert_eq!(
+            queue.enqueue(vec![2], Some(2), t),
+            DatagramQueueOutcome::AboveWatermark
+        );
+        assert_eq!(
+            queue.enqueue(vec![3], Some(3), t),
+            DatagramQueueOutcome::AboveWatermark
+        );
+
+        assert_eq!(queue.len(), 3);
+    }
+
+    #[test]
+    fn high_water_mark_above_hard_limit_is_clamped() {
+        let mut queue = WebTransportDatagramQueue::new();
+        queue.hard_limit = 3;
+        queue.set_high_water_mark(Some(10));
+        let t = now();
+
+        queue.enqueue(vec![1], Some(1), t);
+        queue.enqueue(vec![2], Some(2), t);
+        assert_eq!(
+            queue.enqueue(vec![3], Some(3), t),
+            DatagramQueueOutcome::AboveWatermark,
+            "a watermark above hard_limit must not be silently unreachable"
+        );
+    }
+
+    #[test]
+    fn hard_limit() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+        queue.hard_limit = 3;
+
+        queue.enqueue(vec![1], Some(1), t);
+        queue.enqueue(vec![2], Some(2), t);
+        queue.enqueue(vec![3], Some(3), t);
+        assert_eq!(
+            queue.enqueue(vec![4], Some(4), t),
+            DatagramQueueOutcome::Overflowed { dropped: Some(1) }
+        );
+
+        assert_eq!(queue.len(), 3);
+    }
+
+    #[test]
+    fn hard_limit_untracked_datagram_drops_silently() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+        queue.hard_limit = 1;
+
+        queue.enqueue(vec![1], None, t);
+
+        assert_eq!(
+            queue.enqueue(vec![2], Some(2), t),
+            DatagramQueueOutcome::Overflowed { dropped: None },
+            "an untracked datagram must not be reported with an ID"
+        );
+        assert_eq!(queue.len(), 1);
+    }
+
+    #[test]
+    fn hard_limit_zero_does_not_panic() {
+        let mut queue = WebTransportDatagramQueue::new();
+        queue.hard_limit = 0;
+        let t = now();
+
+        // Nothing queued yet to evict, so the first datagram is accepted
+        // for free rather than panicking on an empty pop_front.
+        assert_eq!(queue.enqueue(vec![1], Some(1), t), DatagramQueueOutcome::Ok);
+        assert_eq!(
+            queue.enqueue(vec![2], Some(2), t),
+            DatagramQueueOutcome::Overflowed { dropped: Some(1) }
+        );
+    }
+
+    #[test]
+    fn max_age_expiration() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t0 = now();
+        queue.set_max_age(Duration::from_millis(100), t0);
+
+        queue.enqueue(vec![1], Some(1), t0);
+
+        // Advance time by 150 ms without sleeping.
+        let t1 = t0 + Duration::from_millis(150);
+
+        let expired = queue.expire_old_datagrams(t1);
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0], Some(1));
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn max_age_expiration_untracked_datagram_reports_nothing() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t0 = now();
+        queue.set_max_age(Duration::from_millis(100), t0);
+
+        queue.enqueue(vec![1], None, t0);
+
+        let t1 = t0 + Duration::from_millis(150);
+        let expired = queue.expire_old_datagrams(t1);
+        assert_eq!(expired, vec![None]);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn next_expiry_is_none_when_empty() {
+        let queue = WebTransportDatagramQueue::new();
+        assert_eq!(queue.next_expiry(), None);
+    }
+
+    #[test]
+    fn next_expiry_is_none_without_a_max_age() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+        queue.enqueue(vec![1], Some(1), t);
+        assert_eq!(queue.next_expiry(), None);
+    }
+
+    #[test]
+    fn next_expiry_tracks_the_oldest_datagram() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t0 = now();
+        queue.set_max_age(Duration::from_millis(50), t0);
+
+        queue.enqueue(vec![1], Some(1), t0);
+        let t1 = t0 + Duration::from_millis(10);
+        queue.enqueue(vec![2], Some(2), t1);
+
+        assert_eq!(queue.next_expiry(), Some(t0 + Duration::from_millis(50)));
+    }
+
+    #[test]
+    fn next_expiry_advances_once_the_oldest_datagram_is_gone() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t0 = now();
+        queue.set_max_age(Duration::from_millis(50), t0);
+
+        queue.enqueue(vec![1], Some(1), t0);
+        let t1 = t0 + Duration::from_millis(10);
+        queue.enqueue(vec![2], Some(2), t1);
+
+        let (_, to_send) = queue.drain(t1, 1);
+        assert_eq!(to_send.len(), 1);
+        assert_eq!(queue.next_expiry(), Some(t1 + Duration::from_millis(50)));
+    }
+
+    #[test]
+    fn drain() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+
+        queue.enqueue(vec![0, 1], Some(1), t);
+        queue.enqueue(vec![0, 2], None, t);
+
+        let (expired, to_send) = queue.drain(t, usize::MAX);
+
+        assert!(expired.is_empty());
+        assert_eq!(to_send.len(), 2);
+        assert_eq!(to_send[0].id, Some(1));
+        assert_eq!(to_send[1].id, None);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn drain_reports_every_expired_datagram() {
+        // Untracked datagrams produce no outcome, but the caller still has to be
+        // able to count them, so `drain` reports one entry per expired datagram.
+        let mut queue = WebTransportDatagramQueue::new();
+        let t0 = now();
+        queue.set_max_age(Duration::from_millis(50), t0);
+
+        queue.enqueue(vec![1], Some(1), t0);
+        queue.enqueue(vec![2], None, t0);
+
+        let (expired, to_send) = queue.drain(t0 + Duration::from_millis(80), usize::MAX);
+        assert_eq!(expired, vec![Some(1), None]);
+        assert!(to_send.is_empty());
+    }
+
+    #[test]
+    fn below_watermark_recovers_after_drain() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+        queue.set_high_water_mark(Some(2));
+
+        assert_eq!(queue.enqueue(vec![1], Some(1), t), DatagramQueueOutcome::Ok);
+        assert_eq!(
+            queue.enqueue(vec![2], Some(2), t),
+            DatagramQueueOutcome::AboveWatermark
+        );
+
+        drop(queue.drain(t, usize::MAX));
+
+        assert_eq!(
+            queue.enqueue(vec![3], Some(3), t),
+            DatagramQueueOutcome::Ok,
+            "draining the queue must put it back below the high water mark"
+        );
+    }
+
+    #[test]
+    fn drain_stops_at_budget() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+        for i in 1..=5 {
+            queue.enqueue(vec![0, i], Some(u64::from(i)), t);
+        }
+
+        let (_, to_send) = queue.drain(t, 2);
+        assert_eq!(
+            to_send.iter().map(|d| d.id).collect::<Vec<_>>(),
+            vec![Some(1), Some(2)]
+        );
+        assert_eq!(queue.len(), 3, "the rest stays queued");
+    }
+
+    #[test]
+    fn drain_budget_zero_keeps_everything() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+        queue.enqueue(vec![1], Some(1), t);
+
+        let (expired, to_send) = queue.drain(t, 0);
+        assert!(expired.is_empty());
+        assert!(to_send.is_empty());
+        assert_eq!(queue.len(), 1);
+    }
+
+    #[test]
+    fn budgeted_drain_expires_even_with_no_budget() {
+        // Expiry is not a send, so it must not be gated on the QUIC layer
+        // having room; otherwise stale datagrams pile up while it is full.
+        let mut queue = WebTransportDatagramQueue::new();
+        let t0 = now();
+        queue.set_max_age(Duration::from_millis(50), t0);
+        queue.enqueue(vec![1], Some(1), t0);
+
+        let (expired, to_send) = queue.drain(t0 + Duration::from_millis(80), 0);
+        assert_eq!(expired, vec![Some(1)]);
+        assert!(to_send.is_empty());
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn partial_drain_leaves_remainder_for_a_later_call() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+        for i in 1..=3 {
+            queue.enqueue(vec![0, i], Some(u64::from(i)), t);
+        }
+
+        let mut served = Vec::new();
+        for _ in 0..3 {
+            let (_, to_send) = queue.drain(t, 1);
+            served.extend(to_send.into_iter().filter_map(|d| d.id));
+        }
+
+        assert_eq!(served, vec![1, 2, 3]);
+        assert!(queue.is_empty());
+    }
+}

--- a/neqo-http3/src/features/extended_connect/datagram_queue.rs
+++ b/neqo-http3/src/features/extended_connect/datagram_queue.rs
@@ -127,10 +127,12 @@ impl DatagramQueue {
     pub fn set_max_age(&mut self, max_age: Duration, now: Instant) -> Vec<Option<DatagramId>> {
         qtrace!("Setting max age to {max_age:?}");
         self.max_age = max_age;
-        self.expire_old_datagrams(now)
+        self.expire(now)
     }
 
-    fn expire_old_datagrams(&mut self, now: Instant) -> Vec<Option<DatagramId>> {
+    /// Remove and return every datagram older than `max_age`, oldest first.
+    /// Returns one entry per expired datagram, `Some(id)` for tracked ones.
+    pub fn expire(&mut self, now: Instant) -> Vec<Option<DatagramId>> {
         let mut expired = Vec::new();
         while self
             .queue
@@ -218,7 +220,7 @@ impl DatagramQueue {
     ) -> (Vec<Option<DatagramId>>, Vec<QueuedDatagram>) {
         // Expiry is not a send, so it must not be gated on `budget`: otherwise
         // stale datagrams pile up while the QUIC layer's queue is full.
-        let expired = self.expire_old_datagrams(now);
+        let expired = self.expire(now);
         let count = budget.min(self.queue.len());
         let to_send = self.queue.drain(..count).collect();
         (expired, to_send)
@@ -379,7 +381,7 @@ mod tests {
         // Advance time by 150 ms without sleeping.
         let t1 = t0 + Duration::from_millis(150);
 
-        let expired = queue.expire_old_datagrams(t1);
+        let expired = queue.expire(t1);
         assert_eq!(expired.len(), 1);
         assert_eq!(expired[0], Some(1));
         assert!(queue.is_empty());
@@ -394,7 +396,7 @@ mod tests {
         queue.enqueue(vec![1], None, t0);
 
         let t1 = t0 + Duration::from_millis(150);
-        let expired = queue.expire_old_datagrams(t1);
+        let expired = queue.expire(t1);
         assert_eq!(expired, vec![None]);
         assert!(queue.is_empty());
     }

--- a/neqo-http3/src/features/extended_connect/datagram_queue.rs
+++ b/neqo-http3/src/features/extended_connect/datagram_queue.rs
@@ -22,6 +22,11 @@ pub enum DatagramOutcome {
     /// Handed to the QUIC layer's outgoing queue. Not a delivery or even a
     /// transmission guarantee; the transport reports the eventual fate
     /// separately via `ConnectionEvent::OutgoingDatagramOutcome`.
+    ///
+    /// On the HTTP DATAGRAM Capsule fallback path (`Session::send_datagram`,
+    /// used when the peer has no QUIC DATAGRAM support), this instead means
+    /// "written to the control stream": that path never touches the queue,
+    /// so it carries no transport-level guarantee at all.
     Sent(DatagramId),
     Expired(DatagramId),
     /// Discarded without being sent: either the QUIC layer refused it when it
@@ -43,6 +48,10 @@ impl DatagramOutcome {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DatagramQueueOutcome {
     /// The queue was below the high water mark.
+    ///
+    /// Also returned, unconditionally, on the HTTP DATAGRAM Capsule
+    /// fallback path (see `DatagramOutcome::Sent`'s docs): that path never
+    /// touches the queue, so this carries no backpressure signal there.
     Ok,
     /// The queue had space, but it was at or above the high water mark.
     AboveWatermark,

--- a/neqo-http3/src/features/extended_connect/datagram_queue.rs
+++ b/neqo-http3/src/features/extended_connect/datagram_queue.rs
@@ -1,0 +1,345 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant},
+};
+
+use neqo_common::{Bytes, qdebug, qtrace};
+
+pub const DEFAULT_HARD_LIMIT: usize = 1000;
+const DEFAULT_MAX_AGE: Duration = Duration::MAX;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DatagramOutcome {
+    Sent(u64),
+    Expired(u64),
+    Overflowed(u64),
+    /// The QUIC layer refused the datagram when it was finally handed over, so
+    /// it was discarded without being sent.
+    Dropped(u64),
+}
+
+impl DatagramOutcome {
+    #[must_use]
+    pub const fn id(&self) -> u64 {
+        match *self {
+            Self::Sent(id) | Self::Expired(id) | Self::Overflowed(id) | Self::Dropped(id) => id,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct QueuedDatagram {
+    pub data: Bytes,
+    /// Caller-supplied tracking ID, or `None` if the caller sent the datagram
+    /// untracked (in which case no [`DatagramOutcome`] is ever reported for it).
+    pub id: Option<u64>,
+    /// Length of the original payload before framing (varint session ID + protocol prefix).
+    pub payload_len: usize,
+    pub timestamp: Instant,
+}
+
+impl QueuedDatagram {
+    pub const fn new(data: Bytes, id: Option<u64>, payload_len: usize, now: Instant) -> Self {
+        Self {
+            data,
+            id,
+            payload_len,
+            timestamp: now,
+        }
+    }
+
+    pub fn age(&self, now: Instant) -> Duration {
+        now.duration_since(self.timestamp)
+    }
+}
+
+/// Per-session outgoing datagram queue with high water mark and max-age support.
+///
+/// Datagrams are enqueued here by [`Self::enqueue`] and drained into
+/// the QUIC layer by [`Self::drain`], which is called during `process_http3()` as part
+/// of `process_output()`. The caller must call `process_output()` after enqueuing
+/// to ensure datagrams are actually transmitted. In Gecko, this happens via
+/// `StreamHasDataToWrite()` -> `ForceSend()`, which asynchronously dispatches
+/// `SendData()` -> `ProcessOutput()` on the next event loop cycle.
+#[derive(Debug)]
+pub struct WebTransportDatagramQueue {
+    queue: VecDeque<QueuedDatagram>,
+    hard_limit: usize,
+    high_water_mark: Option<f64>,
+    max_age: Duration,
+}
+
+impl WebTransportDatagramQueue {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+            hard_limit: DEFAULT_HARD_LIMIT,
+            high_water_mark: None,
+            max_age: DEFAULT_MAX_AGE,
+        }
+    }
+
+    pub fn set_high_water_mark(&mut self, mark: f64) {
+        qtrace!("Setting high water mark to {mark}");
+        self.high_water_mark = if mark.is_infinite() || mark.is_nan() {
+            None
+        } else {
+            Some(mark.max(0.0))
+        };
+    }
+
+    /// Returns one entry per expired datagram, `Some(id)` for tracked ones.
+    /// The caller reports outcomes for the tracked ones and counts them all.
+    pub fn set_max_age(&mut self, age_ms: f64, now: Instant) -> Vec<Option<u64>> {
+        qtrace!("Setting max age to {age_ms} ms");
+        self.max_age = if age_ms.is_infinite() || age_ms.is_nan() {
+            DEFAULT_MAX_AGE
+        } else {
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "age_ms is non-negative; realistic datagram ages fit in u64"
+            )]
+            let ms = age_ms.max(0.0) as u64;
+            Duration::from_millis(ms)
+        };
+        self.expire_old_datagrams(now)
+    }
+
+    fn expire_old_datagrams(&mut self, now: Instant) -> Vec<Option<u64>> {
+        let split = self.queue.partition_point(|d| d.age(now) > self.max_age);
+        if split == 0 {
+            return Vec::new();
+        }
+        let kept = self.queue.split_off(split);
+        let old = std::mem::replace(&mut self.queue, kept);
+        old.into_iter().map(|d| d.id).collect()
+    }
+
+    pub fn enqueue(
+        &mut self,
+        data: Bytes,
+        id: Option<u64>,
+        payload_len: usize,
+        now: Instant,
+    ) -> (bool, Option<DatagramOutcome>) {
+        let dropped = if self.queue.len() >= self.hard_limit {
+            let oldest = self
+                .queue
+                .pop_front()
+                .expect("len() >= hard_limit > 0 implies non-empty");
+            qdebug!(
+                "Queue at hard limit ({}), dropping oldest datagram {:?}",
+                self.hard_limit,
+                oldest.id
+            );
+            oldest.id.map(DatagramOutcome::Overflowed)
+        } else {
+            None
+        };
+
+        let datagram = QueuedDatagram::new(data, id, payload_len, now);
+        self.queue.push_back(datagram);
+
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "queue lengths are small enough that precision loss is not a concern"
+        )]
+        let below_watermark = self
+            .high_water_mark
+            .is_none_or(|mark| (self.queue.len() as f64) < mark);
+        qtrace!(
+            "Enqueued datagram {id:?}, queue size: {}, below watermark: {below_watermark}",
+            self.queue.len()
+        );
+
+        (below_watermark, dropped)
+    }
+
+    /// Drain the queue, expiring old datagrams and returning ready-to-send ones.
+    ///
+    /// Returns `(expired, datagrams_to_send)`, where `expired` has one entry per
+    /// expired datagram (`Some(id)` for tracked ones). The caller is responsible
+    /// for passing each returned [`QueuedDatagram`] to
+    /// [`Connection::send_datagram`][neqo_transport::Connection::send_datagram],
+    /// which enqueues it in the QUIC layer's own outgoing queue. Congestion
+    /// control and MTU checks happen later at packet creation time, not during
+    /// [`Connection::send_datagram`][neqo_transport::Connection::send_datagram],
+    /// so the only error that call can produce is
+    /// [`neqo_transport::Error::TooMuchData`] (datagram exceeds the peer's
+    /// `max_datagram_frame_size` transport parameter). Since
+    /// [`ExtendedConnectSession::send_datagram`][super::session::ExtendedConnectSession::send_datagram]
+    /// already validates size before calling [`Self::enqueue`], this error should
+    /// not occur in practice.
+    pub fn drain(&mut self, now: Instant) -> (Vec<Option<u64>>, Vec<QueuedDatagram>) {
+        // `expire_old_datagrams` walks the queue oldest-first and stops at the first
+        // datagram within `max_age`, so everything left is still fresh.
+        let expired = self.expire_old_datagrams(now);
+        let to_send = self.queue.drain(..).collect();
+        (expired, to_send)
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+}
+
+impl Default for WebTransportDatagramQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_fixture::now;
+
+    use super::*;
+
+    #[test]
+    fn queue_basic() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+
+        let (below_watermark, _) = queue.enqueue(Bytes::from(vec![1, 2, 3]), Some(1), 3, t);
+        assert!(below_watermark);
+        assert_eq!(queue.len(), 1);
+    }
+
+    #[test]
+    fn high_water_mark() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+        queue.set_high_water_mark(2.0);
+
+        assert!(queue.enqueue(Bytes::from(vec![1]), Some(1), 1, t).0);
+        assert!(!queue.enqueue(Bytes::from(vec![2]), Some(2), 1, t).0);
+        assert!(!queue.enqueue(Bytes::from(vec![3]), Some(3), 1, t).0);
+
+        assert_eq!(queue.len(), 3);
+    }
+
+    #[test]
+    fn hard_limit() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+        queue.hard_limit = 3;
+
+        queue.enqueue(Bytes::from(vec![1]), Some(1), 1, t);
+        queue.enqueue(Bytes::from(vec![2]), Some(2), 1, t);
+        queue.enqueue(Bytes::from(vec![3]), Some(3), 1, t);
+        queue.enqueue(Bytes::from(vec![4]), Some(4), 1, t);
+
+        assert_eq!(queue.len(), 3);
+    }
+
+    #[test]
+    fn hard_limit_untracked_datagram_drops_silently() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+        queue.hard_limit = 1;
+
+        queue.enqueue(Bytes::from(vec![1]), None, 1, t);
+        let (_, dropped) = queue.enqueue(Bytes::from(vec![2]), Some(2), 1, t);
+
+        assert_eq!(
+            dropped, None,
+            "untracked datagram must not produce an outcome"
+        );
+        assert_eq!(queue.len(), 1);
+    }
+
+    #[test]
+    fn max_age_expiration() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t0 = now();
+        queue.set_max_age(100.0, t0);
+
+        queue.enqueue(Bytes::from(vec![1]), Some(1), 1, t0);
+
+        let t1 = t0 + Duration::from_millis(150);
+        let expired = queue.expire_old_datagrams(t1);
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0], Some(1));
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn max_age_expiration_untracked_datagram_reports_nothing() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t0 = now();
+        queue.set_max_age(100.0, t0);
+
+        queue.enqueue(Bytes::from(vec![1]), None, 1, t0);
+
+        let t1 = t0 + Duration::from_millis(150);
+        let expired = queue.expire_old_datagrams(t1);
+        assert_eq!(expired, vec![None]);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn drain() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+
+        queue.enqueue(Bytes::from(vec![0, 1]), Some(1), 1, t);
+        queue.enqueue(Bytes::from(vec![0, 2]), None, 1, t);
+
+        let (expired, to_send) = queue.drain(t);
+
+        assert!(expired.is_empty());
+        assert_eq!(to_send.len(), 2);
+        assert_eq!(to_send[0].id, Some(1));
+        assert_eq!(to_send[1].id, None);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn drain_reports_every_expired_datagram() {
+        // Untracked datagrams produce no outcome, but the caller still has to be
+        // able to count them, so `drain` reports one entry per expired datagram.
+        let mut queue = WebTransportDatagramQueue::new();
+        let t0 = now();
+        queue.set_max_age(50.0, t0);
+
+        queue.enqueue(Bytes::from(vec![1]), Some(1), 1, t0);
+        queue.enqueue(Bytes::from(vec![2]), None, 1, t0);
+
+        let (expired, to_send) = queue.drain(t0 + Duration::from_millis(80));
+        assert_eq!(expired, vec![Some(1), None]);
+        assert!(to_send.is_empty());
+    }
+
+    #[test]
+    fn below_watermark_recovers_after_drain() {
+        let mut queue = WebTransportDatagramQueue::new();
+        let t = now();
+        queue.set_high_water_mark(2.0);
+
+        assert!(queue.enqueue(Bytes::from(vec![1]), Some(1), 1, t).0);
+        assert!(!queue.enqueue(Bytes::from(vec![2]), Some(2), 1, t).0);
+
+        drop(queue.drain(t));
+
+        assert!(
+            queue.enqueue(Bytes::from(vec![3]), Some(3), 1, t).0,
+            "draining the queue must put it back below the high water mark"
+        );
+    }
+}

--- a/neqo-http3/src/features/extended_connect/datagram_queue.rs
+++ b/neqo-http3/src/features/extended_connect/datagram_queue.rs
@@ -47,8 +47,10 @@ pub enum DatagramQueueOutcome {
     /// The queue had space, but it was at or above the high water mark.
     AboveWatermark,
     /// The queue was full, so the oldest datagram was dropped to make room.
-    /// `dropped` is its tracking ID, or `None` if it was sent untracked.
-    Overflowed { dropped: Option<DatagramId> },
+    /// If it was tracked, a [`DatagramOutcome::Dropped`] event is reported
+    /// for it separately; the tracking ID isn't carried here too, to avoid
+    /// reporting the same eviction twice.
+    Overflowed,
 }
 
 #[derive(Debug)]
@@ -131,28 +133,31 @@ impl WebTransportDatagramQueue {
         expired
     }
 
+    /// Returns the outcome for the caller to apply backpressure with, and,
+    /// on [`DatagramQueueOutcome::Overflowed`], the tracking ID of the
+    /// evicted datagram (`None` if it was untracked) for the caller to
+    /// report a [`DatagramOutcome::Dropped`] event for separately.
     pub fn enqueue(
         &mut self,
         data: Vec<u8>,
         id: Option<DatagramId>,
         now: Instant,
-    ) -> DatagramQueueOutcome {
+    ) -> (DatagramQueueOutcome, Option<DatagramId>) {
         // `hard_limit` is a fixed constant today, always > 0, so
         // `pop_front` always finds something to evict here. But nothing
         // enforces that invariant, so degrade to no eviction if it were
         // ever violated (e.g. `hard_limit` made configurable down to 0)
         // rather than panic on an empty queue.
-        let overflowed = (self.queue.len() >= self.hard_limit)
+        let evicted = (self.queue.len() >= self.hard_limit)
             .then(|| self.queue.pop_front())
-            .flatten()
-            .map(|oldest| {
-                qdebug!(
-                    "Queue at hard limit ({}), dropping oldest datagram {:?}",
-                    self.hard_limit,
-                    oldest.id
-                );
+            .flatten();
+        if let Some(oldest) = &evicted {
+            qdebug!(
+                "Queue at hard limit ({}), dropping oldest datagram {:?}",
+                self.hard_limit,
                 oldest.id
-            });
+            );
+        }
 
         self.queue.push_back(QueuedDatagram::new(data, id, now));
 
@@ -161,17 +166,17 @@ impl WebTransportDatagramQueue {
             .is_none_or(|mark| self.queue.len() < mark);
         // An overflowing queue is full, so backpressure applies regardless of where
         // the high water mark sits.
-        let outcome = match (overflowed, below_watermark) {
-            (Some(dropped), _) => DatagramQueueOutcome::Overflowed { dropped },
-            (None, true) => DatagramQueueOutcome::Ok,
-            (None, false) => DatagramQueueOutcome::AboveWatermark,
+        let (outcome, dropped) = match (evicted, below_watermark) {
+            (Some(oldest), _) => (DatagramQueueOutcome::Overflowed, oldest.id),
+            (None, true) => (DatagramQueueOutcome::Ok, None),
+            (None, false) => (DatagramQueueOutcome::AboveWatermark, None),
         };
         qtrace!(
             "Enqueued datagram {id:?}, queue size: {}, outcome: {outcome:?}",
             self.queue.len()
         );
 
-        outcome
+        (outcome, dropped)
     }
 
     /// Drain up to `budget` datagrams, expiring old ones first and returning
@@ -259,8 +264,9 @@ mod tests {
         let mut queue = WebTransportDatagramQueue::new();
         let t = now();
 
-        let outcome = queue.enqueue(vec![1, 2, 3], Some(1), t);
+        let (outcome, dropped) = queue.enqueue(vec![1, 2, 3], Some(1), t);
         assert_eq!(outcome, DatagramQueueOutcome::Ok);
+        assert_eq!(dropped, None);
         assert_eq!(queue.len(), 1);
     }
 
@@ -270,14 +276,17 @@ mod tests {
         let t = now();
         queue.set_high_water_mark(Some(2));
 
-        assert_eq!(queue.enqueue(vec![1], Some(1), t), DatagramQueueOutcome::Ok);
+        assert_eq!(
+            queue.enqueue(vec![1], Some(1), t),
+            (DatagramQueueOutcome::Ok, None)
+        );
         assert_eq!(
             queue.enqueue(vec![2], Some(2), t),
-            DatagramQueueOutcome::AboveWatermark
+            (DatagramQueueOutcome::AboveWatermark, None)
         );
         assert_eq!(
             queue.enqueue(vec![3], Some(3), t),
-            DatagramQueueOutcome::AboveWatermark
+            (DatagramQueueOutcome::AboveWatermark, None)
         );
 
         assert_eq!(queue.len(), 3);
@@ -294,7 +303,7 @@ mod tests {
         queue.enqueue(vec![2], Some(2), t);
         assert_eq!(
             queue.enqueue(vec![3], Some(3), t),
-            DatagramQueueOutcome::AboveWatermark,
+            (DatagramQueueOutcome::AboveWatermark, None),
             "a watermark above hard_limit must not be silently unreachable"
         );
     }
@@ -310,7 +319,7 @@ mod tests {
         queue.enqueue(vec![3], Some(3), t);
         assert_eq!(
             queue.enqueue(vec![4], Some(4), t),
-            DatagramQueueOutcome::Overflowed { dropped: Some(1) }
+            (DatagramQueueOutcome::Overflowed, Some(1))
         );
 
         assert_eq!(queue.len(), 3);
@@ -326,7 +335,7 @@ mod tests {
 
         assert_eq!(
             queue.enqueue(vec![2], Some(2), t),
-            DatagramQueueOutcome::Overflowed { dropped: None },
+            (DatagramQueueOutcome::Overflowed, None),
             "an untracked datagram must not be reported with an ID"
         );
         assert_eq!(queue.len(), 1);
@@ -340,10 +349,13 @@ mod tests {
 
         // Nothing queued yet to evict, so the first datagram is accepted
         // for free rather than panicking on an empty pop_front.
-        assert_eq!(queue.enqueue(vec![1], Some(1), t), DatagramQueueOutcome::Ok);
+        assert_eq!(
+            queue.enqueue(vec![1], Some(1), t),
+            (DatagramQueueOutcome::Ok, None)
+        );
         assert_eq!(
             queue.enqueue(vec![2], Some(2), t),
-            DatagramQueueOutcome::Overflowed { dropped: Some(1) }
+            (DatagramQueueOutcome::Overflowed, Some(1))
         );
     }
 
@@ -459,17 +471,20 @@ mod tests {
         let t = now();
         queue.set_high_water_mark(Some(2));
 
-        assert_eq!(queue.enqueue(vec![1], Some(1), t), DatagramQueueOutcome::Ok);
+        assert_eq!(
+            queue.enqueue(vec![1], Some(1), t),
+            (DatagramQueueOutcome::Ok, None)
+        );
         assert_eq!(
             queue.enqueue(vec![2], Some(2), t),
-            DatagramQueueOutcome::AboveWatermark
+            (DatagramQueueOutcome::AboveWatermark, None)
         );
 
         drop(queue.drain(t, usize::MAX));
 
         assert_eq!(
             queue.enqueue(vec![3], Some(3), t),
-            DatagramQueueOutcome::Ok,
+            (DatagramQueueOutcome::Ok, None),
             "draining the queue must put it back below the high water mark"
         );
     }

--- a/neqo-http3/src/features/extended_connect/datagram_queue.rs
+++ b/neqo-http3/src/features/extended_connect/datagram_queue.rs
@@ -85,14 +85,14 @@ impl QueuedDatagram {
 /// `StreamHasDataToWrite()` -> `ForceSend()`, which asynchronously dispatches
 /// `SendData()` -> `ProcessOutput()` on the next event loop cycle.
 #[derive(Debug)]
-pub struct WebTransportDatagramQueue {
+pub struct DatagramQueue {
     queue: VecDeque<QueuedDatagram>,
     hard_limit: usize,
     high_water_mark: Option<usize>,
     max_age: Duration,
 }
 
-impl WebTransportDatagramQueue {
+impl DatagramQueue {
     #[must_use]
     pub const fn new() -> Self {
         Self {
@@ -247,7 +247,7 @@ impl WebTransportDatagramQueue {
     }
 }
 
-impl Default for WebTransportDatagramQueue {
+impl Default for DatagramQueue {
     fn default() -> Self {
         Self::new()
     }
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn queue_basic() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t = now();
 
         let (outcome, dropped) = queue.enqueue(vec![1, 2, 3], Some(1), t);
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn high_water_mark() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t = now();
         queue.set_high_water_mark(Some(2));
 
@@ -294,7 +294,7 @@ mod tests {
 
     #[test]
     fn high_water_mark_above_hard_limit_is_clamped() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         queue.hard_limit = 3;
         queue.set_high_water_mark(Some(10));
         let t = now();
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn hard_limit() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t = now();
         queue.hard_limit = 3;
 
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn hard_limit_untracked_datagram_drops_silently() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t = now();
         queue.hard_limit = 1;
 
@@ -343,7 +343,7 @@ mod tests {
 
     #[test]
     fn hard_limit_zero_does_not_panic() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         queue.hard_limit = 0;
         let t = now();
 
@@ -361,7 +361,7 @@ mod tests {
 
     #[test]
     fn max_age_expiration() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t0 = now();
         queue.set_max_age(Duration::from_millis(100), t0);
 
@@ -378,7 +378,7 @@ mod tests {
 
     #[test]
     fn max_age_expiration_untracked_datagram_reports_nothing() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t0 = now();
         queue.set_max_age(Duration::from_millis(100), t0);
 
@@ -392,13 +392,13 @@ mod tests {
 
     #[test]
     fn next_expiry_is_none_when_empty() {
-        let queue = WebTransportDatagramQueue::new();
+        let queue = DatagramQueue::new();
         assert_eq!(queue.next_expiry(), None);
     }
 
     #[test]
     fn next_expiry_is_none_without_a_max_age() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t = now();
         queue.enqueue(vec![1], Some(1), t);
         assert_eq!(queue.next_expiry(), None);
@@ -406,7 +406,7 @@ mod tests {
 
     #[test]
     fn next_expiry_tracks_the_oldest_datagram() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t0 = now();
         queue.set_max_age(Duration::from_millis(50), t0);
 
@@ -419,7 +419,7 @@ mod tests {
 
     #[test]
     fn next_expiry_advances_once_the_oldest_datagram_is_gone() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t0 = now();
         queue.set_max_age(Duration::from_millis(50), t0);
 
@@ -434,7 +434,7 @@ mod tests {
 
     #[test]
     fn drain() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t = now();
 
         queue.enqueue(vec![0, 1], Some(1), t);
@@ -453,7 +453,7 @@ mod tests {
     fn drain_reports_every_expired_datagram() {
         // Untracked datagrams produce no outcome, but the caller still has to be
         // able to count them, so `drain` reports one entry per expired datagram.
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t0 = now();
         queue.set_max_age(Duration::from_millis(50), t0);
 
@@ -467,7 +467,7 @@ mod tests {
 
     #[test]
     fn below_watermark_recovers_after_drain() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t = now();
         queue.set_high_water_mark(Some(2));
 
@@ -491,7 +491,7 @@ mod tests {
 
     #[test]
     fn drain_stops_at_budget() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t = now();
         for i in 1..=5 {
             queue.enqueue(vec![0, i], Some(u64::from(i)), t);
@@ -507,7 +507,7 @@ mod tests {
 
     #[test]
     fn drain_budget_zero_keeps_everything() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t = now();
         queue.enqueue(vec![1], Some(1), t);
 
@@ -521,7 +521,7 @@ mod tests {
     fn budgeted_drain_expires_even_with_no_budget() {
         // Expiry is not a send, so it must not be gated on the QUIC layer
         // having room; otherwise stale datagrams pile up while it is full.
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t0 = now();
         queue.set_max_age(Duration::from_millis(50), t0);
         queue.enqueue(vec![1], Some(1), t0);
@@ -534,7 +534,7 @@ mod tests {
 
     #[test]
     fn partial_drain_leaves_remainder_for_a_later_call() {
-        let mut queue = WebTransportDatagramQueue::new();
+        let mut queue = DatagramQueue::new();
         let t = now();
         for i in 1..=3 {
             queue.enqueue(vec![0, i], Some(u64::from(i)), t);

--- a/neqo-http3/src/features/extended_connect/datagram_queue.rs
+++ b/neqo-http3/src/features/extended_connect/datagram_queue.rs
@@ -35,6 +35,9 @@ pub enum DatagramOutcome {
 }
 
 impl DatagramOutcome {
+    /// Unused within this workspace today; kept as public API for FFI
+    /// consumers (e.g. Gecko) that receive a `DatagramOutcome` without
+    /// already knowing which id it carries.
     #[must_use]
     pub const fn id(&self) -> DatagramId {
         match *self {
@@ -93,6 +96,13 @@ impl QueuedDatagram {
 /// to ensure datagrams are actually transmitted. In Gecko, this happens via
 /// `StreamHasDataToWrite()` -> `ForceSend()`, which asynchronously dispatches
 /// `SendData()` -> `ProcessOutput()` on the next event loop cycle.
+///
+/// This is the app-to-transport handover point, not the whole path: the
+/// WebTransport `outgoingMaxAge` guarantee only governs how long a datagram
+/// waits *here*. Once [`Self::drain`] hands it to
+/// [`Connection::send_datagram`][neqo_transport::Connection::send_datagram],
+/// it can still sit in the QUIC layer's own fixed-size queue past its
+/// deadline; nothing in this design covers that part of the spec.
 #[derive(Debug)]
 pub struct DatagramQueue {
     queue: VecDeque<QueuedDatagram>,

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -5,11 +5,15 @@
 // except according to those terms.
 
 pub(crate) mod connect_udp_session;
+pub(crate) mod datagram_queue;
 pub mod send_group;
 pub mod session;
 pub mod stats;
 pub(crate) mod webtransport_session;
 pub(crate) mod webtransport_streams;
+
+// Re-export DatagramOutcome for FFI access
+pub use datagram_queue::DatagramOutcome;
 
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod webtransport_session;
 pub(crate) mod webtransport_streams;
 
 // Re-export DatagramOutcome for FFI access
-pub use datagram_queue::{DatagramId, DatagramOutcome, DatagramQueueOutcome};
+pub use datagram_queue::{DEFAULT_HARD_LIMIT, DatagramId, DatagramOutcome, DatagramQueueOutcome};
 
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -5,11 +5,15 @@
 // except according to those terms.
 
 pub(crate) mod connect_udp_session;
+pub(crate) mod datagram_queue;
 pub mod send_group;
 pub mod session;
 pub mod stats;
 pub(crate) mod webtransport_session;
 pub(crate) mod webtransport_streams;
+
+// Re-export DatagramOutcome for FFI access
+pub use datagram_queue::{DatagramId, DatagramOutcome, DatagramQueueOutcome};
 
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
@@ -54,6 +58,12 @@ pub(crate) trait ExtendedConnectEvents: Debug {
         &self,
         session_id: StreamId,
         datagram: Bytes,
+        connect_type: ExtendedConnectType,
+    );
+    fn datagram_outcome(
+        &self,
+        session_id: StreamId,
+        outcome: DatagramOutcome,
         connect_type: ExtendedConnectType,
     );
 }

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -21,9 +21,7 @@ use crate::{
     SendStream, Stream,
     features::extended_connect::{
         ExtendedConnectEvents, ExtendedConnectType, HeaderListener, Headers,
-        datagram_queue::{
-            DatagramId, DatagramOutcome, DatagramQueueOutcome, WebTransportDatagramQueue,
-        },
+        datagram_queue::{DatagramId, DatagramOutcome, DatagramQueue, DatagramQueueOutcome},
         stats::SessionStats,
     },
     frames::HFrame,
@@ -67,7 +65,7 @@ pub(crate) struct Session {
     draining: bool,
     /// Outgoing datagrams awaiting handover to the QUIC layer. Shared by every
     /// extended-CONNECT protocol; the queue itself is protocol-agnostic.
-    datagram_queue: WebTransportDatagramQueue,
+    datagram_queue: DatagramQueue,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -127,7 +125,7 @@ impl Session {
             events,
             protocol,
             draining: false,
-            datagram_queue: WebTransportDatagramQueue::new(),
+            datagram_queue: DatagramQueue::new(),
         }
     }
 
@@ -158,7 +156,7 @@ impl Session {
             events,
             protocol,
             draining: false,
-            datagram_queue: WebTransportDatagramQueue::new(),
+            datagram_queue: DatagramQueue::new(),
         })
     }
 
@@ -470,9 +468,9 @@ impl Session {
             DatagramTracking::None => None,
         };
 
-        let (outcome, dropped) = self
-            .datagram_queue
-            .enqueue(Vec::<u8>::from(dgram_data), id_opt, now);
+        let (outcome, dropped) =
+            self.datagram_queue
+                .enqueue(Vec::<u8>::from(dgram_data), id_opt, now);
         if outcome == DatagramQueueOutcome::Overflowed {
             self.count_dropped_outgoing(1);
         }
@@ -522,7 +520,7 @@ impl Session {
     /// Only as many datagrams as the QUIC layer can currently accept are handed
     /// over; the rest stay queued for a later call, so that a burst is paced
     /// against what the connection can send instead of overflowing the QUIC
-    /// layer's fixed-size queue. See [`WebTransportDatagramQueue::drain`].
+    /// layer's fixed-size queue. See [`DatagramQueue::drain`].
     ///
     /// A no-op once the session is no longer `Active`: nothing enqueues new
     /// datagrams past that point, and any already queued are dropped and
@@ -580,7 +578,7 @@ impl Session {
 
     /// The instant at which this session's datagram queue next needs
     /// [`Self::process_datagram_queue`] called to expire a stale datagram.
-    /// See [`WebTransportDatagramQueue::next_expiry`].
+    /// See [`DatagramQueue::next_expiry`].
     pub(crate) fn next_datagram_expiry(&self) -> Option<Instant> {
         self.datagram_queue.next_expiry()
     }

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -476,6 +476,14 @@ impl Session {
             DatagramTracking::None => None,
         };
 
+        // Expire before enqueueing: otherwise a queue full of stale datagrams
+        // evicts one on `enqueue` below and reports `Overflowed`/`Dropped`
+        // for it, when it should have been reported `Expired`.
+        let expired = self.datagram_queue.expire(now);
+        for outcome in self.record_expired(expired) {
+            self.report_datagram_outcome(outcome);
+        }
+
         let (outcome, dropped) =
             self.datagram_queue
                 .enqueue(Vec::<u8>::from(dgram_data), id_opt, now);

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -363,6 +363,9 @@ impl Session {
             &mut self.control_stream_recv,
             now,
         )? {
+            if new_state.closing_state() {
+                self.drop_queued_datagrams();
+            }
             self.state = new_state;
         }
         Ok(())

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -598,6 +598,7 @@ impl Session {
     pub(crate) fn next_datagram_expiry(&self) -> Option<Instant> {
         self.datagram_queue.next_expiry()
     }
+
     pub(crate) fn set_datagram_high_water_mark(&mut self, mark: Option<usize>) {
         self.datagram_queue.set_high_water_mark(mark);
     }

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -9,10 +9,10 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
     rc::Rc,
     str::from_utf8,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
-use neqo_common::{Bytes, Encoder, Header, MessageType, Role, qdebug, qtrace};
+use neqo_common::{Bytes, Encoder, Header, MessageType, Role, qdebug, qtrace, to_u64};
 use neqo_transport::{AppError, Connection, DatagramTracking, StreamId, streams::SendGroupId};
 use rustc_hash::FxHashSet as HashSet;
 
@@ -20,7 +20,11 @@ use crate::{
     CloseType, Error, Http3StreamType, HttpRecvStream, Priority, ReceiveOutput, RecvStream, Res,
     SendStream, Stream,
     features::extended_connect::{
-        ExtendedConnectEvents, ExtendedConnectType, HeaderListener, Headers, stats::SessionStats,
+        ExtendedConnectEvents, ExtendedConnectType, HeaderListener, Headers,
+        datagram_queue::{
+            DatagramId, DatagramOutcome, DatagramQueueOutcome, WebTransportDatagramQueue,
+        },
+        stats::SessionStats,
     },
     frames::HFrame,
     priority::PriorityHandler,
@@ -61,6 +65,9 @@ pub(crate) struct Session {
     /// CONNECT request.
     protocol: Box<dyn Protocol>,
     draining: bool,
+    /// Outgoing datagrams awaiting handover to the QUIC layer. Shared by every
+    /// extended-CONNECT protocol; the queue itself is protocol-agnostic.
+    datagram_queue: WebTransportDatagramQueue,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -120,6 +127,7 @@ impl Session {
             events,
             protocol,
             draining: false,
+            datagram_queue: WebTransportDatagramQueue::new(),
         }
     }
 
@@ -150,6 +158,7 @@ impl Session {
             events,
             protocol,
             draining: false,
+            datagram_queue: WebTransportDatagramQueue::new(),
         })
     }
 
@@ -234,6 +243,7 @@ impl Session {
         }
         qdebug!("[{self}]: close session type={close_type:?}");
         self.state = State::Done;
+        self.drop_queued_datagrams();
         if !close_type.locally_initiated() {
             self.events.session_end(
                 self.protocol.connect_type(),
@@ -371,6 +381,7 @@ impl Session {
     ) -> Res<()> {
         qdebug!("[{self}]: close_session");
         self.state = State::Done;
+        self.drop_queued_datagrams();
 
         if let Some(close_frame) = self.protocol.close_frame(error, message) {
             self.control_stream_send
@@ -390,33 +401,56 @@ impl Session {
         self.control_stream_send.send_data(conn, buf, now)
     }
 
+    /// Enqueue a datagram for sending.
+    ///
+    /// The datagram is placed into the per-session datagram queue and will be
+    /// moved to the QUIC send queue when `process_datagram_queue()` is called
+    /// (which happens during `process_http3()` as part of `process_output()`).
+    /// The caller must ensure `process_output()` is called afterward to
+    /// actually transmit the datagram.
+    ///
+    /// Returns the state of the queue after the datagram was accepted, so the
+    /// caller can apply backpressure (see `DatagramQueueOutcome`).
+    ///
     /// # Errors
     ///
     /// Returns an error if:
+    /// - The encoded datagram exceeds the peer's `max_datagram_frame_size`
+    ///   (`Error::Transport(neqo_transport::Error::TooMuchData)`).
     /// - The session is not in Active state (`Error::Unavailable`).
-    /// - QUIC datagram or HTTP DATAGRAM Capsule sending fails.
+    /// - The peer supports neither QUIC DATAGRAM nor the HTTP DATAGRAM Capsule
+    ///   (`Error::Transport(neqo_transport::Error::NotAvailable)`).
+    /// - HTTP DATAGRAM Capsule sending fails.
     pub(crate) fn send_datagram<I: Into<DatagramTracking>>(
         &mut self,
         conn: &mut Connection,
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<DatagramQueueOutcome> {
         qtrace!("[{self}] send_datagram state={:?}", self.state);
         if self.state != State::Active {
             qdebug!("[{self}]: cannot send datagram in {:?} state.", self.state);
             debug_assert!(false);
             return Err(Error::Unavailable);
         }
-
-        if conn.remote_datagram_size() == 0 && self.protocol.datagram_capsule_support() {
-            qtrace!("[{self}] remote_datagram_size is 0, trying HTTP DATAGRAM Capsule");
-            return self.protocol.write_datagram_capsule(
-                &mut self.control_stream_send,
-                conn,
-                buf,
-                now,
-            );
+        let remote_datagram_size = conn.remote_datagram_size();
+        if remote_datagram_size == 0 {
+            if self.protocol.datagram_capsule_support() {
+                qtrace!("[{self}] remote_datagram_size is 0, trying HTTP DATAGRAM Capsule");
+                self.protocol.write_datagram_capsule(
+                    &mut self.control_stream_send,
+                    conn,
+                    buf,
+                    now,
+                )?;
+                if let DatagramTracking::Id(id) = id.into() {
+                    self.report_datagram_outcome(DatagramOutcome::Sent(id));
+                }
+                return Ok(DatagramQueueOutcome::Ok);
+            }
+            qdebug!("[{self}] peer does not support QUIC DATAGRAM");
+            return Err(Error::Transport(neqo_transport::Error::NotAvailable));
         }
 
         let mut dgram_data = Encoder::default();
@@ -424,9 +458,130 @@ impl Session {
         self.protocol.write_datagram_prefix(&mut dgram_data);
         dgram_data.encode(buf);
 
-        conn.send_datagram(dgram_data.into(), id)?;
-        qtrace!("[{self}] sent datagram via QUIC datagram");
-        Ok(())
+        if to_u64(dgram_data.len()) > remote_datagram_size {
+            return Err(Error::Transport(neqo_transport::Error::TooMuchData));
+        }
+
+        let id_opt = match id.into() {
+            DatagramTracking::Id(id_val) => Some(id_val),
+            DatagramTracking::None => None,
+        };
+
+        let outcome = self
+            .datagram_queue
+            .enqueue(Vec::<u8>::from(dgram_data), id_opt, now);
+        if let DatagramQueueOutcome::Overflowed { dropped: Some(id) } = outcome {
+            self.report_datagram_outcome(DatagramOutcome::Dropped(id));
+        }
+        qtrace!("[{self}] enqueued datagram for sending via QUIC datagram");
+        Ok(outcome)
+    }
+
+    /// Count every expired datagram and report an outcome for the tracked ones.
+    ///
+    /// Untracked datagrams (`None`) get no outcome, but must still be counted:
+    /// the stat is the number of datagrams that expired, not the number the
+    /// application asked to be notified about.
+    fn record_expired(&mut self, expired: Vec<Option<DatagramId>>) -> Vec<DatagramOutcome> {
+        if let Some(stats) = self.protocol.stats_mut() {
+            stats.datagrams_expired_outgoing += to_u64(expired.len());
+        }
+        expired
+            .into_iter()
+            .flatten()
+            .map(DatagramOutcome::Expired)
+            .collect()
+    }
+
+    /// Report an outcome through this session's own `events`/`connect_type`,
+    /// rather than returning it to the caller: keeps a connect-udp session's
+    /// outcomes from being mis-tagged as `WebTransport` by a caller that
+    /// only knows about `WebTransport`.
+    fn report_datagram_outcome(&self, outcome: DatagramOutcome) {
+        self.events
+            .datagram_outcome(self.id, outcome, self.protocol.connect_type());
+    }
+
+    /// Drain the per-session datagram queue and hand datagrams to the QUIC layer.
+    ///
+    /// Only as many datagrams as the QUIC layer can currently accept are handed
+    /// over; the rest stay queued for a later call, so that a burst is paced
+    /// against what the connection can send instead of overflowing the QUIC
+    /// layer's fixed-size queue. See [`WebTransportDatagramQueue::drain`].
+    ///
+    /// A no-op once the session is no longer `Active`: nothing enqueues new
+    /// datagrams past that point, and any already queued are dropped and
+    /// reported by [`Self::close`]/[`Self::close_session`], not handed to a
+    /// `conn.send_datagram()` the peer has already been told is closed.
+    ///
+    /// Outcomes are reported directly through this session's own `events` and
+    /// `connect_type`, rather than returned to the caller, so a connect-udp
+    /// session's outcomes can't be mis-tagged as `WebTransport` by a caller
+    /// that only knows about `WebTransport`.
+    pub(crate) fn process_datagram_queue(&mut self, conn: &mut Connection, now: Instant) {
+        if self.state != State::Active {
+            return;
+        }
+
+        let (expired, to_send) = self
+            .datagram_queue
+            .drain(now, conn.remaining_datagram_queue_capacity());
+        for outcome in self.record_expired(expired) {
+            self.report_datagram_outcome(outcome);
+        }
+
+        for dgram in to_send {
+            let tracking = dgram
+                .id
+                .map_or(DatagramTracking::None, DatagramTracking::Id);
+            // A datagram the QUIC layer refuses is gone: `drain` already removed it
+            // from the queue. Report it so the application isn't left waiting, and
+            // keep going, since a later datagram may still be small enough to fit.
+            let outcome = match conn.send_datagram(dgram.data, tracking) {
+                Ok(()) => DatagramOutcome::Sent,
+                Err(e) => {
+                    qdebug!("[{self}] QUIC layer refused datagram {:?}: {e}", dgram.id);
+                    DatagramOutcome::Dropped
+                }
+            };
+            if let Some(id) = dgram.id {
+                self.report_datagram_outcome(outcome(id));
+            }
+        }
+    }
+
+    /// Drop every datagram still queued when the session closes, reporting
+    /// each tracked one so the application isn't left waiting for an outcome
+    /// that will never come once nothing will call
+    /// [`Self::process_datagram_queue`] again.
+    fn drop_queued_datagrams(&mut self) {
+        for id in self
+            .datagram_queue
+            .take_all()
+            .into_iter()
+            .filter_map(|d| d.id)
+        {
+            self.report_datagram_outcome(DatagramOutcome::Dropped(id));
+        }
+    }
+
+    /// The instant at which this session's datagram queue next needs
+    /// [`Self::process_datagram_queue`] called to expire a stale datagram.
+    /// See [`WebTransportDatagramQueue::next_expiry`].
+    pub(crate) fn next_datagram_expiry(&self) -> Option<Instant> {
+        self.datagram_queue.next_expiry()
+    }
+    pub(crate) fn set_datagram_high_water_mark(&mut self, mark: Option<usize>) {
+        self.datagram_queue.set_high_water_mark(mark);
+    }
+
+    pub(crate) fn set_datagram_max_age(
+        &mut self,
+        max_age: Duration,
+        now: Instant,
+    ) -> Vec<DatagramOutcome> {
+        let expired = self.datagram_queue.set_max_age(max_age, now);
+        self.record_expired(expired)
     }
 
     pub(crate) fn datagram(&self, datagram: Bytes) {
@@ -628,6 +783,10 @@ pub(crate) trait Protocol: Debug + Display {
             false,
             "stats called for extended connect protocol not tracking stats"
         );
+        None
+    }
+
+    fn stats_mut(&mut self) -> Option<&mut SessionStats> {
         None
     }
 

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -470,10 +470,10 @@ impl Session {
             DatagramTracking::None => None,
         };
 
-        let outcome = self
+        let (outcome, dropped) = self
             .datagram_queue
             .enqueue(Vec::<u8>::from(dgram_data), id_opt, now);
-        if let DatagramQueueOutcome::Overflowed { dropped: Some(id) } = outcome {
+        if let Some(id) = dropped {
             self.report_datagram_outcome(DatagramOutcome::Dropped(id));
         }
         qtrace!("[{self}] enqueued datagram for sending via QUIC datagram");

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -12,7 +12,7 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{Bytes, Encoder, Header, MessageType, Role, qdebug, qtrace};
+use neqo_common::{Bytes, Encoder, Header, MessageType, Role, qdebug, qtrace, to_u64};
 use neqo_transport::{AppError, Connection, DatagramTracking, StreamId, streams::SendGroupId};
 use rustc_hash::FxHashSet as HashSet;
 
@@ -20,7 +20,9 @@ use crate::{
     CloseType, Error, Http3StreamType, HttpRecvStream, Priority, ReceiveOutput, RecvStream, Res,
     SendStream, Stream,
     features::extended_connect::{
-        ExtendedConnectEvents, ExtendedConnectType, HeaderListener, Headers, stats::SessionStats,
+        ExtendedConnectEvents, ExtendedConnectType, HeaderListener, Headers,
+        datagram_queue::{DatagramOutcome, WebTransportDatagramQueue},
+        stats::SessionStats,
     },
     frames::HFrame,
     priority::PriorityHandler,
@@ -62,6 +64,9 @@ pub(crate) struct Session {
     protocol: Box<dyn Protocol>,
     draining: bool,
     role: Role,
+    /// Outgoing datagrams awaiting handover to the QUIC layer. Shared by every
+    /// extended-CONNECT protocol; the queue itself is protocol-agnostic.
+    datagram_queue: WebTransportDatagramQueue,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -123,6 +128,7 @@ impl Session {
             protocol,
             draining: false,
             role,
+            datagram_queue: WebTransportDatagramQueue::new(),
         }
     }
 
@@ -154,6 +160,7 @@ impl Session {
             protocol,
             draining: false,
             role,
+            datagram_queue: WebTransportDatagramQueue::new(),
         })
     }
 
@@ -404,9 +411,23 @@ impl Session {
         self.control_stream_send.send_data(conn, buf, now)
     }
 
+    /// Enqueue a datagram for sending.
+    ///
+    /// The datagram is placed into the per-session datagram queue and will be
+    /// moved to the QUIC send queue when `process_datagram_queue()` is called
+    /// (which happens during `process_http3()` as part of `process_output()`).
+    /// The caller must ensure `process_output()` is called afterward to
+    /// actually transmit the datagram.
+    ///
+    /// Returns `Ok((below_watermark, dropped))` where `below_watermark` is
+    /// `true` if the queue is below the high water mark, and `dropped` is
+    /// `Some((id, outcome))` if the oldest datagram was dropped to make room
+    /// when the queue was at its hard limit.
+    ///
     /// # Errors
     ///
     /// Returns an error if:
+    /// - The datagram exceeds the remote datagram size limit.
     /// - The session is not in Active state (`Error::Unavailable`).
     /// - QUIC datagram or HTTP DATAGRAM Capsule sending fails.
     pub(crate) fn send_datagram<I: Into<DatagramTracking>>(
@@ -415,40 +436,124 @@ impl Session {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<(bool, Option<DatagramOutcome>)> {
         qtrace!("[{self}] send_datagram state={:?}", self.state);
         if self.state != State::Active {
             qdebug!("[{self}]: cannot send datagram in {:?} state.", self.state);
             debug_assert!(false);
             return Err(Error::Unavailable);
         }
-
         if conn.remote_datagram_size() == 0 && self.protocol.datagram_capsule_support() {
             qtrace!("[{self}] remote_datagram_size is 0, trying HTTP DATAGRAM Capsule");
             // Note this isn't updating stats currently, since it doesn't actually
             // send yet (Err(Unavailable)).  If this changes it should update stats
-            return self.protocol.write_datagram_capsule(
-                &mut self.control_stream_send,
-                conn,
-                buf,
-                now,
-            );
+            self.protocol
+                .write_datagram_capsule(&mut self.control_stream_send, conn, buf, now)?;
+            return Ok((true, None));
         }
+
+        // Validate that QUIC DATAGRAM is usable on this connection/path.
+        conn.max_datagram_size()?;
 
         let mut dgram_data = Encoder::default();
         dgram_data.encode_varint(self.id.as_u64() / 4);
         self.protocol.write_datagram_prefix(&mut dgram_data);
         dgram_data.encode(buf);
 
-        let overhead = dgram_data.len() - buf.len();
-        conn.send_datagram(dgram_data.into(), id)?;
-        if let Some(stats) = self.protocol.stats_mut() {
-            stats.datagrams_sent += 1;
-            stats.datagram_bytes_sent += buf.len() as u64;
-            stats.bytes_sent_overhead += overhead as u64;
+        let remote_datagram_size = conn.remote_datagram_size();
+        if remote_datagram_size > 0 && to_u64(dgram_data.len()) > remote_datagram_size {
+            return Err(Error::Transport(neqo_transport::Error::TooMuchData));
         }
-        qtrace!("[{self}] sent datagram via QUIC datagram");
-        Ok(())
+
+        let id_opt = match id.into() {
+            DatagramTracking::Id(id_val) => Some(id_val),
+            DatagramTracking::None => None,
+        };
+
+        let payload_len = buf.len();
+        let (below_watermark, dropped) = self.datagram_queue.enqueue(
+            Bytes::from(Vec::<u8>::from(dgram_data)),
+            id_opt,
+            payload_len,
+            now,
+        );
+
+        qtrace!("[{self}] enqueued datagram for sending via QUIC datagram");
+        Ok((below_watermark, dropped))
+    }
+
+    /// Count every expired datagram and report an outcome for the tracked ones.
+    ///
+    /// Untracked datagrams (`None`) get no outcome, but must still be counted:
+    /// the stat is the number of datagrams that expired, not the number the
+    /// application asked to be notified about.
+    fn record_expired(&mut self, expired: Vec<Option<u64>>) -> Vec<DatagramOutcome> {
+        if let Some(stats) = self.protocol.stats_mut() {
+            stats.datagrams_expired_outgoing += to_u64(expired.len());
+        }
+        expired
+            .into_iter()
+            .flatten()
+            .map(DatagramOutcome::Expired)
+            .collect()
+    }
+
+    /// Drain the per-session datagram queue and hand datagrams to the QUIC layer.
+    pub(crate) fn process_datagram_queue(
+        &mut self,
+        conn: &mut Connection,
+        now: Instant,
+    ) -> Vec<DatagramOutcome> {
+        let (expired, to_send) = self.datagram_queue.drain(now);
+        let mut outcomes = self.record_expired(expired);
+
+        let mut datagrams_sent = 0;
+        let mut payload_bytes = 0;
+        let mut overhead_bytes = 0;
+        for dgram in to_send {
+            let total_len = dgram.data.len();
+            let tracking = dgram
+                .id
+                .map_or(DatagramTracking::None, DatagramTracking::Id);
+            // A datagram the QUIC layer refuses is gone: `drain` already removed it
+            // from the queue. Report it so the application isn't left waiting, and
+            // keep going, since a later datagram may still be small enough to fit.
+            let outcome = match conn.send_datagram(dgram.data.into_vec(), tracking) {
+                Ok(()) => {
+                    datagrams_sent += 1;
+                    payload_bytes += to_u64(dgram.payload_len);
+                    overhead_bytes += to_u64(total_len - dgram.payload_len);
+                    DatagramOutcome::Sent
+                }
+                Err(e) => {
+                    qdebug!("[{self}] QUIC layer refused datagram {:?}: {e}", dgram.id);
+                    DatagramOutcome::Dropped
+                }
+            };
+            if let Some(id) = dgram.id {
+                outcomes.push(outcome(id));
+            }
+        }
+        if let Some(stats) = self.protocol.stats_mut() {
+            stats.datagrams_sent += datagrams_sent;
+            stats.datagram_bytes_sent += payload_bytes;
+            stats.bytes_sent_overhead += overhead_bytes;
+        }
+
+        outcomes
+    }
+
+    pub(crate) fn set_datagram_high_water_mark(&mut self, mark: f64) {
+        self.datagram_queue.set_high_water_mark(mark);
+    }
+
+    pub(crate) fn set_datagram_max_age(
+        &mut self,
+        age_ms: f64,
+        now: Instant,
+    ) -> Vec<DatagramOutcome> {
+        let expired = self.datagram_queue.set_max_age(age_ms, now);
+        self.record_expired(expired)
     }
 
     pub(crate) fn datagram(&mut self, datagram: Bytes) {

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -578,13 +578,11 @@ impl Session {
         self.datagram_queue.set_high_water_mark(mark);
     }
 
-    pub(crate) fn set_datagram_max_age(
-        &mut self,
-        max_age: Duration,
-        now: Instant,
-    ) -> Vec<DatagramOutcome> {
+    pub(crate) fn set_datagram_max_age(&mut self, max_age: Duration, now: Instant) {
         let expired = self.datagram_queue.set_max_age(max_age, now);
-        self.record_expired(expired)
+        for outcome in self.record_expired(expired) {
+            self.report_datagram_outcome(outcome);
+        }
     }
 
     pub(crate) fn datagram(&self, datagram: Bytes) {

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -413,6 +413,14 @@ impl Session {
     /// Returns the state of the queue after the datagram was accepted, so the
     /// caller can apply backpressure (see `DatagramQueueOutcome`).
     ///
+    /// When the peer only supports the HTTP DATAGRAM Capsule fallback (no
+    /// QUIC DATAGRAM support), the capsule is written straight to the
+    /// control stream instead of going through the queue: the returned
+    /// `DatagramQueueOutcome` is always `Ok` on that path and carries no
+    /// backpressure signal, and a resulting `DatagramOutcome::Sent` means
+    /// only "written to the control stream", not "accepted by
+    /// `Connection::send_datagram`" as it does on the queued path.
+    ///
     /// # Errors
     ///
     /// Returns an error if:

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -473,6 +473,9 @@ impl Session {
         let (outcome, dropped) = self
             .datagram_queue
             .enqueue(Vec::<u8>::from(dgram_data), id_opt, now);
+        if outcome == DatagramQueueOutcome::Overflowed {
+            self.count_dropped_outgoing(1);
+        }
         if let Some(id) = dropped {
             self.report_datagram_outcome(DatagramOutcome::Dropped(id));
         }
@@ -503,6 +506,15 @@ impl Session {
     fn report_datagram_outcome(&self, outcome: DatagramOutcome) {
         self.events
             .datagram_outcome(self.id, outcome, self.protocol.connect_type());
+    }
+
+    /// Count every datagram discarded without being sent and without
+    /// expiring, tracked or not: [`Self::report_datagram_outcome`] only
+    /// fires for tracked ones, but the stat must reflect all of them.
+    fn count_dropped_outgoing(&mut self, n: u64) {
+        if let Some(stats) = self.protocol.stats_mut() {
+            stats.datagrams_dropped_outgoing += n;
+        }
     }
 
     /// Drain the per-session datagram queue and hand datagrams to the QUIC layer.
@@ -544,6 +556,7 @@ impl Session {
                 Ok(()) => DatagramOutcome::Sent,
                 Err(e) => {
                     qdebug!("[{self}] QUIC layer refused datagram {:?}: {e}", dgram.id);
+                    self.count_dropped_outgoing(1);
                     DatagramOutcome::Dropped
                 }
             };
@@ -558,12 +571,9 @@ impl Session {
     /// that will never come once nothing will call
     /// [`Self::process_datagram_queue`] again.
     fn drop_queued_datagrams(&mut self) {
-        for id in self
-            .datagram_queue
-            .take_all()
-            .into_iter()
-            .filter_map(|d| d.id)
-        {
+        let dropped = self.datagram_queue.take_all();
+        self.count_dropped_outgoing(to_u64(dropped.len()));
+        for id in dropped.into_iter().filter_map(|d| d.id) {
             self.report_datagram_outcome(DatagramOutcome::Dropped(id));
         }
     }

--- a/neqo-http3/src/features/extended_connect/stats.rs
+++ b/neqo-http3/src/features/extended_connect/stats.rs
@@ -25,7 +25,5 @@
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SessionStats {
     /// Outgoing datagrams that expired before being sent.
-    ///
-    /// Currently always zero; populated once datagram expiry is wired up.
     pub datagrams_expired_outgoing: u64,
 }

--- a/neqo-http3/src/features/extended_connect/stats.rs
+++ b/neqo-http3/src/features/extended_connect/stats.rs
@@ -26,4 +26,10 @@
 pub struct SessionStats {
     /// Outgoing datagrams that expired before being sent.
     pub datagrams_expired_outgoing: u64,
+    /// Outgoing datagrams discarded without being sent and without expiring:
+    /// evicted at the queue's hard limit, refused by the QUIC layer, or
+    /// still queued when the session closed. Counts tracked and untracked
+    /// datagrams alike, unlike the `DatagramOutcome::Dropped` event, which
+    /// only fires for tracked ones.
+    pub datagrams_dropped_outgoing: u64,
 }

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -148,6 +148,61 @@ fn datagram_hard_limit_overflow_reports_outcome() {
     );
 }
 
+/// A queue full of datagrams that are all past `max_age` must expire the
+/// oldest one on the next `send_datagram` call, not evict it as a hard-limit
+/// `Overflowed`/`Dropped`: age, not depth, is why it's leaving the queue.
+#[test]
+fn datagram_hard_limit_overflow_expires_stale_datagrams_first() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    let t0 = now();
+    wt.client
+        .webtransport_set_datagram_max_age(session_id, Duration::from_millis(50), t0)
+        .unwrap();
+
+    let limit = u64::try_from(DEFAULT_HARD_LIMIT).unwrap();
+    for id in 0..limit {
+        let outcome = wt
+            .client
+            .webtransport_send_datagram(session_id, DGRAM, Some(id), t0)
+            .unwrap();
+        assert_eq!(outcome, DatagramQueueOutcome::Ok);
+    }
+
+    // Every queued datagram is now past max_age, so this must expire
+    // datagram 0 rather than hard-limit-evicting it.
+    let t1 = t0 + Duration::from_millis(100);
+    let outcome = wt
+        .client
+        .webtransport_send_datagram(session_id, DGRAM, Some(limit), t1)
+        .unwrap();
+    assert_eq!(outcome, DatagramQueueOutcome::Ok);
+
+    let events: Vec<_> = wt.client.events().collect();
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            Http3ClientEvent::WebTransport(WebTransportEvent::DatagramOutcome {
+                session_id: sid,
+                outcome: DatagramOutcome::Expired(0),
+            }) if *sid == session_id
+        )),
+        "the stale datagram must be reported as Expired"
+    );
+    assert!(
+        !events.iter().any(|e| matches!(
+            e,
+            Http3ClientEvent::WebTransport(WebTransportEvent::DatagramOutcome {
+                outcome: DatagramOutcome::Dropped(0),
+                ..
+            })
+        )),
+        "the stale datagram must not also be reported as Dropped"
+    );
+}
+
 /// `datagrams_dropped_outgoing` must count every eviction, tracked or not:
 /// unlike the `DatagramOutcome::Dropped` event, which only fires for tracked
 /// datagrams, this is the only signal an untracked drop leaves behind.

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -7,7 +7,7 @@
 use std::time::Duration;
 
 use neqo_common::{Encoder, event::Provider as _, to_u64};
-use neqo_transport::ConnectionParameters;
+use neqo_transport::{ConnectionParameters, Output};
 use test_fixture::now;
 
 use crate::{
@@ -201,6 +201,53 @@ fn datagram_dropped_on_session_close_reports_outcome() {
         .unwrap();
 
     wt.cancel_session_client(session_id);
+
+    let dropped_event = |e| {
+        matches!(
+            e,
+            Http3ClientEvent::WebTransport(WebTransportEvent::DatagramOutcome {
+                session_id: sid,
+                outcome: DatagramOutcome::Dropped(42),
+            }) if sid == session_id
+        )
+    };
+    assert!(wt.client.events().any(dropped_event));
+}
+
+/// A peer-initiated close (the `CLOSE_WEBTRANSPORT_SESSION` capsule, handled
+/// via `read_control_stream`) must drop and report queued datagrams exactly
+/// like the locally-initiated paths above: it is the more common close, and
+/// without this a consumer waits forever for an outcome that never arrives.
+#[test]
+fn datagram_dropped_on_peer_initiated_session_close_reports_outcome() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    // Produce the server's close capsule before the client enqueues its
+    // datagram, so the datagram is still queued (nothing has called
+    // `process_output` on the client yet) when the capsule is delivered.
+    // The pacer can defer the very first packet after the frame is queued,
+    // so retry with time advanced by the requested delay until it ships.
+    WtTest::session_close_frame_server(&wt_session, 0, "");
+    let mut when = now();
+    let close_dgram = loop {
+        match wt.server.process_output(when) {
+            Output::Datagram(d) => break Some(d),
+            Output::Callback(delay) => when += delay,
+            Output::None => break None,
+        }
+    };
+
+    wt.client
+        .webtransport_send_datagram(session_id, DGRAM, Some(42u64), now())
+        .unwrap();
+
+    // A single `process` call both reads the close capsule (driving the
+    // session out of `Active` via `read_control_stream`) and attempts to
+    // drain the datagram queue; before drop was wired into that path, the
+    // still-queued datagram was silently abandoned instead of reported.
+    drop(wt.client.process(close_dgram, now()));
 
     let dropped_event = |e| {
         matches!(

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -370,3 +370,55 @@ fn server_datagram_expires_on_an_otherwise_idle_connection() {
     };
     assert!(wt.server.events().any(expired_event));
 }
+
+/// Shortening `max_age` on an idle server connection must take effect at the
+/// new deadline, not linger until the original one: `set_max_age` only
+/// refreshes `Http3Connection`'s cached `next_datagram_expiry` when the
+/// connection is actually processed, so the setter must mark the connection
+/// as needing processing or an otherwise idle connection is never revisited
+/// to pick up the shorter deadline.
+#[test]
+fn server_shortening_max_age_on_idle_connection_still_expires_on_new_deadline() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    wt_session
+        .set_datagram_max_age(Duration::from_secs(10), now())
+        .unwrap();
+
+    // Enough filler datagrams to exhaust the transport's 10-slot queue on
+    // the first (needs-processing-triggered) drain below, so the tracked
+    // datagram is left stuck in the http3-level queue - and so still
+    // subject to max-age - rather than handed to the QUIC layer immediately.
+    for _ in 0..15 {
+        wt_session.send_datagram(DGRAM, None, now()).unwrap();
+    }
+    wt_session
+        .send_datagram(DGRAM, Some(77u64), now())
+        .unwrap();
+
+    let t0 = now();
+    wt.server.process_output(t0);
+
+    // Shorten the deadline well inside the original one; the datagram is
+    // not yet stale at `t0`, so nothing expires synchronously here.
+    wt_session
+        .set_datagram_max_age(Duration::from_millis(30), t0)
+        .unwrap();
+
+    // Otherwise idle: only the datagram-expiry check in `should_be_processed`
+    // (fed by the refreshed cache) can trigger the drain that expires this.
+    wt.server.process_output(t0 + Duration::from_millis(35));
+
+    let expired_event = |e| {
+        matches!(
+            e,
+            Http3ServerEvent::WebTransport(ServerEvent::DatagramOutcome {
+                session,
+                outcome: DatagramOutcome::Expired(77),
+            }) if session.stream_id() == session_id
+        )
+    };
+    assert!(wt.server.events().any(expired_event));
+}

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -4,15 +4,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::{Encoder, to_u64};
+use std::time::Duration;
+
+use neqo_common::{Encoder, event::Provider as _, to_u64};
 use neqo_transport::ConnectionParameters;
 use test_fixture::now;
 
 use crate::{
-    features::extended_connect::tests::webtransport::{
-        DATAGRAM_SIZE, WtTest, wt_default_parameters,
+    Http3ClientEvent, Http3ServerEvent, WebTransportEvent,
+    features::extended_connect::{
+        DatagramOutcome, DatagramQueueOutcome,
+        datagram_queue::DEFAULT_HARD_LIMIT,
+        tests::webtransport::{DATAGRAM_SIZE, WtTest, wt_default_parameters},
     },
-    webtransport::ServerSession,
+    webtransport::{ClientSession as _, ServerEvent, ServerSession},
 };
 
 const DGRAM: &[u8] = &[0, 100];
@@ -27,7 +32,10 @@ fn do_datagram_test(wt: &mut WtTest, wt_session: &ServerSession) {
         Ok(DATAGRAM_SIZE - to_u64(Encoder::varint_len(wt_session.stream_id().as_u64())))
     );
 
-    assert_eq!(wt_session.send_datagram(DGRAM, None, now()), Ok(()));
+    assert_eq!(
+        wt_session.send_datagram(DGRAM, None, now()),
+        Ok(DatagramQueueOutcome::Ok)
+    );
     assert_eq!(wt.send_datagram(wt_session.stream_id(), DGRAM), Ok(()));
 
     wt.exchange_packets();
@@ -74,4 +82,151 @@ fn max_datagram_size_smaller_than_session_prefix() {
 
     assert_eq!(wt_session.max_datagram_size(), Ok(0));
     assert_eq!(wt.max_datagram_size(wt_session.stream_id()), Ok(0));
+}
+
+#[test]
+fn datagram_high_water_mark_reported_via_send_datagram() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    wt.client
+        .webtransport_set_datagram_high_water_mark(session_id, Some(2))
+        .unwrap();
+
+    let mut send = || {
+        wt.client
+            .webtransport_send_datagram(session_id, DGRAM, None, now())
+            .unwrap()
+    };
+
+    assert_eq!(send(), DatagramQueueOutcome::Ok);
+    assert_eq!(send(), DatagramQueueOutcome::AboveWatermark);
+    assert_eq!(send(), DatagramQueueOutcome::AboveWatermark);
+}
+
+#[test]
+fn datagram_hard_limit_overflow_reports_outcome() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    let limit = u64::try_from(DEFAULT_HARD_LIMIT).unwrap();
+    for id in 0..limit {
+        let outcome = wt
+            .client
+            .webtransport_send_datagram(session_id, DGRAM, Some(id), now())
+            .unwrap();
+        assert_eq!(outcome, DatagramQueueOutcome::Ok);
+    }
+
+    let outcome = wt
+        .client
+        .webtransport_send_datagram(session_id, DGRAM, Some(limit), now())
+        .unwrap();
+    assert_eq!(
+        outcome,
+        DatagramQueueOutcome::Overflowed { dropped: Some(0) }
+    );
+}
+
+#[test]
+fn datagram_sent_reports_client_event() {
+    // The `Sent` outcome is what tells the application its datagram actually
+    // reached the QUIC layer; it is only produced when the queue is drained
+    // during `process_output()`.
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    wt.client
+        .webtransport_send_datagram(session_id, DGRAM, Some(9u64), now())
+        .unwrap();
+    wt.exchange_packets();
+
+    let wt_sent_event = |e| {
+        matches!(
+            e,
+            Http3ClientEvent::WebTransport(WebTransportEvent::DatagramOutcome {
+                session_id: sid,
+                outcome: DatagramOutcome::Sent(9),
+            }) if sid == session_id
+        )
+    };
+    assert!(wt.client.events().any(wt_sent_event));
+}
+
+#[test]
+fn datagram_max_age_expiry_reports_client_event() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    let t0 = now();
+    wt.client
+        .webtransport_send_datagram(session_id, DGRAM, Some(7u64), t0)
+        .unwrap();
+
+    let t1 = t0 + Duration::from_millis(200);
+    wt.client
+        .webtransport_set_datagram_max_age(session_id, Duration::from_millis(100), t1)
+        .unwrap();
+
+    let wt_expired_event = |e| {
+        matches!(
+            e,
+            Http3ClientEvent::WebTransport(WebTransportEvent::DatagramOutcome {
+                session_id: sid,
+                outcome: DatagramOutcome::Expired(7),
+            }) if sid == session_id
+        )
+    };
+    assert!(wt.client.events().any(wt_expired_event));
+}
+
+/// A datagram queued on the server must still expire once its max-age
+/// passes, even when nothing else - no other data to send, no other
+/// events, no explicit `set_datagram_max_age` call - would otherwise cause
+/// that connection to be processed. Without `should_be_processed` checking
+/// the pending expiry itself, the connection is skipped indefinitely and
+/// the datagram is never expired.
+#[test]
+fn server_datagram_expires_on_an_otherwise_idle_connection() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    wt_session
+        .set_datagram_max_age(Duration::from_millis(30), now())
+        .unwrap();
+
+    // Enough filler datagrams to exhaust the transport's 10-slot queue on
+    // the first (needs-processing-triggered) drain below, so the tracked
+    // datagram is left stuck in the http3-level queue rather than sent
+    // immediately.
+    for _ in 0..15 {
+        wt_session.send_datagram(DGRAM, None, now()).unwrap();
+    }
+    wt_session
+        .send_datagram(DGRAM, Some(77u64), now())
+        .unwrap();
+
+    let t0 = now();
+    wt.server.process_output(t0);
+
+    // Otherwise idle: nothing else happens between here and the deadline,
+    // so only `should_be_processed`'s datagram-expiry check can trigger
+    // the drain that actually expires it.
+    wt.server.process_output(t0 + Duration::from_millis(35));
+
+    let expired_event = |e| {
+        matches!(
+            e,
+            Http3ServerEvent::WebTransport(ServerEvent::DatagramOutcome {
+                session,
+                outcome: DatagramOutcome::Expired(77),
+            }) if session.stream_id() == session_id
+        )
+    };
+    assert!(wt.server.events().any(expired_event));
 }

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -124,10 +124,21 @@ fn datagram_hard_limit_overflow_reports_outcome() {
         .client
         .webtransport_send_datagram(session_id, DGRAM, Some(limit), now())
         .unwrap();
-    assert_eq!(
-        outcome,
-        DatagramQueueOutcome::Overflowed { dropped: Some(0) }
-    );
+    assert_eq!(outcome, DatagramQueueOutcome::Overflowed);
+
+    // The synchronous `Overflowed` return value no longer carries the
+    // evicted id (to avoid reporting the same eviction twice): a consumer
+    // reconciling ids must get it from this event instead.
+    let dropped_event = |e| {
+        matches!(
+            e,
+            Http3ClientEvent::WebTransport(WebTransportEvent::DatagramOutcome {
+                session_id: sid,
+                outcome: DatagramOutcome::Dropped(0),
+            }) if sid == session_id
+        )
+    };
+    assert!(wt.client.events().any(dropped_event));
 }
 
 #[test]

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -393,9 +393,7 @@ fn server_datagram_expires_on_an_otherwise_idle_connection() {
     for _ in 0..15 {
         wt_session.send_datagram(DGRAM, None, now()).unwrap();
     }
-    wt_session
-        .send_datagram(DGRAM, Some(77u64), now())
-        .unwrap();
+    wt_session.send_datagram(DGRAM, Some(77u64), now()).unwrap();
 
     let t0 = now();
     wt.server.process_output(t0);
@@ -440,9 +438,7 @@ fn server_shortening_max_age_on_idle_connection_still_expires_on_new_deadline() 
     for _ in 0..15 {
         wt_session.send_datagram(DGRAM, None, now()).unwrap();
     }
-    wt_session
-        .send_datagram(DGRAM, Some(77u64), now())
-        .unwrap();
+    wt_session.send_datagram(DGRAM, Some(77u64), now()).unwrap();
 
     let t0 = now();
     wt.server.process_output(t0);

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -139,6 +139,41 @@ fn datagram_hard_limit_overflow_reports_outcome() {
         )
     };
     assert!(wt.client.events().any(dropped_event));
+    assert_eq!(
+        wt.client
+            .webtransport_session_stats(session_id)
+            .unwrap()
+            .datagrams_dropped_outgoing,
+        1
+    );
+}
+
+/// `datagrams_dropped_outgoing` must count every eviction, tracked or not:
+/// unlike the `DatagramOutcome::Dropped` event, which only fires for tracked
+/// datagrams, this is the only signal an untracked drop leaves behind.
+#[test]
+fn datagram_hard_limit_overflow_counts_untracked_drops() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    let limit = u64::try_from(DEFAULT_HARD_LIMIT).unwrap();
+    for _ in 0..limit {
+        wt.client
+            .webtransport_send_datagram(session_id, DGRAM, None, now())
+            .unwrap();
+    }
+    wt.client
+        .webtransport_send_datagram(session_id, DGRAM, None, now())
+        .unwrap();
+
+    assert_eq!(
+        wt.client
+            .webtransport_session_stats(session_id)
+            .unwrap()
+            .datagrams_dropped_outgoing,
+        1
+    );
 }
 
 #[test]

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -184,6 +184,99 @@ fn datagram_max_age_expiry_reports_client_event() {
     assert!(wt.client.events().any(wt_expired_event));
 }
 
+/// A datagram still sitting in the queue when its session closes must be
+/// reported as `Dropped`, not silently discarded: a consumer tracking ids
+/// through the event stream would otherwise wait forever for an outcome
+/// that will never arrive.
+#[test]
+fn datagram_dropped_on_session_close_reports_outcome() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    // Enqueued but not yet drained: no `process_output`/`exchange_packets`
+    // call happens between this and the cancellation below.
+    wt.client
+        .webtransport_send_datagram(session_id, DGRAM, Some(42u64), now())
+        .unwrap();
+
+    wt.cancel_session_client(session_id);
+
+    let dropped_event = |e| {
+        matches!(
+            e,
+            Http3ClientEvent::WebTransport(WebTransportEvent::DatagramOutcome {
+                session_id: sid,
+                outcome: DatagramOutcome::Dropped(42),
+            }) if sid == session_id
+        )
+    };
+    assert!(wt.client.events().any(dropped_event));
+}
+
+/// `ServerSession::set_datagram_high_water_mark` is new public API introduced
+/// alongside its client-side counterpart (see
+/// `datagram_high_water_mark_reported_via_send_datagram`), but had no test of
+/// its own.
+#[test]
+fn server_datagram_high_water_mark_reported_via_send_datagram() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+
+    wt_session.set_datagram_high_water_mark(Some(2)).unwrap();
+
+    let send = || wt_session.send_datagram(DGRAM, None, now()).unwrap();
+    assert_eq!(send(), DatagramQueueOutcome::Ok);
+    assert_eq!(send(), DatagramQueueOutcome::AboveWatermark);
+    assert_eq!(send(), DatagramQueueOutcome::AboveWatermark);
+}
+
+/// `ServerSession::set_datagram_max_age` and `ServerEvent::DatagramOutcome`
+/// are new public API introduced alongside their client-side counterparts,
+/// but had no test of their own.
+#[test]
+fn server_datagram_sent_and_max_age_expiry_report_server_event() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    wt_session.send_datagram(DGRAM, Some(1u64), now()).unwrap();
+    wt.exchange_packets();
+
+    let sent_event = |e| {
+        matches!(
+            e,
+            Http3ServerEvent::WebTransport(ServerEvent::DatagramOutcome {
+                session,
+                outcome: DatagramOutcome::Sent(1),
+            }) if session.stream_id() == session_id
+        )
+    };
+    assert!(wt.server.events().any(sent_event));
+
+    let t0 = now();
+    wt_session.send_datagram(DGRAM, Some(2u64), t0).unwrap();
+    let t1 = t0 + Duration::from_millis(200);
+    wt_session
+        .set_datagram_max_age(Duration::from_millis(100), t1)
+        .unwrap();
+    // `set_datagram_max_age` only pushes the expiry onto the per-connection
+    // handler's event queue; a `process_*` call is what drains that into the
+    // top-level `Http3Server`'s own event queue `wt.server.events()` reads.
+    wt.server.process_output(t1);
+
+    let expired_event = |e| {
+        matches!(
+            e,
+            Http3ServerEvent::WebTransport(ServerEvent::DatagramOutcome {
+                session,
+                outcome: DatagramOutcome::Expired(2),
+            }) if session.stream_id() == session_id
+        )
+    };
+    assert!(wt.server.events().any(expired_event));
+}
+
 /// A datagram queued on the server must still expire once its max-age
 /// passes, even when nothing else - no other data to send, no other
 /// events, no explicit `set_datagram_max_age` call - would otherwise cause

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -4,16 +4,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::{Encoder, to_u64};
+use std::time::Duration;
+
+use neqo_common::{Encoder, event::Provider as _, to_u64};
 use neqo_transport::{ConnectionParameters, Error as TransportError};
 use test_fixture::now;
 
 use crate::{
-    Error, Http3Parameters,
-    features::extended_connect::tests::webtransport::{
-        DATAGRAM_SIZE, WtTest, wt_default_parameters,
+    Error, Http3ClientEvent, Http3Parameters, WebTransportEvent,
+    features::extended_connect::{
+        DatagramOutcome,
+        datagram_queue::DEFAULT_HARD_LIMIT,
+        tests::webtransport::{DATAGRAM_SIZE, WtTest, wt_default_parameters},
     },
-    webtransport::ServerSession,
+    webtransport::{ClientSession as _, ServerSession},
 };
 
 const DGRAM: &[u8] = &[0, 100];
@@ -43,11 +47,11 @@ fn no_datagrams() {
 
     assert_eq!(
         wt_session.send_datagram(DGRAM, None, now()),
-        Err(Error::Transport(TransportError::TooMuchData))
+        Err(Error::Transport(TransportError::NotAvailable))
     );
     assert_eq!(
         wt.send_datagram(wt_session.stream_id(), DGRAM),
-        Err(Error::Transport(TransportError::TooMuchData))
+        Err(Error::Transport(TransportError::NotAvailable))
     );
 
     wt.exchange_packets();
@@ -102,7 +106,7 @@ fn datagrams_server_only() {
 
     assert_eq!(
         wt_session.send_datagram(DGRAM, None, now()),
-        Err(Error::Transport(TransportError::TooMuchData))
+        Err(Error::Transport(TransportError::NotAvailable))
     );
     assert_eq!(wt.send_datagram(wt_session.stream_id(), DGRAM), Ok(()));
 
@@ -134,7 +138,7 @@ fn datagrams_client_only() {
     assert_eq!(wt_session.send_datagram(DGRAM, None, now()), Ok(()));
     assert_eq!(
         wt.send_datagram(wt_session.stream_id(), DGRAM),
-        Err(Error::Transport(TransportError::TooMuchData))
+        Err(Error::Transport(TransportError::NotAvailable))
     );
 
     wt.exchange_packets();
@@ -174,4 +178,109 @@ fn max_datagram_size_smaller_than_session_prefix() {
 
     assert_eq!(wt_session.max_datagram_size(), Ok(0));
     assert_eq!(wt.max_datagram_size(wt_session.stream_id()), Ok(0));
+}
+
+#[test]
+fn datagram_high_water_mark_reported_via_send_datagram() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    wt.client
+        .webtransport_set_datagram_high_water_mark(session_id, 2.0)
+        .unwrap();
+
+    let (below1, dropped1) = wt
+        .client
+        .webtransport_send_datagram(session_id, DGRAM, None, now())
+        .unwrap();
+    let (below2, dropped2) = wt
+        .client
+        .webtransport_send_datagram(session_id, DGRAM, None, now())
+        .unwrap();
+    let (below3, dropped3) = wt
+        .client
+        .webtransport_send_datagram(session_id, DGRAM, None, now())
+        .unwrap();
+
+    assert!(below1);
+    assert!(!below2);
+    assert!(!below3);
+    assert_eq!((dropped1, dropped2, dropped3), (None, None, None));
+}
+
+#[test]
+fn datagram_hard_limit_overflow_reports_outcome() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    let limit = u64::try_from(DEFAULT_HARD_LIMIT).unwrap();
+    for id in 0..limit {
+        let (_, dropped) = wt
+            .client
+            .webtransport_send_datagram(session_id, DGRAM, Some(id), now())
+            .unwrap();
+        assert_eq!(dropped, None);
+    }
+
+    let (_, dropped) = wt
+        .client
+        .webtransport_send_datagram(session_id, DGRAM, Some(limit), now())
+        .unwrap();
+    assert_eq!(dropped, Some(DatagramOutcome::Overflowed(0)));
+}
+
+#[test]
+fn datagram_sent_reports_client_event() {
+    // The `Sent` outcome is what tells the application its datagram actually
+    // reached the QUIC layer; it is only produced when the queue is drained
+    // during `process_output()`.
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    wt.client
+        .webtransport_send_datagram(session_id, DGRAM, Some(9u64), now())
+        .unwrap();
+    wt.exchange_packets();
+
+    let wt_sent_event = |e| {
+        matches!(
+            e,
+            Http3ClientEvent::WebTransport(WebTransportEvent::DatagramOutcome {
+                session_id: sid,
+                outcome: DatagramOutcome::Sent(9),
+            }) if sid == session_id
+        )
+    };
+    assert!(wt.client.events().any(wt_sent_event));
+}
+
+#[test]
+fn datagram_max_age_expiry_reports_client_event() {
+    let mut wt = WtTest::new();
+    let wt_session = wt.create_wt_session();
+    let session_id = wt_session.stream_id();
+
+    let t0 = now();
+    wt.client
+        .webtransport_send_datagram(session_id, DGRAM, Some(7u64), t0)
+        .unwrap();
+
+    let t1 = t0 + Duration::from_millis(200);
+    wt.client
+        .webtransport_set_datagram_max_age(session_id, 100.0, t1)
+        .unwrap();
+
+    let wt_expired_event = |e| {
+        matches!(
+            e,
+            Http3ClientEvent::WebTransport(WebTransportEvent::DatagramOutcome {
+                session_id: sid,
+                outcome: DatagramOutcome::Expired(7),
+            }) if sid == session_id
+        )
+    };
+    assert!(wt.client.events().any(wt_expired_event));
 }

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -622,6 +622,7 @@ impl WtTest {
     fn send_datagram(&mut self, stream_id: StreamId, buf: &[u8]) -> Result<(), Error> {
         self.client
             .webtransport_send_datagram(stream_id, buf, None, now())
+            .map(|_| ())
     }
 
     fn check_datagram_received_client(

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -622,6 +622,7 @@ impl WtTest {
     fn send_datagram(&mut self, stream_id: StreamId, buf: &[u8]) -> Result<(), Error> {
         self.client
             .webtransport_send_datagram(stream_id, buf, None, now())
+            .map(|_| ())
     }
 
     fn send_datagram_server(session: &ServerSession, buf: &[u8]) -> Result<(), Error> {

--- a/neqo-http3/src/features/extended_connect/webtransport_session.rs
+++ b/neqo-http3/src/features/extended_connect/webtransport_session.rs
@@ -247,6 +247,10 @@ impl Protocol for Session {
         Some(&self.stats)
     }
 
+    fn stats_mut(&mut self) -> Option<&mut SessionStats> {
+        Some(&mut self.stats)
+    }
+
     fn register_send_group(&mut self, id: SendGroupId) -> Res<()> {
         Self::register_send_group(self, id)
     }

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -47,6 +47,12 @@ pub struct Http3Server {
     /// so [`Self::process_multiple`]'s callback clamp doesn't need its own
     /// walk over `http3_handlers`.
     next_datagram_expiry: Option<Instant>,
+    /// The handler `next_datagram_expiry` was last read from, so
+    /// [`Self::process_http3`] can tell whether that cached value is still
+    /// trustworthy without rescanning every handler: it is, unless this
+    /// handler was just reprocessed (its expiry may have changed) or is
+    /// gone (its handler was removed).
+    next_datagram_expiry_conn: Option<ConnectionRef>,
 }
 
 impl Display for Http3Server {
@@ -84,6 +90,7 @@ impl Http3Server {
             http3_handlers: HashMap::default(),
             events: Http3ServerEvents::default(),
             next_datagram_expiry: None,
+            next_datagram_expiry_conn: None,
         })
     }
 
@@ -179,35 +186,59 @@ impl Http3Server {
             reason = "ActiveConnectionRef::Hash doesn't access any of the interior mutable types."
         )]
         let mut active_conns = self.server.active_connections();
-        #[expect(
-            clippy::iter_over_hash_type,
-            reason = "OK to loop over handlers in an undefined order: this only decides \
-                      set membership, which doesn't depend on iteration order."
-        )]
-        for (conn, handler) in &self.http3_handlers {
-            if handler.borrow_mut().should_be_processed(now) {
-                active_conns.insert(conn.clone());
-            }
-        }
+        active_conns.extend(
+            self.http3_handlers
+                .iter()
+                .filter(|(_, handler)| handler.borrow_mut().should_be_processed(now))
+                .map(|(c, _)| c)
+                .cloned(),
+        );
+
+        // The cached minimum is only trustworthy if its owning handler isn't
+        // about to be reprocessed below (its expiry may change) and still
+        // has a handler at all (it may be removed by `process_events`).
+        let stale = self.next_datagram_expiry_conn.as_ref().is_none_or(|owner| {
+            active_conns.contains(owner) || !self.http3_handlers.contains_key(owner)
+        });
 
         #[expect(
             clippy::iter_over_hash_type,
             reason = "OK to loop over active connections in an undefined order."
         )]
-        for conn in active_conns {
-            self.process_events(&conn, now);
+        for conn in &active_conns {
+            self.process_events(conn, now);
+            // If the cached minimum is still valid, fold this freshly
+            // processed handler into it instead of rescanning every
+            // handler below.
+            if !stale
+                && let Some(handler) = self.http3_handlers.get(conn)
+                && let Some(expiry) = handler.borrow().next_datagram_expiry()
+                && self.next_datagram_expiry.is_none_or(|cur| expiry < cur)
+            {
+                self.next_datagram_expiry = Some(expiry);
+                self.next_datagram_expiry_conn = Some(conn.clone());
+            }
         }
 
-        // Recompute *after* processing: `process_events` is what drains each
-        // handler's datagram queue and refreshes its cached expiry, so a
-        // pre-loop read (as `should_be_processed` above needs, to decide
-        // which connections to process) would still be looking at last
-        // round's deadline.
-        self.next_datagram_expiry = self
-            .http3_handlers
-            .values()
-            .filter_map(|handler| handler.borrow().next_datagram_expiry())
-            .min();
+        if stale {
+            // The previous minimum can no longer be trusted: rescan every
+            // handler.
+            self.next_datagram_expiry = None;
+            self.next_datagram_expiry_conn = None;
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "OK to loop over handlers in an undefined order: this only decides \
+                          the minimum, which doesn't depend on iteration order."
+            )]
+            for (conn, handler) in &self.http3_handlers {
+                if let Some(expiry) = handler.borrow().next_datagram_expiry()
+                    && self.next_datagram_expiry.is_none_or(|cur| expiry < cur)
+                {
+                    self.next_datagram_expiry = Some(expiry);
+                    self.next_datagram_expiry_conn = Some(conn.clone());
+                }
+            }
+        }
     }
 
     #[expect(

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -43,8 +43,9 @@ pub struct Http3Server {
     events: Http3ServerEvents,
     /// The earliest instant at which any handler's outgoing datagram queue
     /// needs expiring, across every connection. Refreshed by
-    /// [`Self::process_http3`]'s single pass over `http3_handlers`, so
-    /// [`Self::process_multiple`]'s callback clamp doesn't need its own.
+    /// [`Self::process_http3`] after it processes every active connection,
+    /// so [`Self::process_multiple`]'s callback clamp doesn't need its own
+    /// walk over `http3_handlers`.
     next_datagram_expiry: Option<Instant>,
 }
 
@@ -158,9 +159,7 @@ impl Http3Server {
         // http3-layer datagram queue's max-age deadline; clamp it the same
         // way `Http3Client::process_multiple_output` does, so an
         // otherwise-idle connection still wakes up in time to expire a
-        // stale queued datagram. `next_datagram_expiry` was just refreshed
-        // by `process_http3` above, so this needs no `http3_handlers` walk
-        // of its own.
+        // stale queued datagram.
         match out {
             OutputBatch::Callback(delay) => OutputBatch::Callback(
                 self.next_datagram_expiry
@@ -180,17 +179,16 @@ impl Http3Server {
             reason = "ActiveConnectionRef::Hash doesn't access any of the interior mutable types."
         )]
         let mut active_conns = self.server.active_connections();
-        self.next_datagram_expiry = self
-            .http3_handlers
-            .iter()
-            .filter_map(|(conn, handler)| {
-                let mut handler = handler.borrow_mut();
-                if handler.should_be_processed(now) {
-                    active_conns.insert(conn.clone());
-                }
-                handler.next_datagram_expiry()
-            })
-            .min();
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "OK to loop over handlers in an undefined order: this only decides \
+                      set membership, which doesn't depend on iteration order."
+        )]
+        for (conn, handler) in &self.http3_handlers {
+            if handler.borrow_mut().should_be_processed(now) {
+                active_conns.insert(conn.clone());
+            }
+        }
 
         #[expect(
             clippy::iter_over_hash_type,
@@ -199,6 +197,17 @@ impl Http3Server {
         for conn in active_conns {
             self.process_events(&conn, now);
         }
+
+        // Recompute *after* processing: `process_events` is what drains each
+        // handler's datagram queue and refreshes its cached expiry, so a
+        // pre-loop read (as `should_be_processed` above needs, to decide
+        // which connections to process) would still be looking at last
+        // round's deadline.
+        self.next_datagram_expiry = self
+            .http3_handlers
+            .values()
+            .filter_map(|handler| handler.borrow().next_datagram_expiry())
+            .min();
     }
 
     #[expect(

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -41,6 +41,11 @@ pub struct Http3Server {
     http3_parameters: Http3Parameters,
     http3_handlers: HashMap<ConnectionRef, HandlerRef>,
     events: Http3ServerEvents,
+    /// The earliest instant at which any handler's outgoing datagram queue
+    /// needs expiring, across every connection. Refreshed by
+    /// [`Self::process_http3`]'s single pass over `http3_handlers`, so
+    /// [`Self::process_multiple`]'s callback clamp doesn't need its own.
+    next_datagram_expiry: Option<Instant>,
 }
 
 impl Display for Http3Server {
@@ -77,6 +82,7 @@ impl Http3Server {
             http3_parameters,
             http3_handlers: HashMap::default(),
             events: Http3ServerEvents::default(),
+            next_datagram_expiry: None,
         })
     }
 
@@ -152,15 +158,14 @@ impl Http3Server {
         // http3-layer datagram queue's max-age deadline; clamp it the same
         // way `Http3Client::process_multiple_output` does, so an
         // otherwise-idle connection still wakes up in time to expire a
-        // stale queued datagram.
+        // stale queued datagram. `next_datagram_expiry` was just refreshed
+        // by `process_http3` above, so this needs no `http3_handlers` walk
+        // of its own.
         match out {
             OutputBatch::Callback(delay) => OutputBatch::Callback(
-                self.http3_handlers
-                    .values()
-                    .filter_map(|h| h.borrow().next_datagram_expiry())
+                self.next_datagram_expiry
                     .filter(|expiry| *expiry > now)
                     .map(|expiry| expiry - now)
-                    .min()
                     .map_or(delay, |max_age_delay| delay.min(max_age_delay)),
             ),
             out => out,
@@ -175,13 +180,17 @@ impl Http3Server {
             reason = "ActiveConnectionRef::Hash doesn't access any of the interior mutable types."
         )]
         let mut active_conns = self.server.active_connections();
-        active_conns.extend(
-            self.http3_handlers
-                .iter()
-                .filter(|(_, handler)| handler.borrow_mut().should_be_processed(now))
-                .map(|(c, _)| c)
-                .cloned(),
-        );
+        self.next_datagram_expiry = self
+            .http3_handlers
+            .iter()
+            .filter_map(|(conn, handler)| {
+                let mut handler = handler.borrow_mut();
+                if handler.should_be_processed(now) {
+                    active_conns.insert(conn.clone());
+                }
+                handler.next_datagram_expiry()
+            })
+            .min();
 
         #[expect(
             clippy::iter_over_hash_type,

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -24,7 +24,7 @@ use rustc_hash::FxHashMap as HashMap;
 use crate::{
     Http3Parameters, Http3StreamInfo, Res,
     connect_udp::{self, ServerEvents as _},
-    connection::Http3State,
+    connection::{Http3State, clamp_to_expiry},
     connection_server::Http3ServerHandler,
     server_connection_events::{ConnectUdpEvent, Http3ServerConnEvent, WebTransportEvent},
     server_events::{Http3OrWebTransportStream, Http3ServerEvent, Http3ServerEvents},
@@ -162,20 +162,7 @@ impl Http3Server {
         let out = self
             .server
             .process_multiple(Option::<Datagram>::None, now, max_datagrams);
-        // The transport layer's callback delay has no notion of an
-        // http3-layer datagram queue's max-age deadline; clamp it the same
-        // way `Http3Client::process_multiple_output` does, so an
-        // otherwise-idle connection still wakes up in time to expire a
-        // stale queued datagram.
-        match out {
-            OutputBatch::Callback(delay) => OutputBatch::Callback(
-                self.next_datagram_expiry
-                    .filter(|expiry| *expiry > now)
-                    .map(|expiry| expiry - now)
-                    .map_or(delay, |max_age_delay| delay.min(max_age_delay)),
-            ),
-            out => out,
-        }
+        clamp_to_expiry(out, self.next_datagram_expiry, now)
     }
 
     /// Process HTTP3 layer.

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -147,11 +147,11 @@ impl Http3Server {
         qtrace!("[{self}] Process");
         let out = self.server.process_multiple_input(dgrams, now);
         self.process_http3(now);
-        // If we do not that a dgram already try again after process_http3.
         if let OutputBatch::DatagramBatch(d) = out {
             qtrace!("[{self}] Send packet: {d:?}");
             return OutputBatch::DatagramBatch(d);
         }
+        // No datagram yet: try again now that process_http3 has run.
         let out = self
             .server
             .process_multiple(Option::<Datagram>::None, now, max_datagrams);

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -141,14 +141,29 @@ impl Http3Server {
         let out = self.server.process_multiple_input(dgrams, now);
         self.process_http3(now);
         // If we do not that a dgram already try again after process_http3.
+        if let OutputBatch::DatagramBatch(d) = out {
+            qtrace!("[{self}] Send packet: {d:?}");
+            return OutputBatch::DatagramBatch(d);
+        }
+        let out = self
+            .server
+            .process_multiple(Option::<Datagram>::None, now, max_datagrams);
+        // The transport layer's callback delay has no notion of an
+        // http3-layer datagram queue's max-age deadline; clamp it the same
+        // way `Http3Client::process_multiple_output` does, so an
+        // otherwise-idle connection still wakes up in time to expire a
+        // stale queued datagram.
         match out {
-            OutputBatch::DatagramBatch(d) => {
-                qtrace!("[{self}] Send packet: {d:?}");
-                OutputBatch::DatagramBatch(d)
-            }
-            _ => self
-                .server
-                .process_multiple(Option::<Datagram>::None, now, max_datagrams),
+            OutputBatch::Callback(delay) => OutputBatch::Callback(
+                self.http3_handlers
+                    .values()
+                    .filter_map(|h| h.borrow().next_datagram_expiry())
+                    .filter(|expiry| *expiry > now)
+                    .map(|expiry| expiry - now)
+                    .min()
+                    .map_or(delay, |max_age_delay| delay.min(max_age_delay)),
+            ),
+            out => out,
         }
     }
 
@@ -163,7 +178,7 @@ impl Http3Server {
         active_conns.extend(
             self.http3_handlers
                 .iter()
-                .filter(|(_, handler)| handler.borrow_mut().should_be_processed())
+                .filter(|(_, handler)| handler.borrow_mut().should_be_processed(now))
                 .map(|(c, _)| c)
                 .cloned(),
         );
@@ -326,6 +341,28 @@ impl Http3Server {
                                 session_id,
                             ),
                             datagram,
+                        );
+                    }
+                    Http3ServerConnEvent::WebTransport(WebTransportEvent::DatagramOutcome {
+                        session_id,
+                        outcome,
+                    }) => {
+                        self.events.webtransport_datagram_outcome(
+                            ServerSession::new(conn.clone(), Rc::clone(handler), session_id),
+                            outcome,
+                        );
+                    }
+                    Http3ServerConnEvent::ConnectUdp(ConnectUdpEvent::DatagramOutcome {
+                        session_id,
+                        outcome,
+                    }) => {
+                        self.events.connect_udp_datagram_outcome(
+                            connect_udp::ServerSession::new(
+                                conn.clone(),
+                                Rc::clone(handler),
+                                session_id,
+                            ),
+                            outcome,
                         );
                     }
                 }

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -49,6 +49,7 @@ pub enum Http3ServerConnEvent {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum WebTransportEvent {
     Session {
         stream_id: StreamId,
@@ -71,6 +72,7 @@ pub enum WebTransportEvent {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum ConnectUdpEvent {
     Session {
         stream_id: StreamId,

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -284,19 +284,6 @@ impl Http3ServerConnEvents {
         self.events.push(Http3ServerConnEvent::StateChange(state));
     }
 
-    pub fn webtransport_datagram_outcome(
-        &self,
-        session_id: StreamId,
-        outcome: extended_connect::DatagramOutcome,
-    ) {
-        self.events.push(Http3ServerConnEvent::WebTransport(
-            WebTransportEvent::DatagramOutcome {
-                session_id,
-                outcome,
-            },
-        ));
-    }
-
     pub fn priority_update(&self, stream_id: StreamId, priority: Priority) {
         self.events.push(Http3ServerConnEvent::PriorityUpdate {
             stream_id,

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -64,6 +64,10 @@ pub enum WebTransportEvent {
         session_id: StreamId,
         datagram: Bytes,
     },
+    DatagramOutcome {
+        session_id: StreamId,
+        outcome: extended_connect::DatagramOutcome,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -80,6 +84,10 @@ pub enum ConnectUdpEvent {
     Datagram {
         session_id: StreamId,
         datagram: Bytes,
+    },
+    DatagramOutcome {
+        session_id: StreamId,
+        outcome: extended_connect::DatagramOutcome,
     },
 }
 
@@ -238,6 +246,29 @@ impl ExtendedConnectEvents for Http3ServerConnEvents {
         };
         self.events.push(event);
     }
+
+    fn datagram_outcome(
+        &self,
+        session_id: StreamId,
+        outcome: extended_connect::DatagramOutcome,
+        connect_type: ExtendedConnectType,
+    ) {
+        let event = match connect_type {
+            ExtendedConnectType::WebTransport => {
+                Http3ServerConnEvent::WebTransport(WebTransportEvent::DatagramOutcome {
+                    session_id,
+                    outcome,
+                })
+            }
+            ExtendedConnectType::ConnectUdp => {
+                Http3ServerConnEvent::ConnectUdp(ConnectUdpEvent::DatagramOutcome {
+                    session_id,
+                    outcome,
+                })
+            }
+        };
+        self.events.push(event);
+    }
 }
 
 impl Http3ServerConnEvents {
@@ -251,6 +282,19 @@ impl Http3ServerConnEvents {
 
     pub fn connection_state_change(&self, state: Http3State) {
         self.events.push(Http3ServerConnEvent::StateChange(state));
+    }
+
+    pub fn webtransport_datagram_outcome(
+        &self,
+        session_id: StreamId,
+        outcome: extended_connect::DatagramOutcome,
+    ) {
+        self.events.push(Http3ServerConnEvent::WebTransport(
+            WebTransportEvent::DatagramOutcome {
+                session_id,
+                outcome,
+            },
+        ));
     }
 
     pub fn priority_update(&self, stream_id: StreamId, priority: Priority) {

--- a/neqo-http3/src/webtransport.rs
+++ b/neqo-http3/src/webtransport.rs
@@ -19,8 +19,8 @@ use neqo_transport::{
 };
 
 use crate::{
-    Error, Http3Client, Http3OrWebTransportStream, Http3ServerEvent, Http3State, Http3StreamInfo,
-    Http3StreamType, Res, SendGroupId, SessionAcceptAction,
+    Error, Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3ServerEvent, Http3State,
+    Http3StreamInfo, Http3StreamType, Res, SendGroupId, SessionAcceptAction, WebTransportEvent,
     connection::Http3Connection,
     connection_server::Http3ServerHandler,
     features::extended_connect,
@@ -61,6 +61,25 @@ pub trait ClientSession {
     ///
     /// This cannot panic. The max varint length is 8.
     fn webtransport_max_datagram_size(&self, session_id: StreamId) -> Res<u64>;
+
+    /// # Errors
+    ///
+    /// Returns error if the session ID is invalid or is not a WebTransport session.
+    fn webtransport_set_datagram_high_water_mark(
+        &mut self,
+        session_id: StreamId,
+        high_water_mark: f64,
+    ) -> Res<()>;
+
+    /// # Errors
+    ///
+    /// Returns error if the session ID is invalid or is not a WebTransport session.
+    fn webtransport_set_datagram_max_age(
+        &mut self,
+        session_id: StreamId,
+        max_age: f64,
+        now: Instant,
+    ) -> Res<()>;
 
     /// Sets the `SendOrder` for a given stream
     ///
@@ -184,6 +203,16 @@ pub trait ClientSession {
 
     /// Send a `WebTransport` datagram.
     ///
+    /// This enqueues the datagram into a per-session queue. The datagram is
+    /// not actually sent until `process_output()` (or `process()`) is called,
+    /// which drains the queue into the QUIC layer and assembles outgoing
+    /// packets. The caller must call `process_output()` after this to ensure
+    /// timely delivery.
+    ///
+    /// Returns `(below_watermark, dropped)`: `below_watermark` is `true` while the
+    /// queue is below the high water mark, and `dropped` carries the outcome of a
+    /// datagram evicted to make room if the queue was already at its hard limit.
+    ///
     /// # Errors
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
@@ -195,7 +224,7 @@ pub trait ClientSession {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<(bool, Option<extended_connect::DatagramOutcome>)>;
 }
 
 impl ClientSession for Http3Client {
@@ -213,6 +242,37 @@ impl ClientSession for Http3Client {
             .connection()
             .max_datagram_size()?
             .saturating_sub(to_u64(qsid_len)))
+    }
+
+    fn webtransport_set_datagram_high_water_mark(
+        &mut self,
+        session_id: StreamId,
+        high_water_mark: f64,
+    ) -> Res<()> {
+        self.connection_and_handler()
+            .1
+            .webtransport_set_datagram_high_water_mark(session_id, high_water_mark)
+    }
+
+    fn webtransport_set_datagram_max_age(
+        &mut self,
+        session_id: StreamId,
+        max_age: f64,
+        now: Instant,
+    ) -> Res<()> {
+        let expired = self
+            .connection_and_handler()
+            .1
+            .webtransport_set_datagram_max_age(session_id, max_age, now)?;
+        for outcome in expired {
+            self.client_events().insert(Http3ClientEvent::WebTransport(
+                WebTransportEvent::DatagramOutcome {
+                    session_id,
+                    outcome,
+                },
+            ));
+        }
+        Ok(())
     }
 
     fn webtransport_set_sendorder(
@@ -337,7 +397,7 @@ impl ClientSession for Http3Client {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<(bool, Option<extended_connect::DatagramOutcome>)> {
         qtrace!("webtransport_send_datagram session:{session_id:?}");
         let (conn, handler) = self.connection_and_handler();
         handler.webtransport_send_datagram(session_id, conn, buf, id, now)
@@ -421,7 +481,7 @@ trait Handler {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<(bool, Option<extended_connect::DatagramOutcome>)>;
 }
 
 impl Handler for Http3Connection {
@@ -497,7 +557,7 @@ impl Handler for Http3Connection {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<(bool, Option<extended_connect::DatagramOutcome>)> {
         self.extended_connect_send_datagram(session_id, conn, buf, id, now)
     }
 }
@@ -594,6 +654,7 @@ impl ServerHandler for Http3ServerHandler {
         self.mark_needs_processing();
         self.base_handler_mut()
             .webtransport_send_datagram(session_id, conn, buf, id, now)
+            .map(|_| ())
     }
 }
 

--- a/neqo-http3/src/webtransport.rs
+++ b/neqo-http3/src/webtransport.rs
@@ -9,7 +9,7 @@ use std::{
     fmt::{self, Display, Formatter},
     ops::Deref,
     rc::Rc,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use neqo_common::{Bytes, Encoder, Header, qdebug, qinfo, qtrace, to_u64};
@@ -19,8 +19,8 @@ use neqo_transport::{
 };
 
 use crate::{
-    Error, Http3Client, Http3OrWebTransportStream, Http3ServerEvent, Http3State, Http3StreamInfo,
-    Http3StreamType, Res, SendGroupId, SessionAcceptAction,
+    Error, Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3ServerEvent, Http3State,
+    Http3StreamInfo, Http3StreamType, Res, SendGroupId, SessionAcceptAction, WebTransportEvent,
     connection::Http3Connection,
     connection_server::Http3ServerHandler,
     features::extended_connect,
@@ -61,6 +61,31 @@ pub trait ClientSession {
     ///
     /// This cannot panic. The max varint length is 8.
     fn webtransport_max_datagram_size(&self, session_id: StreamId) -> Res<u64>;
+
+    /// `None` means no limit. The caller is responsible for mapping the
+    /// `unrestricted double` `outgoingHighWaterMark` onto this, including NaN
+    /// and the infinities.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the session ID is invalid or is not a WebTransport session.
+    fn webtransport_set_datagram_high_water_mark(
+        &mut self,
+        session_id: StreamId,
+        high_water_mark: Option<usize>,
+    ) -> Res<()>;
+
+    /// [`Duration::MAX`] means no limit, as does the default.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the session ID is invalid or is not a WebTransport session.
+    fn webtransport_set_datagram_max_age(
+        &mut self,
+        session_id: StreamId,
+        max_age: Duration,
+        now: Instant,
+    ) -> Res<()>;
 
     /// Sets the `SendOrder` for a given stream
     ///
@@ -184,6 +209,15 @@ pub trait ClientSession {
 
     /// Send a `WebTransport` datagram.
     ///
+    /// This enqueues the datagram into a per-session queue. The datagram is
+    /// not actually sent until `process_output()` (or `process()`) is called,
+    /// which drains the queue into the QUIC layer and assembles outgoing
+    /// packets. The caller must call `process_output()` after this to ensure
+    /// timely delivery.
+    ///
+    /// Returns the state of the queue after the datagram was accepted, so the
+    /// caller can apply backpressure (see [`extended_connect::DatagramQueueOutcome`]).
+    ///
     /// # Errors
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
@@ -195,7 +229,7 @@ pub trait ClientSession {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<extended_connect::DatagramQueueOutcome>;
 }
 
 impl ClientSession for Http3Client {
@@ -213,6 +247,35 @@ impl ClientSession for Http3Client {
             .connection()
             .max_datagram_size()?
             .saturating_sub(to_u64(qsid_len)))
+    }
+
+    fn webtransport_set_datagram_high_water_mark(
+        &mut self,
+        session_id: StreamId,
+        high_water_mark: Option<usize>,
+    ) -> Res<()> {
+        self.handler()
+            .webtransport_set_datagram_high_water_mark(session_id, high_water_mark)
+    }
+
+    fn webtransport_set_datagram_max_age(
+        &mut self,
+        session_id: StreamId,
+        max_age: Duration,
+        now: Instant,
+    ) -> Res<()> {
+        let expired = self
+            .handler()
+            .webtransport_set_datagram_max_age(session_id, max_age, now)?;
+        for outcome in expired {
+            self.client_events().push(Http3ClientEvent::WebTransport(
+                WebTransportEvent::DatagramOutcome {
+                    session_id,
+                    outcome,
+                },
+            ));
+        }
+        Ok(())
     }
 
     fn webtransport_set_sendorder(
@@ -337,7 +400,7 @@ impl ClientSession for Http3Client {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<extended_connect::DatagramQueueOutcome> {
         qtrace!("webtransport_send_datagram session:{session_id:?}");
         let (conn, handler) = self.connection_and_handler();
         handler.webtransport_send_datagram(session_id, conn, buf, id, now)
@@ -421,7 +484,7 @@ trait Handler {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<extended_connect::DatagramQueueOutcome>;
 }
 
 impl Handler for Http3Connection {
@@ -502,7 +565,7 @@ impl Handler for Http3Connection {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<extended_connect::DatagramQueueOutcome> {
         self.extended_connect_send_datagram(session_id, conn, buf, id, now)
     }
 }
@@ -539,6 +602,31 @@ pub(crate) trait ServerHandler {
         session_id: StreamId,
         buf: &[u8],
         id: I,
+        now: Instant,
+    ) -> Res<extended_connect::DatagramQueueOutcome>;
+
+    /// `None` means no limit. The caller is responsible for mapping the
+    /// `unrestricted double` `outgoingHighWaterMark` onto this, including NaN
+    /// and the infinities.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the session ID is invalid or is not a WebTransport session.
+    fn webtransport_set_datagram_high_water_mark(
+        &mut self,
+        session_id: StreamId,
+        high_water_mark: Option<usize>,
+    ) -> Res<()>;
+
+    /// [`Duration::MAX`] means no limit, as does the default.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the session ID is invalid or is not a WebTransport session.
+    fn webtransport_set_datagram_max_age(
+        &mut self,
+        session_id: StreamId,
+        max_age: Duration,
         now: Instant,
     ) -> Res<()>;
 }
@@ -595,10 +683,35 @@ impl ServerHandler for Http3ServerHandler {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<extended_connect::DatagramQueueOutcome> {
         self.mark_needs_processing();
         self.base_handler_mut()
             .webtransport_send_datagram(session_id, conn, buf, id, now)
+    }
+
+    fn webtransport_set_datagram_high_water_mark(
+        &mut self,
+        session_id: StreamId,
+        high_water_mark: Option<usize>,
+    ) -> Res<()> {
+        self.base_handler_mut()
+            .webtransport_set_datagram_high_water_mark(session_id, high_water_mark)
+    }
+
+    fn webtransport_set_datagram_max_age(
+        &mut self,
+        session_id: StreamId,
+        max_age: Duration,
+        now: Instant,
+    ) -> Res<()> {
+        let expired = self
+            .base_handler_mut()
+            .webtransport_set_datagram_max_age(session_id, max_age, now)?;
+        for outcome in expired {
+            self.server_events()
+                .webtransport_datagram_outcome(session_id, outcome);
+        }
+        Ok(())
     }
 }
 
@@ -707,6 +820,9 @@ impl ServerSession {
 
     /// Send `WebTransport` datagram.
     ///
+    /// Returns the state of the queue after the datagram was accepted, so the
+    /// caller can apply backpressure (see [`extended_connect::DatagramQueueOutcome`]).
+    ///
     /// # Errors
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
@@ -717,7 +833,7 @@ impl ServerSession {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<extended_connect::DatagramQueueOutcome> {
         let session_id = self.stream_handler.stream_id();
         self.stream_handler
             .handler
@@ -729,6 +845,34 @@ impl ServerSession {
                 id,
                 now,
             )
+    }
+
+    /// `None` means no limit. The caller is responsible for mapping the
+    /// `unrestricted double` `outgoingHighWaterMark` onto this, including NaN
+    /// and the infinities.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the session is no longer active.
+    pub fn set_datagram_high_water_mark(&self, high_water_mark: Option<usize>) -> Res<()> {
+        let session_id = self.stream_handler.stream_id();
+        self.stream_handler
+            .handler
+            .borrow_mut()
+            .webtransport_set_datagram_high_water_mark(session_id, high_water_mark)
+    }
+
+    /// [`Duration::MAX`] means no limit, as does the default.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the session is no longer active.
+    pub fn set_datagram_max_age(&self, max_age: Duration, now: Instant) -> Res<()> {
+        let session_id = self.stream_handler.stream_id();
+        self.stream_handler
+            .handler
+            .borrow_mut()
+            .webtransport_set_datagram_max_age(session_id, max_age, now)
     }
 
     // TODO: Currently not called in neqo or gecko. It should likely be called at least from gecko.
@@ -803,6 +947,10 @@ pub enum ServerEvent {
         session: ServerSession,
         datagram: Bytes,
     },
+    DatagramOutcome {
+        session: ServerSession,
+        outcome: extended_connect::DatagramOutcome,
+    },
 }
 
 pub(crate) trait ServerEvents {
@@ -815,6 +963,11 @@ pub(crate) trait ServerEvents {
     );
     fn webtransport_new_stream(&self, stream: Http3OrWebTransportStream);
     fn webtransport_datagram(&self, session: ServerSession, datagram: Bytes);
+    fn webtransport_datagram_outcome(
+        &self,
+        session: ServerSession,
+        outcome: extended_connect::DatagramOutcome,
+    );
 }
 
 impl ServerEvents for Http3ServerEvents {
@@ -849,5 +1002,15 @@ impl ServerEvents for Http3ServerEvents {
             session,
             datagram,
         }));
+    }
+
+    fn webtransport_datagram_outcome(
+        &self,
+        session: ServerSession,
+        outcome: extended_connect::DatagramOutcome,
+    ) {
+        self.push(Http3ServerEvent::WebTransport(
+            ServerEvent::DatagramOutcome { session, outcome },
+        ));
     }
 }

--- a/neqo-http3/src/webtransport.rs
+++ b/neqo-http3/src/webtransport.rs
@@ -19,8 +19,8 @@ use neqo_transport::{
 };
 
 use crate::{
-    Error, Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3ServerEvent, Http3State,
-    Http3StreamInfo, Http3StreamType, Res, SendGroupId, SessionAcceptAction, WebTransportEvent,
+    Error, Http3Client, Http3OrWebTransportStream, Http3ServerEvent, Http3State, Http3StreamInfo,
+    Http3StreamType, Res, SendGroupId, SessionAcceptAction,
     connection::Http3Connection,
     connection_server::Http3ServerHandler,
     features::extended_connect,
@@ -264,18 +264,8 @@ impl ClientSession for Http3Client {
         max_age: Duration,
         now: Instant,
     ) -> Res<()> {
-        let expired = self
-            .handler()
-            .webtransport_set_datagram_max_age(session_id, max_age, now)?;
-        for outcome in expired {
-            self.client_events().push(Http3ClientEvent::WebTransport(
-                WebTransportEvent::DatagramOutcome {
-                    session_id,
-                    outcome,
-                },
-            ));
-        }
-        Ok(())
+        self.handler()
+            .webtransport_set_datagram_max_age(session_id, max_age, now)
     }
 
     fn webtransport_set_sendorder(
@@ -705,14 +695,8 @@ impl ServerHandler for Http3ServerHandler {
         now: Instant,
     ) -> Res<()> {
         self.mark_needs_processing();
-        let expired = self
-            .base_handler_mut()
-            .webtransport_set_datagram_max_age(session_id, max_age, now)?;
-        for outcome in expired {
-            self.server_events()
-                .webtransport_datagram_outcome(session_id, outcome);
-        }
-        Ok(())
+        self.base_handler_mut()
+            .webtransport_set_datagram_max_age(session_id, max_age, now)
     }
 }
 

--- a/neqo-http3/src/webtransport.rs
+++ b/neqo-http3/src/webtransport.rs
@@ -917,6 +917,7 @@ impl Deref for ServerSession {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum ServerEvent {
     NewSession {
         session: ServerSession,

--- a/neqo-http3/src/webtransport.rs
+++ b/neqo-http3/src/webtransport.rs
@@ -704,6 +704,7 @@ impl ServerHandler for Http3ServerHandler {
         max_age: Duration,
         now: Instant,
     ) -> Res<()> {
+        self.mark_needs_processing();
         let expired = self
             .base_handler_mut()
             .webtransport_set_datagram_max_age(session_id, max_age, now)?;

--- a/neqo-http3/tests/connect_udp.rs
+++ b/neqo-http3/tests/connect_udp.rs
@@ -802,8 +802,8 @@ fn connect_udp_server_send_datagram_reports_backpressure() {
     for _ in 0..1000 {
         proxy_session.send_datagram(PING, None, now()).unwrap();
     }
-    assert!(matches!(
+    assert_eq!(
         proxy_session.send_datagram(PING, None, now()),
-        Ok(DatagramQueueOutcome::Overflowed { .. })
-    ));
+        Ok(DatagramQueueOutcome::Overflowed)
+    );
 }

--- a/neqo-http3/tests/connect_udp.rs
+++ b/neqo-http3/tests/connect_udp.rs
@@ -14,7 +14,7 @@ use neqo_http3::{
     ConnectUdpEvent, Error, Http3Client, Http3ClientEvent, Http3Parameters, Http3Server,
     Http3ServerEvent, Http3State, Priority, SessionAcceptAction, WebTransportEvent,
     connect_udp::{ClientSession as _, ServerEvent, ServerSession},
-    features::extended_connect::DatagramOutcome,
+    features::extended_connect::{DatagramOutcome, DatagramQueueOutcome},
     webtransport::ClientSession as _,
 };
 use neqo_transport::{ConnectionParameters, StreamType};
@@ -786,4 +786,24 @@ fn connect_udp_datagram_outcome_uses_connect_udp_event() {
         !mistagged_as_webtransport,
         "a connect-udp session's datagram outcome must never be reported as a WebTransportEvent"
     );
+}
+
+/// The server-side connect-udp `send_datagram` must surface the queue's
+/// `DatagramQueueOutcome`, same as its client-side counterpart and as
+/// `ServerHandler::webtransport_send_datagram` on the WebTransport side:
+/// without this, a connect-udp server has a queue but no backpressure
+/// signal telling it the queue is full.
+#[test]
+fn connect_udp_server_send_datagram_reports_backpressure() {
+    let (_client, _proxy, _session_id, proxy_session) = establish_new_session();
+
+    // `DEFAULT_HARD_LIMIT` (1000) is crate-private, so drive the queue to its
+    // hard limit directly rather than importing it.
+    for _ in 0..1000 {
+        proxy_session.send_datagram(PING, None, now()).unwrap();
+    }
+    assert!(matches!(
+        proxy_session.send_datagram(PING, None, now()),
+        Ok(DatagramQueueOutcome::Overflowed { .. })
+    ));
 }

--- a/neqo-http3/tests/connect_udp.rs
+++ b/neqo-http3/tests/connect_udp.rs
@@ -6,6 +6,8 @@
 
 #![cfg(test)]
 
+use std::time::Duration;
+
 use http::Uri;
 use neqo_common::{Datagram, Tos, event::Provider as _, header::HeadersExt as _, qinfo};
 use neqo_http3::{
@@ -713,6 +715,32 @@ fn connect_udp_session_rejected_by_webtransport_create_stream() {
     let (mut client, _proxy, session_id, _proxy_session) = establish_new_session();
     assert_eq!(
         client.webtransport_create_stream(session_id, StreamType::UniDi),
+        Err(Error::InvalidStreamId)
+    );
+}
+
+/// `webtransport_set_datagram_high_water_mark` must not accept a connect-udp
+/// session id just because it happens to share the extended-CONNECT session
+/// machinery with WebTransport.
+#[test]
+fn connect_udp_session_rejected_by_webtransport_set_datagram_high_water_mark() {
+    fixture_init();
+    let (mut client, _proxy, session_id, _proxy_session) = establish_new_session();
+    assert_eq!(
+        client.webtransport_set_datagram_high_water_mark(session_id, Some(2)),
+        Err(Error::InvalidStreamId)
+    );
+}
+
+/// `webtransport_set_datagram_max_age` must not accept a connect-udp session
+/// id just because it happens to share the extended-CONNECT session
+/// machinery with WebTransport.
+#[test]
+fn connect_udp_session_rejected_by_webtransport_set_datagram_max_age() {
+    fixture_init();
+    let (mut client, _proxy, session_id, _proxy_session) = establish_new_session();
+    assert_eq!(
+        client.webtransport_set_datagram_max_age(session_id, Duration::from_millis(100), now()),
         Err(Error::InvalidStreamId)
     );
 }

--- a/neqo-http3/tests/connect_udp.rs
+++ b/neqo-http3/tests/connect_udp.rs
@@ -14,7 +14,7 @@ use neqo_http3::{
     ConnectUdpEvent, Error, Http3Client, Http3ClientEvent, Http3Parameters, Http3Server,
     Http3ServerEvent, Http3State, Priority, SessionAcceptAction, WebTransportEvent,
     connect_udp::{ClientSession as _, ServerEvent, ServerSession},
-    features::extended_connect::{DatagramOutcome, DatagramQueueOutcome},
+    features::extended_connect::{DEFAULT_HARD_LIMIT, DatagramOutcome, DatagramQueueOutcome},
     webtransport::ClientSession as _,
 };
 use neqo_transport::{ConnectionParameters, StreamType};
@@ -797,9 +797,7 @@ fn connect_udp_datagram_outcome_uses_connect_udp_event() {
 fn connect_udp_server_send_datagram_reports_backpressure() {
     let (_client, _proxy, _session_id, proxy_session) = establish_new_session();
 
-    // `DEFAULT_HARD_LIMIT` (1000) is crate-private, so drive the queue to its
-    // hard limit directly rather than importing it.
-    for _ in 0..1000 {
+    for _ in 0..DEFAULT_HARD_LIMIT {
         proxy_session.send_datagram(PING, None, now()).unwrap();
     }
     assert_eq!(

--- a/neqo-http3/tests/connect_udp.rs
+++ b/neqo-http3/tests/connect_udp.rs
@@ -12,8 +12,9 @@ use http::Uri;
 use neqo_common::{Datagram, Tos, event::Provider as _, header::HeadersExt as _, qinfo};
 use neqo_http3::{
     ConnectUdpEvent, Error, Http3Client, Http3ClientEvent, Http3Parameters, Http3Server,
-    Http3ServerEvent, Http3State, Priority, SessionAcceptAction,
+    Http3ServerEvent, Http3State, Priority, SessionAcceptAction, WebTransportEvent,
     connect_udp::{ClientSession as _, ServerEvent, ServerSession},
+    features::extended_connect::DatagramOutcome,
     webtransport::ClientSession as _,
 };
 use neqo_transport::{ConnectionParameters, StreamType};
@@ -742,5 +743,47 @@ fn connect_udp_session_rejected_by_webtransport_set_datagram_max_age() {
     assert_eq!(
         client.webtransport_set_datagram_max_age(session_id, Duration::from_millis(100), now()),
         Err(Error::InvalidStreamId)
+    );
+}
+
+/// A connect-udp session's datagram outcomes must arrive as
+/// `ConnectUdpEvent::DatagramOutcome`, not `WebTransportEvent::DatagramOutcome`:
+/// both protocols share the same outgoing-datagram-queue machinery, and a
+/// consumer that only knows about one of them must not be handed the other's
+/// event.
+#[test]
+fn connect_udp_datagram_outcome_uses_connect_udp_event() {
+    let (mut client, mut proxy, session_id, _proxy_session) = establish_new_session();
+
+    client
+        .connect_udp_send_datagram(session_id, PING, Some(1u64), now())
+        .unwrap();
+    exchange_packets(&mut client, &mut proxy, false, None);
+
+    let events: Vec<_> = client.events().collect();
+
+    let sent_as_connect_udp = events.iter().any(|e| {
+        matches!(
+            e,
+            Http3ClientEvent::ConnectUdp(ConnectUdpEvent::DatagramOutcome {
+                session_id: sid,
+                outcome: DatagramOutcome::Sent(1),
+            }) if *sid == session_id
+        )
+    });
+    assert!(
+        sent_as_connect_udp,
+        "connect-udp datagram outcome must be reported as a ConnectUdpEvent"
+    );
+
+    let mistagged_as_webtransport = events.iter().any(|e| {
+        matches!(
+            e,
+            Http3ClientEvent::WebTransport(WebTransportEvent::DatagramOutcome { .. })
+        )
+    });
+    assert!(
+        !mistagged_as_webtransport,
+        "a connect-udp session's datagram outcome must never be reported as a WebTransportEvent"
     );
 }

--- a/neqo-http3/tests/connect_udp.rs
+++ b/neqo-http3/tests/connect_udp.rs
@@ -711,3 +711,29 @@ fn connect_udp_session_rejected_by_webtransport_create_stream() {
         Err(Error::InvalidStreamId)
     );
 }
+
+/// `webtransport_set_datagram_high_water_mark` must not accept a connect-udp
+/// session id just because it happens to share the extended-CONNECT session
+/// machinery with WebTransport.
+#[test]
+fn connect_udp_session_rejected_by_webtransport_set_datagram_high_water_mark() {
+    fixture_init();
+    let (mut client, _proxy, session_id, _proxy_session) = establish_new_session();
+    assert_eq!(
+        client.webtransport_set_datagram_high_water_mark(session_id, 2.0),
+        Err(Error::InvalidStreamId)
+    );
+}
+
+/// `webtransport_set_datagram_max_age` must not accept a connect-udp session
+/// id just because it happens to share the extended-CONNECT session
+/// machinery with WebTransport.
+#[test]
+fn connect_udp_session_rejected_by_webtransport_set_datagram_max_age() {
+    fixture_init();
+    let (mut client, _proxy, session_id, _proxy_session) = establish_new_session();
+    assert_eq!(
+        client.webtransport_set_datagram_max_age(session_id, 100.0, now()),
+        Err(Error::InvalidStreamId)
+    );
+}

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -4049,6 +4049,16 @@ impl Connection {
             .is_some_and(|tp| tp.get_empty(ResetStreamAt))
     }
 
+    /// How many more datagrams can be passed to [`Self::send_datagram`] before
+    /// it starts dropping datagrams that are already queued. A caller holding
+    /// its own queue should use this to hand over only what fits, so that
+    /// datagrams it cannot pass on yet stay under its own eviction policy
+    /// rather than being head-dropped here.
+    #[must_use]
+    pub fn remaining_datagram_queue_capacity(&self) -> usize {
+        self.quic_datagrams.remaining_capacity()
+    }
+
     /// Returns the current max size of a datagram that can fit into a packet.
     /// The value will change over time depending on the encoded size of the
     /// packet number, ack frames, etc.

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -442,6 +442,39 @@ fn dgram_unsupported() {
     assert_error(&client, &CloseReason::Transport(Error::ProtocolViolation));
 }
 
+/// `remaining_datagram_queue_capacity` is what a caller holding its own
+/// queue (e.g. an http3-layer `DatagramQueue`) uses to decide how much it
+/// can hand over without being head-dropped here; it must track the queue
+/// exactly, including staying at `0` - not wrapping - once the queue is
+/// full and stays full.
+#[test]
+fn remaining_datagram_queue_capacity_tracks_the_queue() {
+    let (mut client, _server) = connect_datagram();
+
+    assert_eq!(client.remaining_datagram_queue_capacity(), OUTGOING_QUEUE);
+
+    assert_eq!(
+        client.send_datagram(DATA_SMALLER_THAN_MTU.to_vec(), Some(1)),
+        Ok(())
+    );
+    assert_eq!(
+        client.remaining_datagram_queue_capacity(),
+        OUTGOING_QUEUE - 1
+    );
+
+    assert_eq!(
+        client.send_datagram(DATA_SMALLER_THAN_MTU_2.to_vec(), Some(2)),
+        Ok(())
+    );
+    assert_eq!(client.remaining_datagram_queue_capacity(), 0);
+
+    // The queue is already full: this evicts datagram 1 rather than
+    // growing past `OUTGOING_QUEUE`, so capacity stays at 0 rather than
+    // underflowing.
+    assert_eq!(client.send_datagram(DATA_MTU.to_vec(), Some(3)), Ok(()));
+    assert_eq!(client.remaining_datagram_queue_capacity(), 0);
+}
+
 #[test]
 fn outgoing_datagram_queue_full() {
     let (mut client, mut server) = connect_datagram();

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -94,6 +94,13 @@ impl QuicDatagrams {
         self.remote_datagram_size = min(v, QuicDatagram::MAX_SIZE);
     }
 
+    /// How many more datagrams can be queued before [`Self::add_datagram`]
+    /// starts evicting datagrams that are already queued.
+    pub fn remaining_capacity(&self) -> usize {
+        self.max_queued_outgoing_datagrams
+            .saturating_sub(self.datagrams.len())
+    }
+
     /// This function tries to write a datagram frame into a packet. If the
     /// frame does not fit into the packet, the datagram will be dropped and a
     /// [`OutgoingDatagramOutcome::DroppedTooBig`] event will be posted.


### PR DESCRIPTION
Support handling queuing and highwatermarks/max-age datagrams per the WebTransport spec
Was https://github.com/mozilla/neqo/pull/3469