### PR TITLE
fix(transport): back-pressure the outbound QUIC datagram queue

### DIFF
--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -115,6 +115,8 @@ pub enum Http3ClientEvent {
     WebTransport(WebTransportEvent),
     /// `ConnectUdp` events
     ConnectUdp(ConnectUdpEvent),
+    /// The outgoing QUIC datagram queue has space again after having been full.
+    OutgoingDatagramSpaceAvailable,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -290,6 +292,10 @@ impl ExtendedConnectEvents for Http3ClientEvents {
         };
         self.events.push(event);
     }
+
+    fn capsule_space_available(&self) {
+        self.datagram_space_available();
+    }
 }
 
 impl Http3ClientEvents {
@@ -298,6 +304,15 @@ impl Http3ClientEvents {
         if stream_type == StreamType::BiDi {
             self.events.push(Http3ClientEvent::RequestsCreatable);
         }
+    }
+
+    /// Emit the outgoing QUIC datagram queue's resume event, forwarding
+    /// `neqo-transport`'s [`ConnectionEvent::OutgoingDatagramSpaceAvailable`].
+    ///
+    /// [`ConnectionEvent::OutgoingDatagramSpaceAvailable`]: neqo_transport::ConnectionEvent::OutgoingDatagramSpaceAvailable
+    pub(crate) fn datagram_space_available(&self) {
+        self.events
+            .push_unique(Http3ClientEvent::OutgoingDatagramSpaceAvailable);
     }
 
     /// Add a new `AuthenticationNeeded` event

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -62,18 +62,25 @@ pub trait ClientSession {
 
     /// Send a connect-udp datagram.
     ///
+    /// # Returns
+    ///
+    /// `Ok(false)` when the outgoing QUIC datagram queue is full; the sender
+    /// should then wait for an [`OutgoingDatagramSpaceAvailable`] event.
+    ///
     /// # Errors
     ///
     /// It may return [`Error::InvalidStreamId`] if a stream does not exist anymore.
     /// The function returns `TooMuchData` if the supply buffer is bigger than
     /// the allowed remote datagram size.
+    ///
+    /// [`OutgoingDatagramSpaceAvailable`]: crate::Http3ClientEvent::OutgoingDatagramSpaceAvailable
     fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
         &mut self,
         session_id: StreamId,
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<bool>;
 }
 
 impl ClientSession for Http3Client {
@@ -118,7 +125,7 @@ impl ClientSession for Http3Client {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<bool> {
         qtrace!("connect_udp_send_datagram session:{session_id:?}");
         let (conn, handler) = self.connection_and_handler();
         handler.connect_udp_send_datagram(conn, session_id, buf, id, now)
@@ -153,6 +160,7 @@ trait Handler {
         now: Instant,
     ) -> Res<()>;
 
+    /// Returns `Ok(false)` when the outgoing QUIC datagram queue is full.
     fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
         &self,
         conn: &mut Connection,
@@ -160,7 +168,7 @@ trait Handler {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<bool>;
 }
 
 impl Handler for Http3Connection {
@@ -232,7 +240,7 @@ impl Handler for Http3Connection {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<bool> {
         self.extended_connect_send_datagram(session_id, conn, buf, id, now)
     }
 }
@@ -256,6 +264,7 @@ pub(crate) trait ServerHandler {
         now: Instant,
     ) -> Res<()>;
 
+    /// Returns `Ok(false)` when the outgoing QUIC datagram queue is full.
     fn connect_udp_send_datagram<I: Into<DatagramTracking>>(
         &mut self,
         conn: &mut Connection,
@@ -263,7 +272,7 @@ pub(crate) trait ServerHandler {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<bool>;
 }
 
 impl ServerHandler for Http3ServerHandler {
@@ -300,7 +309,7 @@ impl ServerHandler for Http3ServerHandler {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<bool> {
         self.mark_needs_processing();
         self.base_handler_mut()
             .connect_udp_send_datagram(conn, session_id, buf, id, now)
@@ -391,7 +400,7 @@ impl ServerSession {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<bool> {
         let session_id = self.stream_handler.stream_id();
         self.stream_handler
             .handler

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1630,6 +1630,7 @@ impl Http3Connection {
         Ok(())
     }
 
+    /// Returns `Ok(false)` when the outgoing QUIC datagram queue is full.
     pub(crate) fn extended_connect_send_datagram<I: Into<DatagramTracking>>(
         &self,
         session_id: StreamId,
@@ -1637,7 +1638,7 @@ impl Http3Connection {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<bool> {
         self.validate_extended_connect_session(session_id)?
             .borrow_mut()
             .send_datagram(conn, buf, id, now)

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -915,6 +915,9 @@ impl Http3Client {
                 ConnectionEvent::Datagram(dgram) => {
                     self.base_handler.handle_datagram(dgram);
                 }
+                ConnectionEvent::OutgoingDatagramSpaceAvailable => {
+                    self.events.datagram_space_available();
+                }
                 ConnectionEvent::SendStreamComplete { .. }
                 | ConnectionEvent::OutgoingDatagramOutcome { .. }
                 | ConnectionEvent::SconeUpdated(_)

--- a/neqo-http3/src/connection_server.rs
+++ b/neqo-http3/src/connection_server.rs
@@ -284,6 +284,9 @@ impl Http3ServerHandler {
                     }
                 }
                 ConnectionEvent::Datagram(dgram) => self.base_handler.handle_datagram(dgram),
+                ConnectionEvent::OutgoingDatagramSpaceAvailable => {
+                    self.events.datagram_space_available();
+                }
                 ConnectionEvent::AuthenticationNeeded
                 | ConnectionEvent::EchFallbackAuthenticationNeeded { .. }
                 | ConnectionEvent::ZeroRttRejected

--- a/neqo-http3/src/features/extended_connect/connect_udp_session.rs
+++ b/neqo-http3/src/features/extended_connect/connect_udp_session.rs
@@ -6,6 +6,7 @@
 
 use std::{
     fmt::{self, Display, Formatter},
+    num::NonZeroUsize,
     time::Instant,
 };
 
@@ -19,6 +20,7 @@ use crate::{
         session::{DgramContextIdError, State},
     },
     frames::{FrameReader, StreamReaderRecvStreamWrapper, capsule::Capsule},
+    send_message::SendMessage,
 };
 
 #[derive(Debug)]
@@ -132,19 +134,31 @@ impl Protocol for Session {
         let mut dgram_data = Encoder::default();
         self.write_datagram_prefix(&mut dgram_data);
         dgram_data.encode(buf);
-
-        if conn.stream_avail_send_space(self.session_id)? < dgram_data.len() {
-            qdebug!("Not enough space to send datagram capsule, dropping it.");
-            return Ok(());
-        }
         // TODO: Make Capsule abstract over either an owned (Bytes) or borrowed (&[u8]) type
         // to avoid this allocation.
         let capsule = Capsule::Datagram {
             payload: Bytes::from(Vec::from(dgram_data)),
         };
+
+        // The capsule goes on the control stream wrapped in an HTTP/3 DATA frame, so the
+        // flow-control window has to hold both wrappers, not just the payload.
+        let needed = SendMessage::data_frame_len(capsule.encoded_len());
+        if conn.stream_avail_send_space(self.session_id)? < needed {
+            qdebug!("[{self}] datagram capsule exceeds control-stream flow-control space");
+            // Ask to be told when the stream can hold a capsule this size again.
+            // Repeated refusals overwrite this, so the event tracks the most recent
+            // size rather than the largest; the sender retries and re-arms.
+            if let Some(watermark) = NonZeroUsize::new(needed) {
+                conn.stream_set_writable_event_low_watermark(self.session_id, watermark)?;
+            }
+            return Err(Error::FlowControlLimit);
+        }
         let mut enc = Encoder::default();
         capsule.encode(&mut enc);
         control_stream_send.send_data_atomic(conn, enc.as_ref(), now)?;
+        // Drop the watermark a previous refusal raised, so neqo-transport stops
+        // suppressing writable events for other users of the control stream.
+        conn.stream_set_writable_event_low_watermark(self.session_id, NonZeroUsize::MIN)?;
         qtrace!("[{self}] sent datagram via HTTP DATAGRAM Capsule");
         Ok(())
     }

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -56,6 +56,13 @@ pub(crate) trait ExtendedConnectEvents: Debug {
         datagram: Bytes,
         connect_type: ExtendedConnectType,
     );
+    /// The control stream has flow-control space again after a datagram capsule
+    /// was refused with `FlowControlLimit`, so the sender can resume.
+    ///
+    /// This is the HTTP DATAGRAM Capsule path only. On the QUIC datagram path the
+    /// resume event instead originates in `neqo-transport` and is forwarded to
+    /// the HTTP/3 event by the connection.
+    fn capsule_space_available(&self);
 }
 
 #[derive(Debug, PartialEq, Copy, Clone, Eq, strum::Display)]

--- a/neqo-http3/src/features/extended_connect/session.rs
+++ b/neqo-http3/src/features/extended_connect/session.rs
@@ -61,6 +61,9 @@ pub(crate) struct Session {
     /// CONNECT request.
     protocol: Box<dyn Protocol>,
     draining: bool,
+    /// Set when a datagram capsule was refused with `FlowControlLimit`, so a
+    /// resume event fires once the control stream is writable again.
+    datagram_capsule_blocked: bool,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -120,6 +123,7 @@ impl Session {
             events,
             protocol,
             draining: false,
+            datagram_capsule_blocked: false,
         }
     }
 
@@ -150,6 +154,7 @@ impl Session {
             events,
             protocol,
             draining: false,
+            datagram_capsule_blocked: false,
         })
     }
 
@@ -226,6 +231,15 @@ impl Session {
             self.state = State::Done;
         }
         Ok(())
+    }
+
+    fn stream_writable(&mut self) {
+        // The control stream has flow-control space again; if a datagram capsule
+        // was refused, tell the sender it can resume.
+        if self.datagram_capsule_blocked {
+            self.datagram_capsule_blocked = false;
+            self.events.capsule_space_available();
+        }
     }
 
     fn close(&mut self, close_type: CloseType) {
@@ -390,18 +404,21 @@ impl Session {
         self.control_stream_send.send_data(conn, buf, now)
     }
 
+    /// Send a datagram, as a QUIC datagram or, when the peer offers no QUIC
+    /// datagram support, an HTTP DATAGRAM Capsule. Returns `Ok(false)` when the
+    /// outgoing QUIC datagram queue is full.
+    ///
     /// # Errors
     ///
-    /// Returns an error if:
-    /// - The session is not in Active state (`Error::Unavailable`).
-    /// - QUIC datagram or HTTP DATAGRAM Capsule sending fails.
+    /// `Error::Unavailable` if the session is not Active; other errors if
+    /// sending the datagram or capsule fails.
     pub(crate) fn send_datagram<I: Into<DatagramTracking>>(
         &mut self,
         conn: &mut Connection,
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<bool> {
         qtrace!("[{self}] send_datagram state={:?}", self.state);
         if self.state != State::Active {
             qdebug!("[{self}]: cannot send datagram in {:?} state.", self.state);
@@ -411,12 +428,17 @@ impl Session {
 
         if conn.remote_datagram_size() == 0 && self.protocol.datagram_capsule_support() {
             qtrace!("[{self}] remote_datagram_size is 0, trying HTTP DATAGRAM Capsule");
-            return self.protocol.write_datagram_capsule(
-                &mut self.control_stream_send,
-                conn,
-                buf,
-                now,
-            );
+            // The Capsule path errors when the control stream's flow-control
+            // window is exhausted, then emits a resume event once the stream is
+            // writable again (see `stream_writable`).
+            let res =
+                self.protocol
+                    .write_datagram_capsule(&mut self.control_stream_send, conn, buf, now);
+            if matches!(res, Err(Error::FlowControlLimit)) {
+                self.datagram_capsule_blocked = true;
+            }
+            // Fullness is reported by the error above, never as `Ok(false)`.
+            return res.map(|()| true);
         }
 
         let mut dgram_data = Encoder::default();
@@ -424,9 +446,9 @@ impl Session {
         self.protocol.write_datagram_prefix(&mut dgram_data);
         dgram_data.encode(buf);
 
-        conn.send_datagram(dgram_data.into(), id)?;
-        qtrace!("[{self}] sent datagram via QUIC datagram");
-        Ok(())
+        let has_space = conn.send_datagram(dgram_data.into(), id)?;
+        qtrace!("[{self}] sent datagram via QUIC datagram, has_space={has_space}");
+        Ok(has_space)
     }
 
     pub(crate) fn datagram(&self, datagram: Bytes) {
@@ -538,7 +560,9 @@ impl SendStream for Rc<RefCell<Session>> {
         self.borrow_mut().has_data_to_send()
     }
 
-    fn stream_writable(&self) {}
+    fn stream_writable(&self) {
+        self.borrow_mut().stream_writable();
+    }
 
     fn done(&self) -> bool {
         self.borrow_mut().done()
@@ -652,6 +676,15 @@ pub(crate) trait Protocol: Debug + Display {
     fn datagram_capsule_support(&self) -> bool;
 
     /// Write a datagram as an HTTP DATAGRAM Capsule to the control stream.
+    ///
+    /// Capsules are buffered on the control stream, so their limit is that
+    /// stream's flow-control window. A write that would exceed the window returns
+    /// [`FlowControlLimit`] instead of dropping the datagram, and arms a writable
+    /// notification so an [`OutgoingDatagramSpaceAvailable`] event fires once the
+    /// stream can hold a capsule again; a successful write returns `Ok(())`.
+    ///
+    /// [`FlowControlLimit`]: crate::Error::FlowControlLimit
+    /// [`OutgoingDatagramSpaceAvailable`]: crate::Http3ClientEvent::OutgoingDatagramSpaceAvailable
     fn write_datagram_capsule(
         &self,
         _control_stream_send: &mut Box<dyn SendStream>,

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -4,11 +4,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::{Encoder, to_u64};
+use neqo_common::{Encoder, event::Provider as _, to_u64};
 use neqo_transport::ConnectionParameters;
 use test_fixture::now;
 
 use crate::{
+    Http3ClientEvent, Http3ServerEvent,
     features::extended_connect::tests::webtransport::{
         DATAGRAM_SIZE, WtTest, wt_default_parameters,
     },
@@ -27,8 +28,8 @@ fn do_datagram_test(wt: &mut WtTest, wt_session: &ServerSession) {
         Ok(DATAGRAM_SIZE - to_u64(Encoder::varint_len(wt_session.stream_id().as_u64())))
     );
 
-    assert_eq!(wt_session.send_datagram(DGRAM, None, now()), Ok(()));
-    assert_eq!(wt.send_datagram(wt_session.stream_id(), DGRAM), Ok(()));
+    assert_eq!(wt_session.send_datagram(DGRAM, None, now()), Ok(true));
+    assert_eq!(wt.send_datagram(wt_session.stream_id(), DGRAM), Ok(true));
 
     wt.exchange_packets();
     wt.check_datagram_received_client(wt_session.stream_id(), DGRAM);
@@ -74,4 +75,50 @@ fn max_datagram_size_smaller_than_session_prefix() {
 
     assert_eq!(wt_session.max_datagram_size(), Ok(0));
     assert_eq!(wt.max_datagram_size(wt_session.stream_id()), Ok(0));
+}
+
+/// Draining a full outgoing QUIC datagram queue must surface the resume event
+/// on both sides: [`Http3ClientEvent::OutgoingDatagramSpaceAvailable`] to the
+/// client and [`Http3ServerEvent::OutgoingDatagramSpaceAvailable`] to the
+/// server.
+#[test]
+fn outgoing_datagram_space_available_forwarded() {
+    let params = || {
+        wt_default_parameters().connection_parameters(
+            ConnectionParameters::default()
+                .datagram_size(DATAGRAM_SIZE)
+                .outgoing_datagram_queue(1),
+        )
+    };
+    let mut wt = WtTest::new_with_params(params(), params());
+    let wt_session = wt.create_wt_session();
+
+    assert_eq!(wt.send_datagram(wt_session.stream_id(), DGRAM), Ok(false));
+    assert_eq!(wt_session.send_datagram(DGRAM, None, now()), Ok(false));
+    assert!(
+        !wt.client
+            .events()
+            .any(|e| matches!(e, Http3ClientEvent::OutgoingDatagramSpaceAvailable)),
+        "client resume event fired before the queue drained"
+    );
+    assert!(
+        !wt.server
+            .events()
+            .any(|e| matches!(e, Http3ServerEvent::OutgoingDatagramSpaceAvailable { .. })),
+        "server resume event fired before the queue drained"
+    );
+
+    wt.exchange_packets();
+    assert!(
+        wt.client
+            .events()
+            .any(|e| matches!(e, Http3ClientEvent::OutgoingDatagramSpaceAvailable)),
+        "OutgoingDatagramSpaceAvailable was not forwarded to the HTTP/3 client"
+    );
+    assert!(
+        wt.server
+            .events()
+            .any(|e| matches!(e, Http3ServerEvent::OutgoingDatagramSpaceAvailable { .. })),
+        "OutgoingDatagramSpaceAvailable was not forwarded to the HTTP/3 server"
+    );
 }

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -619,7 +619,7 @@ impl WtTest {
         self.client.webtransport_max_datagram_size(stream_id)
     }
 
-    fn send_datagram(&mut self, stream_id: StreamId, buf: &[u8]) -> Result<(), Error> {
+    fn send_datagram(&mut self, stream_id: StreamId, buf: &[u8]) -> Result<bool, Error> {
         self.client
             .webtransport_send_datagram(stream_id, buf, None, now())
     }

--- a/neqo-http3/src/frames/capsule.rs
+++ b/neqo-http3/src/frames/capsule.rs
@@ -37,6 +37,15 @@ impl Capsule {
             }
         }
     }
+
+    /// Number of bytes [`Self::encode`] writes for this capsule.
+    #[must_use]
+    pub const fn encoded_len(&self) -> usize {
+        let Self::Datagram { payload } = self;
+        Encoder::varint_len(self.capsule_type())
+            + Encoder::varint_len(to_u64(payload.len()))
+            + payload.len()
+    }
 }
 
 impl FrameDecoder<Self> for Capsule {
@@ -100,6 +109,18 @@ mod tests {
         assert_eq!(encoded[0], 0x00);
         assert_eq!(encoded[1], 0x05);
         assert_eq!(&encoded[2..], &payload[..]);
+    }
+
+    #[test]
+    fn encoded_len_matches_encode() {
+        for len in [0, 1, 63, 64, 300, 16383, 16384] {
+            let capsule = Capsule::Datagram {
+                payload: Bytes::from(vec![0x2c; len]),
+            };
+            let mut enc = Encoder::default();
+            capsule.encode(&mut enc);
+            assert_eq!(enc.as_ref().len(), capsule.encoded_len());
+        }
     }
 
     #[test]

--- a/neqo-http3/src/send_message.rs
+++ b/neqo-http3/src/send_message.rs
@@ -20,7 +20,7 @@ use neqo_transport::{Connection, StreamId};
 use crate::{
     BufferedStream, CloseType, Error, Http3StreamInfo, Http3StreamType, HttpSendStream, Res,
     SendStream, SendStreamEvents, Stream,
-    frames::HFrame,
+    frames::{HFrame, HFrameType},
     headers_checks::{headers_valid, is_interim, trailers_valid},
 };
 
@@ -137,6 +137,16 @@ impl SendMessage {
             encoder,
             conn_events,
         }
+    }
+
+    /// Bytes a `DATA` frame carrying `payload_len` payload bytes takes on the
+    /// stream: the frame's type and length varints plus the payload. Mirrors
+    /// what [`Self::send_data_atomic`] writes.
+    #[must_use]
+    pub(crate) fn data_frame_len(payload_len: usize) -> usize {
+        Encoder::varint_len(u64::from(HFrameType::DATA))
+            + Encoder::varint_len(to_u64(payload_len))
+            + payload_len
     }
 
     /// # Errors

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -245,6 +245,9 @@ impl Http3Server {
                             remove = true;
                         }
                     }
+                    Http3ServerConnEvent::OutgoingDatagramSpaceAvailable => {
+                        self.events.datagram_space_available(conn.clone());
+                    }
                     Http3ServerConnEvent::PriorityUpdate {
                         stream_id,
                         priority,
@@ -1014,6 +1017,7 @@ mod tests {
                 | Http3ServerEvent::StateChange { .. }
                 | Http3ServerEvent::PriorityUpdate { .. }
                 | Http3ServerEvent::WebTransport(_)
+                | Http3ServerEvent::OutgoingDatagramSpaceAvailable { .. }
                 | Http3ServerEvent::ConnectUdp(_) => {}
             }
         }
@@ -1064,6 +1068,7 @@ mod tests {
                 | Http3ServerEvent::StateChange { .. }
                 | Http3ServerEvent::PriorityUpdate { .. }
                 | Http3ServerEvent::WebTransport(_)
+                | Http3ServerEvent::OutgoingDatagramSpaceAvailable { .. }
                 | Http3ServerEvent::ConnectUdp(_) => {}
             }
         }
@@ -1092,6 +1097,7 @@ mod tests {
                 | Http3ServerEvent::StateChange { .. }
                 | Http3ServerEvent::PriorityUpdate { .. }
                 | Http3ServerEvent::WebTransport(_)
+                | Http3ServerEvent::OutgoingDatagramSpaceAvailable { .. }
                 | Http3ServerEvent::ConnectUdp(_) => {}
             }
         }
@@ -1137,6 +1143,7 @@ mod tests {
                 | Http3ServerEvent::StateChange { .. }
                 | Http3ServerEvent::PriorityUpdate { .. }
                 | Http3ServerEvent::WebTransport(_)
+                | Http3ServerEvent::OutgoingDatagramSpaceAvailable { .. }
                 | Http3ServerEvent::ConnectUdp(_) => {}
             }
         }
@@ -1355,6 +1362,7 @@ mod tests {
                 | Http3ServerEvent::StateChange { .. }
                 | Http3ServerEvent::PriorityUpdate { .. }
                 | Http3ServerEvent::WebTransport(_)
+                | Http3ServerEvent::OutgoingDatagramSpaceAvailable { .. }
                 | Http3ServerEvent::ConnectUdp(_) => {}
             }
         }

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -44,6 +44,8 @@ pub enum Http3ServerConnEvent {
     },
     /// Connection state change.
     StateChange(Http3State),
+    /// The outgoing QUIC datagram queue has space again after having been full.
+    OutgoingDatagramSpaceAvailable,
     WebTransport(WebTransportEvent),
     ConnectUdp(ConnectUdpEvent),
 }
@@ -238,6 +240,10 @@ impl ExtendedConnectEvents for Http3ServerConnEvents {
         };
         self.events.push(event);
     }
+
+    fn capsule_space_available(&self) {
+        self.datagram_space_available();
+    }
 }
 
 impl Http3ServerConnEvents {
@@ -247,6 +253,15 @@ impl Http3ServerConnEvents {
 
     pub fn next_event(&self) -> Option<Http3ServerConnEvent> {
         self.events.next_event()
+    }
+
+    /// Emit the outgoing QUIC datagram queue's resume event, forwarding
+    /// `neqo-transport`'s [`ConnectionEvent::OutgoingDatagramSpaceAvailable`].
+    ///
+    /// [`ConnectionEvent::OutgoingDatagramSpaceAvailable`]: neqo_transport::ConnectionEvent::OutgoingDatagramSpaceAvailable
+    pub(crate) fn datagram_space_available(&self) {
+        self.events
+            .push_unique(Http3ServerConnEvent::OutgoingDatagramSpaceAvailable);
     }
 
     pub fn connection_state_change(&self, state: Http3State) {

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -277,6 +277,10 @@ pub enum Http3ServerEvent {
         stream_id: StreamId,
         priority: Priority,
     },
+    /// The outgoing QUIC datagram queue has space again after having been full.
+    OutgoingDatagramSpaceAvailable {
+        conn: ConnectionRef,
+    },
     WebTransport(crate::webtransport::ServerEvent),
     ConnectUdp(crate::connect_udp::ServerEvent),
 }
@@ -325,6 +329,12 @@ impl Http3ServerEvents {
     pub(crate) fn connection_state_change(&self, conn: ConnectionRef, state: Http3State) {
         self.events
             .push(Http3ServerEvent::StateChange { conn, state });
+    }
+
+    /// Insert an `OutgoingDatagramSpaceAvailable` event.
+    pub(crate) fn datagram_space_available(&self, conn: ConnectionRef) {
+        self.events
+            .push(Http3ServerEvent::OutgoingDatagramSpaceAvailable { conn });
     }
 
     /// Insert a `Data` event.

--- a/neqo-http3/src/webtransport.rs
+++ b/neqo-http3/src/webtransport.rs
@@ -184,18 +184,25 @@ pub trait ClientSession {
 
     /// Send a `WebTransport` datagram.
     ///
+    /// # Returns
+    ///
+    /// `Ok(false)` when the outgoing QUIC datagram queue is full; the sender
+    /// should then wait for an [`OutgoingDatagramSpaceAvailable`] event.
+    ///
     /// # Errors
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     /// The function returns `TooMuchData` if the supply buffer is bigger than
     /// the allowed remote datagram size.
+    ///
+    /// [`OutgoingDatagramSpaceAvailable`]: crate::Http3ClientEvent::OutgoingDatagramSpaceAvailable
     fn webtransport_send_datagram<I: Into<DatagramTracking>>(
         &mut self,
         session_id: StreamId,
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<bool>;
 }
 
 impl ClientSession for Http3Client {
@@ -337,7 +344,7 @@ impl ClientSession for Http3Client {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<bool> {
         qtrace!("webtransport_send_datagram session:{session_id:?}");
         let (conn, handler) = self.connection_and_handler();
         handler.webtransport_send_datagram(session_id, conn, buf, id, now)
@@ -414,6 +421,7 @@ trait Handler {
         now: Instant,
     ) -> Res<extended_connect::stats::SessionStats>;
 
+    /// Returns `Ok(false)` when the outgoing QUIC datagram queue is full.
     fn webtransport_send_datagram<I: Into<DatagramTracking>>(
         &self,
         session_id: StreamId,
@@ -421,7 +429,7 @@ trait Handler {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<bool>;
 }
 
 impl Handler for Http3Connection {
@@ -502,7 +510,7 @@ impl Handler for Http3Connection {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<bool> {
         self.extended_connect_send_datagram(session_id, conn, buf, id, now)
     }
 }
@@ -533,6 +541,7 @@ pub(crate) trait ServerHandler {
         stream_type: StreamType,
     ) -> Res<StreamId>;
 
+    /// Returns `Ok(false)` when the outgoing QUIC datagram queue is full.
     fn webtransport_send_datagram<I: Into<DatagramTracking>>(
         &mut self,
         conn: &mut Connection,
@@ -540,7 +549,7 @@ pub(crate) trait ServerHandler {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()>;
+    ) -> Res<bool>;
 }
 
 impl ServerHandler for Http3ServerHandler {
@@ -595,7 +604,7 @@ impl ServerHandler for Http3ServerHandler {
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<bool> {
         self.mark_needs_processing();
         self.base_handler_mut()
             .webtransport_send_datagram(session_id, conn, buf, id, now)
@@ -707,17 +716,24 @@ impl ServerSession {
 
     /// Send `WebTransport` datagram.
     ///
+    /// # Returns
+    ///
+    /// `Ok(false)` when the outgoing QUIC datagram queue is full; the sender
+    /// should then wait for an [`OutgoingDatagramSpaceAvailable`] event.
+    ///
     /// # Errors
     ///
     /// It may return `InvalidStreamId` if a stream does not exist anymore.
     /// The function returns `TooMuchData` if the supply buffer is bigger than
     /// the allowed remote datagram size.
+    ///
+    /// [`OutgoingDatagramSpaceAvailable`]: crate::Http3ServerEvent::OutgoingDatagramSpaceAvailable
     pub fn send_datagram<I: Into<DatagramTracking>>(
         &self,
         buf: &[u8],
         id: I,
         now: Instant,
-    ) -> Res<()> {
+    ) -> Res<bool> {
         let session_id = self.stream_handler.stream_id();
         self.stream_handler
             .handler

--- a/neqo-http3/tests/connect_udp.rs
+++ b/neqo-http3/tests/connect_udp.rs
@@ -34,20 +34,30 @@ fn disabled_by_default() {
 }
 
 fn initiate_new_session() -> (Http3Client, Http3Server, neqo_http3::StreamId) {
-    let conn_params = ConnectionParameters::default()
+    initiate_new_session_with_client_params(
+        ConnectionParameters::default()
+            .pmtud(true)
+            .datagram_size(1500),
+    )
+}
+
+fn initiate_new_session_with_client_params(
+    client_conn_params: ConnectionParameters,
+) -> (Http3Client, Http3Server, neqo_http3::StreamId) {
+    let proxy_conn_params = ConnectionParameters::default()
         .pmtud(true)
         .datagram_size(1500);
 
     let mut client = http3_client_with_params(
         Http3Parameters::default()
             .connect(true)
-            .connection_parameters(conn_params.clone()),
+            .connection_parameters(client_conn_params),
     );
 
     let mut proxy = http3_server_with_params(
         Http3Parameters::default()
             .connect(true)
-            .connection_parameters(conn_params),
+            .connection_parameters(proxy_conn_params),
     );
 
     // Connect client and proxy.
@@ -75,7 +85,23 @@ fn establish_new_session() -> (
     neqo_http3::StreamId,
     ServerSession,
 ) {
-    let (mut client, mut proxy, connect_udp_session_id) = initiate_new_session();
+    establish_new_session_with_client_params(
+        ConnectionParameters::default()
+            .pmtud(true)
+            .datagram_size(1500),
+    )
+}
+
+fn establish_new_session_with_client_params(
+    client_conn_params: ConnectionParameters,
+) -> (
+    Http3Client,
+    Http3Server,
+    neqo_http3::StreamId,
+    ServerSession,
+) {
+    let (mut client, mut proxy, connect_udp_session_id) =
+        initiate_new_session_with_client_params(client_conn_params);
     exchange_packets(&mut client, &mut proxy, false, None);
     let proxy_session = proxy
         .events()
@@ -494,79 +520,8 @@ fn connect_udp_operation_on_fetch_stream() {
 }
 
 #[test]
-#[expect(clippy::too_many_lines, reason = "OK for a test.")]
 fn session_lifecycle_with_http_datagram_capsule() {
-    fixture_init();
-    neqo_common::log::init(None);
-
-    let conn_params = ConnectionParameters::default().datagram_size(0);
-
-    let mut client = http3_client_with_params(
-        Http3Parameters::default()
-            .connect(true)
-            .connection_parameters(conn_params.clone()),
-    );
-
-    let mut proxy = http3_server_with_params(
-        Http3Parameters::default()
-            .connect(true)
-            .connection_parameters(conn_params),
-    );
-
-    let out = test_fixture::connect_peers(&mut client, &mut proxy);
-    if let Some(dgram) = out {
-        let out = proxy.process(Some(dgram), now()).dgram();
-        if let Some(dgram) = out {
-            client.process_input(dgram, now());
-        }
-    }
-
-    let session_id = client
-        .connect_udp_create_session(
-            now(),
-            &format!("https://[{}]:{}/", DEFAULT_ADDR.ip(), DEFAULT_ADDR.port())
-                .parse::<Uri>()
-                .unwrap(),
-            &[],
-        )
-        .unwrap();
-
-    exchange_packets(&mut client, &mut proxy, false, None);
-
-    let proxy_session = proxy
-        .events()
-        .find_map(|event| {
-            if let Http3ServerEvent::ConnectUdp(ServerEvent::NewSession { session, headers }) =
-                event
-            {
-                assert_eq!(session.stream_id(), session_id);
-                assert!(
-                    headers.contains_header(":method", "CONNECT")
-                        && headers.contains_header(":protocol", "connect-udp")
-                        && headers.contains_header("capsule-protocol", "?1")
-                );
-                session
-                    .response(&SessionAcceptAction::Accept, now())
-                    .unwrap();
-                Some(session)
-            } else {
-                None
-            }
-        })
-        .unwrap();
-
-    exchange_packets(&mut client, &mut proxy, false, None);
-
-    client
-        .events()
-        .find(|e| {
-            matches!(
-                e,
-                Http3ClientEvent::ConnectUdp(ConnectUdpEvent::NewSession { stream_id, status, ..})
-                if *stream_id == session_id && *status == 200
-            )
-        })
-        .unwrap();
+    let (mut client, mut proxy, session_id, proxy_session) = establish_capsule_session(None);
 
     qinfo!("Testing Capsule send (client -> server)");
     client
@@ -714,5 +669,224 @@ fn connect_udp_session_rejected_by_webtransport_create_stream() {
     assert_eq!(
         client.webtransport_create_stream(session_id, StreamType::UniDi),
         Err(Error::InvalidStreamId)
+    );
+}
+
+/// Backpressure surfaces end-to-end through connect-udp: once
+/// `connect_udp_send_datagram` fills the outgoing QUIC datagram queue and
+/// returns `Ok(false)`, draining it must deliver
+/// [`OutgoingDatagramSpaceAvailable`], so a datagram sender that backs off on
+/// `Ok(false)` learns it can resume.
+///
+/// [`OutgoingDatagramSpaceAvailable`]: neqo_http3::Http3ClientEvent::OutgoingDatagramSpaceAvailable
+#[test]
+fn outgoing_datagram_space_available_forwarded() {
+    fixture_init();
+    let (mut client, mut proxy, session_id, _proxy_session) =
+        establish_new_session_with_client_params(
+            ConnectionParameters::default()
+                .pmtud(true)
+                .datagram_size(1500)
+                .outgoing_datagram_queue(1),
+        );
+
+    // Drain session-setup events so the assertions below only observe the
+    // datagram backpressure signal.
+    while client.next_event().is_some() {}
+
+    assert_eq!(
+        client.connect_udp_send_datagram(session_id, PING, None, now()),
+        Ok(false)
+    );
+    assert!(
+        !client
+            .events()
+            .any(|e| matches!(e, Http3ClientEvent::OutgoingDatagramSpaceAvailable)),
+        "resume event fired before the queue drained"
+    );
+
+    exchange_packets(&mut client, &mut proxy, false, None);
+    assert!(
+        client
+            .events()
+            .any(|e| matches!(e, Http3ClientEvent::OutgoingDatagramSpaceAvailable)),
+        "OutgoingDatagramSpaceAvailable was not forwarded through connect-udp"
+    );
+}
+
+/// Establish a connect-udp session over the HTTP DATAGRAM Capsule path, granting
+/// the client only `proxy_max_stream_data` bytes of control-stream flow control.
+fn establish_capsule_session(
+    proxy_max_stream_data: Option<u64>,
+) -> (
+    Http3Client,
+    Http3Server,
+    neqo_http3::StreamId,
+    ServerSession,
+) {
+    fixture_init();
+    neqo_common::log::init(None);
+
+    // `datagram_size(0)` forces the HTTP DATAGRAM Capsule path.
+    let mut proxy_params = ConnectionParameters::default().datagram_size(0);
+    if let Some(v) = proxy_max_stream_data {
+        proxy_params = proxy_params.max_stream_data(StreamType::BiDi, true, v);
+    }
+    let mut client = http3_client_with_params(
+        Http3Parameters::default()
+            .connect(true)
+            .connection_parameters(ConnectionParameters::default().datagram_size(0)),
+    );
+    let mut proxy = http3_server_with_params(
+        Http3Parameters::default()
+            .connect(true)
+            .connection_parameters(proxy_params),
+    );
+
+    let out = test_fixture::connect_peers(&mut client, &mut proxy);
+    if let Some(dgram) = out
+        && let Some(dgram) = proxy.process(Some(dgram), now()).dgram()
+    {
+        client.process_input(dgram, now());
+    }
+
+    let session_id = client
+        .connect_udp_create_session(
+            now(),
+            &format!("https://[{}]:{}/", DEFAULT_ADDR.ip(), DEFAULT_ADDR.port())
+                .parse::<Uri>()
+                .unwrap(),
+            &[],
+        )
+        .unwrap();
+
+    exchange_packets(&mut client, &mut proxy, false, None);
+
+    let proxy_session = proxy
+        .events()
+        .find_map(|event| {
+            if let Http3ServerEvent::ConnectUdp(ServerEvent::NewSession { session, headers }) =
+                event
+            {
+                assert_eq!(session.stream_id(), session_id);
+                assert!(
+                    headers.contains_header(":method", "CONNECT")
+                        && headers.contains_header(":protocol", "connect-udp")
+                        && headers.contains_header("capsule-protocol", "?1")
+                );
+                session
+                    .response(&SessionAcceptAction::Accept, now())
+                    .unwrap();
+                Some(session)
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    exchange_packets(&mut client, &mut proxy, false, None);
+
+    client
+        .events()
+        .find(|e| {
+            matches!(
+                e,
+                Http3ClientEvent::ConnectUdp(ConnectUdpEvent::NewSession { stream_id, status, .. })
+                    if *stream_id == session_id && *status == 200)
+        })
+        .unwrap();
+
+    (client, proxy, session_id, proxy_session)
+}
+
+/// A datagram capsule that would exceed the control stream's flow-control window
+/// is refused with `FlowControlLimit` rather than silently dropped, and the
+/// sender receives a resume event once the window reopens.
+#[test]
+fn datagram_capsule_flow_control_error_and_resume() {
+    let (mut client, mut proxy, session_id, _proxy_session) = establish_capsule_session(Some(2000));
+
+    // Fill the control stream's flow-control window with datagram capsules until
+    // one is refused; a refusal is an error, never a silent drop.
+    let payload = vec![0x2c; 500];
+    let mut refused = false;
+    for _ in 0..100 {
+        match client.connect_udp_send_datagram(session_id, &payload, None, now()) {
+            Ok(_) => {}
+            Err(Error::FlowControlLimit) => {
+                refused = true;
+                break;
+            }
+            Err(e) => panic!("unexpected error: {e:?}"),
+        }
+    }
+    assert!(
+        refused,
+        "the control stream never reached its flow-control limit"
+    );
+    assert!(
+        !client
+            .events()
+            .any(|e| matches!(e, Http3ClientEvent::OutgoingDatagramSpaceAvailable)),
+        "resume event fired before the window reopened"
+    );
+
+    // The proxy reads the buffered capsules and grants more flow-control credit,
+    // reopening the control stream, which must surface the resume event.
+    exchange_packets(&mut client, &mut proxy, false, None);
+    assert!(
+        client
+            .events()
+            .any(|e| matches!(e, Http3ClientEvent::OutgoingDatagramSpaceAvailable)),
+        "resume event not emitted after control-stream flow control reopened"
+    );
+}
+
+/// A datagram whose payload fits the window but whose capsule and DATA frame
+/// framing does not must be refused, not accepted and then truncated and lost.
+#[test]
+fn datagram_capsule_at_flow_control_boundary_is_refused_not_lost() {
+    const WINDOW: u64 = 150;
+
+    let (mut client, mut proxy, session_id, _proxy_session) =
+        establish_capsule_session(Some(WINDOW));
+
+    // A guard that counts only the payload keeps accepting after the framing stops
+    // fitting, and the overflowing capsule is truncated and lost.
+    let mut sent = 0;
+    while client.connect_udp_send_datagram(session_id, &[0x2c; 1], None, now()) == Ok(true) {
+        sent += 1;
+    }
+    assert!(sent > 0, "no send space to fill");
+
+    assert!(
+        !client
+            .events()
+            .any(|e| matches!(e, Http3ClientEvent::OutgoingDatagramSpaceAvailable)),
+        "resume event fired while the window was still closed"
+    );
+
+    // Count before sending anything else: a later send would flush a stranded tail
+    // out of the send buffer and hide the loss.
+    exchange_packets(&mut client, &mut proxy, false, None);
+    let received = proxy
+        .events()
+        .filter(|e| {
+            matches!(
+                e,
+                Http3ServerEvent::ConnectUdp(ServerEvent::Datagram { .. })
+            )
+        })
+        .count();
+    assert_eq!(
+        received, sent,
+        "a datagram was accepted and then lost: the guard under-counts the framing"
+    );
+
+    assert!(
+        client
+            .events()
+            .any(|e| matches!(e, Http3ClientEvent::OutgoingDatagramSpaceAvailable)),
+        "resume event not emitted after the window reopened"
     );
 }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -4096,6 +4096,12 @@ impl Connection {
 
     /// Queue a datagram for sending.
     ///
+    /// The QUIC datagram is always queued. Returns `Ok(true)` if space remains
+    /// afterwards, or `Ok(false)` if the outgoing QUIC datagram queue is now
+    /// full. On `Ok(false)` the application should stop sending and wait for an
+    /// [`OutgoingDatagramSpaceAvailable`] event before sending again; nothing
+    /// already queued is dropped.
+    ///
     /// # Errors
     ///
     /// The function returns `TooMuchData` if the supply buffer is bigger than
@@ -4106,9 +4112,10 @@ impl Connection {
     /// to check the estimated max datagram size and to use smaller datagrams.
     /// `max_datagram_size` is just a current estimate and will change over
     /// time depending on the encoded size of the packet number, ack frames, etc.
-    pub fn send_datagram<I: Into<DatagramTracking>>(&mut self, buf: Vec<u8>, id: I) -> Res<()> {
-        self.quic_datagrams
-            .add_datagram(buf, id.into(), &mut self.stats.borrow_mut())
+    ///
+    /// [`OutgoingDatagramSpaceAvailable`]: crate::ConnectionEvent::OutgoingDatagramSpaceAvailable
+    pub fn send_datagram<I: Into<DatagramTracking>>(&mut self, buf: Vec<u8>, id: I) -> Res<bool> {
+        self.quic_datagrams.add_datagram(buf, id.into())
     }
 
     /// Return the PLMTU of the primary path.

--- a/neqo-transport/src/connection/tests/datagram.rs
+++ b/neqo-transport/src/connection/tests/datagram.rs
@@ -102,7 +102,7 @@ fn datagram_enabled_on_client() {
     let dgram_sent = server.stats().frame_tx.datagram;
     assert_eq!(
         server.send_datagram(DATA_SMALLER_THAN_MTU.to_vec(), Some(1)),
-        Ok(())
+        Ok(true)
     );
     let out = server.process_output(now()).dgram().unwrap();
     assert_eq!(server.stats().frame_tx.datagram, dgram_sent + 1);
@@ -133,7 +133,7 @@ fn datagram_enabled_on_server() {
     let dgram_sent = client.stats().frame_tx.datagram;
     assert_eq!(
         client.send_datagram(DATA_SMALLER_THAN_MTU.to_vec(), Some(1)),
-        Ok(())
+        Ok(true)
     );
     let out = client.process_output(now()).dgram().unwrap();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
@@ -179,7 +179,7 @@ fn limit_data_size() {
     // but they cannot be sent.
     assert_eq!(
         server.send_datagram(DATA_BIGGER_THAN_MTU.to_vec(), Some(1)),
-        Ok(())
+        Ok(true)
     );
 
     let dgram_dropped_s = server.stats().datagram_tx.dropped_too_big;
@@ -198,7 +198,7 @@ fn limit_data_size() {
     // The same test for the client side.
     assert_eq!(
         client.send_datagram(DATA_BIGGER_THAN_MTU.to_vec(), Some(1)),
-        Ok(())
+        Ok(true)
     );
     let dgram_sent_c = client.stats().frame_tx.datagram;
     assert!(client.process_output(now()).dgram().is_none());
@@ -217,11 +217,12 @@ fn after_dgram_dropped_continue_writing_frames() {
     // but they cannot be sent.
     assert_eq!(
         client.send_datagram(DATA_BIGGER_THAN_MTU.to_vec(), Some(1)),
-        Ok(())
+        Ok(true)
     );
+    // Fills the 2-slot queue: queued, but reports no space remains.
     assert_eq!(
         client.send_datagram(DATA_SMALLER_THAN_MTU.to_vec(), Some(2)),
-        Ok(())
+        Ok(false)
     );
 
     let datagram_dropped = |e| {
@@ -249,7 +250,7 @@ fn datagram_acked() {
     let dgram_sent = client.stats().frame_tx.datagram;
     assert_eq!(
         client.send_datagram(DATA_SMALLER_THAN_MTU.to_vec(), Some(1)),
-        Ok(())
+        Ok(true)
     );
     let out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
@@ -303,7 +304,7 @@ fn datagram_after_stream_data() {
 
     // Write a datagram first.
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.send_datagram(DATA_MTU.to_vec(), Some(1)), Ok(()));
+    assert_eq!(client.send_datagram(DATA_MTU.to_vec(), Some(1)), Ok(true));
 
     // Create a stream with normal priority and send some data.
     let stream_id = client.stream_create(StreamType::BiDi).unwrap();
@@ -345,7 +346,7 @@ fn datagram_before_stream_data() {
 
     // Write a datagram.
     let dgram_sent = client.stats().frame_tx.datagram;
-    assert_eq!(client.send_datagram(DATA_MTU.to_vec(), Some(1)), Ok(()));
+    assert_eq!(client.send_datagram(DATA_MTU.to_vec(), Some(1)), Ok(true));
 
     if let ConnectionEvent::Datagram(data) =
         &send_packet_and_get_server_event(&mut client, &mut server)
@@ -369,7 +370,7 @@ fn datagram_lost() {
     let dgram_sent = client.stats().frame_tx.datagram;
     assert_eq!(
         client.send_datagram(DATA_SMALLER_THAN_MTU.to_vec(), Some(1)),
-        Ok(())
+        Ok(true)
     );
     let _out = client.process_output(now()).dgram(); // This packet will be lost.
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
@@ -399,7 +400,7 @@ fn datagram_sent_once() {
     let dgram_sent = client.stats().frame_tx.datagram;
     assert_eq!(
         client.send_datagram(DATA_SMALLER_THAN_MTU.to_vec(), Some(1)),
-        Ok(())
+        Ok(true)
     );
     let _out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
@@ -447,51 +448,316 @@ fn outgoing_datagram_queue_full() {
     let (mut client, mut server) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
+    // Queue capacity is `OUTGOING_QUEUE` == 2. The first datagram leaves space.
     assert_eq!(
         client.send_datagram(DATA_SMALLER_THAN_MTU.to_vec(), Some(1)),
-        Ok(())
+        Ok(true)
     );
+    // The second fills the queue: it is queued, but `false` signals the queue
+    // is now full and the producer should stop.
     assert_eq!(
         client.send_datagram(DATA_SMALLER_THAN_MTU_2.to_vec(), Some(2)),
-        Ok(())
+        Ok(false)
     );
 
-    // The outgoing datagram queue limit is 2, therefore the datagram with id 1
-    // will be dropped after adding one more datagram.
-    let dgram_dropped = client.stats().datagram_tx.dropped_queue_full;
-    assert_eq!(client.send_datagram(DATA_MTU.to_vec(), Some(3)), Ok(()));
-    assert!(matches!(
-        client.next_event().unwrap(),
-        ConnectionEvent::OutgoingDatagramOutcome { id, outcome } if id == 1 && outcome == OutgoingDatagramOutcome::DroppedQueueFull
-    ));
-    assert_eq!(
-        client.stats().datagram_tx.dropped_queue_full,
-        dgram_dropped + 1
-    );
+    // A datagram produced while the queue is full is still accepted (queued),
+    // not dropped; `false` is a high-watermark signal, not a rejection. The
+    // queue now holds three datagrams, one over capacity, and no event has been
+    // emitted yet.
+    assert_eq!(client.send_datagram(DATA_MTU.to_vec(), Some(3)), Ok(false));
+    assert!(client.next_event().is_none());
 
-    // Send DATA_SMALLER_THAN_MTU_2 datagram
+    // Send the first datagram (id 1). That frees one slot, but the queue still
+    // holds two, i.e. it is still at capacity. The application must NOT be told
+    // space is available yet, or it would send straight back into a full queue.
     let out = client.process_output(now()).dgram();
     assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
+    assert!(
+        !client
+            .events()
+            .any(|e| matches!(e, ConnectionEvent::OutgoingDatagramSpaceAvailable)),
+        "resume signalled while the queue was still at capacity"
+    );
+    server.process_input(out.unwrap(), now());
+    assert!(matches!(
+        server.next_event().unwrap(),
+        ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU
+    ));
+
+    // Send the second datagram (id 2). The queue now drops below capacity, so
+    // the resume signal fires.
+    let dgram_sent = client.stats().frame_tx.datagram;
+    let out = client.process_output(now()).dgram();
+    assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
+    assert!(
+        client
+            .events()
+            .any(|e| matches!(e, ConnectionEvent::OutgoingDatagramSpaceAvailable)),
+        "resume not signalled after the queue dropped below capacity"
+    );
     server.process_input(out.unwrap(), now());
     assert!(matches!(
         server.next_event().unwrap(),
         ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU_2
     ));
 
-    // Send DATA_SMALLER_THAN_MTU_2 datagram
-    let dgram_sent2 = client.stats().frame_tx.datagram;
+    // Send the third datagram (id 3), the one accepted while the queue was
+    // full. Nothing was dropped.
+    let dgram_sent = client.stats().frame_tx.datagram;
     let out = client.process_output(now()).dgram();
-    assert_eq!(client.stats().frame_tx.datagram, dgram_sent2 + 1);
+    assert_eq!(client.stats().frame_tx.datagram, dgram_sent + 1);
     server.process_input(out.unwrap(), now());
     assert!(matches!(
         server.next_event().unwrap(),
         ConnectionEvent::Datagram(data) if data == DATA_MTU
     ));
+
+    // The resume fired exactly once, when the queue first dropped below
+    // capacity; draining the rest must not signal it again.
+    assert!(
+        !client
+            .events()
+            .any(|e| matches!(e, ConnectionEvent::OutgoingDatagramSpaceAvailable)),
+        "resume signalled more than once"
+    );
+}
+
+/// A datagram too big to share a packet with other frames is deferred
+/// (`push_front`), a path that skips the resume guard. With the queue full, a
+/// blocked sender must still be released once a later packet drops the datagram.
+#[test]
+fn too_big_datagram_deferred_then_unblocks() {
+    let (mut client, mut server) = connect_datagram();
+
+    // Fill the 2-slot queue. The first datagram is larger than any packet, so it
+    // can never be sent and is ultimately dropped as too big. The second fills
+    // the queue, blocking the application.
+    assert_eq!(
+        client.send_datagram(DATA_BIGGER_THAN_MTU.to_vec(), Some(1)),
+        Ok(true)
+    );
+    assert_eq!(
+        client.send_datagram(DATA_SMALLER_THAN_MTU.to_vec(), Some(2)),
+        Ok(false)
+    );
+
+    // Give the next packet some stream data. It is written before datagrams, so
+    // the oversized datagram at the front of the queue cannot fit alongside it:
+    // it is deferred (`push_front`) and the packet leaves carrying only stream
+    // data. No queue slot is freed, so the sender stays blocked and no resume
+    // event fires yet.
+    let stream_id = client.stream_create(StreamType::UniDi).unwrap();
+    client
+        .stream_send(stream_id, &[7; MIN_INITIAL_PACKET_SIZE])
+        .unwrap();
+
+    let dgram_sent = client.stats().frame_tx.datagram;
+    let dropped = client.stats().datagram_tx.dropped_too_big;
+    let out = client.process_output(now()).dgram();
+    server.process_input(out.expect("a packet with stream data"), now());
+    assert_eq!(
+        client.stats().frame_tx.datagram,
+        dgram_sent,
+        "no datagram is sent while the oversized one blocks the front of the queue"
+    );
+    assert_eq!(
+        client.stats().datagram_tx.dropped_too_big,
+        dropped,
+        "the oversized datagram is deferred, not yet dropped"
+    );
+    assert!(
+        !client
+            .events()
+            .any(|e| matches!(e, ConnectionEvent::OutgoingDatagramSpaceAvailable)),
+        "resume must not fire while the queue is still full"
+    );
+
+    // Drain the rest. Once a packet has no other frames, the oversized datagram
+    // is dropped (freeing a slot) and the second datagram is sent, so the sender
+    // is released exactly once and nothing is stranded.
+    let mut released = 0;
+    for _ in 0..10 {
+        let Some(out) = client.process_output(now()).dgram() else {
+            break;
+        };
+        released += client
+            .events()
+            .filter(|e| matches!(e, ConnectionEvent::OutgoingDatagramSpaceAvailable))
+            .count();
+        server.process_input(out, now());
+    }
+    assert_eq!(released, 1, "the blocked sender is released exactly once");
+    assert_eq!(
+        client.stats().datagram_tx.dropped_too_big,
+        dropped + 1,
+        "the oversized datagram is eventually dropped"
+    );
+    assert_eq!(
+        client.stats().frame_tx.datagram,
+        dgram_sent + 1,
+        "the second datagram is eventually sent"
+    );
+}
+
+/// A queue emptied entirely by [`OutgoingDatagramOutcome::DroppedTooBig`] must
+/// still release a blocked sender: the resume event has to fire even though no
+/// datagram was sent.
+#[test]
+fn dropped_too_big_unblocks() {
+    let (mut client, _server) = connect_datagram();
+
+    // Fill the 2-slot queue with datagrams within the peer's datagram-size
+    // limit (so they are accepted) but too big for any packet (so they are
+    // dropped at send time). The second fills the queue, blocking the app.
+    assert_eq!(
+        client.send_datagram(DATA_BIGGER_THAN_MTU.to_vec(), Some(1)),
+        Ok(true)
+    );
+    assert_eq!(
+        client.send_datagram(DATA_BIGGER_THAN_MTU.to_vec(), Some(2)),
+        Ok(false)
+    );
+    assert!(client.next_event().is_none());
+
+    let dropped = client.stats().datagram_tx.dropped_too_big;
+    // Nothing fits, so no packet carrying a datagram is produced, but both
+    // datagrams are dropped as too big, which empties the queue.
+    assert!(client.process_output(now()).dgram().is_none());
+    assert_eq!(client.stats().datagram_tx.dropped_too_big, dropped + 2);
+
+    // The queue emptied while the application was blocked, so it must be
+    // released even though the slots were freed by drops rather than by a send,
+    // and signalled exactly once.
+    assert_eq!(
+        client
+            .events()
+            .filter(|e| matches!(e, ConnectionEvent::OutgoingDatagramSpaceAvailable))
+            .count(),
+        1,
+        "resume must be signalled exactly once after the queue was emptied by drops"
+    );
+}
+
+/// The resume event must fire only in response to backpressure. If the queue was
+/// never full, sending a datagram must not raise a spurious
+/// [`ConnectionEvent::OutgoingDatagramSpaceAvailable`], or a sender that keys off it
+/// trying to send into a queue that was never constrained.
+#[test]
+fn no_space_available_event_when_never_blocked() {
+    let (mut client, mut server) = connect_datagram();
+
+    // Queue capacity is 2; a single datagram leaves space, so `send_datagram`
+    // never reports the queue as full.
+    assert_eq!(
+        client.send_datagram(DATA_SMALLER_THAN_MTU.to_vec(), Some(1)),
+        Ok(true)
+    );
+    let out = client.process_output(now()).dgram();
+    assert!(
+        !client
+            .events()
+            .any(|e| matches!(e, ConnectionEvent::OutgoingDatagramSpaceAvailable)),
+        "resume signalled although the queue was never full"
+    );
+
+    // Sanity: the datagram was still delivered.
+    server.process_input(out.unwrap(), now());
+    assert!(matches!(
+        server.next_event().unwrap(),
+        ConnectionEvent::Datagram(data) if data == DATA_SMALLER_THAN_MTU
+    ));
+}
+
+/// Backpressure must be repeatable: every time the queue fills and then drains
+/// below capacity the resume event fires again. A one-shot signal would strand a
+/// sender on the second and later rounds.
+#[test]
+fn space_available_event_fires_on_each_fill_drain_cycle() {
+    let (mut client, mut server) = connect_datagram();
+
+    for cycle in 0..3 {
+        // Fill the 2-slot queue: the second send reports it full.
+        assert_eq!(
+            client.send_datagram(DATA_SMALLER_THAN_MTU_2.to_vec(), Some(1)),
+            Ok(true)
+        );
+        assert_eq!(
+            client.send_datagram(DATA_SMALLER_THAN_MTU_2.to_vec(), Some(2)),
+            Ok(false)
+        );
+
+        // Drain the queue onto the wire.
+        while let Some(out) = client.process_output(now()).dgram() {
+            server.process_input(out, now());
+        }
+
+        // The queue dropped below capacity, so this cycle must re-arm and emit.
+        assert!(
+            client
+                .events()
+                .any(|e| matches!(e, ConnectionEvent::OutgoingDatagramSpaceAvailable)),
+            "resume not signalled on fill/drain cycle {cycle}"
+        );
+    }
+}
+
+/// End-to-end backpressure contract: a sender that strictly stops on `Ok(false)`
+/// and only resumes when it sees [`ConnectionEvent::OutgoingDatagramSpaceAvailable`]
+/// make progress. Every datagram it hands over is eventually delivered, with no
+/// stall (the loop is bounded so a stall fails instead of hanging) and no loss.
+#[test]
+fn backpressure_respecting_sender_never_stalls() {
+    const TOTAL: u64 = 50;
+
+    let (mut client, mut server) = connect_datagram();
+    let mut next_id: u64 = 1;
+    let mut received: u64 = 0;
+    let mut blocked = false;
+
+    // Each iteration delivers at least one datagram, so `TOTAL` iterations are
+    // enough; a stall would leave `received` short and fail the assertion below.
+    for _ in 0..TOTAL {
+        // Send while the queue accepts and we have not been told to stop.
+        while !blocked && next_id <= TOTAL {
+            let payload = vec![u8::try_from(next_id % 256).unwrap()];
+            // `false` means the queue is now full: stop until resumed.
+            blocked = !client
+                .send_datagram(payload, Some(next_id))
+                .expect("unexpected send error");
+            next_id += 1;
+        }
+
+        // Move one datagram-bearing packet to the server, if any.
+        if let Some(out) = client.process_output(now()).dgram() {
+            server.process_input(out, now());
+        }
+
+        // Count everything the server received.
+        for event in server.events() {
+            if matches!(event, ConnectionEvent::Datagram(_)) {
+                received += 1;
+            }
+        }
+
+        // Resume strictly on the transport's signal.
+        if client
+            .events()
+            .any(|e| matches!(e, ConnectionEvent::OutgoingDatagramSpaceAvailable))
+        {
+            blocked = false;
+        }
+
+        if received == TOTAL {
+            break;
+        }
+    }
+
+    assert_eq!(received, TOTAL, "sender stalled or datagrams were lost");
 }
 
 fn send_datagram(sender: &mut Connection, receiver: &mut Connection, data: Vec<u8>) {
     let dgram_sent = sender.stats().frame_tx.datagram;
-    assert_eq!(sender.send_datagram(data, Some(1)), Ok(()));
+    assert_eq!(sender.send_datagram(data, Some(1)), Ok(true));
     let out = sender.process_output(now()).dgram().unwrap();
     assert_eq!(sender.stats().frame_tx.datagram, dgram_sent + 1);
 
@@ -546,14 +812,15 @@ fn multiple_quic_datagrams_in_one_packet() {
     let (mut client, mut server) = connect_datagram();
 
     let dgram_sent = client.stats().frame_tx.datagram;
-    // Enqueue 2 datagrams that can fit in a single packet.
+    // Enqueue 2 datagrams that can fit in a single packet. The second fills the
+    // 2-slot queue, so it is queued but reports no space remains.
     assert_eq!(
         client.send_datagram(DATA_SMALLER_THAN_MTU_2.to_vec(), Some(1)),
-        Ok(())
+        Ok(true)
     );
     assert_eq!(
         client.send_datagram(DATA_SMALLER_THAN_MTU_2.to_vec(), Some(2)),
-        Ok(())
+        Ok(false)
     );
 
     let out = client.process_output(now()).dgram();

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -22,7 +22,6 @@ use crate::{
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub enum OutgoingDatagramOutcome {
     DroppedTooBig,
-    DroppedQueueFull,
     Lost,
     Acked,
 }
@@ -78,6 +77,8 @@ pub enum ConnectionEvent {
         id: u64,
         outcome: OutgoingDatagramOutcome,
     },
+    /// The outgoing QUIC datagram queue has space again after having been full.
+    OutgoingDatagramSpaceAvailable,
     /// An update was received to SCONE throughput advice.
     /// The value is the approximate rate in bits per second; None = unknown.
     SconeUpdated(Option<NonZeroU64>),
@@ -203,6 +204,11 @@ impl ConnectionEvents {
 
     pub fn add_datagram(&self, data: &[u8]) {
         self.events.push(ConnectionEvent::Datagram(data.to_vec()));
+    }
+
+    pub fn datagram_space_available(&self) {
+        self.events
+            .push_unique(ConnectionEvent::OutgoingDatagramSpaceAvailable);
     }
 
     pub fn datagram_outcome(

--- a/neqo-transport/src/quic_datagrams.rs
+++ b/neqo-transport/src/quic_datagrams.rs
@@ -4,11 +4,23 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Outbound QUIC datagram queueing and backpressure:
+//!
+//! [`QuicDatagrams::add_datagram`] queues the datagram (unless it exceeds the
+//! peer's datagram-size limit) and reports whether the queue still had room:
+//! `Ok(true)` if so, or `Ok(false)` once a send has filled it. `Ok(false)` is a
+//! high-watermark signal to stop, not a rejection: the datagram is still queued
+//! and nothing already queued is dropped. A single [`OutgoingDatagramSpaceAvailable`]
+//! event fires once the queue drops back below capacity, whether a slot was freed
+//! by sending a datagram or by dropping one too big for any packet.
+//!
+//! [`OutgoingDatagramSpaceAvailable`]: crate::ConnectionEvent::OutgoingDatagramSpaceAvailable
+
 // https://datatracker.ietf.org/doc/html/draft-ietf-quic-datagram
 
 use std::{cmp::min, collections::VecDeque};
 
-use neqo_common::{Buffer, Encoder, qdebug, to_u64};
+use neqo_common::{Buffer, Encoder, qdebug, qtrace, to_u64};
 
 use crate::{
     ConnectionEvents, Error, Res, Stats,
@@ -66,6 +78,9 @@ pub struct QuicDatagrams {
     /// The max size of a datagram that would be acceptable by the peer.
     remote_datagram_size: u64,
     max_queued_outgoing_datagrams: usize,
+    /// Set once a send fills the queue; cleared when a freed slot emits the
+    /// resume event. See the [module documentation](self).
+    blocked: bool,
     /// Datagram queued for sending.
     datagrams: VecDeque<QuicDatagram>,
     conn_events: ConnectionEvents,
@@ -81,6 +96,7 @@ impl QuicDatagrams {
             local_datagram_size,
             remote_datagram_size: 0,
             max_queued_outgoing_datagrams,
+            blocked: false,
             datagrams: VecDeque::with_capacity(max_queued_outgoing_datagrams),
             conn_events,
         }
@@ -127,37 +143,49 @@ impl QuicDatagrams {
                 debug_assert!(builder.len() <= builder.limit());
                 stats.frame_tx.datagram += 1;
                 tokens.push(recovery::Token::Datagram(*dgram.tracking()));
+                qtrace!(
+                    "Sent QUIC datagram, {} remaining in queue.",
+                    self.datagrams.len()
+                );
             } else if tokens.is_empty() {
                 // If the packet is empty, except packet headers, and the
                 // datagram cannot fit, drop it.
                 // Also continue trying to write the next QuicDatagram.
-                qdebug!("QUIC datagram ({}) does not fit MTU.", dgram.data.len());
+                qdebug!(
+                    "QUIC datagram ({}) does not fit MTU, dropping it, {} remaining in queue.",
+                    dgram.data.len(),
+                    self.datagrams.len()
+                );
                 self.conn_events
                     .datagram_outcome(dgram.tracking(), OutgoingDatagramOutcome::DroppedTooBig);
                 stats.datagram_tx.dropped_too_big += 1;
             } else {
                 self.datagrams.push_front(dgram);
-                // Try later on an empty packet.
-                return;
+                // The datagram did not fit and no slot was freed, so leave the
+                // queue as is and try later on an emptier packet.
+                break;
             }
+        }
+        // A send or drop above may have freed a slot and brought the queue below
+        // capacity; resume a blocked application if so. See the module docs.
+        if self.blocked && self.datagrams.len() < self.max_queued_outgoing_datagrams {
+            self.blocked = false;
+            self.conn_events.datagram_space_available();
         }
     }
 
-    /// Add a datagram to the send queue.
+    /// Queue a datagram for sending. See the [module documentation](self) for
+    /// the backpressure contract.
+    ///
+    /// Returns `Ok(true)` if the queue still has room afterwards, or `Ok(false)`
+    /// if this datagram filled it. The datagram is queued in either case.
     ///
     /// # Error
     ///
-    /// The function returns `TooMuchData` if the supply buffer is bigger than
-    /// the allowed remote datagram size. The function does not check if the
-    /// datagram can fit into a packet (i.e. MTU limit). This is checked during
-    /// creation of an actual packet and the datagram will be dropped if it does
-    /// not fit into the packet.
-    pub fn add_datagram(
-        &mut self,
-        data: Vec<u8>,
-        tracking: DatagramTracking,
-        stats: &mut Stats,
-    ) -> Res<()> {
+    /// Returns `TooMuchData` if the supply buffer is bigger than the allowed
+    /// remote datagram size. Whether the datagram fits into a packet (the MTU
+    /// limit) is only checked at send time, where it is dropped if it does not.
+    pub fn add_datagram(&mut self, data: Vec<u8>, tracking: DatagramTracking) -> Res<bool> {
         if to_u64(data.len()) > self.remote_datagram_size {
             qdebug!(
                 "QUIC datagram exceeds remote limit, dropping it, datagram size {}, remote datagram size limit {}.",
@@ -166,19 +194,17 @@ impl QuicDatagrams {
             );
             return Err(Error::TooMuchData);
         }
-        if self.datagrams.len() == self.max_queued_outgoing_datagrams {
-            qdebug!("QUIC datagram queue full, dropping first datagram in queue (head-drop).");
-            self.conn_events.datagram_outcome(
-                self.datagrams
-                    .pop_front()
-                    .ok_or(Error::Internal)?
-                    .tracking(),
-                OutgoingDatagramOutcome::DroppedQueueFull,
-            );
-            stats.datagram_tx.dropped_queue_full += 1;
-        }
         self.datagrams.push_back(QuicDatagram { data, tracking });
-        Ok(())
+        if self.datagrams.len() < self.max_queued_outgoing_datagrams {
+            return Ok(true);
+        }
+        qdebug!(
+            "QUIC datagram queue full (len {} / max {}), applying backpressure.",
+            self.datagrams.len(),
+            self.max_queued_outgoing_datagrams
+        );
+        self.blocked = true;
+        Ok(false)
     }
 
     pub fn handle_datagram(&self, data: &[u8]) -> Res<()> {

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -1417,7 +1417,8 @@ impl SendStream {
     /// event.
     ///
     /// See [`crate::Connection::stream_set_writable_event_low_watermark`].
-    pub const fn set_writable_event_low_watermark(&mut self, watermark: NonZeroUsize) {
+    pub fn set_writable_event_low_watermark(&mut self, watermark: NonZeroUsize) {
+        qdebug!("[{self}] low watermark {watermark}, avail {}", self.avail());
         self.writable_event_low_watermark = watermark;
     }
 
@@ -1731,6 +1732,10 @@ impl SendStream {
             return;
         }
 
+        qtrace!(
+            "[{self}] writable, low watermark {low_watermark}, avail {}",
+            self.avail()
+        );
         self.conn_events.send_stream_writable(self.stream_id);
     }
 }

--- a/neqo-transport/src/stats.rs
+++ b/neqo-transport/src/stats.rs
@@ -131,9 +131,6 @@ pub struct DatagramStats {
     pub lost: usize,
     /// The number of datagrams dropped due to being too large.
     pub dropped_too_big: usize,
-    /// The number of datagrams dropped due to reaching the limit of the
-    /// outgoing queue.
-    pub dropped_queue_full: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
When the outgoing datagram queue was full, `add_datagram` head-dropped the oldest queued datagram. On the MASQUE connect-udp path that silently discards an inner-connection packet the application already handed us, which looks like loss to the inner connection and hurts upload throughput.

Back-pressure instead of dropping, mirroring stream sends. `send_datagram` now always queues the datagram and returns whether the queue still has room:

- `Ok(true)`: queued, and space remains for more.
- `Ok(false)`: queued, but the queue is now full. The caller should stop producing datagrams until it receives `OutgoingDatagramSpaceAvailable`. Nothing already queued is dropped.

The datagram is accepted even when the queue is already at capacity. The application has already produced it, so neqo holds it here, ready to send, rather than leaving it in a queue upstream that neqo cannot reach once space frees. `Ok(false)` is a high-watermark signal to stop, not a rejection.

Once a slot frees while blocked, emit `OutgoingDatagramSpaceAvailable` (surfaced to HTTP/3 clients as `Http3ClientEvent::OutgoingDatagramSpaceAvailable`, analogous to `SendStreamWritable`) so the caller resumes.

This covers the QUIC datagram queue only. The connect-udp HTTP DATAGRAM Capsule fallback (used when the peer offers no QUIC datagram support) still drops on a full control stream and reports success; giving it backpressure is left for a follow-up (see the note on `write_datagram_capsule`).

Removes the now-unreachable `OutgoingDatagramOutcome::DroppedQueueFull` variant and the `dropped_queue_full` stat.

Fixes #2852.

Conflicts with https://github.com/mozilla/neqo/pull/3837.