### PR TITLE
fix: Pad to the PMTUD probe size only when sending a probe

### DIFF
--- a/neqo-transport/src/connection/mod.rs
+++ b/neqo-transport/src/connection/mod.rs
@@ -2513,6 +2513,23 @@ impl Connection {
         probe
     }
 
+    /// Whether to make this packet a PMTUD probe.
+    fn make_pmtud_probe(
+        &self,
+        path: &PathRef,
+        space: PacketNumberSpace,
+        profile: &SendProfile,
+        coalesced: bool,
+    ) -> bool {
+        let path = path.borrow();
+        space == PacketNumberSpace::ApplicationData
+            && self.state.connected()
+            && !coalesced // Only send PMTUD probes using non-coalesced packets.
+            && path.is_primary()
+            && !profile.ack_only() // We could only send ACKs.
+            && path.can_send_pmtud_probe()
+    }
+
     /// Write frames to the provided builder.  Returns a list of tokens used for
     /// tracking loss or acknowledgment, whether any frame was ACK eliciting, and
     /// whether the packet was padded.
@@ -2522,7 +2539,7 @@ impl Connection {
         space: PacketNumberSpace,
         profile: &SendProfile,
         builder: &mut packet::Builder<&mut Vec<u8>>,
-        coalesced: bool, // Whether this packet is coalesced behind another one.
+        make_pmtud_probe: bool,
         now: Instant,
     ) -> (recovery::Tokens, bool, bool) {
         let mut tokens = recovery::Tokens::new();
@@ -2544,7 +2561,12 @@ impl Connection {
 
         // Avoid sending path validation probes until the handshake completes,
         // but send them even when we don't have space.
-        let full_mtu = profile.limit() == path.borrow().plpmtu();
+        let full_mtu = profile.permits_full_mtu(path.borrow().plpmtu());
+        // PMTUD must not record a success for a packet that was never probe-sized.
+        debug_assert!(
+            !make_pmtud_probe
+                || (primary && full_mtu && space == PacketNumberSpace::ApplicationData)
+        );
         if space == PacketNumberSpace::ApplicationData && self.state.connected() {
             // Path validation probes should only be padded if the full MTU is available.
             // The probing code needs to know so it can track that.
@@ -2565,11 +2587,7 @@ impl Connection {
 
         if primary {
             if space == PacketNumberSpace::ApplicationData {
-                if self.state.connected()
-                    && path.borrow().pmtud().needs_probe()
-                    && !coalesced // Only send PMTUD probes using non-coalesced packets.
-                    && full_mtu
-                {
+                if make_pmtud_probe {
                     path.borrow_mut().pmtud_mut().send_probe(
                         builder,
                         &mut tokens,
@@ -2670,7 +2688,7 @@ impl Connection {
             if max_datagrams.get() <= num_datagrams {
                 break;
             }
-            if path.borrow().pmtud().needs_probe() && num_datagrams != 0 {
+            if path.borrow().can_send_pmtud_probe() && num_datagrams != 0 {
                 // Next datagram will be larger due to PMTUD probing.  GSO
                 // requires that all datagrams in a batch are of equal size.
                 // Only the last datagram can be smaller. Given that this would
@@ -2770,6 +2788,9 @@ impl Connection {
         // Frames for different epochs must go in different packets, but then these
         // packets can go in a single datagram
         for space in PacketNumberSpace::iter() {
+            let coalesced = !encoder.is_empty(); // Whether this packet is coalesced behind another one.
+            let make_pmtud_probe = self.make_pmtud_probe(path, space, &profile, coalesced);
+
             // Ensure we have tx crypto state for this epoch, or skip it.
             let Some((epoch, tx)) = self.crypto.states_mut().select_tx_mut(self.version, space)
             else {
@@ -2780,7 +2801,7 @@ impl Connection {
             let header_start = encoder.len();
 
             // Configure the limits and padding for this packet.
-            let limit = if path.borrow().pmtud().needs_probe() {
+            let limit = if make_pmtud_probe {
                 needs_padding = true;
                 debug_assert!(path.borrow().pmtud().probe_size() >= profile.limit());
                 path.borrow().pmtud().probe_size()
@@ -2829,7 +2850,7 @@ impl Connection {
                 self.write_closing_frames(close, &mut builder, space, now, path, &mut tokens);
             } else {
                 (tokens, ack_eliciting, padded) =
-                    self.write_frames(path, space, &profile, &mut builder, header_start != 0, now);
+                    self.write_frames(path, space, &profile, &mut builder, make_pmtud_probe, now);
             }
             if builder.packet_empty() {
                 // Nothing to include in this packet.

--- a/neqo-transport/src/connection/tests/pmtud.rs
+++ b/neqo-transport/src/connection/tests/pmtud.rs
@@ -64,13 +64,14 @@ fn gso_with_max_mtu() {
     }
 }
 
+/// Use an IPv6 address since the default test connection uses IPv6.
+const VPN_ADDR: SocketAddr = SocketAddr::new(
+    IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+    12345,
+);
+
 /// Simulates VPN by changing the source address of a datagram to an IPv6 VPN endpoint.
 fn via_vpn(d: &Datagram) -> Datagram {
-    // Use an IPv6 address since the default test connection uses IPv6.
-    const VPN_ADDR: SocketAddr = SocketAddr::new(
-        IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
-        12345,
-    );
     Datagram::new(VPN_ADDR, d.destination(), d.tos(), &d[..])
 }
 
@@ -190,4 +191,91 @@ fn vpn_migration_triggers_pmtud() {
     let expected_vpn_mtu = 1380 - header_size;
     assert_eq!(server.plpmtu(), expected_vpn_mtu);
     assert_eq!(client.plpmtu(), expected_vpn_mtu);
+}
+
+/// A probe that cannot be sent yet must not raise the size of the packets sent meanwhile.
+#[test]
+fn deferred_probe_respects_amplification_limit() {
+    fixture_init();
+    let now = now();
+    let mut client = new_client(ConnectionParameters::default().pmtud(true));
+    let mut server = new_server(ConnectionParameters::default().pmtud(true));
+    connect(&mut client, &mut server);
+
+    // The server will fill whatever limit it is given.
+    let stream = server.stream_create(StreamType::UniDi).unwrap();
+    fill_stream(&mut server, stream);
+
+    // A small packet from a new client address migrates the server to an unvalidated path.
+    let c_stream = client.stream_create(StreamType::UniDi).unwrap();
+    client.stream_send(c_stream, &[0x42; 150]).unwrap();
+    let small = client.process_output(now).dgram().unwrap();
+    server.process_input(via_vpn(&small), now);
+
+    let limit = {
+        let path = server.paths.primary().unwrap();
+        let path = path.borrow();
+        assert!(!path.is_valid(), "path is unvalidated");
+        assert!(path.pmtud().needs_probe(), "PMTUD wants to probe");
+        assert!(
+            path.pmtud().probe_size() > path.amplification_limit(),
+            "the probe does not fit, so it cannot be sent yet"
+        );
+        path.amplification_limit()
+    };
+
+    let pmtud_tx = server.stats().pmtud_tx;
+    let d = server.process_output(now).dgram().unwrap();
+    assert_eq!(d.destination(), VPN_ADDR, "sent on the unvalidated path");
+    assert_eq!(server.stats().pmtud_tx, pmtud_tx, "no probe was sent");
+    assert!(
+        d.len() <= limit,
+        "sent {} bytes against an amplification limit of {limit}",
+        d.len()
+    );
+}
+
+/// A probe must wait for a budget that covers the probe, not just the PLPMTU, which is
+/// what `send_profile()` clamps any larger budget to.
+#[test]
+fn probe_waits_for_budget_covering_probe_size() {
+    fixture_init();
+    let now = now();
+    let mut client = new_client(ConnectionParameters::default().pmtud(true));
+    let mut server = new_server(ConnectionParameters::default().pmtud(true));
+    connect(&mut client, &mut server);
+
+    // The server will fill whatever limit it is given.
+    let stream = server.stream_create(StreamType::UniDi).unwrap();
+    fill_stream(&mut server, stream);
+
+    // Sized so the amplification limit lands between the PLPMTU and the probe size.
+    let c_stream = client.stream_create(StreamType::UniDi).unwrap();
+    client.stream_send(c_stream, &[0x42; 400]).unwrap();
+    let small = client.process_output(now).dgram().unwrap();
+    server.process_input(via_vpn(&small), now);
+
+    let limit = {
+        let path = server.paths.primary().unwrap();
+        let path = path.borrow();
+        let limit = path.amplification_limit();
+        assert!(!path.is_valid(), "path is unvalidated");
+        assert!(path.pmtud().needs_probe(), "PMTUD wants to probe");
+        assert!(
+            path.plpmtu() < limit && limit < path.pmtud().probe_size(),
+            "budget {limit} must sit between PLPMTU {} and probe size {}",
+            path.plpmtu(),
+            path.pmtud().probe_size()
+        );
+        limit
+    };
+
+    let pmtud_tx = server.stats().pmtud_tx;
+    let d = server.process_output(now).dgram().unwrap();
+    assert_eq!(server.stats().pmtud_tx, pmtud_tx, "no probe was sent");
+    assert!(
+        d.len() <= limit,
+        "sent {} bytes against an amplification limit of {limit}",
+        d.len()
+    );
 }

--- a/neqo-transport/src/path.rs
+++ b/neqo-transport/src/path.rs
@@ -1154,6 +1154,17 @@ impl Path {
         }
     }
 
+    /// Get the number of bytes that can be sent on this path now.
+    pub fn send_budget(&self) -> usize {
+        self.sender().cwnd_avail().min(self.amplification_limit())
+    }
+
+    /// Whether a PMTUD probe is needed and fits in the budget. Probes consume the
+    /// congestion window like any other packet; see RFC 9000, Section 14.4.
+    pub fn can_send_pmtud_probe(&self) -> bool {
+        self.pmtud().needs_probe() && self.send_budget() >= self.pmtud().probe_size()
+    }
+
     /// Update the `QLog` instance.
     pub fn set_qlog(&mut self, qlog: Qlog) {
         self.sender.set_qlog(qlog.clone());

--- a/neqo-transport/src/recovery/mod.rs
+++ b/neqo-transport/src/recovery/mod.rs
@@ -114,6 +114,12 @@ impl SendProfile {
     pub const fn limit(&self) -> usize {
         self.limit
     }
+
+    /// Whether the next packet can be `plpmtu`-sized.
+    #[must_use]
+    pub const fn permits_full_mtu(&self, plpmtu: usize) -> bool {
+        self.limit >= plpmtu
+    }
 }
 
 #[derive(Debug)]
@@ -1033,7 +1039,7 @@ impl Loss {
         {
             profile
         } else {
-            let limit = min(sender.cwnd_avail(), path.amplification_limit());
+            let limit = path.send_budget();
             if limit > mtu {
                 // More than an MTU available; we might need to pace.
                 if sender


### PR DESCRIPTION
A pending PMTID probe that cannot be sent (because it exceeds cwnd) must not cause the size of other packets sent to increase.