### PR TITLE
chore: Pin neqo deps to Gecko

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
@@ -434,9 +434,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fnv"
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -899,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
@@ -923,9 +923,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs11-bindings"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f2b11de4fec7f1e085891d4a4bf16a8b1beb49978837a80d4e9e705b99295c"
+checksum = "f81e0ffd4db150990a30013e47ebeeab2a71cfb27d1cbd83d1ec43d7b297e0c1"
 dependencies = [
  "bindgen",
 ]

--- a/test/README.md
+++ b/test/README.md
@@ -63,8 +63,17 @@ Dependencies are managed via `test/pyproject.toml` and resolved automatically by
 uv run --project test compare-lockfile
 ```
 
-Fetches Gecko's `Cargo.lock` and reports which packages match, which differ,
-and whether mismatches are production-affecting or dev/build-only.
+Fetches Gecko's `Cargo.lock` and checks that ours is aligned with it. Hard
+violations are duplicate versions Gecko doesn't itself carry, and shared
+dependencies sitting on a version other than Gecko's. Everything else is
+advisory: deps ahead of Gecko that the next vendor picks up, deps on a semver
+range Gecko doesn't carry, and pins another crate's version requirement rules
+out. Mismatches are labelled production-affecting or dev/build-only.
+
+Exit status is `0` when every invariant holds, `1` when there are hard
+violations, and `2` if the check could not run (no `Cargo.lock`, `cargo` or
+network failure) — so a broken environment is distinguishable from a real
+violation.
 
 ### Update versions
 
@@ -72,12 +81,27 @@ and whether mismatches are production-affecting or dev/build-only.
 uv run --project test update-lockfile
 ```
 
-Aligns shared dependencies with Gecko's pinned versions and updates packages
-Gecko doesn't depend on (dev/build tools and neqo-exclusive packages) to their
-latest available versions.
+Pins every dependency Gecko carries to Gecko's exact version, dev- and
+build-dependencies included, staying as close to Gecko as cargo allows. Where a
+requirement rules Gecko's version out, the version is left alone rather than
+bumped to latest. Packages Gecko has no version of, and packages only neqo uses
+within Gecko, are bumped to their newest compatible version.
 
-Set `GITHUB_TOKEN` (or `GITHUB_API_TOKEN`) in the environment to avoid GitHub
-API rate limits when fetching Gecko metadata.
+Drift is only a hard violation for packages whose version can reach a Gecko build
+of neqo — those reachable via normal or build edges from the crates Gecko vendors.
+For the rest, matching Gecko is preferred but harmless to miss.
+
+Both commands end with the same markdown block, `Why each version differs from
+Gecko`, explaining per package why its version is what it is and why that is
+safe. `update-lockfile` prefixes it with `Lockfile changes`, a before → after
+list of what that run moved. Both are paste-ready for a commit message or PR
+description. `Cargo.lock` itself cannot carry the rationale: cargo reserializes
+the file on every write and drops any hand-added comments.
+
+Both need a working `cargo` (they read the resolved dependency graph via `cargo
+metadata --locked`). Setting `GITHUB_TOKEN` (or `GITHUB_API_TOKEN`) is optional
+and only raises GitHub's rate limit for the one API call that lists Gecko's
+`netwerk/` crates.
 
 ### Linting and type checking
 

--- a/test/compare_lockfile.py
+++ b/test/compare_lockfile.py
@@ -10,8 +10,11 @@ Compare Cargo.lock versions with Gecko's and verify alignment invariants.
 
 Checks three invariants:
   (A) HARD:     No package version duplicates unless Gecko has the same split.
-  (B) ADVISORY: No shared dep newer than Gecko (warn; staged for next vendor).
-  (C) HARD:     No shared production dep older than Gecko (update-lockfile missed it).
+  (B) ADVISORY: Deps ahead of Gecko that Gecko picks up when neqo is vendored, deps
+                on a semver range Gecko doesn't carry (nothing to pin to), and deps
+                another crate's version requirement rules out pinning.
+  (C) HARD:     Every other shared dep, dev- and build-dependencies included, sits
+                on Gecko's exact version (update-lockfile missed it).
 
 Exits 0 if no hard violations, 1 otherwise.
 
@@ -19,21 +22,56 @@ Usage: uv run --project test compare-lockfile
 """
 
 import sys
-
-from packaging.version import Version
+from typing import NamedTuple
 
 from lockfile_utils import (
-    classify_version_relation,
+    PinPlan,
+    PinPolicy,
+    VersionIndex,
+    collect_pin_targets,
+    divergence_rationales,
     find_dependents,
     find_dev_only_packages,
-    find_neqo_or_workspace_deps,
+    find_divergences,
+    find_neqo_only_deps,
     find_non_gecko_duplicates,
-    get_all_versions,
-    group_by_semver_range,
-    is_ahead_of_gecko,
+    find_pinnable_packages,
+    format_rationales,
+    load_cargo_metadata,
     load_lockfiles,
+    load_version_requirements,
+    parse_packages,
     semver_range,
+    versions_by_name,
 )
+
+
+class Issue(NamedTuple):
+    """One of our versions of a package that doesn't line up with Gecko's."""
+
+    description: str
+    our_ver: str
+    # None when we hold a version in a semver range Gecko doesn't carry at all.
+    gecko_ver: str | None
+
+
+class Mismatch(NamedTuple):
+    """A package with at least one version that doesn't line up with Gecko's."""
+
+    name: str
+    our_vers: str
+    gecko_vers: str
+    status: str
+    issues: list[Issue]
+    category: str = ""
+
+
+class Match(NamedTuple):
+    """A package whose versions all line up with Gecko's."""
+
+    name: str
+    our_vers: str
+    gecko_vers: str
 
 
 # ---------------------------------------------------------------------------
@@ -41,110 +79,77 @@ from lockfile_utils import (
 # ---------------------------------------------------------------------------
 
 def find_version_issues(
-    ours: list[tuple[str, str]], theirs: list[tuple[str, str]]
-) -> list[tuple[str, str, str | None]]:
+    name: str,
+    ours: set[str],
+    theirs: set[str],
+    plan: PinPlan,
+) -> list[Issue]:
     """Find version mismatches between our and Gecko's versions of a package.
 
-    Returns list of (description, our_ver, gecko_ver) tuples for each issue.
-    gecko_ver is None when we have a version in a range Gecko doesn't carry.
+    Versions that update-lockfile pins, or would pin if a requirement allowed it,
+    are reported against their pin target; the rest fall back to Gecko's version in
+    the same semver range.
     """
-    gecko_by_range = group_by_semver_range([v for v, _s in theirs])
-    issues: list[tuple[str, str, str | None]] = []
-
-    for v, _s in ours:
-        sv_rng = semver_range(v)
-        gecko_in_range = gecko_by_range.get(sv_rng, [])
-        relation = classify_version_relation(v, gecko_in_range)
-
-        if relation == "no-range":
-            issues.append((f"we have {v}, Gecko doesn't have {sv_rng}.x", v, None))
-        elif relation != "match":
-            gecko_ver = max(gecko_in_range, key=Version)
-            issues.append((f"{v} vs {gecko_ver}", v, gecko_ver))
+    issues: list[Issue] = []
+    for div in find_divergences(name, ours, theirs, plan):
+        if div.pin_target:
+            desc = f"{div.our_ver} vs. {div.pin_target}"
+        elif div.blocked:
+            desc = (
+                f"{div.our_ver} vs. {div.blocked.gecko_ver}, ruled out by "
+                f"{div.blocked.requirer}'s "
+                f'`{name} = "{div.blocked.requirement}"`'
+            )
+        elif div.gecko_ver is None:
+            rng = semver_range(div.our_ver)
+            desc = f"we have {div.our_ver}, Gecko doesn't have {rng}.x"
+        else:
+            desc = f"{div.our_ver} vs. {div.gecko_ver}"
+        issues.append(Issue(desc, div.our_ver, div.gecko_ver))
 
     return issues
 
 
 def compare_versions(
-    our_versions: dict, gecko_versions: dict, common: list[str]
-) -> tuple[list, list]:
-    """Compare versions for common packages and classify as match or mismatch.
-
-    Returns (matches, mismatches) where:
-    - matches:    [(name, our_str, their_str), ...]
-    - mismatches: [(name, our_str, their_str, status, issues), ...]
-    """
-    mismatches = []
-    matches = []
+    our_versions: VersionIndex,
+    gecko_versions: VersionIndex,
+    common: list[str],
+    plan: PinPlan,
+) -> tuple[list[Match], list[Mismatch]]:
+    """Compare versions for common packages and split into matches and mismatches."""
+    matches: list[Match] = []
+    mismatches: list[Mismatch] = []
 
     for name in common:
-        ours = our_versions[name]
-        theirs = gecko_versions[name]
+        ours, theirs = our_versions[name], gecko_versions[name]
+        our_str = ", ".join(sorted(ours))
+        their_str = ", ".join(sorted(theirs))
 
-        our_str = ", ".join(sorted({v for v, _s in ours}))
-        their_str = ", ".join(sorted({v for v, _s in theirs}))
-
-        issues = find_version_issues(ours, theirs)
-
+        issues = find_version_issues(name, ours, theirs, plan)
         if issues:
-            status = "✗ " + "; ".join(desc for desc, _, _ in issues)
-            mismatches.append((name, our_str, their_str, status, issues))
+            status = "✗ " + "; ".join(issue.description for issue in issues)
+            mismatches.append(Mismatch(name, our_str, their_str, status, issues))
         else:
-            matches.append((name, our_str, their_str))
+            matches.append(Match(name, our_str, their_str))
 
     return matches, mismatches
 
 
-def filter_neqo_only_mismatches(
-    mismatches: list,
-    matches: list,
-    gecko_versions: dict,
-    gecko_lock: dict,
-    our_lock: dict,
-) -> tuple[list, list, set[str]]:
-    """Filter mismatches for neqo-only packages where our version is ahead.
-
-    These are expected since update-lockfile updates neqo-only deps to latest.
-    Also filters transitive cases: packages whose version in our lockfile is only
-    pulled in by neqo-only (or workspace) crates.
-
-    Returns (filtered_matches, filtered_mismatches, neqo_only).
-    """
-    neqo_only, neqo_or_workspace = find_neqo_or_workspace_deps(gecko_lock, our_lock)
-
-    filtered = []
-    for name, our_str, their_str, status, issues in mismatches:
-        if name not in neqo_or_workspace:
-            filtered.append((name, our_str, their_str, status, issues))
-            continue
-
-        remaining = [
-            (desc, our_ver, gecko_ver)
-            for desc, our_ver, gecko_ver in issues
-            if not is_ahead_of_gecko(our_ver, gecko_ver, gecko_versions[name])
-        ]
-
-        if not remaining:
-            matches.append((name, our_str, their_str))
-        else:
-            new_status = "✗ " + "; ".join(d for d, _, _ in remaining)
-            filtered.append((name, our_str, their_str, new_status, remaining))
-
-    return matches, filtered, neqo_only
-
-
 def categorize_mismatch(
-    name: str, issues: list, neqo_only: set[str], dev_only: set[str], our_lock: dict
+    mismatch: Mismatch, neqo_only: set[str], dev_only: set[str], our_lock: dict
 ) -> str:
     """Categorize a mismatch as neqo-only, dev/build only, or PRODUCTION."""
+    name = mismatch.name
     if name in neqo_only:
         return "neqo-only"
 
-    for _desc, our_ver, _gecko_ver in issues:
-        dependents = find_dependents(our_lock, name, our_ver)
-        if not dependents:
-            dependents = find_dependents(our_lock, name)
-        if not all(d.split()[0] in dev_only for d in dependents):
+    for issue in mismatch.issues:
+        # A dependency entry omits the version when the package appears only once,
+        # so fall back to every dependent of the package.
+        dependents = find_dependents(our_lock, name, issue.our_ver) or find_dependents(
+            our_lock, name
+        )
+        if not all(dep in dev_only for dep, _ver in dependents):
             return "PRODUCTION"
 
     return "dev/build only"
@@ -155,7 +160,7 @@ def categorize_mismatch(
 # ---------------------------------------------------------------------------
 
 def check_invariant_a(
-    our_lock: dict, gecko_versions: dict
+    our_lock: dict, gecko_versions: VersionIndex
 ) -> list[tuple[str, str, str]]:
     """Check invariant A: no non-Gecko duplicate package versions.
 
@@ -172,40 +177,37 @@ def check_invariant_a(
 
 
 def classify_issues_by_severity(
-    mismatches: list,
+    mismatches: list[Mismatch],
+    plan: PinPlan,
+    pinnable: set[str],
     neqo_only: set[str],
     dev_only: set[str],
     our_lock: dict,
-) -> tuple[list, list]:
-    """Split mismatches into hard violations and warnings.
+) -> tuple[list[Mismatch], list[Mismatch]]:
+    """Split mismatches into hard violations and warnings, filling in the category.
 
-    Hard violations: shared production deps that are BEHIND Gecko (invariant C).
-    Warnings:        anything ahead of Gecko (invariant B), neqo-only mismatches,
-                     dev/build-only mismatches, and "no Gecko range" cases.
-
-    Returns (hard_violations, warnings) where each entry is
-    (name, our_str, their_str, status, issues, category).
+    Hard violations: versions update-lockfile pins to Gecko that haven't been moved
+                     yet (invariant C).  Dev- and build-dependencies count: Gecko
+                     doesn't adopt them when neqo is vendored, so a mismatch in
+                     either direction is a real misalignment.
+    Warnings:        everything update-lockfile leaves alone — neqo-only deps ahead
+                     of Gecko, versions in a semver range Gecko doesn't carry, and
+                     pins another crate's requirement rules out (invariant B).
     """
-    hard_violations = []
-    warnings = []
+    hard_violations: list[Mismatch] = []
+    warnings: list[Mismatch] = []
 
-    for name, our_str, their_str, status, issues in mismatches:
-        category = categorize_mismatch(name, issues, neqo_only, dev_only, our_lock)
-
-        # Check if any issue is a BEHIND move for a production dep.
-        has_hard_behind = (
-            category == "PRODUCTION"
-            and any(
-                gecko_ver is not None and Version(our_ver) < Version(gecko_ver)
-                for _, our_ver, gecko_ver in issues
-            )
+    for mismatch in mismatches:
+        categorized = mismatch._replace(
+            category=categorize_mismatch(mismatch, neqo_only, dev_only, our_lock)
         )
-
-        entry = (name, our_str, their_str, status, issues, category)
-        if has_hard_behind:
-            hard_violations.append(entry)
-        else:
-            warnings.append(entry)
+        # Only a violation when the version could actually reach a Gecko build;
+        # elsewhere we still aim for Gecko's version, but missing it harms nothing.
+        is_hard = mismatch.name in pinnable and any(
+            (mismatch.name, issue.our_ver) in plan.targets
+            for issue in mismatch.issues
+        )
+        (hard_violations if is_hard else warnings).append(categorized)
 
     return hard_violations, warnings
 
@@ -214,33 +216,44 @@ def classify_issues_by_severity(
 # Reporting
 # ---------------------------------------------------------------------------
 
+TABLE_WIDTH = 110
+
+
+def table_row(name: str, ours: str, theirs: str, status: str) -> str:
+    """Format one row of the package comparison table."""
+    return f"{name:<30} {ours:<25} {theirs:<25} {status}"
+
+
+def print_section(label: str, count: int) -> None:
+    """Print a rule-delimited section heading."""
+    print(f"\n{'=' * TABLE_WIDTH}")
+    print(f"{label} ({count}):")
+    print("=" * TABLE_WIDTH)
+
+
 def print_invariant_a_violations(violations: list[tuple[str, str, str]]) -> None:
-    print(f"\n{'=' * 110}")
-    print(f"HARD VIOLATIONS — Invariant A: non-Gecko duplicate versions ({len(violations)}):")
-    print(f"{'=' * 110}")
-    for name, off_ver, desc in violations:
+    print_section(
+        "HARD VIOLATIONS — Invariant A: non-Gecko duplicate versions", len(violations)
+    )
+    for name, _off_ver, desc in violations:
         print(f"  {name}: {desc}")
     print("  Run update-lockfile to attempt auto-resolution.")
 
 
-def print_version_violations(label: str, entries: list) -> None:
-    print(f"\n{'=' * 110}")
-    print(f"{label} ({len(entries)}):")
-    print(f"{'=' * 110}")
-    print(
-        f"{'Package':<30} {'Our Version(s)':<25} {'Gecko Version(s)':<25} {'Status'}"
-    )
-    print("-" * 110)
-    for name, our_str, their_str, status, _issues, category in entries:
-        print(f"{name:<30} {our_str:<25} {their_str:<25} {status}")
-        print(f"  ({category})")
+def print_version_violations(label: str, entries: list[Mismatch]) -> None:
+    print_section(label, len(entries))
+    print(table_row("Package", "Our Version(s)", "Gecko Version(s)", "Status"))
+    print("-" * TABLE_WIDTH)
+    for entry in entries:
+        print(table_row(entry.name, entry.our_vers, entry.gecko_vers, entry.status))
+        print(f"  ({entry.category})")
 
 
-def print_matches(matches: list) -> None:
-    print(f"{'Package':<30} {'Our Version(s)':<25} {'Gecko Version(s)':<25} {'Status'}")
-    print("=" * 110)
-    for name, our_str, their_str in matches:
-        print(f"{name:<30} {our_str:<25} {their_str:<25} ✓ Match")
+def print_matches(matches: list[Match]) -> None:
+    print(table_row("Package", "Our Version(s)", "Gecko Version(s)", "Status"))
+    print("=" * TABLE_WIDTH)
+    for match in matches:
+        print(table_row(match.name, match.our_vers, match.gecko_vers, "✓ Match"))
 
 
 # ---------------------------------------------------------------------------
@@ -251,8 +264,8 @@ def main():
     """Compare Cargo.lock versions with Gecko's and verify alignment invariants."""
     our_lock, gecko_lock = load_lockfiles()
 
-    gecko_versions = get_all_versions(gecko_lock)
-    our_versions = get_all_versions(our_lock)
+    gecko_versions = versions_by_name(gecko_lock)
+    our_versions = versions_by_name(our_lock)
 
     common = sorted(set(gecko_versions) & set(our_versions))
 
@@ -260,18 +273,25 @@ def main():
     dup_violations = check_invariant_a(our_lock, gecko_versions)
 
     # --- Invariants B/C: version alignment ---
-    matches, mismatches = compare_versions(our_versions, gecko_versions, common)
+    # pin_targets is the same set of moves update-lockfile applies, so anything
+    # still listed here is a version it would have pinned.  Moves no requirement
+    # in the graph allows come back as blocked and stay advisory.
+    metadata = load_cargo_metadata()
+    neqo_only = find_neqo_only_deps(gecko_lock, our_lock)
+    pinnable = find_pinnable_packages(metadata, gecko_lock)
+    plan = collect_pin_targets(
+        set(common),
+        neqo_only,
+        parse_packages(gecko_lock),
+        parse_packages(our_lock),
+        load_version_requirements(metadata),
+    )
 
-    if mismatches:
-        matches, mismatches, neqo_only = filter_neqo_only_mismatches(
-            mismatches, matches, gecko_versions, gecko_lock, our_lock
-        )
-    else:
-        neqo_only: set[str] = set()
+    matches, mismatches = compare_versions(our_versions, gecko_versions, common, plan)
 
-    dev_only = find_dev_only_packages()
-    hard_behind, warnings = classify_issues_by_severity(
-        mismatches, neqo_only, dev_only, our_lock
+    dev_only = find_dev_only_packages(metadata)
+    hard_misaligned, warnings = classify_issues_by_severity(
+        mismatches, plan, pinnable, neqo_only, dev_only, our_lock
     )
 
     # --- Print report ---
@@ -281,20 +301,28 @@ def main():
     if dup_violations:
         print_invariant_a_violations(dup_violations)
 
-    if hard_behind:
+    if hard_misaligned:
         print_version_violations(
-            "HARD VIOLATIONS — Invariant C: shared production deps behind Gecko",
-            hard_behind,
+            "HARD VIOLATIONS — Invariant C: shared deps not pinned to Gecko",
+            hard_misaligned,
         )
 
     if warnings:
         print_version_violations("WARNINGS (advisory only)", warnings)
 
+    # --- Rationale for every package that differs from Gecko ---
+    policy = PinPolicy.build(gecko_lock, metadata, neqo_only)
+    entries = divergence_rationales(parse_packages(our_lock), policy, our_lock, plan)
+    print(format_rationales("Why each version differs from Gecko", entries))
+
     # --- Summary ---
-    n_hard = len(dup_violations) + len(hard_behind)
+    n_hard = len(dup_violations) + len(hard_misaligned)
     print(f"\nSummary: {len(matches)} matches, {len(mismatches)} mismatches")
     print(f"  Duplicates:  {len(dup_violations)} hard violation(s)")
-    print(f"  Behind Gecko: {len(hard_behind)} hard violation(s), {len(warnings)} warning(s)")
+    print(
+        f"  Not pinned to Gecko: {len(hard_misaligned)} hard violation(s), "
+        f"{len(warnings)} warning(s)"
+    )
     if n_hard:
         print(f"\nTotal: {n_hard} hard violation(s) — run update-lockfile to fix.")
     else:

--- a/test/lockfile_utils.py
+++ b/test/lockfile_utils.py
@@ -9,21 +9,131 @@
 Shared utilities for Cargo.lock comparison and update scripts.
 """
 
+import json
 import os
+import subprocess
 import sys
+from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
+from typing import NamedTuple, NoReturn
 from urllib.request import Request, urlopen
 
 import tomlkit
 from packaging.version import Version
+from semantic_version import SimpleSpec
+from semantic_version import Version as SemVer
 
 GECKO_RAW_URL = (
     "https://raw.githubusercontent.com/mozilla-firefox/firefox/refs/heads/main"
 )
 GECKO_LOCKFILE_URL = f"{GECKO_RAW_URL}/Cargo.lock"
+GECKO_API_URL = "https://api.github.com/repos/mozilla-firefox/firefox"
+
+# Gecko vendors neqo from this repository.  The packages it sources from here are
+# the roots through which a version we pin can reach a Gecko build.
+GECKO_NEQO_SOURCE = "github.com/mozilla/neqo"
+
+# Our lockfile, relative to the workspace root both scripts must be run from.
+LOCKFILE = Path("Cargo.lock")
 
 # Timeout in seconds for HTTP requests.
 HTTP_TIMEOUT = 30
+
+# Exit code for environment and tooling errors, kept distinct from 1 so callers can
+# tell "the check could not run" from "the check found violations".
+EXIT_TOOL_ERROR = 2
+
+
+# A lockfile's packages, as name -> {version -> {"deps": [...], "source": ...}}.
+PackageIndex = dict[str, dict[str, dict]]
+
+# A lockfile's versions, as name -> {version, ...}.
+VersionIndex = dict[str, set[str]]
+
+# Semver requirements on each package, as name -> [(requiring crate, requirement)].
+Requirements = dict[str, list[tuple[str, str]]]
+
+
+class BlockedPin(NamedTuple):
+    """A pin to Gecko's version that a crate's requirement rules out."""
+
+    gecko_ver: str
+    requirer: str
+    requirement: str
+
+
+class Divergence(NamedTuple):
+    """One of our versions that doesn't line up with Gecko's, and why."""
+
+    our_ver: str
+    # What we would move to; None when Gecko carries nothing in this semver line.
+    gecko_ver: str | None
+    pin_target: str | None = None
+    blocked: BlockedPin | None = None
+
+
+class PinPlan(NamedTuple):
+    """What aligning with Gecko would do: versions to pin, and pins ruled out."""
+
+    targets: dict[tuple[str, str], str]
+    blocked: dict[tuple[str, str], BlockedPin]
+
+
+class Rationale(NamedTuple):
+    """Why a package sits where it does: a shared group label, plus any specifics."""
+
+    category: str
+    note: str
+    detail: str = ""
+
+
+class PinPolicy(NamedTuple):
+    """The sets that decide how each package's version is treated.
+
+    Bundled together because deciding "why is this version what it is" needs all of
+    them, and both scripts ask that question.
+    """
+
+    gecko_versions: VersionIndex
+    neqo_only: set[str]
+    pinnable: set[str]
+    dev_only: set[str]
+    # Only Gecko's crates.io releases; its local shims and git forks carry crates.io
+    # version numbers but different code, so they are never pin targets.
+    gecko_releases: VersionIndex
+    requirements: Requirements
+
+    @classmethod
+    def build(
+        cls, gecko_lock: dict, metadata: dict, neqo_only: set[str]
+    ) -> "PinPolicy":
+        """Assemble the policy from Gecko's lockfile and our resolved graph."""
+        gecko_pkgs = parse_packages(gecko_lock)
+        return cls(
+            versions_by_name(gecko_lock),
+            neqo_only,
+            find_pinnable_packages(metadata, gecko_lock),
+            find_dev_only_packages(metadata),
+            {
+                name: {v for v, info in vers.items() if is_registry_package(info)}
+                for name, vers in gecko_pkgs.items()
+            },
+            load_version_requirements(metadata),
+        )
+
+
+def run_cargo(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run a cargo subcommand, capturing its output and never raising."""
+    return subprocess.run(
+        ["cargo", *args], capture_output=True, text=True, check=False
+    )
+
+
+def fatal(message: str) -> NoReturn:
+    """Report an environment or tooling error and exit with EXIT_TOOL_ERROR."""
+    print(message, file=sys.stderr)
+    sys.exit(EXIT_TOOL_ERROR)
 
 
 def github_api_request(url: str) -> bytes:
@@ -40,13 +150,32 @@ def github_api_request(url: str) -> bytes:
         return response.read()
 
 
-def load_lockfile(src: str) -> dict:
+def load_lockfile(src: str | Path) -> dict:
     """Load a Cargo.lock from a path or URL."""
-    if src.startswith(("http://", "https://")):
+    if isinstance(src, str) and src.startswith(("http://", "https://")):
         with urlopen(src, timeout=HTTP_TIMEOUT) as response:
             return tomlkit.loads(response.read().decode())
-    with open(src, "r", encoding="utf-8") as f:
-        return tomlkit.load(f)
+    return tomlkit.loads(Path(src).read_text(encoding="utf-8"))
+
+
+def packages(lock: dict) -> list[dict]:
+    """Return a lockfile's [[package]] entries."""
+    return lock.get("package", [])
+
+
+def current_lock() -> dict:
+    """Load the lockfile as it stands in the working tree."""
+    return load_lockfile(LOCKFILE)
+
+
+def current_packages() -> PackageIndex:
+    """Parse the working tree's lockfile into name -> {version -> info}."""
+    return parse_packages(current_lock())
+
+
+def current_versions() -> set[tuple[str, str]]:
+    """Return the (name, version) pairs currently in the lockfile."""
+    return version_pairs(current_lock())
 
 
 def load_lockfiles() -> tuple[dict, dict]:
@@ -58,96 +187,90 @@ def load_lockfiles() -> tuple[dict, dict]:
     try:
         gecko_lock = load_lockfile(GECKO_LOCKFILE_URL)
     except Exception as e:
-        sys.exit(f"Error fetching Gecko lockfile: {e}")
+        fatal(f"Error fetching Gecko lockfile: {e}")
 
     try:
-        our_lock = load_lockfile("Cargo.lock")
+        our_lock = current_lock()
     except FileNotFoundError:
-        sys.exit("Error: Cargo.lock not found. Run from the workspace root.")
+        fatal("Error: Cargo.lock not found. Run from the workspace root.")
 
     return our_lock, gecko_lock
 
 
 def semver_range(version: str) -> str:
     """Extract major.minor from a version string."""
-    parts = version.split(".")
-    if len(parts) >= 2:
-        return f"{parts[0]}.{parts[1]}"
-    return parts[0]
+    major, _, rest = version.partition(".")
+    minor = rest.partition(".")[0]
+    return f"{major}.{minor}" if minor else major
 
 
-def group_by_semver_range(versions: list[str]) -> dict[str, list[str]]:
+def group_by_semver_range(versions: Iterable[str]) -> dict[str, list[str]]:
     """Group version strings by their major.minor semver range.
 
     Returns a dict of "major.minor" -> [version, ...].
     """
-    by_range: dict[str, list[str]] = {}
+    by_range: dict[str, list[str]] = defaultdict(list)
     for ver in versions:
-        by_range.setdefault(semver_range(ver), []).append(ver)
+        by_range[semver_range(ver)].append(ver)
     return by_range
 
 
-def parse_packages(lock: dict) -> dict[str, dict[str, dict]]:
+def parse_packages(lock: dict) -> PackageIndex:
     """Parse lockfile into a dict of name -> {version -> {deps, source}}.
 
     Tracks all versions of each package, not just one.
     """
-    packages: dict[str, dict[str, dict]] = {}
-    for pkg in lock.get("package", []):
-        name = pkg["name"]
-        version = pkg["version"]
-        source = pkg.get("source")
-
-        if name not in packages:
-            packages[name] = {}
-
-        packages[name][version] = {
-            "deps": [d.split()[0] for d in pkg.get("dependencies", [])],
-            "source": source,
+    parsed: PackageIndex = defaultdict(dict)
+    for pkg in packages(lock):
+        parsed[pkg["name"]][pkg["version"]] = {
+            "deps": [dep.partition(" ")[0] for dep in pkg.get("dependencies", [])],
+            "source": pkg.get("source"),
         }
-    return packages
+    return parsed
 
 
-def get_duplicate_packages(lock: dict) -> dict[str, list[str]]:
+def version_pairs(lock: dict) -> set[tuple[str, str]]:
+    """Return the (name, version) pairs a lockfile contains."""
+    return {(pkg["name"], pkg["version"]) for pkg in packages(lock)}
+
+
+def group_versions(pairs: Iterable[tuple[str, str]]) -> VersionIndex:
+    """Group (name, version) pairs into name -> {version, ...}."""
+    by_name: VersionIndex = defaultdict(set)
+    for name, ver in pairs:
+        by_name[name].add(ver)
+    return by_name
+
+
+def versions_by_name(lock: dict) -> VersionIndex:
+    """Map each package name in a lockfile to the versions it appears at."""
+    return group_versions(version_pairs(lock))
+
+
+def get_duplicate_packages(lock: dict) -> VersionIndex:
     """Find packages that appear multiple times with different versions.
 
-    Returns a dict of package name -> list of versions for packages with duplicates.
+    Returns a dict of package name -> versions, for packages with duplicates.
     """
-    versions: dict[str, list[str]] = {}
-    for pkg in lock.get("package", []):
-        versions.setdefault(pkg["name"], []).append(pkg["version"])
-    return {name: vers for name, vers in versions.items() if len(vers) > 1}
-
-
-def get_all_versions(lock: dict) -> dict[str, list[tuple[str, str]]]:
-    """Parse lockfile into name -> [(version, source), ...].
-
-    Convenience wrapper around parse_packages for simple version listing.
-    """
-    packages = parse_packages(lock)
     return {
-        name: [(ver, info.get("source") or "local") for ver, info in versions.items()]
-        for name, versions in packages.items()
+        name: vers for name, vers in versions_by_name(lock).items() if len(vers) > 1
     }
 
 
-def find_dependents(lock: dict, package: str, version: str | None = None) -> list[str]:
+def find_dependents(
+    lock: dict, package: str, version: str | None = None
+) -> list[tuple[str, str]]:
     """Find all packages that directly depend on the given package.
 
     If version is specified, only return dependents that use that specific version.
-    Returns list of "name version" strings.
+    Returns a list of (name, version) pairs.
     """
     dependents = []
-    for pkg in lock.get("package", []):
-        deps = pkg.get("dependencies", [])
-        for dep in deps:
-            parts = dep.split()
-            dep_name = parts[0]
-            dep_ver = parts[1] if len(parts) > 1 else None
-
-            if dep_name == package:
-                if version is None or dep_ver == version:
-                    dependents.append(f"{pkg['name']} {pkg['version']}")
+    for pkg in packages(lock):
+        for dep in pkg.get("dependencies", []):
+            dep_name, _, dep_ver = dep.partition(" ")
+            if dep_name == package and version in (None, dep_ver or None):
+                dependents.append((pkg["name"], pkg["version"]))
     return dependents
 
 
@@ -157,17 +280,16 @@ def build_dependents_map(lock: dict) -> dict[str, set[str]]:
     Unlike find_dependents, this builds the full map once for efficiency
     when checking multiple packages.
     """
-    dependents: dict[str, set[str]] = {}
-    for pkg in lock.get("package", []):
+    dependents: dict[str, set[str]] = defaultdict(set)
+    for pkg in packages(lock):
         for dep in pkg.get("dependencies", []):
-            dep_name = dep.split()[0]
-            dependents.setdefault(dep_name, set()).add(pkg["name"])
+            dependents[dep.partition(" ")[0]].add(pkg["name"])
     return dependents
 
 
 def workspace_crates(lock: dict) -> set[str]:
     """Return the set of workspace crate names (packages with no source)."""
-    return {pkg["name"] for pkg in lock.get("package", []) if not pkg.get("source")}
+    return {pkg["name"] for pkg in packages(lock) if not pkg.get("source")}
 
 
 def expand_dependents_closure(
@@ -198,45 +320,39 @@ def is_registry_package(info: dict) -> bool:
 def fetch_netwerk_crates() -> set[str]:
     """Fetch the list of Rust crate names under Gecko's netwerk/ directory.
 
-    Uses GitHub's code search API to find Cargo.toml files.
+    Reads the netwerk/ subtree via GitHub's git tree API, which needs no
+    authentication.  Failures are fatal: this set decides which packages count as
+    neqo-only, and silently returning a short list would quietly change every
+    verdict that follows.
     """
-    import json
-    import urllib.parse
+    tree_url = f"{GECKO_API_URL}/git/trees/main:netwerk?recursive=1"
+    try:
+        tree = json.loads(github_api_request(tree_url).decode())
+    except Exception as e:
+        fatal(f"Error: could not list Gecko's netwerk/ directory: {e}")
+
+    if "tree" not in tree:
+        fatal(f"Error: unexpected response listing netwerk/: {tree.get('message')}")
+    if tree.get("truncated"):
+        fatal("Error: GitHub truncated the netwerk/ listing; cannot enumerate crates.")
+
+    manifests = [
+        entry["path"] for entry in tree["tree"] if entry["path"].endswith("Cargo.toml")
+    ]
+    if not manifests:
+        fatal("Error: no Cargo.toml files found under Gecko's netwerk/.")
 
     crates: set[str] = set()
-
-    # Search for Cargo.toml files in netwerk/ (fewer than 100 expected).
-    query = urllib.parse.quote(
-        "filename:Cargo.toml path:netwerk repo:mozilla-firefox/firefox"
-    )
-    search_url = f"https://api.github.com/search/code?q={query}&per_page=100"
-
-    try:
-        data = json.loads(github_api_request(search_url).decode())
-        if data.get("incomplete_results"):
-            print(
-                "Warning: GitHub search returned incomplete results.",
-                file=sys.stderr,
-            )
-    except Exception as e:
-        print(f"Warning: Could not search Gecko repo: {e}", file=sys.stderr)
-        return crates
-
-    # Fetch each Cargo.toml and extract the crate name.
-    for item in data.get("items", []):
-        path = item.get("path", "")
+    for path in manifests:
+        raw_url = f"{GECKO_RAW_URL}/netwerk/{path}"
         try:
-            raw_url = f"{GECKO_RAW_URL}/{path}"
             with urlopen(raw_url, timeout=HTTP_TIMEOUT) as response:
-                content = response.read().decode()
-                for line in content.split("\n"):
-                    if line.strip().startswith("name"):
-                        if "=" in line and '"' in line:
-                            name = line.split('"')[1]
-                            crates.add(name)
-                            break
+                cargo = tomlkit.loads(response.read().decode())
         except Exception as e:
-            print(f"Warning: Could not fetch {path}: {e}", file=sys.stderr)
+            fatal(f"Error: could not fetch netwerk/{path}: {e}")
+        name = cargo.get("package", {}).get("name")
+        if name:
+            crates.add(str(name))
 
     return crates
 
@@ -254,7 +370,7 @@ def find_neqo_only_deps(gecko_lock: dict, our_lock: dict) -> set[str]:
     netwerk_crates = fetch_netwerk_crates()
     gecko_neqo_crates = {
         pkg["name"]
-        for pkg in gecko_lock.get("package", [])
+        for pkg in packages(gecko_lock)
         if pkg["name"] in netwerk_crates or pkg["name"].startswith("neqo")
     }
 
@@ -264,71 +380,6 @@ def find_neqo_only_deps(gecko_lock: dict, our_lock: dict) -> set[str]:
     neqo_only = expand_dependents_closure(seeds, gecko_dependents)
 
     return neqo_only - seeds  # Exclude seed crates.
-
-
-def find_neqo_or_workspace_deps(
-    gecko_lock: dict, our_lock: dict
-) -> tuple[set[str], set[str]]:
-    """Find neqo-only deps and expand transitively using our lockfile.
-
-    Returns (neqo_only, neqo_or_workspace) where:
-    - neqo_only: packages only neqo depends on in Gecko's graph
-    - neqo_or_workspace: neqo_only expanded with packages whose dependents
-      in our lockfile are all neqo-only or workspace crates
-    """
-    neqo_only = find_neqo_only_deps(gecko_lock, our_lock)
-    neqo_or_workspace = expand_dependents_closure(
-        neqo_only | workspace_crates(our_lock),
-        build_dependents_map(our_lock),
-    )
-    return neqo_only, neqo_or_workspace
-
-
-def collect_dep_categories() -> tuple[set[str], set[str]]:
-    """Collect normal and dev/build dependency names from workspace Cargo.toml files.
-
-    Returns (normal_deps, dev_build_roots).
-    """
-    with open("Cargo.toml", "r", encoding="utf-8") as f:
-        workspace = tomlkit.load(f)
-
-    members = workspace.get("workspace", {}).get("members", [])
-
-    dev_build_roots = set()
-    normal_deps = set()
-
-    for member in members:
-        member_toml = Path(member) / "Cargo.toml"
-        if not member_toml.exists():
-            continue
-        with open(member_toml, "r", encoding="utf-8") as f:
-            cargo = tomlkit.load(f)
-
-        normal_deps.update(cargo.get("dependencies", {}))
-        dev_build_roots.update(cargo.get("dev-dependencies", {}))
-        dev_build_roots.update(cargo.get("build-dependencies", {}))
-
-    ws_deps = workspace.get("workspace", {})
-    dev_build_roots.update(ws_deps.get("dev-dependencies", {}))
-    dev_build_roots.update(ws_deps.get("build-dependencies", {}))
-
-    return normal_deps, dev_build_roots
-
-
-def is_ahead_of_gecko(
-    our_ver: str, gecko_ver: str | None, gecko_versions_for_name: list[tuple[str, str]]
-) -> bool:
-    """Check if our version is ahead of (newer than) the Gecko version.
-
-    If gecko_ver is None, compares against Gecko's highest version for the package.
-    """
-    if gecko_ver is not None:
-        return Version(our_ver) > Version(gecko_ver)
-    gecko_max = max(
-        (Version(v) for v, _ in gecko_versions_for_name),
-        default=Version("0"),
-    )
-    return Version(our_ver) > gecko_max
 
 
 def classify_version_relation(our_ver: str, gecko_vers_in_range: list[str]) -> str:
@@ -349,8 +400,208 @@ def classify_version_relation(our_ver: str, gecko_vers_in_range: list[str]) -> s
     return "behind" if our_v < gecko_v else "ahead"
 
 
+def load_cargo_metadata() -> dict:
+    """Run `cargo metadata` and return the parsed resolve graph.
+
+    `--locked` keeps this read-only: cargo errors out rather than rewriting
+    Cargo.lock.  Callers re-run it after changing the lockfile, since the resolved
+    graph and its requirements move with it.
+    """
+    result = run_cargo(
+        "metadata", "--format-version", "1", "--all-features", "--locked"
+    )
+    if result.returncode != 0:
+        fatal(f"Error running cargo metadata: {result.stderr.strip()}")
+
+    return json.loads(result.stdout)
+
+
+def load_version_requirements(metadata: dict) -> Requirements:
+    """Collect the semver requirements the dependency graph places on each package.
+
+    Only requirements cargo actually resolves against are collected: registry deps
+    that are normal or build dependencies, plus dev-dependencies of our own
+    workspace crates (cargo ignores dev-dependencies of third-party crates).
+
+    Returns {package name: [(requiring crate, requirement), ...]}.
+    """
+    members = set(metadata.get("workspace_members", []))
+
+    # Edges cargo actually resolved, as {requiring package id: {dep package name}}.
+    # Declared dependencies include optional ones no enabled feature turns on, and
+    # their requirements constrain nothing.
+    by_id = {pkg["id"]: pkg["name"] for pkg in metadata["packages"]}
+    resolved = {
+        node["id"]: {
+            by_id[dep["pkg"]] for dep in node.get("deps", []) if dep["pkg"] in by_id
+        }
+        for node in metadata.get("resolve", {}).get("nodes", [])
+    }
+
+    requirements: Requirements = defaultdict(list)
+    for pkg in metadata["packages"]:
+        for dep in pkg["dependencies"]:
+            if not (dep.get("source") or "").startswith("registry"):
+                continue  # Path or git dep: a different crate that shares the name.
+            if dep.get("kind") == "dev" and pkg["id"] not in members:
+                continue
+            if dep["name"] not in resolved.get(pkg["id"], ()):
+                continue
+            requirements[dep["name"]].append((pkg["name"], dep["req"]))
+
+    return requirements
+
+
+def _requirement_matches(req: str, version: str) -> bool:
+    """Check a Cargo semver requirement against a concrete version.
+
+    Build metadata is stripped, as Cargo ignores it when comparing.  Requirements
+    we can't parse are treated as satisfied, so they never block a pin.
+    """
+    comparators = ",".join(part.strip().split("+")[0] for part in req.split(","))
+    try:
+        return SemVer(version.split("+")[0]) in SimpleSpec(comparators)
+    except ValueError:
+        return True
+
+
+def find_blocking_requirements(
+    name: str,
+    our_ver: str,
+    targets: Iterable[str],
+    requirements: Requirements,
+) -> list[tuple[str, str]]:
+    """Find requirements that `our_ver` satisfies but no version in `targets` does.
+
+    Only requirements `our_ver` currently satisfies are considered: those are the
+    dependents cargo resolved onto this lockfile entry, and so the ones any move has
+    to keep satisfying.  Requirements matching some other entry of the same package
+    constrain that entry, not this one.
+
+    Pass a single target to ask "can we make this one move?", or all of Gecko's
+    releases to ask "is any of them reachable at all?".
+    """
+    candidates = list(targets)
+    return [
+        (requirer, req)
+        for requirer, req in sorted(set(requirements.get(name, [])))
+        if _requirement_matches(req, our_ver)
+        and not any(_requirement_matches(req, target) for target in candidates)
+    ]
+
+
+def find_compatible_gecko_range(
+    sv_range: str, gecko_by_range: dict[str, list[str]]
+) -> list[str]:
+    """Find Gecko versions in a compatible semver range.
+
+    For major >= 1, looks for the closest higher range first, then falls back
+    to the closest lower range (to pin us to Gecko's version even if it means
+    a cross-range downgrade for genuinely shared deps).
+    Returns [] for 0.x packages (each minor is its own incompatible API).
+    """
+    major = sv_range.split(".")[0]
+    if major == "0":
+        return []
+
+    sv = Version(sv_range)
+
+    for gr in sorted(gecko_by_range, key=Version, reverse=True):
+        if gr.split(".")[0] == major and Version(gr) > sv:
+            return gecko_by_range[gr]
+
+    for gr in sorted(gecko_by_range, key=Version, reverse=True):
+        if gr.split(".")[0] == major and Version(gr) < sv:
+            return gecko_by_range[gr]
+
+    return []
+
+
+def align_package_with_gecko(
+    name: str,
+    gecko_pkgs: PackageIndex,
+    our_pkgs: PackageIndex,
+) -> dict[tuple[str, str], str]:
+    """Compute version moves to align a package's versions with Gecko's.
+
+    Emits moves for versions that differ from Gecko's, in both directions.
+    Returns {(name, our_ver): gecko_ver} for versions that need moving.
+    """
+    updates: dict[tuple[str, str], str] = {}
+    our_versions = our_pkgs[name]
+
+    if all(not is_registry_package(info) for info in our_versions.values()):
+        return updates
+
+    # Only pin against Gecko versions that come from a registry.  Gecko's local
+    # shim crates (versioned x.y.999) and its git forks carry crates.io version
+    # numbers but different code, so matching their version buys us nothing.
+    gecko_real = [
+        v for v, info in gecko_pkgs[name].items() if is_registry_package(info)
+    ]
+    if not gecko_real:
+        return updates
+
+    gecko_by_range = group_by_semver_range(gecko_real)
+    registry_vers = [v for v, info in our_versions.items() if is_registry_package(info)]
+
+    for sv_rng, our_vers in group_by_semver_range(registry_vers).items():
+        gecko_vers = gecko_by_range.get(sv_rng) or find_compatible_gecko_range(
+            sv_rng, gecko_by_range
+        )
+        if not gecko_vers:
+            continue
+
+        gecko_ver = max(gecko_vers, key=Version)
+        for our_ver in our_vers:
+            if classify_version_relation(our_ver, gecko_vers) in ("behind", "ahead"):
+                updates[(name, our_ver)] = gecko_ver
+
+    return updates
+
+
+def collect_pin_targets(
+    common: set[str],
+    neqo_only: set[str],
+    gecko_pkgs: PackageIndex,
+    our_pkgs: PackageIndex,
+    requirements: Requirements,
+) -> PinPlan:
+    """Collect the version moves that pin shared packages to Gecko's versions.
+
+    This is the single definition of "which of our package versions must move, and
+    to what": update-lockfile applies these moves, compare-lockfile reports any that
+    are still outstanding as hard violations.
+
+    Skips neqo-only packages, which Gecko picks up when neqo is vendored and which
+    are therefore free to run ahead.  Dev- and build-dependencies are pinned like
+    any other shared dep, since Gecko never adopts our versions of them.
+
+    Returns the plan for registry crates that need moving.
+    """
+    pins: dict[tuple[str, str], str] = {}
+    blocked: dict[tuple[str, str], BlockedPin] = {}
+
+    for name in common:
+        if name in neqo_only:
+            continue
+        for key, gecko_ver in align_package_with_gecko(
+            name, gecko_pkgs, our_pkgs
+        ).items():
+            _, our_ver = key
+            blockers = find_blocking_requirements(
+                name, our_ver, [gecko_ver], requirements
+            )
+            if blockers:
+                blocked[key] = BlockedPin(gecko_ver, *blockers[0])
+            else:
+                pins[key] = gecko_ver
+
+    return PinPlan(pins, blocked)
+
+
 def find_non_gecko_duplicates(
-    our_lock: dict, gecko_versions: dict[str, list[tuple[str, str]]]
+    our_lock: dict, gecko_versions: VersionIndex
 ) -> dict[str, list[str]]:
     """Find package versions that are duplicates not sanctioned by Gecko (invariant A).
 
@@ -373,8 +624,7 @@ def find_non_gecko_duplicates(
         our_by_range = group_by_semver_range(registry_vers)
 
         if name in gecko_versions:
-            gecko_vers = [v for v, _ in gecko_versions[name]]
-            gecko_ranges = set(group_by_semver_range(gecko_vers).keys())
+            gecko_ranges = set(group_by_semver_range(gecko_versions[name]))
             off_versions = [
                 v for v in registry_vers if semver_range(v) not in gecko_ranges
             ]
@@ -384,9 +634,7 @@ def find_non_gecko_duplicates(
                 our_by_range,
                 key=lambda r: max(Version(v) for v in our_by_range[r]),
             )
-            off_versions = [
-                v for v in registry_vers if semver_range(v) != keep_range
-            ]
+            off_versions = [v for v in registry_vers if semver_range(v) != keep_range]
 
         if off_versions:
             result[name] = off_versions
@@ -394,30 +642,278 @@ def find_non_gecko_duplicates(
     return result
 
 
-def find_dev_only_packages() -> set[str]:
-    """Find packages that are only dev-dependencies or build-dependencies.
+def reachable_packages(
+    metadata: dict, roots: Iterable[str], kinds: set[str | None]
+) -> set[str]:
+    """Walk the resolved graph from `roots`, following only the given edge kinds.
 
-    These don't affect Gecko integration since Gecko doesn't use our dev/build deps.
+    A dependency's kind is null for a normal dependency, "dev" or "build" otherwise.
+    Returns the names of every package reached, roots included.
     """
-    normal_deps, dev_build_roots = collect_dep_categories()
+    nodes = {node["id"]: node for node in metadata.get("resolve", {}).get("nodes", [])}
+    names = {pkg["id"]: pkg["name"] for pkg in metadata["packages"]}
 
-    with open("Cargo.lock", "r", encoding="utf-8") as f:
-        lock = tomlkit.load(f)
-
-    pkg_deps: dict[str, list[str]] = {}
-    for pkg in lock.get("package", []):
-        pkg_deps[pkg["name"]] = [d.split()[0] for d in pkg.get("dependencies", [])]
-
-    dev_only = set()
-    to_visit = list(dev_build_roots - normal_deps)
-
+    reached: set[str] = set()
+    to_visit = list(roots)
     while to_visit:
-        pkg = to_visit.pop()
-        if pkg in dev_only:
+        pkg_id = to_visit.pop()
+        if pkg_id in reached:
             continue
-        dev_only.add(pkg)
-        for dep in pkg_deps.get(pkg, []):
-            if dep not in dev_only and dep not in normal_deps:
-                to_visit.append(dep)
+        reached.add(pkg_id)
+        for dep in nodes.get(pkg_id, {}).get("deps", []):
+            if any(k.get("kind") in kinds for k in dep.get("dep_kinds", [])):
+                to_visit.append(dep["pkg"])
 
-    return dev_only
+    return {names[pkg_id] for pkg_id in reached if pkg_id in names}
+
+
+def find_dev_only_packages(metadata: dict) -> set[str]:
+    """Find packages reachable only through dev- or build-dependency edges.
+
+    Whatever a normal-edge walk from the workspace crates never reaches is
+    dev/build-only.  Using the resolve graph rather than the Cargo.toml tables picks
+    up `[target."cfg(...)".dependencies]` and renamed deps
+    (`nss = { package = "nss-rs" }`) for free.
+    """
+    normal = reachable_packages(metadata, metadata.get("workspace_members", []), {None})
+    return {pkg["name"] for pkg in metadata["packages"]} - normal
+
+
+def find_vendored_crates(gecko_lock: dict) -> set[str]:
+    """Return the names of our crates that Gecko vendors from our repository."""
+    return {
+        pkg["name"]
+        for pkg in packages(gecko_lock)
+        if GECKO_NEQO_SOURCE in (pkg.get("source") or "")
+    }
+
+
+def find_pinnable_packages(metadata: dict, gecko_lock: dict) -> set[str]:
+    """Find packages whose version can reach a Gecko build of neqo.
+
+    Walks our resolved graph from the crates Gecko vendors, following normal and
+    build edges: Gecko builds a vendored crate's dependencies and runs its build
+    scripts, but ignores its dev-dependencies.  Anything outside this set Gecko
+    resolves from its own tree no matter what we hold, so pinning it to Gecko's
+    version buys nothing — `cc`, reached only via our fuzz and bench harnesses,
+    is the motivating case.
+    """
+    vendored = find_vendored_crates(gecko_lock)
+    ids = [
+        pkg["id"] for pkg in metadata["packages"] if pkg["name"] in vendored
+    ]
+    return reachable_packages(metadata, ids, {None, "build"})
+
+
+# ---------------------------------------------------------------------------
+# Explaining version choices
+# ---------------------------------------------------------------------------
+
+def explain_version(
+    name: str,
+    our_ver: str,
+    policy: PinPolicy,
+    our_lock: dict,
+    *,
+    pin_target: str | None = None,
+    blocked: BlockedPin | None = None,
+) -> Rationale:
+    """Say why `name` sits at `our_ver`, as a group label plus any specifics.
+
+    `pin_target` marks a version that should have been pinned but hasn't been;
+    `blocked` marks one a requirement stops us pinning.  Everything else is derived
+    from the policy sets, so the wording can't drift from the actual decision.
+    """
+    gecko_vers = policy.gecko_versions.get(name, set())
+
+    if not our_ver:
+        return Rationale(
+            "Dropped", "nothing in our graph depends on them any more"
+        )
+
+    if pin_target:
+        return Rationale(
+            "Not pinned to Gecko yet",
+            "these reach a Gecko build, so they have to match — run `update-lockfile`"
+            if name in policy.pinnable
+            else "we track Gecko even where it cannot affect Firefox — run "
+            "`update-lockfile`",
+            f"should be {pin_target}",
+        )
+
+    if blocked:
+        return Rationale(
+            "Cannot match Gecko",
+            "another crate's requirement rules Gecko's version out; Gecko still "
+            "builds neqo with its own copy",
+            f"`{blocked.requirer}` needs `{blocked.requirement}`",
+        )
+
+    if not gecko_vers:
+        return Rationale(
+            "Not in Gecko at all",
+            "no Gecko crate depends on them, so the version is ours to choose",
+        )
+
+    # Matching comes first: we now aim for Gecko's version everywhere, so landing on
+    # it is the answer regardless of whether Gecko could have reached it through us.
+    if our_ver in gecko_vers:
+        return Rationale(
+            "Pinned to Gecko",
+            "identical to Gecko, so vendoring neqo changes nothing",
+        )
+
+    if not policy.gecko_releases.get(name):
+        return Rationale(
+            "Gecko's copy isn't the crates.io crate",
+            "it is a local shim or a git fork, so matching the version number would "
+            "not match the code behind it",
+        )
+
+    if name in policy.neqo_only:
+        return Rationale(
+            "Only neqo uses them in Gecko",
+            "Gecko picks up whatever we hold at the next vendor",
+        )
+
+    if name not in policy.pinnable:
+        pullers = sorted({dep for dep, _ver in find_dependents(our_lock, name)})
+        return Rationale(
+            "Gecko resolves these itself",
+            "we reach them only from tooling Gecko doesn't vendor, so our version "
+            "cannot change what it builds neqo with",
+            "via " + ", ".join(f"`{p}`" for p in pullers) if pullers else "",
+        )
+
+    # No pin was attempted because Gecko's versions sit on another semver line.  A
+    # requirement usually explains why we are on ours; name it rather than shrug.
+    releases = policy.gecko_releases.get(name, set())
+    blockers = find_blocking_requirements(
+        name, our_ver, releases, policy.requirements
+    )
+    if blockers:
+        return Rationale(
+            "Cannot match Gecko",
+            "another crate's requirement rules Gecko's version out; Gecko still "
+            "builds neqo with its own copy",
+            ", ".join(f"`{who}` needs `{req}`" for who, req in blockers),
+        )
+
+    return Rationale(
+        "No compatible Gecko version",
+        "Gecko's is on a different semver line and nothing in our graph pins us to "
+        "ours, so moving would be an API change, not an alignment",
+    )
+
+
+def find_divergences(
+    name: str,
+    our_vers: Iterable[str],
+    gecko_vers: Iterable[str],
+    plan: PinPlan,
+) -> list[Divergence]:
+    """Find our versions of `name` that don't line up with Gecko's.
+
+    The single definition of "diverging": a version update-lockfile pins, one a
+    requirement stops it pinning, or one whose semver line disagrees with Gecko's.
+    Callers render this differently but must agree on the set.
+    """
+    by_range = group_by_semver_range(gecko_vers)
+    found = []
+    for our_ver in sorted(our_vers):
+        key = (name, our_ver)
+        if (pinned := plan.targets.get(key)) is not None:
+            found.append(Divergence(our_ver, pinned, pin_target=pinned))
+        elif (pin := plan.blocked.get(key)) is not None:
+            found.append(Divergence(our_ver, pin.gecko_ver, blocked=pin))
+        else:
+            in_range = by_range.get(semver_range(our_ver), [])
+            relation = classify_version_relation(our_ver, in_range)
+            if relation == "no-range":
+                found.append(Divergence(our_ver, None))
+            elif relation != "match":
+                found.append(Divergence(our_ver, max(in_range, key=Version)))
+    return found
+
+
+def change_rationales(
+    before: set[tuple[str, str]],
+    after: set[tuple[str, str]],
+    policy: PinPolicy,
+    our_lock: dict,
+    plan: PinPlan,
+) -> list[tuple[str, str, Rationale]]:
+    """Explain every version that moved between two lockfile states.
+
+    Diffing the whole run rather than tracking each action means transitive moves,
+    additions and removals are explained alongside the ones we asked for.
+    """
+    old, new = group_versions(before), group_versions(after)
+    entries = []
+    for name in sorted(set(old) | set(new)):
+        if old.get(name) == new.get(name):
+            continue
+        was = ", ".join(sorted(old.get(name, set()))) or "absent"
+        now = ", ".join(sorted(new.get(name, set())))
+        why = explain_version(
+            name,
+            # Explain against the surviving version; a removed package has none.
+            max(new.get(name, set()), key=Version, default=""),
+            policy,
+            our_lock,
+            blocked=next(
+                (p for (n, _v), p in plan.blocked.items() if n == name), None
+            ),
+        )
+        entries.append((name, f"{was} → {now}" if now else "", why))
+    return entries
+
+
+def divergence_rationales(
+    our_pkgs: PackageIndex,
+    policy: PinPolicy,
+    our_lock: dict,
+    plan: PinPlan,
+) -> list[tuple[str, str, Rationale]]:
+    """Explain every version of ours that doesn't line up with Gecko's.
+
+    Both scripts render this, so the decision of what counts as diverging lives
+    here rather than in either of them.
+    """
+    entries = []
+    for name in sorted(set(our_pkgs) & set(policy.gecko_versions)):
+        gecko_vers = policy.gecko_versions[name]
+        gecko_str = ", ".join(sorted(gecko_vers))
+        for div in find_divergences(name, our_pkgs[name], gecko_vers, plan):
+            why = explain_version(
+                name,
+                div.our_ver,
+                policy,
+                our_lock,
+                pin_target=div.pin_target,
+                blocked=div.blocked,
+            )
+            entries.append((name, f"{div.our_ver} vs. {gecko_str}", why))
+    return entries
+
+
+def format_rationales(heading: str, entries: list[tuple[str, str, Rationale]]) -> str:
+    """Render (package, change, rationale) triples as markdown, grouped by reason.
+
+    Most runs move a dozen packages for the same handful of reasons, so the reason
+    is stated once per group rather than once per package.
+    """
+    if not entries:
+        return ""
+
+    groups: dict[tuple[str, str], list[str]] = defaultdict(list)
+    for name, change, why in entries:
+        suffix = f" ({why.detail})" if why.detail else ""
+        label = f"`{name}` {change}".strip()
+        groups[(why.category, why.note)].append(f"{label}{suffix}")
+
+    lines = [f"\n## {heading}\n"]
+    for (category, note), items in groups.items():
+        lines.append(f"- **{category}** — {note}:")
+        lines.extend(f"  - {item}" for item in items)
+    return "\n".join(lines)

--- a/test/pyproject.toml
+++ b/test/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
     "packaging",
+    "semantic-version",
     "tomlkit",
 ]
 
@@ -23,6 +24,10 @@ dev = ["mypy", "ruff"]
 
 [tool.mypy]
 exclude = "mozlog"
+
+[[tool.mypy.overrides]]
+module = "semantic_version"
+ignore_missing_imports = true
 
 [build-system]
 requires = ["hatchling"]

--- a/test/update_lockfile.py
+++ b/test/update_lockfile.py
@@ -11,137 +11,126 @@ Update Cargo.lock to align with Gecko's versions.
 This script compares our Cargo.lock with Firefox/Gecko's Cargo.lock and runs
 cargo update commands to align versions.  The rules are:
 
-- Deps not in Gecko (dev/build tools) and deps only neqo uses within Gecko are
-  bumped to their newest compatible version.
-- Shared production deps are pinned to Gecko's exact version (up or down).
-- Shared dev/build-only deps are upgraded to Gecko's version if behind, but
-  left alone if ahead (they don't affect Gecko's runtime).
-- Deps Gecko doesn't depend on (or only neqo uses) are bumped to latest.
+- Every dep Gecko carries is pinned to Gecko's exact version, up or down, dev- and
+  build-dependencies included, so we stay as close to Gecko as cargo allows.  Pins
+  another crate's version requirement rules out are reported, not attempted, and
+  the version is left where it is rather than chasing latest.
+- Deps Gecko has no version of, and deps only neqo uses within Gecko, are bumped to
+  their newest compatible version.
 - Non-Gecko duplicate versions are auto-resolved where possible.
+
+Only deps whose version can reach a Gecko build of neqo — those reachable via
+normal or build edges from the crates Gecko vendors — count as hard violations when
+they drift; for the rest, matching Gecko is preferred but not required.
 
 Usage: uv run --project test update-lockfile
 """
 
-import subprocess
 import sys
-from graphlib import TopologicalSorter
-from pathlib import Path
+from collections import defaultdict
+from graphlib import CycleError, TopologicalSorter
 
 from packaging.version import Version
 
 from lockfile_utils import (
+    LOCKFILE,
+    PackageIndex,
+    PinPlan,
+    PinPolicy,
+    VersionIndex,
     build_dependents_map,
-    classify_version_relation,
+    change_rationales,
+    collect_pin_targets,
+    current_lock,
+    divergence_rationales,
+    current_packages,
+    current_versions,
     find_dependents,
     find_dev_only_packages,
     find_non_gecko_duplicates,
-    find_neqo_or_workspace_deps,
-    get_all_versions,
+    find_neqo_only_deps,
+    format_rationales,
     get_duplicate_packages,
-    group_by_semver_range,
     is_registry_package,
-    load_lockfile,
+    load_cargo_metadata,
     load_lockfiles,
+    load_version_requirements,
+    packages,
     parse_packages,
+    run_cargo,
+    versions_by_name,
 )
 
 
-def _cargo_update_specs(
-    specs: list[str],
-    original_content: str,
-    original_duplicates: dict,
-    lockfile_path: Path,
-) -> set[tuple[str, str]]:
-    """Run cargo update for the given name@version specs.
+def try_cargo_update(specs: list[str]) -> set[tuple[str, str]]:
+    """Run cargo update for the given name@version specs, or roll back.
 
-    Returns the set of (name, version) entries present after the update,
-    or an empty set (after reverting) if the update would introduce new
-    duplicate dependencies.
+    Snapshots the lockfile first and restores it if cargo fails or if the update
+    would add a duplicate version, so callers don't have to track it themselves.
+    Returns the (name, version) entries present afterwards, or an empty set if the
+    update was rolled back.
     """
-    result = subprocess.run(
-        ["cargo", "update"] + [arg for s in specs for arg in ["-p", s]],
-        capture_output=True,
-        text=True,
-        check=False,
+    snapshot = LOCKFILE.read_text(encoding="utf-8")
+    duplicates_before = get_duplicate_packages(current_lock())
+
+    result = run_cargo(
+        "update", *(arg for spec in specs for arg in ("-p", spec))
     )
-    if result.returncode != 0:
-        lockfile_path.write_text(original_content, encoding="utf-8")
-        return set()
+    if result.returncode == 0:
+        new_lock = current_lock()
+        regressed = any(
+            len(vers) > len(duplicates_before.get(name, ()))
+            for name, vers in get_duplicate_packages(new_lock).items()
+        )
+        if not regressed:
+            return {(pkg["name"], pkg["version"]) for pkg in packages(new_lock)}
 
-    new_lock = load_lockfile("Cargo.lock")
-    new_duplicates = get_duplicate_packages(new_lock)
-    regressed = {
-        name
-        for name, vers in new_duplicates.items()
-        if len(vers) > len(original_duplicates.get(name, []))
-    }
-    if regressed:
-        lockfile_path.write_text(original_content, encoding="utf-8")
-        return set()
-
-    return {(pkg["name"], pkg["version"]) for pkg in new_lock.get("package", [])}
+    LOCKFILE.write_text(snapshot, encoding="utf-8")
+    return set()
 
 
-def update_neqo_only_packages(packages: list[str]) -> dict[str, tuple[str, str]]:
-    """Update all listed packages together to their latest versions.
+def update_to_latest(names: list[str]) -> tuple[dict[str, tuple[str, str]], list[str]]:
+    """Update all named packages to their latest compatible versions.
 
     Tries a batch update first (allows transitive deps to unify), then falls
     back to per-package updates so that packages which would introduce duplicates
     are skipped while the rest still get updated.
 
-    Returns a dict of package name -> (old_version, new_version).
+    Returns ({package name: (old_version, new_version)}, rejected specs), where a
+    rejected spec is one cargo refused or that would have added a duplicate.
     """
-    if not packages:
-        return {}
+    if not names:
+        return {}, []
 
-    lockfile_path = Path("Cargo.lock")
-    original_content = lockfile_path.read_text(encoding="utf-8")
-    original_lock = load_lockfile("Cargo.lock")
-    original_versions = {
-        (pkg["name"], pkg["version"])
-        for pkg in original_lock.get("package", [])
-        if pkg["name"] in packages
-    }
-    original_duplicates = get_duplicate_packages(original_lock)
+    before = {(n, v) for n, v in current_versions() if n in names}
+    # name@version, to disambiguate packages present at several versions.  Sorted
+    # so the retry order, and so the report, are reproducible.
+    specs = [f"{name}@{ver}" for name, ver in sorted(before)]
 
-    # Use name@version to avoid ambiguity when a package has multiple versions.
-    specs = [f"{name}@{ver}" for name, ver in original_versions]
-
-    # Try batch update first; fall back to per-package if it introduces duplicates.
-    new_versions = _cargo_update_specs(
-        specs, original_content, original_duplicates, lockfile_path
-    )
-    if not new_versions:
-        # Restore original and retry one spec at a time.
-        lockfile_path.write_text(original_content, encoding="utf-8")
-        current_content = original_content
-        current_duplicates = original_duplicates
-        new_versions = {
-            (pkg["name"], pkg["version"]) for pkg in original_lock.get("package", [])
-        }
+    rejected: list[str] = []
+    after = try_cargo_update(specs)
+    if not after:
+        # The batch was rejected as a whole; retry one spec at a time.
+        after = current_versions()
         for spec in specs:
-            name, ver = spec.split("@", 1)
-            if (name, ver) not in new_versions:
-                continue  # Already moved by a transitive update; skip.
-            result_versions = _cargo_update_specs(
-                [spec], current_content, current_duplicates, lockfile_path
-            )
-            if result_versions:
-                current_content = lockfile_path.read_text(encoding="utf-8")
-                current_duplicates = get_duplicate_packages(load_lockfile("Cargo.lock"))
-                new_versions = result_versions
+            name, _, ver = spec.partition("@")
+            if (name, ver) not in after:
+                continue  # Already moved by a transitive update.
+            if retried := try_cargo_update([spec]):
+                after = retried
+            else:
+                rejected.append(spec)
 
-    new_versions_for_pkgs = {(n, v) for n, v in new_versions if n in packages}
-    updated = {}
-    for name, new_ver in new_versions_for_pkgs - original_versions:
-        old = [v for n, v in original_versions if n == name]
-        if old:
-            updated[name] = (old[0], new_ver)
-
-    return updated
+    old_versions = dict(before)
+    updated = {
+        name: (old_versions[name], new_ver)
+        for name, new_ver in {(n, v) for n, v in after if n in names} - before
+        if name in old_versions
+    }
+    return updated, rejected
 
 
-def run_free_updates(names: set[str], our_pkgs: dict, label: str) -> None:
+def run_free_updates(names: set[str], our_pkgs: PackageIndex, label: str) -> None:
     """Update a set of packages to their latest available versions."""
     packages_to_update = [
         name
@@ -152,111 +141,17 @@ def run_free_updates(names: set[str], our_pkgs: dict, label: str) -> None:
         return
 
     print(f"\nUpdating {len(packages_to_update)} {label}...")
-    updated = update_neqo_only_packages(packages_to_update)
+    updated, rejected = update_to_latest(packages_to_update)
+    for name, (old_ver, new_ver) in sorted(updated.items()):
+        print(f"  {name}: {old_ver} -> {new_ver}")
     if updated:
-        for name, (old_ver, new_ver) in sorted(updated.items()):
-            print(f"  {name}: {old_ver} -> {new_ver}")
         print(f"Updated {len(updated)} package(s)")
-    else:
+    if rejected:
+        # Distinct from "nothing to do": cargo refused these, or taking them would
+        # have added a duplicate version.
+        print(f"Could not update {len(rejected)} package(s): {', '.join(rejected)}")
+    elif not updated:
         print(f"All {label} already at newest compatible version")
-
-
-def find_compatible_gecko_range(
-    sv_range: str, gecko_by_range: dict[str, list[str]]
-) -> list[str]:
-    """Find Gecko versions in a compatible semver range.
-
-    For major >= 1, looks for the closest higher range first, then falls back
-    to the closest lower range (to pin us to Gecko's version even if it means
-    a cross-range downgrade for genuinely shared deps).
-    Returns [] for 0.x packages (each minor is its own incompatible API).
-    """
-    major = sv_range.split(".")[0]
-    if major == "0":
-        return []
-
-    sv = Version(sv_range)
-
-    for gr in sorted(gecko_by_range, key=Version, reverse=True):
-        if gr.split(".")[0] == major and Version(gr) > sv:
-            return gecko_by_range[gr]
-
-    for gr in sorted(gecko_by_range, key=Version, reverse=True):
-        if gr.split(".")[0] == major and Version(gr) < sv:
-            return gecko_by_range[gr]
-
-    return []
-
-
-def align_package_with_gecko(
-    name: str,
-    gecko_pkgs: dict,
-    our_pkgs: dict,
-) -> dict[tuple[str, str], str]:
-    """Compute version moves to align a package's versions with Gecko's.
-
-    Emits moves for versions that differ from Gecko's (both upgrades and
-    downgrades). Callers are responsible for filtering out undesired directions
-    (e.g. skipping downgrades of dev-only packages). Skips 999-patched versions.
-    Returns {(name, our_ver): gecko_ver} for versions that need moving.
-    """
-    updates: dict[tuple[str, str], str] = {}
-    our_versions = our_pkgs[name]
-
-    if all(not is_registry_package(info) for info in our_versions.values()):
-        return updates
-
-    # Only consider real (non-999) Gecko versions.
-    gecko_real = [v for v in gecko_pkgs[name] if not v.endswith(".999")]
-    if not gecko_real:
-        return updates
-
-    gecko_by_range = group_by_semver_range(gecko_real)
-    registry_vers = [v for v, info in our_versions.items() if is_registry_package(info)]
-
-    for sv_rng, our_vers in group_by_semver_range(registry_vers).items():
-        gecko_vers = gecko_by_range.get(sv_rng) or find_compatible_gecko_range(
-            sv_rng, gecko_by_range
-        )
-        if not gecko_vers:
-            continue
-
-        gecko_ver = max(gecko_vers, key=Version)
-        for our_ver in our_vers:
-            relation = classify_version_relation(our_ver, gecko_vers)
-            if relation in ("behind", "ahead"):
-                updates[(name, our_ver)] = gecko_ver
-
-    return updates
-
-
-def collect_version_updates(
-    common: set[str],
-    neqo_only: set[str],
-    dev_only: set[str],
-    gecko_pkgs: dict,
-    our_pkgs: dict,
-) -> dict[tuple[str, str], str]:
-    """Collect version moves needed to align shared packages with Gecko.
-
-    Skips neqo-only packages (handled separately via free updates).
-    Skips downgrades for dev/build-only packages — they don't affect Gecko's
-    runtime so there is no benefit to pinning them to Gecko's version.
-    Returns {(name, our_ver): gecko_ver} for registry crates that need moving.
-    """
-    version_updates: dict[tuple[str, str], str] = {}
-
-    for name in common:
-        if name in neqo_only:
-            continue
-        for (n, our_ver), gecko_ver in align_package_with_gecko(
-            name, gecko_pkgs, our_pkgs
-        ).items():
-            if name in dev_only and Version(our_ver) > Version(gecko_ver):
-                continue
-            version_updates[(n, our_ver)] = gecko_ver
-
-    return version_updates
 
 
 def cargo_update_precise(name: str, our_ver: str, gecko_ver: str) -> str | None:
@@ -264,11 +159,8 @@ def cargo_update_precise(name: str, our_ver: str, gecko_ver: str) -> str | None:
 
     Returns None on success, or an error message on failure.
     """
-    result = subprocess.run(
-        ["cargo", "update", "-p", f"{name}@{our_ver}", "--precise", gecko_ver],
-        capture_output=True,
-        text=True,
-        check=False,
+    result = run_cargo(
+        "update", "-p", f"{name}@{our_ver}", "--precise", gecko_ver
     )
     if result.returncode == 0:
         return None
@@ -285,30 +177,55 @@ def build_dependency_graph(
 ) -> dict[str, list[str]]:
     """Build a dependency graph for the packages being updated.
 
+    Nodes are package names, so a crate that dev-depends on itself (as several of
+    ours do) would show up as a self-edge; those are dropped, since a cycle makes
+    TopologicalSorter raise.
     Returns a dict suitable for TopologicalSorter: {name: [dependency_names]}.
     """
     all_names = {name for name, _ in version_updates}
     graph: dict[str, list[str]] = {name: [] for name in all_names}
 
-    our_pkgs = parse_packages(load_lockfile("Cargo.lock"))
+    our_pkgs = current_packages()
     for name in all_names:
         for info in our_pkgs.get(name, {}).values():
             for dep in info["deps"]:
-                if dep in all_names:
+                if dep in all_names and dep != name:
                     graph[name].append(dep)
 
     return graph
 
 
+def update_order(graph: dict[str, list[str]]) -> list[str]:
+    """Order packages dependencies-first, falling back to any order on a cycle.
+
+    Ordering is an optimisation — it lets a dependency move before its dependents
+    retry — so a cycle we can't order is not worth aborting a partially applied
+    update over.
+    """
+    try:
+        return list(TopologicalSorter(graph).static_order())
+    except CycleError as e:
+        print(f"Note: dependency cycle {e.args[1]}; updating in arbitrary order.")
+        return sorted(graph)
+
+
 def apply_version_updates(
     version_updates: dict[tuple[str, str], str],
-) -> tuple[list, list, dict]:
+) -> tuple[
+    list[tuple[str, str, str]],
+    list[tuple[str, str, str]],
+    dict[tuple[str, str], tuple[str, str]],
+]:
     """Apply version updates via cargo update --precise.
 
     Uses topological sort and retries until no more progress is made.
     Returns (updated, downgraded, failed).
     """
     graph = build_dependency_graph(version_updates)
+    moves: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for (name, our_ver), gecko_ver in version_updates.items():
+        moves[name].append((our_ver, gecko_ver))
+
     updated = []
     downgraded = []
     failed: dict[tuple[str, str], tuple[str, str]] = {}
@@ -317,18 +234,11 @@ def apply_version_updates(
     while made_progress:
         made_progress = False
         failed.clear()
-        our_pkgs = parse_packages(load_lockfile("Cargo.lock"))
+        our_pkgs = current_packages()
 
-        for name in TopologicalSorter(graph).static_order():
-            pending = [
-                (our_ver, gecko_ver)
-                for (n, our_ver), gecko_ver in version_updates.items()
-                if n == name
-            ]
-            for our_ver, gecko_ver in pending:
-                if name not in our_pkgs or our_ver not in our_pkgs[name]:
-                    continue
-                if our_ver == gecko_ver:
+        for name in update_order(graph):
+            for our_ver, gecko_ver in moves[name]:
+                if our_ver == gecko_ver or our_ver not in our_pkgs.get(name, {}):
                     continue
 
                 is_downgrade = Version(gecko_ver) < Version(our_ver)
@@ -349,7 +259,7 @@ def apply_version_updates(
 
 
 def dedup_non_gecko_duplicates(
-    gecko_versions: dict,
+    gecko_versions: VersionIndex,
     safe_dependents: set[str],
 ) -> tuple[list[tuple[str, str]], list[tuple[str, str, str]]]:
     """Attempt to eliminate package version duplicates not present in Gecko.
@@ -363,13 +273,11 @@ def dedup_non_gecko_duplicates(
     - resolved:   [(name, off_ver), ...]         successfully eliminated
     - unresolved: [(name, off_ver, reason), ...]  could not be eliminated
     """
-    lockfile_path = Path("Cargo.lock")
     resolved: list[tuple[str, str]] = []
     attempted: set[tuple[str, str]] = set()
 
     while True:
-        our_lock = load_lockfile("Cargo.lock")
-        offenders = find_non_gecko_duplicates(our_lock, gecko_versions)
+        offenders = find_non_gecko_duplicates(current_lock(), gecko_versions)
         pending = [
             (name, off_ver)
             for name, off_vers in offenders.items()
@@ -383,44 +291,38 @@ def dedup_non_gecko_duplicates(
         for name, off_ver in pending:
             attempted.add((name, off_ver))
 
-            our_lock = load_lockfile("Cargo.lock")
-            all_deps = find_dependents(our_lock, name, off_ver)
-            safe_deps = [d for d in all_deps if d.split()[0] in safe_dependents]
-
+            safe_deps = [
+                dep
+                for dep in find_dependents(current_lock(), name, off_ver)
+                if dep[0] in safe_dependents
+            ]
             if not safe_deps:
                 continue
 
-            original_content = lockfile_path.read_text(encoding="utf-8")
-            original_duplicates = get_duplicate_packages(our_lock)
-            specs = [f"{d.split()[0]}@{d.split()[1]}" for d in safe_deps]
-
-            after = _cargo_update_specs(
-                specs, original_content, original_duplicates, lockfile_path
-            )
+            snapshot = LOCKFILE.read_text(encoding="utf-8")
+            after = try_cargo_update([f"{n}@{v}" for n, v in safe_deps])
 
             if after and (name, off_ver) not in after:
                 resolved.append((name, off_ver))
                 progress = True
             else:
-                # _cargo_update_specs reverts on duplicate regression; also
-                # revert here if the off-version wasn't actually eliminated.
-                lockfile_path.write_text(original_content, encoding="utf-8")
+                # try_cargo_update only rolls back its own failures; also revert if
+                # the off-version survived the update.
+                LOCKFILE.write_text(snapshot, encoding="utf-8")
 
         if not progress:
             break
 
     # Build the unresolved report from whatever duplicates still remain.
-    our_lock = load_lockfile("Cargo.lock")
-    final_offenders = find_non_gecko_duplicates(our_lock, gecko_versions)
+    our_lock = current_lock()
     unresolved: list[tuple[str, str, str]] = []
-    for name, off_vers in final_offenders.items():
+    for name, off_vers in find_non_gecko_duplicates(our_lock, gecko_versions).items():
         for off_ver in off_vers:
             all_deps = find_dependents(our_lock, name, off_ver)
-            safe_deps = [d for d in all_deps if d.split()[0] in safe_dependents]
             if not all_deps:
                 reason = "no dependents found"
-            elif not safe_deps:
-                blockers = ", ".join(sorted({d.split()[0] for d in all_deps}))
+            elif not any(n in safe_dependents for n, _ in all_deps):
+                blockers = ", ".join(sorted({n for n, _ in all_deps}))
                 reason = f"pinned by non-safe dependent(s): {blockers}"
             else:
                 reason = "cargo could not collapse onto surviving version"
@@ -429,17 +331,18 @@ def dedup_non_gecko_duplicates(
     return resolved, unresolved
 
 
-def report_failures(failed: dict) -> None:
-    """Report failed version updates, categorized by dev-only vs production."""
-    dev_only = find_dev_only_packages()
-    dependents = build_dependents_map(load_lockfile("Cargo.lock"))
+def report_failures(
+    failed: dict[tuple[str, str], tuple[str, str]], dev_only: set[str]
+) -> None:
+    """Report failed version updates, categorized by dev-only vs. production."""
+    dependents = build_dependents_map(current_lock())
 
     dev_failures = {}
     real_failures = {}
     for (name, our_ver), (gecko_ver, err) in failed.items():
         pkg_dependents = dependents.get(name, set())
         if pkg_dependents and all(d in dev_only for d in pkg_dependents):
-            dev_failures[(name, our_ver)] = (gecko_ver, pkg_dependents)
+            dev_failures[(name, our_ver)] = (gecko_ver, pkg_dependents, err)
         else:
             real_failures[(name, our_ver)] = (gecko_ver, err)
 
@@ -450,118 +353,71 @@ def report_failures(failed: dict) -> None:
 
     if dev_failures:
         print(
-            f"\nSkipped {len(dev_failures)} package(s) "
-            f"due to dev-dependency constraints:"
+            f"\nFailed {len(dev_failures)} package(s) "
+            f"reachable only from dev/build dependencies:"
         )
-        print(
-            "  (These don't affect Gecko integration "
-            "since Gecko ignores dev-dependencies)"
-        )
-        for (name, our_ver), (gecko_ver, blockers) in dev_failures.items():
+        for (name, our_ver), (gecko_ver, blockers, err) in dev_failures.items():
             print(
-                f"  {name}: {our_ver} -> {gecko_ver} "
-                f"(blocked by: {', '.join(sorted(blockers))})"
+                f"  {name}: {our_ver} -> {gecko_ver}: {err} "
+                f"(pulled in by: {', '.join(sorted(blockers))})"
             )
 
 
-def main():
-    """Update Cargo.lock to align with Gecko's versions."""
-    our_lock, gecko_lock = load_lockfiles()
+def align_with_gecko(
+    gecko_pkgs: PackageIndex, gecko_lock: dict, neqo_only: set[str]
+) -> None:
+    """Pin every shared dep to Gecko's version, and report what moved.
 
-    gecko_pkgs = parse_packages(gecko_lock)
-    gecko_versions = get_all_versions(gecko_lock)
-    our_pkgs = parse_packages(our_lock)
+    Repeats until no new pin targets appear, since a `cargo update --precise` can
+    pull transitive deps to versions that themselves need pinning.
+    """
+    before = current_versions()
+    updated: list[tuple[str, str, str]] = []
+    downgraded: list[tuple[str, str, str]] = []
+    failed: dict[tuple[str, str], tuple[str, str]] = {}
+    attempted: set[tuple[str, str]] = set()
 
-    common = set(gecko_pkgs) & set(our_pkgs)
-    print(
-        f"{len(gecko_pkgs)} packages in Gecko, {len(our_pkgs)} in ours, "
-        f"{len(common)} in common",
-        file=sys.stderr,
-    )
+    while True:
+        plan = pin_targets_now(gecko_pkgs, neqo_only, load_cargo_metadata())
+        pending = {k: v for k, v in plan.targets.items() if k not in attempted}
+        if not pending:
+            break
 
-    neqo_only, _ = find_neqo_or_workspace_deps(gecko_lock, our_lock)
+        attempted |= set(pending)
+        round_updated, round_downgraded, round_failed = apply_version_updates(pending)
+        updated += round_updated
+        downgraded += round_downgraded
+        failed.update(round_failed)
 
-    # Phase 1: Bump packages Gecko doesn't pin to their latest versions.
-    # Includes packages absent from Gecko entirely and packages only neqo
-    # uses within Gecko.  Any transitive conflicts are resolved in Phase 2.
-    free_to_update = (set(our_pkgs) - set(gecko_pkgs)) | (neqo_only & common)
-    run_free_updates(free_to_update, our_pkgs, "packages Gecko doesn't pin")
-
-    # Reload after free updates so Phase 2 sees the current lockfile.
-    our_pkgs = parse_packages(load_lockfile("Cargo.lock"))
-    common = set(gecko_pkgs) & set(our_pkgs)
-
-    # Phase 2: Align shared deps to Gecko's exact version (up or down).
-    # Dev/build-only deps are only upgraded, never downgraded (see collect_version_updates).
-    dev_only = find_dev_only_packages()
-    version_updates = collect_version_updates(
-        common, neqo_only, dev_only, gecko_pkgs, our_pkgs
-    )
-
-    if version_updates:
-        # Snapshot before alignment for the transitive-change report.
-        before_versions = {
-            (name, ver) for name, versions in our_pkgs.items() for ver in versions
-        }
-
-        updated, downgraded, failed = apply_version_updates(version_updates)
-
-        # Re-align packages cargo silently moved to non-Gecko versions during
-        # the above updates (transitive deps resolved to crates.io latest).
-        # Track attempted keys to guarantee termination.
-        attempted: set[tuple[str, str]] = set(version_updates.keys())
-        while True:
-            updated_our_pkgs = parse_packages(load_lockfile("Cargo.lock"))
-            current_common = set(gecko_pkgs) & set(updated_our_pkgs)
-            new_updates: dict[tuple[str, str], str] = {}
-            for name in current_common:
-                if name in neqo_only:
-                    continue
-                for key, gecko_ver in align_package_with_gecko(
-                    name, gecko_pkgs, updated_our_pkgs
-                ).items():
-                    _, our_ver = key
-                    if key not in attempted:
-                        if name in dev_only and Version(our_ver) > Version(gecko_ver):
-                            continue
-                        new_updates[key] = gecko_ver
-            if not new_updates:
-                break
-            attempted |= set(new_updates.keys())
-            extra_updated, extra_downgraded, extra_failed = apply_version_updates(new_updates)
-            updated.extend(extra_updated)
-            downgraded.extend(extra_downgraded)
-            failed.update(extra_failed)
-
-        # Detect silently-changed packages not explicitly tracked.
-        after_versions = {
-            (pkg["name"], pkg["version"])
-            for pkg in load_lockfile("Cargo.lock").get("package", [])
-        }
-        explicitly_changed = {name for name, _, _ in updated + downgraded}
-        silent = sorted(
-            {name for name, _ in after_versions - before_versions}
-            - explicitly_changed
-        )
-
-        print()
-        if updated:
-            print(f"Updated {len(updated)} package(s)")
-        if downgraded:
-            print(f"Downgraded {len(downgraded)} package(s)")
-        if silent:
-            print(f"Also updated (transitive): {', '.join(silent)}")
-        if failed:
-            report_failures(failed)
-    else:
+    if not (updated or downgraded or failed):
         print("\nAll shared packages aligned with Gecko versions")
+        return
 
-    # Phase 3: Auto-dedup — collapse non-Gecko duplicate versions.
-    # Only safe dependents (dev/build or neqo-only, never shared Gecko crates)
-    # are bumped during dedup.  Re-load after Phase 2 so the set reflects any
-    # packages that cargo added or removed during alignment.
-    current_pkgs = parse_packages(load_lockfile("Cargo.lock"))
-    safe_dependents = (set(current_pkgs) - set(gecko_pkgs)) | neqo_only
+    # Anything that moved without being asked to came along as a transitive dep.
+    explicit = {name for name, _, _ in updated + downgraded}
+    silent = sorted({name for name, _ in current_versions() - before} - explicit)
+
+    print()
+    if updated:
+        print(f"Updated {len(updated)} package(s)")
+    if downgraded:
+        print(f"Downgraded {len(downgraded)} package(s)")
+    if silent:
+        print(f"Also updated (transitive): {', '.join(silent)}")
+    if failed:
+        report_failures(failed, find_dev_only_packages(load_cargo_metadata()))
+
+
+def report_dedup(
+    gecko_versions: VersionIndex, gecko_pkgs: PackageIndex, neqo_only: set[str]
+) -> None:
+    """Collapse non-Gecko duplicate versions and report the outcome.
+
+    Only safe dependents (dev/build or neqo-only, never shared Gecko crates) get
+    bumped.  The set is derived from the current lockfile, so it reflects packages
+    cargo added or removed while aligning.
+    """
+    safe_dependents = (set(current_packages()) - set(gecko_pkgs)) | neqo_only
     resolved, unresolved = dedup_non_gecko_duplicates(gecko_versions, safe_dependents)
 
     if resolved:
@@ -573,28 +429,66 @@ def main():
         for name, off_ver, reason in sorted(unresolved):
             print(f"  {name} {off_ver}: {reason}")
 
-    # Phase 4: Warn about packages we're ahead of Gecko on (staged for vendor).
-    final_lock = load_lockfile("Cargo.lock")
-    final_pkgs = parse_packages(final_lock)
-    final_common = set(gecko_pkgs) & set(final_pkgs)
 
-    ahead = []
-    for name in sorted(final_common):
-        if name in neqo_only:
-            continue
-        our_vers = list(final_pkgs[name].keys())
-        gecko_vers = [v for v, _ in gecko_versions.get(name, [])]
-        if not gecko_vers:
-            continue
-        gecko_max = max(gecko_vers, key=Version)
-        our_max = max(our_vers, key=Version)
-        if Version(our_max) > Version(gecko_max):
-            ahead.append((name, our_max, gecko_max))
+def pin_targets_now(
+    gecko_pkgs: PackageIndex, neqo_only: set[str], metadata: dict
+) -> PinPlan:
+    """The pin plan for the lockfile as it currently stands."""
+    our_pkgs = current_packages()
+    return collect_pin_targets(
+        set(gecko_pkgs) & set(our_pkgs),
+        neqo_only,
+        gecko_pkgs,
+        our_pkgs,
+        load_version_requirements(metadata),
+    )
 
-    if ahead:
-        print("\nPackages ahead of Gecko (staged for next vendor):")
-        for name, our_ver, gecko_ver in ahead:
-            print(f"  {name}: {our_ver} > {gecko_ver}")
+
+def main():
+    """Update Cargo.lock to align with Gecko's versions."""
+    our_lock, gecko_lock = load_lockfiles()
+    before = current_versions()
+
+    gecko_pkgs = parse_packages(gecko_lock)
+    gecko_versions = versions_by_name(gecko_lock)
+    our_pkgs = parse_packages(our_lock)
+
+    common = set(gecko_pkgs) & set(our_pkgs)
+    print(
+        f"{len(gecko_pkgs)} packages in Gecko, {len(our_pkgs)} in ours, "
+        f"{len(common)} in common",
+        file=sys.stderr,
+    )
+
+    neqo_only = find_neqo_only_deps(gecko_lock, our_lock)
+
+    # Phase 1: bump packages Gecko has no version of, plus those only neqo uses
+    # within Gecko, to their newest compatible version.  Everything Gecko does pin
+    # is left for Phase 2 to match.  Transitive conflicts resolve there too.
+    free_to_update = (set(our_pkgs) - set(gecko_pkgs)) | (neqo_only & common)
+    run_free_updates(free_to_update, our_pkgs, "packages Gecko doesn't pin")
+
+    # Phase 2: pin shared deps to Gecko's exact version, up or down.
+    align_with_gecko(gecko_pkgs, gecko_lock, neqo_only)
+
+    # Phase 3: collapse duplicate versions Gecko doesn't itself carry.
+    report_dedup(gecko_versions, gecko_pkgs, neqo_only)
+
+    # Phase 4: explain what moved, then what still differs and why that is safe.
+    # Recomputed against the finished lockfile so both reflect where we ended up.
+    metadata = load_cargo_metadata()
+    policy = PinPolicy.build(gecko_lock, metadata, neqo_only)
+    plan = pin_targets_now(gecko_pkgs, neqo_only, metadata)
+    our_pkgs, our_lock = current_packages(), current_lock()
+
+    changes = change_rationales(before, current_versions(), policy, our_lock, plan)
+    print(format_rationales("Lockfile changes", changes) or "\nNo version changes.")
+    print(
+        format_rationales(
+            "Why each version differs from Gecko",
+            divergence_rationales(our_pkgs, policy, our_lock, plan),
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/test/uv.lock
+++ b/test/uv.lock
@@ -183,6 +183,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },
+    { name = "semantic-version" },
     { name = "tomlkit" },
 ]
 
@@ -195,6 +196,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "packaging" },
+    { name = "semantic-version" },
     { name = "tomlkit" },
 ]
 
@@ -245,6 +247,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "semantic-version"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c", size = 52289, upload-time = "2022-05-26T13:35:23.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177", size = 15552, upload-time = "2022-05-26T13:35:21.206Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why each version differs from Gecko

- **Gecko's copy isn't the crates.io crate** — it is a local shim or a git fork, so matching the version number would not match the code behind it:
  - `bindgen` 0.72.1 vs. 0.69.999, 0.72.0
  - `hermit-abi` 0.5.2 vs. 0.3.999
  - `r-efi` 5.3.0 vs. 5.999.999
  - `r-efi` 6.0.0 vs. 5.999.999
  - `test-fixture` 0.31.1 vs. 0.1.0
- **Cannot match Gecko** — another crate's requirement rules Gecko's version out; Gecko still builds neqo with its own copy:
  - `cc` 1.2.65 vs. 1.2.30 (`codspeed` needs `^1.2.40`)
  - `glob` 0.3.3 vs. 0.3.1 (`codspeed` needs `^0.3.2`)
  - `itertools` 0.10.5 vs. 0.13.0, 0.14.999, 0.15.0 (`bindgen` needs `>=0.10, <0.14`, `codspeed-criterion-compat-walltime` needs `^0.10`, `criterion-plot` needs `^0.10`)
  - `shlex` 2.0.1 vs. 1.3.0 (`cc` needs `^2.0.1`)
- **Only neqo uses them in Gecko** — Gecko picks up whatever we hold at the next vendor:
  - `clap-verbosity-flag` 3.0.4 vs. 3.0.1
  - `quinn-udp` 0.6.1 vs. 0.6.0
  - `ref-cast` 1.0.25 vs. 1.0.24
  - `ref-cast-impl` 1.0.25 vs. 1.0.24
- **Gecko resolves these itself** — we reach them only from tooling Gecko doesn't vendor, so our version cannot change what it builds neqo with:
  - `getrandom` 0.4.3 vs. 0.2.999, 0.3.3 (via `codspeed`, `jobserver`)
  - `nix` 0.31.2 vs. 0.30.1 (via `codspeed`)

Also update the update scripts.