### PR TITLE
Reject 0-RTT downgrade of the extended CONNECT setting

### DIFF
--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1699,6 +1699,8 @@ impl Http3Connection {
                     HSettingType::MaxHeaderListSize,
                     HSettingType::MaxTableCapacity,
                     HSettingType::BlockedStreams,
+                    // RFC 9114, Section 7.2.4.2 covers omitted non-default settings.
+                    HSettingType::EnableConnect,
                     // [RFC 9297, Section 2.1.1](https://www.rfc-editor.org/rfc/rfc9297.html#section-2.1.1)
                     // requires a client that stored SETTINGS_H3_DATAGRAM with its
                     // 0-RTT state to terminate the connection with H3_SETTINGS_ERROR

--- a/neqo-http3/src/connection.rs
+++ b/neqo-http3/src/connection.rs
@@ -1699,7 +1699,6 @@ impl Http3Connection {
                     HSettingType::MaxHeaderListSize,
                     HSettingType::MaxTableCapacity,
                     HSettingType::BlockedStreams,
-                    // RFC 9114, Section 7.2.4.2 covers omitted non-default settings.
                     HSettingType::EnableConnect,
                     // [RFC 9297, Section 2.1.1](https://www.rfc-editor.org/rfc/rfc9297.html#section-2.1.1)
                     // requires a client that stored SETTINGS_H3_DATAGRAM with its

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -4277,6 +4277,26 @@ mod tests {
     }
 
     #[test]
+    fn zero_rtt_new_server_setting_connect_smaller() {
+        // The server advertised SETTINGS_ENABLE_CONNECT_PROTOCOL=1 before, and now withholds it.
+        zero_rtt_change_settings(
+            &[
+                HSetting::new(HSettingType::MaxTableCapacity, 100),
+                HSetting::new(HSettingType::BlockedStreams, 100),
+                HSetting::new(HSettingType::MaxHeaderListSize, 10000),
+                HSetting::new(HSettingType::EnableConnect, 1),
+            ],
+            &[
+                HSetting::new(HSettingType::MaxTableCapacity, 100),
+                HSetting::new(HSettingType::BlockedStreams, 100),
+                HSetting::new(HSettingType::MaxHeaderListSize, 10000),
+            ],
+            &Http3State::Closing(CloseReason::Application(265)),
+            ENCODER_STREAM_DATA_WITH_CAP_INSTRUCTION,
+        );
+    }
+
+    #[test]
     fn zero_rtt_max_table_size_first_omitted() {
         // send server original settings without MaxTableCapacity
         // send new server setting with MaxTableCapacity

--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -4277,7 +4277,7 @@ mod tests {
     }
 
     #[test]
-    fn zero_rtt_new_server_setting_connect_smaller() {
+    fn zero_rtt_extended_connect_disabled() {
         // The server advertised SETTINGS_ENABLE_CONNECT_PROTOCOL=1 before, and now withholds it.
         zero_rtt_change_settings(
             &[


### PR DESCRIPTION
On a resumed connection, Neqo currently accepts a new SETTINGS frame that omits `SETTINGS_ENABLE_CONNECT_PROTOCOL` even when the stored 0-RTT value was 1. The feature negotiation then disables extended CONNECT, but the connection remains open.

RFC 9114 Section 7.2.4.2 requires `H3_SETTINGS_ERROR` when a server accepts 0-RTT and then omits an understood setting that previously had a non-default value. The setting's default is 0, so omission after a stored value of 1 is covered by that rule.

This adds `EnableConnect` to the existing 0-RTT settings comparison and includes a regression test for the omitted-setting case.

Validation:

- `cargo test --locked --release -p neqo-http3`
- `cargo check --locked -p neqo-http3`
- `cargo fmt --all -- --check`
- `cargo clippy --locked -p neqo-http3 --all-targets -- -D warnings`