### PR TITLE
chore: use Vec instead of SmallVec in RecvdPackets::write_frame

### DIFF
--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -18,7 +18,6 @@ use enumset::{EnumSet, EnumSetType};
 use log::{Level, log_enabled};
 use neqo_common::{Buffer, Ecn, MAX_VARINT, qdebug, qtrace, qwarn, to_u64};
 use nss::Epoch;
-use smallvec::SmallVec;
 use strum::{Display, EnumIter};
 
 use crate::{
@@ -451,7 +450,7 @@ impl RecvdPackets {
             .filter(|r| r.ack_needed())
             .take(max_ranges)
             .cloned()
-            .collect::<SmallVec<[_; MAX_TRACKED_RANGES]>>();
+            .collect::<Vec<_>>();
         if ranges.is_empty() {
             return;
         }


### PR DESCRIPTION
Per #2781.

The `SmallVec` here is collected and then `into_boxed_slice()`d two lines
later, so the inline capacity never actually avoids an allocation — it just
adds a copy pass, plus ~776 bytes of stack frame on every ACK write
(`MAX_TRACKED_RANGES` is 32, `PacketRange` is 24 bytes).

I couldn't resolve this locally. Running `transfer_simulated` A/B/A/B, two
runs of the *identical* build gave a ±20% confidence interval (p = 0.57 and
0.81), so the local noise floor is far above any effect this change could
plausibly have.

Opening as a draft to get CI's instruction-count numbers. Happy to close it
if they show a regression.

Also checked the three `SmallVec` uses in `send_stream.rs` (lines 221, 318,
398) while looking at this issue. Those are local scratch in `RangeTracker`
and `TxBuffer`, neither of which derives `Clone`, so they don't have the
shape that caused the #2779 regression. I'd leave those alone.