### PR TITLE
test: $/ cross-repo resolution (do not merge)

### DIFF
--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   machete:
-    uses: mozilla/actions/.github/workflows/machete.yml@96ce92daf6ecffbe02728649f25f32a15eba543e # v2.0.2
+    uses: mozilla/actions/.github/workflows/machete.yml@fdbc149234005e066f838be6bb654dfb0b570cee # TEST mozilla/actions#127 - DO NOT MERGE

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   format:
-    uses: mozilla/actions/.github/workflows/rustfmt.yml@96ce92daf6ecffbe02728649f25f32a15eba543e # v2.0.2
+    uses: mozilla/actions/.github/workflows/rustfmt.yml@fdbc149234005e066f838be6bb654dfb0b570cee # TEST mozilla/actions#127 - DO NOT MERGE

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -15,6 +15,6 @@ jobs:
     name: Check semver
     runs-on: ubuntu-24.04
     steps:
-      - uses: mozilla/actions/semver@96ce92daf6ecffbe02728649f25f32a15eba543e # v2.0.2
+      - uses: mozilla/actions/semver@fdbc149234005e066f838be6bb654dfb0b570cee # TEST mozilla/actions#127 - DO NOT MERGE
         with:
           package: mtu


### PR DESCRIPTION
Throwaway. Points rustfmt/machete/semver at mozilla/actions#127 to verify `$/` resolves against mozilla/actions rather than the caller.