### PR TITLE
fix: Don't drop samples from corpus

### DIFF
--- a/test/make-fuzz-corpus.sh
+++ b/test/make-fuzz-corpus.sh
@@ -102,10 +102,4 @@ for fuzzer in $(cargo fuzz list); do
     after=$(find "$corpus" -type f | wc -l | tr -d ' ')
     diff=$((after - before))
     echo "$fuzzer fuzzer: $diff new samples added (now $after)"
-
-    # Minimize the merged corpus.
-    echo "$fuzzer fuzzer: Minimizing merged corpus..."
-    minimize_corpus "$fuzzer" "$corpus"
-    final=$(find "$corpus" -type f | wc -l | tr -d ' ')
-    echo "$fuzzer fuzzer: Final corpus size: $final samples"
 done


### PR DESCRIPTION
Even if the current test suite no longer generates them.

The removal of server push in #3816 made the test suite loose a bunch of samples, and #3944 hence wants to trim the corpus. Fix the workflow so it leaves the existing corpus be.