### PR TITLE
fix: Box `ConnectionIdEntry`

### DIFF
--- a/neqo-transport/src/cid.rs
+++ b/neqo-transport/src/cid.rs
@@ -589,7 +589,7 @@ impl ConnectionIdManager {
 
         while let Some(entry) = self.lost_new_connection_id.pop() {
             if entry.write(builder, stats) {
-                tokens.push(recovery::Token::NewConnectionId(entry));
+                tokens.push(recovery::Token::NewConnectionId(Box::new(entry)));
             } else {
                 // This shouldn't happen often.
                 self.lost_new_connection_id.push(entry);
@@ -612,7 +612,7 @@ impl ConnectionIdManager {
                 // TODO: generate the stateless reset tokens from the connection ID and a key.
                 let entry = ConnectionIdEntry::new(seqno, cid, Srt::random());
                 entry.write(builder, stats);
-                tokens.push(recovery::Token::NewConnectionId(entry));
+                tokens.push(recovery::Token::NewConnectionId(Box::new(entry)));
             }
         }
     }

--- a/neqo-transport/src/recovery/token.rs
+++ b/neqo-transport/src/recovery/token.rs
@@ -61,7 +61,7 @@ pub enum Token {
         reason = "This is how it is called in the spec."
     )]
     NewToken(usize),
-    NewConnectionId(ConnectionIdEntry<Srt>),
+    NewConnectionId(Box<ConnectionIdEntry<Srt>>), // Boxed, because largest by far & rarely used.
     RetireConnectionId(u64),
     AckFrequency(AckRate),
     Datagram(DatagramTracking),


### PR DESCRIPTION
To avoid large enum variant.