### PR TITLE
fix: Don't auto-init log in benches

### DIFF
--- a/neqo-common/benches/decoder.rs
+++ b/neqo-common/benches/decoder.rs
@@ -47,5 +47,9 @@ fn benchmark_decoder(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, benchmark_decoder);
+criterion_group! {
+    name = benches;
+    config = { neqo_common::log::init(None); Criterion::default() };
+    targets = benchmark_decoder
+}
 criterion_main!(benches);

--- a/neqo-common/src/log.rs
+++ b/neqo-common/src/log.rs
@@ -55,13 +55,13 @@ pub fn init(level_filter: Option<log::LevelFilter>) {
 
 /// Log an error message using the neqo logging framework.
 ///
-/// Automatically initializes logging in test/bench builds before logging.
+/// Automatically initializes logging in test builds before logging.
 /// Equivalent to `log::error!` but with automatic initialization.
 #[macro_export]
 #[clippy::format_args]
 macro_rules! qerror {
     ($($arg:tt)*) => ( {
-        #[cfg(any(test, feature = "bench"))]
+        #[cfg(test)]
         ::neqo_common::log::init(None);
         ::log::error!($($arg)*);
     } );
@@ -69,13 +69,13 @@ macro_rules! qerror {
 
 /// Log a warning message using the neqo logging framework.
 ///
-/// Automatically initializes logging in test/bench builds before logging.
+/// Automatically initializes logging in test builds before logging.
 /// Equivalent to `log::warn!` but with automatic initialization.
 #[macro_export]
 #[clippy::format_args]
 macro_rules! qwarn {
     ($($arg:tt)*) => ( {
-        #[cfg(any(test, feature = "bench"))]
+        #[cfg(test)]
         ::neqo_common::log::init(None);
         ::log::warn!($($arg)*);
     } );
@@ -83,13 +83,13 @@ macro_rules! qwarn {
 
 /// Log an informational message using the neqo logging framework.
 ///
-/// Automatically initializes logging in test/bench builds before logging.
+/// Automatically initializes logging in test builds before logging.
 /// Equivalent to `log::info!` but with automatic initialization.
 #[macro_export]
 #[clippy::format_args]
 macro_rules! qinfo {
     ($($arg:tt)*) => ( {
-        #[cfg(any(test, feature = "bench"))]
+        #[cfg(test)]
         ::neqo_common::log::init(None);
         ::log::info!($($arg)*);
     } );
@@ -97,13 +97,13 @@ macro_rules! qinfo {
 
 /// Log a debug message using the neqo logging framework.
 ///
-/// Automatically initializes logging in test/bench builds before logging.
+/// Automatically initializes logging in test builds before logging.
 /// Equivalent to `log::debug!` but with automatic initialization.
 #[macro_export]
 #[clippy::format_args]
 macro_rules! qdebug {
     ($($arg:tt)*) => ( {
-        #[cfg(any(test, feature = "bench"))]
+        #[cfg(test)]
         ::neqo_common::log::init(None);
         ::log::debug!($($arg)*);
     } );
@@ -111,13 +111,13 @@ macro_rules! qdebug {
 
 /// Log a trace message using the neqo logging framework.
 ///
-/// Automatically initializes logging in test/bench builds before logging.
+/// Automatically initializes logging in test builds before logging.
 /// Equivalent to `log::trace!` but with automatic initialization.
 #[macro_export]
 #[clippy::format_args]
 macro_rules! qtrace {
     ($($arg:tt)*) => ( {
-        #[cfg(any(test, feature = "bench"))]
+        #[cfg(test)]
         ::neqo_common::log::init(None);
         ::log::trace!($($arg)*);
     } );

--- a/neqo-transport/benches/frame_decode.rs
+++ b/neqo-transport/benches/frame_decode.rs
@@ -51,5 +51,9 @@ fn benchmark(c: &mut Criterion) {
     frame_decode(c, 1_000);
 }
 
-criterion_group!(benches, benchmark);
+criterion_group! {
+    name = benches;
+    config = { neqo_common::log::init(None); Criterion::default() };
+    targets = benchmark
+}
 criterion_main!(benches);

--- a/neqo-transport/benches/pacer.rs
+++ b/neqo-transport/benches/pacer.rs
@@ -95,10 +95,9 @@ fn pacer_spend_disabled(c: &mut Criterion) {
     });
 }
 
-criterion_group!(
-    benches,
-    pacer_spend_pacing_limited,
-    pacer_next_fast_path,
-    pacer_spend_disabled,
-);
+criterion_group! {
+    name = benches;
+    config = { neqo_common::log::init(None); Criterion::default() };
+    targets = pacer_spend_pacing_limited, pacer_next_fast_path, pacer_spend_disabled
+}
 criterion_main!(benches);

--- a/neqo-transport/benches/range_tracker.rs
+++ b/neqo-transport/benches/range_tracker.rs
@@ -150,12 +150,13 @@ fn mark_acked_fragmented(c: &mut Criterion) {
     });
 }
 
-criterion_group!(
-    benches,
-    benchmark_coalesce,
-    mark_sent_sequential,
-    mark_sent_retransmit,
-    mark_acked_gap_empty_covered,
-    mark_acked_fragmented,
-);
+criterion_group! {
+    name = benches;
+    config = { neqo_common::log::init(None); Criterion::default() };
+    targets = benchmark_coalesce,
+        mark_sent_sequential,
+        mark_sent_retransmit,
+        mark_acked_gap_empty_covered,
+        mark_acked_fragmented
+}
 criterion_main!(benches);

--- a/neqo-transport/benches/rx_stream_orderer.rs
+++ b/neqo-transport/benches/rx_stream_orderer.rs
@@ -124,11 +124,9 @@ fn inbound_duplicates(c: &mut Criterion) {
     });
 }
 
-criterion_group!(
-    benches,
-    inbound_in_order,
-    inbound_with_loss,
-    inbound_reordered,
-    inbound_duplicates,
-);
+criterion_group! {
+    name = benches;
+    config = { neqo_common::log::init(None); Criterion::default() };
+    targets = inbound_in_order, inbound_with_loss, inbound_reordered, inbound_duplicates
+}
 criterion_main!(benches);

--- a/neqo-transport/benches/send_streams.rs
+++ b/neqo-transport/benches/send_streams.rs
@@ -210,15 +210,16 @@ fn write_frames_3_groups_9_sendordered(c: &mut Criterion) {
     });
 }
 
-criterion_group!(
-    benches,
-    write_frames_1_stream,
-    write_frames_5_streams,
-    write_frames_20_streams,
-    write_frames_5_fair_all_active,
-    write_frames_20_fair_all_active,
-    write_frames_3_groups_9_streams,
-    write_frames_5_sendordered,
-    write_frames_3_groups_9_sendordered,
-);
+criterion_group! {
+    name = benches;
+    config = { neqo_common::log::init(None); Criterion::default() };
+    targets = write_frames_1_stream,
+        write_frames_5_streams,
+        write_frames_20_streams,
+        write_frames_5_fair_all_active,
+        write_frames_20_fair_all_active,
+        write_frames_3_groups_9_streams,
+        write_frames_5_sendordered,
+        write_frames_3_groups_9_sendordered
+}
 criterion_main!(benches);

--- a/neqo-transport/benches/sent_packets.rs
+++ b/neqo-transport/benches/sent_packets.rs
@@ -106,5 +106,9 @@ fn remove_expired(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, take_ranges, track, remove_expired);
+criterion_group! {
+    name = benches;
+    config = { neqo_common::log::init(None); Criterion::default() };
+    targets = take_ranges, track, remove_expired
+}
 criterion_main!(benches);


### PR DESCRIPTION
Make benches explicitly init logging once to reduce overheads.