### PR TITLE
chore: prepare v0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -515,7 +515,7 @@ dependencies = [
  "neqo-qpack",
  "neqo-transport",
  "nss-rs",
- "test-fixture 0.30.1",
+ "test-fixture 0.31.0",
 ]
 
 [[package]]
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "cfg_aliases",
  "clap",
@@ -742,14 +742,14 @@ dependencies = [
  "rustc-hash",
  "strum",
  "test-fixture 0.1.0",
- "test-fixture 0.30.1",
+ "test-fixture 0.31.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "neqo-common"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -760,14 +760,14 @@ dependencies = [
  "sha1",
  "static_assertions",
  "strum",
- "test-fixture 0.30.1",
+ "test-fixture 0.31.0",
  "thiserror",
  "windows",
 ]
 
 [[package]]
 name = "neqo-http3"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enumset",
@@ -783,13 +783,13 @@ dependencies = [
  "sfv",
  "static_assertions",
  "strum",
- "test-fixture 0.30.1",
+ "test-fixture 0.31.0",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-qpack"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "log",
  "neqo-common",
@@ -797,13 +797,13 @@ dependencies = [
  "qlog",
  "rustc-hash",
  "static_assertions",
- "test-fixture 0.30.1",
+ "test-fixture 0.31.0",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-transport"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -819,13 +819,13 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "strum",
- "test-fixture 0.30.1",
+ "test-fixture 0.31.0",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-udp"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.30.1"
+version = "0.31.0"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
User-visible changes since v0.30.1:

- Update nss-rs to 0.14.6, now requiring NSS >= 3.126 (#3882)
- WebTransport getStats() support (#3835)
- Reliable reset handling for HTTP/3 (#3777)
- Optionally close a connection after N consecutive PTOs (#3662)
- Remove HTTP/3 server push (#3816)
- Keep the server serving on spurious UDP `ConnectionReset` (#3895)
- Respond to each key update only once (#3893)
- Limit discontiguous STREAM reassembly ranges (#3896)
- Reject 0-RTT downgrade of h3 datagram and WebTransport settings (#3852)
- Reject connection-specific header fields in HTTP/3 messages (#3806)
- Reject qpack dynamic reference at or above required insert count (#3807)
- Discard server Initial packets that carry a token (#3814)

Blocked on:
- https://github.com/mozilla/neqo/pull/3900

Bugzilla tracking: https://bugzilla.mozilla.org/show_bug.cgi?id=2065405