### PR TITLE
feat: Add `next_timeout` to the public API

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -11,7 +11,7 @@ use std::{
     net::SocketAddr,
     num::NonZeroUsize,
     rc::Rc,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use neqo_common::{
@@ -863,6 +863,12 @@ impl Http3Client {
         self.process_http3(now);
 
         out
+    }
+
+    /// The delay after which [`Self::process_multiple_output`] needs to be called again.
+    #[must_use]
+    pub fn next_timeout(&mut self, now: Instant) -> Option<Duration> {
+        self.conn.next_timeout(now)
     }
 
     /// This function takes the provided result and check for an error.

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -865,7 +865,9 @@ impl Http3Client {
         out
     }
 
-    /// The delay after which [`Self::process_multiple_output`] needs to be called again.
+    /// The minimum delay after which [`Self::process_multiple_output`] needs to be called again.
+    ///
+    /// Only the QUIC layer is inspected, so HTTP/3 activity queued can shorten this.
     #[must_use]
     pub fn next_timeout(&mut self, now: Instant) -> Option<Duration> {
         self.conn.next_timeout(now)

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1163,7 +1163,7 @@ impl Connection {
         self.streams.cleanup_closed_streams();
     }
 
-    /// Get the time that we next need to be called back, relative to `now`.
+    /// Time until we next need a callback, `None` if never, zero if already due.
     fn next_delay(&mut self, now: Instant, paced: bool) -> Option<Duration> {
         qtrace!("[{self}] Get callback delay {now:?}");
 
@@ -1226,9 +1226,7 @@ impl Connection {
         // drive it.
 
         let earliest = delays.into_iter().min()?;
-        // TODO(agrover, mt) - need to analyze and fix #47
-        // rather than just clamping to zero here.
-        debug_assert!(earliest > now);
+        // Zero if already due, which only a caller that skipped `process_timer` sees.
         let delay = earliest.saturating_duration_since(now);
         qdebug!("[{self}] delay duration {delay:?}");
         self.hrtime.update(delay / 4);
@@ -1246,9 +1244,16 @@ impl Connection {
     }
 
     /// The minimum delay after which [`Self::process_multiple_output`] needs to be called again.
+    ///
+    /// Sending or receiving before then can shorten it.
+    ///
+    /// `None` means no callback needed, except for a not-yet-started client, which needs one now.
+    ///
+    /// Pacing is excluded. While the sender is pacer-blocked, [`Self::process_multiple_output`]
+    /// returns a shorter delay than this.
     #[must_use]
     pub fn next_timeout(&mut self, now: Instant) -> Option<Duration> {
-        // Not paced: waking early is harmless.
+        // `Pacer::next` can be in the past when it is not blocking, so leave it out.
         self.next_delay(now, false)
     }
 
@@ -1279,9 +1284,12 @@ impl Connection {
 
         match self.output(now, max_datagrams) {
             SendOptionBatch::Yes(dgram) => OutputBatch::DatagramBatch(dgram),
-            SendOptionBatch::No(paced) => self
-                .next_delay(now, paced)
-                .map_or(OutputBatch::None, OutputBatch::Callback),
+            SendOptionBatch::No(paced) => {
+                self.next_delay(now, paced).map_or(OutputBatch::None, |d| {
+                    debug_assert!(!d.is_zero());
+                    OutputBatch::Callback(d)
+                })
+            }
         }
     }
 

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1245,7 +1245,7 @@ impl Connection {
             .expect("max_datagrams is 1")
     }
 
-    /// The delay after which [`Self::process_multiple_output`] needs to be called again.
+    /// The minimum delay after which [`Self::process_multiple_output`] needs to be called again.
     #[must_use]
     pub fn next_timeout(&mut self, now: Instant) -> Option<Duration> {
         // Not paced: waking early is harmless.

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -1164,13 +1164,17 @@ impl Connection {
     }
 
     /// Get the time that we next need to be called back, relative to `now`.
-    fn next_delay(&mut self, now: Instant, paced: bool) -> Duration {
+    fn next_delay(&mut self, now: Instant, paced: bool) -> Option<Duration> {
         qtrace!("[{self}] Get callback delay {now:?}");
+
+        if matches!(self.state, State::Init | State::Closed(_)) {
+            return None;
+        }
 
         // Only one timer matters when closing...
         if let State::Closing { timeout, .. } | State::Draining { timeout, .. } = self.state {
             self.hrtime.update(Self::LOOSE_TIMER_RESOLUTION);
-            return timeout.duration_since(now);
+            return Some(timeout.duration_since(now));
         }
 
         let mut delays = SmallVec::<[_; 7]>::new();
@@ -1221,14 +1225,14 @@ impl Connection {
         // timeout for it  It is expected that other activities will
         // drive it.
 
-        let earliest = delays.into_iter().min().expect("at least one delay");
+        let earliest = delays.into_iter().min()?;
         // TODO(agrover, mt) - need to analyze and fix #47
         // rather than just clamping to zero here.
         debug_assert!(earliest > now);
         let delay = earliest.saturating_duration_since(now);
         qdebug!("[{self}] delay duration {delay:?}");
         self.hrtime.update(delay / 4);
-        delay
+        Some(delay)
     }
 
     /// Wrapper around [`Connection::process_multiple_output`] that processes a
@@ -1239,6 +1243,13 @@ impl Connection {
         self.process_multiple_output(now, 1.try_into().expect(">0"))
             .try_into()
             .expect("max_datagrams is 1")
+    }
+
+    /// The delay after which [`Self::process_multiple_output`] needs to be called again.
+    #[must_use]
+    pub fn next_timeout(&mut self, now: Instant) -> Option<Duration> {
+        // Not paced: waking early is harmless.
+        self.next_delay(now, false)
     }
 
     /// Get output packets, as a result of receiving packets, or actions taken
@@ -1268,13 +1279,9 @@ impl Connection {
 
         match self.output(now, max_datagrams) {
             SendOptionBatch::Yes(dgram) => OutputBatch::DatagramBatch(dgram),
-            SendOptionBatch::No(paced) => match self.state {
-                State::Init | State::Closed(_) => OutputBatch::None,
-                State::Closing { timeout, .. } | State::Draining { timeout, .. } => {
-                    OutputBatch::Callback(timeout.duration_since(now))
-                }
-                _ => OutputBatch::Callback(self.next_delay(now, paced)),
-            },
+            SendOptionBatch::No(paced) => self
+                .next_delay(now, paced)
+                .map_or(OutputBatch::None, OutputBatch::Callback),
         }
     }
 

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -922,3 +922,23 @@ fn max_pto_counter_resets_on_ack() {
     assert_eq!(client.loss_recovery.pto_count(), 2);
     assert!(!matches!(client.state(), State::Closed(_)));
 }
+
+#[test]
+fn no_next_timeout_before_start() {
+    let mut client = default_client();
+    assert_eq!(client.next_timeout(now()), None);
+}
+
+#[test]
+fn next_timeout_no_later_than_callback() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+
+    let now = now();
+    let Output::Callback(callback) = client.process_output(now) else {
+        panic!("an idle connection should ask for a callback");
+    };
+    let timeout = client.next_timeout(now).expect("a callback is needed");
+    assert!(timeout <= callback);
+}

--- a/neqo-transport/src/connection/tests/idle.rs
+++ b/neqo-transport/src/connection/tests/idle.rs
@@ -942,3 +942,33 @@ fn next_timeout_no_later_than_callback() {
     let timeout = client.next_timeout(now).expect("a callback is needed");
     assert!(timeout <= callback);
 }
+
+/// Querying after a deadline has passed reports zero rather than panicking.
+#[test]
+fn next_timeout_overdue() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+
+    let Output::Callback(callback) = client.process_output(now()) else {
+        panic!("an idle connection should ask for a callback");
+    };
+    // Deliberately no `process_output` in between, so the deadline is still armed.
+    let overdue = now() + callback + Duration::from_secs(1);
+    assert_eq!(client.next_timeout(overdue), Some(Duration::ZERO));
+}
+
+/// A closing connection needs a callback; once closed it needs none.
+#[test]
+fn next_timeout_while_closing() {
+    let mut client = default_client();
+    let mut server = default_server();
+    connect_force_idle(&mut client, &mut server);
+
+    let now = now();
+    client.close(now, 0, "");
+    let timeout = client.next_timeout(now).expect("closing needs a callback");
+    _ = client.process_output(now + timeout);
+    assert!(matches!(client.state(), State::Closed(_)));
+    assert_eq!(client.next_timeout(now + timeout), None);
+}


### PR DESCRIPTION
So neqo users can query the next timeout without producing output.