### PR TITLE
chore: Enforce comments above attributes across the codebase

### DIFF
--- a/.github/workflows/comment-order.yml
+++ b/.github/workflows/comment-order.yml
@@ -1,0 +1,23 @@
+name: Check comment order
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  comment-order:
+    name: Check comment order
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: mxinden-bot/actions/comment-order@f38b7065827a200dda0a359c481357ac86020e40 # claude/enforce-test-annotations-vgu3ar

--- a/mtu/src/bsd.rs
+++ b/mtu/src/bsd.rs
@@ -51,10 +51,10 @@ use crate::{
 #[cfg(target_os = "macos")]
 const ALIGN: usize = size_of::<libc::c_int>();
 
-#[cfg(bsd)]
 // See https://github.com/freebsd/freebsd-src/blob/524a425d30fce3d5e47614db796046830b1f6a83/sys/net/route.h#L362-L371
 // See https://github.com/NetBSD/src/blob/4b50954e98313db58d189dd87b4541929efccb09/sys/net/route.h#L329-L331
 // See https://github.com/Arquivotheca/Solaris-8/blob/2ad1d32f9eeed787c5adb07eb32544276e2e2444/osnet_volume/usr/src/cmd/cmd-inet/usr.sbin/route.c#L238-L239
+#[cfg(bsd)]
 const ALIGN: usize = size_of::<libc::c_long>();
 
 #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]

--- a/neqo-bin/src/client/mod.rs
+++ b/neqo-bin/src/client/mod.rs
@@ -105,51 +105,51 @@ pub struct Args {
     #[arg(name = "max-push", short = 'p', long, default_value = "10")]
     max_concurrent_push_streams: u64,
 
-    #[arg(name = "download-in-series", long)]
     /// Download resources in series using separate connections.
+    #[arg(name = "download-in-series", long)]
     download_in_series: bool,
 
-    #[arg(name = "concurrency", long, default_value = "100")]
     /// The maximum number of requests to have outstanding at one time.
+    #[arg(name = "concurrency", long, default_value = "100")]
     concurrency: usize,
 
-    #[arg(name = "output-read-data", long)]
     /// Output received data to stdout
+    #[arg(name = "output-read-data", long)]
     output_read_data: bool,
 
-    #[arg(name = "output-dir", long)]
     /// Save contents of fetched URLs to a directory
+    #[arg(name = "output-dir", long)]
     output_dir: Option<PathBuf>,
 
-    #[arg(short = 'r', long, hide = true)]
     /// Client attempts to resume by making multiple connections to servers.
     /// Requires that 2 or more URLs are listed for each server.
     /// Use this for 0-RTT: the stack always attempts 0-RTT on resumption.
+    #[arg(short = 'r', long, hide = true)]
     resume: bool,
 
-    #[arg(long)]
     /// Save the resumption token to a file after connecting.
+    #[arg(long)]
     save_token: Option<PathBuf>,
 
-    #[arg(long)]
     /// Load a resumption token from a file and attempt 0-RTT.
+    #[arg(long)]
     load_token: Option<PathBuf>,
 
-    #[arg(name = "key-update", long, hide = true)]
     /// Attempt to initiate a key update immediately after confirming the connection.
+    #[arg(name = "key-update", long, hide = true)]
     key_update: bool,
 
-    #[arg(name = "ech", long)]
     /// Enable encrypted client hello (ECH).
     /// This takes an encoded ECH configuration in hexadecimal format.
+    #[arg(name = "ech", long)]
     ech: Option<EchConfig>,
 
-    #[arg(name = "ipv4-only", short = '4', long)]
     /// Connect only over IPv4
+    #[arg(name = "ipv4-only", short = '4', long)]
     ipv4_only: bool,
 
-    #[arg(name = "ipv6-only", short = '6', long)]
     /// Connect only over IPv6
+    #[arg(name = "ipv6-only", short = '6', long)]
     ipv6_only: bool,
 
     /// The test that this client will run. Currently, we only support "upload".

--- a/neqo-bin/src/lib.rs
+++ b/neqo-bin/src/lib.rs
@@ -35,14 +35,14 @@ pub struct SharedArgs {
     #[command(flatten)]
     verbose: Option<clap_verbosity_flag::Verbosity>,
 
-    #[arg(short = 'a', long, default_value = "h3")]
     /// ALPN labels to negotiate.
     ///
     /// This client still only does HTTP/3 no matter what the ALPN says.
+    #[arg(short = 'a', long, default_value = "h3")]
     alpn: String,
 
-    #[arg(name = "qlog-dir", long, value_parser=clap::value_parser!(PathBuf))]
     /// Enable QLOG logging and QLOG traces to this directory
+    #[arg(name = "qlog-dir", long, value_parser=clap::value_parser!(PathBuf))]
     qlog_dir: Option<PathBuf>,
 
     #[arg(name = "encoder-table-size", long, default_value = "16384")]
@@ -54,13 +54,13 @@ pub struct SharedArgs {
     #[arg(name = "max-blocked-streams", short = 'b', long, default_value = "10")]
     max_blocked_streams: u16,
 
-    #[arg(short = 'c', long, number_of_values = 1)]
     /// The set of TLS cipher suites to enable.
     /// From: `TLS_AES_128_GCM_SHA256`, `TLS_AES_256_GCM_SHA384`, `TLS_CHACHA20_POLY1305_SHA256`.
+    #[arg(short = 'c', long, number_of_values = 1)]
     ciphers: Vec<String>,
 
-    #[arg(name = "qns-test", long)]
     /// Enable special behavior for use with QUIC Network Simulator
+    #[arg(name = "qns-test", long)]
     qns_test: Option<String>,
 
     #[command(flatten)]
@@ -93,6 +93,11 @@ impl SharedArgs {
 
 #[derive(Clone, Debug, Parser)]
 pub struct QuicParameters {
+    /// A list of versions to support, in hex.
+    /// The first is the version to attempt.
+    /// Adding multiple values adds versions in order of preference.
+    /// If the first listed version appears in the list twice, the position
+    /// of the second entry determines the preference order of that version.
     #[arg(
         short = 'Q',
         long,
@@ -100,59 +105,54 @@ pub struct QuicParameters {
         value_delimiter = ' ',
         number_of_values = 1,
         value_parser = from_str)]
-    /// A list of versions to support, in hex.
-    /// The first is the version to attempt.
-    /// Adding multiple values adds versions in order of preference.
-    /// If the first listed version appears in the list twice, the position
-    /// of the second entry determines the preference order of that version.
     pub quic_version: Vec<Version>,
 
-    #[arg(long, default_value = "16")]
     /// Set the `MAX_STREAMS_BIDI` limit.
+    #[arg(long, default_value = "16")]
     pub max_streams_bidi: u64,
 
-    #[arg(long, default_value = "16")]
     /// Set the `MAX_STREAMS_UNI` limit.
+    #[arg(long, default_value = "16")]
     pub max_streams_uni: u64,
 
-    #[arg(long = "idle", default_value = "30")]
     /// The idle timeout for connections, in seconds.
+    #[arg(long = "idle", default_value = "30")]
     pub idle_timeout: u64,
 
-    #[arg(long = "init_rtt", default_value_t = DEFAULT_INITIAL_RTT.as_millis() as u64)]
     /// The initial round-trip time, in milliseconds.
+    #[arg(long = "init_rtt", default_value_t = DEFAULT_INITIAL_RTT.as_millis() as u64)]
     pub initial_rtt_ms: u64,
 
+    /// The congestion control algorithm to use.
     #[arg(long = "cc", default_value = "cubic",
         value_parser = clap::builder::PossibleValuesParser::new(CongestionControl::VARIANTS)
             .map(|s| s.parse::<CongestionControl>().unwrap()))]
-    /// The congestion control algorithm to use.
     pub congestion_control: CongestionControl,
 
+    /// The slow start algorithm to use.
     #[arg(long = "ss", default_value = "classic",
         value_parser = clap::builder::PossibleValuesParser::new(SlowStart::VARIANTS)
             .map(|s| s.parse::<SlowStart>().unwrap()))]
-    /// The slow start algorithm to use.
     pub slow_start: SlowStart,
 
-    #[arg(long = "no-pacing")]
     /// Whether to disable pacing.
+    #[arg(long = "no-pacing")]
     pub no_pacing: bool,
 
-    #[arg(long)]
     /// Whether to disable path MTU discovery.
+    #[arg(long)]
     pub no_pmtud: bool,
 
-    #[arg(long)]
     /// Whether to slice the SNI.
+    #[arg(long)]
     pub no_sni_slicing: bool,
 
-    #[arg(name = "preferred-address-v4", long)]
     /// An IPv4 address for the server preferred address.
+    #[arg(name = "preferred-address-v4", long)]
     pub preferred_address_v4: Option<String>,
 
-    #[arg(name = "preferred-address-v6", long)]
     /// An IPv6 address for the server preferred address.
+    #[arg(name = "preferred-address-v6", long)]
     pub preferred_address_v6: Option<String>,
 }
 

--- a/neqo-bin/src/server/mod.rs
+++ b/neqo-bin/src/server/mod.rs
@@ -80,22 +80,22 @@ pub struct Args {
     #[arg(default_value = "[::]:4433")]
     hosts: Vec<String>,
 
-    #[arg(short = 'd', long)]
     /// NSS database directory [default: `$TEST_FIXTURE_DB` or the bundled NSS test DB].
+    #[arg(short = 'd', long)]
     db: Option<PathBuf>,
 
-    #[arg(short = 'k', long, default_value = "key")]
     /// Name of key from NSS database.
+    #[arg(short = 'k', long, default_value = "key")]
     key: String,
 
-    #[arg(name = "retry", long)]
     /// Force a retry
+    #[arg(name = "retry", long)]
     retry: bool,
 
-    #[arg(name = "ech", long)]
     /// Enable encrypted client hello (ECH).
     /// This generates a new set of ECH keys when it is invoked.
     /// The resulting configuration is printed to stdout in hexadecimal format.
+    #[arg(name = "ech", long)]
     ech: bool,
 }
 

--- a/neqo-bin/src/udp.rs
+++ b/neqo-bin/src/udp.rs
@@ -30,11 +30,11 @@ impl Socket {
 
         let socket = std::net::UdpSocket::bind(addr)?;
         let state = quinn_udp::UdpSocketState::new((&socket).into())?;
-        #[cfg(apple)]
         // SAFETY: Quinn-udp resolves `sendmsg_x`/`recvmsg_x` via `dlsym` at
         // runtime and falls back to standard `sendmsg`/`recvmsg` if unavailable,
         // so this is safe on all supported Apple OS versions.
         // neqo-bin always enables the Apple fast datapath as a canary.
+        #[cfg(apple)]
         unsafe {
             state.set_apple_fast_path();
         }

--- a/neqo-common/src/lib.rs
+++ b/neqo-common/src/lib.rs
@@ -97,8 +97,8 @@ where
     usize::try_from(v).expect("usize should be large enough for this value")
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Enum, Display)]
 /// Client or Server.
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Enum, Display)]
 pub enum Role {
     Client,
     Server,

--- a/neqo-common/src/tos.rs
+++ b/neqo-common/src/tos.rs
@@ -15,8 +15,8 @@ use strum::{EnumIter, FromRepr};
 #[derive(Copy, Clone, PartialEq, Eq, Enum, Default, Debug, FromRepr, EnumIter)]
 #[repr(u8)]
 pub enum Ecn {
-    #[default]
     /// Not-ECT, Not ECN-Capable Transport, RFC3168
+    #[default]
     NotEct = 0b00,
     /// ECT(1), ECN-Capable Transport(1), RFC8311 and RFC9331
     Ect1 = 0b01,
@@ -63,8 +63,8 @@ impl Ecn {
 #[derive(Copy, Clone, PartialEq, Eq, Enum, Default, Debug, FromRepr)]
 #[repr(u8)]
 pub enum Dscp {
-    #[default]
     /// Class Selector 0, RFC2474
+    #[default]
     Cs0 = 0b0000_0000,
     /// Lower-Effort, RFC8622
     Le = 0b0000_0100,

--- a/neqo-http3/src/frames/reader.rs
+++ b/neqo-http3/src/frames/reader.rs
@@ -315,11 +315,11 @@ impl FrameReader {
         Ok(res)
     }
 
-    #[cfg(feature = "build-fuzzing-corpus")]
     /// Write `HFrame` data to indicated fuzzing corpus.
     ///
     /// The output consists of the varint-encoded frame type and length, followed by the optional
     /// payload data.
+    #[cfg(feature = "build-fuzzing-corpus")]
     fn write_item_to_fuzzing_corpus(&self, corpus: &str, data: Option<&[u8]>) {
         // We need to include the frame type and length varints before the data
         // to create a complete frame that the fuzzer can process.

--- a/neqo-http3/tests/httpconn.rs
+++ b/neqo-http3/tests/httpconn.rs
@@ -471,9 +471,9 @@ fn zerortt() {
     process_client_events(&mut hconn_c);
 }
 
-#[test]
 /// When a client has an outstanding fetch, it will send keepalives.
 /// Test that it will successfully run until the connection times out.
+#[test]
 fn fetch_noresponse_will_idletimeout() {
     let mut hconn_c = default_http3_client();
     let mut hconn_s = default_http3_server();

--- a/neqo-qpack/src/fuzz.rs
+++ b/neqo-qpack/src/fuzz.rs
@@ -9,8 +9,8 @@
 #[cfg(feature = "build-fuzzing-corpus")]
 pub use write_corpus::write_item_to_fuzzing_corpus;
 
-#[cfg(feature = "build-fuzzing-corpus")]
 /// Helpers to write data to the fuzzing corpus.
+#[cfg(feature = "build-fuzzing-corpus")]
 mod write_corpus {
     use neqo_transport::StreamId;
 
@@ -23,8 +23,8 @@ mod write_corpus {
     }
 }
 
-#[cfg(fuzzing)]
 /// Helpers to support fuzzing.
+#[cfg(fuzzing)]
 mod fuzzing {
     use crate::{
         Decoder, Error, Res,

--- a/neqo-qpack/src/stats.rs
+++ b/neqo-qpack/src/stats.rs
@@ -6,8 +6,8 @@
 
 // Tracking of some useful statistics.
 
-#[derive(Default, Debug, Clone)]
 /// `QPack` statistics
+#[derive(Default, Debug, Clone)]
 pub struct Stats {
     pub dynamic_table_inserts: usize,
     // This is the number of header blocks that reference the dynamic table.

--- a/neqo-transport/src/cc/classic_cc.rs
+++ b/neqo-transport/src/cc/classic_cc.rs
@@ -2145,11 +2145,11 @@ mod tests {
         assert_eq!(cc_stats.cwnd, Some(cc.cwnd_min()));
     }
 
-    #[test]
     // There was a bug in the stat logic that it never got initialized if a connection never made it
     // past the point of being app-limited, i.e. it returned `0` if a connection never grew the
     // congestion window. This test asserts that it is getting initialized to the initial window
     // size on the first ack, even if the congestion window doesn't grow.
+    #[test]
     fn cwnd_stat_app_limited() {
         let mut cc = make_cc_cubic();
         let now = now();

--- a/neqo-transport/src/cc/tests/new_reno.rs
+++ b/neqo-transport/src/cc/tests/new_reno.rs
@@ -162,8 +162,8 @@ fn issue_876() {
     assert_eq!(cc.bytes_in_flight(), 4 * cc.max_datagram_size());
 }
 
-#[test]
 // https://github.com/mozilla/neqo/pull/1465
+#[test]
 fn issue_1465() {
     let mut cc = make_cc_newreno();
     let mut cc_stats = CongestionControlStats::default();

--- a/neqo-transport/src/connection/idle.rs
+++ b/neqo-transport/src/connection/idle.rs
@@ -13,20 +13,20 @@ use neqo_common::qtrace;
 
 use crate::recovery;
 
-#[derive(Debug, Clone)]
 /// There's a little bit of different behavior for resetting idle timeout. See
 /// -transport 10.2 ("Idle Timeout").
+#[derive(Debug, Clone)]
 enum IdleTimeoutState {
     Init,
     PacketReceived(Instant),
     AckElicitingPacketSent(Instant),
 }
 
-#[derive(Debug, Clone)]
 /// There's a little bit of different behavior for resetting idle timeout. See
 /// -transport 10.1 ("Idle Timeout").
 ///
 /// <https://datatracker.ietf.org/doc/html/rfc9000#section-10.1>
+#[derive(Debug, Clone)]
 pub struct IdleTimeout {
     timeout: Duration,
     state: IdleTimeoutState,

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -97,9 +97,9 @@ pub enum ZeroRttState {
     Rejected,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
 /// Type returned from `process()` and `process_output()`. Users are required to
 /// call these repeatedly until `Callback` or `None` is returned.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Output {
     /// Connection requires no action.
     None,

--- a/neqo-transport/src/connection/state.rs
+++ b/neqo-transport/src/connection/state.rs
@@ -16,8 +16,8 @@ use crate::{
     recovery,
 };
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 /// The state of the Connection.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum State {
     /// A newly created connection.
     Init,

--- a/neqo-transport/src/connection/tests/cc.rs
+++ b/neqo-transport/src/connection/tests/cc.rs
@@ -22,8 +22,8 @@ use crate::{
     stream_id::StreamType,
 };
 
-#[test]
 /// Verify initial CWND is honored.
+#[test]
 fn cc_slow_start() {
     let mut client = default_client();
     let mut server = default_server();
@@ -126,8 +126,8 @@ fn cc_slow_start_to_cong_avoidance_recovery_period(congestion_signal: Congestion
     assert!(cwnd(&client) < cwnd_before_cong);
 }
 
-#[test]
 /// Verify that CC moves to cong avoidance when a packet is marked lost.
+#[test]
 fn cc_slow_start_to_cong_avoidance_recovery_period_due_to_packet_loss() {
     cc_slow_start_to_cong_avoidance_recovery_period(CongestionSignal::PacketLoss);
 }
@@ -138,9 +138,9 @@ fn cc_slow_start_to_cong_avoidance_recovery_period_due_to_ecn_ce() {
     cc_slow_start_to_cong_avoidance_recovery_period(CongestionSignal::EcnCe);
 }
 
-#[test]
 /// Verify that CC stays in recovery period when packet sent before start of
 /// recovery period is acked.
+#[test]
 fn cc_cong_avoidance_recovery_period_unchanged() {
     let mut client = default_client();
     let mut server = default_server();
@@ -177,9 +177,9 @@ fn cc_cong_avoidance_recovery_period_unchanged() {
     assert_eq!(cwnd1, cwnd2);
 }
 
-#[test]
 /// Ensure that a single packet is sent after entering recovery, even
 /// when that exceeds the available congestion window.
+#[test]
 fn single_packet_on_recovery() {
     let mut client = default_client();
     let mut server = default_server();
@@ -280,8 +280,8 @@ fn cc_cong_avoidance_recovery_period_to_cong_avoidance_cubic() {
     cc_cong_avoidance_recovery_period_to_cong_avoidance(CongestionControl::Cubic);
 }
 
-#[test]
 /// Verify transition to persistent congestion state if conditions are met.
+#[test]
 fn cc_slow_start_to_persistent_congestion_no_acks() {
     let mut client = default_client();
     let mut server = default_server();
@@ -301,8 +301,8 @@ fn cc_slow_start_to_persistent_congestion_no_acks() {
     induce_persistent_congestion(&mut client, &mut server, stream, now);
 }
 
-#[test]
 /// Verify transition to persistent congestion state if conditions are met.
+#[test]
 fn cc_slow_start_to_persistent_congestion_some_acks() {
     let mut client = default_client();
     let mut server = default_server();
@@ -329,9 +329,9 @@ fn cc_slow_start_to_persistent_congestion_some_acks() {
     induce_persistent_congestion(&mut client, &mut server, stream, now);
 }
 
-#[test]
 /// Verify persistent congestion moves to slow start after recovery period
 /// ends.
+#[test]
 fn cc_persistent_congestion_to_slow_start() {
     let mut client = default_client();
     let mut server = default_server();

--- a/neqo-transport/src/connection/tests/handshake.rs
+++ b/neqo-transport/src/connection/tests/handshake.rs
@@ -817,8 +817,8 @@ fn corrupted_initial() {
     assert_eq!(server.stats().dropped_rx, 2);
 }
 
-#[test]
 // Absent path PTU discovery, max v6 packet size should be PATH_MTU_V6.
+#[test]
 fn verify_pkt_honors_mtu() {
     let mut client = default_client();
     let mut server = default_server();

--- a/neqo-transport/src/connection/tests/stream.rs
+++ b/neqo-transport/src/connection/tests/stream.rs
@@ -55,8 +55,8 @@ fn stream_create() {
     assert_eq!(server.stream_create(StreamType::BiDi).unwrap(), 5);
 }
 
-#[test]
 // tests stream send/recv after connection is established.
+#[test]
 fn transfer() {
     let mut client = default_client();
     let mut server = default_server();
@@ -308,8 +308,8 @@ fn ordergroup_7() {
     fairness_test(source, 5, 3, &result);
 }
 
-#[test]
 // Send fin even if a peer closes a remote bidi send stream before sending any data.
+#[test]
 fn report_fin_when_stream_closed_wo_data() {
     // Note that the two servers in this test will get different anti-replay filters.
     // That's OK because we aren't testing anti-replay.
@@ -487,8 +487,8 @@ fn exceed_max_data() {
     assert_error(&server, &CloseReason::Transport(Error::FlowControl));
 }
 
-#[test]
 // If we send a stop_sending to the peer, we should not accept more data from the peer.
+#[test]
 fn do_not_accept_data_after_stop_sending() {
     // Note that the two servers in this test will get different anti-replay filters.
     // That's OK because we aren't testing anti-replay.
@@ -535,9 +535,9 @@ impl crate::connection::test_internal::FrameWriter for Writer {
     }
 }
 
-#[test]
 /// Server sends a number of stream-related frames for a client-initiated stream that is not yet
 /// created. This should cause the client to close the connection.
+#[test]
 fn illegal_stream_related_frames() {
     fn test_with_illegal_frame(frame: &[u64]) {
         let mut client = default_client();
@@ -564,10 +564,10 @@ fn illegal_stream_related_frames() {
     }
 }
 
-#[test]
 /// Server sends a stream-related frame for the wrong half of an existing
 /// unidirectional stream. This should cause the client to close the connection
 /// with `STREAM_STATE_ERROR`.
+#[test]
 fn wrong_directional_stream_frames() {
     // The directional check only fires once the targeted half exists, so the
     // creating role makes the stream before the offending frame is injected.
@@ -606,8 +606,8 @@ fn wrong_directional_stream_frames() {
     }
 }
 
-#[test]
 /// Regression <https://github.com/mozilla/neqo/pull/2358>.
+#[test]
 fn legal_out_of_order_frame_on_remote_initiated_closed_stream() {
     const REQUEST: &[u8] = b"ping";
     let mut client = default_client();
@@ -652,8 +652,8 @@ fn legal_out_of_order_frame_on_remote_initiated_closed_stream() {
     );
 }
 
-#[test]
 // Server sends stop_sending, the client simultaneous sends reset.
+#[test]
 fn simultaneous_stop_sending_and_reset() {
     let mut client = default_client();
     let mut server = default_server();
@@ -695,8 +695,8 @@ fn simultaneous_stop_sending_and_reset() {
     );
 }
 
-#[test]
 /// Make a stream data or control frame arrive after the stream has been used and cleared.
+#[test]
 fn late_stream_related_frames() {
     fn late_stream_related_frame(frame_type: FrameType) {
         let mut client = default_client();

--- a/neqo-transport/src/recv_stream.rs
+++ b/neqo-transport/src/recv_stream.rs
@@ -500,8 +500,8 @@ impl RxStreamOrderer {
 }
 
 /// QUIC receiving states, based on -transport 3.2.
-#[derive(Debug, Display)]
 // Because a dead_code warning is easier than clippy::unused_self, see https://github.com/rust-lang/rust/issues/68408
+#[derive(Debug, Display)]
 enum RecvStreamState {
     Recv {
         fc: ReceiverFlowControl<StreamId>,

--- a/neqo-transport/src/send_stream.rs
+++ b/neqo-transport/src/send_stream.rs
@@ -3584,8 +3584,8 @@ mod tests {
         }
     }
 
-    #[test]
     // Verify lost frames handle fin properly
+    #[test]
     fn send_stream_get_frame_data() {
         let conn_fc = connection_fc(100);
         let conn_events = ConnectionEvents::default();
@@ -3724,8 +3724,8 @@ mod tests {
         );
     }
 
-    #[test]
     // Verify lost frames handle fin properly with zero length fin
+    #[test]
     fn send_stream_get_frame_zerolength_fin() {
         let conn_fc = connection_fc(100);
         let conn_events = ConnectionEvents::default();

--- a/neqo-transport/tests/common/mod.rs
+++ b/neqo-transport/tests/common/mod.rs
@@ -94,8 +94,8 @@ pub fn connect(client: &mut Connection, server: &mut Server) -> ConnectionRef {
     connected_server(server)
 }
 
-#[cfg(test)]
 /// Scrub through client events to find a resumption token.
+#[cfg(test)]
 pub fn find_ticket(client: &mut Connection) -> ResumptionToken {
     client
         .events()
@@ -109,8 +109,8 @@ pub fn find_ticket(client: &mut Connection) -> ResumptionToken {
         .unwrap()
 }
 
-#[cfg(test)]
 /// Connect to the server and have it generate a ticket.
+#[cfg(test)]
 pub fn generate_ticket(server: &mut Server) -> ResumptionToken {
     let mut client = default_client();
     let server_conn = connect(&mut client, server);

--- a/neqo-udp/src/lib.rs
+++ b/neqo-udp/src/lib.rs
@@ -44,8 +44,8 @@ const RECV_BUF_SIZE: usize = u16::MAX as usize;
 /// - Apple: no segmentation offloading available, use multiple buffers
 #[cfg(not(apple))]
 const NUM_BUFS: usize = 1;
-#[cfg(apple)]
 // Value approximated based on neqo-bin "Download" benchmark only.
+#[cfg(apple)]
 const NUM_BUFS: usize = 16;
 
 /// A UDP receive buffer.

--- a/test-fixture/src/sim/rng.rs
+++ b/test-fixture/src/sim/rng.rs
@@ -84,8 +84,8 @@ impl Default for Random {
         Self::new(&nss::random::<32>())
     }
 
-    #[cfg(feature = "disable-random")]
     // Use a fixed seed for a deterministic sequence of numbers.
+    #[cfg(feature = "disable-random")]
     fn default() -> Self {
         Self::new(&[1; 32])
     }


### PR DESCRIPTION
A comment or doc comment placed between an item's attributes and the item splits the attributes from what they annotate; comments belong above the attributes. Rust's style guide asks for doc comments before attributes, but neither rustfmt nor clippy enforce it and neither covers plain // comments.

Depends on https://github.com/mozilla/actions/pull/119.