### PR TITLE
fix(mtu): build clean on iOS, tvOS and visionOS

### DIFF
--- a/mtu/build.rs
+++ b/mtu/build.rs
@@ -13,6 +13,16 @@ fn main() {
                 target_os = "netbsd",
                 target_os = "solaris"
             )
+        },
+        // Platforms that have no `interface_and_mtu_impl` and fall back to the
+        // stub in `lib.rs`. They need none of the supporting machinery.
+        unsupported: {
+            any(
+                target_os = "ios",
+                target_os = "tvos",
+                target_os = "visionos",
+                target_os = "redox"
+            )
         }
     }
 }

--- a/mtu/src/lib.rs
+++ b/mtu/src/lib.rs
@@ -52,7 +52,7 @@ use std::{
     net::IpAddr,
 };
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(unsupported)))]
 macro_rules! asserted_const_with_type {
     ($name:ident, $t1:ty, $e:expr, $t2:ty) => {
         #[allow(
@@ -75,7 +75,7 @@ mod linux;
 #[cfg(target_os = "windows")]
 mod windows;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(unsupported)))]
 mod routesocket;
 
 #[cfg(any(target_os = "macos", bsd))]
@@ -91,14 +91,14 @@ fn default_err() -> Error {
 }
 
 /// Prepare an error for cases that "should never happen".
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(unsupported)))]
 fn unlikely_err(msg: String) -> Error {
     debug_assert!(false, "{msg}");
     Error::other(msg)
 }
 
 /// Align `size` to the next multiple of `align` (which needs to be a power of two).
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(unsupported)))]
 const fn aligned_by(size: usize, align: usize) -> usize {
     if size == 0 {
         align
@@ -110,14 +110,9 @@ const fn aligned_by(size: usize, align: usize) -> usize {
 // Platforms currently not supported.
 //
 // See <https://github.com/mozilla/mtu/issues/82>.
-#[cfg(any(
-    target_os = "ios",
-    target_os = "tvos",
-    target_os = "visionos",
-    target_os = "redox"
-))]
-pub fn interface_and_mtu_impl(remote: IpAddr) -> Result<(String, usize)> {
-    return Err(default_err());
+#[cfg(unsupported)]
+fn interface_and_mtu_impl(_remote: IpAddr) -> Result<(String, usize)> {
+    Err(default_err())
 }
 
 /// Return the name and maximum transmission unit (MTU) of the outgoing network interface towards a
@@ -135,7 +130,7 @@ pub fn interface_and_mtu(remote: IpAddr) -> Result<(String, usize)> {
     interface_and_mtu_impl(remote)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(unsupported)))]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};


### PR DESCRIPTION
## The problem

`mtu` gates its route-socket machinery on `cfg(not(target_os = "windows"))`. That predicate also selects iOS, tvOS, visionOS and Redox — the platforms that fall through to the unsupported-platform stub at `mtu/src/lib.rs:113`. So `mod routesocket`, `unlikely_err`, `aligned_by` and the `asserted_const_with_type` macro all get compiled on those targets while nothing can reach them.

Against the workspace's `-D warnings`, that is 12 errors:

```
$ cargo clippy --locked -p mtu --all-targets --target aarch64-apple-ios -- -D warnings
error: unused macro definition: `asserted_const_with_type`
error: unused variable: `remote`
error: function `unlikely_err` is never used
error: function `aligned_by` is never used
error: type alias `AtomicRouteSocketSeq` is never used
error: type alias `RouteSocketSeq` is never used
error: static `SEQ` is never used
error: struct `RouteSocket` is never constructed
error: associated functions `new` and `new_seq` are never used
error: function `check_result` is never used
error: docs for function returning `Result` missing `# Errors` section
error: unneeded `return` statement
error: could not compile `mtu` (lib) due to 12 previous errors
```

The `lib test` target fails harder than a lint. `test::LOOPBACK`'s `cfg!` chain has no arm for these platforms and falls through to `unreachable!()`, and because it initialises a `const` that is evaluated at compile time:

```
error[E0080]: evaluation panicked: internal error: entered unreachable code
error: could not compile `mtu` (lib test) due to 3 previous errors
```

Identical counts on `aarch64-apple-tvos` and `aarch64-apple-visionos`.

To be upfront about the severity: **CI does not currently build these targets.** `clippy.yml` runs a host-only matrix, and `check-mtu.yml` covers Android and the BSDs but no Apple mobile platform. So this is dormant rather than a gate the CI is failing today — it would surface the moment anyone adds an iOS job, or for a downstream consumer building for those targets.

## The change

Add an `unsupported` cfg alias alongside the existing `bsd` one, and gate the supporting machinery on `not(unsupported)` so those platforms compile only the stub. This keeps the platform list in one place rather than repeating the four-`target_os` `any(...)` at each site.

The test module is gated off there too — `interface_and_mtu` can only ever return an error on a platform with no implementation, so the loopback assertions have nothing to assert.

The stub itself drops its `pub` (every other platform's impl is a private module import, so this was the only target where `interface_and_mtu_impl` leaked into the public API), takes `_remote`, and loses a needless `return`.

## Verification

```
aarch64-apple-ios       exit=0  errors=0     (was 12)
aarch64-apple-tvos      exit=0  errors=0     (was 12)
aarch64-apple-visionos  exit=0  errors=0     (was 12)
```

Host build unchanged:

```
$ cargo clippy --locked -p mtu --all-targets -- -D warnings
exit=0, 0 errors

$ cargo test --locked -p mtu
test result: ok. 9 passed; 0 failed
test result: ok. 1 passed; 0 failed

$ cargo +nightly fmt --all -- --check
exit=0, no output

$ cargo doc --locked -p mtu --no-deps --document-private-items
exit=0
```

## Not addressed here

The code comment above the stub points at `mozilla/mtu#82` for the tracking discussion. That repo was archived when `mtu` moved into this workspace and its issue tracker is disabled, so the link is now unreachable — I left it alone rather than guess at a replacement, but it may be worth repointing or dropping.

Adding an actual iOS/tvOS/visionOS job to `check-mtu.yml` would keep this from regressing. Happy to follow up with that separately if you want it; it seemed like a decision for you rather than something to bundle in here.
