### PR TITLE
feat: count syscalls, bytes and connection stats in the benchmarks

### DIFF
--- a/.github/scripts/perfcompare.py
+++ b/.github/scripts/perfcompare.py
@@ -203,11 +203,57 @@ def _sudo_nice_env() -> list[str]:
     return ["sudo", "nice", "-n", "-20"] + (["env"] + env_args if env_args else [])
 
 
+def _read_proc(path: str) -> str:
+    """Contents of a `/proc` file, empty if absent, e.g. IPv6 off. Says so, as empty
+    counters otherwise read as "nothing moved"."""
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except OSError as e:
+        print(f"note: {path} unreadable ({e}), its counters will be missing")
+        return ""
+
+
+def _udp_counters() -> dict[str, int]:
+    """UDP counters keyed by name, both families, as `--host` picks one."""
+    counters: dict[str, int] = {}
+    # IPv4 spells these as a `Udp:` line naming the fields, then a `Udp:` line of values.
+    udp = [
+        line.split()[1:]
+        for line in _read_proc("/proc/net/snmp").splitlines()
+        if line.startswith("Udp: ")
+    ]
+    for names, values in zip(udp[::2], udp[1::2], strict=False):
+        counters.update(
+            (f"Udp{n}", int(v)) for n, v in zip(names, values, strict=False)
+        )
+    # IPv6 spells them one `Udp6<name> <value>` per line.
+    counters.update(
+        (fields[0], int(fields[1]))
+        for line in _read_proc("/proc/net/snmp6").splitlines()
+        if len(fields := line.split()) == 2 and fields[0].startswith("Udp6")
+    )
+    return counters
+
+
 def hyperfine(cfg, scmd, ccmd, name, out_dir, md=False):
     """Run hyperfine benchmark."""
     tag = shlex.quote(_tag(scmd))
     ws = shlex.quote(str(cfg.workspace))
     out_dir.mkdir(exist_ok=True)
+
+    def with_stats(cmd: str, role: str) -> str:
+        """Have neqo append one record per connection, attributing a slow run to a PTO
+        (`pto_counts`) or loss (`lost`). The server reports on close, before it is killed."""
+        if f"neqo-{role}" not in cmd:
+            return cmd
+        return f"{cmd} --stats-file {shlex.quote(str(out_dir / f'{name}.{role}.jsonl'))}"
+
+    scmd, ccmd = with_stats(scmd, "server"), with_stats(ccmd, "client")
+    # Both hooks run outside the timed region, so this is a before/after pair per run.
+    rcvbuf = (
+        "awk '/^Udp:/{if(!h){for(i=2;i<=NF;i++)if($i==\"RcvbufErrors\")c=i;h=1}else print $c}'"
+        f" /proc/net/snmp >> {shlex.quote(str(out_dir / f'{name}.rcvbuferrors'))}"
+    )
     cmd = [
         *_sudo_nice_env(),
         "setarch",
@@ -226,14 +272,25 @@ def hyperfine(cfg, scmd, ccmd, name, out_dir, md=False):
         "--min-runs",
         str(cfg.runs),
         "--prepare",
-        f"{ws}/{scmd} & echo $! >> /cpusets/{shlex.quote(cfg.server_set)}/tasks; sleep 0.2",
+        (
+            f"{ws}/{scmd} & echo $! >> /cpusets/{shlex.quote(cfg.server_set)}/tasks; sleep 0.2;"
+            f" {rcvbuf}"
+        ),
         "--conclude",
-        f"pkill -9 {tag}",
+        f"pkill -9 {tag}; {rcvbuf}",
     ]
     if md:
         cmd += ["--export-markdown", str(out_dir / f"{name}.md")]
     cmd.append(f"echo $$ >> /cpusets/{shlex.quote(cfg.client_set)}/tasks; {ws}/{ccmd}")
+    before = _udp_counters()
     result = sh(cmd, check=True, stderr=subprocess.PIPE, text=True)
+    # `*RcvbufErrors` tells whether loss was a receive-queue overrun. Only what moved.
+    after = _udp_counters()
+    deltas = {key: after.get(key, value) - value for key, value in before.items()}
+    (out_dir / f"{name}.udp").write_text(
+        "".join(f"{key} {delta}\n" for key, delta in deltas.items() if delta),
+        encoding="utf-8",
+    )
     # Surface hyperfine's own outlier warnings in the PR summary, not just the raw log.
     if result.stderr:
         print(result.stderr, end="")

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,6 +12,8 @@ env:
   # Per-symbol IPC comes from the `perf report` dumps. No cache or TLB events: only 4 counters.
   PERF_OPT: record -N -F2999 --call-graph fp -e cycles:u,cycles/freq=999/k,instructions/freq=999/u,page-faults,major-faults,cpu-migrations,kmem:rss_stat,sched:sched_switch -m 4096
   # Exact counts, so IPC has no sampling error. `--no-big-num`, as separators are locale-dependent.
+  # Tracepoints cost none of the four counters. With the `lo` deltas: sends per byte.
+  PERF_TRACEPOINTS: syscalls:sys_enter_sendmsg,syscalls:sys_enter_sendmmsg,syscalls:sys_enter_recvmsg,syscalls:sys_enter_recvmmsg
   PERF_STAT_OPT: stat --no-big-num -e instructions:u,cycles:u,cycles:k,task-clock,page-faults,major-faults,context-switches,cpu-migrations
   MTU: 1504 # https://github.com/microsoft/msquic/issues/4618
   CFLAGS: -fno-omit-frame-pointer
@@ -156,7 +158,22 @@ jobs:
               bench_exec "$PR_BENCH" -- --bench --baseline-lenient baseline --noplot | filter_cset | tee -a ../results.txt
             fi
           done
+          lo_stat() { cat "/sys/class/net/lo/statistics/$1"; }
+          # Run `perf $1` on the benchmark in $3.., writing to $2, and append the `lo` deltas
+          # like `perf stat`'s own lines: into its output, or beside the binary `perf.data`.
+          measure() {
+            local sub="$1" out="$2" tx pkt; shift 2
+            tx=$(lo_stat tx_bytes); pkt=$(lo_stat tx_packets)
+            # shellcheck disable=SC2086
+            bench_exec perf -- $sub -o "$out" "$@" | filter_cset
+            [ "${out##*.}" = txt ] || out="$out.lo"
+            printf '%20s      lo-tx-bytes\n%20s      lo-tx-packets\n' \
+              "$(( $(lo_stat tx_bytes) - tx ))" "$(( $(lo_stat tx_packets) - pkt ))" \
+              | sudo tee -a "$out" >/dev/null
+          }
           # Run `perf $1` over every benchmark in $2 for $5 seconds, writing $4 under $3/<side>/.
+          # The transfers run over `[::1]`, so `lo` sees exactly them. Compare per byte:
+          # criterion fits whole iterations in, so the sides do different amounts of work.
           perf_dir() {
             local subcmd="$1" dir="$2" out ext="$4" secs="$5"
             out="$3/$(basename "$dir")"
@@ -168,15 +185,20 @@ jobs:
               if [ -n "$VARIANTS" ]; then
                 while IFS= read -r VARIANT; do
                   SAFE_NAME="${BIN_NAME}_$(sanitize_name "$VARIANT")"
-                  # shellcheck disable=SC2086
-                  bench_exec perf -- $subcmd -o "$out/$SAFE_NAME.$ext" "$BENCH" --bench --noplot --profile-time "$secs" --exact "$VARIANT" | filter_cset
+                  measure "$subcmd" "$out/$SAFE_NAME.$ext" "$BENCH" --bench --noplot --profile-time "$secs" --exact "$VARIANT"
                 done <<< "$VARIANTS"
               else
-                # shellcheck disable=SC2086
-                bench_exec perf -- $subcmd -o "$out/$BIN_NAME.$ext" "$BENCH" --bench --noplot --profile-time "$secs" | filter_cset
+                measure "$subcmd" "$out/$BIN_NAME.$ext" "$BENCH" --bench --noplot --profile-time "$secs"
               fi
             done
           }
+          # `perf stat` fails outright on an event it cannot open, so add the tracepoints
+          # only once they open. Probe them alone, or another event's failure is blamed here.
+          if bench_exec perf -- stat -e "$PERF_TRACEPOINTS" -- true >/dev/null 2>&1; then
+            PERF_STAT_OPT="$PERF_STAT_OPT,$PERF_TRACEPOINTS"
+          else
+            echo "::warning::syscall tracepoints unavailable, continuing without them"
+          fi
           # `stat` for both sides first, so `record`'s overhead cannot skew the IPC comparison.
           for SIDE in ../dist/neqo ../dist/neqo-baseline; do
             perf_dir "$PERF_STAT_OPT" "$SIDE" ../stats txt 5
@@ -261,6 +283,7 @@ jobs:
           path: |
             profiles/*/*.svg
             profiles/*/*.report.txt
+            profiles/*/*.lo
             stats/*/*.txt
             *.txt
             *.md


### PR DESCRIPTION
`perf stat` records instructions, cycles and faults, but nothing that counts syscalls or bytes, so a change in GSO batch size cannot be told apart from a change in per-datagram cost. Per-connection stats likewise attribute a slow run to a PTO or to loss instead of leaving it to inference.