### PR TITLE
fix(transport): respond to each key update only once

### DIFF
--- a/neqo-transport/src/connection/tests/keys.rs
+++ b/neqo-transport/src/connection/tests/keys.rs
@@ -222,6 +222,64 @@ fn key_update_consecutive() {
     check_discarded(&mut client, &dgram, false, 1, 0);
 }
 
+// Receiving the same key update packet twice must not be treated as two key
+// updates. The packet carrying a new key phase is decrypted with a key state
+// that has recorded a single packet number, which is how `needs_update` detects
+// a key update. Redelivering the packet leaves that state unchanged, so
+// `needs_update` fires again before the read keys rotate.
+#[test]
+fn key_update_received_twice() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+    let now = now();
+
+    // The server initiates a key update, so its next packet carries the new key
+    // phase.
+    assert!(server.initiate_key_update().is_ok());
+    assert_eq!(server.get_epochs(), (Some(4), Some(3)));
+    let dgram = send_something(&mut server, now);
+
+    // The client updates its write keys and arms the read-key timer, but does
+    // not rotate its read keys until that timer fires.
+    client.process_input(dgram.clone(), now);
+    assert_eq!(client.get_epochs(), (Some(4), Some(3)));
+
+    // The same packet again, before the timer fires, used to trip a debug
+    // assertion in `CryptoStates::maybe_update_write`. It must be a no-op.
+    client.process_input(dgram, now);
+    assert_eq!(client.get_epochs(), (Some(4), Some(3)));
+}
+
+// The same key update packet, redelivered after the read keys have rotated,
+// must not be treated as a fresh update. By then `read_update_time` is cleared,
+// so a guard keyed on it would let the duplicate through: the client would roll
+// its keys forward again (with assertions compiled out, no crash) and drive an
+// unsolicited key update, ratcheting the key phase ahead of the server.
+#[test]
+fn key_update_received_after_rotation() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+    let mut now = now();
+
+    assert!(server.initiate_key_update().is_ok());
+    let dgram = send_something(&mut server, now);
+
+    // The client responds to the update and arms the read-key timer.
+    client.process_input(dgram.clone(), now);
+    assert_eq!(client.get_epochs(), (Some(4), Some(3)));
+
+    // Let the timer fire so the client rotates its read keys to the new epoch.
+    now += AT_LEAST_PTO;
+    drop(client.process_output(now));
+    assert_eq!(client.get_epochs(), (Some(4), Some(4)));
+
+    // Redelivering the packet now must not start another key update.
+    client.process_input(dgram, now);
+    assert_eq!(client.get_epochs(), (Some(4), Some(4)));
+}
+
 // Key updates can't be initiated too early.
 #[test]
 fn key_update_before_confirmed() {

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -632,6 +632,11 @@ impl CryptoDxState {
         self.epoch & 1 != 1
     }
 
+    #[must_use]
+    pub const fn epoch(&self) -> usize {
+        self.epoch
+    }
+
     /// This is a continuation of a previous, so adjust the range accordingly.
     /// Fail if the two ranges overlap.  Do nothing if the directions don't match.
     pub fn continuation(&mut self, prev: &Self) -> Res<()> {
@@ -868,6 +873,11 @@ pub struct CryptoStates {
     // If this is set, then we have noticed a genuine update.
     // Once this time passes, we should switch in new keys.
     read_update_time: Option<Instant>,
+    // The read epoch of the most recent key update we have responded to.
+    // A duplicate of the packet that carried an update decrypts with the same
+    // keys and would otherwise be detected as that update again; comparing
+    // against this stops us from responding to the same update twice.
+    read_update_epoch: Option<usize>,
 }
 
 impl CryptoStates {
@@ -1307,7 +1317,17 @@ impl CryptoStates {
     /// Prepare to update read keys.  This doesn't happen immediately as
     /// we want to ensure that we can continue to receive any delayed
     /// packets that use the old keys.  So we just set a timer.
-    pub fn key_update_received(&mut self, expiration: Instant) -> Res<()> {
+    pub fn key_update_received(&mut self, epoch: usize, expiration: Instant) -> Res<()> {
+        // Respond to each key update once. A duplicate of the packet that
+        // carried the update decrypts with the same keys and is detected as
+        // the same update again; responding twice would advance the write keys
+        // a second time and trip an assertion in `maybe_update_write`.
+        if self.read_update_epoch.is_some_and(|e| epoch <= e) {
+            qtrace!("[{self}] Ignoring duplicate key update for epoch {epoch}");
+            return Ok(());
+        }
+        self.read_update_epoch = Some(epoch);
+
         qtrace!("[{self}] Key update received");
         // If we received a key update, then we assume that the peer has
         // acknowledged a packet we sent in this epoch. It's OK to do that
@@ -1402,6 +1422,7 @@ impl CryptoStates {
             app_read: Some(app_read(3)),
             app_read_next: Some(app_read(4)),
             read_update_time: None,
+            read_update_epoch: None,
         }
     }
 
@@ -1451,6 +1472,7 @@ impl CryptoStates {
             app_read: Some(app_read(3)),
             app_read_next: Some(app_read(4)),
             read_update_time: None,
+            read_update_epoch: None,
         }
     }
 }

--- a/neqo-transport/src/packet/mod.rs
+++ b/neqo-transport/src/packet/mod.rs
@@ -990,7 +990,10 @@ impl<'a> Public<'a> {
         // If this is the first packet ever successfully decrypted
         // using `rx`, make sure to initiate a key update.
         if rx.needs_update() {
-            crypto.key_update_received(release_at).map_err(make_err)?;
+            let rx_epoch = rx.epoch();
+            crypto
+                .key_update_received(rx_epoch, release_at)
+                .map_err(make_err)?;
         }
         crypto.check_pn_overlap().map_err(make_err)?;
         Ok(Decrypted {


### PR DESCRIPTION
A key update is detected from the first packet that decrypts with the new key phase, which the decrypt path recognizes from the key state having recorded a single packet number. A network duplicate of that packet decrypts with the same keys and leaves its recorded range unchanged, so it is detected as a key update again: `key_update_received` runs a second time and trips the `read_update_time.is_none()` assertion in `maybe_update_write`. With assertions compiled out it instead drives an unsolicited key update once the read keys have rotated, ratcheting the key phase ahead of the peer.

Record the read epoch of the update we last responded to and ignore any detection at or below it. A key phase is only updated once, so a duplicate can no longer re-enter the key update path, before or after the read keys rotate.

Reported at [Bugzilla bug 2063380](https://bugzilla.mozilla.org/show_bug.cgi?id=2063380).