### PR TITLE
fix: Drop `space` from `AckToken` and `CryptoRecoveryToken`

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -3563,7 +3563,7 @@ impl Connection {
     /// to retransmit the frame as needed.
     fn handle_lost_packets(&mut self, lost_packets: &[sent::Packet]) {
         for lost in lost_packets {
-            let space = PacketNumberSpace::from(lost.packet_type());
+            let space = lost.space();
             for token in lost.tokens() {
                 qdebug!("[{self}] Lost: {token:?}");
                 match token {

--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -3563,16 +3563,17 @@ impl Connection {
     /// to retransmit the frame as needed.
     fn handle_lost_packets(&mut self, lost_packets: &[sent::Packet]) {
         for lost in lost_packets {
+            let space = PacketNumberSpace::from(lost.packet_type());
             for token in lost.tokens() {
                 qdebug!("[{self}] Lost: {token:?}");
                 match token {
-                    recovery::Token::Ack(ack_token) => {
+                    recovery::Token::Ack(_) => {
                         // If we lost an ACK frame during the handshake, send another one.
-                        if ack_token.space() != PacketNumberSpace::ApplicationData {
-                            self.acks.immediate_ack(ack_token.space(), lost.time_sent());
+                        if space != PacketNumberSpace::ApplicationData {
+                            self.acks.immediate_ack(space, lost.time_sent());
                         }
                     }
-                    recovery::Token::Crypto(ct) => self.crypto.lost(ct),
+                    recovery::Token::Crypto(ct) => self.crypto.lost(space, ct),
                     recovery::Token::HandshakeDone => self.state_signaling.handshake_done(),
                     recovery::Token::NewToken(seqno) => self.new_token.lost(*seqno),
                     recovery::Token::NewConnectionId(ncid) => self.cid_manager.lost(ncid),
@@ -3647,8 +3648,8 @@ impl Connection {
             for token in acked.tokens() {
                 match token {
                     recovery::Token::Stream(stream_token) => self.streams.acked(stream_token),
-                    recovery::Token::Ack(at) => self.acks.acked(at),
-                    recovery::Token::Crypto(ct) => self.crypto.acked(ct),
+                    recovery::Token::Ack(at) => self.acks.acked(space, at),
+                    recovery::Token::Crypto(ct) => self.crypto.acked(space, ct),
                     recovery::Token::NewToken(seqno) => self.new_token.acked(*seqno),
                     recovery::Token::NewConnectionId(entry) => self.cid_manager.acked(entry),
                     recovery::Token::RetireConnectionId(seqno) => {

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -349,24 +349,22 @@ impl Crypto {
             .write_frame(space, sni_slicing, builder, tokens, stats);
     }
 
-    pub fn acked(&mut self, token: &CryptoRecoveryToken) {
+    pub fn acked(&mut self, space: PacketNumberSpace, token: &CryptoRecoveryToken) {
         qdebug!(
-            "Acked crypto frame space={} offset={} length={}",
-            token.space,
+            "Acked crypto frame space={space} offset={} length={}",
             token.offset,
             token.length
         );
-        self.streams.acked(token);
+        self.streams.acked(space, token);
     }
 
-    pub fn lost(&mut self, token: &CryptoRecoveryToken) {
+    pub fn lost(&mut self, space: PacketNumberSpace, token: &CryptoRecoveryToken) {
         qinfo!(
-            "Lost crypto frame space={} offset={} length={}",
-            token.space,
+            "Lost crypto frame space={space} offset={} length={}",
             token.offset,
             token.length
         );
-        self.streams.lost(token);
+        self.streams.lost(space, token);
     }
 
     /// Mark any outstanding frames in the indicated space as "lost" so
@@ -1576,15 +1574,15 @@ impl CryptoStreams {
             .read_to_end(buf))
     }
 
-    pub fn acked(&mut self, token: &CryptoRecoveryToken) {
-        if let Some(cs) = self.get_mut(token.space) {
+    pub fn acked(&mut self, space: PacketNumberSpace, token: &CryptoRecoveryToken) {
+        if let Some(cs) = self.get_mut(space) {
             cs.tx.mark_as_acked(token.offset, token.length);
         }
     }
 
-    pub fn lost(&mut self, token: &CryptoRecoveryToken) {
+    pub fn lost(&mut self, space: PacketNumberSpace, token: &CryptoRecoveryToken) {
         // See BZ 1624800, ignore lost packets in spaces we've dropped keys
-        if let Some(cs) = self.get_mut(token.space) {
+        if let Some(cs) = self.get_mut(space) {
             cs.tx.mark_as_lost(token.offset, token.length);
         }
     }
@@ -1688,7 +1686,6 @@ impl CryptoStreams {
             cs.tx.mark_as_sent(offset, len);
             qdebug!("CRYPTO for {space} offset={offset}, len={len}");
             tokens.push(recovery::Token::Crypto(CryptoRecoveryToken {
-                space,
                 offset,
                 length: len,
             }));
@@ -1783,9 +1780,9 @@ impl Default for CryptoStreams {
     }
 }
 
+/// Does not record the packet number space, that can be derived from packet types
 #[derive(Debug, Clone)]
 pub struct CryptoRecoveryToken {
-    space: PacketNumberSpace,
     offset: u64,
     length: usize,
 }

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -1780,7 +1780,8 @@ impl Default for CryptoStreams {
     }
 }
 
-/// The packet number space is not recorded because it can be derived from the carrying packet's type.
+/// The packet number space is not recorded because it can be derived from the carrying packet's
+/// type.
 #[derive(Debug, Clone)]
 pub struct CryptoRecoveryToken {
     offset: u64,

--- a/neqo-transport/src/crypto.rs
+++ b/neqo-transport/src/crypto.rs
@@ -1780,7 +1780,7 @@ impl Default for CryptoStreams {
     }
 }
 
-/// Does not record the packet number space, that can be derived from packet types
+/// The packet number space is not recorded because it can be derived from the carrying packet's type.
 #[derive(Debug, Clone)]
 pub struct CryptoRecoveryToken {
     offset: u64,

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -547,7 +547,7 @@ impl Loss {
     }
 
     pub fn on_packet_sent(&mut self, path: &PathRef, mut sent_packet: sent::Packet, now: Instant) {
-        let pn_space = PacketNumberSpace::from(sent_packet.packet_type());
+        let pn_space = sent_packet.space();
         qtrace!("[{self}] packet {pn_space}-{} sent", sent_packet.pn());
         if let Some(pto) = self.pto_state.as_mut() {
             pto.pto_sent(pn_space);
@@ -1568,7 +1568,7 @@ mod tests {
                 recovery::Tokens::new(),
                 ON_SENT_SIZE,
             );
-            let pn_space = PacketNumberSpace::from(sent_pkt.packet_type());
+            let pn_space = sent_pkt.space();
             lr.on_packet_sent(sent_pkt, now());
             lr.on_ack_received(
                 pn_space,

--- a/neqo-transport/src/recovery/sent.rs
+++ b/neqo-transport/src/recovery/sent.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{packet, recovery};
+use crate::{packet, recovery, tracking::PacketNumberSpace};
 
 /// The reason a packet was declared lost.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,6 +71,12 @@ impl Packet {
     #[must_use]
     pub const fn packet_type(&self) -> packet::Type {
         self.pt
+    }
+
+    /// The packet number space of this packet.
+    #[must_use]
+    pub fn space(&self) -> PacketNumberSpace {
+        PacketNumberSpace::from(self.pt)
     }
 
     /// The number of the packet.

--- a/neqo-transport/src/recovery/token.rs
+++ b/neqo-transport/src/recovery/token.rs
@@ -12,7 +12,7 @@ use crate::{
     send_stream,
     stateless_reset::Token as Srt,
     stream_id::{StreamId, StreamType},
-    tracking::AckToken,
+    tracking::PacketRange,
 };
 
 pub type Tokens = Vec<Token>;
@@ -52,7 +52,7 @@ pub enum StreamRecoveryToken {
 #[derive(Debug, Clone)]
 pub enum Token {
     Stream(StreamRecoveryToken),
-    Ack(AckToken),
+    Ack(Box<[PacketRange]>),
     Crypto(CryptoRecoveryToken),
     HandshakeDone,
     KeepAlive, // Special PING.

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -175,7 +175,7 @@ const MAX_ACKS_PER_FRAME: usize = 32;
 
 /// A structure that tracks what was included in an ACK.
 ///
-/// Does not record the packet number space, that can be derived from packet types
+/// The packet number space is not recorded because it can be derived from the carrying packet's type.
 #[derive(Debug, Clone)]
 pub struct AckToken {
     ranges: Box<[PacketRange]>,

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -173,14 +173,6 @@ pub const DEFAULT_ACK_PACKET_TOLERANCE: packet::Number = 1;
 const MAX_TRACKED_RANGES: usize = 32;
 const MAX_ACKS_PER_FRAME: usize = 32;
 
-/// A structure that tracks what was included in an ACK.
-///
-/// The packet number space is not recorded because it can be derived from the carrying packet's type.
-#[derive(Debug, Clone)]
-pub struct AckToken {
-    ranges: Box<[PacketRange]>,
-}
-
 /// A structure that tracks what packets have been received,
 /// and what needs acknowledgement for a packet number space.
 #[derive(Debug)]
@@ -498,9 +490,7 @@ impl RecvdPackets {
         self.last_ack_time = Some(now);
         self.unacknowledged_count = 0;
 
-        tokens.push(recovery::Token::Ack(AckToken {
-            ranges: ranges.into_boxed_slice(),
-        }));
+        tokens.push(recovery::Token::Ack(ranges.into_boxed_slice()));
     }
 }
 
@@ -579,9 +569,9 @@ impl AckTracker {
             .min()
     }
 
-    pub fn acked(&mut self, pn_space: PacketNumberSpace, token: &AckToken) {
+    pub fn acked(&mut self, pn_space: PacketNumberSpace, acked: &[PacketRange]) {
         if let Some(space) = self.get_mut(pn_space) {
-            space.acknowledged(&token.ranges);
+            space.acknowledged(acked);
         }
     }
 

--- a/neqo-transport/src/tracking.rs
+++ b/neqo-transport/src/tracking.rs
@@ -174,17 +174,11 @@ const MAX_TRACKED_RANGES: usize = 32;
 const MAX_ACKS_PER_FRAME: usize = 32;
 
 /// A structure that tracks what was included in an ACK.
+///
+/// Does not record the packet number space, that can be derived from packet types
 #[derive(Debug, Clone)]
 pub struct AckToken {
-    space: PacketNumberSpace,
     ranges: Box<[PacketRange]>,
-}
-
-impl AckToken {
-    /// Get the space for this token.
-    pub const fn space(&self) -> PacketNumberSpace {
-        self.space
-    }
 }
 
 /// A structure that tracks what packets have been received,
@@ -505,7 +499,6 @@ impl RecvdPackets {
         self.unacknowledged_count = 0;
 
         tokens.push(recovery::Token::Ack(AckToken {
-            space: self.space,
             ranges: ranges.into_boxed_slice(),
         }));
     }
@@ -586,8 +579,8 @@ impl AckTracker {
             .min()
     }
 
-    pub fn acked(&mut self, token: &AckToken) {
-        if let Some(space) = self.get_mut(token.space) {
+    pub fn acked(&mut self, pn_space: PacketNumberSpace, token: &AckToken) {
+        if let Some(space) = self.get_mut(pn_space) {
             space.acknowledged(&token.ranges);
         }
     }
@@ -989,7 +982,7 @@ mod tests {
         );
         assert_eq!(frame_stats.ack, 1);
         if let recovery::Token::Ack(tok) = &tokens[0] {
-            tracker.acked(tok); // Should be a noop.
+            tracker.acked(PacketNumberSpace::Initial, tok); // Should be a noop.
         } else {
             panic!("not an ACK token");
         }


### PR DESCRIPTION
`AckToken` and `CryptoRecoveryToken` each stored the packet number space, which duplicates the space implied by the packet carrying the token

Shrinks both from 24 to 16 bytes. Prep work for reducing the size of `Token`.