### PR TITLE
fix: reject 0-RTT downgrade of h3 datagram and webtransport settings

### DIFF
--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1713,6 +1713,8 @@ impl Http3Connection {
                     HSettingType::MaxHeaderListSize,
                     HSettingType::MaxTableCapacity,
                     HSettingType::BlockedStreams,
+                    HSettingType::EnableWebTransport,
+                    HSettingType::EnableH3Datagram,
                 ] {
                     let zero_rtt_value = settings.get(*st);
                     let new_value = new_settings.get(*st);

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1713,6 +1713,12 @@ impl Http3Connection {
                     HSettingType::MaxHeaderListSize,
                     HSettingType::MaxTableCapacity,
                     HSettingType::BlockedStreams,
+                    // [RFC 9297, Section 2.1.1](https://www.rfc-editor.org/rfc/rfc9297.html#section-2.1.1)
+                    // requires a client that stored SETTINGS_H3_DATAGRAM with its
+                    // 0-RTT state to terminate the connection with H3_SETTINGS_ERROR
+                    // if the server's new value is smaller than the stored one.
+                    // [draft-ietf-webtrans-http3, Section 3.2](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3#section-3.2)
+                    // states the same rule for the WebTransport setting.
                     HSettingType::EnableWebTransport,
                     HSettingType::EnableH3Datagram,
                 ] {

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -4627,6 +4627,67 @@ mod tests {
     }
 
     #[test]
+    fn zero_rtt_new_server_setting_h3_datagram_smaller() {
+        // The server advertised SETTINGS_H3_DATAGRAM=1 before, and now withholds it.
+        zero_rtt_change_settings(
+            &[
+                HSetting::new(HSettingType::MaxTableCapacity, 100),
+                HSetting::new(HSettingType::BlockedStreams, 100),
+                HSetting::new(HSettingType::MaxHeaderListSize, 10000),
+                HSetting::new(HSettingType::EnableH3Datagram, 1),
+            ],
+            &[
+                HSetting::new(HSettingType::MaxTableCapacity, 100),
+                HSetting::new(HSettingType::BlockedStreams, 100),
+                HSetting::new(HSettingType::MaxHeaderListSize, 10000),
+            ],
+            &Http3State::Closing(CloseReason::Application(265)),
+            ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
+        );
+    }
+
+    #[test]
+    fn zero_rtt_new_server_setting_h3_datagram_bigger() {
+        // Turning SETTINGS_H3_DATAGRAM on for the resumed connection is allowed.
+        zero_rtt_change_settings(
+            &[
+                HSetting::new(HSettingType::MaxTableCapacity, 100),
+                HSetting::new(HSettingType::BlockedStreams, 100),
+                HSetting::new(HSettingType::MaxHeaderListSize, 10000),
+            ],
+            &[
+                HSetting::new(HSettingType::MaxTableCapacity, 100),
+                HSetting::new(HSettingType::BlockedStreams, 100),
+                HSetting::new(HSettingType::MaxHeaderListSize, 10000),
+                HSetting::new(HSettingType::EnableH3Datagram, 1),
+            ],
+            &Http3State::Connected,
+            ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
+        );
+    }
+
+    #[test]
+    fn zero_rtt_new_server_setting_webtransport_smaller() {
+        // The server advertised SETTINGS_ENABLE_WEBTRANSPORT=1 before, and now sends 0.
+        zero_rtt_change_settings(
+            &[
+                HSetting::new(HSettingType::MaxTableCapacity, 100),
+                HSetting::new(HSettingType::BlockedStreams, 100),
+                HSetting::new(HSettingType::MaxHeaderListSize, 10000),
+                HSetting::new(HSettingType::EnableWebTransport, 1),
+            ],
+            &[
+                HSetting::new(HSettingType::MaxTableCapacity, 100),
+                HSetting::new(HSettingType::BlockedStreams, 100),
+                HSetting::new(HSettingType::MaxHeaderListSize, 10000),
+                HSetting::new(HSettingType::EnableWebTransport, 0),
+            ],
+            &Http3State::Closing(CloseReason::Application(265)),
+            ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
+        );
+    }
+
+    #[test]
     fn zero_rtt_max_table_size_first_omitted() {
         // send server original settings without MaxTableCapacity
         // send new server setting with MaxTableCapacity


### PR DESCRIPTION
Without the change, on a resumed connection:

    ---- zero_rtt_new_server_setting_h3_datagram_smaller stdout ----
    assertion `left == right` failed
      left: Connected
     right: Closing(Application(265))

`handle_settings` already rejects a server that lowers a setting it sent before
0-RTT, but the list it walks holds only the three QPACK and header-size
settings. `SETTINGS_H3_DATAGRAM` and `SETTINGS_ENABLE_WEBTRANSPORT` also go into
the resumption token, so a client can send HTTP Datagrams and WebTransport
CONNECTs in 0-RTT against a remembered value the server is then free to
withdraw.

Before: the server omits `SETTINGS_H3_DATAGRAM` on the resumed connection,
`NegotiationState` flips to `Failed`, and the connection stays up.

After: the connection closes with H3_SETTINGS_ERROR, which RFC 9297, Section
2.1.1 asks of a client that stored the setting with its 0-RTT state.
draft-ietf-webtrans-http3, Section 3.2 says the same for the WebTransport
session limit.

Raising a setting from 0 to 1 stays allowed, so only the downgrade direction
changes. The tradeoff is that a server which quietly dropped either feature on
resumption now loses the connection. `SETTINGS_ENABLE_CONNECT_PROTOCOL` is left
out, since RFC 9220 has no comparable 0-RTT rule.
