### PR TITLE
remove debug_assert that could cause debug builds to fail in a race condition

### DIFF
--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -457,7 +457,6 @@ impl Session {
         qtrace!("[{self}] send_datagram state={:?}", self.state);
         if self.state != State::Active {
             qdebug!("[{self}]: cannot send datagram in {:?} state.", self.state);
-            debug_assert!(false);
             return Err(Error::Unavailable);
         }
         let remote_datagram_size = conn.remote_datagram_size();

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -450,7 +450,6 @@ impl Session {
         qtrace!("[{self}] send_datagram state={:?}", self.state);
         if self.state != State::Active {
             qdebug!("[{self}]: cannot send datagram in {:?} state.", self.state);
-            debug_assert!(false);
             return Err(Error::Unavailable);
         }
         if conn.remote_datagram_size() == 0 && self.protocol.datagram_capsule_support() {


### PR DESCRIPTION
Remove a debug assert that could cause debug builds to fail in a race condition, plus one that should never happen
Was https://github.com/mozilla/neqo/pull/3478
