### PR TITLE
fix: Report packet and datagram sizes accurately in qlog

### DIFF
--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -129,15 +129,16 @@ impl Qlog {
         F: FnOnce() -> Option<qlog::events::EventData>,
     {
         self.add_event_with_stream(now, |s, now| {
-            f().map_or(Ok(false), |ev_data| {
-                s.add_event_data_with_instant(ev_data, now).map(|()| true)
-            })
+            let Some(ev_data) = f() else {
+                return Ok(false);
+            };
+            s.add_event_data_with_instant(ev_data, now)?;
+            Ok(true)
         });
     }
 
-    /// If logging enabled, closure is given the Qlog stream to write events and
-    /// frames to, along with the time to write them at. Reports whether it
-    /// wrote an event.
+    /// If logging enabled, closure is given the Qlog stream to write timestamped events and
+    /// frames to. Reports whether it wrote an event.
     pub fn add_event_with_stream<F>(&mut self, now: Instant, f: F)
     where
         F: FnOnce(&mut QlogStreamer, Instant) -> Result<bool, qlog::Error>,
@@ -295,22 +296,14 @@ mod test {
         // Back at the earlier time, and so must be logged at it.
         log.add_event_at(|| Some(EV_DATA), now);
 
-        // Absolute times depend on the trace's reference time, so compare the two.
+        // Events carry the same data, so if written at the same time they produce identical lines.
         let output = contents.to_string();
-        let times = output
+        let events = output
             .lines()
             .filter(|l| l.contains("spin_bit_updated"))
-            .filter_map(|l| {
-                l.split("\"time\":")
-                    .nth(1)?
-                    .split(',')
-                    .next()?
-                    .parse::<f64>()
-                    .ok()
-            })
             .collect::<Vec<_>>();
-        assert_eq!(times.len(), 2, "expected both events in {output}");
-        assert_eq!(times[0], times[1], "clamped to a non-event in {output}");
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0], events[1]);
     }
 
     #[test]

--- a/neqo-common/src/qlog.rs
+++ b/neqo-common/src/qlog.rs
@@ -6,6 +6,7 @@
 
 use std::{
     cell::RefCell,
+    cmp::max,
     fmt::{self, Display},
     fs::OpenOptions,
     io::BufWriter,
@@ -33,6 +34,10 @@ pub struct Qlog {
 pub struct SharedStreamer {
     qlog_path: PathBuf,
     streamer: QlogStreamer,
+    /// The time of the most recent event written.
+    last: Option<Instant>,
+    /// Hands out [`Qlog::next_datagram_id`].
+    next_datagram_id: u32,
 }
 
 impl Qlog {
@@ -86,6 +91,8 @@ impl Qlog {
             inner: Some(Rc::new(RefCell::new(Some(SharedStreamer {
                 qlog_path,
                 streamer,
+                last: None,
+                next_datagram_id: 0,
             })))),
         })
     }
@@ -102,24 +109,38 @@ impl Qlog {
         self.inner.as_ref().is_some_and(|rc| rc.borrow().is_some())
     }
 
+    /// Make an opaque identifier for a datagram.
+    pub fn next_datagram_id(&mut self) -> u32 {
+        self.inner
+            .as_mut()
+            .and_then(|inner| {
+                inner.borrow_mut().as_mut().map(|shared| {
+                    let id = shared.next_datagram_id;
+                    shared.next_datagram_id = id.wrapping_add(1);
+                    id
+                })
+            })
+            .unwrap_or_default()
+    }
+
     /// If logging enabled, closure may generate an event to be logged.
     pub fn add_event_at<F>(&mut self, f: F, now: Instant)
     where
         F: FnOnce() -> Option<qlog::events::EventData>,
     {
-        self.add_event_with_stream(|s| {
-            if let Some(ev_data) = f() {
-                s.add_event_data_with_instant(ev_data, now)?;
-            }
-            Ok(())
+        self.add_event_with_stream(now, |s, now| {
+            f().map_or(Ok(false), |ev_data| {
+                s.add_event_data_with_instant(ev_data, now).map(|()| true)
+            })
         });
     }
 
     /// If logging enabled, closure is given the Qlog stream to write events and
-    /// frames to.
-    pub fn add_event_with_stream<F>(&mut self, f: F)
+    /// frames to, along with the time to write them at. Reports whether it
+    /// wrote an event.
+    pub fn add_event_with_stream<F>(&mut self, now: Instant, f: F)
     where
-        F: FnOnce(&mut QlogStreamer) -> Result<(), qlog::Error>,
+        F: FnOnce(&mut QlogStreamer, Instant) -> Result<bool, qlog::Error>,
     {
         let Some(inner) = self.inner.as_mut() else {
             return;
@@ -134,9 +155,12 @@ impl Qlog {
             return;
         };
 
-        match f(&mut shared_streamer.streamer) {
+        let now = shared_streamer.last.map_or(now, |last| max(last, now));
+
+        match f(&mut shared_streamer.streamer, now) {
+            Ok(true) => shared_streamer.last = Some(now),
             // `Error::Done` means "event was below the importance threshold" - not an actual error.
-            Ok(()) | Err(qlog::Error::Done) => (),
+            Ok(false) | Err(qlog::Error::Done) => (),
             Err(e) => {
                 log::error!("Qlog event generation failed with error {e}; closing qlog.");
                 // Set the inner Option to None to disable future logging for other references.
@@ -196,6 +220,9 @@ pub fn new_trace(role: Role) -> TraceSeq {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
+    use std::time::Instant;
+
+    use qlog::streamer::QlogStreamer;
     use test_fixture::EXPECTED_LOG_HEADER;
 
     use super::Qlog;
@@ -204,6 +231,11 @@ mod test {
         qlog::events::EventData::SpinBitUpdated(qlog::events::connectivity::SpinBitUpdated {
             state: true,
         });
+
+    /// A write that fails, which closes the qlog.
+    fn write_error(_: &mut QlogStreamer, _: Instant) -> Result<bool, qlog::Error> {
+        Err(qlog::Error::IoError(std::io::Error::other("e")))
+    }
 
     const EXPECTED_LOG_EVENT: &str = concat!(
         "\u{1e}",
@@ -245,10 +277,40 @@ mod test {
         let (mut log, contents) = test_fixture::new_neqo_qlog();
         let mut log_clone = log.clone();
         let before_error = contents.to_string();
-        log.add_event_with_stream(|_| Err(qlog::Error::IoError(std::io::Error::other("e"))));
+        log.add_event_with_stream(test_fixture::now(), write_error);
         // The cloned instance still has inner=Some, but the RefCell contains None.
         log_clone.add_event_at(|| Some(EV_DATA), test_fixture::now());
         assert_eq!(contents.to_string(), before_error);
+    }
+
+    #[test]
+    fn no_event_does_not_advance_the_clamp() {
+        let (mut log, contents) = test_fixture::new_neqo_qlog();
+        let now = test_fixture::now();
+        let later = now + std::time::Duration::from_secs(1);
+
+        log.add_event_at(|| Some(EV_DATA), now);
+        // Offered a later time, but writes nothing, so the clamp stays put.
+        log.add_event_at(|| None, later);
+        // Back at the earlier time, and so must be logged at it.
+        log.add_event_at(|| Some(EV_DATA), now);
+
+        // Absolute times depend on the trace's reference time, so compare the two.
+        let output = contents.to_string();
+        let times = output
+            .lines()
+            .filter(|l| l.contains("spin_bit_updated"))
+            .filter_map(|l| {
+                l.split("\"time\":")
+                    .nth(1)?
+                    .split(',')
+                    .next()?
+                    .parse::<f64>()
+                    .ok()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(times.len(), 2, "expected both events in {output}");
+        assert_eq!(times[0], times[1], "clamped to a non-event in {output}");
     }
 
     #[test]
@@ -261,7 +323,7 @@ mod test {
         // Disabled on a clone whose underlying streamer was killed by a write error.
         let mut log = log;
         let clone = log.clone();
-        log.add_event_with_stream(|_| Err(qlog::Error::IoError(std::io::Error::other("e"))));
+        log.add_event_with_stream(test_fixture::now(), write_error);
         assert!(!clone.is_enabled());
     }
 }

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -48,7 +48,7 @@ use crate::{
     frame::{CloseError, Frame, FrameEncoder as _, FrameType},
     packet::{self},
     path::{Path, PathRef, Paths},
-    qlog,
+    qlog::{self, PacketDroppedTrigger, TransportOwner},
     quic_datagrams::{DATAGRAM_FRAME_TYPE_VARINT_LEN, DatagramTracking, QuicDatagrams},
     recovery::{self, SendProfile, sent},
     recv_stream,
@@ -214,16 +214,17 @@ enum SendOption {
     ),
 }
 
-/// Used by `Connection::preprocess` to determine what to do
-/// with an packet before attempting to remove protection.
+/// What `Connection::preprocess_packet` makes of a packet.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PreprocessResult {
-    /// End processing and return successfully.
-    End,
-    /// Stop processing this datagram and move on to the next.
-    Next,
+    /// A Version Negotiation packet was accepted.
+    VersionNegotiation,
+    /// Drop this packet and the rest of the datagram, logging why.
+    Discard(PacketDroppedTrigger),
+    /// Preprocessing did everything this packet needs.
+    Handled,
     /// Continue and process this packet.
-    Continue,
+    Process,
 }
 
 /// `AddressValidationInfo` holds information relevant to either
@@ -1333,15 +1334,16 @@ impl Connection {
         output
     }
 
-    fn handle_retry(&mut self, packet: &packet::Public, now: Instant) -> Res<()> {
+    /// Returns whether the Retry was accepted.
+    fn handle_retry(&mut self, packet: &packet::Public, now: Instant) -> Res<bool> {
         qinfo!("[{self}] received Retry");
         if matches!(self.address_validation, AddressValidationInfo::Retry { .. }) {
             self.stats.borrow_mut().pkt_dropped("Extra Retry");
-            return Ok(());
+            return Ok(false);
         }
         if packet.token().is_empty() {
             self.stats.borrow_mut().pkt_dropped("Retry without a token");
-            return Ok(());
+            return Ok(false);
         }
         let odcid = self
             .original_destination_cid
@@ -1351,7 +1353,7 @@ impl Connection {
             self.stats
                 .borrow_mut()
                 .pkt_dropped("Retry with bad integrity tag");
-            return Ok(());
+            return Ok(false);
         }
         // RFC 9000, Section 17.2.5.2: a client MUST discard a Retry packet that
         // carries a Source Connection ID identical to the Destination Connection ID
@@ -1361,7 +1363,7 @@ impl Connection {
             self.stats
                 .borrow_mut()
                 .pkt_dropped("Retry with SCID matching our Initial DCID");
-            return Ok(());
+            return Ok(false);
         }
         // At this point, we should only have the connection ID that we generated.
         // Update to the one that the server prefers.
@@ -1369,7 +1371,7 @@ impl Connection {
             self.stats
                 .borrow_mut()
                 .pkt_dropped("Retry without an existing path");
-            return Ok(());
+            return Ok(false);
         };
 
         path.borrow_mut().set_remote_cid(packet.scid());
@@ -1393,7 +1395,7 @@ impl Connection {
             token: packet.token().to_vec(),
             retry_source_cid: retry_scid,
         };
-        Ok(())
+        Ok(true)
     }
 
     fn discard_keys(&mut self, space: PacketNumberSpace, now: Instant) {
@@ -1456,13 +1458,14 @@ impl Connection {
             );
             for saved in self.saved_datagrams.take_saved() {
                 qtrace!("[{self}] input saved @{:?}: {:?}", saved.t, saved.d);
-                self.input(saved.d, saved.t, now);
+                // Reported as received when it arrived, so not again here.
+                self.input_with_id(saved.d, saved.datagram_id, saved.t, now);
             }
         }
     }
 
     /// In case a datagram arrives that we can only partially process, save any
-    /// part that we don't have keys for.
+    /// part that we don't have keys for. A full store means losing it instead.
     #[expect(
         clippy::needless_pass_by_value,
         reason = "To consume an owned datagram below."
@@ -1472,6 +1475,8 @@ impl Connection {
         epoch: Epoch,
         d: Datagram<impl AsRef<[u8]>>,
         remaining: usize,
+        packet_len: usize,
+        datagram_id: u32,
         now: Instant,
     ) {
         let d = Datagram::new(
@@ -1480,11 +1485,26 @@ impl Connection {
             d.tos(),
             d[d.len() - remaining..].to_vec(),
         );
-        self.saved_datagrams.save(epoch, d, now);
-        self.stats.borrow_mut().saved_datagrams += 1;
-        // We already counted the datagram as received in [`input_path`]. We
-        // will do so again when we (re-)process it, so reduce the count now.
-        self.stats.borrow_mut().packets_rx -= 1;
+        if self.saved_datagrams.save(epoch, d, datagram_id, now) {
+            qlog::packet_buffered(&mut self.qlog, datagram_id, packet_len, now);
+            self.stats.borrow_mut().saved_datagrams += 1;
+            // We already counted the datagram as received in [`input_path`]. We
+            // will do so again when we (re-)process it, so reduce the count now.
+            self.stats.borrow_mut().packets_rx -= 1;
+        } else {
+            self.stats.borrow_mut().pkt_dropped("Saved datagrams full");
+            // This packet did parse, so unlike trailing padding it is worth naming,
+            // at the same length the sibling branch would have buffered it at.
+            qlog::packet_dropped(
+                &mut self.qlog,
+                None,
+                packet_len,
+                datagram_id,
+                None,
+                PacketDroppedTrigger::InternalError,
+                now,
+            );
+        }
     }
 
     /// Perform version negotiation.
@@ -1534,6 +1554,13 @@ impl Connection {
         }
     }
 
+    /// Count a packet as dropped and say why, so that the statistics and the qlog
+    /// cannot give different reasons for the same packet.
+    fn discard(&self, reason: impl AsRef<str>, trigger: PacketDroppedTrigger) -> PreprocessResult {
+        self.stats.borrow_mut().pkt_dropped(reason);
+        PreprocessResult::Discard(trigger)
+    }
+
     /// Perform any processing that we might have to do on packets prior to
     /// attempting to remove protection.
     #[expect(clippy::too_many_lines, reason = "Yeah, it's a work in progress.")]
@@ -1545,10 +1572,10 @@ impl Connection {
         now: Instant,
     ) -> Res<PreprocessResult> {
         if dcid.is_some_and(|d| d != &packet.dcid()) {
-            self.stats
-                .borrow_mut()
-                .pkt_dropped("Coalesced packet has different DCID");
-            return Ok(PreprocessResult::Next);
+            return Ok(self.discard(
+                "Coalesced packet has different DCID",
+                PacketDroppedTrigger::ConnectionUnknown,
+            ));
         }
 
         if (packet.packet_type() == packet::Type::Initial
@@ -1559,7 +1586,10 @@ impl Connection {
             // If we have received a packet from a different address than we have sent to
             // we should ignore the packet. In such a case a path will be a newly created
             // temporary path, not the primary path.
-            return Ok(PreprocessResult::Next);
+            return Ok(self.discard(
+                "Received on a non-primary path",
+                PacketDroppedTrigger::ConnectionUnknown,
+            ));
         }
 
         match (packet.packet_type(), &self.state, &self.role) {
@@ -1569,18 +1599,17 @@ impl Connection {
             // is preferred here: the token length sits in the unprotected header, so an
             // off-path injection must not be able to tear down the connection.
             (packet::Type::Initial, _, Role::Client) if !packet.token().is_empty() => {
-                self.stats
-                    .borrow_mut()
-                    .pkt_dropped("Client received an Initial with a token");
-                return Ok(PreprocessResult::Next);
+                return Ok(self.discard(
+                    "Client received an Initial with a token",
+                    PacketDroppedTrigger::Invalid,
+                ));
             }
             (packet::Type::Initial, State::Init, Role::Server) => {
                 let version = packet.version().ok_or(Error::ProtocolViolation)?;
                 if !packet.is_valid_initial()
                     || !self.conn_params.get_versions().all().contains(&version)
                 {
-                    self.stats.borrow_mut().pkt_dropped("Invalid Initial");
-                    return Ok(PreprocessResult::Next);
+                    return Ok(self.discard("Invalid Initial", PacketDroppedTrigger::Invalid));
                 }
                 qinfo!(
                     "[{self}] Received valid Initial packet with scid {:?} dcid {:?}",
@@ -1596,7 +1625,6 @@ impl Connection {
                     self.conn_params.randomize_first_pn_enabled(),
                 )?;
                 self.original_destination_cid = Some(dcid);
-                self.set_state(State::WaitInitial, now);
 
                 // We need to make sure that we set this transport parameter.
                 // This has to happen prior to processing the packet so that
@@ -1607,6 +1635,7 @@ impl Connection {
                         .local_mut()
                         .set_bytes(OriginalDestinationConnectionId, packet.dcid().to_vec());
                 }
+                self.set_state(State::WaitInitial, now);
             }
             (packet::Type::VersionNegotiation, State::WaitInitial, Role::Client) => {
                 if let Ok(versions) = packet.supported_versions() {
@@ -1619,18 +1648,20 @@ impl Connection {
                         // Ignore VersionNegotiation packets that contain the current version.
                         // Or don't have the right connection ID.
                         // Or are received after a Retry.
-                        self.stats.borrow_mut().pkt_dropped("Invalid VN");
-                    } else {
-                        self.version_negotiation(&versions, now)?;
+                        return Ok(self.discard("Invalid VN", PacketDroppedTrigger::Invalid));
                     }
+                    self.version_negotiation(&versions, now)?;
                 } else {
-                    self.stats.borrow_mut().pkt_dropped("VN with no versions");
+                    return Ok(self.discard("VN with no versions", PacketDroppedTrigger::Invalid));
                 }
-                return Ok(PreprocessResult::End);
+                return Ok(PreprocessResult::VersionNegotiation);
             }
             (packet::Type::Retry, State::WaitInitial, Role::Client) => {
-                self.handle_retry(packet, now)?;
-                return Ok(PreprocessResult::Next);
+                return Ok(if self.handle_retry(packet, now)? {
+                    PreprocessResult::Handled
+                } else {
+                    PreprocessResult::Discard(PacketDroppedTrigger::Invalid)
+                });
             }
             (packet::Type::Handshake | packet::Type::Short, State::WaitInitial, Role::Client)
                 // This packet can't be processed now, but it could be a sign
@@ -1651,22 +1682,20 @@ impl Connection {
                 packet::Type::VersionNegotiation | packet::Type::Retry | packet::Type::OtherVersion,
                 ..,
             ) => {
-                self.stats
-                    .borrow_mut()
-                    .pkt_dropped(format!("{:?}", packet.packet_type()));
-                return Ok(PreprocessResult::Next);
+                return Ok(self.discard(
+                    format!("{:?}", packet.packet_type()),
+                    PacketDroppedTrigger::Unsupported,
+                ));
             }
             _ => {}
         }
 
         let res = match self.state {
-            State::Init => {
-                self.stats
-                    .borrow_mut()
-                    .pkt_dropped("Received while in Init state");
-                PreprocessResult::Next
-            }
-            State::WaitInitial => PreprocessResult::Continue,
+            State::Init => self.discard(
+                "Received while in Init state",
+                PacketDroppedTrigger::Unsupported,
+            ),
+            State::WaitInitial => PreprocessResult::Process,
             State::WaitVersion | State::Handshaking | State::Connected | State::Confirmed => {
                 if self.cid_manager.is_valid(packet.dcid()) {
                     if self.role == Role::Server && packet.packet_type() == packet::Type::Handshake
@@ -1674,12 +1703,12 @@ impl Connection {
                         // Server has received a Handshake packet -> discard Initial keys and states
                         self.discard_keys(PacketNumberSpace::Initial, now);
                     }
-                    PreprocessResult::Continue
+                    PreprocessResult::Process
                 } else {
-                    self.stats
-                        .borrow_mut()
-                        .pkt_dropped(format!("Invalid DCID {:?}", packet.dcid()));
-                    PreprocessResult::Next
+                    self.discard(
+                        format!("Invalid DCID {:?}", packet.dcid()),
+                        PacketDroppedTrigger::ConnectionUnknown,
+                    )
                 }
             }
             State::Closing { .. } => {
@@ -1695,14 +1724,16 @@ impl Connection {
                 //
                 // <https://www.rfc-editor.org/rfc/rfc9000.html#section-10.2.1-2>
                 self.state_signaling.send_close();
-                PreprocessResult::Next
+                // The packet is answered but not processed, so its bytes are
+                // discarded; a trace that omitted them could not add up.
+                self.discard("Received while closing", PacketDroppedTrigger::Rejected)
             }
             State::Draining { .. } | State::Closed(..) => {
                 // Do nothing.
-                self.stats
-                    .borrow_mut()
-                    .pkt_dropped(format!("State {:?}", self.state));
-                PreprocessResult::Next
+                self.discard(
+                    format!("State {:?}", self.state),
+                    PacketDroppedTrigger::Unsupported,
+                )
             }
         };
         Ok(res)
@@ -1787,6 +1818,18 @@ impl Connection {
         received: Instant,
         now: Instant,
     ) {
+        let datagram_id = self.qlog.next_datagram_id();
+        qlog::datagram_received(&mut self.qlog, datagram_id, d.len(), now);
+        self.input_with_id(d, datagram_id, received, now);
+    }
+
+    fn input_with_id(
+        &mut self,
+        d: Datagram<impl AsRef<[u8]> + AsMut<[u8]>>,
+        datagram_id: u32,
+        received: Instant,
+        now: Instant,
+    ) {
         // First determine the path.
         let path = self.paths.find_path(
             d.destination(),
@@ -1796,21 +1839,58 @@ impl Connection {
             &mut self.stats.borrow_mut(),
         );
         path.borrow_mut().add_received(d.len());
-        let res = self.input_path(&path, d, received);
+        let res = self.input_path(&path, d, datagram_id, received);
         _ = self.capture_error(Some(path), now, FrameType::Padding, res);
+    }
+
+    /// Report bytes that could not be used; `len` runs to the end of the datagram.
+    ///
+    /// Anything after the first packet is reported as padding. Those bytes were sent
+    /// and received, so they took up bandwidth and have to be accounted for, but
+    /// padding can be any value: there is no telling it from a packet that cannot be
+    /// used, so naming a packet type would be a guess.
+    fn drop_rest_of_datagram(
+        &mut self,
+        packet_type: Option<packet::Type>,
+        len: usize,
+        dgram_len: usize,
+        datagram_id: u32,
+        trigger: PacketDroppedTrigger,
+        now: Instant,
+    ) {
+        let (packet_type, details, trigger) = if len == dgram_len {
+            (packet_type, None, trigger)
+        } else {
+            (
+                None,
+                Some("padding".to_string()),
+                PacketDroppedTrigger::General,
+            )
+        };
+        qlog::packet_dropped(
+            &mut self.qlog,
+            packet_type,
+            len,
+            datagram_id,
+            details,
+            trigger,
+            now,
+        );
     }
 
     fn input_path(
         &mut self,
         path: &PathRef,
         mut d: Datagram<impl AsRef<[u8]> + AsMut<[u8]>>,
+        datagram_id: u32,
         now: Instant,
     ) -> Res<()> {
         qtrace!("[{self}] {} input {}", path.borrow(), Hex::new(&d));
         let tos = d.tos();
         let remote = d.source();
         let mut slc = d.as_mut();
-        self.stats.borrow_mut().bytes_rx += slc.len();
+        let dgram_len = slc.len();
+        self.stats.borrow_mut().bytes_rx += dgram_len;
         let mut dcid = None;
         let pto = path.borrow().rtt().pto(self.confirmed());
 
@@ -1819,23 +1899,44 @@ impl Connection {
             self.stats.borrow_mut().packets_rx += 1;
             self.stats.borrow_mut().dscp_rx[tos.into()] += 1;
             let slc_len = slc.len();
-            let (packet, remainder) =
-                match packet::Public::decode(slc, self.cid_manager.decoder().as_ref()) {
-                    Ok((packet, remainder)) => {
-                        #[cfg(feature = "build-fuzzing-corpus")]
-                        neqo_common::write_item_to_fuzzing_corpus("packet", packet.data());
-                        (packet, remainder)
-                    }
-                    Err(e) => {
-                        qinfo!("[{self}] Garbage packet: {e}");
-                        self.stats.borrow_mut().pkt_dropped("Garbage packet");
-                        break;
-                    }
-                };
+            // Bound here so the `cid_manager` borrow ends before `self` is needed below.
+            let decoded = packet::Public::decode(slc, self.cid_manager.decoder().as_ref());
+            let (packet, remainder) = match decoded {
+                Ok((packet, remainder)) => {
+                    #[cfg(feature = "build-fuzzing-corpus")]
+                    neqo_common::write_item_to_fuzzing_corpus("packet", packet.data());
+                    (packet, remainder)
+                }
+                Err(e) => {
+                    qinfo!("[{self}] Garbage packet: {e}");
+                    self.stats.borrow_mut().pkt_dropped("Garbage packet");
+                    // The header did not parse, so the packet type is unknown.
+                    self.drop_rest_of_datagram(
+                        None,
+                        slc_len,
+                        dgram_len,
+                        datagram_id,
+                        PacketDroppedTrigger::Invalid,
+                        now,
+                    );
+                    break;
+                }
+            };
             match self.preprocess_packet(&packet, path, dcid.as_ref(), now)? {
-                PreprocessResult::Continue => (),
-                PreprocessResult::Next => break,
-                PreprocessResult::End => return Ok(()),
+                PreprocessResult::Process => (),
+                PreprocessResult::Discard(trigger) => {
+                    self.drop_rest_of_datagram(
+                        Some(packet.packet_type()),
+                        slc_len,
+                        dgram_len,
+                        datagram_id,
+                        trigger,
+                        now,
+                    );
+                    break;
+                }
+                PreprocessResult::Handled => break,
+                PreprocessResult::VersionNegotiation => return Ok(()),
             }
 
             qtrace!("[{self}] Received unverified packet {packet:?}");
@@ -1844,48 +1945,17 @@ impl Connection {
             match packet.decrypt(self.crypto.states_mut(), now + pto) {
                 Ok(payload) => {
                     // OK, we have a valid packet.
-                    let pn = payload.pn();
                     self.idle_timeout.on_packet_received(now);
                     self.log_packet(
                         packet::MetaData::new_in(path, tos, packet_len, &payload, self.version),
+                        datagram_id,
                         now,
                     );
 
                     #[cfg(feature = "build-fuzzing-corpus")]
-                    if payload.packet_type() == packet::Type::Initial {
-                        let target = if self.role == Role::Client {
-                            "server_initial"
-                        } else {
-                            "client_initial"
-                        };
-                        neqo_common::write_item_to_fuzzing_corpus(target, &payload[..]);
-                    }
+                    self.save_fuzzing_corpus(&payload);
 
-                    let space = PacketNumberSpace::from(payload.packet_type());
-                    if let Some(space) = self.acks.get_mut(space) {
-                        if space.is_duplicate(pn) {
-                            qdebug!("Duplicate packet {space}-{pn}");
-                            self.stats.borrow_mut().dups_rx += 1;
-                        } else {
-                            match self.process_packet(path, &payload, now) {
-                                Ok(migrate) => {
-                                    self.postprocess_packet(
-                                        path, tos, remote, &payload, pn, migrate, now,
-                                    );
-                                }
-                                Err(e) => {
-                                    self.ensure_error_path(path, &payload, now);
-                                    return Err(e);
-                                }
-                            }
-                        }
-                    } else {
-                        qdebug!(
-                            "[{self}] Received packet {space} for untracked space {}",
-                            payload.pn()
-                        );
-                        return Err(Error::ProtocolViolation);
-                    }
+                    self.process_decrypted(path, tos, remote, &payload, now)?;
                     dcid = Some(ConnectionId::from(payload.dcid()));
                 }
                 Err(e) => {
@@ -1893,8 +1963,7 @@ impl Connection {
                         Error::KeysPending(epoch) => {
                             // This packet can't be decrypted because we don't have the keys yet.
                             // Don't check this packet for a stateless reset, just return.
-                            let remaining = slc_len;
-                            self.save_datagram(epoch, d, remaining, now);
+                            self.save_datagram(epoch, d, slc_len, packet_len, datagram_id, now);
                             return Ok(());
                         }
                         // Exhausting read keys is fatal. So is a packet that
@@ -1911,7 +1980,15 @@ impl Connection {
                     // the rest of the datagram on the floor, but don't generate an error.
                     self.check_stateless_reset(path, e.data, dcid.is_none(), now)?;
                     self.stats.borrow_mut().pkt_dropped("Decryption failure");
-                    qlog::packet_dropped(&mut self.qlog, &e, now);
+                    qlog::packet_dropped(
+                        &mut self.qlog,
+                        Some(e.packet_type()),
+                        e.len(),
+                        datagram_id,
+                        Some(e.error.to_string()),
+                        PacketDroppedTrigger::DecryptionFailure,
+                        now,
+                    );
                     dcid = Some(e.dcid);
                 }
             }
@@ -1919,6 +1996,19 @@ impl Connection {
         }
         self.check_stateless_reset(path, &d, dcid.is_none(), now)?;
         Ok(())
+    }
+
+    /// Keep the peer's Initial packets for fuzzing to work from.
+    #[cfg(feature = "build-fuzzing-corpus")]
+    fn save_fuzzing_corpus(&self, payload: &packet::Decrypted) {
+        if payload.packet_type() == packet::Type::Initial {
+            let target = if self.role == Role::Client {
+                "server_initial"
+            } else {
+                "client_initial"
+            };
+            neqo_common::write_item_to_fuzzing_corpus(target, &payload[..]);
+        }
     }
 
     /// Handle receiving a packet for which keys have been discarded.
@@ -1932,6 +2022,38 @@ impl Connection {
         if self.role == Role::Server && epoch == Epoch::Handshake && self.state == State::Confirmed
         {
             self.state_signaling.handshake_done();
+        }
+    }
+
+    /// Process a packet that authenticated, unless it is a duplicate.
+    fn process_decrypted(
+        &mut self,
+        path: &PathRef,
+        tos: Tos,
+        remote: SocketAddr,
+        payload: &packet::Decrypted,
+        now: Instant,
+    ) -> Res<()> {
+        let pn = payload.pn();
+        let space = PacketNumberSpace::from(payload.packet_type());
+        let Some(space) = self.acks.get_mut(space) else {
+            qdebug!("[{self}] Received packet {space} for untracked space {pn}");
+            return Err(Error::ProtocolViolation);
+        };
+        if space.is_duplicate(pn) {
+            qdebug!("Duplicate packet {space}-{pn}");
+            self.stats.borrow_mut().dups_rx += 1;
+            return Ok(());
+        }
+        match self.process_packet(path, payload, now) {
+            Ok(migrate) => {
+                self.postprocess_packet(path, tos, remote, payload, pn, migrate, now);
+                Ok(())
+            }
+            Err(e) => {
+                self.ensure_error_path(path, payload, now);
+                Err(e)
+            }
         }
     }
 
@@ -2762,6 +2884,7 @@ impl Connection {
         let mut needs_padding = false;
         let grease_quic_bit = self.can_grease_quic_bit();
         let version = self.version();
+        let datagram_id = self.qlog.next_datagram_id();
 
         // Determine how we are sending packets (PTO, etc..).
         let profile = self.loss_recovery.send_profile(&path.borrow(), now);
@@ -2776,6 +2899,7 @@ impl Connection {
                 continue;
             };
             let aead_expansion = tx.expansion();
+            let crypto_pad = tx.extra_padding();
 
             let header_start = encoder.len();
 
@@ -2847,11 +2971,12 @@ impl Connection {
                     path,
                     pt,
                     pn,
-                    builder.len() + aead_expansion,
+                    builder.lengths(crypto_pad, aead_expansion),
                     &builder.as_ref()[payload_start..],
                     packet_tos,
                     self.version,
                 ),
+                datagram_id,
                 now,
             );
 
@@ -2932,7 +3057,8 @@ impl Connection {
                 }
                 self.loss_recovery.on_packet_sent(path, initial, now);
             }
-            path.borrow_mut().add_sent(encoder.len());
+            path.borrow_mut().add_sent(encoder.len()); // Only now is the size of the datagram final.
+            qlog::datagram_sent(&mut self.qlog, datagram_id, encoder.len(), now);
             Ok(SendOption::Yes)
         }
     }
@@ -3121,7 +3247,12 @@ impl Connection {
             self.cid_manager.set_limit(max_active_cids);
         }
         self.set_initial_limits();
-        qlog::connection_tparams_set(&mut self.qlog, &self.tps.borrow(), now);
+        qlog::tparams_set(
+            &mut self.qlog,
+            &self.tps.borrow(),
+            TransportOwner::Remote,
+            now,
+        );
         Ok(())
     }
 
@@ -3768,6 +3899,14 @@ impl Connection {
         if state > self.state {
             qdebug!("[{self}] State change from {:?} -> {state:?}", self.state);
             let old_state = self.state.clone();
+            if old_state == State::Init {
+                qlog::tparams_set(
+                    &mut self.qlog,
+                    &self.tps.borrow(),
+                    TransportOwner::Local,
+                    now,
+                );
+            }
             self.state = state.clone();
             if self.state.closed() {
                 self.streams.clear_streams();
@@ -4111,7 +4250,7 @@ impl Connection {
         self.paths.primary().unwrap().borrow().plpmtu()
     }
 
-    fn log_packet(&mut self, meta: packet::MetaData, now: Instant) {
+    fn log_packet(&mut self, meta: packet::MetaData, datagram_id: u32, now: Instant) {
         if log::log_enabled!(log::Level::Debug) {
             let mut s = String::new();
             let mut d = Decoder::from(meta.payload());
@@ -4128,7 +4267,7 @@ impl Connection {
             qdebug!("[{self}] {meta}{s}");
         }
 
-        qlog::packet_io(&mut self.qlog, meta, now);
+        qlog::packet_io(&mut self.qlog, meta, datagram_id, now);
     }
 }
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -46,7 +46,7 @@ use crate::{
     ecn,
     events::{ConnectionEvent, ConnectionEvents, OutgoingDatagramOutcome},
     frame::{CloseError, Frame, FrameEncoder as _, FrameType},
-    packet::{self},
+    packet::{self, metadata::Direction},
     path::{Path, PathRef, Paths},
     qlog::{self, PacketDroppedTrigger, TransportOwner},
     quic_datagrams::{DATAGRAM_FRAME_TYPE_VARINT_LEN, DatagramTracking, QuicDatagrams},
@@ -1493,8 +1493,6 @@ impl Connection {
             self.stats.borrow_mut().packets_rx -= 1;
         } else {
             self.stats.borrow_mut().pkt_dropped("Saved datagrams full");
-            // This packet did parse, so unlike trailing padding it is worth naming,
-            // at the same length the sibling branch would have buffered it at.
             qlog::packet_dropped(
                 &mut self.qlog,
                 None,
@@ -1554,8 +1552,7 @@ impl Connection {
         }
     }
 
-    /// Count a packet as dropped and say why, so that the statistics and the qlog
-    /// cannot give different reasons for the same packet.
+    /// Count a packet as dropped and say why.
     fn discard(&self, reason: impl AsRef<str>, trigger: PacketDroppedTrigger) -> PreprocessResult {
         self.stats.borrow_mut().pkt_dropped(reason);
         PreprocessResult::Discard(trigger)
@@ -1724,8 +1721,6 @@ impl Connection {
                 //
                 // <https://www.rfc-editor.org/rfc/rfc9000.html#section-10.2.1-2>
                 self.state_signaling.send_close();
-                // The packet is answered but not processed, so its bytes are
-                // discarded; a trace that omitted them could not add up.
                 self.discard("Received while closing", PacketDroppedTrigger::Rejected)
             }
             State::Draining { .. } | State::Closed(..) => {
@@ -1819,7 +1814,13 @@ impl Connection {
         now: Instant,
     ) {
         let datagram_id = self.qlog.next_datagram_id();
-        qlog::datagram_received(&mut self.qlog, datagram_id, d.len(), now);
+        qlog::datagram_io(
+            &mut self.qlog,
+            Direction::Rx,
+            datagram_id,
+            d.len(),
+            received,
+        );
         self.input_with_id(d, datagram_id, received, now);
     }
 
@@ -1843,39 +1844,43 @@ impl Connection {
         _ = self.capture_error(Some(path), now, FrameType::Padding, res);
     }
 
-    /// Report bytes that could not be used; `len` runs to the end of the datagram.
-    ///
-    /// Anything after the first packet is reported as padding. Those bytes were sent
-    /// and received, so they took up bandwidth and have to be accounted for, but
-    /// padding can be any value: there is no telling it from a packet that cannot be
-    /// used, so naming a packet type would be a guess.
-    fn drop_rest_of_datagram(
+    /// Report bytes that could not be used.
+    fn drop_unusable(
         &mut self,
-        packet_type: Option<packet::Type>,
+        packet: Option<&packet::Public>,
         len: usize,
-        dgram_len: usize,
+        first: bool,
         datagram_id: u32,
         trigger: PacketDroppedTrigger,
         now: Instant,
     ) {
-        let (packet_type, details, trigger) = if len == dgram_len {
-            (packet_type, None, trigger)
+        let (packet_type, packet_len) = if first {
+            packet.map_or((None, len), |p| (Some(p.packet_type()), p.len()))
         } else {
+            (None, 0)
+        };
+        for (packet_type, len, details, trigger) in [
+            (packet_type, packet_len, None, trigger),
             (
                 None,
-                Some("padding".to_string()),
+                len - packet_len,
+                Some("padding"),
                 PacketDroppedTrigger::General,
-            )
-        };
-        qlog::packet_dropped(
-            &mut self.qlog,
-            packet_type,
-            len,
-            datagram_id,
-            details,
-            trigger,
-            now,
-        );
+            ),
+        ] {
+            if len > 0 {
+                let details = details.map(ToOwned::to_owned);
+                qlog::packet_dropped(
+                    &mut self.qlog,
+                    packet_type,
+                    len,
+                    datagram_id,
+                    details,
+                    trigger,
+                    now,
+                );
+            }
+        }
     }
 
     fn input_path(
@@ -1899,7 +1904,7 @@ impl Connection {
             self.stats.borrow_mut().packets_rx += 1;
             self.stats.borrow_mut().dscp_rx[tos.into()] += 1;
             let slc_len = slc.len();
-            // Bound here so the `cid_manager` borrow ends before `self` is needed below.
+            let first = slc_len == dgram_len;
             let decoded = packet::Public::decode(slc, self.cid_manager.decoder().as_ref());
             let (packet, remainder) = match decoded {
                 Ok((packet, remainder)) => {
@@ -1910,29 +1915,15 @@ impl Connection {
                 Err(e) => {
                     qinfo!("[{self}] Garbage packet: {e}");
                     self.stats.borrow_mut().pkt_dropped("Garbage packet");
-                    // The header did not parse, so the packet type is unknown.
-                    self.drop_rest_of_datagram(
-                        None,
-                        slc_len,
-                        dgram_len,
-                        datagram_id,
-                        PacketDroppedTrigger::Invalid,
-                        now,
-                    );
+                    let trigger = PacketDroppedTrigger::Invalid;
+                    self.drop_unusable(None, slc_len, first, datagram_id, trigger, now);
                     break;
                 }
             };
             match self.preprocess_packet(&packet, path, dcid.as_ref(), now)? {
                 PreprocessResult::Process => (),
                 PreprocessResult::Discard(trigger) => {
-                    self.drop_rest_of_datagram(
-                        Some(packet.packet_type()),
-                        slc_len,
-                        dgram_len,
-                        datagram_id,
-                        trigger,
-                        now,
-                    );
+                    self.drop_unusable(Some(&packet), slc_len, first, datagram_id, trigger, now);
                     break;
                 }
                 PreprocessResult::Handled => break,
@@ -2025,7 +2016,7 @@ impl Connection {
         }
     }
 
-    /// Process a packet that authenticated, unless it is a duplicate.
+    /// Process a packet that decrypted, unless it is a duplicate.
     fn process_decrypted(
         &mut self,
         path: &PathRef,
@@ -2899,7 +2890,6 @@ impl Connection {
                 continue;
             };
             let aead_expansion = tx.expansion();
-            let crypto_pad = tx.extra_padding();
 
             let header_start = encoder.len();
 
@@ -2966,12 +2956,21 @@ impl Connection {
                 tokens.push(recovery::Token::EcnEct0);
             }
 
+            // Scoped, because logging needs `self` again below.
+            let lengths = {
+                let tx = self
+                    .crypto
+                    .states_mut()
+                    .tx_mut(self.version, epoch)
+                    .ok_or(Error::Internal)?;
+                builder.lengths(tx)
+            };
             self.log_packet(
                 packet::MetaData::new_out(
                     path,
                     pt,
                     pn,
-                    builder.lengths(crypto_pad, aead_expansion),
+                    lengths,
                     &builder.as_ref()[payload_start..],
                     packet_tos,
                     self.version,
@@ -3058,7 +3057,13 @@ impl Connection {
                 self.loss_recovery.on_packet_sent(path, initial, now);
             }
             path.borrow_mut().add_sent(encoder.len()); // Only now is the size of the datagram final.
-            qlog::datagram_sent(&mut self.qlog, datagram_id, encoder.len(), now);
+            qlog::datagram_io(
+                &mut self.qlog,
+                Direction::Tx,
+                datagram_id,
+                encoder.len(),
+                now,
+            );
             Ok(SendOption::Yes)
         }
     }
@@ -3121,7 +3126,7 @@ impl Connection {
         qdebug!("[{self}] client_start");
         debug_assert_eq!(self.role, Role::Client);
         if let Some(path) = self.paths.primary() {
-            qlog::client_connection_started(&mut self.qlog, &path, now);
+            qlog::connection_started(&mut self.qlog, &path, now);
             qlog::recovery_parameters_set(
                 &mut self.qlog,
                 path.borrow().plpmtu(),
@@ -3848,7 +3853,7 @@ impl Connection {
             let path = self.paths.primary().ok_or(Error::NoAvailablePath)?;
             path.borrow_mut().set_valid(now);
             // Generate a qlog event that the server connection started.
-            qlog::server_connection_started(&mut self.qlog, &path, now);
+            qlog::connection_started(&mut self.qlog, &path, now);
             qlog::recovery_parameters_set(
                 &mut self.qlog,
                 path.borrow().plpmtu(),

--- a/neqo-transport/src/connection/tests/mod.rs
+++ b/neqo-transport/src/connection/tests/mod.rs
@@ -48,6 +48,7 @@ mod migration;
 mod null;
 mod pmtud;
 mod priority;
+mod qlog;
 mod recovery;
 mod reset_stream_at;
 mod resumption;
@@ -142,8 +143,12 @@ fn zero_len_cid_client(local_addr: SocketAddr, remote_addr: SocketAddr) -> Conne
 }
 
 pub fn new_server(params: ConnectionParameters) -> Connection {
+    new_server_with_qlog(params).0
+}
+
+fn new_server_with_qlog(params: ConnectionParameters) -> (Connection, test_fixture::SharedVec) {
     fixture_init();
-    let (log, _contents) = new_neqo_qlog();
+    let (log, contents) = new_neqo_qlog();
     let mut c = Connection::new_server(
         test_fixture::DEFAULT_KEYS,
         test_fixture::DEFAULT_ALPN,
@@ -154,7 +159,7 @@ pub fn new_server(params: ConnectionParameters) -> Connection {
     c.set_qlog(log);
     c.server_enable_0rtt(&test_fixture::anti_replay(), AllowZeroRtt {})
         .expect("enable 0-RTT");
-    c
+    (c, contents)
 }
 pub fn default_server() -> Connection {
     new_server(ConnectionParameters::default())

--- a/neqo-transport/src/connection/tests/qlog.rs
+++ b/neqo-transport/src/connection/tests/qlog.rs
@@ -9,10 +9,7 @@
 //! reports its own size, that everything received is accounted for, and that
 //! events do not go backwards in time.
 
-use std::{
-    collections::HashMap,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use neqo_common::{Datagram, Decoder};
 use test_fixture::{datagram, now, strip_padding};
@@ -85,10 +82,7 @@ fn datagrams_sent_reports_the_padded_size() {
     let packet = named(&trace, "transport:packet_sent")
         .next()
         .expect("a packet_sent event");
-    assert!(
-        raw_length(packet).unwrap() < len as u64,
-        "expected the Initial to be padded out, trace: {trace}"
-    );
+    assert!(raw_length(packet).unwrap() < len as u64);
 }
 
 #[test]
@@ -99,11 +93,12 @@ fn coalesced_packet_lengths_agree_with_the_peer() {
     drop((client, server));
 
     let (sent, received) = (client_log.to_string(), server_log.to_string());
+    // Both lengths, so that `payload_length` is held to the same standard.
     let key = |l: &str| {
         Some((
             field(l, "\"packet_type\":")?.to_owned(),
             number(l, "\"packet_number\":")?,
-            raw_length(l)?,
+            (raw_length(l)?, number(l, "\"payload_length\":")?),
         ))
     };
     let tx = named(&sent, "transport:packet_sent")
@@ -112,16 +107,13 @@ fn coalesced_packet_lengths_agree_with_the_peer() {
     let rx = named(&received, "transport:packet_received")
         .filter_map(key)
         .collect::<Vec<_>>();
-    assert!(
-        tx.len() > 1 && !rx.is_empty(),
-        "sent {tx:?} received {rx:?}"
-    );
+    assert!(tx.len() > 1 && !rx.is_empty());
 
     // Every packet the server decoded has to match what the client said it sent.
     let mut compared = 0;
-    for (packet_type, pn, len) in &rx {
-        if let Some((_, _, sent_len)) = tx.iter().find(|(t, n, _)| t == packet_type && n == pn) {
-            assert_eq!(sent_len, len);
+    for (packet_type, pn, lengths) in &rx {
+        if let Some((_, _, sent)) = tx.iter().find(|(t, n, _)| t == packet_type && n == pn) {
+            assert_eq!(sent, lengths);
             compared += 1;
         }
     }
@@ -130,28 +122,39 @@ fn coalesced_packet_lengths_agree_with_the_peer() {
 
 #[test]
 fn packets_name_their_datagram() {
-    let (mut client, contents) = new_client_with_qlog(ConnectionParameters::default());
-    let mut server = default_server();
+    let (mut client, client_log) = new_client_with_qlog(ConnectionParameters::default());
+    let (mut server, server_log) = new_server_with_qlog(ConnectionParameters::default());
     connect(&mut client, &mut server);
-    drop(client);
+    drop((client, server));
 
-    let trace = contents.to_string();
-    let datagrams = named(&trace, "transport:datagrams_sent")
-        .filter_map(|l| number(l, "\"datagram_ids\":["))
-        .collect::<Vec<_>>();
-    assert!(!datagrams.is_empty(), "no datagrams_sent in {trace}");
+    // Both directions, because each side decides the `datagram_id` for what it logs.
+    names_its_datagram(
+        &client_log.to_string(),
+        "transport:datagrams_sent",
+        "transport:packet_sent",
+    );
+    names_its_datagram(
+        &server_log.to_string(),
+        "transport:datagrams_received",
+        "transport:packet_received",
+    );
+}
 
-    let mut per_datagram: HashMap<u64, usize> = HashMap::new();
-    for packet in named(&trace, "transport:packet_sent") {
+/// Every packet names a datagram that was itself reported, and some datagram carried
+/// more than one packet, so that coalescing is recoverable from the trace.
+fn names_its_datagram(trace: &str, datagrams: &str, packets: &str) {
+    let reported =
+        |id| named(trace, datagrams).any(|d| number(d, "\"datagram_ids\":[") == Some(id));
+    let mut coalesced = false;
+    let mut last = None;
+    for packet in named(trace, packets) {
         let id = number(packet, "\"datagram_id\":").expect("a datagram_id");
-        assert!(
-            datagrams.contains(&id),
-            "packet in unreported datagram {id}: {packet}"
-        );
-        *per_datagram.entry(id).or_default() += 1;
+        assert!(reported(id), "packet in unreported datagram {id}: {packet}");
+        // Packets of one datagram are logged together, so a repeat means coalescing.
+        coalesced |= last == Some(id);
+        last = Some(id);
     }
-    let shared = per_datagram.values().filter(|n| **n > 1).count();
-    assert!(shared > 0, "expected coalescing during the handshake");
+    assert!(coalesced, "expected a coalesced datagram in {trace}");
 }
 
 const RTT: Duration = Duration::from_millis(100);
@@ -235,13 +238,10 @@ fn dropping_a_datagram_is_reported() {
     let trace = contents.to_string();
     let buffered = named(&trace, "transport:packet_buffered").count();
     assert_eq!(buffered, SavedDatagrams::CAPACITY, "trace: {trace}");
-
-    let dropped = named(&trace, "transport:packet_dropped")
-        .filter_map(raw_length)
-        .collect::<Vec<_>>();
     assert!(
-        dropped.contains(&(last as u64)),
-        "expected a dropped datagram of {last} bytes, got {dropped:?}, trace: {trace}"
+        named(&trace, "transport:packet_dropped")
+            .filter_map(raw_length)
+            .any(|len| len == last as u64)
     );
 }
 
@@ -253,11 +253,10 @@ fn transport_parameters_are_logged_for_both_peers() {
     drop(client);
 
     let trace = contents.to_string();
-    let peers = named(&trace, "transport:parameters_set")
-        .filter_map(|l| field(l, "\"owner\":").map(ToOwned::to_owned))
-        .collect::<Vec<_>>();
-    assert!(peers.contains(&"local".to_owned()), "trace: {trace}");
-    assert!(peers.contains(&"remote".to_owned()), "trace: {trace}");
+    let owner =
+        |o| named(&trace, "transport:parameters_set").any(|l| field(l, "\"owner\":") == Some(o));
+    assert!(owner("local"), "trace: {trace}");
+    assert!(owner("remote"), "trace: {trace}");
 }
 
 #[test]
@@ -271,10 +270,7 @@ fn server_logs_its_original_destination_connection_id() {
     let local = named(&trace, "transport:parameters_set")
         .find(|l| field(l, "\"owner\":") == Some("local"))
         .expect("the server's own parameters");
-    assert!(
-        field(local, "\"original_destination_connection_id\":").is_some_and(|v| !v.is_empty()),
-        "trace: {trace}"
-    );
+    assert!(field(local, "\"original_destination_connection_id\":").is_some_and(|v| !v.is_empty()));
 }
 
 #[test]
@@ -291,10 +287,10 @@ fn stateless_reset_token_is_not_logged() {
     drop(client);
 
     let trace = contents.to_string();
-    let logged = named(&trace, "transport:parameters_set")
-        .filter_map(|l| field(l, "\"stateless_reset_token\":"))
-        .collect::<Vec<_>>();
-    assert_eq!(logged, vec![""], "trace: {trace}");
+    let mut logged = named(&trace, "transport:parameters_set")
+        .filter_map(|l| field(l, "\"stateless_reset_token\":"));
+    assert_eq!(logged.next(), Some(""), "trace: {trace}");
+    assert_eq!(logged.next(), None, "trace: {trace}");
 }
 
 /// The DCID and SCID of the client's first Initial, to address a packet back at it.
@@ -327,11 +323,7 @@ fn an_accepted_retry_is_not_reported_as_dropped() {
     drop(client);
 
     let trace = contents.to_string();
-    assert_eq!(
-        named(&trace, "transport:packet_dropped").count(),
-        0,
-        "trace: {trace}"
-    );
+    assert_eq!(named(&trace, "transport:packet_dropped").count(), 0);
 }
 
 #[cfg(not(feature = "disable-encryption"))]
@@ -354,9 +346,13 @@ fn rejected_retry_is_reported_as_dropped() {
     drop(client);
 
     let trace = contents.to_string();
-    let dropped = named(&trace, "transport:packet_dropped").collect::<Vec<_>>();
-    assert_eq!(dropped.len(), 1, "trace: {trace}");
-    assert_eq!(raw_length(dropped[0]), Some(len as u64), "trace: {trace}");
+    let mut dropped = named(&trace, "transport:packet_dropped");
+    assert_eq!(
+        dropped.next().and_then(raw_length),
+        Some(len as u64),
+        "{trace}"
+    );
+    assert_eq!(dropped.next(), None, "trace: {trace}");
 }
 
 #[test]
@@ -382,32 +378,6 @@ fn received_datagram_is_reported_once() {
 }
 
 #[test]
-fn received_packets_name_their_datagram() {
-    let mut client = default_client();
-    let (mut server, contents) = new_server_with_qlog(ConnectionParameters::default());
-    connect(&mut client, &mut server);
-    drop((client, server));
-
-    let trace = contents.to_string();
-    let datagrams = named(&trace, "transport:datagrams_received")
-        .filter_map(|l| number(l, "\"datagram_ids\":["))
-        .collect::<Vec<_>>();
-    assert!(!datagrams.is_empty(), "no datagrams_received in {trace}");
-
-    let mut per_datagram: HashMap<u64, usize> = HashMap::new();
-    for packet in named(&trace, "transport:packet_received") {
-        let id = number(packet, "\"datagram_id\":").expect("a datagram_id");
-        assert!(
-            datagrams.contains(&id),
-            "packet in unreported datagram {id}: {packet}"
-        );
-        *per_datagram.entry(id).or_default() += 1;
-    }
-    let shared = per_datagram.values().filter(|n| **n > 1).count();
-    assert!(shared > 0, "expected a coalesced datagram in {trace}");
-}
-
-#[test]
 fn replayed_datagrams_are_not_counted_twice() {
     let mut client = default_client();
     let (mut server, contents) = new_server_with_qlog(ConnectionParameters::default());
@@ -426,12 +396,7 @@ fn replayed_datagrams_are_not_counted_twice() {
 
     let trace = contents.to_string();
     let received = named(&trace, "transport:datagrams_received").count();
-    assert_eq!(
-        received - before,
-        1,
-        "replay reported {} extra datagrams, trace: {trace}",
-        received - before - 1
-    );
+    assert_eq!(received - before, 1);
 
     // Every datagram set aside is one that was reported as received.
     let ids = named(&trace, "transport:datagrams_received")
@@ -468,81 +433,52 @@ fn rejected_version_negotiation_is_reported() {
     assert_eq!(dropped.len(), 1, "trace: {trace}");
     // Reported against the datagram it arrived in, at the size that arrived.
     assert_eq!(raw_length(dropped[0]), Some(len as u64), "trace: {trace}");
-    assert!(
-        number(dropped[0], "\"datagram_id\":").is_some(),
-        "trace: {trace}"
-    );
+    assert!(number(dropped[0], "\"datagram_id\":").is_some());
 }
 
-/// The sum of a trace's `raw` lengths, for the events named.
-fn total(trace: &str, name: &str) -> u64 {
-    named(trace, name).filter_map(raw_length).sum()
-}
-
-/// Every byte that arrives is accounted for, exactly once, by a packet event:
-/// received, dropped, or set aside. This is what the datagram events are for, so it
-/// is checked on both roles and across a close, where packets keep arriving but stop
-/// being processed.
 #[test]
 fn every_received_byte_is_accounted_for() {
     let (mut client, client_log) = new_client_with_qlog(ConnectionParameters::default());
     let (mut server, server_log) = new_server_with_qlog(ConnectionParameters::default());
-    connect(&mut client, &mut server);
+    let mut t = now();
+    let last = handshake_but_for_the_last_flight(&mut client, &mut server, &mut t);
+    // Buffered by the server, and replayed when the flight below supplies the keys.
+    fill_saved_datagrams(&mut client, &mut server, t);
+    t += RTT;
+    _ = server.process(Some(last), t).dgram();
+    assert_eq!(*server.state(), State::Confirmed);
 
-    let d = send_something(&mut client, now());
-    server.process_input(d, now());
     // Held back, so that it reaches the client only once it is closing.
-    let late = send_something(&mut server, now());
-
-    client.close(now(), 0, "done");
+    let late = send_something(&mut server, t);
+    client.close(t, 0, "done");
     assert!(matches!(client.state(), State::Closing { .. }));
-    client.process_input(late, now());
+    client.process_input(late, t);
     drop((client, server));
 
-    for (role, trace) in [
-        ("client", client_log.to_string()),
-        ("server", server_log.to_string()),
-    ] {
-        let arrived = named(&trace, "transport:datagrams_received")
-            .filter_map(raw_list_length)
-            .sum::<u64>();
-        let accounted = total(&trace, "transport:packet_received")
-            + total(&trace, "transport:packet_dropped")
-            + total(&trace, "transport:packet_buffered");
-        let mut per: HashMap<u64, (u64, u64)> = HashMap::new();
-        for e in named(&trace, "transport:datagrams_received") {
-            if let (Some(id), Some(len)) = (number(e, "\"datagram_ids\":["), raw_list_length(e)) {
-                per.entry(id).or_default().0 += len;
-            }
-        }
-        for n in [
-            "transport:packet_received",
-            "transport:packet_dropped",
-            "transport:packet_buffered",
-        ] {
-            for e in named(&trace, n) {
-                if let (Some(id), Some(len)) = (number(e, "\"datagram_id\":"), raw_length(e)) {
-                    per.entry(id).or_default().1 += len;
-                }
-            }
-        }
-        let off = per
-            .iter()
-            .filter(|(_, (a, b))| a != b)
-            .map(|(id, (a, b))| (*id, *a, *b))
-            .collect::<Vec<_>>();
-        assert!(
-            off.is_empty(),
-            "{role}: (datagram, arrived, accounted) {off:?}"
-        );
-        assert_eq!(arrived, accounted, "{role}");
-        assert!(arrived > 0, "{role} received nothing");
-    }
+    let server_trace = server_log.to_string();
+    assert!(named(&server_trace, "transport:packet_buffered").count() > 0);
+    accounts_for_every_byte(&client_log.to_string());
+    accounts_for_every_byte(&server_trace);
 }
 
-/// Trailing bytes that cannot be used are reported as padding: they were sent and
-/// received, so they took up bandwidth, but there is no telling padding from a packet
-/// we cannot use, so no packet type is claimed for them.
+/// Every byte that arrived in a datagram is accounted for by that datagram's packet
+/// events, and none is counted twice.
+fn accounts_for_every_byte(trace: &str) {
+    let mut datagrams = 0;
+    for d in named(trace, "transport:datagrams_received") {
+        let id = number(d, "\"datagram_ids\":[").expect("a datagram_id");
+        let accounted = ["transport:packet_received", "transport:packet_dropped"]
+            .into_iter()
+            .flat_map(|name| named(trace, name))
+            .filter(|p| number(p, "\"datagram_id\":") == Some(id))
+            .filter_map(raw_length)
+            .sum::<u64>();
+        assert_eq!(raw_list_length(d), Some(accounted), "datagram {id}: {d}");
+        datagrams += 1;
+    }
+    assert!(datagrams > 0, "nothing arrived in {trace}");
+}
+
 #[test]
 fn trailing_bytes_are_reported_as_padding() {
     let mut client = default_client();
@@ -554,18 +490,14 @@ fn trailing_bytes_are_reported_as_padding() {
     drop(server);
 
     let trace = contents.to_string();
-    let initial = named(&trace, "transport:packet_received")
+    let padding = named(&trace, "transport:packet_dropped")
         .next()
-        .expect("the Initial");
-    let dropped = named(&trace, "transport:packet_dropped").collect::<Vec<_>>();
-    assert_eq!(dropped.len(), 1, "trace: {trace}");
+        .expect("the padding");
     // Named as padding, with no packet type invented for it.
-    assert_eq!(field(dropped[0], "\"details\":"), Some("padding"));
-    assert_eq!(field(dropped[0], "\"packet_type\":"), None);
-    // And it covers exactly the bytes the Initial did not.
-    assert_eq!(
-        raw_length(initial).unwrap() + raw_length(dropped[0]).unwrap(),
-        len as u64,
-        "trace: {trace}"
-    );
+    assert_eq!(field(padding, "\"details\":"), Some("padding"));
+    assert_eq!(field(padding, "\"packet_type\":"), None);
+    // This is the case the accounting rests on, so hold it to the sum as well: the
+    // handshake tests strip padding, so nothing else covers it.
+    assert!(raw_length(padding).unwrap() < len as u64);
+    accounts_for_every_byte(&trace);
 }

--- a/neqo-transport/src/connection/tests/qlog.rs
+++ b/neqo-transport/src/connection/tests/qlog.rs
@@ -1,0 +1,571 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Tests for what a trace says, as opposed to what the connection does. These
+//! check the things a reader of a trace has to be able to rely on: that a packet
+//! reports its own size, that everything received is accounted for, and that
+//! events do not go backwards in time.
+
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+use neqo_common::{Datagram, Decoder};
+use test_fixture::{datagram, now, strip_padding};
+
+use super::{
+    super::State, Connection, ConnectionParameters, connect, default_client, default_server,
+    maybe_authenticate, new_client_with_qlog, new_server_with_qlog, send_something,
+};
+use crate::{
+    saved::SavedDatagrams,
+    stateless_reset::Token as Srt,
+    tparams::{TransportParameter, TransportParameterId::StatelessResetToken},
+    version::Version,
+};
+
+/// The lines of a JSON-SEQ trace that are events, i.e. everything but the header.
+fn events(trace: &str) -> impl Iterator<Item = &str> {
+    trace
+        .lines()
+        .map(|l| l.trim_start_matches('\u{1e}'))
+        .filter(|l| l.contains("\"name\":"))
+}
+
+fn named<'a>(trace: &'a str, name: &'a str) -> impl Iterator<Item = &'a str> {
+    events(trace).filter(move |l| l.contains(&format!("\"name\":\"{name}\"")))
+}
+
+/// The value that follows `key`, up to the next `,`, `}` or `]`. Enough of a
+/// parser for these traces, and avoids pulling in a JSON dependency.
+fn field<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    let rest = &line[line.find(key)? + key.len()..];
+    let end = rest.find([',', '}', ']']).unwrap_or(rest.len());
+    Some(rest[..end].trim_matches('"'))
+}
+
+fn number(line: &str, key: &str) -> Option<u64> {
+    field(line, key)?.parse().ok()
+}
+
+/// The `raw` length of a packet event, anchored on the enclosing object.
+fn raw_length(line: &str) -> Option<u64> {
+    number(line, "\"raw\":{\"length\":")
+}
+
+/// As [`raw_length`], for the datagram events, whose `raw` is a list.
+fn raw_list_length(line: &str) -> Option<u64> {
+    number(line, "\"raw\":[{\"length\":")
+}
+
+/// Every event's time, in order of appearance.
+fn times(trace: &str) -> Vec<f64> {
+    events(trace)
+        .filter_map(|l| field(l, "\"time\":").and_then(|t| t.parse().ok()))
+        .collect()
+}
+
+#[test]
+fn datagrams_sent_reports_the_padded_size() {
+    let (mut client, contents) = new_client_with_qlog(ConnectionParameters::default());
+    let dgram = client.process_output(now()).dgram().expect("a datagram");
+    let len = dgram.len();
+    drop(client);
+
+    let trace = contents.to_string();
+    let sent = named(&trace, "transport:datagrams_sent")
+        .next()
+        .expect("a datagrams_sent event");
+    assert_eq!(raw_list_length(sent), Some(len as u64));
+
+    let packet = named(&trace, "transport:packet_sent")
+        .next()
+        .expect("a packet_sent event");
+    assert!(
+        raw_length(packet).unwrap() < len as u64,
+        "expected the Initial to be padded out, trace: {trace}"
+    );
+}
+
+#[test]
+fn coalesced_packet_lengths_agree_with_the_peer() {
+    let (mut client, client_log) = new_client_with_qlog(ConnectionParameters::default());
+    let (mut server, server_log) = new_server_with_qlog(ConnectionParameters::default());
+    connect(&mut client, &mut server);
+    drop((client, server));
+
+    let (sent, received) = (client_log.to_string(), server_log.to_string());
+    let key = |l: &str| {
+        Some((
+            field(l, "\"packet_type\":")?.to_owned(),
+            number(l, "\"packet_number\":")?,
+            raw_length(l)?,
+        ))
+    };
+    let tx = named(&sent, "transport:packet_sent")
+        .filter_map(key)
+        .collect::<Vec<_>>();
+    let rx = named(&received, "transport:packet_received")
+        .filter_map(key)
+        .collect::<Vec<_>>();
+    assert!(
+        tx.len() > 1 && !rx.is_empty(),
+        "sent {tx:?} received {rx:?}"
+    );
+
+    // Every packet the server decoded has to match what the client said it sent.
+    let mut compared = 0;
+    for (packet_type, pn, len) in &rx {
+        if let Some((_, _, sent_len)) = tx.iter().find(|(t, n, _)| t == packet_type && n == pn) {
+            assert_eq!(sent_len, len);
+            compared += 1;
+        }
+    }
+    assert_eq!(compared, rx.len(), "sent {tx:?} received {rx:?}");
+}
+
+#[test]
+fn packets_name_their_datagram() {
+    let (mut client, contents) = new_client_with_qlog(ConnectionParameters::default());
+    let mut server = default_server();
+    connect(&mut client, &mut server);
+    drop(client);
+
+    let trace = contents.to_string();
+    let datagrams = named(&trace, "transport:datagrams_sent")
+        .filter_map(|l| number(l, "\"datagram_ids\":["))
+        .collect::<Vec<_>>();
+    assert!(!datagrams.is_empty(), "no datagrams_sent in {trace}");
+
+    let mut per_datagram: HashMap<u64, usize> = HashMap::new();
+    for packet in named(&trace, "transport:packet_sent") {
+        let id = number(packet, "\"datagram_id\":").expect("a datagram_id");
+        assert!(
+            datagrams.contains(&id),
+            "packet in unreported datagram {id}: {packet}"
+        );
+        *per_datagram.entry(id).or_default() += 1;
+    }
+    let shared = per_datagram.values().filter(|n| **n > 1).count();
+    assert!(shared > 0, "expected coalescing during the handshake");
+}
+
+const RTT: Duration = Duration::from_millis(100);
+
+fn handshake_but_for_the_last_flight(
+    client: &mut Connection,
+    server: &mut Connection,
+    t: &mut Instant,
+) -> Datagram {
+    let c1 = client.process_output(*t).dgram().map(strip_padding);
+    let c2 = client.process_output(*t).dgram().map(strip_padding);
+
+    *t += RTT / 2;
+    server.process_input(c1.unwrap(), *t);
+    let s1 = server.process(c2, *t).dgram().map(strip_padding);
+
+    *t += RTT / 2;
+    let dgram = client.process(s1, *t).dgram().map(strip_padding);
+    *t += RTT / 2;
+    let dgram = server.process(dgram, *t).dgram().map(strip_padding);
+
+    *t += RTT / 2;
+    client.process_input(dgram.unwrap(), *t);
+    maybe_authenticate(client);
+    strip_padding(
+        client
+            .process_output(*t)
+            .dgram()
+            .expect("a final client flight"),
+    )
+}
+
+/// Fill the server's store with 1-RTT datagrams it has no keys for yet.
+fn fill_saved_datagrams(client: &mut Connection, server: &mut Connection, t: Instant) {
+    for _ in 0..SavedDatagrams::CAPACITY {
+        let d = send_something(client, t);
+        server.process_input(strip_padding(d), t);
+    }
+    assert_eq!(server.stats().saved_datagrams, SavedDatagrams::CAPACITY);
+}
+
+#[test]
+fn event_times_do_not_go_backwards() {
+    let mut client = default_client();
+    let (mut server, contents) = new_server_with_qlog(ConnectionParameters::default());
+    let mut t = now();
+    let last = handshake_but_for_the_last_flight(&mut client, &mut server, &mut t);
+
+    fill_saved_datagrams(&mut client, &mut server, t);
+
+    t += RTT;
+    _ = server.process(Some(last), t).dgram();
+    assert_eq!(*server.state(), State::Confirmed);
+    drop(server);
+
+    let trace = contents.to_string();
+    let times = times(&trace);
+    assert!(times.len() > 10, "too few events in {trace}");
+    for (a, b) in times.iter().zip(times.iter().skip(1)) {
+        assert!(a <= b, "time went from {a} back to {b}, trace: {trace}");
+    }
+}
+
+#[test]
+fn dropping_a_datagram_is_reported() {
+    let mut client = default_client();
+    let (mut server, contents) = new_server_with_qlog(ConnectionParameters::default());
+    let mut t = now();
+    _ = handshake_but_for_the_last_flight(&mut client, &mut server, &mut t);
+
+    // One more than the store holds, so the last one is dropped.
+    let mut last = 0;
+    for _ in 0..=SavedDatagrams::CAPACITY {
+        let d = strip_padding(send_something(&mut client, t));
+        last = d.len();
+        server.process_input(d, t + RTT / 2);
+    }
+    assert_eq!(server.stats().saved_datagrams, SavedDatagrams::CAPACITY);
+    drop(server);
+
+    let trace = contents.to_string();
+    let buffered = named(&trace, "transport:packet_buffered").count();
+    assert_eq!(buffered, SavedDatagrams::CAPACITY, "trace: {trace}");
+
+    let dropped = named(&trace, "transport:packet_dropped")
+        .filter_map(raw_length)
+        .collect::<Vec<_>>();
+    assert!(
+        dropped.contains(&(last as u64)),
+        "expected a dropped datagram of {last} bytes, got {dropped:?}, trace: {trace}"
+    );
+}
+
+#[test]
+fn transport_parameters_are_logged_for_both_peers() {
+    let (mut client, contents) = new_client_with_qlog(ConnectionParameters::default());
+    let mut server = default_server();
+    connect(&mut client, &mut server);
+    drop(client);
+
+    let trace = contents.to_string();
+    let peers = named(&trace, "transport:parameters_set")
+        .filter_map(|l| field(l, "\"owner\":").map(ToOwned::to_owned))
+        .collect::<Vec<_>>();
+    assert!(peers.contains(&"local".to_owned()), "trace: {trace}");
+    assert!(peers.contains(&"remote".to_owned()), "trace: {trace}");
+}
+
+#[test]
+fn server_logs_its_original_destination_connection_id() {
+    let mut client = default_client();
+    let (mut server, contents) = new_server_with_qlog(ConnectionParameters::default());
+    connect(&mut client, &mut server);
+    drop(server);
+
+    let trace = contents.to_string();
+    let local = named(&trace, "transport:parameters_set")
+        .find(|l| field(l, "\"owner\":") == Some("local"))
+        .expect("the server's own parameters");
+    assert!(
+        field(local, "\"original_destination_connection_id\":").is_some_and(|v| !v.is_empty()),
+        "trace: {trace}"
+    );
+}
+
+#[test]
+fn stateless_reset_token_is_not_logged() {
+    let (mut client, contents) = new_client_with_qlog(ConnectionParameters::default());
+    let mut server = default_server();
+    server
+        .set_local_tparam(
+            StatelessResetToken,
+            TransportParameter::Bytes(vec![77; Srt::LEN]),
+        )
+        .unwrap();
+    connect(&mut client, &mut server);
+    drop(client);
+
+    let trace = contents.to_string();
+    let logged = named(&trace, "transport:parameters_set")
+        .filter_map(|l| field(l, "\"stateless_reset_token\":"))
+        .collect::<Vec<_>>();
+    assert_eq!(logged, vec![""], "trace: {trace}");
+}
+
+/// The DCID and SCID of the client's first Initial, to address a packet back at it.
+fn client_cids(client: &mut Connection) -> (Vec<u8>, Vec<u8>) {
+    let initial = client
+        .process_output(now())
+        .dgram()
+        .expect("a datagram")
+        .to_vec();
+    // Skip the first byte and the version, then the length-prefixed DCID and SCID.
+    let mut dec = Decoder::from(&initial[5..]);
+    let dcid = dec.decode_vec(1).expect("client DCID").to_vec();
+    let scid = dec.decode_vec(1).expect("client SCID").to_vec();
+    (dcid, scid)
+}
+
+#[cfg(not(feature = "disable-encryption"))]
+#[test]
+fn an_accepted_retry_is_not_reported_as_dropped() {
+    let (mut client, contents) = new_client_with_qlog(ConnectionParameters::default());
+    let (dcid, scid) = client_cids(&mut client);
+    let mut server_scid = dcid.clone();
+    server_scid[0] ^= 0xff;
+
+    let retry =
+        crate::packet::Builder::retry(Version::default(), &scid, &server_scid, &[0x01], &dcid)
+            .expect("build retry");
+    drop(client.process(Some(datagram(retry)), now()));
+    assert_eq!(client.stats().dropped_rx, 0, "the Retry was accepted");
+    drop(client);
+
+    let trace = contents.to_string();
+    assert_eq!(
+        named(&trace, "transport:packet_dropped").count(),
+        0,
+        "trace: {trace}"
+    );
+}
+
+#[cfg(not(feature = "disable-encryption"))]
+#[test]
+fn rejected_retry_is_reported_as_dropped() {
+    let (mut client, contents) = new_client_with_qlog(ConnectionParameters::default());
+    let (dcid, scid) = client_cids(&mut client);
+    let mut server_scid = dcid.clone();
+    server_scid[0] ^= 0xff;
+
+    let retry =
+        crate::packet::Builder::retry(Version::default(), &scid, &server_scid, &[0x01], &dcid)
+            .expect("build retry");
+    let len = retry.len();
+    // The first is accepted, so the second is an extra one and is discarded.
+    drop(client.process(Some(datagram(retry.clone())), now()));
+    assert_eq!(client.stats().dropped_rx, 0, "the first Retry was accepted");
+    drop(client.process(Some(datagram(retry)), now()));
+    assert_eq!(client.stats().dropped_rx, 1, "the second was rejected");
+    drop(client);
+
+    let trace = contents.to_string();
+    let dropped = named(&trace, "transport:packet_dropped").collect::<Vec<_>>();
+    assert_eq!(dropped.len(), 1, "trace: {trace}");
+    assert_eq!(raw_length(dropped[0]), Some(len as u64), "trace: {trace}");
+}
+
+#[test]
+fn received_datagram_is_reported_once() {
+    let mut client = default_client();
+    let (mut server, contents) = new_server_with_qlog(ConnectionParameters::default());
+    let ci = client.process_output(now()).dgram().expect("a datagram");
+    let len = ci.len();
+
+    server.process_input(ci, now());
+    drop(server);
+
+    let trace = contents.to_string();
+    let received = named(&trace, "transport:datagrams_received")
+        .filter_map(raw_list_length)
+        .collect::<Vec<_>>();
+    assert_eq!(received, vec![len as u64], "trace: {trace}");
+
+    let packet = named(&trace, "transport:packet_received")
+        .next()
+        .expect("a packet_received event");
+    assert!(raw_length(packet).unwrap() < len as u64, "{trace}");
+}
+
+#[test]
+fn received_packets_name_their_datagram() {
+    let mut client = default_client();
+    let (mut server, contents) = new_server_with_qlog(ConnectionParameters::default());
+    connect(&mut client, &mut server);
+    drop((client, server));
+
+    let trace = contents.to_string();
+    let datagrams = named(&trace, "transport:datagrams_received")
+        .filter_map(|l| number(l, "\"datagram_ids\":["))
+        .collect::<Vec<_>>();
+    assert!(!datagrams.is_empty(), "no datagrams_received in {trace}");
+
+    let mut per_datagram: HashMap<u64, usize> = HashMap::new();
+    for packet in named(&trace, "transport:packet_received") {
+        let id = number(packet, "\"datagram_id\":").expect("a datagram_id");
+        assert!(
+            datagrams.contains(&id),
+            "packet in unreported datagram {id}: {packet}"
+        );
+        *per_datagram.entry(id).or_default() += 1;
+    }
+    let shared = per_datagram.values().filter(|n| **n > 1).count();
+    assert!(shared > 0, "expected a coalesced datagram in {trace}");
+}
+
+#[test]
+fn replayed_datagrams_are_not_counted_twice() {
+    let mut client = default_client();
+    let (mut server, contents) = new_server_with_qlog(ConnectionParameters::default());
+    let mut t = now();
+    let last = handshake_but_for_the_last_flight(&mut client, &mut server, &mut t);
+
+    fill_saved_datagrams(&mut client, &mut server, t);
+
+    // Everything saved is replayed by handing over the flight that supplies the
+    // keys, so only that one datagram arrives from here on.
+    let before = named(&contents.to_string(), "transport:datagrams_received").count();
+    t += RTT;
+    _ = server.process(Some(last), t).dgram();
+    assert_eq!(*server.state(), State::Confirmed);
+    drop(server);
+
+    let trace = contents.to_string();
+    let received = named(&trace, "transport:datagrams_received").count();
+    assert_eq!(
+        received - before,
+        1,
+        "replay reported {} extra datagrams, trace: {trace}",
+        received - before - 1
+    );
+
+    // Every datagram set aside is one that was reported as received.
+    let ids = named(&trace, "transport:datagrams_received")
+        .filter_map(|l| number(l, "\"datagram_ids\":["))
+        .collect::<Vec<_>>();
+    let buffered = named(&trace, "transport:packet_buffered")
+        .filter_map(|l| number(l, "\"datagram_id\":"))
+        .collect::<Vec<_>>();
+    assert_eq!(buffered.len(), SavedDatagrams::CAPACITY, "trace: {trace}");
+    for id in &buffered {
+        assert!(ids.contains(id), "packet_buffered names {id}: {trace}");
+    }
+}
+
+#[test]
+fn rejected_version_negotiation_is_reported() {
+    let (mut client, contents) = new_client_with_qlog(ConnectionParameters::default());
+    let (dcid, scid) = client_cids(&mut client);
+
+    // Offering the version already in use has to be ignored, per RFC 9000.
+    let vn = crate::packet::Builder::version_negotiation(
+        &scid,
+        &dcid,
+        Version::default().wire_version(),
+        &[Version::default()],
+    );
+    let len = vn.len();
+    drop(client.process(Some(datagram(vn)), now()));
+    assert_eq!(client.stats().dropped_rx, 1, "the VN was rejected");
+    drop(client);
+
+    let trace = contents.to_string();
+    let dropped = named(&trace, "transport:packet_dropped").collect::<Vec<_>>();
+    assert_eq!(dropped.len(), 1, "trace: {trace}");
+    // Reported against the datagram it arrived in, at the size that arrived.
+    assert_eq!(raw_length(dropped[0]), Some(len as u64), "trace: {trace}");
+    assert!(
+        number(dropped[0], "\"datagram_id\":").is_some(),
+        "trace: {trace}"
+    );
+}
+
+/// The sum of a trace's `raw` lengths, for the events named.
+fn total(trace: &str, name: &str) -> u64 {
+    named(trace, name).filter_map(raw_length).sum()
+}
+
+/// Every byte that arrives is accounted for, exactly once, by a packet event:
+/// received, dropped, or set aside. This is what the datagram events are for, so it
+/// is checked on both roles and across a close, where packets keep arriving but stop
+/// being processed.
+#[test]
+fn every_received_byte_is_accounted_for() {
+    let (mut client, client_log) = new_client_with_qlog(ConnectionParameters::default());
+    let (mut server, server_log) = new_server_with_qlog(ConnectionParameters::default());
+    connect(&mut client, &mut server);
+
+    let d = send_something(&mut client, now());
+    server.process_input(d, now());
+    // Held back, so that it reaches the client only once it is closing.
+    let late = send_something(&mut server, now());
+
+    client.close(now(), 0, "done");
+    assert!(matches!(client.state(), State::Closing { .. }));
+    client.process_input(late, now());
+    drop((client, server));
+
+    for (role, trace) in [
+        ("client", client_log.to_string()),
+        ("server", server_log.to_string()),
+    ] {
+        let arrived = named(&trace, "transport:datagrams_received")
+            .filter_map(raw_list_length)
+            .sum::<u64>();
+        let accounted = total(&trace, "transport:packet_received")
+            + total(&trace, "transport:packet_dropped")
+            + total(&trace, "transport:packet_buffered");
+        let mut per: HashMap<u64, (u64, u64)> = HashMap::new();
+        for e in named(&trace, "transport:datagrams_received") {
+            if let (Some(id), Some(len)) = (number(e, "\"datagram_ids\":["), raw_list_length(e)) {
+                per.entry(id).or_default().0 += len;
+            }
+        }
+        for n in [
+            "transport:packet_received",
+            "transport:packet_dropped",
+            "transport:packet_buffered",
+        ] {
+            for e in named(&trace, n) {
+                if let (Some(id), Some(len)) = (number(e, "\"datagram_id\":"), raw_length(e)) {
+                    per.entry(id).or_default().1 += len;
+                }
+            }
+        }
+        let off = per
+            .iter()
+            .filter(|(_, (a, b))| a != b)
+            .map(|(id, (a, b))| (*id, *a, *b))
+            .collect::<Vec<_>>();
+        assert!(
+            off.is_empty(),
+            "{role}: (datagram, arrived, accounted) {off:?}"
+        );
+        assert_eq!(arrived, accounted, "{role}");
+        assert!(arrived > 0, "{role} received nothing");
+    }
+}
+
+/// Trailing bytes that cannot be used are reported as padding: they were sent and
+/// received, so they took up bandwidth, but there is no telling padding from a packet
+/// we cannot use, so no packet type is claimed for them.
+#[test]
+fn trailing_bytes_are_reported_as_padding() {
+    let mut client = default_client();
+    let (mut server, contents) = new_server_with_qlog(ConnectionParameters::default());
+    // A client Initial is padded out, so the server sees trailing bytes it cannot use.
+    let ci = client.process_output(now()).dgram().expect("a datagram");
+    let len = ci.len();
+    server.process_input(ci, now());
+    drop(server);
+
+    let trace = contents.to_string();
+    let initial = named(&trace, "transport:packet_received")
+        .next()
+        .expect("the Initial");
+    let dropped = named(&trace, "transport:packet_dropped").collect::<Vec<_>>();
+    assert_eq!(dropped.len(), 1, "trace: {trace}");
+    // Named as padding, with no packet type invented for it.
+    assert_eq!(field(dropped[0], "\"details\":"), Some("padding"));
+    assert_eq!(field(dropped[0], "\"packet_type\":"), None);
+    // And it covers exactly the bytes the Initial did not.
+    assert_eq!(
+        raw_length(initial).unwrap() + raw_length(dropped[0]).unwrap(),
+        len as u64,
+        "trace: {trace}"
+    );
+}

--- a/neqo-transport/src/packet/metadata.rs
+++ b/neqo-transport/src/packet/metadata.rs
@@ -32,6 +32,7 @@ pub struct MetaData<'a> {
     tos: Tos,
     len: usize,
     payload: &'a [u8],
+    payload_len: usize, // Can exceed `payload`: header protection padding is added later.
 }
 
 impl MetaData<'_> {
@@ -50,6 +51,7 @@ impl MetaData<'_> {
             version,
             tos,
             len,
+            payload_len: decrypted.len(),
             payload: decrypted,
         }
     }
@@ -58,7 +60,7 @@ impl MetaData<'_> {
         path: &'a PathRef,
         packet_type: packet::Type,
         packet_number: packet::Number,
-        length: usize,
+        lengths: packet::Lengths,
         payload: &'a [u8],
         tos: Tos,
         version: Version,
@@ -70,8 +72,9 @@ impl MetaData<'_> {
             packet_number,
             version,
             tos,
-            len: length,
+            len: lengths.packet,
             payload,
+            payload_len: lengths.payload,
         }
     }
 
@@ -88,6 +91,11 @@ impl MetaData<'_> {
     #[must_use]
     pub const fn payload(&self) -> &[u8] {
         self.payload
+    }
+
+    #[must_use]
+    pub const fn payload_length(&self) -> usize {
+        self.payload_len
     }
 }
 

--- a/neqo-transport/src/packet/metadata.rs
+++ b/neqo-transport/src/packet/metadata.rs
@@ -30,9 +30,9 @@ pub struct MetaData<'a> {
     packet_number: packet::Number,
     version: Version,
     tos: Tos,
-    len: usize,
+    /// `payload` can exceed `lengths.payload`: header protection padding is added later.
+    lengths: packet::Lengths,
     payload: &'a [u8],
-    payload_len: usize, // Can exceed `payload`: header protection padding is added later.
 }
 
 impl MetaData<'_> {
@@ -50,8 +50,10 @@ impl MetaData<'_> {
             packet_number: decrypted.pn(),
             version,
             tos,
-            len,
-            payload_len: decrypted.len(),
+            lengths: packet::Lengths {
+                packet: len,
+                payload: decrypted.len(),
+            },
             payload: decrypted,
         }
     }
@@ -72,9 +74,8 @@ impl MetaData<'_> {
             packet_number,
             version,
             tos,
-            len: lengths.packet,
+            lengths,
             payload,
-            payload_len: lengths.payload,
         }
     }
 
@@ -85,7 +86,7 @@ impl MetaData<'_> {
 
     #[must_use]
     pub const fn length(&self) -> usize {
-        self.len
+        self.lengths.packet
     }
 
     #[must_use]
@@ -95,7 +96,7 @@ impl MetaData<'_> {
 
     #[must_use]
     pub const fn payload_length(&self) -> usize {
-        self.payload_len
+        self.lengths.payload
     }
 }
 
@@ -133,7 +134,7 @@ impl Display for MetaData<'_> {
             self.packet_type,
             self.path.borrow(),
             self.tos,
-            self.len,
+            self.lengths.packet,
         )
     }
 }

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -7,7 +7,7 @@
 // Encoding and decoding packets off the wire.
 
 use std::{
-    cmp::min,
+    cmp::{max, min},
     fmt,
     ops::{Deref, DerefMut, Range},
     time::Instant,
@@ -126,6 +126,13 @@ struct BuilderOffsets {
     len: usize,
     /// The location of the packet number field.
     pn: Range<usize>,
+}
+
+/// What a packet measures on the wire: the whole thing, and its payload alone.
+#[derive(Debug, Clone, Copy)]
+pub struct Lengths {
+    pub packet: usize,
+    pub payload: usize,
 }
 
 /// A packet builder that can be used to produce short packets and long packets.
@@ -429,6 +436,24 @@ impl<B: Buffer> Builder<B> {
         self.encoder.as_mut()[self.offsets.len + 1] = (len & 0xff) as u8;
     }
 
+    /// Where [`Self::pad_for_crypto`] pads to.
+    const fn crypto_pad_target(&self, crypto_pad: usize) -> usize {
+        self.offsets.pn.start + MAX_PACKET_NUMBER_LEN + crypto_pad
+    }
+
+    /// What this packet will measure on the wire.
+    ///
+    /// This is more than [`Self::len`], because [`Self::build`] pads for header protection and
+    /// AEAD expansion. Unlike [`Self::len`], it covers only this packet and not the datagram.
+    #[must_use]
+    pub fn lengths(&self, crypto_pad: usize, expansion: usize) -> Lengths {
+        let end = max(self.len(), self.crypto_pad_target(crypto_pad));
+        Lengths {
+            packet: end - self.header.start + expansion,
+            payload: end - self.header.end,
+        }
+    }
+
     fn pad_for_crypto(&mut self, crypto: &CryptoDxState) {
         // Make sure that there is enough data in the packet.
         // The length of the packet number plus the payload length needs to
@@ -442,11 +467,8 @@ impl<B: Buffer> Builder<B> {
         //
         // <https://datatracker.ietf.org/doc/html/rfc9001#section-5.4.2>
 
-        let crypto_pad = crypto.extra_padding();
-        self.encoder.pad_to(
-            self.offsets.pn.start + MAX_PACKET_NUMBER_LEN + crypto_pad,
-            0,
-        );
+        self.encoder
+            .pad_to(self.crypto_pad_target(crypto.extra_padding()), 0);
     }
 
     /// A lot of frames here are just a collection of varints.
@@ -488,6 +510,9 @@ impl<B: Buffer> Builder<B> {
             return Err(Error::Internal);
         }
 
+        let expected = self.lengths(crypto.extra_padding(), crypto.expansion());
+        let header_start = self.header.start;
+
         self.pad_for_crypto(crypto);
         if self.offsets.len > 0 {
             self.write_len(crypto.expansion());
@@ -520,6 +545,7 @@ impl<B: Buffer> Builder<B> {
         }
 
         qtrace!("Packet built {}", Hex::new(&self.encoder));
+        debug_assert_eq!(self.encoder.len() - header_start, expected.packet);
         Ok(self.encoder)
     }
 

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -437,8 +437,8 @@ impl<B: Buffer> Builder<B> {
     }
 
     /// Where [`Self::pad_for_crypto`] pads to.
-    const fn crypto_pad_target(&self, crypto_pad: usize) -> usize {
-        self.offsets.pn.start + MAX_PACKET_NUMBER_LEN + crypto_pad
+    fn crypto_pad_target(&self, crypto: &CryptoDxState) -> usize {
+        self.offsets.pn.start + MAX_PACKET_NUMBER_LEN + crypto.extra_padding()
     }
 
     /// What this packet will measure on the wire.
@@ -446,10 +446,10 @@ impl<B: Buffer> Builder<B> {
     /// This is more than [`Self::len`], because [`Self::build`] pads for header protection and
     /// AEAD expansion. Unlike [`Self::len`], it covers only this packet and not the datagram.
     #[must_use]
-    pub fn lengths(&self, crypto_pad: usize, expansion: usize) -> Lengths {
-        let end = max(self.len(), self.crypto_pad_target(crypto_pad));
+    pub fn lengths(&self, crypto: &CryptoDxState) -> Lengths {
+        let end = max(self.len(), self.crypto_pad_target(crypto));
         Lengths {
-            packet: end - self.header.start + expansion,
+            packet: end - self.header.start + crypto.expansion(),
             payload: end - self.header.end,
         }
     }
@@ -467,8 +467,7 @@ impl<B: Buffer> Builder<B> {
         //
         // <https://datatracker.ietf.org/doc/html/rfc9001#section-5.4.2>
 
-        self.encoder
-            .pad_to(self.crypto_pad_target(crypto.extra_padding()), 0);
+        self.encoder.pad_to(self.crypto_pad_target(crypto), 0);
     }
 
     /// A lot of frames here are just a collection of varints.
@@ -510,7 +509,7 @@ impl<B: Buffer> Builder<B> {
             return Err(Error::Internal);
         }
 
-        let expected = self.lengths(crypto.extra_padding(), crypto.expansion());
+        let expected = self.lengths(crypto);
         let header_start = self.header.start;
 
         self.pad_for_crypto(crypto);

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -16,16 +16,17 @@ use qlog::events::{
     ApplicationErrorCode, ConnectionErrorCode, EventData, RawInfo,
     connectivity::{
         ConnectionClosed, ConnectionClosedTrigger, ConnectionStarted, ConnectionState,
-        ConnectionStateUpdated, MtuUpdated, TransportOwner,
+        ConnectionStateUpdated, MtuUpdated,
     },
     quic::{
-        AckedRanges, CongestionStateUpdated, CongestionStateUpdatedTrigger, ErrorSpace,
-        LossTimerEventType, LossTimerUpdated, MetricsUpdated, PacketDropped, PacketDroppedTrigger,
-        PacketHeader, PacketLost, PacketLostTrigger, PacketNumberSpace as QlogPacketNumberSpace,
-        PacketReceived, PacketSent, PacketsAcked, QuicFrame, RecoveryParametersSet, StreamType,
-        TimerType, VersionInformation,
+        AckedRanges, CongestionStateUpdated, CongestionStateUpdatedTrigger, DatagramsReceived,
+        DatagramsSent, ErrorSpace, LossTimerEventType, LossTimerUpdated, MetricsUpdated,
+        PacketBuffered, PacketBufferedTrigger, PacketDropped, PacketHeader, PacketLost,
+        PacketLostTrigger, PacketNumberSpace as QlogPacketNumberSpace, PacketReceived, PacketSent,
+        PacketsAcked, QuicFrame, RecoveryParametersSet, StreamType, TimerType, VersionInformation,
     },
 };
+pub use qlog::events::{connectivity::TransportOwner, quic::PacketDroppedTrigger}; // Re-export
 use smallvec::SmallVec;
 
 use crate::{
@@ -56,37 +57,61 @@ fn to_hex<T: AsRef<[u8]>>(v: T) -> String {
     Hex::new(v).to_string()
 }
 
-pub fn connection_tparams_set(qlog: &mut Qlog, tph: &TransportParametersHandler, now: Instant) {
+/// Some qlog fields are `u32` and not optional, while the varints they carry
+/// are wider. Saturate rather than wrap.
+fn to_u32(v: u64) -> u32 {
+    u32::try_from(v).unwrap_or(u32::MAX)
+}
+
+/// A length is all that is known about most of what is logged raw.
+fn raw(len: usize) -> RawInfo {
+    RawInfo {
+        length: Some(to_u64(len)),
+        ..Default::default()
+    }
+}
+
+pub fn tparams_set(
+    qlog: &mut Qlog,
+    tph: &TransportParametersHandler,
+    owner: TransportOwner,
+    now: Instant,
+) {
     qlog.add_event_at(
         || {
-            let remote = tph.remote();
-            #[expect(clippy::cast_possible_truncation, reason = "These are OK.")]
+            let tp = match &owner {
+                TransportOwner::Local => tph.local(),
+                TransportOwner::Remote => tph.remote(),
+            };
+            // These fields are narrower than the parameters they carry, so a value
+            // that does not fit is left out rather than truncated into a lie.
             let ev_data =
                 EventData::TransportParametersSet(qlog::events::quic::TransportParametersSet {
-                    owner: Some(TransportOwner::Remote),
-                    original_destination_connection_id: remote
+                    owner: Some(owner),
+                    original_destination_connection_id: tp
                         .get_bytes(OriginalDestinationConnectionId)
                         .map(to_hex),
-                    stateless_reset_token: remote.get_bytes(StatelessResetToken).map(to_hex),
-                    disable_active_migration: remote.get_empty(DisableMigration).then_some(true),
-                    max_idle_timeout: Some(remote.get_integer(TransportParameterId::IdleTimeout)),
-                    max_udp_payload_size: Some(remote.get_integer(MaxUdpPayloadSize) as u32),
-                    ack_delay_exponent: Some(remote.get_integer(AckDelayExponent) as u16),
-                    max_ack_delay: Some(remote.get_integer(MaxAckDelay) as u16),
-                    active_connection_id_limit: Some(
-                        remote.get_integer(ActiveConnectionIdLimit) as u32
-                    ),
-                    initial_max_data: Some(remote.get_integer(InitialMaxData)),
+                    stateless_reset_token: tp.get_bytes(StatelessResetToken).map(|_| String::new()), // Don't log the SRT
+                    disable_active_migration: tp.get_empty(DisableMigration).then_some(true),
+                    max_idle_timeout: Some(tp.get_integer(TransportParameterId::IdleTimeout)),
+                    max_udp_payload_size: u32::try_from(tp.get_integer(MaxUdpPayloadSize)).ok(),
+                    ack_delay_exponent: u16::try_from(tp.get_integer(AckDelayExponent)).ok(),
+                    max_ack_delay: u16::try_from(tp.get_integer(MaxAckDelay)).ok(),
+                    active_connection_id_limit: u32::try_from(
+                        tp.get_integer(ActiveConnectionIdLimit),
+                    )
+                    .ok(),
+                    initial_max_data: Some(tp.get_integer(InitialMaxData)),
                     initial_max_stream_data_bidi_local: Some(
-                        remote.get_integer(InitialMaxStreamDataBidiLocal),
+                        tp.get_integer(InitialMaxStreamDataBidiLocal),
                     ),
                     initial_max_stream_data_bidi_remote: Some(
-                        remote.get_integer(InitialMaxStreamDataBidiRemote),
+                        tp.get_integer(InitialMaxStreamDataBidiRemote),
                     ),
-                    initial_max_stream_data_uni: Some(remote.get_integer(InitialMaxStreamDataUni)),
-                    initial_max_streams_bidi: Some(remote.get_integer(InitialMaxStreamsBidi)),
-                    initial_max_streams_uni: Some(remote.get_integer(InitialMaxStreamsUni)),
-                    preferred_address: remote.get_preferred_address().and_then(|(paddr, cid)| {
+                    initial_max_stream_data_uni: Some(tp.get_integer(InitialMaxStreamDataUni)),
+                    initial_max_streams_bidi: Some(tp.get_integer(InitialMaxStreamsBidi)),
+                    initial_max_streams_uni: Some(tp.get_integer(InitialMaxStreamsUni)),
+                    preferred_address: tp.get_preferred_address().and_then(|(paddr, cid)| {
                         Some(qlog::events::quic::PreferredAddress {
                             ip_v4: paddr.ipv4()?.ip().to_string(),
                             ip_v6: paddr.ipv6()?.ip().to_string(),
@@ -225,13 +250,13 @@ pub fn server_version_information_failed(
     );
 }
 
-pub fn packet_io(qlog: &mut Qlog, meta: packet::MetaData, now: Instant) {
+pub fn packet_io(qlog: &mut Qlog, meta: packet::MetaData, datagram_id: u32, now: Instant) {
     qlog.add_event_at(
         || {
             let mut d = Decoder::from(meta.payload());
             let raw = RawInfo {
                 length: Some(to_u64(meta.length())),
-                payload_length: None,
+                payload_length: Some(to_u64(meta.payload_length())),
                 data: None,
             };
 
@@ -250,12 +275,14 @@ pub fn packet_io(qlog: &mut Qlog, meta: packet::MetaData, now: Instant) {
                     header: meta.into(),
                     frames: Some(frames),
                     raw: Some(raw),
+                    datagram_id: Some(datagram_id),
                     ..Default::default()
                 })),
                 Direction::Rx => Some(EventData::PacketReceived(PacketReceived {
                     header: meta.into(),
                     frames: Some(frames.to_vec()),
                     raw: Some(raw),
+                    datagram_id: Some(datagram_id),
                     ..Default::default()
                 })),
             }
@@ -263,32 +290,82 @@ pub fn packet_io(qlog: &mut Qlog, meta: packet::MetaData, now: Instant) {
         now,
     );
 }
-pub fn packet_dropped(qlog: &mut Qlog, decrypt_err: &packet::DecryptionError, now: Instant) {
+
+/// `packet_type` is `None` when the header did not parse.
+///
+/// `len` runs from this packet to the end of the datagram.
+pub fn packet_dropped(
+    qlog: &mut Qlog,
+    packet_type: Option<packet::Type>,
+    len: usize,
+    datagram_id: u32,
+    details: Option<String>,
+    trigger: PacketDroppedTrigger,
+    now: Instant,
+) {
     qlog.add_event_at(
         || {
-            let header =
-                PacketHeader::with_type(decrypt_err.packet_type().into(), None, None, None, None);
-            let raw = RawInfo {
-                length: Some(to_u64(decrypt_err.len())),
-                ..Default::default()
-            };
+            Some(EventData::PacketDropped(PacketDropped {
+                header: packet_type
+                    .map(|pt| PacketHeader::with_type(pt.into(), None, None, None, None)),
+                raw: Some(raw(len)),
+                datagram_id: Some(datagram_id),
+                details,
+                trigger: Some(trigger),
+            }))
+        },
+        now,
+    );
+}
 
-            let ev_data = EventData::PacketDropped(PacketDropped {
-                header: Some(header),
-                raw: Some(raw),
-                details: Some(decrypt_err.error.to_string()),
-                trigger: Some(PacketDroppedTrigger::DecryptionFailure),
-                ..Default::default()
-            });
+/// A packet was set aside because the keys to decrypt it are not available yet.
+/// It is logged again, as received, once it can be processed.
+pub fn packet_buffered(qlog: &mut Qlog, datagram_id: u32, len: usize, now: Instant) {
+    qlog.add_event_at(
+        || {
+            Some(EventData::PacketBuffered(PacketBuffered {
+                header: None,
+                raw: Some(raw(len)),
+                datagram_id: Some(datagram_id),
+                trigger: Some(PacketBufferedTrigger::KeysUnavailable),
+            }))
+        },
+        now,
+    );
+}
 
-            Some(ev_data)
+pub fn datagram_sent(qlog: &mut Qlog, datagram_id: u32, len: usize, now: Instant) {
+    datagram_io(qlog, Direction::Tx, datagram_id, len, now);
+}
+
+pub fn datagram_received(qlog: &mut Qlog, datagram_id: u32, len: usize, now: Instant) {
+    datagram_io(qlog, Direction::Rx, datagram_id, len, now);
+}
+
+fn datagram_io(qlog: &mut Qlog, direction: Direction, datagram_id: u32, len: usize, now: Instant) {
+    qlog.add_event_at(
+        || {
+            let (count, raw, datagram_ids) =
+                (Some(1), Some(vec![raw(len)]), Some(vec![datagram_id]));
+            Some(match direction {
+                Direction::Tx => EventData::DatagramsSent(DatagramsSent {
+                    count,
+                    raw,
+                    datagram_ids,
+                }),
+                Direction::Rx => EventData::DatagramsReceived(DatagramsReceived {
+                    count,
+                    raw,
+                    datagram_ids,
+                }),
+            })
         },
         now,
     );
 }
 
 pub fn packets_lost(qlog: &mut Qlog, pkts: &[sent::Packet], now: Instant) {
-    qlog.add_event_with_stream(|stream| {
+    qlog.add_event_with_stream(now, |stream, now| {
         for pkt in pkts {
             let header =
                 PacketHeader::with_type(pkt.packet_type().into(), Some(pkt.pn()), None, None, None);
@@ -306,7 +383,7 @@ pub fn packets_lost(qlog: &mut Qlog, pkts: &[sent::Packet], now: Instant) {
 
             stream.add_event_data_with_instant(ev_data, now)?;
         }
-        Ok(())
+        Ok(!pkts.is_empty())
     });
 }
 
@@ -578,11 +655,6 @@ fn loss_timer_updated(
 // Helper functions
 
 #[expect(clippy::too_many_lines, reason = "Yeah, but it's a nice match.")]
-#[expect(
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    reason = "We need to truncate here."
-)]
 impl From<Frame<'_>> for QuicFrame {
     fn from(frame: Frame) -> Self {
         match frame {
@@ -613,8 +685,14 @@ impl From<Frame<'_>> for QuicFrame {
                     )
                 });
 
+                #[expect(
+                    clippy::cast_precision_loss,
+                    reason = "qlog ack_delay is f32, there is no lossless conversion"
+                )]
+                let ack_delay = Some(ack_delay as f32 / 1000.0);
+
                 Self::Ack {
-                    ack_delay: Some(ack_delay as f32 / 1000.0),
+                    ack_delay,
                     acked_ranges,
                     ect1: ecn_count.map(|c| c[Ecn::Ect1]),
                     ect0: ecn_count.map(|c| c[Ecn::Ect0]),
@@ -717,14 +795,15 @@ impl From<Frame<'_>> for QuicFrame {
                 connection_id,
                 stateless_reset_token,
             } => Self::NewConnectionId {
-                sequence_number: sequence_number as u32,
-                retire_prior_to: retire_prior as u32,
-                connection_id_length: Some(connection_id.len() as u8),
+                sequence_number: to_u32(sequence_number),
+                retire_prior_to: to_u32(retire_prior),
+                // A CID is at most 20 bytes, so this always fits.
+                connection_id_length: u8::try_from(connection_id.len()).ok(),
                 connection_id: to_hex(connection_id),
                 stateless_reset_token: Some(to_hex(stateless_reset_token)),
             },
             Frame::RetireConnectionId { sequence_number } => Self::RetireConnectionId {
-                sequence_number: sequence_number as u32,
+                sequence_number: to_u32(sequence_number),
             },
             Frame::PathChallenge { data } => Self::PathChallenge {
                 data: Some(to_hex(data)),

--- a/neqo-transport/src/qlog.rs
+++ b/neqo-transport/src/qlog.rs
@@ -46,7 +46,7 @@ use crate::{
             InitialMaxStreamsBidi, InitialMaxStreamsUni, MaxAckDelay, MaxUdpPayloadSize,
             OriginalDestinationConnectionId, StatelessResetToken,
         },
-        TransportParametersHandler,
+        TransportParameters, TransportParametersHandler,
     },
     tracking::PacketNumberSpace,
     version::{self, Version},
@@ -59,7 +59,7 @@ fn to_hex<T: AsRef<[u8]>>(v: T) -> String {
 
 /// Some qlog fields are `u32` and not optional, while the varints they carry
 /// are wider. Saturate rather than wrap.
-fn to_u32(v: u64) -> u32 {
+fn force_u32(v: u64) -> u32 {
     u32::try_from(v).unwrap_or(u32::MAX)
 }
 
@@ -69,6 +69,12 @@ fn raw(len: usize) -> RawInfo {
         length: Some(to_u64(len)),
         ..Default::default()
     }
+}
+
+/// A transport parameter, for a qlog field narrower than the varint that carries it.
+/// A value that does not fit is left out rather than reported wrongly.
+fn narrow<T: TryFrom<u64>>(tp: &TransportParameters, id: TransportParameterId) -> Option<T> {
+    T::try_from(tp.get_integer(id)).ok()
 }
 
 pub fn tparams_set(
@@ -83,8 +89,7 @@ pub fn tparams_set(
                 TransportOwner::Local => tph.local(),
                 TransportOwner::Remote => tph.remote(),
             };
-            // These fields are narrower than the parameters they carry, so a value
-            // that does not fit is left out rather than truncated into a lie.
+            let int = |id| Some(tp.get_integer(id));
             let ev_data =
                 EventData::TransportParametersSet(qlog::events::quic::TransportParametersSet {
                     owner: Some(owner),
@@ -93,24 +98,17 @@ pub fn tparams_set(
                         .map(to_hex),
                     stateless_reset_token: tp.get_bytes(StatelessResetToken).map(|_| String::new()), // Don't log the SRT
                     disable_active_migration: tp.get_empty(DisableMigration).then_some(true),
-                    max_idle_timeout: Some(tp.get_integer(TransportParameterId::IdleTimeout)),
-                    max_udp_payload_size: u32::try_from(tp.get_integer(MaxUdpPayloadSize)).ok(),
-                    ack_delay_exponent: u16::try_from(tp.get_integer(AckDelayExponent)).ok(),
-                    max_ack_delay: u16::try_from(tp.get_integer(MaxAckDelay)).ok(),
-                    active_connection_id_limit: u32::try_from(
-                        tp.get_integer(ActiveConnectionIdLimit),
-                    )
-                    .ok(),
-                    initial_max_data: Some(tp.get_integer(InitialMaxData)),
-                    initial_max_stream_data_bidi_local: Some(
-                        tp.get_integer(InitialMaxStreamDataBidiLocal),
-                    ),
-                    initial_max_stream_data_bidi_remote: Some(
-                        tp.get_integer(InitialMaxStreamDataBidiRemote),
-                    ),
-                    initial_max_stream_data_uni: Some(tp.get_integer(InitialMaxStreamDataUni)),
-                    initial_max_streams_bidi: Some(tp.get_integer(InitialMaxStreamsBidi)),
-                    initial_max_streams_uni: Some(tp.get_integer(InitialMaxStreamsUni)),
+                    max_idle_timeout: int(TransportParameterId::IdleTimeout),
+                    max_udp_payload_size: narrow(tp, MaxUdpPayloadSize),
+                    ack_delay_exponent: narrow(tp, AckDelayExponent),
+                    max_ack_delay: narrow(tp, MaxAckDelay),
+                    active_connection_id_limit: narrow(tp, ActiveConnectionIdLimit),
+                    initial_max_data: int(InitialMaxData),
+                    initial_max_stream_data_bidi_local: int(InitialMaxStreamDataBidiLocal),
+                    initial_max_stream_data_bidi_remote: int(InitialMaxStreamDataBidiRemote),
+                    initial_max_stream_data_uni: int(InitialMaxStreamDataUni),
+                    initial_max_streams_bidi: int(InitialMaxStreamsBidi),
+                    initial_max_streams_uni: int(InitialMaxStreamsUni),
                     preferred_address: tp.get_preferred_address().and_then(|(paddr, cid)| {
                         Some(qlog::events::quic::PreferredAddress {
                             ip_v4: paddr.ipv4()?.ip().to_string(),
@@ -130,15 +128,7 @@ pub fn tparams_set(
     );
 }
 
-pub fn server_connection_started(qlog: &mut Qlog, path: &PathRef, now: Instant) {
-    connection_started(qlog, path, now);
-}
-
-pub fn client_connection_started(qlog: &mut Qlog, path: &PathRef, now: Instant) {
-    connection_started(qlog, path, now);
-}
-
-fn connection_started(qlog: &mut Qlog, path: &PathRef, now: Instant) {
+pub fn connection_started(qlog: &mut Qlog, path: &PathRef, now: Instant) {
     qlog.add_event_at(
         || {
             let p = path.deref().borrow();
@@ -334,15 +324,13 @@ pub fn packet_buffered(qlog: &mut Qlog, datagram_id: u32, len: usize, now: Insta
     );
 }
 
-pub fn datagram_sent(qlog: &mut Qlog, datagram_id: u32, len: usize, now: Instant) {
-    datagram_io(qlog, Direction::Tx, datagram_id, len, now);
-}
-
-pub fn datagram_received(qlog: &mut Qlog, datagram_id: u32, len: usize, now: Instant) {
-    datagram_io(qlog, Direction::Rx, datagram_id, len, now);
-}
-
-fn datagram_io(qlog: &mut Qlog, direction: Direction, datagram_id: u32, len: usize, now: Instant) {
+pub fn datagram_io(
+    qlog: &mut Qlog,
+    direction: Direction,
+    datagram_id: u32,
+    len: usize,
+    now: Instant,
+) {
     qlog.add_event_at(
         || {
             let (count, raw, datagram_ids) =
@@ -794,16 +782,17 @@ impl From<Frame<'_>> for QuicFrame {
                 retire_prior,
                 connection_id,
                 stateless_reset_token,
-            } => Self::NewConnectionId {
-                sequence_number: to_u32(sequence_number),
-                retire_prior_to: to_u32(retire_prior),
-                // A CID is at most 20 bytes, so this always fits.
-                connection_id_length: u8::try_from(connection_id.len()).ok(),
-                connection_id: to_hex(connection_id),
-                stateless_reset_token: Some(to_hex(stateless_reset_token)),
-            },
+            } => {
+                Self::NewConnectionId {
+                    sequence_number: force_u32(sequence_number),
+                    retire_prior_to: force_u32(retire_prior),
+                    connection_id_length: u8::try_from(connection_id.len()).ok(), /* CID is at most 20 bytes, so always fits. */
+                    connection_id: to_hex(connection_id),
+                    stateless_reset_token: Some(to_hex(stateless_reset_token)),
+                }
+            }
             Frame::RetireConnectionId { sequence_number } => Self::RetireConnectionId {
-                sequence_number: to_u32(sequence_number),
+                sequence_number: force_u32(sequence_number),
             },
             Frame::PathChallenge { data } => Self::PathChallenge {
                 data: Some(to_hex(data)),

--- a/neqo-transport/src/saved.rs
+++ b/neqo-transport/src/saved.rs
@@ -15,6 +15,8 @@ pub struct SavedDatagram {
     pub d: Datagram,
     /// The time that the datagram was received.
     pub t: Instant,
+    /// The qlog ID the datagram was reported as received under.
+    pub datagram_id: u32,
 }
 
 #[derive(Default)]
@@ -42,14 +44,17 @@ impl SavedDatagrams {
         self.handshake.len() == Self::CAPACITY || self.application_data.len() == Self::CAPACITY
     }
 
-    pub fn save(&mut self, epoch: Epoch, d: Datagram, t: Instant) {
+    /// Returns whether the datagram was saved.
+    pub fn save(&mut self, epoch: Epoch, d: Datagram, datagram_id: u32, t: Instant) -> bool {
         let store = self.store(epoch);
 
         if store.len() < Self::CAPACITY {
             qdebug!("saving {epoch:?} datagram of {} bytes", d.len());
-            store.push(SavedDatagram { d, t });
+            store.push(SavedDatagram { d, t, datagram_id });
+            true
         } else {
             qinfo!("not saving {epoch:?} datagram of {} bytes", d.len());
+            false
         }
     }
 
@@ -92,7 +97,7 @@ mod tests {
     #[should_panic(expected = "unexpected space")]
     fn save_panics_for_invalid_epoch() {
         let mut saved = SavedDatagrams::default();
-        saved.save(Epoch::Initial, make_dgram(), now());
+        saved.save(Epoch::Initial, make_dgram(), 0, now());
     }
 
     #[test]
@@ -102,12 +107,12 @@ mod tests {
 
         // Fill to exactly CAPACITY.
         for _ in 0..SavedDatagrams::CAPACITY {
-            saved.save(Epoch::ApplicationData, make_dgram(), t);
+            assert!(saved.save(Epoch::ApplicationData, make_dgram(), 0, t));
         }
         assert!(saved.is_either_full());
 
-        // One more should be silently dropped.
-        saved.save(Epoch::ApplicationData, make_dgram(), t);
+        // One more should be dropped, and say so.
+        assert!(!saved.save(Epoch::ApplicationData, make_dgram(), 0, t));
 
         saved.make_available(Epoch::ApplicationData);
         let taken = saved.take_saved();

--- a/neqo-transport/src/saved.rs
+++ b/neqo-transport/src/saved.rs
@@ -111,7 +111,7 @@ mod tests {
         }
         assert!(saved.is_either_full());
 
-        // One more should be dropped, and say so.
+        // One more should be dropped.
         assert!(!saved.save(Epoch::ApplicationData, make_dgram(), 0, t));
 
         saved.make_available(Epoch::ApplicationData);

--- a/neqo-transport/src/server.rs
+++ b/neqo-transport/src/server.rs
@@ -35,8 +35,13 @@ use crate::{
     cid::{ConnectionId, ConnectionIdGenerator, ConnectionIdRef},
     connection::{Connection, Output, State},
     packet::{self, MIN_INITIAL_PACKET_SIZE, Public},
-    saved::SavedDatagram,
 };
+
+/// A datagram whose processing was deferred, along with the time it arrived at.
+struct DeferredDatagram {
+    d: Datagram,
+    t: Instant,
+}
 
 /// A `ServerZeroRttChecker` is a simple wrapper around a single checker.
 /// It uses `RefCell` so that the wrapped checker can be shared between
@@ -128,7 +133,7 @@ pub struct Server {
     /// an immediate return without further processing of the remaining
     /// datagrams. To be processed on consecutive calls to
     /// [`Server::process_multiple`].
-    saved_datagrams: VecDeque<SavedDatagram>,
+    saved_datagrams: VecDeque<DeferredDatagram>,
 }
 
 impl Server {
@@ -398,6 +403,15 @@ impl Server {
         }
     }
 
+    /// Set datagrams aside for a later call to [`Server::process_multiple`].
+    fn defer<A: AsRef<[u8]>>(&mut self, dgrams: impl Iterator<Item = Datagram<A>>, now: Instant) {
+        self.saved_datagrams
+            .extend(dgrams.map(|d| DeferredDatagram {
+                d: d.to_owned(),
+                t: now,
+            }));
+    }
+
     /// Process new input datagrams on the connection.
     pub fn process_multiple_input<
         A: AsRef<[u8]> + AsMut<[u8]>,
@@ -408,13 +422,9 @@ impl Server {
         now: Instant,
     ) -> OutputBatch {
         // Process input datagrams from previous call.
-        while let Some(SavedDatagram { d, t }) = self.saved_datagrams.pop_front() {
+        while let Some(DeferredDatagram { d, t }) = self.saved_datagrams.pop_front() {
             if let OutputBatch::DatagramBatch(b) = self.process_input(std::iter::once(d), t) {
-                self.saved_datagrams
-                    .extend(dgrams.into_iter().map(|d| SavedDatagram {
-                        d: d.to_owned(),
-                        t: now,
-                    }));
+                self.defer(dgrams.into_iter(), now);
                 return OutputBatch::DatagramBatch(b);
             }
         }
@@ -500,10 +510,7 @@ impl Server {
                     now,
                 );
 
-                self.saved_datagrams.extend(dgrams.map(|d| SavedDatagram {
-                    d: d.to_owned(),
-                    t: now,
-                }));
+                self.defer(dgrams, now);
 
                 return OutputBatch::DatagramBatch(
                     Datagram::new(destination, source, Tos::default(), vn).into(),
@@ -520,10 +527,7 @@ impl Server {
                     // `dgram`.
                     let initial = InitialDetails::new(&packet);
                     if let o @ Output::Datagram(_) = self.handle_initial(initial, dgram, now) {
-                        self.saved_datagrams.extend(dgrams.map(|d| SavedDatagram {
-                            d: d.to_owned(),
-                            t: now,
-                        }));
+                        self.defer(dgrams, now);
                         return o.into();
                     }
                 }


### PR DESCRIPTION
Report each packet at its own length and payload length on the wire, including the padding header protection adds.

Add datagrams_sent, datagrams_received, datagram_dropped and packet_buffered, with a datagram_id on packet events, so a trace accounts for every byte.

Hold event timestamps to the last one written, which qlog requires.

Log local transport parameters, and only count as dropped what preprocessing actually discards.