### PR TITLE
chore(Cargo.lock): update to quinn-udp v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
+checksum = "3ca72c3f2792761ab5fa848490694cbc728c7f659669ed4320c4c79c12150966"
 dependencies = [
  "cfg_aliases",
  "libc",


### PR DESCRIPTION
See changelog for details:
https://github.com/quinn-rs/quinn/releases/tag/quinn-udp-0.6.2

Firefox patch: https://bugzilla.mozilla.org/show_bug.cgi?id=2069696