### PR TITLE
fix(mtu): gate unix helpers on supported platforms, not just non-windows

### DIFF
--- a/mtu/build.rs
+++ b/mtu/build.rs
@@ -13,6 +13,14 @@ fn main() {
                 target_os = "netbsd",
                 target_os = "solaris"
             )
+        },
+        supported_unix: {
+            any(
+                target_os = "macos",
+                bsd,
+                target_os = "linux",
+                target_os = "android"
+            )
         }
     }
 }

--- a/mtu/src/lib.rs
+++ b/mtu/src/lib.rs
@@ -52,7 +52,7 @@ use std::{
     net::IpAddr,
 };
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(supported_unix)]
 macro_rules! asserted_const_with_type {
     ($name:ident, $t1:ty, $e:expr, $t2:ty) => {
         #[allow(
@@ -75,7 +75,7 @@ mod linux;
 #[cfg(target_os = "windows")]
 mod windows;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(supported_unix)]
 mod routesocket;
 
 #[cfg(any(target_os = "macos", bsd))]
@@ -91,14 +91,14 @@ fn default_err() -> Error {
 }
 
 /// Prepare an error for cases that "should never happen".
-#[cfg(not(target_os = "windows"))]
+#[cfg(supported_unix)]
 fn unlikely_err(msg: String) -> Error {
     debug_assert!(false, "{msg}");
     Error::other(msg)
 }
 
 /// Align `size` to the next multiple of `align` (which needs to be a power of two).
-#[cfg(not(target_os = "windows"))]
+#[cfg(supported_unix)]
 const fn aligned_by(size: usize, align: usize) -> usize {
     if size == 0 {
         align
@@ -116,8 +116,8 @@ const fn aligned_by(size: usize, align: usize) -> usize {
     target_os = "visionos",
     target_os = "redox"
 ))]
-pub fn interface_and_mtu_impl(remote: IpAddr) -> Result<(String, usize)> {
-    return Err(default_err());
+fn interface_and_mtu_impl(_remote: IpAddr) -> Result<(String, usize)> {
+    Err(default_err())
 }
 
 /// Return the name and maximum transmission unit (MTU) of the outgoing network interface towards a
@@ -203,7 +203,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(supported_unix)]
     fn aligned_by() {
         for (size, align, expected) in [
             (0, 8, 8),
@@ -253,7 +253,7 @@ mod test {
 
     #[test]
     #[should_panic(expected = "test error")]
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(supported_unix)]
     #[cfg(debug_assertions)]
     fn unlikely_error_panics() {
         crate::unlikely_err("test error".to_string());


### PR DESCRIPTION
`mtu` doesn't pass `clippy -D warnings` on the Apple mobile targets. On `aarch64-apple-ios`,
`aarch64-apple-tvos` and `aarch64-apple-visionos` it fails with 12 errors each; `aarch64-apple-darwin`
is clean.

**To be clear about scope: no CI job builds these targets today, so nothing of yours is red.**
`clippy.yml` runs host-only with no `--target`, `check-android` runs `cargo ndk test --no-run` rather
than clippy, and `check-mtu.yml` covers Android/Linux/macOS/BSD/Solaris. This is lint hygiene on
platforms the crate already claims to compile for, not a broken gate.

## Cause

`asserted_const_with_type!`, the `routesocket` module, `unlikely_err` and `aligned_by` are gated
`#[cfg(not(target_os = "windows"))]`, but their only consumers are `bsd.rs` and `linux.rs`. On
ios/tvos/visionos neither consumer compiles, so everything behind that gate is dead code and the
`-D warnings` gate turns each one into an error.

Fixing the unsupported-platform stub alone would leave 10 of the 12 — the gate itself is the issue.

## The 12, identical on all three targets

```
error: unused macro definition: `asserted_const_with_type`
error: unused variable: `remote`
error: function `unlikely_err` is never used
error: function `aligned_by` is never used
error: type alias `AtomicRouteSocketSeq` is never used
error: type alias `RouteSocketSeq` is never used
error: static `SEQ` is never used
error: struct `RouteSocket` is never constructed
error: associated functions `new` and `new_seq` are never used
error: function `check_result` is never used
error: docs for function returning `Result` missing `# Errors` section
error: unneeded `return` statement
error: could not compile `mtu` (lib) due to 12 previous errors
```

## The change

A `supported_unix` cfg alias in `mtu/build.rs`, mirroring the existing `bsd` alias idiom:

```rust
supported_unix: {
    any(target_os = "macos", bsd, target_os = "linux", target_os = "android")
}
```

Six `#[cfg(not(target_os = "windows"))]` become `#[cfg(supported_unix)]` at the helper and test
sites, and the unsupported-platform `interface_and_mtu_impl` becomes non-`pub` like the other
platform impls (which is what drops `missing_errors_doc`), with the unused parameter and needless
return quieted.

**Left alone deliberately:** the `not(target_os = "windows")` on the `no_ipv6` binding in `inet_v6`.
It's the non-windows half of a pair — narrowing it would leave the binding undefined on iOS.

## Verification

| target | before | after |
|---|---|---|
| `aarch64-apple-ios` | 12 errors, exit 101 | **exit 0** |
| `aarch64-apple-tvos` | 12 errors, exit 101 | **exit 0** |
| `aarch64-apple-visionos` | 12 errors, exit 101 | **exit 0** |
| `aarch64-apple-darwin` | exit 0 | **exit 0** |

All three targets install prebuilt std on **stable** — no nightly, no `-Z build-std`.

Regression checks, all exit 0: `x86_64-unknown-linux-gnu`, `aarch64-linux-android`,
`x86_64-unknown-freebsd`, `x86_64-unknown-netbsd`, `x86_64-pc-windows-gnu`. **The BSD ones are the
load-bearing check** — they confirm `cfg_aliases` expands the nested `bsd` alias inside
`supported_unix`; had it not, BSD would have silently lost `routesocket`.

Also: `cargo test -p mtu` 9/9 pass on darwin, `cargo +nightly fmt --all -- --check` clean, and
`cargo hack clippy -p mtu --target aarch64-apple-ios --feature-powerset --no-dev-deps
--exclude-features gecko -- -D warnings` exits 0.

## Related, not closed

`#2927` ("MTU: Support ios, tvos and visionos", `help wanted`) asks for real MTU *lookup* on these
platforms — iOS has no `<net/route.h>`. This PR does not implement that; it only makes the existing
stub lint-clean. Worth linking, not closing.

## Known gap, deliberately not in this PR

`--all-targets` on iOS still hits one `error[E0080]`: `test::LOOPBACK` at `mtu/src/lib.rs:172` has no
iOS arm and falls through to `unreachable!()`, which const-eval executes. **Pre-existing** — on
pristine `main` iOS `--all-targets` has 12 lib errors plus 3 lib-test errors including this one;
with this PR it's the only one left. Picking loopback name/MTU values for iOS is a value decision
rather than a lint fix, so I've left it to you. Happy to follow up if you name the values.
