### PR TITLE
fix(http3): allow WebTransport when the peer lacks reliable reset 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "libfuzzer-sys",
  "neqo-common",
@@ -515,7 +515,7 @@ dependencies = [
  "neqo-qpack",
  "neqo-transport",
  "nss-rs",
- "test-fixture 0.31.0",
+ "test-fixture 0.31.1",
 ]
 
 [[package]]
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "neqo-bin"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "cfg_aliases",
  "clap",
@@ -742,14 +742,14 @@ dependencies = [
  "rustc-hash",
  "strum",
  "test-fixture 0.1.0",
- "test-fixture 0.31.0",
+ "test-fixture 0.31.1",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "neqo-common"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -760,14 +760,14 @@ dependencies = [
  "sha1",
  "static_assertions",
  "strum",
- "test-fixture 0.31.0",
+ "test-fixture 0.31.1",
  "thiserror",
  "windows",
 ]
 
 [[package]]
 name = "neqo-http3"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enumset",
@@ -783,13 +783,13 @@ dependencies = [
  "sfv",
  "static_assertions",
  "strum",
- "test-fixture 0.31.0",
+ "test-fixture 0.31.1",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-qpack"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "log",
  "neqo-common",
@@ -797,13 +797,13 @@ dependencies = [
  "qlog",
  "rustc-hash",
  "static_assertions",
- "test-fixture 0.31.0",
+ "test-fixture 0.31.1",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-transport"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "codspeed-criterion-compat",
  "enum-map",
@@ -819,13 +819,13 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "strum",
- "test-fixture 0.31.0",
+ "test-fixture 0.31.1",
  "thiserror",
 ]
 
 [[package]]
 name = "neqo-udp"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "test-fixture"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "log",
  "neqo-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Neqo, the Mozilla implementation of QUIC in Rust."
 keywords = ["quic", "http3", "neqo", "mozilla", "ietf", "firefox"]
 categories = ["network-programming", "web-programming"]
 readme = "README.md"
-version = "0.31.0"
+version = "0.31.1"
 # Keep in sync with `.rustfmt.toml` `edition`.
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/neqo-http3/src/features/extended_connect/mod.rs
+++ b/neqo-http3/src/features/extended_connect/mod.rs
@@ -17,7 +17,7 @@ mod tests;
 
 use std::{cell::RefCell, fmt::Debug, mem, rc::Rc};
 
-use neqo_common::{Bytes, Header, Role};
+use neqo_common::{Bytes, Header, Role, qdebug};
 use neqo_transport::StreamId;
 
 use crate::{
@@ -97,10 +97,6 @@ impl TransportPrerequisites {
             reliable_reset,
         }
     }
-
-    const fn all(&self) -> bool {
-        self.datagrams && self.reliable_reset
-    }
 }
 
 #[derive(Debug)]
@@ -130,12 +126,11 @@ impl ExtendedConnectFeature {
         settings: &HSettings,
         transport_prereqs: &TransportPrerequisites,
     ) {
-        // A WebTransport client must confirm the server supports everything WebTransport needs:
-        // extended CONNECT, HTTP/3 datagrams (SETTINGS), and the datagram/reliable-reset
-        // transport parameters.
+        // reset_stream_at is also required (draft Section 4.4), but too few servers support it
+        // yet, so we don't gate on it for now (falls back to RESET_STREAM). See #3917.
         let conditions_met = match self.connect_type {
             ExtendedConnectType::WebTransport => {
-                transport_prereqs.all()
+                transport_prereqs.datagrams
                     && settings.get(HSettingType::EnableH3Datagram) == 1
                     && (self.role == Role::Server
                         || (settings.get(HSettingType::EnableConnect) == 1
@@ -146,6 +141,14 @@ impl ExtendedConnectFeature {
             }
         };
         self.feature_negotiation.negotiate(conditions_met);
+        if self.connect_type == ExtendedConnectType::WebTransport
+            && self.enabled()
+            && !transport_prereqs.reliable_reset
+        {
+            qdebug!(
+                "WebTransport negotiated without peer reliable reset; stream resets use RESET_STREAM"
+            );
+        }
     }
 
     #[must_use]

--- a/neqo-http3/src/features/mod.rs
+++ b/neqo-http3/src/features/mod.rs
@@ -137,8 +137,8 @@ mod tests {
     }
 
     /// A WebTransport client only negotiates when the server advertises everything it needs
-    /// (extended CONNECT, HTTP/3 datagrams, and the datagram/reliable-reset transport
-    /// parameters); a server has no such requirements on the peer.
+    /// (extended CONNECT, HTTP/3 datagrams, and the datagram transport parameter); a server
+    /// has no such requirements on the peer.
     #[test]
     fn webtransport_feature_checks() {
         // Everything the server must advertise via SETTINGS for a client to use WebTransport.

--- a/neqo-http3/src/features/mod.rs
+++ b/neqo-http3/src/features/mod.rs
@@ -216,6 +216,28 @@ mod tests {
         ));
     }
 
+    /// WebTransport negotiates whether or not the peer advertises the `reset_stream_at`
+    /// transport parameter (reliable reset). The draft (Section 4.4) requires reliable reset,
+    /// but the extension is new and rarely deployed, so neqo tolerates peers without it,
+    /// resetting such streams with a plain `RESET_STREAM` rather than refusing WebTransport.
+    #[test]
+    fn webtransport_ignores_peer_reliable_reset() {
+        let full = HSettings::new(&[
+            HSetting::new(HSettingType::EnableWebTransport, 1),
+            HSetting::new(HSettingType::EnableH3Datagram, 1),
+            HSetting::new(HSettingType::EnableConnect, 1),
+        ]);
+        for reliable_reset in [false, true] {
+            let mut f =
+                ExtendedConnectFeature::new(ExtendedConnectType::WebTransport, Role::Client, true);
+            f.handle_settings(&full, &TransportPrerequisites::new(true, reliable_reset));
+            assert!(
+                f.enabled(),
+                "WebTransport must negotiate regardless of peer reliable reset support"
+            );
+        }
+    }
+
     /// Confirm that the necessary features for `CONNECT_UDP` are validated.
     #[test]
     fn connect_udp_feature_checks() {


### PR DESCRIPTION
Since #3756, neqo makes the peer's reset_stream_at transport parameter (reliable reset) a requirement for WebTransport, following the WebTransport draft (draft-ietf-webtrans-http3, Section 4.4), which resets a WebTransport data stream with RESET_STREAM_AT.

reset_stream_at is a very new QUIC extension that few deployed servers implement yet, so requiring it breaks WebTransport with most current servers, including the WebTransport web platform test server. It failed every WebTransport web platform test in Firefox and backed out the neqo v0.31.0 uplift ([Bug 2065405](https://bugzilla.mozilla.org/show_bug.cgi?id=2065405)). The stream layer already handles peers without reliable reset: WebTransportSendStream falls back to a plain RESET_STREAM.

Stop requiring reliable reset from the peer. neqo still advertises reset_stream_at and uses RESET_STREAM_AT when the peer supports it.

Note this targets the `v0.31` branch and bumps the patch version to `v0.31.1`. Once merged, I will bring the fix into `main`.
