### PR TITLE
refactor: Extract shared event queue for transport and http3

### DIFF
--- a/neqo-common/src/event.rs
+++ b/neqo-common/src/event.rs
@@ -71,10 +71,10 @@ impl<T> Queue<T> {
         self.events.borrow_mut().clear();
     }
 
-    /// Determine whether there are pending events.
+    /// Determine whether the queue is empty.
     #[must_use]
-    pub fn has_events(&self) -> bool {
-        !self.events.borrow().is_empty()
+    pub fn is_empty(&self) -> bool {
+        self.events.borrow().is_empty()
     }
 
     /// Take the first event.
@@ -185,13 +185,13 @@ mod tests {
         q.push(2);
         q.push(3);
         q.remove_matching(|e| *e == 2);
-        assert!(q.has_events());
+        assert!(!q.is_empty());
         assert_eq!(q.next_event(), Some(1));
         assert_eq!(q.next_event(), Some(3));
         assert_eq!(q.next_event(), None);
         q.push(4);
         q.clear();
-        assert!(!q.has_events());
+        assert!(q.is_empty());
     }
 
     #[test]

--- a/neqo-common/src/event.rs
+++ b/neqo-common/src/event.rs
@@ -4,6 +4,92 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
+
+/// A shared FIFO of events. Clones share the same underlying queue.
+#[derive(Debug)]
+pub struct Queue<T> {
+    events: Rc<RefCell<VecDeque<T>>>,
+}
+
+impl<T> Default for Queue<T> {
+    fn default() -> Self {
+        Self {
+            events: Rc::default(),
+        }
+    }
+}
+
+impl<T> Clone for Queue<T> {
+    fn clone(&self) -> Self {
+        Self {
+            events: Rc::clone(&self.events),
+        }
+    }
+}
+
+impl<T> Queue<T> {
+    /// Append `event`, regardless of what is already queued.
+    pub fn push(&self, event: T) {
+        self.events.borrow_mut().push_back(event);
+    }
+
+    /// Append `event` unless an equal event is already queued.
+    /// An existing equal event keeps its place in the queue.
+    pub fn push_unique(&self, event: T)
+    where
+        T: PartialEq,
+    {
+        let mut q = self.events.borrow_mut();
+        if !q.contains(&event) {
+            q.push_back(event);
+        }
+    }
+
+    /// Append `event` unless a queued event matches `is_duplicate`.
+    /// An existing match keeps its place in the queue.
+    pub fn push_unique_by<F>(&self, event: T, is_duplicate: F)
+    where
+        F: Fn(&T) -> bool,
+    {
+        let mut q = self.events.borrow_mut();
+        if !q.iter().any(is_duplicate) {
+            q.push_back(event);
+        }
+    }
+
+    /// Remove all queued events matching `f`.
+    pub fn remove_matching<F>(&self, f: F)
+    where
+        F: Fn(&T) -> bool,
+    {
+        self.events.borrow_mut().retain(|event| !f(event));
+    }
+
+    /// Remove all queued events.
+    pub fn clear(&self) {
+        self.events.borrow_mut().clear();
+    }
+
+    /// Determine whether there are pending events.
+    #[must_use]
+    pub fn has_events(&self) -> bool {
+        !self.events.borrow().is_empty()
+    }
+
+    /// Take the first event.
+    #[must_use]
+    pub fn next_event(&self) -> Option<T> {
+        self.events.borrow_mut().pop_front()
+    }
+
+    /// Take all events.
+    #[must_use]
+    pub fn take_all(&self) -> VecDeque<T> {
+        self.events.take()
+    }
+}
+
 /// An event provider is able to generate a stream of events.
 pub trait Provider {
     type Event;
@@ -64,5 +150,57 @@ mod tests {
         let mut p = MockProvider(std::collections::VecDeque::new());
         assert!(!p.has_events());
         assert_eq!(p.events().next(), None);
+    }
+
+    #[test]
+    fn queue_push_allows_duplicates() {
+        let q = super::Queue::default();
+        q.push(1);
+        q.push(1);
+        assert_eq!(q.take_all(), [1, 1]);
+    }
+
+    #[test]
+    fn queue_push_unique_keeps_first() {
+        let q = super::Queue::default();
+        q.push_unique(1);
+        q.push_unique(2);
+        q.push_unique(1);
+        assert_eq!(q.take_all(), [1, 2]);
+    }
+
+    #[test]
+    fn queue_push_unique_by_matches_key() {
+        let q = super::Queue::default();
+        q.push_unique_by((1, 'a'), |(k, _)| *k == 1);
+        q.push_unique_by((1, 'b'), |(k, _)| *k == 1);
+        q.push_unique_by((2, 'c'), |(k, _)| *k == 2);
+        assert_eq!(q.take_all(), [(1, 'a'), (2, 'c')]);
+    }
+
+    #[test]
+    fn queue_remove_clear_next() {
+        let q = super::Queue::default();
+        q.push(1);
+        q.push(2);
+        q.push(3);
+        q.remove_matching(|e| *e == 2);
+        assert!(q.has_events());
+        assert_eq!(q.next_event(), Some(1));
+        assert_eq!(q.next_event(), Some(3));
+        assert_eq!(q.next_event(), None);
+        q.push(4);
+        q.clear();
+        assert!(!q.has_events());
+    }
+
+    #[test]
+    fn queue_clones_share() {
+        let q = super::Queue::default();
+        let clone = q.clone();
+        clone.push(1);
+        assert_eq!(q.next_event(), Some(1));
+        clone.push(2);
+        assert_eq!(q.next_event(), Some(2));
     }
 }

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -403,7 +403,7 @@ impl EventProvider for Http3ClientEvents {
 
     /// Check if there is any event present.
     fn has_events(&self) -> bool {
-        self.events.has_events()
+        !self.events.is_empty()
     }
 
     /// Take the first event.

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -6,7 +6,7 @@
 
 use neqo_common::{
     Bytes, Header,
-    event::{Provider as EventProvider, Queue},
+    event::{Provider as EventProvider, Queue as EventQueue},
     qtrace,
 };
 use neqo_transport::{AppError, StreamId, StreamType};
@@ -119,7 +119,7 @@ pub enum Http3ClientEvent {
 
 #[derive(Debug, Default, Clone)]
 pub struct Http3ClientEvents {
-    events: Queue<Http3ClientEvent>,
+    events: EventQueue<Http3ClientEvent>,
 }
 
 impl RecvStreamEvents for Http3ClientEvents {

--- a/neqo-http3/src/client_events.rs
+++ b/neqo-http3/src/client_events.rs
@@ -4,9 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{cell::RefCell, collections::VecDeque, rc::Rc};
-
-use neqo_common::{Bytes, Header, event::Provider as EventProvider, qtrace};
+use neqo_common::{
+    Bytes, Header,
+    event::{Provider as EventProvider, Queue},
+    qtrace,
+};
 use neqo_transport::{AppError, StreamId, StreamType};
 use nss::ResumptionToken;
 
@@ -117,13 +119,13 @@ pub enum Http3ClientEvent {
 
 #[derive(Debug, Default, Clone)]
 pub struct Http3ClientEvents {
-    events: Rc<RefCell<VecDeque<Http3ClientEvent>>>,
+    events: Queue<Http3ClientEvent>,
 }
 
 impl RecvStreamEvents for Http3ClientEvents {
     /// Add a new `DataReadable` event
     fn data_readable(&self, stream_info: &Http3StreamInfo) {
-        self.insert(Http3ClientEvent::DataReadable {
+        self.events.push(Http3ClientEvent::DataReadable {
             stream_id: stream_info.stream_id(),
         });
     }
@@ -148,7 +150,7 @@ impl RecvStreamEvents for Http3ClientEvents {
             }
         };
 
-        self.insert(Http3ClientEvent::Reset {
+        self.events.push(Http3ClientEvent::Reset {
             stream_id,
             error,
             local,
@@ -165,7 +167,7 @@ impl HttpRecvStreamEvents for Http3ClientEvents {
         interim: bool,
         fin: bool,
     ) {
-        self.insert(Http3ClientEvent::HeaderReady {
+        self.events.push(Http3ClientEvent::HeaderReady {
             stream_id: stream_info.stream_id(),
             headers,
             interim,
@@ -177,7 +179,7 @@ impl HttpRecvStreamEvents for Http3ClientEvents {
 impl SendStreamEvents for Http3ClientEvents {
     /// Add a new `DataWritable` event.
     fn data_writable(&self, stream_info: &Http3StreamInfo) {
-        self.insert(Http3ClientEvent::DataWritable {
+        self.events.push(Http3ClientEvent::DataWritable {
             stream_id: stream_info.stream_id(),
         });
     }
@@ -186,7 +188,8 @@ impl SendStreamEvents for Http3ClientEvents {
         let stream_id = stream_info.stream_id();
         self.remove_send_stream_events(stream_id);
         if let CloseType::ResetRemote(error) = close_type {
-            self.insert(Http3ClientEvent::StopSending { stream_id, error });
+            self.events
+                .push(Http3ClientEvent::StopSending { stream_id, error });
         }
     }
 }
@@ -201,7 +204,7 @@ impl ExtendedConnectEvents for Http3ClientEvents {
     ) {
         match connect_type {
             ExtendedConnectType::WebTransport => {
-                self.insert(Http3ClientEvent::WebTransport(
+                self.events.push(Http3ClientEvent::WebTransport(
                     WebTransportEvent::NewSession {
                         stream_id,
                         status,
@@ -210,11 +213,12 @@ impl ExtendedConnectEvents for Http3ClientEvents {
                 ));
             }
             ExtendedConnectType::ConnectUdp => {
-                self.insert(Http3ClientEvent::ConnectUdp(ConnectUdpEvent::NewSession {
-                    stream_id,
-                    status,
-                    headers,
-                }));
+                self.events
+                    .push(Http3ClientEvent::ConnectUdp(ConnectUdpEvent::NewSession {
+                        stream_id,
+                        status,
+                        headers,
+                    }));
             }
         }
     }
@@ -242,7 +246,7 @@ impl ExtendedConnectEvents for Http3ClientEvents {
                 })
             }
         };
-        self.insert(event);
+        self.events.push(event);
     }
 
     fn extended_connect_new_stream(
@@ -250,14 +254,14 @@ impl ExtendedConnectEvents for Http3ClientEvents {
         stream_info: Http3StreamInfo,
         emit_readable: bool,
     ) -> Res<()> {
-        self.insert(Http3ClientEvent::WebTransport(
+        self.events.push(Http3ClientEvent::WebTransport(
             WebTransportEvent::NewStream {
                 stream_id: stream_info.stream_id(),
                 session_id: stream_info.session_id().ok_or(Error::Internal)?,
             },
         ));
         if emit_readable {
-            self.insert(Http3ClientEvent::DataReadable {
+            self.events.push(Http3ClientEvent::DataReadable {
                 stream_id: stream_info.stream_id(),
             });
         }
@@ -284,7 +288,7 @@ impl ExtendedConnectEvents for Http3ClientEvents {
                 })
             }
         };
-        self.insert(event);
+        self.events.push(event);
     }
 }
 
@@ -292,60 +296,56 @@ impl Http3ClientEvents {
     /// Add a new `RequestCreatable` event
     pub(crate) fn new_requests_creatable(&self, stream_type: StreamType) {
         if stream_type == StreamType::BiDi {
-            self.insert(Http3ClientEvent::RequestsCreatable);
+            self.events.push(Http3ClientEvent::RequestsCreatable);
         }
     }
 
     /// Add a new `AuthenticationNeeded` event
     pub(crate) fn authentication_needed(&self) {
-        self.insert(Http3ClientEvent::AuthenticationNeeded);
+        self.events.push(Http3ClientEvent::AuthenticationNeeded);
     }
 
     /// Add a new `AuthenticationNeeded` event
     pub(crate) fn ech_fallback_authentication_needed(&self, public_name: String) {
-        self.insert(Http3ClientEvent::EchFallbackAuthenticationNeeded { public_name });
+        self.events
+            .push(Http3ClientEvent::EchFallbackAuthenticationNeeded { public_name });
     }
 
     /// Add a new resumption token event.
     pub(crate) fn resumption_token(&self, token: ResumptionToken) {
-        self.insert(Http3ClientEvent::ResumptionToken(token));
+        self.events.push(Http3ClientEvent::ResumptionToken(token));
     }
 
     /// Add a new `ZeroRttRejected` event.
     pub(crate) fn zero_rtt_rejected(&self) {
-        self.insert(Http3ClientEvent::ZeroRttRejected);
+        self.events.push(Http3ClientEvent::ZeroRttRejected);
     }
 
     /// Add a new `GoawayReceived` event.
     pub(crate) fn goaway_received(&self) {
-        self.remove(|evt| matches!(evt, Http3ClientEvent::RequestsCreatable));
-        self.insert(Http3ClientEvent::GoawayReceived);
+        self.events
+            .remove_matching(|evt| matches!(evt, Http3ClientEvent::RequestsCreatable));
+        self.events.push(Http3ClientEvent::GoawayReceived);
     }
 
-    pub fn insert(&self, event: Http3ClientEvent) {
-        self.events.borrow_mut().push_back(event);
-    }
-
-    fn remove<F>(&self, f: F)
-    where
-        F: Fn(&Http3ClientEvent) -> bool,
-    {
-        self.events.borrow_mut().retain(|evt| !f(evt));
+    /// Append an event, allowing duplicates.
+    pub(crate) fn push(&self, event: Http3ClientEvent) {
+        self.events.push(event);
     }
 
     /// Add a new `StateChange` event.
     pub(crate) fn connection_state_change(&self, state: Http3State) {
         match state {
             // If closing, existing events no longer relevant.
-            Http3State::Closing { .. } | Http3State::Closed(_) => self.events.borrow_mut().clear(),
+            Http3State::Closing { .. } | Http3State::Closed(_) => self.events.clear(),
             Http3State::Connected => {
-                self.remove(|evt| {
+                self.events.remove_matching(|evt| {
                     matches!(evt, Http3ClientEvent::StateChange(Http3State::ZeroRtt))
                 });
             }
             _ => (),
         }
-        self.insert(Http3ClientEvent::StateChange(state));
+        self.events.push(Http3ClientEvent::StateChange(state));
     }
 
     /// Remove events for a stream that is being torn down.
@@ -358,7 +358,7 @@ impl Http3ClientEvents {
     /// transport will delay delivery of the reset event, so the only case where we get
     /// a reset is where existing data is not intended to be reliably delivered.
     fn remove_recv_stream_events(&self, stream_id: StreamId, keep_header_ready: bool) {
-        self.remove(|evt| match evt {
+        self.events.remove_matching(|evt| match evt {
             Http3ClientEvent::HeaderReady { stream_id: x, .. } if *x == stream_id => {
                 !keep_header_ready
             }
@@ -373,7 +373,7 @@ impl Http3ClientEvents {
     }
 
     fn remove_send_stream_events(&self, stream_id: StreamId) {
-        self.remove(|evt| {
+        self.events.remove_matching(|evt| {
             matches!(evt,
                 Http3ClientEvent::DataWritable { stream_id: x }
                 | Http3ClientEvent::StopSending { stream_id: x, .. } if *x == stream_id)
@@ -383,14 +383,15 @@ impl Http3ClientEvents {
     pub fn negotiation_done(&self, feature_type: HSettingType, succeeded: bool) {
         match feature_type {
             HSettingType::EnableWebTransport => {
-                self.insert(Http3ClientEvent::WebTransport(
+                self.events.push(Http3ClientEvent::WebTransport(
                     WebTransportEvent::Negotiated(succeeded),
                 ));
             }
             HSettingType::EnableConnect => {
-                self.insert(Http3ClientEvent::ConnectUdp(ConnectUdpEvent::Negotiated(
-                    succeeded,
-                )));
+                self.events
+                    .push(Http3ClientEvent::ConnectUdp(ConnectUdpEvent::Negotiated(
+                        succeeded,
+                    )));
             }
             _ => qtrace!("HSetting {feature_type:?} {succeeded} not handled"),
         }
@@ -402,12 +403,12 @@ impl EventProvider for Http3ClientEvents {
 
     /// Check if there is any event present.
     fn has_events(&self) -> bool {
-        !self.events.borrow().is_empty()
+        self.events.has_events()
     }
 
     /// Take the first event.
     fn next_event(&mut self) -> Option<Self::Event> {
-        self.events.borrow_mut().pop_front()
+        self.events.next_event()
     }
 }
 
@@ -422,7 +423,7 @@ mod tests {
     fn has_events() {
         let events = Http3ClientEvents::default();
         assert!(!events.has_events());
-        events.insert(Http3ClientEvent::GoawayReceived);
+        events.push(Http3ClientEvent::GoawayReceived);
         assert!(events.has_events());
     }
 }

--- a/neqo-http3/src/connect_udp.rs
+++ b/neqo-http3/src/connect_udp.rs
@@ -454,7 +454,7 @@ pub(crate) trait ServerEvents {
 
 impl ServerEvents for Http3ServerEvents {
     fn connect_udp_new_session(&self, session: ServerSession, headers: Vec<Header>) {
-        self.insert(Http3ServerEvent::ConnectUdp(ServerEvent::NewSession {
+        self.push(Http3ServerEvent::ConnectUdp(ServerEvent::NewSession {
             session,
             headers,
         }));
@@ -466,7 +466,7 @@ impl ServerEvents for Http3ServerEvents {
         reason: extended_connect::session::CloseReason,
         headers: Option<Vec<Header>>,
     ) {
-        self.insert(Http3ServerEvent::ConnectUdp(ServerEvent::SessionClosed {
+        self.push(Http3ServerEvent::ConnectUdp(ServerEvent::SessionClosed {
             session,
             reason,
             headers,
@@ -474,7 +474,7 @@ impl ServerEvents for Http3ServerEvents {
     }
 
     fn connect_udp_datagram(&self, session: ServerSession, datagram: Bytes) {
-        self.insert(Http3ServerEvent::ConnectUdp(ServerEvent::Datagram {
+        self.push(Http3ServerEvent::ConnectUdp(ServerEvent::Datagram {
             session,
             datagram,
         }));

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -1016,7 +1016,7 @@ impl Http3Client {
             Http3State::Closing(..) | Http3State::Closed(..)
         ) {
             for session_id in self.base_handler.drain_webtransport_sessions() {
-                self.events.insert(Http3ClientEvent::WebTransport(
+                self.events.push(Http3ClientEvent::WebTransport(
                     WebTransportEvent::Draining {
                         stream_id: session_id,
                     },

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -4,9 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{cell::RefCell, collections::VecDeque, rc::Rc};
-
-use neqo_common::{Bytes, Header, header::HeadersExt as _};
+use neqo_common::{Bytes, Header, event::Queue, header::HeadersExt as _};
 use neqo_transport::{AppError, StreamId};
 
 use crate::{
@@ -87,7 +85,7 @@ pub enum ConnectUdpEvent {
 
 #[derive(Debug, Default, Clone)]
 pub struct Http3ServerConnEvents {
-    events: Rc<RefCell<VecDeque<Http3ServerConnEvent>>>,
+    events: Queue<Http3ServerConnEvent>,
 }
 
 impl SendStreamEvents for Http3ServerConnEvents {
@@ -95,7 +93,7 @@ impl SendStreamEvents for Http3ServerConnEvents {
         if close_type != CloseType::Done
             && let Some(error) = close_type.error()
         {
-            self.insert(Http3ServerConnEvent::StreamStopSending {
+            self.events.push(Http3ServerConnEvent::StreamStopSending {
                 stream_info: *stream_info,
                 error,
             });
@@ -103,7 +101,7 @@ impl SendStreamEvents for Http3ServerConnEvents {
     }
 
     fn data_writable(&self, stream_info: &Http3StreamInfo) {
-        self.insert(Http3ServerConnEvent::DataWritable {
+        self.events.push(Http3ServerConnEvent::DataWritable {
             stream_info: *stream_info,
         });
     }
@@ -112,7 +110,7 @@ impl SendStreamEvents for Http3ServerConnEvents {
 impl RecvStreamEvents for Http3ServerConnEvents {
     /// Add a new `DataReadable` event
     fn data_readable(&self, stream_info: &Http3StreamInfo) {
-        self.insert(Http3ServerConnEvent::DataReadable {
+        self.events.push(Http3ServerConnEvent::DataReadable {
             stream_info: *stream_info,
         });
     }
@@ -121,7 +119,7 @@ impl RecvStreamEvents for Http3ServerConnEvents {
         if close_type != CloseType::Done {
             self.remove_events_for_stream_id(stream_info);
             if let Some(error) = close_type.error() {
-                self.insert(Http3ServerConnEvent::StreamReset {
+                self.events.push(Http3ServerConnEvent::StreamReset {
                     stream_info: *stream_info,
                     error,
                 });
@@ -139,7 +137,7 @@ impl HttpRecvStreamEvents for Http3ServerConnEvents {
         _interim: bool,
         fin: bool,
     ) {
-        self.insert(Http3ServerConnEvent::Headers {
+        self.events.push(Http3ServerConnEvent::Headers {
             stream_info: *stream_info,
             headers,
             fin,
@@ -149,15 +147,16 @@ impl HttpRecvStreamEvents for Http3ServerConnEvents {
     fn extended_connect_new_session(&self, stream_id: StreamId, headers: Vec<Header>) {
         match headers.find_header(":protocol").map(Header::value) {
             Some(b"webtransport") => {
-                self.insert(Http3ServerConnEvent::WebTransport(
+                self.events.push(Http3ServerConnEvent::WebTransport(
                     WebTransportEvent::Session { stream_id, headers },
                 ));
             }
             Some(b"connect-udp") => {
-                self.insert(Http3ServerConnEvent::ConnectUdp(ConnectUdpEvent::Session {
-                    stream_id,
-                    headers,
-                }));
+                self.events
+                    .push(Http3ServerConnEvent::ConnectUdp(ConnectUdpEvent::Session {
+                        stream_id,
+                        headers,
+                    }));
             }
             Some(_) => {
                 unimplemented!("Extended connect other than webtransport or connect-udp")
@@ -202,7 +201,7 @@ impl ExtendedConnectEvents for Http3ServerConnEvents {
                 })
             }
         };
-        self.insert(event);
+        self.events.push(event);
     }
 
     fn extended_connect_new_stream(
@@ -211,7 +210,7 @@ impl ExtendedConnectEvents for Http3ServerConnEvents {
         emit_readable: bool,
     ) -> Res<()> {
         debug_assert!(!emit_readable, "only set by client");
-        self.insert(Http3ServerConnEvent::WebTransport(
+        self.events.push(Http3ServerConnEvent::WebTransport(
             WebTransportEvent::NewStream(stream_info),
         ));
         Ok(())
@@ -237,43 +236,32 @@ impl ExtendedConnectEvents for Http3ServerConnEvents {
                 })
             }
         };
-        self.insert(event);
+        self.events.push(event);
     }
 }
 
 impl Http3ServerConnEvents {
-    fn insert(&self, event: Http3ServerConnEvent) {
-        self.events.borrow_mut().push_back(event);
-    }
-
-    fn remove<F>(&self, f: F)
-    where
-        F: Fn(&Http3ServerConnEvent) -> bool,
-    {
-        self.events.borrow_mut().retain(|evt| !f(evt));
-    }
-
     pub fn has_events(&self) -> bool {
-        !self.events.borrow().is_empty()
+        self.events.has_events()
     }
 
     pub fn next_event(&self) -> Option<Http3ServerConnEvent> {
-        self.events.borrow_mut().pop_front()
+        self.events.next_event()
     }
 
     pub fn connection_state_change(&self, state: Http3State) {
-        self.insert(Http3ServerConnEvent::StateChange(state));
+        self.events.push(Http3ServerConnEvent::StateChange(state));
     }
 
     pub fn priority_update(&self, stream_id: StreamId, priority: Priority) {
-        self.insert(Http3ServerConnEvent::PriorityUpdate {
+        self.events.push(Http3ServerConnEvent::PriorityUpdate {
             stream_id,
             priority,
         });
     }
 
     fn remove_events_for_stream_id(&self, stream_info: &Http3StreamInfo) {
-        self.remove(|evt| {
+        self.events.remove_matching(|evt| {
             matches!(evt,
                 Http3ServerConnEvent::Headers { stream_info: x, .. } | Http3ServerConnEvent::DataReadable { stream_info: x, .. } if x == stream_info)
         });

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use neqo_common::{Bytes, Header, event::Queue, header::HeadersExt as _};
+use neqo_common::{Bytes, Header, event::Queue as EventQueue, header::HeadersExt as _};
 use neqo_transport::{AppError, StreamId};
 
 use crate::{
@@ -85,7 +85,7 @@ pub enum ConnectUdpEvent {
 
 #[derive(Debug, Default, Clone)]
 pub struct Http3ServerConnEvents {
-    events: Queue<Http3ServerConnEvent>,
+    events: EventQueue<Http3ServerConnEvent>,
 }
 
 impl SendStreamEvents for Http3ServerConnEvents {

--- a/neqo-http3/src/server_connection_events.rs
+++ b/neqo-http3/src/server_connection_events.rs
@@ -242,7 +242,7 @@ impl ExtendedConnectEvents for Http3ServerConnEvents {
 
 impl Http3ServerConnEvents {
     pub fn has_events(&self) -> bool {
-        self.events.has_events()
+        !self.events.is_empty()
     }
 
     pub fn next_event(&self) -> Option<Http3ServerConnEvent> {

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -12,7 +12,7 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{Header, event::Queue, qdebug};
+use neqo_common::{Header, event::Queue as EventQueue, qdebug};
 use neqo_transport::{AppError, Connection, StreamId, server::ConnectionRef};
 
 use crate::{
@@ -283,7 +283,7 @@ pub enum Http3ServerEvent {
 
 #[derive(Debug, Default, Clone)]
 pub struct Http3ServerEvents {
-    events: Queue<Http3ServerEvent>,
+    events: EventQueue<Http3ServerEvent>,
 }
 
 impl Http3ServerEvents {

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -6,14 +6,13 @@
 
 use std::{
     cell::RefCell,
-    collections::VecDeque,
     fmt::{self, Display, Formatter},
     ops::Deref,
     rc::Rc,
     time::Instant,
 };
 
-use neqo_common::{Header, qdebug};
+use neqo_common::{Header, event::Queue, qdebug};
 use neqo_transport::{AppError, Connection, StreamId, server::ConnectionRef};
 
 use crate::{
@@ -284,27 +283,28 @@ pub enum Http3ServerEvent {
 
 #[derive(Debug, Default, Clone)]
 pub struct Http3ServerEvents {
-    events: Rc<RefCell<VecDeque<Http3ServerEvent>>>,
+    events: Queue<Http3ServerEvent>,
 }
 
 impl Http3ServerEvents {
-    pub(crate) fn insert(&self, event: Http3ServerEvent) {
-        self.events.borrow_mut().push_back(event);
+    /// Append an event, allowing duplicates.
+    pub(crate) fn push(&self, event: Http3ServerEvent) {
+        self.events.push(event);
     }
 
     /// Take all events
     pub fn events(&self) -> impl Iterator<Item = Http3ServerEvent> + use<> {
-        self.events.replace(VecDeque::new()).into_iter()
+        self.events.take_all().into_iter()
     }
 
     /// Whether there is request pending.
     pub fn has_events(&self) -> bool {
-        !self.events.borrow().is_empty()
+        self.events.has_events()
     }
 
     /// Take the next event if present.
     pub fn next_event(&self) -> Option<Http3ServerEvent> {
-        self.events.borrow_mut().pop_front()
+        self.events.next_event()
     }
 
     /// Insert a `Headers` event.
@@ -314,7 +314,7 @@ impl Http3ServerEvents {
         headers: Vec<Header>,
         fin: bool,
     ) {
-        self.insert(Http3ServerEvent::Headers {
+        self.events.push(Http3ServerEvent::Headers {
             stream: request,
             headers,
             fin,
@@ -323,7 +323,8 @@ impl Http3ServerEvents {
 
     /// Insert a `StateChange` event.
     pub(crate) fn connection_state_change(&self, conn: ConnectionRef, state: Http3State) {
-        self.insert(Http3ServerEvent::StateChange { conn, state });
+        self.events
+            .push(Http3ServerEvent::StateChange { conn, state });
     }
 
     /// Insert a `Data` event.
@@ -335,7 +336,7 @@ impl Http3ServerEvents {
         data: Vec<u8>,
         fin: bool,
     ) {
-        self.insert(Http3ServerEvent::Data {
+        self.events.push(Http3ServerEvent::Data {
             stream: Http3OrWebTransportStream::new(conn, handler, stream_info),
             data,
             fin,
@@ -348,7 +349,7 @@ impl Http3ServerEvents {
         handler: Rc<RefCell<Http3ServerHandler>>,
         stream_info: Http3StreamInfo,
     ) {
-        self.insert(Http3ServerEvent::DataWritable {
+        self.events.push(Http3ServerEvent::DataWritable {
             stream: Http3OrWebTransportStream::new(conn, handler, stream_info),
         });
     }
@@ -360,7 +361,7 @@ impl Http3ServerEvents {
         stream_info: Http3StreamInfo,
         error: AppError,
     ) {
-        self.insert(Http3ServerEvent::StreamReset {
+        self.events.push(Http3ServerEvent::StreamReset {
             stream: Http3OrWebTransportStream::new(conn, handler, stream_info),
             error,
         });
@@ -373,14 +374,14 @@ impl Http3ServerEvents {
         stream_info: Http3StreamInfo,
         error: AppError,
     ) {
-        self.insert(Http3ServerEvent::StreamStopSending {
+        self.events.push(Http3ServerEvent::StreamStopSending {
             stream: Http3OrWebTransportStream::new(conn, handler, stream_info),
             error,
         });
     }
 
     pub(crate) fn priority_update(&self, stream_id: StreamId, priority: Priority) {
-        self.insert(Http3ServerEvent::PriorityUpdate {
+        self.events.push(Http3ServerEvent::PriorityUpdate {
             stream_id,
             priority,
         });

--- a/neqo-http3/src/server_events.rs
+++ b/neqo-http3/src/server_events.rs
@@ -299,7 +299,7 @@ impl Http3ServerEvents {
 
     /// Whether there is request pending.
     pub fn has_events(&self) -> bool {
-        self.events.has_events()
+        !self.events.is_empty()
     }
 
     /// Take the next event if present.

--- a/neqo-http3/src/webtransport.rs
+++ b/neqo-http3/src/webtransport.rs
@@ -819,7 +819,7 @@ pub(crate) trait ServerEvents {
 
 impl ServerEvents for Http3ServerEvents {
     fn webtransport_new_session(&self, session: ServerSession, headers: Vec<Header>) {
-        self.insert(Http3ServerEvent::WebTransport(ServerEvent::NewSession {
+        self.push(Http3ServerEvent::WebTransport(ServerEvent::NewSession {
             session,
             headers,
         }));
@@ -831,7 +831,7 @@ impl ServerEvents for Http3ServerEvents {
         reason: extended_connect::session::CloseReason,
         headers: Option<Vec<Header>>,
     ) {
-        self.insert(Http3ServerEvent::WebTransport(ServerEvent::SessionClosed {
+        self.push(Http3ServerEvent::WebTransport(ServerEvent::SessionClosed {
             session,
             reason,
             headers,
@@ -839,13 +839,13 @@ impl ServerEvents for Http3ServerEvents {
     }
 
     fn webtransport_new_stream(&self, stream: Http3OrWebTransportStream) {
-        self.insert(Http3ServerEvent::WebTransport(ServerEvent::NewStream(
+        self.push(Http3ServerEvent::WebTransport(ServerEvent::NewStream(
             stream,
         )));
     }
 
     fn webtransport_datagram(&self, session: ServerSession, datagram: Bytes) {
-        self.insert(Http3ServerEvent::WebTransport(ServerEvent::Datagram {
+        self.push(Http3ServerEvent::WebTransport(ServerEvent::Datagram {
             session,
             datagram,
         }));

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -8,7 +8,7 @@
 
 use std::{net::SocketAddr, num::NonZeroU64};
 
-use neqo_common::event::{Provider as EventProvider, Queue};
+use neqo_common::event::{Provider as EventProvider, Queue as EventQueue};
 use nss::ResumptionToken;
 
 use crate::{
@@ -90,13 +90,12 @@ pub enum ConnectionEvent {
 
 #[derive(Debug, Default, Clone)]
 pub struct ConnectionEvents {
-    events: Queue<ConnectionEvent>,
+    events: EventQueue<ConnectionEvent>,
 }
 
 impl ConnectionEvents {
     pub fn authentication_needed(&self) {
-        self.events
-            .push_unique(ConnectionEvent::AuthenticationNeeded);
+        self.events.push(ConnectionEvent::AuthenticationNeeded);
     }
 
     pub fn ech_fallback_authentication_needed(&self, public_name: String) {
@@ -105,8 +104,7 @@ impl ConnectionEvents {
     }
 
     pub fn new_stream(&self, stream_id: StreamId) {
-        self.events
-            .push_unique(ConnectionEvent::NewStream { stream_id });
+        self.events.push(ConnectionEvent::NewStream { stream_id });
     }
 
     pub fn recv_stream_readable(&self, stream_id: StreamId) {
@@ -157,12 +155,13 @@ impl ConnectionEvents {
         self.events.remove_matching(|evt| {
             matches!(evt,
                 ConnectionEvent::SendStreamWritable { stream_id: x } |
-                ConnectionEvent::SendStreamStopSending { stream_id: x, .. }
+                ConnectionEvent::SendStreamStopSending { stream_id: x, .. } |
+                ConnectionEvent::SendStreamComplete { stream_id: x }
                 if *x == stream_id)
         });
 
         self.events
-            .push_unique(ConnectionEvent::SendStreamComplete { stream_id });
+            .push(ConnectionEvent::SendStreamComplete { stream_id });
     }
 
     pub fn send_stream_creatable(&self, stream_type: StreamType) {
@@ -180,15 +179,14 @@ impl ConnectionEvents {
     }
 
     pub fn client_resumption_token(&self, token: ResumptionToken) {
-        self.events
-            .push_unique(ConnectionEvent::ResumptionToken(token));
+        self.events.push(ConnectionEvent::ResumptionToken(token));
     }
 
     pub fn client_0rtt_rejected(&self) {
         // If 0rtt rejected, must start over and existing events are no longer
         // relevant.
         self.events.clear();
-        self.events.push_unique(ConnectionEvent::ZeroRttRejected);
+        self.events.push(ConnectionEvent::ZeroRttRejected);
     }
 
     pub fn recv_stream_complete(&self, stream_id: StreamId) {
@@ -220,7 +218,7 @@ impl ConnectionEvents {
 
     pub fn path_migrated(&self, local: SocketAddr, remote: SocketAddr) {
         self.events
-            .push_unique(ConnectionEvent::PathMigrated { local, remote });
+            .push(ConnectionEvent::PathMigrated { local, remote });
     }
 }
 
@@ -253,10 +251,6 @@ mod tests {
         evts.client_0rtt_rejected();
         assert_eq!(evts.events().count(), 1);
         assert_eq!(evts.events().count(), 0);
-
-        evts.new_stream(4.into());
-        evts.new_stream(4.into());
-        assert_eq!(evts.events().count(), 1);
 
         evts.recv_stream_readable(6.into());
         evts.recv_stream_reset(6.into(), 66);

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -6,9 +6,9 @@
 
 // Collecting a list of events relevant to whoever is using the Connection.
 
-use std::{cell::RefCell, collections::VecDeque, net::SocketAddr, num::NonZeroU64, rc::Rc};
+use std::{net::SocketAddr, num::NonZeroU64};
 
-use neqo_common::event::Provider as EventProvider;
+use neqo_common::event::{Provider as EventProvider, Queue};
 use nss::ResumptionToken;
 
 use crate::{
@@ -90,99 +90,121 @@ pub enum ConnectionEvent {
 
 #[derive(Debug, Default, Clone)]
 pub struct ConnectionEvents {
-    events: Rc<RefCell<VecDeque<ConnectionEvent>>>,
+    events: Queue<ConnectionEvent>,
 }
 
 impl ConnectionEvents {
     pub fn authentication_needed(&self) {
-        self.insert(ConnectionEvent::AuthenticationNeeded);
+        self.events
+            .push_unique(ConnectionEvent::AuthenticationNeeded);
     }
 
     pub fn ech_fallback_authentication_needed(&self, public_name: String) {
-        self.insert(ConnectionEvent::EchFallbackAuthenticationNeeded { public_name });
+        self.events
+            .push_unique(ConnectionEvent::EchFallbackAuthenticationNeeded { public_name });
     }
 
     pub fn new_stream(&self, stream_id: StreamId) {
-        self.insert(ConnectionEvent::NewStream { stream_id });
+        self.events
+            .push_unique(ConnectionEvent::NewStream { stream_id });
     }
 
     pub fn recv_stream_readable(&self, stream_id: StreamId) {
-        self.insert(ConnectionEvent::RecvStreamReadable { stream_id });
+        self.events
+            .push_unique(ConnectionEvent::RecvStreamReadable { stream_id });
     }
 
     pub fn recv_stream_reset(&self, stream_id: StreamId, app_error: AppError) {
         // If reset, no longer readable.
-        self.remove(|evt| matches!(evt, ConnectionEvent::RecvStreamReadable { stream_id: x } if *x == stream_id.as_u64()));
+        self.events.remove_matching(|evt| matches!(evt, ConnectionEvent::RecvStreamReadable { stream_id: x } if *x == stream_id.as_u64()));
 
-        self.insert(ConnectionEvent::RecvStreamReset {
-            stream_id,
-            app_error,
-        });
+        // A duplicate is any reset for the stream, even with a different error.
+        self.events.push_unique_by(
+            ConnectionEvent::RecvStreamReset {
+                stream_id,
+                app_error,
+            },
+            |evt| {
+                matches!(evt, ConnectionEvent::RecvStreamReset { stream_id: x, .. }
+                    if *x == stream_id)
+            },
+        );
     }
 
     pub fn send_stream_writable(&self, stream_id: StreamId) {
-        self.insert(ConnectionEvent::SendStreamWritable { stream_id });
+        self.events
+            .push_unique(ConnectionEvent::SendStreamWritable { stream_id });
     }
 
     pub fn send_stream_stop_sending(&self, stream_id: StreamId, app_error: AppError) {
         // If stopped, no longer writable.
-        self.remove(|evt| matches!(evt, ConnectionEvent::SendStreamWritable { stream_id: x } if *x == stream_id));
+        self.events.remove_matching(|evt| matches!(evt, ConnectionEvent::SendStreamWritable { stream_id: x } if *x == stream_id));
 
-        self.insert(ConnectionEvent::SendStreamStopSending {
-            stream_id,
-            app_error,
-        });
+        // A duplicate is any stop for the stream, even with a different error.
+        self.events.push_unique_by(
+            ConnectionEvent::SendStreamStopSending {
+                stream_id,
+                app_error,
+            },
+            |evt| {
+                matches!(evt, ConnectionEvent::SendStreamStopSending { stream_id: x, .. }
+                    if *x == stream_id)
+            },
+        );
     }
 
     pub fn send_stream_complete(&self, stream_id: StreamId) {
-        self.remove(|evt| {
+        self.events.remove_matching(|evt| {
             matches!(evt,
                 ConnectionEvent::SendStreamWritable { stream_id: x } |
                 ConnectionEvent::SendStreamStopSending { stream_id: x, .. }
                 if *x == stream_id)
         });
 
-        self.insert(ConnectionEvent::SendStreamComplete { stream_id });
+        self.events
+            .push_unique(ConnectionEvent::SendStreamComplete { stream_id });
     }
 
     pub fn send_stream_creatable(&self, stream_type: StreamType) {
-        self.insert(ConnectionEvent::SendStreamCreatable { stream_type });
+        self.events
+            .push_unique(ConnectionEvent::SendStreamCreatable { stream_type });
     }
 
     pub fn connection_state_change(&self, state: State) {
         // If closing, existing events no longer relevant.
         match state {
-            State::Closing { .. } | State::Closed(_) => self.events.borrow_mut().clear(),
+            State::Closing { .. } | State::Closed(_) => self.events.clear(),
             _ => (),
         }
-        self.insert(ConnectionEvent::StateChange(state));
+        self.events.push_unique(ConnectionEvent::StateChange(state));
     }
 
     pub fn client_resumption_token(&self, token: ResumptionToken) {
-        self.insert(ConnectionEvent::ResumptionToken(token));
+        self.events
+            .push_unique(ConnectionEvent::ResumptionToken(token));
     }
 
     pub fn client_0rtt_rejected(&self) {
         // If 0rtt rejected, must start over and existing events are no longer
         // relevant.
-        self.events.borrow_mut().clear();
-        self.insert(ConnectionEvent::ZeroRttRejected);
+        self.events.clear();
+        self.events.push_unique(ConnectionEvent::ZeroRttRejected);
     }
 
     pub fn recv_stream_complete(&self, stream_id: StreamId) {
         // If stopped, no longer readable.
-        self.remove(|evt| matches!(evt, ConnectionEvent::RecvStreamReadable { stream_id: x } if *x == stream_id.as_u64()));
+        self.events.remove_matching(|evt| matches!(evt, ConnectionEvent::RecvStreamReadable { stream_id: x } if *x == stream_id.as_u64()));
     }
 
     pub fn scone_updated(&self, scone: Bitrate) {
-        self.remove(|evt| matches!(evt, ConnectionEvent::SconeUpdated(_)));
-        self.insert(ConnectionEvent::SconeUpdated(Option::from(scone)));
+        self.events
+            .remove_matching(|evt| matches!(evt, ConnectionEvent::SconeUpdated(_)));
+        self.events
+            .push_unique(ConnectionEvent::SconeUpdated(Option::from(scone)));
     }
 
     pub fn add_datagram(&self, data: &[u8]) {
-        self.events
-            .borrow_mut()
-            .push_back(ConnectionEvent::Datagram(data.to_vec()));
+        self.events.push(ConnectionEvent::Datagram(data.to_vec()));
     }
 
     pub fn datagram_outcome(
@@ -192,41 +214,13 @@ impl ConnectionEvents {
     ) {
         if let DatagramTracking::Id(id) = dgram_tracker {
             self.events
-                .borrow_mut()
-                .push_back(ConnectionEvent::OutgoingDatagramOutcome { id: *id, outcome });
+                .push(ConnectionEvent::OutgoingDatagramOutcome { id: *id, outcome });
         }
     }
 
     pub fn path_migrated(&self, local: SocketAddr, remote: SocketAddr) {
-        self.insert(ConnectionEvent::PathMigrated { local, remote });
-    }
-
-    fn insert(&self, event: ConnectionEvent) {
-        let mut q = self.events.borrow_mut();
-
-        // Special-case two enums that are not strictly PartialEq equal but that
-        // we wish to avoid inserting duplicates.
-        let already_present = match &event {
-            ConnectionEvent::SendStreamStopSending { stream_id, .. } => q.iter().any(|evt| {
-                matches!(evt, ConnectionEvent::SendStreamStopSending { stream_id: x, .. }
-		                    if *x == *stream_id)
-            }),
-            ConnectionEvent::RecvStreamReset { stream_id, .. } => q.iter().any(|evt| {
-                matches!(evt, ConnectionEvent::RecvStreamReset { stream_id: x, .. }
-		                    if *x == *stream_id)
-            }),
-            _ => q.contains(&event),
-        };
-        if !already_present {
-            q.push_back(event);
-        }
-    }
-
-    fn remove<F>(&self, f: F)
-    where
-        F: Fn(&ConnectionEvent) -> bool,
-    {
-        self.events.borrow_mut().retain(|evt| !f(evt));
+        self.events
+            .push_unique(ConnectionEvent::PathMigrated { local, remote });
     }
 }
 
@@ -234,11 +228,11 @@ impl EventProvider for ConnectionEvents {
     type Event = ConnectionEvent;
 
     fn has_events(&self) -> bool {
-        !self.events.borrow().is_empty()
+        self.events.has_events()
     }
 
     fn next_event(&mut self) -> Option<Self::Event> {
-        self.events.borrow_mut().pop_front()
+        self.events.next_event()
     }
 }
 

--- a/neqo-transport/src/events.rs
+++ b/neqo-transport/src/events.rs
@@ -228,7 +228,7 @@ impl EventProvider for ConnectionEvents {
     type Event = ConnectionEvent;
 
     fn has_events(&self) -> bool {
-        self.events.has_events()
+        !self.events.is_empty()
     }
 
     fn next_event(&mut self) -> Option<Self::Event> {


### PR DESCRIPTION
The event queues in `neqo-transport` and `neqo-http3` each wrapped their own `Rc<RefCell<VecDeque<_>>>` and both named the append method `insert`, though transport's dropped duplicates and http3's did not.

Move the wrapper into `neqo-common` as `event::Queue<T>`, offering `push` to append and `push_unique` to append only if no equal event is queued. No behavior change.

Noticed while working on https://github.com/mozilla/neqo/pull/3859.