### PR TITLE
fix: `pacer_spend_pacing_limited` was defunct

### DIFF
--- a/neqo-transport/benches/pacer.rs
+++ b/neqo-transport/benches/pacer.rs
@@ -17,29 +17,33 @@ use neqo_transport::Pacer;
 const RTT: Duration = Duration::from_millis(50);
 const MTU: usize = 1_350;
 const CWND: usize = MTU * 100;
+const CALLS: usize = 1_000;
 
-/// PRIMARY: `spend()` when pacing is enabled and each call is credit-limited.
-/// This is the dominant case during a paced bulk transfer: the pacer has just
-/// enough credit for each packet and the call does the full division.
-///
-/// For pacing to actually limit, the inter-packet interval
-/// `RTT * MTU / (CWND * 2)` must exceed GRANULARITY (1 ms).
-/// With RTT=50ms, MTU=1350: CWND must be ≤ 33 750 bytes.
-/// `CWND_LIMITED`=MTU*10=13 500 gives a 2.5ms inter-packet interval.
+// These loops need `black_box` to survive the optimizer: `&p` keeps the pacer's
+// loads and stores, and opaque arguments keep `spend()`'s arithmetic.
+
+/// PRIMARY: `spend()` in the steady state of a paced bulk transfer, where the
+/// sender waits out the pacing interval and `self.c` returns to zero each call.
 fn pacer_spend_pacing_limited(c: &mut Criterion) {
     const CWND_LIMITED: usize = MTU * 10;
+    // One packet of credit per call: `RTT * MTU / (CWND_LIMITED * SPEEDUP)`.
+    const INTERVAL: Duration = RTT.checked_div(20).expect("divisor is not zero");
     let now = test_fixture::now();
     c.bench_function("Pacer::spend pacing-limited", |b| {
         b.iter_batched(
             || {
-                // Pacer starts with one packet of credit; after the first
-                // spend() call it reaches zero credit and subsequent calls
-                // exercise the pacing-limited path (full division).
-                Pacer::new(true, now, MTU, MTU)
+                let mut p = Pacer::new(true, now, MTU, MTU);
+                // Drain the initial burst to reach the steady state.
+                p.spend(now, RTT, CWND_LIMITED, MTU);
+                assert_eq!(p.next(RTT, CWND_LIMITED), now + INTERVAL);
+                p
             },
             |mut p| {
-                for _ in 0..1_000 {
-                    p.spend(now, RTT, CWND_LIMITED, MTU);
+                let (rtt, cwnd, count) = black_box((RTT, CWND_LIMITED, MTU));
+                let mut t = now;
+                for _ in 0..CALLS {
+                    t += INTERVAL;
+                    p.spend(t, rtt, cwnd, count);
                 }
                 black_box(p)
             },
@@ -57,10 +61,10 @@ fn pacer_next_fast_path(c: &mut Criterion) {
             // Full credit: next() will return immediately.
             || Pacer::new(true, now, CWND, MTU),
             |p| {
-                for _ in 0..1_000 {
+                for _ in 0..CALLS {
                     black_box(p.next(RTT, CWND));
+                    black_box(&p);
                 }
-                black_box(p)
             },
             BatchSize::SmallInput,
         );
@@ -75,10 +79,10 @@ fn pacer_spend_disabled(c: &mut Criterion) {
         b.iter_batched(
             || Pacer::new(false, now, CWND, MTU),
             |mut p| {
-                for _ in 0..1_000 {
+                for _ in 0..CALLS {
                     p.spend(now, RTT, CWND, MTU);
+                    black_box(&p);
                 }
-                black_box(p)
             },
             BatchSize::SmallInput,
         );


### PR DESCRIPTION
Because it never advanced `now`.