### PR TITLE
fix: drop HTTP/3 handlers whose connection is gone

### DIFF
--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -211,7 +211,7 @@ impl super::HttpServer for HttpServer {
                         self.send_response(&stream, response, now);
                     }
                 }
-                // `Closing` occurs once; `Closed` is dropped before it is seen.
+                // `Closing` fires immediately; `Closed` only after the drain timeout.
                 Http3ServerEvent::StateChange {
                     conn,
                     state: Http3State::Closing(_),

--- a/neqo-http3/src/server.rs
+++ b/neqo-http3/src/server.rs
@@ -15,7 +15,7 @@ use std::{
 
 use neqo_common::{Datagram, qtrace};
 use neqo_transport::{
-    ConnectionIdGenerator, Output, OutputBatch,
+    ConnectionIdGenerator, Output, OutputBatch, State,
     server::{ConnectionRef, Server, ValidateAddress},
 };
 use nss::{AntiReplay, Cipher, PrivateKey, PublicKey, ZeroRttChecker};
@@ -140,15 +140,25 @@ impl Http3Server {
         qtrace!("[{self}] Process");
         let out = self.server.process_multiple_input(dgrams, now);
         self.process_http3(now);
-        // If we do not that a dgram already try again after process_http3.
-        match out {
-            OutputBatch::DatagramBatch(d) => {
-                qtrace!("[{self}] Send packet: {d:?}");
-                OutputBatch::DatagramBatch(d)
-            }
-            _ => self
+        // Try again if input processing did not already produce a datagram.
+        if let OutputBatch::DatagramBatch(d) = out {
+            qtrace!("[{self}] Send packet: {d:?}");
+            OutputBatch::DatagramBatch(d)
+        } else {
+            let out = self
                 .server
-                .process_multiple(Option::<Datagram>::None, now, max_datagrams),
+                .process_multiple(Option::<Datagram>::None, now, max_datagrams);
+            if !matches!(out, OutputBatch::DatagramBatch(_)) {
+                self.http3_handlers.retain(|c, _| {
+                    let State::Closed(error) = c.borrow().state().clone() else {
+                        return true;
+                    };
+                    self.events
+                        .connection_state_change(c.clone(), Http3State::Closed(error));
+                    false
+                });
+            }
+            out
         }
     }
 
@@ -421,9 +431,10 @@ mod tests {
     use std::{
         collections::HashMap,
         ops::{Deref, DerefMut},
+        time::Duration,
     };
 
-    use neqo_common::{Encoder, event::Provider as _};
+    use neqo_common::{Datagram, Encoder, event::Provider as _};
     use neqo_qpack as qpack;
     use neqo_transport::{
         CloseReason, Connection, ConnectionEvent, State, StreamId, StreamType, ZeroRttState,
@@ -602,6 +613,69 @@ mod tests {
         }
         assert!(connected);
         (client, token.unwrap())
+    }
+
+    /// `Closed` must fire once, even when another connection's traffic delays retirement.
+    #[test]
+    fn closed_event_fires_once_alongside_other_traffic() {
+        let mut server = default_server();
+        let (mut a, _) = connect_and_receive_settings_with_server(&mut server);
+        let (mut b, _) = connect_and_receive_settings_with_server(&mut server);
+
+        a.close(now(), 0, "done");
+        let out = a.process_output(now());
+        _ = server.process(out.dgram(), now());
+
+        // Give B something to send, so the server owes it an ACK on the next call.
+        let sid = b.stream_create(StreamType::BiDi).unwrap();
+        _ = b.stream_send(sid, b"ping");
+        let bout = b.process_output(now());
+
+        // Past A's drain period; B's ACK makes the output step return early, skipping retain.
+        let t = now() + Duration::from_secs(30);
+        _ = server.process(bout.dgram(), t);
+
+        let mut closed_count = 0;
+        for i in 0..5 {
+            while let Some(e) = server.next_event() {
+                if let Http3ServerEvent::StateChange {
+                    state: Http3State::Closed(_),
+                    ..
+                } = e
+                {
+                    closed_count += 1;
+                }
+            }
+            _ = server.process_output(t + Duration::from_millis(i + 1));
+        }
+        assert_eq!(closed_count, 1, "Closed must be emitted exactly once");
+    }
+
+    /// A handler must not outlive its connection.
+    #[test]
+    fn handlers_do_not_accumulate() {
+        const CONNECTIONS: usize = 5;
+        let mut server = default_server();
+        for _ in 0..CONNECTIONS {
+            let (mut client, _) = connect_and_receive_settings_with_server(&mut server);
+            client.close(now(), 0, "done");
+            let out = client.process_output(now());
+            _ = server.process(out.dgram(), now());
+            // Past the draining period.
+            _ = server.process(Option::<Datagram>::None, now() + Duration::from_secs(30));
+        }
+        assert!(
+            server.http3_handlers.is_empty(),
+            "{} handlers left for {CONNECTIONS} closed connections",
+            server.http3_handlers.len()
+        );
+        assert!(server.events().any(|e| matches!(
+            e,
+            Http3ServerEvent::StateChange {
+                state: Http3State::Closed(_),
+                ..
+            }
+        )));
     }
 
     fn connect_and_receive_settings() -> (Http3Server, Connection, ResumptionToken) {


### PR DESCRIPTION
A handler is only removed on observing `Http3State::Closed`, which does not arrive when the transport retires the connection first.

This means a longer-running server accumulated entries, causing slowdowns.