### PR TITLE
chore: Disable Rust "security" updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,20 +3,17 @@
 
 version: 2
 updates:
-  # We don't really use Dependabot for Rust dependencies, since we are tracking Gecko,
-  # but we do want to be notified of security vulnerabilities.
+  # We don't really use Dependabot for Rust dependencies, since we are tracking Gecko
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
-    # Disable all non-security updates.
+    # Disable version and security updates.
     # <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit>
     open-pull-requests-limit: 0
-    cooldown:
-      default-days: 10
-      semver-major-days: 20
-      semver-minor-days: 10
-      semver-patch-days: 5
+    # <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore-->
+    ignore:
+      - dependency-name: "*"
   - package-ecosystem: "github-actions"
     directories:
       - "/.github/actions/*"


### PR DESCRIPTION
We're stuck with the Gecko versions anyway.