### PR TITLE
ci: sample instructions and record perf stat counters

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -11,3 +11,4 @@ paths:
   .github/workflows/**/*.{yml,yaml}:
     ignore:
       - 'specifying action "\$/[^"]+" in invalid format because ref is missing'
+      - 'reusable workflow call "\$/[^"]+" at "uses" is not following the format'

--- a/.github/scripts/format-bench-results.py
+++ b/.github/scripts/format-bench-results.py
@@ -139,7 +139,8 @@ def process_input(input_file) -> tuple[list[str], list[str], set[str]]:
                 changed.add(name)
             split = BENCH_LINE_RE.match(line)
             name = split.group("name") if split else line
-            content = bold_middle_pct(split.group("rest")) if split else ""
+            # Match the indent the strip below leaves on criterion's later lines.
+            content = bold_middle_pct(" " * 7 + split.group("rest")) if split else ""
             status = ""
             time_pct = ""
             in_change = False
@@ -269,16 +270,17 @@ def write_stat_markdown(stats_dir: Path, changed: set[str]) -> None:
         ]
 
     moved = [row for row in rows if row.name in changed]
-    if changed and not moved:
+    if moved:
+        summary = table(moved)
+    elif changed:
         print("::warning::no IPC rows match the benchmarks criterion reported on")
+        summary = ["No `perf stat` data for the benchmarks whose timing changed."]
+    else:
+        summary = ["Criterion reported no significant timing changes."]
     lines = [
         "### Instructions per cycle",
         "",
-        *(
-            table(moved)
-            if moved
-            else ["Criterion reported no significant timing changes."]
-        ),
+        *summary,
         "",
         "<details><summary>All benchmarks</summary>",
         "",

--- a/.github/scripts/format-bench-results.py
+++ b/.github/scripts/format-bench-results.py
@@ -199,15 +199,12 @@ def parse_stat(path: Path) -> Stat:
     return Stat(name, counters, multiplexed)
 
 
-def disturbance(*sides: Stat) -> str:
-    """Describe counters that indicate a disturbed run, worst of the sides given."""
-    notes = []
-    # Not migrations: those benchmarks are threaded, and the cpuset has two CPUs.
+def warn_if_untrustworthy(name: str, *sides: Stat) -> None:
+    """Annotate counters that make the measurement itself, not just the run, suspect."""
     if worst := max(side.counters.get("major-faults", 0.0) for side in sides):
-        notes.append(f"{worst:.0f} major fault{'s' if worst > 1 else ''}")
+        print(f"::warning::{worst:.0f} major faults in {name}, so it swapped")
     if any(side.multiplexed for side in sides):
-        notes.append("counters multiplexed, so these are estimates")
-    return f":warning: {', '.join(notes)}" if notes else ""
+        print(f"::warning::counters multiplexed in {name}, so its IPC is an estimate")
 
 
 class StatRow(NamedTuple):
@@ -217,12 +214,11 @@ class StatRow(NamedTuple):
     before: float
     after: float
     delta: float
-    note: str
 
     def markdown(self) -> str:
         return (
             f"| {self.name} | {self.before:.2f} | {self.after:.2f} "
-            f"| {self.delta:+.1f}% | {self.note} |"
+            f"| {self.delta:+.1f}% |"
         )
 
 
@@ -239,14 +235,9 @@ def stat_rows(stats_dir: Path) -> list[StatRow]:
         if before is None or after is None:
             print(f"::warning::no IPC counters in {after_file.name}")
             continue
+        warn_if_untrustworthy(after_stat.name, before_stat, after_stat)
         rows.append(
-            StatRow(
-                after_stat.name,
-                before,
-                after,
-                100 * (after - before) / before,
-                disturbance(before_stat, after_stat),
-            )
+            StatRow(after_stat.name, before, after, 100 * (after - before) / before)
         )
     return sorted(rows, key=lambda row: -abs(row.delta))
 
@@ -269,8 +260,8 @@ def write_stat_markdown(stats_dir: Path, changed: set[str]) -> None:
 
     def table(rows: list[StatRow]) -> list[str]:
         return [
-            "| Benchmark | IPC before | IPC after | ΔIPC | Notes |",
-            "|:---|---:|---:|---:|:---|",
+            "| Benchmark | IPC before | IPC after | ΔIPC |",
+            "|:---|---:|---:|---:|",
             *(row.markdown() for row in rows),
         ]
 

--- a/.github/scripts/format-bench-results.py
+++ b/.github/scripts/format-bench-results.py
@@ -43,7 +43,7 @@ def bold_middle_pct(line: str) -> str:
     if match:
         start, end = match.start(), match.end()
         bracket = line[start + 1 : end - 1]  # Content inside brackets
-        parts = bracket.split("%")
+        parts = bracket.split("%", 2)
         if len(parts) >= 3:
             new_bracket = f"{parts[0]}%<b>{parts[1]}</b>%{parts[2]}"
             return line[: start + 1] + new_bracket + line[end - 1 :]

--- a/.github/scripts/format-bench-results.py
+++ b/.github/scripts/format-bench-results.py
@@ -14,10 +14,9 @@ import sys
 from pathlib import Path
 from typing import NamedTuple
 
-# Measured on the bencher over 13 benchmarks with identical code on both sides:
-# the largest run-to-run IPC difference was 1.3%, the mean 0.4%.
+# Measured with identical code on both sides: IPC differed by at most 1.3%, and a
+# shielded CPU still context-switched about 3 times a second.
 SIGNIFICANT_IPC_PCT = 2.0
-# Same run: a shielded CPU still yields to kernel threads, at up to about 3 switches/s.
 MAX_SWITCHES_PER_SEC = 10.0
 
 # Only numeric values, so `<not counted>` and prose lines simply do not match.
@@ -171,10 +170,33 @@ def process_input(input_file) -> tuple[list[str], list[str]]:
     return all_results, significant_results
 
 
-def parse_stat(path: Path) -> tuple[str, dict[str, float]]:
-    """Return the benchmark name and counters from one `perf stat` output file."""
+class Stat(NamedTuple):
+    """One `perf stat` run."""
+
+    name: str
+    counters: dict[str, float]
+    multiplexed: bool
+
+    @property
+    def ipc(self) -> float | None:
+        """Instructions per cycle, both in user mode so the ratio is consistent."""
+        instructions = self.counters.get("instructions:u")
+        cycles = self.counters.get("cycles:u")
+        return instructions / cycles if instructions and cycles else None
+
+    @property
+    def switches_per_sec(self) -> float:
+        """Context switches per second, `task-clock` being in milliseconds."""
+        clock = self.counters.get("task-clock")
+        switches = self.counters.get("context-switches", 0.0)
+        return 1000 * switches / clock if clock else 0.0
+
+
+def parse_stat(path: Path) -> Stat:
+    """Read one `perf stat` output file."""
     name = path.stem
     counters: dict[str, float] = {}
+    multiplexed = False
     for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         if match := EXACT_RE.search(line):
             name = match.group("name")
@@ -183,40 +205,22 @@ def parse_stat(path: Path) -> tuple[str, dict[str, float]]:
                 match.group("value").replace(",", "")
             )
             if scaled := MULTIPLEX_RE.search(line):
-                counters[match.group("event") + "%"] = float(scaled.group(1))
-    return name, counters
+                multiplexed |= float(scaled.group(1)) < 100
+    return Stat(name, counters, multiplexed)
 
 
-def ipc(counters: dict[str, float]) -> float | None:
-    """Instructions per cycle, both in user mode so the ratio is consistent."""
-    instructions = counters.get("instructions:u")
-    cycles = counters.get("cycles:u")
-    if not instructions or not cycles:
-        return None
-    return instructions / cycles
-
-
-def disturbance(*sides: dict[str, float]) -> str:
+def disturbance(*sides: Stat) -> str:
     """Describe counters that indicate a disturbed run, worst of the sides given."""
     notes = []
     for event, label in (
-        ("cpu-migrations", "CPU migrations"),
-        ("major-faults", "major faults"),
+        ("cpu-migrations", "CPU migration"),
+        ("major-faults", "major fault"),
     ):
-        worst = max(side.get(event, 0) for side in sides)
-        if worst > 0:
-            notes.append(f"{int(worst)} {label}")
-    rate = max(
-        (
-            1000 * side["context-switches"] / side["task-clock"]
-            for side in sides
-            if side.get("task-clock") and side.get("context-switches")
-        ),
-        default=0.0,
-    )
-    if rate > MAX_SWITCHES_PER_SEC:
+        if worst := max(side.counters.get(event, 0.0) for side in sides):
+            notes.append(f"{worst:.0f} {label}{'s' if worst > 1 else ''}")
+    if (rate := max(side.switches_per_sec for side in sides)) > MAX_SWITCHES_PER_SEC:
         notes.append(f"{rate:.0f} context switches/s")
-    if any(v < 100 for side in sides for k, v in side.items() if k.endswith("%")):
+    if any(side.multiplexed for side in sides):
         notes.append("counters multiplexed, so these are estimates")
     return f":warning: {', '.join(notes)}" if notes else ""
 
@@ -249,19 +253,18 @@ def stat_rows(stats_dir: Path) -> list[StatRow]:
         before_file = stats_dir / "neqo-baseline" / after_file.name
         if not before_file.is_file():
             continue
-        name, after_counters = parse_stat(after_file)
-        _, before_counters = parse_stat(before_file)
-        before, after = ipc(before_counters), ipc(after_counters)
+        after_stat, before_stat = parse_stat(after_file), parse_stat(before_file)
+        before, after = before_stat.ipc, after_stat.ipc
         if before is None or after is None:
             print(f"::warning::no IPC counters in {after_file.name}")
             continue
         rows.append(
             StatRow(
-                name,
+                after_stat.name,
                 before,
                 after,
                 100 * (after - before) / before,
-                disturbance(before_counters, after_counters),
+                disturbance(before_stat, after_stat),
             )
         )
     return sorted(rows, key=lambda row: -abs(row.delta))
@@ -269,7 +272,7 @@ def stat_rows(stats_dir: Path) -> list[StatRow]:
 
 def write_stat_markdown(stats_dir: Path) -> None:
     """Write perf-stat.md, highlighting the benchmarks that moved."""
-    # The self-hosted runner keeps its workspace, so drop any earlier run's table first.
+    # The runner keeps its workspace, so drop an earlier run's table.
     out = Path("perf-stat.md")
     out.unlink(missing_ok=True)
     rows = stat_rows(stats_dir)

--- a/.github/scripts/format-bench-results.py
+++ b/.github/scripts/format-bench-results.py
@@ -14,14 +14,9 @@ import sys
 from pathlib import Path
 from typing import NamedTuple
 
-# Measured with identical code on both sides: IPC differed by at most 1.3%, and a
-# shielded CPU still context-switched about 3 times a second.
-SIGNIFICANT_IPC_PCT = 2.0
-MAX_SWITCHES_PER_SEC = 10.0
-
-# Only numeric values, so `<not counted>` and prose lines simply do not match.
+# Unseparated numbers only, so a locale-formatted value cannot parse to the wrong one.
 COUNTER_RE = re.compile(
-    r"^\s*(?P<value>[\d,]+(?:\.\d+)?)\s+(?:msec\s+)?(?P<event>[\w:/=.-]+)"
+    r"^\s*(?P<value>\d+(?:\.\d+)?)\s+(?:msec\s+)?(?P<event>[\w:/=.-]+)"
 )
 # Prefer criterion's own variant name over the sanitized file name.
 EXACT_RE = re.compile(r"counter stats for '.*--exact (?P<name>[^']+)'")
@@ -184,13 +179,6 @@ class Stat(NamedTuple):
         cycles = self.counters.get("cycles:u")
         return instructions / cycles if instructions and cycles else None
 
-    @property
-    def switches_per_sec(self) -> float:
-        """Context switches per second, `task-clock` being in milliseconds."""
-        clock = self.counters.get("task-clock")
-        switches = self.counters.get("context-switches", 0.0)
-        return 1000 * switches / clock if clock else 0.0
-
 
 def parse_stat(path: Path) -> Stat:
     """Read one `perf stat` output file."""
@@ -201,9 +189,7 @@ def parse_stat(path: Path) -> Stat:
         if match := EXACT_RE.search(line):
             name = match.group("name")
         elif match := COUNTER_RE.match(line):
-            counters[match.group("event")] = float(
-                match.group("value").replace(",", "")
-            )
+            counters[match.group("event")] = float(match.group("value"))
             if scaled := MULTIPLEX_RE.search(line):
                 multiplexed |= float(scaled.group(1)) < 100
     return Stat(name, counters, multiplexed)
@@ -218,8 +204,6 @@ def disturbance(*sides: Stat) -> str:
     ):
         if worst := max(side.counters.get(event, 0.0) for side in sides):
             notes.append(f"{worst:.0f} {label}{'s' if worst > 1 else ''}")
-    if (rate := max(side.switches_per_sec for side in sides)) > MAX_SWITCHES_PER_SEC:
-        notes.append(f"{rate:.0f} context switches/s")
     if any(side.multiplexed for side in sides):
         notes.append("counters multiplexed, so these are estimates")
     return f":warning: {', '.join(notes)}" if notes else ""
@@ -234,15 +218,10 @@ class StatRow(NamedTuple):
     delta: float
     note: str
 
-    @property
-    def significant(self) -> bool:
-        return abs(self.delta) >= SIGNIFICANT_IPC_PCT
-
     def markdown(self) -> str:
-        bold = "**" if self.significant else ""
         return (
             f"| {self.name} | {self.before:.2f} | {self.after:.2f} "
-            f"| {bold}{self.delta:+.1f}%{bold} | {self.note} |"
+            f"| {self.delta:+.1f}% | {self.note} |"
         )
 
 
@@ -252,6 +231,7 @@ def stat_rows(stats_dir: Path) -> list[StatRow]:
     for after_file in sorted((stats_dir / "neqo").glob("*.txt")):
         before_file = stats_dir / "neqo-baseline" / after_file.name
         if not before_file.is_file():
+            print(f"::notice::no baseline `perf stat` output for {after_file.name}")
             continue
         after_stat, before_stat = parse_stat(after_file), parse_stat(before_file)
         before, after = before_stat.ipc, after_stat.ipc
@@ -271,7 +251,7 @@ def stat_rows(stats_dir: Path) -> list[StatRow]:
 
 
 def write_stat_markdown(stats_dir: Path) -> None:
-    """Write perf-stat.md, highlighting the benchmarks that moved."""
+    """Write perf-stat.md, largest change first."""
     # The runner keeps its workspace, so drop an earlier run's table.
     out = Path("perf-stat.md")
     out.unlink(missing_ok=True)
@@ -284,35 +264,20 @@ def write_stat_markdown(stats_dir: Path) -> None:
             print(f"::warning::no IPC rows parsed from {stats_dir}")
         return
 
-    def table(rows: list[StatRow]) -> list[str]:
-        return [
-            "| Benchmark | IPC before | IPC after | ΔIPC | |",
-            "|:---|---:|---:|---:|:---|",
-            *(row.markdown() for row in rows),
-        ]
-
-    significant = [row for row in rows if row.significant]
     lines = [
         "### Instructions per cycle",
         "",
         (
             "A diagnostic, not a verdict: read it beside criterion's timing above. "
             "Removing work shifts the instruction mix, so a real speedup can show "
-            "lower IPC. Totals are not comparable across runs, only this ratio. A "
+            "lower IPC. Totals are not comparable across runs, only this ratio, and "
+            "they include criterion's batch setup, which its timing excludes. A "
             ":warning: marks signs of interference."
         ),
         "",
-        *(
-            table(significant)
-            if significant
-            else ["No significant differences in instructions per cycle."]
-        ),
-        "",
-        "<details><summary>All benchmarks</summary>",
-        "",
-        *table(rows),
-        "",
-        "</details>",
+        "| Benchmark | IPC before | IPC after | ΔIPC | |",
+        "|:---|---:|---:|---:|:---|",
+        *(row.markdown() for row in rows),
     ]
     out.write_text("\n".join(lines) + "\n", encoding="utf-8")
 

--- a/.github/scripts/format-bench-results.py
+++ b/.github/scripts/format-bench-results.py
@@ -14,8 +14,11 @@ import sys
 from pathlib import Path
 from typing import NamedTuple
 
-# The machine's run-to-run IPC spread is around 0.5%, so flag several times that.
+# Measured on the bencher over 13 benchmarks with identical code on both sides:
+# the largest run-to-run IPC difference was 1.3%, the mean 0.4%.
 SIGNIFICANT_IPC_PCT = 2.0
+# Same run: a shielded CPU still yields to kernel threads, at up to about 3 switches/s.
+MAX_SWITCHES_PER_SEC = 10.0
 
 # Only numeric values, so `<not counted>` and prose lines simply do not match.
 COUNTER_RE = re.compile(
@@ -194,16 +197,25 @@ def ipc(counters: dict[str, float]) -> float | None:
 
 
 def disturbance(*sides: dict[str, float]) -> str:
-    """Describe counters that should be zero, worst of the sides given."""
+    """Describe counters that indicate a disturbed run, worst of the sides given."""
     notes = []
     for event, label in (
-        ("context-switches", "context switches"),
         ("cpu-migrations", "CPU migrations"),
         ("major-faults", "major faults"),
     ):
         worst = max(side.get(event, 0) for side in sides)
         if worst > 0:
             notes.append(f"{int(worst)} {label}")
+    rate = max(
+        (
+            1000 * side["context-switches"] / side["task-clock"]
+            for side in sides
+            if side.get("task-clock") and side.get("context-switches")
+        ),
+        default=0.0,
+    )
+    if rate > MAX_SWITCHES_PER_SEC:
+        notes.append(f"{rate:.0f} context switches/s")
     if any(v < 100 for side in sides for k, v in side.items() if k.endswith("%")):
         notes.append("counters multiplexed, so these are estimates")
     return f":warning: {', '.join(notes)}" if notes else ""
@@ -241,6 +253,7 @@ def stat_rows(stats_dir: Path) -> list[StatRow]:
         _, before_counters = parse_stat(before_file)
         before, after = ipc(before_counters), ipc(after_counters)
         if before is None or after is None:
+            print(f"::warning::no IPC counters in {after_file.name}")
             continue
         rows.append(
             StatRow(
@@ -261,7 +274,10 @@ def write_stat_markdown(stats_dir: Path) -> None:
     out.unlink(missing_ok=True)
     rows = stat_rows(stats_dir)
     if not rows:
-        if any(stats_dir.rglob("*.txt")):
+        # `rglob` on a missing directory is empty, not an error, so check separately.
+        if not stats_dir.is_dir():
+            print(f"::warning::{stats_dir} is not a directory")
+        elif any(stats_dir.rglob("*.txt")):
             print(f"::warning::no IPC rows parsed from {stats_dir}")
         return
 
@@ -277,10 +293,10 @@ def write_stat_markdown(stats_dir: Path) -> None:
         "### Instructions per cycle",
         "",
         (
-            "Lower means more stalling for the same work. Counter totals are not "
-            "comparable between runs, because criterion chooses its own iteration "
-            "count, so only this ratio is. A :warning: marks a run with signs of "
-            "interference; treat its IPC with suspicion."
+            "A diagnostic, not a verdict: read it beside criterion's timing above. "
+            "Removing work shifts the instruction mix, so a real speedup can show "
+            "lower IPC. Totals are not comparable across runs, only this ratio. A "
+            ":warning: marks signs of interference."
         ),
         "",
         *(
@@ -289,7 +305,7 @@ def write_stat_markdown(stats_dir: Path) -> None:
             else ["No significant differences in instructions per cycle."]
         ),
         "",
-        "<details><summary>All results</summary>",
+        "<details><summary>All benchmarks</summary>",
         "",
         *table(rows),
         "",

--- a/.github/scripts/format-bench-results.py
+++ b/.github/scripts/format-bench-results.py
@@ -23,6 +23,8 @@ COUNTER_RE = re.compile(
 )
 # Prefer criterion's own variant name over the sanitized file name.
 EXACT_RE = re.compile(r"counter stats for '.*--exact (?P<name>[^']+)'")
+# perf appends an enable fraction when it time-shares counters, making them estimates.
+MULTIPLEX_RE = re.compile(r"\((\d+\.\d+)%\)\s*$")
 
 
 def extract_middle_pct(line: str) -> str:
@@ -177,6 +179,8 @@ def parse_stat(path: Path) -> tuple[str, dict[str, float]]:
             counters[match.group("event")] = float(
                 match.group("value").replace(",", "")
             )
+            if scaled := MULTIPLEX_RE.search(line):
+                counters[match.group("event") + "%"] = float(scaled.group(1))
     return name, counters
 
 
@@ -200,6 +204,8 @@ def disturbance(*sides: dict[str, float]) -> str:
         worst = max(side.get(event, 0) for side in sides)
         if worst > 0:
             notes.append(f"{int(worst)} {label}")
+    if any(v < 100 for side in sides for k, v in side.items() if k.endswith("%")):
+        notes.append("counters multiplexed, so these are estimates")
     return f":warning: {', '.join(notes)}" if notes else ""
 
 
@@ -250,6 +256,9 @@ def stat_rows(stats_dir: Path) -> list[StatRow]:
 
 def write_stat_markdown(stats_dir: Path) -> None:
     """Write perf-stat.md, highlighting the benchmarks that moved."""
+    # The self-hosted runner keeps its workspace, so drop any earlier run's table first.
+    out = Path("perf-stat.md")
+    out.unlink(missing_ok=True)
     rows = stat_rows(stats_dir)
     if not rows:
         if any(stats_dir.rglob("*.txt")):
@@ -270,7 +279,8 @@ def write_stat_markdown(stats_dir: Path) -> None:
         (
             "Lower means more stalling for the same work. Counter totals are not "
             "comparable between runs, because criterion chooses its own iteration "
-            "count, so only this ratio is."
+            "count, so only this ratio is. A :warning: marks a run with signs of "
+            "interference; treat its IPC with suspicion."
         ),
         "",
         *(
@@ -285,7 +295,7 @@ def write_stat_markdown(stats_dir: Path) -> None:
         "",
         "</details>",
     ]
-    Path("perf-stat.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    out.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def main() -> None:

--- a/.github/scripts/format-bench-results.py
+++ b/.github/scripts/format-bench-results.py
@@ -55,10 +55,10 @@ def flush(
     time_pct: str,
     all_results: list[str],
     significant_results: list[str],
-) -> None:
-    """Output a benchmark result as a collapsible."""
+) -> bool:
+    """Output a benchmark result as a collapsible, returning whether it changed."""
     if not name:
-        return
+        return False
 
     # Determine status text and whether this is significant
     significant = False
@@ -86,6 +86,7 @@ def flush(
     all_results.append(collapsible)
     if significant:
         significant_results.append(collapsible)
+    return significant
 
 
 def _should_skip_line(line: str) -> bool:
@@ -112,10 +113,11 @@ def _detect_status(line: str, current_status: str) -> str:
     return current_status
 
 
-def process_input(input_file) -> tuple[list[str], list[str]]:
-    """Process benchmark input and return (all_results, significant_results)."""
+def process_input(input_file) -> tuple[list[str], list[str], set[str]]:
+    """Return (all_results, significant_results, names criterion says changed)."""
     all_results: list[str] = []
     significant_results: list[str] = []
+    changed: set[str] = set()
 
     name = ""
     content = ""
@@ -131,7 +133,8 @@ def process_input(input_file) -> tuple[list[str], list[str]]:
 
         # New benchmark: starts at column 0, has content, not "Found"
         if line and not line[0].isspace() and not re.match(r"^Found.*outlier", line):
-            flush(name, content, status, time_pct, all_results, significant_results)
+            if flush(name, content, status, time_pct, all_results, significant_results):
+                changed.add(name)
             name = line
             content = ""
             status = ""
@@ -161,8 +164,9 @@ def process_input(input_file) -> tuple[list[str], list[str]]:
                 content += "\n"
             content += processed_line
 
-    flush(name, content, status, time_pct, all_results, significant_results)
-    return all_results, significant_results
+    if flush(name, content, status, time_pct, all_results, significant_results):
+        changed.add(name)
+    return all_results, significant_results, changed
 
 
 class Stat(NamedTuple):
@@ -198,12 +202,9 @@ def parse_stat(path: Path) -> Stat:
 def disturbance(*sides: Stat) -> str:
     """Describe counters that indicate a disturbed run, worst of the sides given."""
     notes = []
-    for event, label in (
-        ("cpu-migrations", "CPU migration"),
-        ("major-faults", "major fault"),
-    ):
-        if worst := max(side.counters.get(event, 0.0) for side in sides):
-            notes.append(f"{worst:.0f} {label}{'s' if worst > 1 else ''}")
+    # Not migrations: those benchmarks are threaded, and the cpuset has two CPUs.
+    if worst := max(side.counters.get("major-faults", 0.0) for side in sides):
+        notes.append(f"{worst:.0f} major fault{'s' if worst > 1 else ''}")
     if any(side.multiplexed for side in sides):
         notes.append("counters multiplexed, so these are estimates")
     return f":warning: {', '.join(notes)}" if notes else ""
@@ -250,8 +251,8 @@ def stat_rows(stats_dir: Path) -> list[StatRow]:
     return sorted(rows, key=lambda row: -abs(row.delta))
 
 
-def write_stat_markdown(stats_dir: Path) -> None:
-    """Write perf-stat.md."""
+def write_stat_markdown(stats_dir: Path, changed: set[str]) -> None:
+    """Write perf-stat.md, leading with the benchmarks criterion says moved."""
     # The runner keeps its workspace, so drop an earlier run's table.
     out = Path("perf-stat.md")
     out.unlink(missing_ok=True)
@@ -266,12 +267,30 @@ def write_stat_markdown(stats_dir: Path) -> None:
             print(f"::warning::no IPC rows parsed from {stats_dir}")
         return
 
+    def table(rows: list[StatRow]) -> list[str]:
+        return [
+            "| Benchmark | IPC before | IPC after | ΔIPC | Notes |",
+            "|:---|---:|---:|---:|:---|",
+            *(row.markdown() for row in rows),
+        ]
+
+    moved = [row for row in rows if row.name in changed]
+    if changed and not moved:
+        print("::warning::no IPC rows match the benchmarks criterion reported on")
     lines = [
         "### Instructions per cycle",
         "",
-        "| Benchmark | IPC before | IPC after | ΔIPC | |",
-        "|:---|---:|---:|---:|:---|",
-        *(row.markdown() for row in rows),
+        *(
+            table(moved)
+            if moved
+            else ["No instructions per cycle for benchmarks whose timing changed."]
+        ),
+        "",
+        "<details><summary>All benchmarks</summary>",
+        "",
+        *table(rows),
+        "",
+        "</details>",
     ]
     out.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -281,15 +300,15 @@ def main() -> None:
     # Read from file argument or stdin
     if len(sys.argv) > 1:
         with open(sys.argv[1], encoding="utf-8") as f:
-            all_results, significant_results = process_input(f)
+            all_results, significant_results, changed = process_input(f)
     else:
-        all_results, significant_results = process_input(sys.stdin)
+        all_results, significant_results, changed = process_input(sys.stdin)
 
     if len(sys.argv) > 2:
         # Never let the secondary output take the benchmark comment down with it.
         try:
-            write_stat_markdown(Path(sys.argv[2]))
-        except (OSError, ValueError) as e:
+            write_stat_markdown(Path(sys.argv[2]), changed)
+        except Exception as e:  # noqa: BLE001
             print(f"::warning::could not summarize perf stat output: {e}")
 
     with open("all-bench-results.md", "w", encoding="utf-8") as f:

--- a/.github/scripts/format-bench-results.py
+++ b/.github/scripts/format-bench-results.py
@@ -262,7 +262,7 @@ def write_stat_markdown(stats_dir: Path) -> None:
     rows = stat_rows(stats_dir)
     if not rows:
         if any(stats_dir.rglob("*.txt")):
-            print(f"::warning::no IPC rows parsed from {stats_dir}", file=sys.stderr)
+            print(f"::warning::no IPC rows parsed from {stats_dir}")
         return
 
     def table(rows: list[StatRow]) -> list[str]:
@@ -308,7 +308,11 @@ def main() -> None:
         all_results, significant_results = process_input(sys.stdin)
 
     if len(sys.argv) > 2:
-        write_stat_markdown(Path(sys.argv[2]))
+        # Never let the secondary output take the benchmark comment down with it.
+        try:
+            write_stat_markdown(Path(sys.argv[2]))
+        except (OSError, ValueError) as e:
+            print(f"::warning::could not summarize perf stat output: {e}")
 
     with open("all-bench-results.md", "w", encoding="utf-8") as f:
         f.write("\n".join(all_results))

--- a/.github/scripts/format-bench-results.py
+++ b/.github/scripts/format-bench-results.py
@@ -267,14 +267,6 @@ def write_stat_markdown(stats_dir: Path) -> None:
     lines = [
         "### Instructions per cycle",
         "",
-        (
-            "A diagnostic, not a verdict: read it beside criterion's timing above. "
-            "Removing work shifts the instruction mix, so a real speedup can show "
-            "lower IPC. Totals are not comparable across runs, only this ratio, and "
-            "they include criterion's batch setup, which its timing excludes. A "
-            ":warning: marks signs of interference."
-        ),
-        "",
         "| Benchmark | IPC before | IPC after | ΔIPC | |",
         "|:---|---:|---:|---:|:---|",
         *(row.markdown() for row in rows),

--- a/.github/scripts/format-bench-results.py
+++ b/.github/scripts/format-bench-results.py
@@ -18,6 +18,8 @@ from typing import NamedTuple
 COUNTER_RE = re.compile(
     r"^\s*(?P<value>\d+(?:\.\d+)?)\s+(?:msec\s+)?(?P<event>[\w:/=.-]+)"
 )
+# Criterion pads ids of 23 characters or fewer onto their `time:` line.
+BENCH_LINE_RE = re.compile(r"^(?P<name>.*?)\s+(?P<rest>time:\s+\[.*)$")
 # Prefer criterion's own variant name over the sanitized file name.
 EXACT_RE = re.compile(r"counter stats for '.*--exact (?P<name>[^']+)'")
 # perf appends an enable fraction when it time-shares counters, making them estimates.
@@ -135,8 +137,9 @@ def process_input(input_file) -> tuple[list[str], list[str], set[str]]:
         if line and not line[0].isspace() and not re.match(r"^Found.*outlier", line):
             if flush(name, content, status, time_pct, all_results, significant_results):
                 changed.add(name)
-            name = line
-            content = ""
+            split = BENCH_LINE_RE.match(line)
+            name = split.group("name") if split else line
+            content = bold_middle_pct(split.group("rest")) if split else ""
             status = ""
             time_pct = ""
             in_change = False
@@ -200,7 +203,7 @@ def parse_stat(path: Path) -> Stat:
 
 
 def warn_if_untrustworthy(name: str, *sides: Stat) -> None:
-    """Annotate counters that make the measurement itself, not just the run, suspect."""
+    """Annotate counters that make the measurement itself suspect."""
     if worst := max(side.counters.get("major-faults", 0.0) for side in sides):
         print(f"::warning::{worst:.0f} major faults in {name}, so it swapped")
     if any(side.multiplexed for side in sides):
@@ -274,7 +277,7 @@ def write_stat_markdown(stats_dir: Path, changed: set[str]) -> None:
         *(
             table(moved)
             if moved
-            else ["No instructions per cycle for benchmarks whose timing changed."]
+            else ["Criterion reported no significant timing changes."]
         ),
         "",
         "<details><summary>All benchmarks</summary>",

--- a/.github/scripts/format-bench-results.py
+++ b/.github/scripts/format-bench-results.py
@@ -4,10 +4,25 @@
 Reads benchmark output from stdin or a file and writes:
 - all-bench-results.md: All benchmark results as collapsibles
 - significant-results.md: Only results with regressions or improvements
+
+Given a `perf stat` output directory as a second argument, also writes:
+- perf-stat.md: Instructions per cycle per benchmark, for both sides
 """
 
 import re
 import sys
+from pathlib import Path
+from typing import NamedTuple
+
+# The machine's run-to-run IPC spread is around 0.5%, so flag several times that.
+SIGNIFICANT_IPC_PCT = 2.0
+
+# Only numeric values, so `<not counted>` and prose lines simply do not match.
+COUNTER_RE = re.compile(
+    r"^\s*(?P<value>[\d,]+(?:\.\d+)?)\s+(?:msec\s+)?(?P<event>[\w:/=.-]+)"
+)
+# Prefer criterion's own variant name over the sanitized file name.
+EXACT_RE = re.compile(r"counter stats for '.*--exact (?P<name>[^']+)'")
 
 
 def extract_middle_pct(line: str) -> str:
@@ -151,6 +166,128 @@ def process_input(input_file) -> tuple[list[str], list[str]]:
     return all_results, significant_results
 
 
+def parse_stat(path: Path) -> tuple[str, dict[str, float]]:
+    """Return the benchmark name and counters from one `perf stat` output file."""
+    name = path.stem
+    counters: dict[str, float] = {}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if match := EXACT_RE.search(line):
+            name = match.group("name")
+        elif match := COUNTER_RE.match(line):
+            counters[match.group("event")] = float(
+                match.group("value").replace(",", "")
+            )
+    return name, counters
+
+
+def ipc(counters: dict[str, float]) -> float | None:
+    """Instructions per cycle, both in user mode so the ratio is consistent."""
+    instructions = counters.get("instructions:u")
+    cycles = counters.get("cycles:u")
+    if not instructions or not cycles:
+        return None
+    return instructions / cycles
+
+
+def disturbance(*sides: dict[str, float]) -> str:
+    """Describe counters that should be zero, worst of the sides given."""
+    notes = []
+    for event, label in (
+        ("context-switches", "context switches"),
+        ("cpu-migrations", "CPU migrations"),
+        ("major-faults", "major faults"),
+    ):
+        worst = max(side.get(event, 0) for side in sides)
+        if worst > 0:
+            notes.append(f"{int(worst)} {label}")
+    return f":warning: {', '.join(notes)}" if notes else ""
+
+
+class StatRow(NamedTuple):
+    """One benchmark's IPC before and after, as a percentage change."""
+
+    name: str
+    before: float
+    after: float
+    delta: float
+    note: str
+
+    @property
+    def significant(self) -> bool:
+        return abs(self.delta) >= SIGNIFICANT_IPC_PCT
+
+    def markdown(self) -> str:
+        bold = "**" if self.significant else ""
+        return (
+            f"| {self.name} | {self.before:.2f} | {self.after:.2f} "
+            f"| {bold}{self.delta:+.1f}%{bold} | {self.note} |"
+        )
+
+
+def stat_rows(stats_dir: Path) -> list[StatRow]:
+    """Compare each benchmark's `perf stat` output, largest change first."""
+    rows = []
+    for after_file in sorted((stats_dir / "neqo").glob("*.txt")):
+        before_file = stats_dir / "neqo-baseline" / after_file.name
+        if not before_file.is_file():
+            continue
+        name, after_counters = parse_stat(after_file)
+        _, before_counters = parse_stat(before_file)
+        before, after = ipc(before_counters), ipc(after_counters)
+        if before is None or after is None:
+            continue
+        rows.append(
+            StatRow(
+                name,
+                before,
+                after,
+                100 * (after - before) / before,
+                disturbance(before_counters, after_counters),
+            )
+        )
+    return sorted(rows, key=lambda row: -abs(row.delta))
+
+
+def write_stat_markdown(stats_dir: Path) -> None:
+    """Write perf-stat.md, highlighting the benchmarks that moved."""
+    rows = stat_rows(stats_dir)
+    if not rows:
+        if any(stats_dir.rglob("*.txt")):
+            print(f"::warning::no IPC rows parsed from {stats_dir}", file=sys.stderr)
+        return
+
+    def table(rows: list[StatRow]) -> list[str]:
+        return [
+            "| Benchmark | IPC before | IPC after | ΔIPC | |",
+            "|:---|---:|---:|---:|:---|",
+            *(row.markdown() for row in rows),
+        ]
+
+    significant = [row for row in rows if row.significant]
+    lines = [
+        "### Instructions per cycle",
+        "",
+        (
+            "Lower means more stalling for the same work. Counter totals are not "
+            "comparable between runs, because criterion chooses its own iteration "
+            "count, so only this ratio is."
+        ),
+        "",
+        *(
+            table(significant)
+            if significant
+            else ["No significant differences in instructions per cycle."]
+        ),
+        "",
+        "<details><summary>All results</summary>",
+        "",
+        *table(rows),
+        "",
+        "</details>",
+    ]
+    Path("perf-stat.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 def main() -> None:
     """Parse benchmark results and write Markdown output files."""
     # Read from file argument or stdin
@@ -159,6 +296,9 @@ def main() -> None:
             all_results, significant_results = process_input(f)
     else:
         all_results, significant_results = process_input(sys.stdin)
+
+    if len(sys.argv) > 2:
+        write_stat_markdown(Path(sys.argv[2]))
 
     with open("all-bench-results.md", "w", encoding="utf-8") as f:
         f.write("\n".join(all_results))

--- a/.github/scripts/format-bench-results.py
+++ b/.github/scripts/format-bench-results.py
@@ -251,7 +251,7 @@ def stat_rows(stats_dir: Path) -> list[StatRow]:
 
 
 def write_stat_markdown(stats_dir: Path) -> None:
-    """Write perf-stat.md, largest change first."""
+    """Write perf-stat.md."""
     # The runner keeps its workspace, so drop an earlier run's table.
     out = Path("perf-stat.md")
     out.unlink(missing_ok=True)
@@ -260,7 +260,9 @@ def write_stat_markdown(stats_dir: Path) -> None:
         # `rglob` on a missing directory is empty, not an error, so check separately.
         if not stats_dir.is_dir():
             print(f"::warning::{stats_dir} is not a directory")
-        elif any(stats_dir.rglob("*.txt")):
+        elif not any(stats_dir.rglob("*.txt")):
+            print(f"::warning::no `perf stat` output under {stats_dir}")
+        else:
             print(f"::warning::no IPC rows parsed from {stats_dir}")
         return
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,7 +10,7 @@ env:
   RUSTUP_TOOLCHAIN: stable
   # `cycles:u` stays first: samply makes the first `-e` event its sample table, the rest markers.
   # Per-symbol IPC comes from the `perf report` dumps. No cache or TLB events: only 4 counters.
-  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles/freq=999/k,instructions/freq=999/u,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
+  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles/freq=999/k,instructions/freq=999/u,page-faults,major-faults,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
   # Exact counts, so IPC has no sampling error. `--no-big-num`, as separators are locale-dependent.
   PERF_STAT_OPT: stat --no-big-num -e instructions:u,cycles:u,cycles:k,task-clock,page-faults,major-faults,context-switches,cpu-migrations
   MTU: 1504 # https://github.com/microsoft/msquic/issues/4618

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,11 +9,13 @@ env:
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
   RUSTUP_TOOLCHAIN: stable
   # samply makes the first `-e` event its sample table and the rest markers, so `cycles:u` stays
-  # first. `instructions` gives per-symbol IPC. The fault and scheduling counters flag a disturbed
+  # first. `instructions` gives per-symbol IPC, read off the `perf report` dumps in the artifact,
+  # as the profiler cannot aggregate markers. The fault and scheduling counters flag a disturbed
   # run. No cache or TLB events: only 4 counters, 3 with the NMI watchdog.
   PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles/freq=999/k,instructions/freq=999/u,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
   # Exact counts, so IPC has no sampling error; only the ratio compares across runs.
-  PERF_STAT_OPT: stat -e instructions:u,cycles:u,cycles:k,task-clock,page-faults,major-faults,context-switches,cpu-migrations
+  # `--no-big-num`, as the thousands separators it replaces are locale-dependent.
+  PERF_STAT_OPT: stat --no-big-num -e instructions:u,cycles:u,cycles:k,task-clock,page-faults,major-faults,context-switches,cpu-migrations
   MTU: 1504 # https://github.com/microsoft/msquic/issues/4618
   CFLAGS: -fno-omit-frame-pointer
   CXXFLAGS: -fno-omit-frame-pointer
@@ -167,11 +169,11 @@ jobs:
                 while IFS= read -r VARIANT; do
                   SAFE_NAME="${BIN_NAME}_$(sanitize_name "$VARIANT")"
                   # shellcheck disable=SC2086
-                  bench_exec perf -- $subcmd -o "$out/$SAFE_NAME.$ext" "$BENCH" --bench --noplot --discard-baseline --exact "$VARIANT" | filter_cset
+                  bench_exec perf -- $subcmd -o "$out/$SAFE_NAME.$ext" "$BENCH" --bench --noplot --profile-time 5 --exact "$VARIANT" | filter_cset
                 done <<< "$VARIANTS"
               else
                 # shellcheck disable=SC2086
-                bench_exec perf -- $subcmd -o "$out/$BIN_NAME.$ext" "$BENCH" --bench --noplot --discard-baseline | filter_cset
+                bench_exec perf -- $subcmd -o "$out/$BIN_NAME.$ext" "$BENCH" --bench --noplot --profile-time 5 | filter_cset
               fi
             done
           }
@@ -194,6 +196,8 @@ jobs:
             samply import "$f" -o "$f.samply.json.gz" --save-only --presymbolicate
             # Generate flamegraphs from the cycles event (perf.data has multiple events)
             perf script -i "$f" | inferno-collapse-perf --event-filter cycles | inferno-flamegraph --colors rust > "${f//.perf/.svg}"
+            # One self-cost histogram per event, so IPC can be read off per symbol.
+            perf report -i "$f" --stdio --no-children --percent-limit 1 > "${f%.perf}.report.txt"
           done
 
       # Re-enable turboboost, hyperthreading, use powersave governor, remove all CPU sets, restore MTU.
@@ -256,6 +260,7 @@ jobs:
           name: ${{ github.event.repository.name }}-${{ github.event.pull_request.head.sha }}-bench-perf
           path: |
             profiles/*/*.svg
+            profiles/*/*.report.txt
             stats/*/*.txt
             *.txt
             *.md

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -118,7 +118,8 @@ jobs:
         env:
           BENCH_SET: ${{ steps.cpu-tuning.outputs.bench-set }}
         run: |
-          bench_exec() { sudo nice -n -20 env "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" "TEST_FIXTURE_DB=$TEST_FIXTURE_DB" setarch --addr-no-randomize cset proc --set="$BENCH_SET" --exec "$@"; }
+          # `LC_ALL=C`, as perf formats counters for the locale, decimal separator included.
+          bench_exec() { sudo nice -n -20 env "LC_ALL=C" "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" "TEST_FIXTURE_DB=$TEST_FIXTURE_DB" setarch --addr-no-randomize cset proc --set="$BENCH_SET" --exec "$@"; }
           filter_cset() { grep -v '^cset' || test $? = 1; }
           shopt -s extglob nullglob
 
@@ -154,9 +155,10 @@ jobs:
               bench_exec "$PR_BENCH" -- --bench --baseline-lenient baseline --noplot | filter_cset | tee -a ../results.txt
             fi
           done
-          # Run `perf $1` over every benchmark in $2, writing $4 files under $3/<side>/.
+          # Run `perf $1` over every benchmark in $2, writing $4 files under $3/<side>/,
+          # profiling each variant for $5 seconds.
           perf_dir() {
-            local subcmd="$1" dir="$2" out ext="$4"
+            local subcmd="$1" dir="$2" out ext="$4" secs="$5"
             out="$3/$(basename "$dir")"
             local BENCH BIN_NAME VARIANTS SAFE_NAME VARIANT
             mkdir -p "$out"
@@ -167,20 +169,21 @@ jobs:
                 while IFS= read -r VARIANT; do
                   SAFE_NAME="${BIN_NAME}_$(sanitize_name "$VARIANT")"
                   # shellcheck disable=SC2086
-                  bench_exec perf -- $subcmd -o "$out/$SAFE_NAME.$ext" "$BENCH" --bench --noplot --profile-time 5 --exact "$VARIANT" | filter_cset
+                  bench_exec perf -- $subcmd -o "$out/$SAFE_NAME.$ext" "$BENCH" --bench --noplot --profile-time "$secs" --exact "$VARIANT" | filter_cset
                 done <<< "$VARIANTS"
               else
                 # shellcheck disable=SC2086
-                bench_exec perf -- $subcmd -o "$out/$BIN_NAME.$ext" "$BENCH" --bench --noplot --profile-time 5 | filter_cset
+                bench_exec perf -- $subcmd -o "$out/$BIN_NAME.$ext" "$BENCH" --bench --noplot --profile-time "$secs" | filter_cset
               fi
             done
           }
           # `stat` for both sides first, so `record`'s overhead cannot skew the IPC comparison.
           for SIDE in ../dist/neqo ../dist/neqo-baseline; do
-            perf_dir "$PERF_STAT_OPT" "$SIDE" ../stats txt
+            perf_dir "$PERF_STAT_OPT" "$SIDE" ../stats txt 5
           done
+          # Longer, because the flamegraphs need samples, not just an exact ratio.
           for SIDE in ../dist/neqo ../dist/neqo-baseline; do
-            perf_dir "$PERF_OPT" "$SIDE" ../profiles perf
+            perf_dir "$PERF_OPT" "$SIDE" ../profiles perf 15
           done
           # bench_exec runs as root via sudo nice, so fix ownership of all files it wrote
           sudo chown -R "$(id -u)" target/criterion ../profiles ../stats
@@ -193,7 +196,7 @@ jobs:
             # Convert for profiler.firefox.com
             samply import "$f" -o "$f.samply.json.gz" --save-only --presymbolicate
             # Generate flamegraphs from the cycles event (perf.data has multiple events)
-            perf script -i "$f" | inferno-collapse-perf --event-filter cycles | inferno-flamegraph --colors rust > "${f//.perf/.svg}"
+            perf script -i "$f" | inferno-collapse-perf --event-filter cycles | inferno-flamegraph --colors rust > "${f%.perf}.svg"
             # One self-cost histogram per event, so IPC can be read off per symbol.
             perf report -i "$f" --stdio --no-children -g none --percent-limit 0.1 \
               -F overhead,period,symbol,dso > "${f%.perf}.report.txt"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -132,7 +132,7 @@ jobs:
             sudo chown -R --no-dereference "$(id -u)" target
           fi
           # Start empty, so a removed benchmark leaves no stale file to compare against.
-          rm -rf target/criterion ../profiles ../stats
+          rm -rf target/criterion ../profiles ../stats ../results.txt ../results-baseline.txt
           # Run baseline and PR builds interleaved.
           sanitize_name() { echo "$1" | tr '/ ()' '___-' | tr -s '_'; }
           variants() { "$1" --bench --list 2>/dev/null | sed -n 's/: benchmark$//p' || true; }
@@ -177,7 +177,7 @@ jobs:
               fi
             done
           }
-          # Both `stat` passes back to back, so the compared sides are adjacent in time.
+          # `stat` for both sides first, so `record`'s overhead cannot skew the IPC comparison.
           for SIDE in ../dist/neqo ../dist/neqo-baseline; do
             perf_dir "$PERF_STAT_OPT" "$SIDE" ../stats txt
           done
@@ -197,7 +197,8 @@ jobs:
             # Generate flamegraphs from the cycles event (perf.data has multiple events)
             perf script -i "$f" | inferno-collapse-perf --event-filter cycles | inferno-flamegraph --colors rust > "${f//.perf/.svg}"
             # One self-cost histogram per event, so IPC can be read off per symbol.
-            perf report -i "$f" --stdio --no-children --percent-limit 1 > "${f%.perf}.report.txt"
+            perf report -i "$f" --stdio --no-children -g none --percent-limit 0.1 \
+              -F overhead,period,symbol,dso > "${f%.perf}.report.txt"
           done
 
       # Re-enable turboboost, hyperthreading, use powersave governor, remove all CPU sets, restore MTU.

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,13 +8,11 @@ env:
   CARGO_PROFILE_RELEASE_LTO: true
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
   RUSTUP_TOOLCHAIN: stable
-  # samply makes the first `-e` event its sample table and the rest markers, so `cycles:u` stays
-  # first. `instructions` gives per-symbol IPC, read off the `perf report` dumps in the artifact,
-  # as the profiler cannot aggregate markers. The fault and scheduling counters flag a disturbed
-  # run. No cache or TLB events: only 4 counters, 3 with the NMI watchdog.
+  # `cycles:u` stays first: samply makes the first `-e` event its sample table, the rest markers.
+  # Read per-symbol IPC off the `perf report` dumps, as the profiler cannot aggregate markers.
+  # No cache or TLB events: only 4 counters, 3 with the NMI watchdog.
   PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles/freq=999/k,instructions/freq=999/u,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
-  # Exact counts, so IPC has no sampling error; only the ratio compares across runs.
-  # `--no-big-num`, as the thousands separators it replaces are locale-dependent.
+  # Exact counts, so IPC has no sampling error. `--no-big-num`, as separators are locale-dependent.
   PERF_STAT_OPT: stat --no-big-num -e instructions:u,cycles:u,cycles:k,task-clock,page-faults,major-faults,context-switches,cpu-migrations
   MTU: 1504 # https://github.com/microsoft/msquic/issues/4618
   CFLAGS: -fno-omit-frame-pointer

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -50,10 +50,13 @@ jobs:
           benches: "true"
           baseline-ref: origin/${{ env.BASE_REF }}
 
+  build-samply:
+    uses: ./.github/workflows/build-samply.yml
+
   bench:
     name: cargo bench
     runs-on: "self-hosted" # zizmor: ignore[self-hosted-runner]
-    needs: [build]
+    needs: [build, build-samply]
     defaults:
       run:
         shell: bash
@@ -87,9 +90,11 @@ jobs:
         uses: $/.github/actions/install-build-deps
         with:
           version: ${{ env.RUSTUP_TOOLCHAIN }}
-          tools: inferno, samply
+          tools: inferno
           nss: "false" # Uses the NSS libraries bundled with the downloaded binaries.
           rust-cache: "false"
+
+      - uses: $/.github/actions/install-samply
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,7 +8,12 @@ env:
   CARGO_PROFILE_RELEASE_LTO: true
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
   RUSTUP_TOOLCHAIN: stable
-  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles:k,kmem:rss_stat,sched:sched_switch -m 2048
+  # samply makes the first `-e` event its sample table and the rest markers, so `cycles:u` stays
+  # first. `instructions` gives per-symbol IPC. The fault and scheduling counters flag a disturbed
+  # run. No cache or TLB events: only 4 counters, 3 with the NMI watchdog.
+  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles/freq=999/k,instructions/freq=999/u,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
+  # Exact counts, so IPC has no sampling error; only the ratio compares across runs.
+  PERF_STAT_OPT: stat -e instructions:u,cycles:u,cycles:k,task-clock,page-faults,major-faults,context-switches,cpu-migrations
   MTU: 1504 # https://github.com/microsoft/msquic/issues/4618
   CFLAGS: -fno-omit-frame-pointer
   CXXFLAGS: -fno-omit-frame-pointer
@@ -127,14 +132,15 @@ jobs:
           rm -rf target/criterion
           # Run baseline and PR builds interleaved.
           sanitize_name() { echo "$1" | tr '/ ()' '___-' | tr -s '_'; }
+          variants() { "$1" --bench --list 2>/dev/null | sed -n 's/: benchmark$//p' || true; }
           for PR_BENCH in ../dist/neqo/!(neqo-client|neqo-server); do
             BIN_NAME=$(basename "$PR_BENCH")
             BASELINE_BENCH="../dist/neqo-baseline/$BIN_NAME"
             [ -f "$BASELINE_BENCH" ] || BASELINE_BENCH=""
-            VARIANTS=$("$PR_BENCH" --bench --list 2>/dev/null | sed -n 's/: benchmark$//p' || true)
+            VARIANTS=$(variants "$PR_BENCH")
             if [ -n "$VARIANTS" ]; then
               BASELINE_VARIANTS=""
-              [ -n "$BASELINE_BENCH" ] && BASELINE_VARIANTS=$("$BASELINE_BENCH" --bench --list 2>/dev/null | sed -n 's/: benchmark$//p' || true)
+              [ -n "$BASELINE_BENCH" ] && BASELINE_VARIANTS=$(variants "$BASELINE_BENCH")
               while IFS= read -r VARIANT; do
                 if [ -n "$BASELINE_BENCH" ] && grep -qxF "$VARIANT" <<< "$BASELINE_VARIANTS"; then
                   bench_exec "$BASELINE_BENCH" -- --bench --save-baseline baseline --noplot --exact "$VARIANT" | filter_cset | tee -a ../results-baseline.txt
@@ -147,31 +153,33 @@ jobs:
               bench_exec "$PR_BENCH" -- --bench --baseline-lenient baseline --noplot | filter_cset | tee -a ../results.txt
             fi
           done
-          profile_dir() {
-            local dir="$1" outdir
-            outdir=$(basename "$dir")
+          # Run `perf $1` over every benchmark in $2, writing $4 files under $3/<side>/.
+          perf_dir() {
+            local subcmd="$1" dir="$2" out ext="$4"
+            out="$3/$(basename "$dir")"
             local BENCH BIN_NAME VARIANTS SAFE_NAME VARIANT
-            mkdir -p "../profiles/$outdir"
+            mkdir -p "$out"
             for BENCH in "$dir"/!(neqo-client|neqo-server); do
               BIN_NAME=$(basename "$BENCH")
-              VARIANTS=$("$BENCH" --bench --list 2>/dev/null | sed -n 's/: benchmark$//p' || true)
+              VARIANTS=$(variants "$BENCH")
               if [ -n "$VARIANTS" ]; then
                 while IFS= read -r VARIANT; do
                   SAFE_NAME="${BIN_NAME}_$(sanitize_name "$VARIANT")"
                   # shellcheck disable=SC2086
-                  bench_exec perf -- $PERF_OPT -o "../profiles/$outdir/$SAFE_NAME.perf" "$BENCH" --bench --noplot --discard-baseline --exact "$VARIANT" | filter_cset
+                  bench_exec perf -- $subcmd -o "$out/$SAFE_NAME.$ext" "$BENCH" --bench --noplot --discard-baseline --exact "$VARIANT" | filter_cset
                 done <<< "$VARIANTS"
               else
                 # shellcheck disable=SC2086
-                bench_exec perf -- $PERF_OPT -o "../profiles/$outdir/$BIN_NAME.perf" "$BENCH" --bench --noplot --discard-baseline | filter_cset
+                bench_exec perf -- $subcmd -o "$out/$BIN_NAME.$ext" "$BENCH" --bench --noplot --discard-baseline | filter_cset
               fi
             done
           }
-          profile_dir ../dist/neqo
-          # Also profile the baseline
-          profile_dir ../dist/neqo-baseline
+          for SIDE in ../dist/neqo ../dist/neqo-baseline; do
+            perf_dir "$PERF_OPT" "$SIDE" ../profiles perf
+            perf_dir "$PERF_STAT_OPT" "$SIDE" ../stats txt
+          done
           # bench_exec runs as root via sudo nice, so fix ownership of all files it wrote
-          sudo chown -R "$(id -u)" target/criterion ../profiles
+          sudo chown -R "$(id -u)" target/criterion ../profiles ../stats
 
       # Runs before the machine is restored, because symbolication needs `kptr_restrict`.
       - name: Post-process perf data
@@ -199,7 +207,7 @@ jobs:
         run: |
           SHA=$(cd neqo && git log origin/"$BASE_REF" -1 --format=%H)
           echo "$SHA" > baseline-sha.txt
-          python3 neqo/.github/scripts/format-bench-results.py results.txt
+          python3 neqo/.github/scripts/format-bench-results.py results.txt stats
           # Build final markdown output
           {
             echo "### Benchmark results"
@@ -216,6 +224,10 @@ jobs:
             cat all-bench-results.md
             echo
             echo "</details>"
+            if [ -s perf-stat.md ]; then
+              echo
+              cat perf-stat.md
+            fi
           } > results.md
           rm -f all-bench-results.md significant-results.md
           cat results.md > "$GITHUB_STEP_SUMMARY"
@@ -240,6 +252,7 @@ jobs:
           name: ${{ github.event.repository.name }}-${{ github.event.pull_request.head.sha }}-bench-perf
           path: |
             profiles/*/*.svg
+            stats/*/*.txt
             *.txt
             *.md
             event.json

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -158,6 +158,8 @@ jobs:
             local subcmd="$1" dir="$2" out ext="$4"
             out="$3/$(basename "$dir")"
             local BENCH BIN_NAME VARIANTS SAFE_NAME VARIANT
+            # Start empty, so a removed benchmark leaves no stale file to compare against.
+            sudo rm -rf "$out"
             mkdir -p "$out"
             for BENCH in "$dir"/!(neqo-client|neqo-server); do
               BIN_NAME=$(basename "$BENCH")
@@ -174,9 +176,12 @@ jobs:
               fi
             done
           }
+          # Both `stat` passes back to back, so the compared sides are adjacent in time.
+          for SIDE in ../dist/neqo ../dist/neqo-baseline; do
+            perf_dir "$PERF_STAT_OPT" "$SIDE" ../stats txt
+          done
           for SIDE in ../dist/neqo ../dist/neqo-baseline; do
             perf_dir "$PERF_OPT" "$SIDE" ../profiles perf
-            perf_dir "$PERF_STAT_OPT" "$SIDE" ../stats txt
           done
           # bench_exec runs as root via sudo nice, so fix ownership of all files it wrote
           sudo chown -R "$(id -u)" target/criterion ../profiles ../stats
@@ -229,7 +234,7 @@ jobs:
               cat perf-stat.md
             fi
           } > results.md
-          rm -f all-bench-results.md significant-results.md
+          rm -f all-bench-results.md significant-results.md perf-stat.md
           cat results.md > "$GITHUB_STEP_SUMMARY"
           echo "$TESTBED" > testbed.txt
           cp "$EVENT_PATH" event.json
@@ -282,4 +287,4 @@ jobs:
         if: always()
         run: |
           rm -- * || true
-          rm -r -- binaries dist profiles comment-data || true
+          rm -r -- binaries dist profiles stats comment-data || true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -129,7 +129,8 @@ jobs:
           if [ -d target ]; then
             sudo chown -R --no-dereference "$(id -u)" target
           fi
-          rm -rf target/criterion
+          # Start empty, so a removed benchmark leaves no stale file to compare against.
+          rm -rf target/criterion ../profiles ../stats
           # Run baseline and PR builds interleaved.
           sanitize_name() { echo "$1" | tr '/ ()' '___-' | tr -s '_'; }
           variants() { "$1" --bench --list 2>/dev/null | sed -n 's/: benchmark$//p' || true; }
@@ -158,8 +159,6 @@ jobs:
             local subcmd="$1" dir="$2" out ext="$4"
             out="$3/$(basename "$dir")"
             local BENCH BIN_NAME VARIANTS SAFE_NAME VARIANT
-            # Start empty, so a removed benchmark leaves no stale file to compare against.
-            sudo rm -rf "$out"
             mkdir -p "$out"
             for BENCH in "$dir"/!(neqo-client|neqo-server); do
               BIN_NAME=$(basename "$BENCH")

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,8 +9,7 @@ env:
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
   RUSTUP_TOOLCHAIN: stable
   # `cycles:u` stays first: samply makes the first `-e` event its sample table, the rest markers.
-  # Read per-symbol IPC off the `perf report` dumps, as the profiler cannot aggregate markers.
-  # No cache or TLB events: only 4 counters, 3 with the NMI watchdog.
+  # Per-symbol IPC comes from the `perf report` dumps. No cache or TLB events: only 4 counters.
   PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles/freq=999/k,instructions/freq=999/u,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
   # Exact counts, so IPC has no sampling error. `--no-big-num`, as separators are locale-dependent.
   PERF_STAT_OPT: stat --no-big-num -e instructions:u,cycles:u,cycles:k,task-clock,page-faults,major-faults,context-switches,cpu-migrations
@@ -51,7 +50,7 @@ jobs:
           baseline-ref: origin/${{ env.BASE_REF }}
 
   build-samply:
-    uses: ./.github/workflows/build-samply.yml
+    uses: $/.github/workflows/build-samply.yml
 
   bench:
     name: cargo bench
@@ -199,7 +198,7 @@ jobs:
             # Generate flamegraphs from the cycles event (perf.data has multiple events)
             perf script -i "$f" | inferno-collapse-perf --event-filter cycles | inferno-flamegraph --colors rust > "${f%.perf}.svg"
             # Per-symbol IPC: divide the `instructions` section by `cycles:u`, both self cost.
-            perf report -i "$f" --stdio --no-children -g none --percent-limit 0.1 \
+            perf report -i "$f" --stdio --no-children -g none \
               -F overhead,period,symbol,dso > "${f%.perf}.report.txt"
           done
 
@@ -252,7 +251,6 @@ jobs:
           name: ${{ github.event.repository.name }}-${{ github.event.pull_request.head.sha }}-bench-samply
           path: |
             profiles/*/*.samply.json.gz
-            profiles/*/*.syms.json
           compression-level: 9
 
       - name: Export performance data

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -99,9 +99,6 @@ jobs:
       - name: Set up build artifacts
         run: |
           chmod +x dist/neqo/* dist/neqo-baseline/*
-          mkdir -p binaries/neqo binaries/neqo-baseline
-          cp dist/neqo/* binaries/neqo/
-          cp dist/neqo-baseline/* binaries/neqo-baseline/
           {
             echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/dist/lib:$LD_LIBRARY_PATH"
             echo "TEST_FIXTURE_DB=$GITHUB_WORKSPACE/dist/test-fixture/db"
@@ -118,8 +115,8 @@ jobs:
         env:
           BENCH_SET: ${{ steps.cpu-tuning.outputs.bench-set }}
         run: |
-          # `LC_ALL=C`, as perf formats counters for the locale, decimal separator included.
-          bench_exec() { sudo nice -n -20 env "LC_ALL=C" "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" "TEST_FIXTURE_DB=$TEST_FIXTURE_DB" setarch --addr-no-randomize cset proc --set="$BENCH_SET" --exec "$@"; }
+          # `MTU` is part of the benchmark names `--exact` matches; `LC_ALL=C` keeps perf parseable.
+          bench_exec() { sudo nice -n -20 env "MTU=$MTU" "LC_ALL=C" "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" "TEST_FIXTURE_DB=$TEST_FIXTURE_DB" setarch --addr-no-randomize cset proc --set="$BENCH_SET" --exec "$@"; }
           filter_cset() { grep -v '^cset' || test $? = 1; }
           shopt -s extglob nullglob
 
@@ -155,8 +152,7 @@ jobs:
               bench_exec "$PR_BENCH" -- --bench --baseline-lenient baseline --noplot | filter_cset | tee -a ../results.txt
             fi
           done
-          # Run `perf $1` over every benchmark in $2, writing $4 files under $3/<side>/,
-          # profiling each variant for $5 seconds.
+          # Run `perf $1` over every benchmark in $2 for $5 seconds, writing $4 under $3/<side>/.
           perf_dir() {
             local subcmd="$1" dir="$2" out ext="$4" secs="$5"
             out="$3/$(basename "$dir")"
@@ -197,7 +193,7 @@ jobs:
             samply import "$f" -o "$f.samply.json.gz" --save-only --presymbolicate
             # Generate flamegraphs from the cycles event (perf.data has multiple events)
             perf script -i "$f" | inferno-collapse-perf --event-filter cycles | inferno-flamegraph --colors rust > "${f%.perf}.svg"
-            # One self-cost histogram per event, so IPC can be read off per symbol.
+            # Per-symbol IPC: divide the `instructions` section by `cycles:u`, both self cost.
             perf report -i "$f" --stdio --no-children -g none --percent-limit 0.1 \
               -F overhead,period,symbol,dso > "${f%.perf}.report.txt"
           done
@@ -252,7 +248,6 @@ jobs:
           path: |
             profiles/*/*.samply.json.gz
             profiles/*/*.syms.json
-            binaries
           compression-level: 9
 
       - name: Export performance data
@@ -293,4 +288,4 @@ jobs:
         if: always()
         run: |
           rm -- * || true
-          rm -r -- binaries dist profiles stats comment-data || true
+          rm -r -- dist profiles stats comment-data || true

--- a/.github/workflows/build-samply.yml
+++ b/.github/workflows/build-samply.yml
@@ -13,10 +13,6 @@ jobs:
     name: Build samply
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          sparse-checkout: .github/actions
       # Keyed on the revision, so it is built once per bump. Restored first, so a hit skips below.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: cache

--- a/.github/workflows/build-samply.yml
+++ b/.github/workflows/build-samply.yml
@@ -1,0 +1,45 @@
+name: Build samply
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build-samply:
+    name: Build samply
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions
+      - uses: ./.github/actions/install-build-deps
+        with:
+          version: stable
+          nss: "false"
+          rust-cache: "false"
+      - name: Resolve samply revision
+        id: samply
+        run: echo "rev=$(git ls-remote https://github.com/mstange/samply main | cut -f1)" >> "$GITHUB_OUTPUT"
+      # Keyed on the revision, so the first workflow to need it builds and the rest hit the cache.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: cache
+        with:
+          path: samply/bin/samply
+          key: samply-${{ runner.os }}-${{ runner.arch }}-${{ steps.samply.outputs.rev }}
+      - name: Build samply
+        if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          REV: ${{ steps.samply.outputs.rev }}
+          # This build doesn't need the profiling settings the rest of the workflow uses.
+          CARGO_PROFILE_RELEASE_DEBUG: false
+          CARGO_PROFILE_RELEASE_LTO: false
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 16
+          RUSTFLAGS: ""
+        run: cargo install --locked --git https://github.com/mstange/samply --rev "$REV" --root samply samply
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: samply
+          path: samply/bin/samply
+          retention-days: 1

--- a/.github/workflows/build-samply.yml
+++ b/.github/workflows/build-samply.yml
@@ -17,17 +17,18 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: .github/actions
-      - uses: $/.github/actions/install-build-deps
-        with:
-          version: stable
-          nss: "false"
-          rust-cache: "false"
-      # Keyed on the revision, so it is built once per bump.
+      # Keyed on the revision, so it is built once per bump. Restored first, so a hit skips below.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: cache
         with:
           path: samply/bin/samply
           key: samply-${{ runner.os }}-${{ runner.arch }}-${{ env.SAMPLY_REV }}
+      - uses: $/.github/actions/install-build-deps
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          version: stable
+          nss: "false"
+          rust-cache: "false"
       - name: Build samply
         if: steps.cache.outputs.cache-hit != 'true'
         run: cargo install --locked --git https://github.com/mstange/samply --rev "$SAMPLY_REV" --root samply samply

--- a/.github/workflows/build-samply.yml
+++ b/.github/workflows/build-samply.yml
@@ -5,6 +5,9 @@ on:
 permissions:
   contents: read
 
+env:
+  SAMPLY_REV: a2252a6ef2ec2c9c77337b71644be58c93c7c6a8 # 2026-08-27 TODO: Bump occasionally.
+
 jobs:
   build-samply:
     name: Build samply
@@ -14,30 +17,20 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: .github/actions
-      - uses: ./.github/actions/install-build-deps
+      - uses: $/.github/actions/install-build-deps
         with:
           version: stable
           nss: "false"
           rust-cache: "false"
-      - name: Resolve samply revision
-        id: samply
-        run: echo "rev=$(git ls-remote https://github.com/mstange/samply main | cut -f1)" >> "$GITHUB_OUTPUT"
-      # Keyed on the revision, so the first workflow to need it builds and the rest hit the cache.
+      # Keyed on the revision, so it is built once per bump.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: cache
         with:
           path: samply/bin/samply
-          key: samply-${{ runner.os }}-${{ runner.arch }}-${{ steps.samply.outputs.rev }}
+          key: samply-${{ runner.os }}-${{ runner.arch }}-${{ env.SAMPLY_REV }}
       - name: Build samply
         if: steps.cache.outputs.cache-hit != 'true'
-        env:
-          REV: ${{ steps.samply.outputs.rev }}
-          # This build doesn't need the profiling settings the rest of the workflow uses.
-          CARGO_PROFILE_RELEASE_DEBUG: false
-          CARGO_PROFILE_RELEASE_LTO: false
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 16
-          RUSTFLAGS: ""
-        run: cargo install --locked --git https://github.com/mstange/samply --rev "$REV" --root samply samply
+        run: cargo install --locked --git https://github.com/mstange/samply --rev "$SAMPLY_REV" --root samply samply
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: samply

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -196,7 +196,10 @@ jobs:
             # Convert for profiler.firefox.com
             samply import "$f" -o "$f.samply.json.gz" --save-only --presymbolicate
             # Generate flamegraphs from the cycles event (perf.data has multiple events)
-            perf script -i "$f" | inferno-collapse-perf --event-filter cycles | inferno-flamegraph --colors rust > "${f//.perf/.svg}"
+            perf script -i "$f" | inferno-collapse-perf --event-filter cycles | inferno-flamegraph --colors rust > "${f%.perf}.svg"
+            # One self-cost histogram per event, so IPC can be read off per symbol.
+            perf report -i "$f" --stdio --no-children -g none --percent-limit 0.1 \
+              -F overhead,period,symbol,dso > "${f%.perf}.report.txt"
           done
 
       # Re-enable turboboost, hyperthreading, use powersave governor, remove all CPU sets, restore MTU.

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -91,7 +91,7 @@ jobs:
           artifact-name: build-s2n
 
   build-samply:
-    uses: ./.github/workflows/build-samply.yml
+    uses: $/.github/workflows/build-samply.yml
 
   perfcompare:
     name: Performance comparison
@@ -203,7 +203,7 @@ jobs:
             # Generate flamegraphs from the cycles event (perf.data has multiple events)
             perf script -i "$f" | inferno-collapse-perf --event-filter cycles | inferno-flamegraph --colors rust > "${f%.perf}.svg"
             # Per-symbol IPC: divide the `instructions` section by `cycles:u`, both self cost.
-            perf report -i "$f" --stdio --no-children -g none --percent-limit 0.1 \
+            perf report -i "$f" --stdio --no-children -g none \
               -F overhead,period,symbol,dso > "${f%.perf}.report.txt"
           done
 
@@ -255,7 +255,6 @@ jobs:
           name: ${{ github.event.repository.name }}-${{ github.event.pull_request.head.sha }}-perfcompare-samply
           path: |
             *.samply.json.gz
-            *.syms.json
           compression-level: 9
 
       - name: Export performance data

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -90,10 +90,13 @@ jobs:
           impl: s2n
           artifact-name: build-s2n
 
+  build-samply:
+    uses: ./.github/workflows/build-samply.yml
+
   perfcompare:
     name: Performance comparison
     runs-on: "self-hosted" # zizmor: ignore[self-hosted-runner]
-    needs: [build-neqo, build-google, build-quiche, build-s2n]
+    needs: [build-neqo, build-google, build-quiche, build-s2n, build-samply]
     defaults:
       run:
         shell: bash
@@ -127,9 +130,11 @@ jobs:
         uses: $/.github/actions/install-build-deps
         with:
           version: ${{ env.RUSTUP_TOOLCHAIN }}
-          tools: hyperfine, inferno, samply
+          tools: hyperfine, inferno
           nss: "false" # Uses the NSS libraries bundled with the downloaded binaries.
           rust-cache: "false"
+
+      - uses: $/.github/actions/install-samply
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -9,7 +9,7 @@ env:
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
   RUSTUP_TOOLCHAIN: stable
   # See bench.yml for the event choices; `cycles:u` has to stay first.
-  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles/freq=999/k,instructions/freq=999/u,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
+  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles/freq=999/k,instructions/freq=999/u,page-faults,major-faults,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
   MTU: 1504 # https://github.com/microsoft/msquic/issues/4618
   CFLAGS: -fno-omit-frame-pointer
   CXXFLAGS: -fno-omit-frame-pointer

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -8,7 +8,8 @@ env:
   CARGO_PROFILE_RELEASE_LTO: true
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
   RUSTUP_TOOLCHAIN: stable
-  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles:k,kmem:rss_stat,sched:sched_switch -m 2048
+  # See bench.yml for the event choices; `cycles:u` has to stay first.
+  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles/freq=999/k,instructions/freq=999/u,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
   MTU: 1504 # https://github.com/microsoft/msquic/issues/4618
   CFLAGS: -fno-omit-frame-pointer
   CXXFLAGS: -fno-omit-frame-pointer

--- a/.github/workflows/perfcompare.yml
+++ b/.github/workflows/perfcompare.yml
@@ -197,7 +197,7 @@ jobs:
             samply import "$f" -o "$f.samply.json.gz" --save-only --presymbolicate
             # Generate flamegraphs from the cycles event (perf.data has multiple events)
             perf script -i "$f" | inferno-collapse-perf --event-filter cycles | inferno-flamegraph --colors rust > "${f%.perf}.svg"
-            # One self-cost histogram per event, so IPC can be read off per symbol.
+            # Per-symbol IPC: divide the `instructions` section by `cycles:u`, both self cost.
             perf report -i "$f" --stdio --no-children -g none --percent-limit 0.1 \
               -F overhead,period,symbol,dso > "${f%.perf}.report.txt"
           done
@@ -251,7 +251,6 @@ jobs:
           path: |
             *.samply.json.gz
             *.syms.json
-            binaries
           compression-level: 9
 
       - name: Export performance data

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -11,7 +11,7 @@ env:
   RUSTUP_TOOLCHAIN: stable
   TRANSFER_SIZE: 33554432 # 32 MiB
   # Not the bench.yml set: GitHub-hosted runners have `cycles` but not `instructions`.
-  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles:k,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
+  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles:k,page-faults,major-faults,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
   # Profiling build settings; see also bench.yml and perfcompare.yml. `RUSTFLAGS` is needed here
   # because this workflow builds neqo inline rather than via the build-neqo action.
   CARGO_PROFILE_RELEASE_DEBUG: true

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -10,8 +10,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTUP_TOOLCHAIN: stable
   TRANSFER_SIZE: 33554432 # 32 MiB
-  # Not the bench.yml event set: GitHub-hosted runners have `cycles` but not `instructions`.
-  # The fault and scheduling counters are software events, so they need no PMU.
+  # Not the bench.yml set: GitHub-hosted runners have `cycles` but not `instructions`.
   PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles:k,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
   # Profiling build settings; see also bench.yml and perfcompare.yml. `RUSTFLAGS` is needed here
   # because this workflow builds neqo inline rather than via the build-neqo action.
@@ -75,7 +74,7 @@ jobs:
           artifact-name: ${{ matrix.impl }}-binaries
 
   build-samply:
-    uses: ./.github/workflows/build-samply.yml
+    uses: $/.github/workflows/build-samply.yml
 
   build-neqo:
     name: Build neqo (${{ matrix.ref.name }})
@@ -190,7 +189,6 @@ jobs:
           name: bench-${{ matrix.bench.crate }}-${{ matrix.bench.bench }}-${{ matrix.ref.name }}
           path: |
             *.samply.json.gz
-            *.syms.json
           retention-days: 90
           if-no-files-found: ignore
 
@@ -325,7 +323,6 @@ jobs:
           name: perfcompare-${{ matrix.combo.client }}-${{ matrix.combo.server }}-${{ matrix.ref.name }}
           path: |
             *.samply.json.gz
-            *.syms.json
           retention-days: 90
           if-no-files-found: ignore
 

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -10,8 +10,9 @@ env:
   RUST_BACKTRACE: 1
   RUSTUP_TOOLCHAIN: stable
   TRANSFER_SIZE: 33554432 # 32 MiB
-  # See bench.yml for the event choices; `cycles:u` has to stay first.
-  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles/freq=999/k,instructions/freq=999/u,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
+  # Deliberately not the richer event set in bench.yml: this workflow runs on GitHub-hosted
+  # runners, whose virtual PMU has `cycles` but not `instructions`.
+  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles:k,kmem:rss_stat,sched:sched_switch -m 2048
   # Profiling build settings; see also bench.yml and perfcompare.yml. `RUSTFLAGS` is needed here
   # because this workflow builds neqo inline rather than via the build-neqo action.
   CARGO_PROFILE_RELEASE_DEBUG: true

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -10,9 +10,8 @@ env:
   RUST_BACKTRACE: 1
   RUSTUP_TOOLCHAIN: stable
   TRANSFER_SIZE: 33554432 # 32 MiB
-  # Deliberately not the richer event set in bench.yml: this workflow runs on GitHub-hosted
-  # runners, whose virtual PMU has `cycles` but not `instructions`. The fault and scheduling
-  # counters are software events, so they work anywhere and flag a disturbed shared runner.
+  # Not the bench.yml event set: GitHub-hosted runners have `cycles` but not `instructions`.
+  # The fault and scheduling counters are software events, so they need no PMU.
   PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles:k,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 2048
   # Profiling build settings; see also bench.yml and perfcompare.yml. `RUSTFLAGS` is needed here
   # because this workflow builds neqo inline rather than via the build-neqo action.

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -11,8 +11,9 @@ env:
   RUSTUP_TOOLCHAIN: stable
   TRANSFER_SIZE: 33554432 # 32 MiB
   # Deliberately not the richer event set in bench.yml: this workflow runs on GitHub-hosted
-  # runners, whose virtual PMU has `cycles` but not `instructions`.
-  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles:k,kmem:rss_stat,sched:sched_switch -m 2048
+  # runners, whose virtual PMU has `cycles` but not `instructions`. The fault and scheduling
+  # counters are software events, so they work anywhere and flag a disturbed shared runner.
+  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles:k,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 2048
   # Profiling build settings; see also bench.yml and perfcompare.yml. `RUSTFLAGS` is needed here
   # because this workflow builds neqo inline rather than via the build-neqo action.
   CARGO_PROFILE_RELEASE_DEBUG: true

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -12,7 +12,7 @@ env:
   TRANSFER_SIZE: 33554432 # 32 MiB
   # Not the bench.yml event set: GitHub-hosted runners have `cycles` but not `instructions`.
   # The fault and scheduling counters are software events, so they need no PMU.
-  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles:k,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 2048
+  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles:k,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
   # Profiling build settings; see also bench.yml and perfcompare.yml. `RUSTFLAGS` is needed here
   # because this workflow builds neqo inline rather than via the build-neqo action.
   CARGO_PROFILE_RELEASE_DEBUG: true

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -10,7 +10,8 @@ env:
   RUST_BACKTRACE: 1
   RUSTUP_TOOLCHAIN: stable
   TRANSFER_SIZE: 33554432 # 32 MiB
-  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles:k,kmem:rss_stat,sched:sched_switch -m 2048
+  # See bench.yml for the event choices; `cycles:u` has to stay first.
+  PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles/freq=999/k,instructions/freq=999/u,page-faults,major-faults,context-switches,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
   # Profiling build settings; see also bench.yml and perfcompare.yml. `RUSTFLAGS` is needed here
   # because this workflow builds neqo inline rather than via the build-neqo action.
   CARGO_PROFILE_RELEASE_DEBUG: true

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -74,44 +74,8 @@ jobs:
           impl: ${{ matrix.impl }}
           artifact-name: ${{ matrix.impl }}-binaries
 
-  # The released samply ignores `--presymbolicate` when importing, so the profiles would carry no
-  # symbols. Build it once here rather than in every profiling job.
   build-samply:
-    name: Build samply
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          sparse-checkout: .github/actions
-      - uses: ./.github/actions/install-build-deps
-        with:
-          version: stable
-          nss: "false"
-          rust-cache: "false"
-      - name: Resolve samply revision
-        id: samply
-        run: echo "rev=$(git ls-remote https://github.com/mstange/samply main | cut -f1)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: cache
-        with:
-          path: samply/bin/samply
-          key: samply-${{ runner.os }}-${{ runner.arch }}-${{ steps.samply.outputs.rev }}
-      - name: Build samply
-        if: steps.cache.outputs.cache-hit != 'true'
-        env:
-          REV: ${{ steps.samply.outputs.rev }}
-          # This build doesn't need the profiling settings the rest of the workflow uses.
-          CARGO_PROFILE_RELEASE_DEBUG: false
-          CARGO_PROFILE_RELEASE_LTO: false
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 16
-          RUSTFLAGS: ""
-        run: cargo install --locked --git https://github.com/mstange/samply --rev "$REV" --root samply samply
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: samply
-          path: samply/bin/samply
-          retention-days: 1
+    uses: ./.github/workflows/build-samply.yml
 
   build-neqo:
     name: Build neqo (${{ matrix.ref.name }})
@@ -226,7 +190,7 @@ jobs:
           name: bench-${{ matrix.bench.crate }}-${{ matrix.bench.bench }}-${{ matrix.ref.name }}
           path: |
             *.samply.json.gz
-            binaries
+            *.syms.json
           retention-days: 90
           if-no-files-found: ignore
 
@@ -361,7 +325,7 @@ jobs:
           name: perfcompare-${{ matrix.combo.client }}-${{ matrix.combo.server }}-${{ matrix.ref.name }}
           path: |
             *.samply.json.gz
-            binaries
+            *.syms.json
           retention-days: 90
           if-no-files-found: ignore
 


### PR DESCRIPTION
Adds an instructions event so profiles show per-symbol IPC, and fault and scheduling counters that flag a disturbed run. Kernel cycles sample at a lower frequency to stay within the four available counters.

Also runs perf stat over each benchmark and renders an IPC comparison table into the PR comment.